### PR TITLE
create configs.transcode.ffmpegDirectory on enable if it does not exist

### DIFF
--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -307,6 +307,10 @@ exports.enableTranscode = async (val) => {
   const loadConfig = await this.loadFile(config.configFile);
   if (!loadConfig.transcode) { loadConfig.transcode = {}; }
   loadConfig.transcode.enabled = val;
+  if (val == true && !loadConfig.transcode.ffmpegDirectory) {
+      // default value hard coded until UI enables changing
+      loadConfig.transcode.ffmpegDirectory = "/opt/mstream/bin/ffmpeg";
+  }
   await this.saveFile(loadConfig, config.configFile);
 
   config.program.transcode.enabled = val;


### PR DESCRIPTION
Running mStream from Docker without a pre-existing config.json file, enabling transcoding through the UI doesn't work.  The binaries are downloaded correctly, but without an output directory provided to `ffbinaries.downloadFiles()` the extract-and-chmod+x step fails silently.  Resolves https://github.com/IrosTheBeggar/mStream/issues/359.