### PR TITLE
Fix flex overflow render in Safari

### DIFF
--- a/webapp/alpha/spa.css
+++ b/webapp/alpha/spa.css
@@ -685,11 +685,12 @@ body {
 
 .header-tab{
   z-index: 1000;
-  display: flex;
   padding-left: 6px;
 }
 
 .grow {
+  flex: 1;
+  overflow-y: auto;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
There are some people still using "vintage" Apple. Proposed PR fixes playlist scrollbars render in HighSierra/Safari. To be more precise, currently MStream CSS contains some bug in flexbox containers hierarchy (google: "flex overflow", e.g. https://stackoverflow.com/questions/43502451/nested-flexbox-ui-with-scrolling-content-rendered-differently-in-safari-and-in-m), which was pretty annoying several years ago, but by now managed to be handled by modern browsers.