### PR TITLE
update docs for admin ui and password config

### DIFF
--- a/docs/cli_arguments.md
+++ b/docs/cli_arguments.md
@@ -1,10 +1,10 @@
-As of v5-alpha there are only two arguments:
+As of v4.7.0 there is only one cli parameter:
 
-`--wizard` && `--json`
+`--json` || `-j`
 
-These both accept an argument of a config file
+It accepts an argument of a json config file path
 ```
 mstream -j /path/to/config.json
 ```
 
-NOTE: v5 aims to simplify the setup process of mstream as much as possible.  I might remove the wizard in favor of Admin UI later in the development of v5.  If you have any opinions, let me know in the discord channel or on github.
+NOTE: v5 aims to simplify the setup process of mstream as much as possible. The `--wizard` argument was removed in favor of Admin UI. If you have any opinions, let me know in the discord channel or on github.

--- a/docs/json_config.md
+++ b/docs/json_config.md
@@ -1,11 +1,3 @@
-# Use The Wizard
-
-Editing JSON by hand is tedious. All the json config options can be edited by using the cli wizard.  To use it:
-
-```
-mstream --wizard /path/to/config.json
-```
-
 # JSON config
 
 Using a JSON config with mStream allows for more advanced configurations.  This example contains all configurable params for reference purposes.  
@@ -35,11 +27,13 @@ Using a JSON config with mStream allows for more advanced configurations.  This 
   },
   "users": {
     "paul": {
-      "password":"p@ssword",
+      "password": "bKD6We4x40qcA2sDqVV0EHz1yiu5XDhnFlL6+JRrvMw=",
+      "salt": "PMsisJwG3F3m7atHtny40Q==",
       "vpaths": ["blues", "rock"]
     },
     "james": {
-      "password": "qwerty",
+     "password": "qBg8vlOcqrhFpgVDd/2jVHgHamvb6xspjhxrpl5m3Is=",
+      "salt": "6cm1jPJ1Xl/ocLbaNijpJg==",
       "vpaths": "rock",
       "lastfm-user": "username",
       "lastfm-password": "password"
@@ -88,6 +82,8 @@ If there is no users object, the login system will not be enabled and anyone wil
 
 A basic user example.  
 
+Note that the hashed password and salt can be generated automatically by creating a new user via the admin ui.
+
 ```json
 {
   "folders": {
@@ -95,7 +91,8 @@ A basic user example.
   },
   "users": {
     "paul": {
-      "password":"p@ssword",
+      "password": "bKD6We4x40qcA2sDqVV0EHz1yiu5XDhnFlL6+JRrvMw=",
+      "salt": "PMsisJwG3F3m7atHtny40Q==",
       "vpaths": "media"
     }
   }


### PR DESCRIPTION
- remove `--wizard` cli parameter
- add password salt in user example (with actual generated values from `p@assword` and `qwerty`)
- add note about generating users via admin ui

connected to [issue](https://github.com/IrosTheBeggar/mStream/issues/293)