### PR TITLE
Add ReplayGain support.

### DIFF
--- a/modules/db-read/database-public-loki.js
+++ b/modules/db-read/database-public-loki.js
@@ -25,6 +25,7 @@ const mapFunDefault = function(left, right) {
     'album-art': left.aaFile,
     filepath: left.filepath,
     rating: right.rating,
+    "replaygain-track-db": left.replaygainTrackDb,
     vpath: left.vpath
   };
 };
@@ -137,7 +138,8 @@ exports.setup = function (mstream, program) {
         "title": result[0].title ? result[0].title : null,
         "year": result[0].year ? result[0].year : null,
         "album-art": result[0].aaFile ? result[0].aaFile : null,
-        "rating": result[0].rating ? result[0].rating : null
+        "rating": result[0].rating ? result[0].rating : null,
+        "replaygain-track-db": result[0]['replaygain-track-db'] ? result[0]['replaygain-track-db'] : null
       }
     });
   });
@@ -279,7 +281,8 @@ exports.setup = function (mstream, program) {
             "title": result[0].title ? result[0].title : null,
             "year": result[0].year ? result[0].year : null,
             "album-art": result[0].aaFile ? result[0].aaFile : null,
-            "rating": result[0].rating ? result[0].rating : null
+            "rating": result[0].rating ? result[0].rating : null,
+            "replaygain-track-db": result[0]['replaygain-track-db'] ? result[0]['replaygain-track-db'] : null
           };
         }
       }
@@ -448,7 +451,8 @@ exports.setup = function (mstream, program) {
             "year": row.year ? row.year : null,
             "album-art": row.aaFile ? row.aaFile : null,
             "filename": fe.basename(row.filepath),
-            "rating": row.rating ? row.rating : null
+            "rating": row.rating ? row.rating : null,
+            "replaygain-track-db": row['replaygain-track-db'] ? row['replaygain-track-db'] : null
           }
         });
       }
@@ -567,7 +571,8 @@ exports.setup = function (mstream, program) {
         "title": randomSong.title ? randomSong.title : null,
         "year": randomSong.year ? randomSong.year : null,
         "album-art": randomSong.aaFile ? randomSong.aaFile : null,
-        "rating": randomSong.rating ? randomSong.rating : null
+        "rating": randomSong.rating ? randomSong.rating : null,
+        "replaygain-track-db": randomSong['replaygain-track-db'] ? randomSong['replaygain-track-db'] : null
       }
     });
 
@@ -669,6 +674,7 @@ exports.setup = function (mstream, program) {
         'album-art': right.aaFile,
         filepath: right.filepath,
         rating: left.rating,
+        "replaygain-track-db": right.replaygainTrackDb,
         vpath: right.vpath
       };
     };
@@ -700,7 +706,8 @@ exports.setup = function (mstream, program) {
           "year": row.year ? row.year : null,
           "album-art": row.aaFile ? row.aaFile : null,
           "filename": fe.basename(row.filepath),
-          "rating": row.rating ? row.rating : null
+          "rating": row.rating ? row.rating : null,
+          "replaygain-track-db": row['replaygain-track-db'] ? row['replaygain-track-db'] : null
         }
       });
     }
@@ -752,7 +759,8 @@ exports.setup = function (mstream, program) {
           "year": row.year ? row.year : null,
           "album-art": row.aaFile ? row.aaFile : null,
           "filename": fe.basename(row.filepath),
-          "rating": row.rating ? row.rating : null
+          "rating": row.rating ? row.rating : null,
+          "replaygain-track": row.replaygainTrack ? row.replaygainTrack : null
         }
       });
     }

--- a/modules/db-write/database-default-loki.js
+++ b/modules/db-write/database-default-loki.js
@@ -75,7 +75,8 @@ exports.insertEntries = function (arrayOfSongs, vpath) {
         "hash": song.hash,
         "aaFile": song.aaFile ? song.aaFile : null,
         "vpath": vpath,
-        "ts": Math.floor(Date.now() / 1000)
+        "ts": Math.floor(Date.now() / 1000),
+        "replaygainTrackDb": song.replaygain_track_gain ? song.replaygain_track_gain.dB : null
       });
 
       saveCounter++;

