### PR TITLE
fix admin add folder error

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -142,7 +142,7 @@ exports.setup = (mstream) => {
     });
     const input = joiValidate(schema, req.body);
 
-    await admin.addDirectory(input.directory, input.vpath, input.autoAccess, mstream);
+    await admin.addDirectory(input.value.directory, input.value.vpath, input.value.autoAccess, mstream);
     res.json({});
 
     try {


### PR DESCRIPTION
Fix the error when adding a folder.

The form data is wrapped as `value` inside the return of `joiValidate()`.

![image](https://user-images.githubusercontent.com/33346345/141522231-f79c9169-8ce1-47a5-bbab-d2c96a06e6e8.png)
