### PR TITLE
typo and improved clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ mStream can be configured with a JSON file that is loaded on boot. You can use t
 
 ```shell
 # Brings up an interactive shell program to edit all things in the config
-mstream --wizard /path/to/config.json
+mstream --wizard /path/to/package.json
 
 # Boot mStream with the config file
-mstream -j /path/to/config.json
+mstream -j /path/to/package.json
 ```
 
 ## Quick Test Configurations
@@ -119,7 +119,7 @@ Interested in getting in contact?  [Check out our Discord channel](https://disco
 
 ## Credits
 
-mStream is is built on top some great open-source libraries:
+mStream is built on top some great open-source libraries:
 
 * [music-metadata](https://github.com/Borewit/music-metadata) - The best metadata parser for NodeJS
 * [LokiJS](https://github.com/techfort/LokiJS) - A native, in-memory, database written in JavaScript.  LokiJS is the reason mStream is so fast and easy to install


### PR DESCRIPTION
i'm a noob and i really think clarity is key entering the "world of everything." had a few inopportune attempts at building mstream because the readme said conf.json instead of its' file name package.json... of which there are two .json files, the package and package-lock.json. Maybe this is a config.json file and i couldn't find it yet this thing built and ran anyways and I'm about to find errors. lmk if there is some logic i'm missing -- i'm pretty sure this is more one to one for the build process 