### PR TITLE
Fix another add-directory error

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -146,7 +146,7 @@ exports.setup = (mstream) => {
     res.json({});
 
     try {
-      dbQueue.scanVPath(input.vpath);
+      dbQueue.scanVPath(input.value.vpath);
     }catch (err) {
       winston.error('/api/v1/admin/directory failed to add ', { stack: err });
     }


### PR DESCRIPTION
There's another spot where input.vpath needs to be replaced by input.value.vpath in the code for adding a directory, otherwise it doesn't get scanned properly.