### PR TITLE
Escape question marks in filenames

### DIFF
--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -520,6 +520,7 @@ const VUEPLAYERCORE = (() => {
     var rawFilepath = filepath;
     filepath = filepath.replace(/\%/g, "%25");
     filepath = filepath.replace(/\#/g, "%23");
+    filepath = filepath.replace(/\?/g, "%3F");
     if (filepath.charAt(0) === '/') {
       filepath = filepath.substr(1);
     }

--- a/webapp/assets/js/api2.js
+++ b/webapp/assets/js/api2.js
@@ -177,6 +177,7 @@ var MSTREAMAPI = (function () {
     var rawFilepath = filepath;
     filepath = filepath.replace(/\%/g, "%25");
     filepath = filepath.replace(/\#/g, "%23");
+    filepath = filepath.replace(/\?/g, "%3F");
     if (filepath.charAt(0) === '/') {
       filepath = filepath.substr(1);
     }


### PR DESCRIPTION
This should fix #397.

Factoring out the URL-encoding, and checking it for other potentially problematic characters, might be worth doing though.