### PR TITLE
Retain folder structure of uploaded directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "lokijs": "^1.5.6",
     "make-dir": "^3.0.0",
     "mime-types": "^2.1.22",
+    "mkdirp": "^0.5.1",
     "music-metadata": "^3.6.1",
     "nanoid": "^2.0.1",
     "winston": "^3.2.1",

--- a/public/js/mstream.js
+++ b/public/js/mstream.js
@@ -156,7 +156,7 @@ $(document).ready(function () {
       for (var i = 0; i < fileExplorerArray.length; i++) {
         directoryString += fileExplorerArray[i] + "/";
       }
-      file.directory = directoryString;
+      file.directory = directoryString + file.fullPath.substring(0, file.fullPath.indexOf(file.name));
     }
   });
 

--- a/public/js/winamp.js
+++ b/public/js/winamp.js
@@ -79,7 +79,7 @@ $(document).ready(function () {
       for (var i = 0; i < fileExplorerArray.length; i++) {
         directoryString += fileExplorerArray[i] + "/";
       }
-      file.directory = directoryString;
+      file.directory = directoryString + file.fullPath.substring(0, file.fullPath.indexOf(file.name));
     }
   });
 


### PR DESCRIPTION
This commit introdues new dependency mkdirp in order to retain folder structure of uploaded directories on server side. On browser side I used an undocumented member `file.fullPath`, which I found working on Google Chrome. Its probably a bad idea to rely on undocumented solutions, so please check if you can find a better one.