### PR TITLE
Fix volume increase on track change or restart

### DIFF
--- a/public/js/mstream.player.js
+++ b/public/js/mstream.player.js
@@ -441,12 +441,16 @@ var MSTREAMPLAYER = (function () {
     // connect to visualizer
     if (VIZ) {
       var audioCtx =  VIZ.get();
-      var analyser = audioCtx.createAnalyser();
       try {
-        var source = audioCtx.createMediaElementSource(lPlayer.playerObject._sounds[0]._node);
-        source.connect(analyser);
-        source.connect(audioCtx.destination);
-        VIZ.connect(analyser);
+        var audioNode = lPlayer.playerObject._sounds[0]._node;
+        if (!audioNode.previouslyConnectedViz) {
+          var analyser = audioCtx.createAnalyser();
+          var source = audioCtx.createMediaElementSource(audioNode);
+          source.connect(analyser);
+          source.connect(audioCtx.destination);
+          VIZ.connect(analyser);
+          audioNode.previouslyConnectedViz = true;
+        }
       } catch( err) {
         console.log(err)
       }


### PR DESCRIPTION
When clicking on the currently playing item in "Now Playing" a few
times:

In Chrome, an exception is thrown:

Failed to execute 'createMediaElementSource' on 'AudioContext': HTMLMediaElement already connected previously to a different MediaElementSourceNode.

but Firefox is happy to try connecting the same source multiple times,
leading to apparent volume increases despite gain and volume settings
remaining constant.