--- a/public/css/mstream-player.css
+++ b/public/css/mstream-player.css
@@ -464,3 +464,19 @@ input[type=range]:focus::-ms-fill-lower {
 input[type=range]:focus::-ms-fill-upper {
   background: #5c5c5c;
 }
+
+#rg-pregain-info {
+  color: rgb(102, 132, 178);
+  font-weight: 800;
+  font-size: 13px;
+  font-family: 'Jura', sans-serif;
+  width: 34px;
+  padding: 13px 0;
+  opacity: 0;
+  transition: opacity 0.25s;
+  text-align: right;
+}
+
+#rg-status {
+  transition: opacity 0.25s;
+}

--- a/public/mstream.html
+++ b/public/mstream.html
@@ -425,6 +425,7 @@
                     <p v-cloak class="metadata-panel-text">Artist: {{ (meta.artist) ? meta.artist : '' }}</p>
                     <p v-cloak class="metadata-panel-text">Album: {{ (meta.album) ? meta.album : '' }}</p>
                     <p v-cloak class="metadata-panel-text">Year: {{ (meta.year) ? meta.year : '' }}</p>
+                    <p v-cloak class="metadata-panel-text">Gain: {{ (meta['replaygain-track-db']) ? String(meta['replaygain-track-db']) + " db" : 'n/a' }}</p>
                   </div>
                 </div>
 
@@ -474,6 +475,10 @@
               </span>
             </div>
 
+			<div v-on:click="toggleReplayGain" class="next-button" title="ReplayGain">
+			  <div id="rg-pregain-info">{{playerStats.replayGainPreGainDb}}db</div>
+              <svg id="rg-status" v-bind:class="{ 'aux-button-active': playerStats.replayGain }" class="center" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid" style="width:35px;webkit-logical-width:35px;webkit-logical-height:25px;user-select:none;transform-origin:12.5px 12.5px;r:0;perspective-origin:12.5px 12.5px;overflow-y:hidden;overflow-x:hidden;inline-size:35px;height:25px;d:none;block-size:25px;background:0% 0%/auto padding-box border-box" overflow="hidden" display="block" fill="#fff"><g transform="translate(-.938 19.85)" style="y:0;user-select:none;transform:matrix(1,0,0,1,-.9375,19.85);perspective-origin:0 0"><g class="ld" style="y:0;x:0;user-select:none;transform-origin:7.9375px 0;transform:none;r:0;perspective-origin:0 0;line-height:31.4286px;font:400 22px/31.4286px 'Varela Round','century gothic',verdana;d:none"><text style="y:0;user-select:none;r:0;perspective-origin:7.9375px 0;line-height:31.4286px;font:400 22px/31.4286px Arial" white-space="nowrap" display="block">R</text></g></g><g transform="translate(14.938 19.85)" style="y:0;user-select:none;transform:matrix(1,0,0,1,14.9375,19.85);perspective-origin:0 0"><g class="ld" style="y:0;x:0;user-select:none;transform-origin:5.5px 0;transform:none;r:0;perspective-origin:0 0;line-height:31.4286px;font:400 22px/31.4286px 'Varela Round','century gothic',verdana;d:none"><text style="y:0;user-select:none;r:0;perspective-origin:5.5px 0;line-height:31.4286px;font:400 22px/31.4286px Arial" white-space="nowrap" display="block">G</text></g></g></svg>
+			</div>
             <div v-on:click="toggleVolume" class="player-button">
               <img class="noselect fill-white center" :src="volumeSrc" title="Mute/Unmute">
             </div>


### PR DESCRIPTION
I've added ReplayGain (track-level only) support in this pull request.

There's a new "RG" button next to the volume mute control. It can be clicked to activate ReplayGain, and further clicks cycle through a list of predefined pre-gain values before disabling ReplayGain.

The user's ReplayGain activation and pre-gain settings are saved.

The metadata db will need to be rebuilt so that the ReplayGain metadata for each track is made available.

Thanks for this project!