### PR TITLE
Fix npm link issue with sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "musicmetadata": "^2.0.3",
     "nat-upnp": "^1.1.0",
     "public-ip": "^2.0.1",
-    "sqlite3": "^3.1.4",
+    "sqlite3": "3.1.8",
     "uuid": "^3.0.1",
     "ws": "^1.1.1"
   }


### PR DESCRIPTION
An issue with 3.1.9 (mapbox/node-sqlite3#866) causes npm link to fail. Pin `sqlite3` to 3.1.8 as a workaround.