### PR TITLE
Support range request combined with ffmpeg

### DIFF
--- a/modules/ffmpeg.js
+++ b/modules/ffmpeg.js
@@ -4,10 +4,19 @@ const ffmpeg = require("fluent-ffmpeg");
 const winston = require('winston');
 
 const codecMap = {
-  'mp3': 'libmp3lame',
-  'opus': 'libopus',
-  'aac': 'aac'
+  'mp3': {codec: 'libmp3lame', contentType: 'audio/mpeg'},
+  'opus': {codec: 'libopus', contentType: 'audio/ogg'},
+  'aac': {codec: 'aac', contentType: 'audio/aac'}
 };
+
+function initHeaders(res, audioTypeId, audioPath) {
+  const contentType = codecMap[audioTypeId].contentType;
+  return res.header({
+    'Accept-Ranges': 'bytes',
+    'Content-Type': contentType,
+//    'Content-Length': stat.size
+  });
+}
 
 exports.setup = (mstream, program) => {
   const platform = ffbinaries.detectPlatform();
@@ -36,20 +45,31 @@ exports.setup = (mstream, program) => {
           return;
         }
 
-        ffmpeg(pathInfo.fullPath)
-          .noVideo()
-          .format(program.transcode.defaultCodec)
-          .audioCodec(codecMap[program.transcode.defaultCodec])
-          .audioBitrate(program.transcode.defaultBitrate)
-          .on('end', () => {
-            // console.log('file has been converted succesfully');
-          })
-          .on('error', err => {
-            winston.error('Transcoding Error!');
-            console.log(err);
-          })
-          // save to stream
-          .pipe(res, { end: true });
+        // Stream audio data
+        if (req.method === 'GET') {
+
+          initHeaders(res, program.transcode.defaultCodec, pathInfo.fullPath);
+
+          ffmpeg(pathInfo.fullPath)
+            .noVideo()
+            .format(program.transcode.defaultCodec)
+            .audioCodec(codecMap[program.transcode.defaultCodec].codec)
+            .audioBitrate(program.transcode.defaultBitrate)
+            .on('end', () => {
+              // console.log('file has been converted succesfully');
+            })
+            .on('error', err => {
+              winston.error('Transcoding Error!');
+              console.log(err);
+            })
+            // save to stream
+            .pipe(res, { end: true });
+        } else if (req.method === 'HEAD') {
+          // The HEAD request should return the same headers as the GET request, but not the body
+          initHeaders(res, program.transcode.defaultCodec, pathInfo.fullPath).sendStatus(200);
+        } else {
+          res.sendStatus(405); // Method not allowed
+        }
       });
     }
   );


### PR DESCRIPTION
In order to be able to seek in the media stream, I believe a proper handling [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) is required,

This PR is a start of that work towards the range requests.

### Testing
To be able to test the HTTP-range-requests in a controlled environment I have put a simple client together which is using the HTTP-range-requests to download audio information: [mstream-http-range-client](https://github.com/Borewit/mstream-http-range-client)

Related issue: #213 _Transcoding bugs_