### PR TITLE
Security: Hardcoded Last.fm API secret in default configuration

### DIFF
--- a/src/state/config.js
+++ b/src/state/config.js
@@ -47,8 +47,8 @@ const rpnOptions = Joi.object({
 });
 
 const lastFMOptions = Joi.object({
-  apiKey: Joi.string().default('25627de528b6603d6471cd331ac819e0'),
-  apiSecret: Joi.string().default('a9df934fc504174d4cb68853d9feb143')
+  apiKey: Joi.string().allow('').default(process.env.LASTFM_API_KEY || ''),
+  apiSecret: Joi.string().allow('').default(process.env.LASTFM_API_SECRET || '')
 });
 
 const federationOptions = Joi.object({


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `src/state/config.js`.

**Context:**
The default config embeds a concrete `lastFM.apiSecret` (and paired API key) directly in source code. Because this repository is public, anyone can reuse these credentials to impersonate this application against Last.fm APIs, consume quota/rate limits, and potentially disrupt legitimate users of the feature. This is a real credential exposure, not a placeholder.


**Proposed fix:**
Remove the hardcoded defaults and load these values from environment variables or user config at runtime. For example: `apiKey: Joi.string().default(process.env.LASTFM_API_KEY || '')`, `apiSecret: Joi.string().default(process.env.LASTFM_API_SECRET || '')`, then enforce non-empty values only when Last.fm integration is enabled. Also rotate/revoke the currently exposed secret with Last.fm.

**Files touched:**
- `src/state/config.js` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
