### PR TITLE
subsort tracks by filename

### DIFF
--- a/modules/db-read/database-public-loki.js
+++ b/modules/db-read/database-public-loki.js
@@ -391,7 +391,7 @@ exports.setup = function (mstream, program) {
           {'album': { '$eq': album }},
           artistClause
         ]
-      }).simplesort('track').data();
+      }).compoundsort(['track','filepath']).data();
 
       for (let row of results) {
         var relativePath = fe.relative(program.folders[row.vpath].root, row.filepath);


### PR DESCRIPTION
sort tracks by track number and then by filename. This is good if the media files do not have metadata, but the track number is at the beginning of the file name.