### PR TITLE
CLI audio player fallback for server-side playback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must stay LF-only: CRLF endings from Windows checkouts
+# break the shebang line when they're exec'd inside Linux containers.
+*.sh text eol=lf

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -12,7 +12,7 @@ import * as imageCompress from '../db/image-compress-manager.js';
 import * as transcode from './transcode.js';
 import * as db from '../db/manager.js';
 import { joiValidate } from '../util/validation.js';
-import { bootRustPlayer, killRustPlayer, proxyToRust } from './server-playback.js';
+import { bootRustPlayer, killRustPlayer, proxyToRust, getActiveBackend, getDetectedCliPlayers } from './server-playback.js';
 import { listImplementedMethods } from './subsonic/index.js';
 import { listTokenAuthAttempts, clearTokenAuthAttempts, generateApiKey } from './subsonic/auth.js';
 import * as nowPlaying from './subsonic/now-playing.js';
@@ -454,6 +454,15 @@ export function setup(mstream) {
 
     await admin.editRustPlayerPort(req.body.rustPlayerPort);
     res.json({});
+  });
+
+  mstream.get("/api/v1/admin/server-audio/info", (req, res) => {
+    const active = getActiveBackend();
+    res.json({
+      backend: active.backend,
+      player: active.player,
+      detectedCliPlayers: getDetectedCliPlayers(),
+    });
   });
 
   mstream.post("/api/v1/admin/config/secret", async (req, res) => {

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -190,7 +190,8 @@ export function setup(mstream) {
         vpaths: libraries.map(l => l.name),
         allowMkdir: user.allow_mkdir === 1,
         allowUpload: user.allow_upload === 1,
-        allowFileModify: user.allow_file_modify === 1
+        allowFileModify: user.allow_file_modify === 1,
+        allowServerAudio: user.allow_server_audio === 1
       };
     }
     res.json(result);
@@ -237,7 +238,8 @@ export function setup(mstream) {
       vpaths: Joi.array().items(Joi.string()).required(),
       admin: Joi.boolean().optional().default(false),
       allowMkdir: Joi.boolean().optional().default(true),
-      allowUpload: Joi.boolean().optional().default(true)
+      allowUpload: Joi.boolean().optional().default(true),
+      allowServerAudio: Joi.boolean().optional().default(true)
     });
     const input = joiValidate(schema, req.body);
 
@@ -247,7 +249,8 @@ export function setup(mstream) {
       input.value.admin,
       input.value.vpaths,
       input.value.allowMkdir,
-      input.value.allowUpload
+      input.value.allowUpload,
+      input.value.allowServerAudio
     );
     res.json({});
   });
@@ -322,11 +325,19 @@ export function setup(mstream) {
       admin: Joi.boolean().required(),
       allowMkdir: Joi.boolean().required(),
       allowUpload: Joi.boolean().required(),
-      allowFileModify: Joi.boolean().optional().default(true)
+      allowFileModify: Joi.boolean().optional().default(true),
+      allowServerAudio: Joi.boolean().optional().default(true)
     });
     joiValidate(schema, req.body);
 
-    await admin.editUserAccess(req.body.username, req.body.admin, req.body.allowMkdir, req.body.allowUpload, req.body.allowFileModify);
+    await admin.editUserAccess(
+      req.body.username,
+      req.body.admin,
+      req.body.allowMkdir,
+      req.body.allowUpload,
+      req.body.allowFileModify,
+      req.body.allowServerAudio
+    );
     res.json({});
   });
 
@@ -436,12 +447,12 @@ export function setup(mstream) {
 
     await admin.editAutoBootServerAudio(req.body.autoBootServerAudio);
 
-    // Start or stop the Rust player immediately
-    if (req.body.autoBootServerAudio) {
-      bootRustPlayer();
-    } else {
-      killRustPlayer();
-    }
+    // Flag controls Rust preference now. Either way, re-boot server audio so
+    // the active backend matches the new setting:
+    //   true  → kill current backend, boot Rust (with CLI fallback)
+    //   false → kill current backend, boot CLI directly
+    killRustPlayer();
+    bootRustPlayer();
 
     res.json({});
   });

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -12,7 +12,7 @@ import * as imageCompress from '../db/image-compress-manager.js';
 import * as transcode from './transcode.js';
 import * as db from '../db/manager.js';
 import { joiValidate } from '../util/validation.js';
-import { bootRustPlayer, killRustPlayer, proxyToRust, getActiveBackend, getDetectedCliPlayers } from './server-playback.js';
+import { bootRustPlayer, killRustPlayer, proxyToRust, getActiveBackend, getDetectedCliPlayers, refreshDetectedCliPlayers } from './server-playback.js';
 import { listImplementedMethods } from './subsonic/index.js';
 import { listTokenAuthAttempts, clearTokenAuthAttempts, generateApiKey } from './subsonic/auth.js';
 import * as nowPlaying from './subsonic/now-playing.js';
@@ -450,9 +450,9 @@ export function setup(mstream) {
     // Flag controls Rust preference now. Either way, re-boot server audio so
     // the active backend matches the new setting:
     //   true  → kill current backend, boot Rust (with CLI fallback)
-    //   false → kill current backend, boot CLI directly
+    //   false → kill current backend, boot CLI directly (MPD preferred)
     killRustPlayer();
-    bootRustPlayer();
+    await bootRustPlayer();
 
     res.json({});
   });
@@ -474,6 +474,14 @@ export function setup(mstream) {
       player: active.player,
       detectedCliPlayers: getDetectedCliPlayers(),
     });
+  });
+
+  // Re-run the CLI player detection probe. Use this after installing or
+  // removing a player (mpv, vlc, mplayer, or an MPD daemon) without having
+  // to restart the server.
+  mstream.post("/api/v1/admin/server-audio/detect", async (req, res) => {
+    const detected = await refreshDetectedCliPlayers();
+    res.json({ detectedCliPlayers: detected });
   });
 
   mstream.post("/api/v1/admin/config/secret", async (req, res) => {

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -63,7 +63,8 @@ export function setup(mstream) {
         id: null,
         allow_upload: adminLocked ? 0 : 1,
         allow_mkdir: adminLocked ? 0 : 1,
-        allow_file_modify: adminLocked ? 0 : 1
+        allow_file_modify: adminLocked ? 0 : 1,
+        allow_server_audio: 1
       };
       return next();
     }
@@ -97,7 +98,8 @@ export function setup(mstream) {
         admin: false,
         allow_upload: 0,
         allow_mkdir: 0,
-        allow_file_modify: 0
+        allow_file_modify: 0,
+        allow_server_audio: 0
       };
       return next();
     }

--- a/src/api/cli-audio/base.js
+++ b/src/api/cli-audio/base.js
@@ -1,0 +1,287 @@
+/**
+ * BaseCliAdapter — shared queue state + HTTP-style request dispatcher.
+ *
+ * Sub-classes provide concrete player control by overriding the `_*` hooks
+ * (e.g. _loadFile, _pause, _getPosition). The base class manages queue,
+ * shuffle, loop, and translates the REST-ish routes used by the Rust binary
+ * into adapter method calls, so `proxyToCli()` can be a drop-in replacement
+ * for `proxyToRust()` in server-playback.js.
+ */
+
+const LOOP_MODES = ['none', 'one', 'all'];
+
+export class BaseCliAdapter {
+  constructor(playerName) {
+    this.playerName = playerName;
+    this.queue = [];
+    this.queueIndex = 0;
+    this.shuffle = false;
+    this.loopMode = 'none';
+    this.volume = 1.0;
+    this.paused = false;
+    this.stopped = true;
+    this.currentFile = '';
+    this.duration = 0;
+  }
+
+  // ── Subclass hooks (override these) ────────────────────────────────────
+
+  async start() { /* spawn + connect */ }
+  async stop() { /* kill */ }
+
+  async _loadFile(_absPath) { throw new Error('not implemented'); }
+  async _pause() { throw new Error('not implemented'); }
+  async _resume() { throw new Error('not implemented'); }
+  async _stop() { throw new Error('not implemented'); }
+  async _seek(_seconds) { throw new Error('not implemented'); }
+  async _setVolume(_vol01) { throw new Error('not implemented'); }
+  async _getPosition() { return 0; }
+  async _getDuration() { return this.duration; }
+
+  // ── High-level actions ─────────────────────────────────────────────────
+
+  async play(absPath) {
+    this.queue = [absPath];
+    this.queueIndex = 0;
+    await this._loadFile(absPath);
+    this.currentFile = absPath;
+    this.paused = false;
+    this.stopped = false;
+  }
+
+  async pause() {
+    await this._pause();
+    this.paused = true;
+  }
+
+  async resume() {
+    await this._resume();
+    this.paused = false;
+  }
+
+  async stopPlayback() {
+    await this._stop();
+    this.currentFile = '';
+    this.paused = false;
+    this.stopped = true;
+  }
+
+  async seek(seconds) {
+    await this._seek(Number(seconds) || 0);
+  }
+
+  async setVolume(vol01) {
+    const v = Math.max(0, Math.min(1, Number(vol01) || 0));
+    await this._setVolume(v);
+    this.volume = v;
+  }
+
+  async setShuffle(value) {
+    this.shuffle = !!value;
+  }
+
+  async cycleLoop() {
+    const idx = LOOP_MODES.indexOf(this.loopMode);
+    this.loopMode = LOOP_MODES[(idx + 1) % LOOP_MODES.length];
+  }
+
+  async next() {
+    const idx = this._pickNextIndex();
+    if (idx === null) { throw new Error('Already at end of queue'); }
+    this.queueIndex = idx;
+    await this._loadCurrent();
+  }
+
+  async previous() {
+    if (this.queue.length === 0) { throw new Error('Queue is empty'); }
+    if (this.queueIndex === 0) {
+      if (this.loopMode === 'all') {
+        this.queueIndex = this.queue.length - 1;
+        await this._loadCurrent();
+      } else {
+        await this._seek(0);
+      }
+    } else {
+      this.queueIndex -= 1;
+      await this._loadCurrent();
+    }
+  }
+
+  async queueAdd(absPath) {
+    const wasEmpty = this.queue.length === 0;
+    this.queue.push(absPath);
+    if (wasEmpty) {
+      this.queueIndex = 0;
+      await this._loadCurrent();
+    }
+  }
+
+  async queueAddMany(absPaths) {
+    const wasEmpty = this.queue.length === 0;
+    for (const p of absPaths) { this.queue.push(p); }
+    if (wasEmpty && this.queue.length > 0) {
+      this.queueIndex = 0;
+      await this._loadCurrent();
+    }
+  }
+
+  async queuePlayIndex(index) {
+    if (index < 0 || index >= this.queue.length) {
+      throw new Error('Index out of range');
+    }
+    this.queueIndex = index;
+    await this._loadCurrent();
+  }
+
+  async queueRemove(index) {
+    if (index < 0 || index >= this.queue.length) {
+      throw new Error('Index out of range');
+    }
+    this.queue.splice(index, 1);
+    if (this.queue.length === 0) {
+      this.queueIndex = 0;
+      await this.stopPlayback();
+    } else if (index < this.queueIndex) {
+      this.queueIndex -= 1;
+    } else if (index === this.queueIndex) {
+      this.queueIndex = Math.min(index, this.queue.length - 1);
+      await this._loadCurrent();
+    }
+  }
+
+  async queueClear() {
+    this.queue = [];
+    this.queueIndex = 0;
+    await this.stopPlayback();
+  }
+
+  async getStatus() {
+    const position = await this._getPosition().catch(() => 0);
+    const duration = await this._getDuration().catch(() => this.duration);
+    return {
+      playing: !this.paused && !this.stopped && this.currentFile !== '',
+      paused: this.paused,
+      position: Number(position) || 0,
+      duration: Number(duration) || 0,
+      volume: this.volume,
+      file: this.currentFile,
+      queue_index: this.queueIndex,
+      queue_length: this.queue.length,
+      shuffle: this.shuffle,
+      loop_mode: this.loopMode,
+    };
+  }
+
+  async getQueue() {
+    return { queue: this.queue.slice() };
+  }
+
+  // ── Internal helpers ───────────────────────────────────────────────────
+
+  _pickNextIndex() {
+    if (this.queue.length === 0) { return null; }
+    if (this.loopMode === 'one') { return this.queueIndex; }
+    if (this.shuffle) {
+      if (this.queue.length <= 1) { return 0; }
+      const offset = Math.floor(Math.random() * (this.queue.length - 1)) + 1;
+      return (this.queueIndex + offset) % this.queue.length;
+    }
+    const next = this.queueIndex + 1;
+    if (next < this.queue.length) { return next; }
+    if (this.loopMode === 'all') { return 0; }
+    return null;
+  }
+
+  async _loadCurrent() {
+    if (this.queueIndex < 0 || this.queueIndex >= this.queue.length) { return; }
+    const path = this.queue[this.queueIndex];
+    await this._loadFile(path);
+    this.currentFile = path;
+    this.paused = false;
+    this.stopped = false;
+  }
+
+  // Called by the subclass when the current track finishes on its own.
+  // Advances the queue respecting shuffle/loop, and loads the next track.
+  async _onTrackEnded() {
+    const idx = this._pickNextIndex();
+    if (idx === null) {
+      this.stopped = true;
+      this.currentFile = '';
+      return;
+    }
+    this.queueIndex = idx;
+    try { await this._loadCurrent(); } catch (_e) { /* swallow */ }
+  }
+
+  // ── Route dispatcher (matches rust binary paths) ───────────────────────
+
+  async handleRequest(method, rustPath, body = {}) {
+    try {
+      const data = await this._dispatch(method, rustPath, body || {});
+      return { status: 200, data: data ?? { ok: true } };
+    } catch (e) {
+      return { status: 400, data: { error: e.message } };
+    }
+  }
+
+  async _dispatch(method, rustPath, body) {
+    const key = `${method} ${rustPath}`;
+    switch (key) {
+      case 'POST /play':
+        if (!body.file) { throw new Error('Missing file'); }
+        await this.play(body.file);
+        return { ok: true };
+      case 'POST /pause':
+        await this.pause();
+        return { ok: true };
+      case 'POST /resume':
+        await this.resume();
+        return { ok: true };
+      case 'POST /stop':
+        await this.stopPlayback();
+        return { ok: true };
+      case 'POST /next':
+        await this.next();
+        return { ok: true };
+      case 'POST /previous':
+        await this.previous();
+        return { ok: true };
+      case 'POST /seek':
+        await this.seek(body.position);
+        return { ok: true };
+      case 'POST /volume':
+        await this.setVolume(body.volume);
+        return { ok: true };
+      case 'POST /shuffle':
+        await this.setShuffle(body.value);
+        return { ok: true };
+      case 'POST /loop':
+        await this.cycleLoop();
+        return { ok: true };
+      case 'POST /queue/add':
+        if (!body.file) { throw new Error('Missing file'); }
+        await this.queueAdd(body.file);
+        return { ok: true };
+      case 'POST /queue/add-many':
+        if (!Array.isArray(body.files)) { throw new Error('Missing files'); }
+        await this.queueAddMany(body.files);
+        return { ok: true };
+      case 'POST /queue/play-index':
+        await this.queuePlayIndex(Number(body.index));
+        return { ok: true };
+      case 'POST /queue/remove':
+        await this.queueRemove(Number(body.index));
+        return { ok: true };
+      case 'POST /queue/clear':
+        await this.queueClear();
+        return { ok: true };
+      case 'GET /status':
+        return this.getStatus();
+      case 'GET /queue':
+        return this.getQueue();
+      default:
+        throw new Error(`Unsupported route: ${key}`);
+    }
+  }
+}

--- a/src/api/cli-audio/index.js
+++ b/src/api/cli-audio/index.js
@@ -5,7 +5,9 @@
  * a known CLI music player and boots an adapter that mimics the Rust binary's
  * HTTP API. `proxyToCli` is a drop-in replacement for `proxyToRust`.
  *
- * Priority order is defined in PLAYERS below — first installed wins.
+ * Priority order is defined in PLAYERS below — first installed wins. MPD is a
+ * special case: there's no binary to spawn, we just TCP-probe localhost:6600
+ * (overridable via MSTREAM_MPD_HOST).
  */
 
 import child_process from 'child_process';
@@ -13,45 +15,66 @@ import winston from 'winston';
 import { MpvAdapter } from './mpv.js';
 import { VlcAdapter } from './vlc.js';
 import { MplayerAdapter } from './mplayer.js';
+import { MpdAdapter, probeMpd } from './mpd.js';
 
 /**
- * Priority list. First entry whose binary is found on PATH is used.
- * `probeArgs` should be a lightweight flag that returns quickly and exits 0
- * (or at least produces version text without blocking on stdin).
+ * Priority list. First available entry is used.
+ *
+ * Each entry defines how to detect and instantiate a player:
+ *   kind: 'spawn' — requires a binary on PATH; detected by running `probeArgs`
+ *   kind: 'daemon' — connects to a long-running daemon; detected by `probe()`
  */
 export const PLAYERS = [
-  { name: 'mpv',     binary: 'mpv',     probeArgs: ['--version'], AdapterClass: MpvAdapter,     label: 'mpv' },
-  { name: 'vlc',     binary: 'vlc',     probeArgs: ['--version'], AdapterClass: VlcAdapter,     label: 'VLC' },
-  { name: 'mplayer', binary: 'mplayer', probeArgs: ['-v'],        AdapterClass: MplayerAdapter, label: 'MPlayer' },
+  { name: 'mpv',     kind: 'spawn',  binary: 'mpv',     probeArgs: ['--version'], AdapterClass: MpvAdapter,     label: 'mpv' },
+  { name: 'mpd',     kind: 'daemon', probe: () => probeMpd(),                     AdapterClass: MpdAdapter,     label: 'MPD' },
+  { name: 'vlc',     kind: 'spawn',  binary: 'vlc',     probeArgs: ['--version'], AdapterClass: VlcAdapter,     label: 'VLC' },
+  { name: 'mplayer', kind: 'spawn',  binary: 'mplayer', probeArgs: ['-v'],        AdapterClass: MplayerAdapter, label: 'MPlayer' },
 ];
 
-function probe(binary, args) {
+function probeBinary(binary, args) {
+  // Async probe: we used to call spawnSync here, but that blocks the Node
+  // event loop, which starves the MPD TCP probe's 'data' callback and makes
+  // its short timeout misfire. Using spawn lets every probe run concurrently.
+  return new Promise((resolve) => {
+    let proc;
+    try {
+      proc = child_process.spawn(binary, args, { windowsHide: true });
+    } catch (_e) {
+      return resolve(false);
+    }
+    let gotOutput = false;
+    const mark = () => { gotOutput = true; };
+    const timer = setTimeout(() => {
+      try { proc.kill(); } catch (_) { /* ignore */ }
+      resolve(gotOutput);
+    }, 3000);
+    // Most players print a version banner on stdout or stderr. As long as
+    // the binary resolved and produced output, count it as available —
+    // exit codes vary (mplayer -v returns non-zero because it wants a file).
+    if (proc.stdout) { proc.stdout.on('data', mark); }
+    if (proc.stderr) { proc.stderr.on('data', mark); }
+    proc.on('exit', () => { clearTimeout(timer); resolve(gotOutput); });
+    proc.on('error', () => { clearTimeout(timer); resolve(false); });
+  });
+}
+
+async function isAvailable(player) {
   try {
-    const res = child_process.spawnSync(binary, args, {
-      encoding: 'utf8',
-      timeout: 3000,
-      windowsHide: true,
-    });
-    if (res.error) { return false; }
-    const out = (res.stdout || '') + (res.stderr || '');
-    // Most players print a version banner; as long as the binary resolved and
-    // produced output, count it as available. Exit code varies (mplayer -v can
-    // return non-zero because it expects a file argument).
-    return out.length > 0;
+    if (player.kind === 'daemon') { return await player.probe(); }
+    return await probeBinary(player.binary, player.probeArgs);
   } catch (_e) {
     return false;
   }
 }
 
 /**
- * Returns the subset of PLAYERS that are actually installed, in priority order.
+ * Returns the subset of PLAYERS that are actually installed / reachable, in
+ * priority order. Probes TCP daemons concurrently so we don't serialize
+ * connection timeouts.
  */
-export function detectAvailablePlayers() {
-  const found = [];
-  for (const p of PLAYERS) {
-    if (probe(p.binary, p.probeArgs)) { found.push(p.name); }
-  }
-  return found;
+export async function detectAvailablePlayers() {
+  const flags = await Promise.all(PLAYERS.map((p) => isAvailable(p)));
+  return PLAYERS.filter((_, i) => flags[i]).map((p) => p.name);
 }
 
 // ── Active adapter state ───────────────────────────────────────────────────
@@ -71,8 +94,9 @@ export async function bootCliPlayer() {
   if (activeAdapter) { return activePlayerName; }
 
   for (const p of PLAYERS) {
-    if (!probe(p.binary, p.probeArgs)) { continue; }
-    const adapter = new p.AdapterClass(p.binary);
+    const available = await isAvailable(p);
+    if (!available) { continue; }
+    const adapter = p.kind === 'spawn' ? new p.AdapterClass(p.binary) : new p.AdapterClass();
     try {
       await adapter.start();
       activeAdapter = adapter;

--- a/src/api/cli-audio/index.js
+++ b/src/api/cli-audio/index.js
@@ -89,11 +89,22 @@ export function isCliActive() { return activeAdapter !== null; }
 /**
  * Detect + start the first available CLI player. Returns the player name if
  * started, or null if none could be started.
+ *
+ * If `preferredName` is provided and that player is available, it's tried
+ * first regardless of registry position. Remaining players are attempted in
+ * the default priority order if the preferred choice isn't installed or
+ * fails to start.
  */
-export async function bootCliPlayer() {
+export async function bootCliPlayer(preferredName = null) {
   if (activeAdapter) { return activePlayerName; }
 
-  for (const p of PLAYERS) {
+  const ordered = PLAYERS.slice();
+  if (preferredName) {
+    const idx = ordered.findIndex((p) => p.name === preferredName);
+    if (idx > 0) { ordered.unshift(ordered.splice(idx, 1)[0]); }
+  }
+
+  for (const p of ordered) {
     const available = await isAvailable(p);
     if (!available) { continue; }
     const adapter = p.kind === 'spawn' ? new p.AdapterClass(p.binary) : new p.AdapterClass();

--- a/src/api/cli-audio/index.js
+++ b/src/api/cli-audio/index.js
@@ -1,0 +1,106 @@
+/**
+ * cli-audio/index.js — CLI-player fallback for server-side playback.
+ *
+ * When the Rust audio binary isn't available, this module probes the host for
+ * a known CLI music player and boots an adapter that mimics the Rust binary's
+ * HTTP API. `proxyToCli` is a drop-in replacement for `proxyToRust`.
+ *
+ * Priority order is defined in PLAYERS below — first installed wins.
+ */
+
+import child_process from 'child_process';
+import winston from 'winston';
+import { MpvAdapter } from './mpv.js';
+import { VlcAdapter } from './vlc.js';
+import { MplayerAdapter } from './mplayer.js';
+
+/**
+ * Priority list. First entry whose binary is found on PATH is used.
+ * `probeArgs` should be a lightweight flag that returns quickly and exits 0
+ * (or at least produces version text without blocking on stdin).
+ */
+export const PLAYERS = [
+  { name: 'mpv',     binary: 'mpv',     probeArgs: ['--version'], AdapterClass: MpvAdapter,     label: 'mpv' },
+  { name: 'vlc',     binary: 'vlc',     probeArgs: ['--version'], AdapterClass: VlcAdapter,     label: 'VLC' },
+  { name: 'mplayer', binary: 'mplayer', probeArgs: ['-v'],        AdapterClass: MplayerAdapter, label: 'MPlayer' },
+];
+
+function probe(binary, args) {
+  try {
+    const res = child_process.spawnSync(binary, args, {
+      encoding: 'utf8',
+      timeout: 3000,
+      windowsHide: true,
+    });
+    if (res.error) { return false; }
+    const out = (res.stdout || '') + (res.stderr || '');
+    // Most players print a version banner; as long as the binary resolved and
+    // produced output, count it as available. Exit code varies (mplayer -v can
+    // return non-zero because it expects a file argument).
+    return out.length > 0;
+  } catch (_e) {
+    return false;
+  }
+}
+
+/**
+ * Returns the subset of PLAYERS that are actually installed, in priority order.
+ */
+export function detectAvailablePlayers() {
+  const found = [];
+  for (const p of PLAYERS) {
+    if (probe(p.binary, p.probeArgs)) { found.push(p.name); }
+  }
+  return found;
+}
+
+// ── Active adapter state ───────────────────────────────────────────────────
+
+let activeAdapter = null;
+let activePlayerName = null;
+
+export function getActivePlayerName() { return activePlayerName; }
+export function getActiveAdapter() { return activeAdapter; }
+export function isCliActive() { return activeAdapter !== null; }
+
+/**
+ * Detect + start the first available CLI player. Returns the player name if
+ * started, or null if none could be started.
+ */
+export async function bootCliPlayer() {
+  if (activeAdapter) { return activePlayerName; }
+
+  for (const p of PLAYERS) {
+    if (!probe(p.binary, p.probeArgs)) { continue; }
+    const adapter = new p.AdapterClass(p.binary);
+    try {
+      await adapter.start();
+      activeAdapter = adapter;
+      activePlayerName = p.name;
+      winston.info(`[cli-audio] started ${p.label} as fallback audio player`);
+      return p.name;
+    } catch (err) {
+      winston.warn(`[cli-audio] ${p.label} detected but failed to start: ${err.message}`);
+      try { await adapter.stop(); } catch (_) { /* ignore */ }
+    }
+  }
+  return null;
+}
+
+export async function killCliPlayer() {
+  if (!activeAdapter) { return; }
+  try { await activeAdapter.stop(); } catch (_) { /* ignore */ }
+  activeAdapter = null;
+  activePlayerName = null;
+}
+
+/**
+ * Drop-in counterpart to server-playback.js's proxyToRust. Takes the same
+ * method/rustPath/body triple and returns `{ status, data }`.
+ */
+export function proxyToCli(method, rustPath, body) {
+  if (!activeAdapter) {
+    return Promise.reject(new Error('CLI audio player is not running'));
+  }
+  return activeAdapter.handleRequest(method, rustPath, body);
+}

--- a/src/api/cli-audio/mpd.js
+++ b/src/api/cli-audio/mpd.js
@@ -1,0 +1,229 @@
+/**
+ * MpdAdapter — controls an already-running MPD daemon over its text protocol.
+ *
+ * Unlike the other adapters we don't spawn a process: MPD is a long-running
+ * daemon users configure themselves (music_directory, audio output, etc.).
+ * We just connect to it, verify the welcome banner, and forward commands.
+ *
+ * Connection target is read from MSTREAM_MPD_HOST, with two supported forms:
+ *   - "host:port"      — TCP (default: 127.0.0.1:6600)
+ *   - "/path/to/sock"  — Unix socket (common on Debian/Ubuntu)
+ *
+ * MPD 0.22+ restricts `file://` URIs to local (Unix-socket) connections for
+ * security, so the Unix socket path is strongly preferred when the server
+ * runs on the same host as MPD.
+ *
+ * Wire format (text, line-based):
+ *   Request:  "<command> [<args>]\n"
+ *   Response: key/value lines terminated by "OK\n" (success) or
+ *             "ACK [<err>@<line>] {<cmd>} <msg>\n" (failure).
+ */
+
+import net from 'net';
+import winston from 'winston';
+import { BaseCliAdapter } from './base.js';
+
+export const MPD_DEFAULT_HOST = '127.0.0.1';
+export const MPD_DEFAULT_PORT = 6600;
+
+/**
+ * Parse either "host:port" or "/absolute/socket/path". Absolute-path form
+ * (starts with `/` on Unix) routes via a Unix socket; everything else is
+ * treated as TCP.
+ */
+export function parseMpdHost(value) {
+  const raw = (value || '').trim();
+  if (!raw) { return { kind: 'tcp', host: MPD_DEFAULT_HOST, port: MPD_DEFAULT_PORT }; }
+  if (raw.startsWith('/')) { return { kind: 'unix', path: raw }; }
+  const m = raw.match(/^([^:]+)(?::(\d+))?$/);
+  if (!m) { return { kind: 'tcp', host: MPD_DEFAULT_HOST, port: MPD_DEFAULT_PORT }; }
+  return { kind: 'tcp', host: m[1], port: m[2] ? Number(m[2]) : MPD_DEFAULT_PORT };
+}
+
+function connectOpts(target) {
+  return target.kind === 'unix' ? { path: target.path } : { host: target.host, port: target.port };
+}
+
+/**
+ * Opens a short-lived connection and checks for MPD's "OK MPD <ver>" banner.
+ * Used both by the registry's detection probe and by the adapter's own health
+ * check. Resolves true/false, never rejects.
+ */
+export function probeMpd({ target, timeoutMs = 1000 } = {}) {
+  const t = target || parseMpdHost(process.env.MSTREAM_MPD_HOST || '');
+  return new Promise((resolve) => {
+    let done = false;
+    let sock;
+    const finish = (ok) => {
+      if (done) { return; }
+      done = true;
+      try { sock && sock.destroy(); } catch (_) { /* ignore */ }
+      resolve(ok);
+    };
+    try { sock = net.connect(connectOpts(t)); }
+    catch (_e) { return finish(false); }
+    sock.setTimeout(timeoutMs);
+    sock.once('data', (chunk) => finish(/^OK MPD /.test(chunk.toString())));
+    sock.once('error', () => finish(false));
+    sock.once('timeout', () => finish(false));
+  });
+}
+
+export class MpdAdapter extends BaseCliAdapter {
+  constructor(hostArg) {
+    super('mpd');
+    const envHost = process.env.MSTREAM_MPD_HOST;
+    this.target = parseMpdHost(hostArg || envHost || '');
+    this._sock = null;
+    this._buf = '';
+    this._queue = []; // { resolve, reject, lines: [] }
+    this._active = null;
+  }
+
+  async start() {
+    await this._connect();
+    // Reset any prior session state so our queue mirror agrees with the daemon.
+    try { await this._send('clear'); } catch (_) { /* ignore */ }
+    try { await this._send('consume 0'); } catch (_) { /* ignore */ }
+    try { await this._send('single 0'); } catch (_) { /* ignore */ }
+    try { await this._send('repeat 0'); } catch (_) { /* ignore */ }
+  }
+
+  async stop() {
+    if (this._sock) { try { this._sock.destroy(); } catch (_) { /* ignore */ } this._sock = null; }
+    // Fail any in-flight commands
+    if (this._active) { this._active.reject(new Error('mpd closed')); this._active = null; }
+    for (const p of this._queue) { p.reject(new Error('mpd closed')); }
+    this._queue = [];
+  }
+
+  _describeTarget() {
+    return this.target.kind === 'unix' ? this.target.path : `${this.target.host}:${this.target.port}`;
+  }
+
+  _connect() {
+    return new Promise((resolve, reject) => {
+      const sock = net.connect(connectOpts(this.target));
+      let greeted = false;
+      sock.setTimeout(3000);
+      sock.on('data', (chunk) => {
+        if (!greeted) {
+          // First packet is MPD's "OK MPD <version>\n" banner
+          const text = chunk.toString();
+          const idx = text.indexOf('\n');
+          const banner = idx >= 0 ? text.slice(0, idx) : text;
+          if (!/^OK MPD /.test(banner)) {
+            sock.destroy();
+            return reject(new Error(`Unexpected MPD banner: ${banner}`));
+          }
+          greeted = true;
+          sock.setTimeout(0);
+          this._sock = sock;
+          this._sock.on('data', (c) => this._onData(c));
+          this._sock.on('close', () => {
+            if (this._sock === sock) { this._sock = null; }
+            if (this._active) { this._active.reject(new Error('mpd closed')); this._active = null; }
+          });
+          this._sock.on('error', () => {});
+          winston.info(`[cli-audio:mpd] connected to ${this._describeTarget()}`);
+          // Feed any buffered bytes after the banner into the parser
+          const rest = idx >= 0 ? text.slice(idx + 1) : '';
+          if (rest) { this._onData(Buffer.from(rest)); }
+          return resolve();
+        }
+      });
+      sock.once('error', (e) => reject(e));
+      sock.once('timeout', () => { sock.destroy(); reject(new Error('mpd connect timeout')); });
+    });
+  }
+
+  _onData(chunk) {
+    this._buf += chunk.toString();
+    while (true) {
+      const nl = this._buf.indexOf('\n');
+      if (nl < 0) { break; }
+      const line = this._buf.slice(0, nl);
+      this._buf = this._buf.slice(nl + 1);
+      if (!this._active) { continue; }
+      if (/^OK\b/.test(line)) {
+        const out = this._active; this._active = null;
+        out.resolve(out.lines);
+        this._drain();
+      } else if (/^ACK /.test(line)) {
+        const out = this._active; this._active = null;
+        out.reject(new Error(line));
+        this._drain();
+      } else {
+        this._active.lines.push(line);
+      }
+    }
+  }
+
+  _drain() {
+    if (this._active || this._queue.length === 0 || !this._sock || this._sock.destroyed) { return; }
+    this._active = this._queue.shift();
+    try {
+      this._sock.write(this._active.cmd + '\n');
+    } catch (e) {
+      const a = this._active; this._active = null;
+      a.reject(e);
+      this._drain();
+    }
+  }
+
+  _send(cmd) {
+    return new Promise((resolve, reject) => {
+      if (!this._sock || this._sock.destroyed) { return reject(new Error('mpd not connected')); }
+      this._queue.push({ cmd, lines: [], resolve, reject });
+      this._drain();
+    });
+  }
+
+  _escape(s) {
+    return '"' + String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+  }
+
+  _toUri(absPath) {
+    // MPD accepts file:// URIs for absolute paths (0.19+).
+    const p = absPath.replace(/\\/g, '/');
+    if (p.startsWith('/')) { return 'file://' + p; }
+    return 'file:///' + p;
+  }
+
+  _parseKV(lines) {
+    const out = {};
+    for (const line of lines) {
+      const idx = line.indexOf(':');
+      if (idx > 0) { out[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim(); }
+    }
+    return out;
+  }
+
+  async _loadFile(absPath) {
+    await this._send('clear');
+    await this._send(`add ${this._escape(this._toUri(absPath))}`);
+    await this._send('play 0');
+  }
+
+  async _pause() { await this._send('pause 1'); }
+  async _resume() { await this._send('pause 0'); }
+  async _stop() { await this._send('stop'); }
+  async _seek(seconds) { await this._send(`seekcur ${Math.max(0, Math.floor(seconds))}`); }
+  async _setVolume(vol01) { await this._send(`setvol ${Math.round(Math.max(0, Math.min(1, vol01)) * 100)}`); }
+
+  async _getPosition() {
+    try {
+      const kv = this._parseKV(await this._send('status'));
+      const t = kv.elapsed || (kv.time ? kv.time.split(':')[0] : '0');
+      return Number(t) || 0;
+    } catch (_e) { return 0; }
+  }
+
+  async _getDuration() {
+    try {
+      const kv = this._parseKV(await this._send('status'));
+      const d = kv.duration || (kv.time ? kv.time.split(':')[1] : '0');
+      return Number(d) || 0;
+    } catch (_e) { return 0; }
+  }
+}

--- a/src/api/cli-audio/mplayer.js
+++ b/src/api/cli-audio/mplayer.js
@@ -1,0 +1,108 @@
+/**
+ * MplayerAdapter — controls mplayer via its `-slave` mode over stdin/stdout.
+ *
+ * MPlayer reads text commands from stdin and emits answers on stdout in the
+ * form "ANS_<name>=<value>". We keep a rolling buffer of answers so position
+ * and length reads can pull the most recent value without needing per-command
+ * correlation (there's no request-id mechanism).
+ */
+
+import child_process from 'child_process';
+import winston from 'winston';
+import { BaseCliAdapter } from './base.js';
+
+export class MplayerAdapter extends BaseCliAdapter {
+  constructor(binary = 'mplayer') {
+    super('mplayer');
+    this.binary = binary;
+    this._proc = null;
+    this._stdoutBuf = '';
+    this._answers = new Map();
+  }
+
+  async start() {
+    this._proc = child_process.spawn(this.binary, [
+      '-slave',
+      '-quiet',
+      '-idle',
+      '-really-quiet',
+      '-msglevel', 'all=0:global=4',
+      '-nolirc',
+    ], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    this._proc.on('error', (err) => {
+      winston.error(`[cli-audio:mplayer] process error: ${err.message}`);
+      this._proc = null;
+    });
+
+    this._proc.on('exit', (code) => {
+      winston.info(`[cli-audio:mplayer] exited (code ${code})`);
+      this._proc = null;
+    });
+
+    this._proc.stdout.on('data', (chunk) => this._onStdout(chunk));
+    this._proc.stderr.on('data', () => {});
+
+    await new Promise((r) => setTimeout(r, 300));
+    winston.info('[cli-audio:mplayer] started');
+  }
+
+  async stop() {
+    if (this._proc) {
+      try { this._proc.stdin.write('quit\n'); } catch (_) { /* ignore */ }
+      try { this._proc.kill('SIGTERM'); } catch (_) { /* ignore */ }
+      this._proc = null;
+    }
+  }
+
+  _onStdout(chunk) {
+    this._stdoutBuf += chunk.toString();
+    const lines = this._stdoutBuf.split('\n');
+    this._stdoutBuf = lines.pop();
+    for (const line of lines) {
+      const t = line.trim();
+      const m = t.match(/^ANS_([A-Za-z0-9_]+)=(.*)$/);
+      if (m) { this._answers.set(m[1], m[2]); }
+      if (/EOF code:/.test(t) || /GLOBAL: EOF/.test(t)) {
+        this._onTrackEnded().catch(() => {});
+      }
+    }
+  }
+
+  _send(cmd) {
+    if (!this._proc || !this._proc.stdin.writable) {
+      throw new Error('mplayer not running');
+    }
+    this._proc.stdin.write(cmd + '\n');
+  }
+
+  _wait(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+  async _ask(property, readKey, timeoutMs = 400) {
+    this._answers.delete(readKey);
+    this._send(`pausing_keep_force get_property ${property}`);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (this._answers.has(readKey)) {
+        const v = this._answers.get(readKey);
+        return Number(v);
+      }
+      await this._wait(40);
+    }
+    return 0;
+  }
+
+  async _loadFile(absPath) {
+    const quoted = absPath.replace(/"/g, '\\"');
+    this._send(`loadfile "${quoted}" 0`);
+  }
+
+  async _pause() { this._send('pause'); }
+  async _resume() { this._send('pause'); }
+  async _stop() { this._send('stop'); }
+  async _seek(seconds) { this._send(`seek ${Math.floor(seconds)} 2`); }
+  async _setVolume(vol01) { this._send(`volume ${Math.round(vol01 * 100)} 1`); }
+
+  _getPosition() { return this._ask('time_pos', 'time_pos'); }
+  _getDuration() { return this._ask('length', 'length'); }
+}

--- a/src/api/cli-audio/mpv.js
+++ b/src/api/cli-audio/mpv.js
@@ -1,0 +1,176 @@
+/**
+ * MpvAdapter — controls mpv via its JSON IPC socket.
+ *
+ * Launches mpv in idle mode with --input-ipc-server pointed at a Unix socket
+ * (or named pipe on Windows). Commands are sent as one JSON object per line;
+ * responses echo the originating request_id. Queue is managed in Node.js
+ * (BaseCliAdapter) but we use mpv's native `loadfile` / `playlist-clear` to
+ * pipe files into the player.
+ */
+
+import net from 'net';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import child_process from 'child_process';
+import winston from 'winston';
+import { BaseCliAdapter } from './base.js';
+
+function socketPath() {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\mpv-mstream-${process.pid}`;
+  }
+  return path.join(os.tmpdir(), `mpv-mstream-${process.pid}.sock`);
+}
+
+export class MpvAdapter extends BaseCliAdapter {
+  constructor(binary = 'mpv') {
+    super('mpv');
+    this.binary = binary;
+    this._sockPath = socketPath();
+    this._proc = null;
+    this._sock = null;
+    this._buf = '';
+    this._reqId = 1;
+    this._pending = new Map();
+    this._connectRetries = 0;
+  }
+
+  async start() {
+    if (process.platform !== 'win32') {
+      try { fs.unlinkSync(this._sockPath); } catch (_) { /* no stale socket */ }
+    }
+
+    this._proc = child_process.spawn(this.binary, [
+      '--idle=yes',
+      '--no-video',
+      '--no-terminal',
+      '--really-quiet',
+      '--gapless-audio=yes',
+      `--input-ipc-server=${this._sockPath}`,
+    ], { stdio: 'ignore', detached: false });
+
+    this._proc.on('error', (err) => {
+      winston.error(`[cli-audio:mpv] process error: ${err.message}`);
+      this._proc = null;
+    });
+
+    this._proc.on('exit', (code) => {
+      winston.info(`[cli-audio:mpv] exited (code ${code})`);
+      this._proc = null;
+      if (this._sock) { try { this._sock.destroy(); } catch (_) { /* already closed */ } this._sock = null; }
+      for (const [id, p] of this._pending) {
+        clearTimeout(p.timer);
+        p.reject(new Error('mpv exited'));
+        this._pending.delete(id);
+      }
+    });
+
+    this._connectRetries = 0;
+    await this._waitForIpc();
+  }
+
+  async stop() {
+    if (this._sock) { try { this._sock.destroy(); } catch (_) { /* closed */ } this._sock = null; }
+    if (this._proc) { try { this._proc.kill('SIGTERM'); } catch (_) { /* dead */ } this._proc = null; }
+  }
+
+  _waitForIpc() {
+    return new Promise((resolve, reject) => {
+      const tryConnect = () => {
+        if (!this._proc) { return reject(new Error('mpv process not running')); }
+        const sock = net.connect(this._sockPath);
+        sock.once('connect', () => {
+          this._sock = sock;
+          this._buf = '';
+          sock.on('data', (chunk) => this._onSockData(chunk));
+          sock.on('close', () => {
+            if (this._sock === sock) { this._sock = null; }
+          });
+          sock.on('error', () => {});
+          winston.info('[cli-audio:mpv] IPC connected');
+          resolve();
+        });
+        sock.once('error', () => {
+          sock.destroy();
+          if (this._connectRetries >= 12) {
+            return reject(new Error('mpv IPC socket did not appear'));
+          }
+          this._connectRetries += 1;
+          setTimeout(tryConnect, 250);
+        });
+      };
+      setTimeout(tryConnect, 400);
+    });
+  }
+
+  _onSockData(chunk) {
+    this._buf += chunk.toString();
+    const lines = this._buf.split('\n');
+    this._buf = lines.pop();
+    for (const line of lines) {
+      const t = line.trim();
+      if (!t) { continue; }
+      try { this._onMessage(JSON.parse(t)); } catch (_) { /* bad JSON */ }
+    }
+  }
+
+  _onMessage(msg) {
+    if (msg.request_id !== undefined) {
+      const p = this._pending.get(msg.request_id);
+      if (!p) { return; }
+      this._pending.delete(msg.request_id);
+      clearTimeout(p.timer);
+      if (msg.error === 'success') {
+        p.resolve(msg.data !== undefined ? msg.data : null);
+      } else {
+        p.reject(new Error(msg.error || 'mpv error'));
+      }
+      return;
+    }
+    if (msg.event === 'end-file' && msg.reason === 'eof') {
+      this._onTrackEnded().catch(() => {});
+    }
+  }
+
+  _command(args, timeoutMs = 4000) {
+    return new Promise((resolve, reject) => {
+      if (!this._sock || this._sock.destroyed) {
+        return reject(new Error('mpv IPC not connected'));
+      }
+      const id = this._reqId++;
+      const timer = setTimeout(() => {
+        this._pending.delete(id);
+        reject(new Error('mpv IPC timeout'));
+      }, timeoutMs);
+      this._pending.set(id, { resolve, reject, timer });
+      try {
+        this._sock.write(JSON.stringify({ command: args, request_id: id }) + '\n');
+      } catch (e) {
+        this._pending.delete(id);
+        clearTimeout(timer);
+        reject(e);
+      }
+    });
+  }
+
+  async _loadFile(absPath) {
+    await this._command(['loadfile', absPath, 'replace']);
+  }
+
+  async _pause() { await this._command(['set_property', 'pause', true]); }
+  async _resume() { await this._command(['set_property', 'pause', false]); }
+  async _stop() { await this._command(['stop']); }
+  async _seek(seconds) { await this._command(['seek', seconds, 'absolute']); }
+  async _setVolume(vol01) { await this._command(['set_property', 'volume', vol01 * 100]); }
+
+  async _getPosition() {
+    try { return await this._command(['get_property', 'time-pos']); }
+    catch (_e) { return 0; }
+  }
+
+  async _getDuration() {
+    try { return await this._command(['get_property', 'duration']); }
+    catch (_e) { return 0; }
+  }
+}

--- a/src/api/cli-audio/vlc.js
+++ b/src/api/cli-audio/vlc.js
@@ -1,0 +1,139 @@
+/**
+ * VlcAdapter — controls VLC via its rc (remote-control) text interface.
+ *
+ * Launches `vlc --intf rc --rc-host 127.0.0.1:PORT` on a random free port and
+ * sends single-line text commands over TCP. VLC replies with multi-line ASCII;
+ * we consume output line-by-line but don't pair requests to responses (the rc
+ * interface doesn't tag replies), so read-back commands parse the latest line
+ * matching a known prefix.
+ */
+
+import net from 'net';
+import child_process from 'child_process';
+import winston from 'winston';
+import { BaseCliAdapter } from './base.js';
+
+function pickPort() {
+  return 24000 + Math.floor(Math.random() * 1000);
+}
+
+export class VlcAdapter extends BaseCliAdapter {
+  constructor(binary = 'vlc') {
+    super('vlc');
+    this.binary = binary;
+    this._port = pickPort();
+    this._proc = null;
+    this._sock = null;
+    this._buf = '';
+    this._lastLines = [];
+  }
+
+  async start() {
+    this._proc = child_process.spawn(this.binary, [
+      '--intf', 'rc',
+      '--rc-host', `127.0.0.1:${this._port}`,
+      '--no-video',
+      '--quiet',
+      '--no-random',
+      '--play-and-stop',
+    ], { stdio: 'ignore', detached: false });
+
+    this._proc.on('error', (err) => {
+      winston.error(`[cli-audio:vlc] process error: ${err.message}`);
+      this._proc = null;
+    });
+
+    this._proc.on('exit', (code) => {
+      winston.info(`[cli-audio:vlc] exited (code ${code})`);
+      this._proc = null;
+      if (this._sock) { try { this._sock.destroy(); } catch (_) { /* closed */ } this._sock = null; }
+    });
+
+    await this._waitForSocket();
+  }
+
+  async stop() {
+    if (this._sock) { try { this._sock.destroy(); } catch (_) { /* closed */ } this._sock = null; }
+    if (this._proc) { try { this._proc.kill('SIGTERM'); } catch (_) { /* dead */ } this._proc = null; }
+  }
+
+  _waitForSocket() {
+    return new Promise((resolve, reject) => {
+      let attempts = 0;
+      const tryConnect = () => {
+        if (!this._proc) { return reject(new Error('vlc not running')); }
+        const s = net.connect(this._port, '127.0.0.1');
+        s.once('connect', () => {
+          this._sock = s;
+          this._buf = '';
+          s.on('data', (chunk) => this._onData(chunk));
+          s.on('close', () => { if (this._sock === s) { this._sock = null; } });
+          s.on('error', () => {});
+          winston.info(`[cli-audio:vlc] rc connected on port ${this._port}`);
+          resolve();
+        });
+        s.once('error', () => {
+          s.destroy();
+          attempts += 1;
+          if (attempts > 20) { return reject(new Error('vlc rc port did not open')); }
+          setTimeout(tryConnect, 250);
+        });
+      };
+      setTimeout(tryConnect, 500);
+    });
+  }
+
+  _onData(chunk) {
+    this._buf += chunk.toString();
+    const lines = this._buf.split('\n');
+    this._buf = lines.pop();
+    for (const line of lines) {
+      const t = line.replace(/\r$/, '').trim();
+      if (t) { this._lastLines.push(t); }
+    }
+    if (this._lastLines.length > 40) {
+      this._lastLines = this._lastLines.slice(-40);
+    }
+  }
+
+  _send(cmd) {
+    return new Promise((resolve, reject) => {
+      if (!this._sock || this._sock.destroyed) { return reject(new Error('vlc rc not connected')); }
+      try {
+        this._sock.write(cmd + '\n');
+        resolve();
+      } catch (e) { reject(e); }
+    });
+  }
+
+  _wait(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+  async _readNumeric(cmd) {
+    this._lastLines = [];
+    await this._send(cmd);
+    await this._wait(120);
+    for (let i = this._lastLines.length - 1; i >= 0; i--) {
+      const m = this._lastLines[i].match(/-?\d+(\.\d+)?/);
+      if (m) { return Number(m[0]); }
+    }
+    return 0;
+  }
+
+  async _loadFile(absPath) {
+    await this._send('clear');
+    await this._send(`add ${absPath}`);
+    this.duration = await this._readNumeric('get_length');
+  }
+
+  async _pause() { await this._send('pause'); }
+  async _resume() { await this._send('play'); }
+  async _stop() { await this._send('stop'); }
+  async _seek(seconds) { await this._send(`seek ${Math.floor(seconds)}`); }
+  async _setVolume(vol01) { await this._send(`volume ${Math.round(vol01 * 320)}`); }
+
+  _getPosition() { return this._readNumeric('get_time'); }
+  async _getDuration() {
+    const d = await this._readNumeric('get_length');
+    return d || this.duration;
+  }
+}

--- a/src/api/server-playback.js
+++ b/src/api/server-playback.js
@@ -23,13 +23,17 @@ killQueue.addToKillQueue(() => {
   cliAudio.killCliPlayer().catch(() => {});
 });
 
-// Snapshot of CLI detection (populated on first bootRustPlayer call) so the
+// Snapshot of CLI detection (refreshed on each boot-server-audio call) so the
 // admin endpoint can report what's installed without re-probing on every hit.
-let _detectedCliPlayers = null;
+// Detection is now async (MPD requires a TCP probe), so callers that want a
+// fresh value should await refreshDetectedCliPlayers(); the admin route uses
+// the cached value.
+let _detectedCliPlayers = [];
+async function refreshDetectedCliPlayers() {
+  _detectedCliPlayers = await cliAudio.detectAvailablePlayers();
+  return _detectedCliPlayers;
+}
 export function getDetectedCliPlayers() {
-  if (_detectedCliPlayers === null) {
-    _detectedCliPlayers = cliAudio.detectAvailablePlayers();
-  }
   return _detectedCliPlayers;
 }
 
@@ -58,36 +62,68 @@ function findRustBinary() {
   return null;
 }
 
+// Has the currently-spawned rust process stayed up long enough that we
+// consider startup successful? Used by the rust-fallback path: if rust dies
+// before this goes true, we treat the spawn as failed and roll over to CLI.
+let _rustStartupSettled = false;
+const RUST_SETTLE_MS = 2000;
+
+async function bootCliFallback(reason) {
+  if (cliAudio.isCliActive()) { return; }
+  await refreshDetectedCliPlayers();
+  if (_detectedCliPlayers.length === 0) {
+    winston.warn(`[server-audio] ${reason}; no CLI audio players detected — server audio unavailable`);
+    return;
+  }
+  try {
+    const name = await cliAudio.bootCliPlayer();
+    if (name) {
+      winston.info(`[server-audio] ${reason}; using CLI fallback: ${name}`);
+    } else {
+      winston.warn(`[server-audio] ${reason}; CLI players detected but none would start`);
+    }
+  } catch (err) {
+    winston.error(`[server-audio] CLI fallback failed: ${err.message}`);
+  }
+}
+
+/**
+ * Boot whichever server-audio backend is appropriate.
+ *
+ *   autoBootServerAudio: true  → prefer the Rust binary; fall back to a CLI
+ *                                player if the binary is missing or the spawn
+ *                                dies during startup.
+ *   autoBootServerAudio: false → skip Rust entirely and use the first
+ *                                available CLI player.
+ *
+ * Name is kept for backwards-compatibility with existing callers in
+ * src/server.js and src/api/admin.js.
+ */
 export function bootRustPlayer() {
-  if (!config.program.autoBootServerAudio) { return; }
   if (rustPlayerProcess) { return; }
+
+  if (!config.program.autoBootServerAudio) {
+    bootCliFallback('autoBootServerAudio=false').catch(() => {});
+    return;
+  }
 
   const bin = findRustBinary();
   if (!bin) {
-    winston.warn('autoBootServerAudio is enabled but rust-server-audio binary not found; probing for CLI fallback');
-    _detectedCliPlayers = cliAudio.detectAvailablePlayers();
-    if (_detectedCliPlayers.length === 0) {
-      winston.warn('No CLI audio players detected — server audio will be unavailable');
-      return;
-    }
-    cliAudio.bootCliPlayer().then((name) => {
-      if (name) {
-        winston.info(`Server audio fallback active: ${name}`);
-      } else {
-        winston.warn('Detected CLI players failed to start — server audio will be unavailable');
-      }
-    }).catch((err) => {
-      winston.error(`Failed to boot CLI audio player: ${err.message}`);
-    });
+    bootCliFallback('rust-server-audio binary not found').catch(() => {});
     return;
   }
 
   const port = getRustPort();
   winston.info(`Starting rust-server-audio on port ${port}`);
 
+  _rustStartupSettled = false;
   rustPlayerProcess = child_process.spawn(bin, ['--port', String(port)], {
     stdio: ['ignore', 'pipe', 'pipe']
   });
+
+  const settleTimer = setTimeout(() => {
+    _rustStartupSettled = true;
+  }, RUST_SETTLE_MS);
 
   rustPlayerProcess.stdout.on('data', (data) => {
     winston.info(`[rust-audio] ${data.toString().trim()}`);
@@ -98,13 +134,24 @@ export function bootRustPlayer() {
   });
 
   rustPlayerProcess.on('close', (code) => {
+    clearTimeout(settleTimer);
     winston.info(`rust-server-audio exited with code ${code}`);
+    const settled = _rustStartupSettled;
     rustPlayerProcess = null;
+    if (!settled) {
+      // Died during startup → roll over to CLI.
+      bootCliFallback(`rust-server-audio exited early (code ${code})`).catch(() => {});
+    }
   });
 
   rustPlayerProcess.on('error', (err) => {
+    clearTimeout(settleTimer);
     winston.error(`Failed to start rust-server-audio: ${err.message}`);
+    const settled = _rustStartupSettled;
     rustPlayerProcess = null;
+    if (!settled) {
+      bootCliFallback(`rust-server-audio spawn failed: ${err.message}`).catch(() => {});
+    }
   });
 }
 
@@ -191,6 +238,15 @@ export function absoluteToVpath(absolutePath) {
 }
 
 export function setup(mstream) {
+
+  // ── Per-user permission gate ────────────────────────────────────────────
+  // Any route under /api/v1/server-playback requires allow_server_audio.
+  // Admins always pass; everyone else must have the flag set.
+  mstream.all('/api/v1/server-playback/{*path}', (req, res, next) => {
+    if (req.user && req.user.admin === true) { return next(); }
+    if (req.user && (req.user.allow_server_audio === 1 || req.user.allow_server_audio === true)) { return next(); }
+    return res.status(403).json({ error: 'Server audio access disabled for this user' });
+  });
 
   // ── Simple proxy routes (no path translation needed) ────────────────────
 

--- a/src/api/server-playback.js
+++ b/src/api/server-playback.js
@@ -23,13 +23,11 @@ killQueue.addToKillQueue(() => {
   cliAudio.killCliPlayer().catch(() => {});
 });
 
-// Snapshot of CLI detection (refreshed on each boot-server-audio call) so the
-// admin endpoint can report what's installed without re-probing on every hit.
-// Detection is now async (MPD requires a TCP probe), so callers that want a
-// fresh value should await refreshDetectedCliPlayers(); the admin route uses
-// the cached value.
+// Snapshot of CLI detection. Refreshed eagerly at boot, on autoBoot toggle,
+// and whenever an admin hits /api/v1/admin/server-audio/detect. Exported so
+// the admin info endpoint can read it without re-probing on every hit.
 let _detectedCliPlayers = [];
-async function refreshDetectedCliPlayers() {
+export async function refreshDetectedCliPlayers() {
   _detectedCliPlayers = await cliAudio.detectAvailablePlayers();
   return _detectedCliPlayers;
 }
@@ -68,15 +66,14 @@ function findRustBinary() {
 let _rustStartupSettled = false;
 const RUST_SETTLE_MS = 2000;
 
-async function bootCliFallback(reason) {
+async function bootCliFallback(reason, preferredPlayer = null) {
   if (cliAudio.isCliActive()) { return; }
-  await refreshDetectedCliPlayers();
   if (_detectedCliPlayers.length === 0) {
     winston.warn(`[server-audio] ${reason}; no CLI audio players detected — server audio unavailable`);
     return;
   }
   try {
-    const name = await cliAudio.bootCliPlayer();
+    const name = await cliAudio.bootCliPlayer(preferredPlayer);
     if (name) {
       winston.info(`[server-audio] ${reason}; using CLI fallback: ${name}`);
     } else {
@@ -91,25 +88,35 @@ async function bootCliFallback(reason) {
  * Boot whichever server-audio backend is appropriate.
  *
  *   autoBootServerAudio: true  → prefer the Rust binary; fall back to a CLI
- *                                player if the binary is missing or the spawn
- *                                dies during startup.
- *   autoBootServerAudio: false → skip Rust entirely and use the first
- *                                available CLI player.
+ *                                player if the binary is missing, the spawn
+ *                                fails (permission denied, etc.), or the
+ *                                process exits during startup.
+ *   autoBootServerAudio: false → skip Rust entirely and prefer MPD, since
+ *                                that's the CLI option most often used on
+ *                                self-hosted / NAS setups where a dedicated
+ *                                audio daemon is already running. Falls back
+ *                                to other installed CLI players if MPD isn't
+ *                                available.
  *
  * Name is kept for backwards-compatibility with existing callers in
- * src/server.js and src/api/admin.js.
+ * src/server.js and src/api/admin.js. Returns a Promise; callers that don't
+ * need to await may fire-and-forget.
  */
-export function bootRustPlayer() {
+export async function bootRustPlayer() {
   if (rustPlayerProcess) { return; }
 
+  // Refresh the CLI detection snapshot so the fallback decision (and the
+  // admin /info endpoint) have current data.
+  await refreshDetectedCliPlayers();
+
   if (!config.program.autoBootServerAudio) {
-    bootCliFallback('autoBootServerAudio=false').catch(() => {});
+    await bootCliFallback('autoBootServerAudio=false', 'mpd');
     return;
   }
 
   const bin = findRustBinary();
   if (!bin) {
-    bootCliFallback('rust-server-audio binary not found').catch(() => {});
+    await bootCliFallback('rust-server-audio binary not found');
     return;
   }
 

--- a/src/api/server-playback.js
+++ b/src/api/server-playback.js
@@ -9,6 +9,7 @@ import * as vpath from '../util/vpath.js';
 import * as db from '../db/manager.js';
 import { getDirname } from '../util/esm-helpers.js';
 import * as killQueue from '../state/kill-list.js';
+import * as cliAudio from './cli-audio/index.js';
 
 const __dirname = getDirname(import.meta.url);
 
@@ -19,7 +20,24 @@ killQueue.addToKillQueue(() => {
     rustPlayerProcess.kill();
     rustPlayerProcess = null;
   }
+  cliAudio.killCliPlayer().catch(() => {});
 });
+
+// Snapshot of CLI detection (populated on first bootRustPlayer call) so the
+// admin endpoint can report what's installed without re-probing on every hit.
+let _detectedCliPlayers = null;
+export function getDetectedCliPlayers() {
+  if (_detectedCliPlayers === null) {
+    _detectedCliPlayers = cliAudio.detectAvailablePlayers();
+  }
+  return _detectedCliPlayers;
+}
+
+export function getActiveBackend() {
+  if (rustPlayerProcess) { return { backend: 'rust', player: 'rust-server-audio' }; }
+  if (cliAudio.isCliActive()) { return { backend: 'cli', player: cliAudio.getActivePlayerName() }; }
+  return { backend: null, player: null };
+}
 
 function getRustPort() {
   return config.program.rustPlayerPort || 3333;
@@ -46,7 +64,21 @@ export function bootRustPlayer() {
 
   const bin = findRustBinary();
   if (!bin) {
-    winston.warn('autoBootServerAudio is enabled but rust-server-audio binary not found');
+    winston.warn('autoBootServerAudio is enabled but rust-server-audio binary not found; probing for CLI fallback');
+    _detectedCliPlayers = cliAudio.detectAvailablePlayers();
+    if (_detectedCliPlayers.length === 0) {
+      winston.warn('No CLI audio players detected — server audio will be unavailable');
+      return;
+    }
+    cliAudio.bootCliPlayer().then((name) => {
+      if (name) {
+        winston.info(`Server audio fallback active: ${name}`);
+      } else {
+        winston.warn('Detected CLI players failed to start — server audio will be unavailable');
+      }
+    }).catch((err) => {
+      winston.error(`Failed to boot CLI audio player: ${err.message}`);
+    });
     return;
   }
 
@@ -81,6 +113,7 @@ export function killRustPlayer() {
     rustPlayerProcess.kill();
     rustPlayerProcess = null;
   }
+  cliAudio.killCliPlayer().catch(() => {});
 }
 
 // Proxy a request to the Rust binary and pipe the response back.
@@ -124,6 +157,18 @@ export function proxyToRust(method, rustPath, body) {
   });
 }
 
+// Dispatch to whichever backend is active. Rust is preferred; CLI is used
+// when the Rust binary is missing but a CLI fallback has been booted.
+function proxyPlayback(method, rustPath, body) {
+  if (rustPlayerProcess) {
+    return proxyToRust(method, rustPath, body);
+  }
+  if (cliAudio.isCliActive()) {
+    return cliAudio.proxyToCli(method, rustPath, body);
+  }
+  return Promise.reject(new Error('Server audio player is not running'));
+}
+
 // Resolve a virtual path (e.g. "55/song.mp3") to an absolute filesystem path
 export function resolveFilePath(filePath, user) {
   const info = vpath.getVPathInfo(filePath, user);
@@ -161,7 +206,7 @@ export function setup(mstream) {
   for (const [mstreamPath, rustPath] of Object.entries(simplePostRoutes)) {
     mstream.post(mstreamPath, async (req, res) => {
       try {
-        const result = await proxyToRust('POST', rustPath, req.body || {});
+        const result = await proxyPlayback('POST', rustPath, req.body || {});
         res.status(result.status).json(result.data);
       } catch (e) {
         res.status(503).json({ error: e.message });
@@ -173,7 +218,7 @@ export function setup(mstream) {
 
   mstream.post('/api/v1/server-playback/seek', async (req, res) => {
     try {
-      const result = await proxyToRust('POST', '/seek', req.body);
+      const result = await proxyPlayback('POST', '/seek', req.body);
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(503).json({ error: e.message });
@@ -182,7 +227,7 @@ export function setup(mstream) {
 
   mstream.post('/api/v1/server-playback/volume', async (req, res) => {
     try {
-      const result = await proxyToRust('POST', '/volume', req.body);
+      const result = await proxyPlayback('POST', '/volume', req.body);
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(503).json({ error: e.message });
@@ -191,7 +236,7 @@ export function setup(mstream) {
 
   mstream.post('/api/v1/server-playback/shuffle', async (req, res) => {
     try {
-      const result = await proxyToRust('POST', '/shuffle', req.body);
+      const result = await proxyPlayback('POST', '/shuffle', req.body);
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(503).json({ error: e.message });
@@ -202,7 +247,12 @@ export function setup(mstream) {
 
   mstream.get('/api/v1/server-playback/status', async (req, res) => {
     try {
-      const result = await proxyToRust('GET', '/status');
+      const result = await proxyPlayback('GET', '/status');
+      if (result.data && typeof result.data === 'object' && !Array.isArray(result.data)) {
+        const active = getActiveBackend();
+        result.data.backend = active.backend;
+        result.data.player = active.player;
+      }
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(503).json({ error: e.message });
@@ -211,7 +261,7 @@ export function setup(mstream) {
 
   mstream.get('/api/v1/server-playback/queue', async (req, res) => {
     try {
-      const result = await proxyToRust('GET', '/queue');
+      const result = await proxyPlayback('GET', '/queue');
       // Convert absolute paths back to virtual paths for the frontend
       if (result.data && result.data.queue) {
         result.data.queue = result.data.queue.map(absoluteToVpath);
@@ -228,7 +278,7 @@ export function setup(mstream) {
   mstream.post('/api/v1/server-playback/play', async (req, res) => {
     try {
       const absolutePath = resolveFilePath(req.body.file, req.user);
-      const result = await proxyToRust('POST', '/play', { file: absolutePath });
+      const result = await proxyPlayback('POST', '/play', { file: absolutePath });
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(e.message.includes('not running') ? 503 : 400).json({ error: e.message });
@@ -239,7 +289,7 @@ export function setup(mstream) {
   mstream.post('/api/v1/server-playback/queue/add', async (req, res) => {
     try {
       const absolutePath = resolveFilePath(req.body.file, req.user);
-      const result = await proxyToRust('POST', '/queue/add', { file: absolutePath });
+      const result = await proxyPlayback('POST', '/queue/add', { file: absolutePath });
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(e.message.includes('not running') ? 503 : 400).json({ error: e.message });
@@ -250,7 +300,7 @@ export function setup(mstream) {
   mstream.post('/api/v1/server-playback/queue/add-many', async (req, res) => {
     try {
       const files = req.body.files.map((f) => resolveFilePath(f, req.user));
-      const result = await proxyToRust('POST', '/queue/add-many', { files });
+      const result = await proxyPlayback('POST', '/queue/add-many', { files });
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(e.message.includes('not running') ? 503 : 400).json({ error: e.message });
@@ -260,7 +310,7 @@ export function setup(mstream) {
   // POST /queue/play-index — jump to index
   mstream.post('/api/v1/server-playback/queue/play-index', async (req, res) => {
     try {
-      const result = await proxyToRust('POST', '/queue/play-index', req.body);
+      const result = await proxyPlayback('POST', '/queue/play-index', req.body);
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(503).json({ error: e.message });
@@ -270,7 +320,7 @@ export function setup(mstream) {
   // POST /queue/remove — remove by index
   mstream.post('/api/v1/server-playback/queue/remove', async (req, res) => {
     try {
-      const result = await proxyToRust('POST', '/queue/remove', req.body);
+      const result = await proxyPlayback('POST', '/queue/remove', req.body);
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(503).json({ error: e.message });
@@ -280,7 +330,7 @@ export function setup(mstream) {
   // POST /queue/clear — stop and empty queue
   mstream.post('/api/v1/server-playback/queue/clear', async (req, res) => {
     try {
-      const result = await proxyToRust('POST', '/queue/clear', {});
+      const result = await proxyPlayback('POST', '/queue/clear', {});
       res.status(result.status).json(result.data);
     } catch (e) {
       res.status(503).json({ error: e.message });
@@ -292,9 +342,9 @@ export function setup(mstream) {
 
 export function setupBeforeAuth(mstream) {
   mstream.get('/server-remote', async (req, res) => {
-    // Check if the Rust audio service is reachable before serving the page
+    // Check if any audio backend (rust or CLI fallback) is reachable
     try {
-      await proxyToRust('GET', '/status');
+      await proxyPlayback('GET', '/status');
     } catch (_e) {
       res.status(503).send(
         '<!doctype html><html><head><meta charset="utf-8"><title>Server Audio Unavailable</title>' +
@@ -348,7 +398,7 @@ export function setupBeforeAuth(mstream) {
       );
 
       res.send(page);
-    } catch (e) {
+    } catch (_e) {
       res.status(500).json({ error: 'Failed to serve server-remote page' });
     }
   });

--- a/src/api/server-playback.js
+++ b/src/api/server-playback.js
@@ -244,15 +244,25 @@ export function absoluteToVpath(absolutePath) {
   return path.basename(absolutePath);
 }
 
+// Single source of truth for "may this user touch server audio?" — shared
+// between the /api/v1/server-playback/* middleware and the /server-remote
+// page handler so the two can't drift apart.
+function userCanUseServerAudio(user) {
+  if (!user) { return false; }
+  if (user.admin === true) { return true; }
+  return user.allow_server_audio === 1 || user.allow_server_audio === true;
+}
+
 export function setup(mstream) {
 
   // ── Per-user permission gate ────────────────────────────────────────────
   // Any route under /api/v1/server-playback requires allow_server_audio.
   // Admins always pass; everyone else must have the flag set.
   mstream.all('/api/v1/server-playback/{*path}', (req, res, next) => {
-    if (req.user && req.user.admin === true) { return next(); }
-    if (req.user && (req.user.allow_server_audio === 1 || req.user.allow_server_audio === true)) { return next(); }
-    return res.status(403).json({ error: 'Server audio access disabled for this user' });
+    if (!userCanUseServerAudio(req.user)) {
+      return res.status(403).json({ error: 'Server audio access disabled for this user' });
+    }
+    next();
   });
 
   // ── Simple proxy routes (no path translation needed) ────────────────────
@@ -399,12 +409,18 @@ export function setup(mstream) {
       res.status(503).json({ error: e.message });
     }
   });
-}
 
-// ── Server-Remote route (serves the webapp with serverAudioMode flag) ─────
-
-export function setupBeforeAuth(mstream) {
+  // ── /server-remote page (serves the webapp with serverAudioMode flag) ──
+  //
+  // Previously lived in setupBeforeAuth() so anyone could hit the page, but
+  // that let unauthenticated users probe whether server audio was running.
+  // The page only makes sense for users who can actually control playback,
+  // so it now sits behind the same auth + permission checks as the APIs.
   mstream.get('/server-remote', async (req, res) => {
+    if (!userCanUseServerAudio(req.user)) {
+      return res.status(403).json({ error: 'Server audio access disabled for this user' });
+    }
+
     // Check if any audio backend (rust or CLI fallback) is reachable
     try {
       await proxyPlayback('GET', '/status');
@@ -466,3 +482,7 @@ export function setupBeforeAuth(mstream) {
     }
   });
 }
+
+// Retained so existing call sites in src/server.js keep compiling — /server-
+// remote was moved into setup() so it sits behind auth now.
+export function setupBeforeAuth() {}

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -1,7 +1,7 @@
 // SQLite schema definitions and migration system for mStream.
 // Uses PRAGMA user_version for tracking which migrations have been applied.
 
-export const SCHEMA_VERSION = 16;
+export const SCHEMA_VERSION = 17;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -358,6 +358,13 @@ export const SCHEMA_V16 = `
   ALTER TABLE tracks ADD COLUMN bit_depth    INTEGER;
 `;
 
+export const SCHEMA_V17 = `
+  -- Per-user server-audio access flag. Gates /api/v1/server-playback/* and
+  -- the /server-remote page; admins always pass. Defaults to 1 so existing
+  -- users keep their access on upgrade.
+  ALTER TABLE users ADD COLUMN allow_server_audio INTEGER NOT NULL DEFAULT 1;
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -378,4 +385,5 @@ export const MIGRATIONS = [
   { version: 14, sql: SCHEMA_V14, rescanRequired: true },
   { version: 15, sql: SCHEMA_V15 },
   { version: 16, sql: SCHEMA_V16, rescanRequired: true },
+  { version: 17, sql: SCHEMA_V17 },
 ];

--- a/src/server.js
+++ b/src/server.js
@@ -292,8 +292,9 @@ export async function serveIt(configFile) {
       subsonicServer.start();
     }
 
-    // Auto-boot the Rust server audio player if configured
-    serverPlaybackApi.bootRustPlayer();
+    // Boot server audio (Rust preferred, CLI fallback) — runs CLI detection
+    // eagerly so the admin endpoint has fresh data by the time it's called.
+    serverPlaybackApi.bootRustPlayer().catch(() => {});
   });
 }
 

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -76,7 +76,7 @@ export async function removeDirectory(vpath) {
 
 // ── User management (now in SQLite) ─────────────────────────────────────────
 
-export async function addUser(username, password, admin, vpaths, allowMkdir, allowUpload) {
+export async function addUser(username, password, admin, vpaths, allowMkdir, allowUpload, allowServerAudio = true) {
   const existing = db.getUserByUsername(username);
   if (existing) { throw new Error(`'${username}' already exists`); }
 
@@ -84,9 +84,9 @@ export async function addUser(username, password, admin, vpaths, allowMkdir, all
   const d = db.getDB();
 
   const result = d.prepare(
-    `INSERT INTO users (username, password, salt, is_admin, allow_upload, allow_mkdir)
-     VALUES (?, ?, ?, ?, ?, ?)`
-  ).run(username, hash.hashPassword, hash.salt, admin ? 1 : 0, allowUpload ? 1 : 0, allowMkdir ? 1 : 0);
+    `INSERT INTO users (username, password, salt, is_admin, allow_upload, allow_mkdir, allow_server_audio)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(username, hash.hashPassword, hash.salt, admin ? 1 : 0, allowUpload ? 1 : 0, allowMkdir ? 1 : 0, allowServerAudio ? 1 : 0);
 
   const userId = Number(result.lastInsertRowid);
 
@@ -141,13 +141,13 @@ export async function editUserVPaths(username, vpaths) {
   db.invalidateCache();
 }
 
-export async function editUserAccess(username, admin, allowMkdir, allowUpload, allowFileModify = true) {
+export async function editUserAccess(username, admin, allowMkdir, allowUpload, allowFileModify = true, allowServerAudio = true) {
   const user = db.getUserByUsername(username);
   if (!user) { throw new Error(`'${username}' does not exist`); }
 
   db.getDB().prepare(
-    'UPDATE users SET is_admin = ?, allow_mkdir = ?, allow_upload = ?, allow_file_modify = ? WHERE id = ?'
-  ).run(admin ? 1 : 0, allowMkdir ? 1 : 0, allowUpload ? 1 : 0, allowFileModify ? 1 : 0, user.id);
+    'UPDATE users SET is_admin = ?, allow_mkdir = ?, allow_upload = ?, allow_file_modify = ?, allow_server_audio = ? WHERE id = ?'
+  ).run(admin ? 1 : 0, allowMkdir ? 1 : 0, allowUpload ? 1 : 0, allowFileModify ? 1 : 0, allowServerAudio ? 1 : 0, user.id);
 
   db.invalidateCache();
 }

--- a/test/cli-audio/Dockerfile
+++ b/test/cli-audio/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       vlc-bin \
       vlc-plugin-base \
       mplayer \
+      mpd \
       ffmpeg \
       ca-certificates \
  && rm -rf /var/lib/apt/lists/*
@@ -34,13 +35,16 @@ RUN npm init -y >/dev/null && npm install --omit=dev --no-audit --no-fund winsto
 
 COPY src/api/cli-audio ./src/api/cli-audio
 COPY test/cli-audio/test-routing.mjs ./test/cli-audio/test-routing.mjs
+COPY test/cli-audio/mpd.conf        ./test/cli-audio/mpd.conf
+COPY test/cli-audio/entrypoint.sh   ./test/cli-audio/entrypoint.sh
 
-# Pre-generate a short sine-wave MP3 that all three players can decode.
+# Pre-generate a short sine-wave MP3 that all four players can decode.
 RUN ffmpeg -y -f lavfi -i "sine=frequency=440:duration=10" -ac 2 -ar 44100 \
       -c:a libmp3lame -q:a 5 /tmp/test-tone.mp3 \
+ && chmod +x /app/test/cli-audio/entrypoint.sh \
  && chown -R tester:tester /app /tmp/test-tone.mp3
 
 USER tester
 ENV HOME=/home/tester
 
-CMD ["node", "test/cli-audio/test-routing.mjs"]
+CMD ["/app/test/cli-audio/entrypoint.sh"]

--- a/test/cli-audio/Dockerfile
+++ b/test/cli-audio/Dockerfile
@@ -1,0 +1,46 @@
+# Docker image for routing-smoke-testing the CLI audio adapters.
+# Installs mpv, vlc (via cvlc), and mplayer, plus ffmpeg to pre-generate a
+# short test tone. Headless containers have no audio device, so we shadow
+# each binary with a wrapper in /usr/local/bin that forces a null audio
+# output — this lets the players run end-to-end without erroring out on
+# missing ALSA/PulseAudio.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      mpv \
+      vlc-bin \
+      vlc-plugin-base \
+      mplayer \
+      ffmpeg \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Shadow each binary with a wrapper that prepends null-audio flags.
+# /usr/local/bin comes before /usr/bin in PATH, so `spawn('mpv', …)` hits
+# the wrapper first. The wrapper invokes the real binary by absolute path
+# to avoid recursion.
+RUN { echo '#!/bin/sh'; echo 'exec /usr/bin/mpv --ao=null "$@"'; } > /usr/local/bin/mpv \
+ && { echo '#!/bin/sh'; echo 'exec /usr/bin/vlc --aout=dummy "$@"'; } > /usr/local/bin/vlc \
+ && { echo '#!/bin/sh'; echo 'exec /usr/bin/mplayer -ao null "$@"'; } > /usr/local/bin/mplayer \
+ && chmod +x /usr/local/bin/mpv /usr/local/bin/vlc /usr/local/bin/mplayer
+
+# VLC refuses to run as root, so set up an unprivileged user for the test.
+RUN useradd -m -u 1001 -s /bin/bash tester
+
+WORKDIR /app
+
+# Minimal dependency install — our adapters only need winston.
+RUN npm init -y >/dev/null && npm install --omit=dev --no-audit --no-fund winston >/dev/null
+
+COPY src/api/cli-audio ./src/api/cli-audio
+COPY test/cli-audio/test-routing.mjs ./test/cli-audio/test-routing.mjs
+
+# Pre-generate a short sine-wave MP3 that all three players can decode.
+RUN ffmpeg -y -f lavfi -i "sine=frequency=440:duration=10" -ac 2 -ar 44100 \
+      -c:a libmp3lame -q:a 5 /tmp/test-tone.mp3 \
+ && chown -R tester:tester /app /tmp/test-tone.mp3
+
+USER tester
+ENV HOME=/home/tester
+
+CMD ["node", "test/cli-audio/test-routing.mjs"]

--- a/test/cli-audio/entrypoint.sh
+++ b/test/cli-audio/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Starts MPD in the background, waits for the control port to be reachable,
+# then hands off to the Node routing harness.
+set -e
+
+mpd --no-daemon /app/test/cli-audio/mpd.conf &
+MPD_PID=$!
+
+# Wait up to 5s for MPD's TCP port to accept connections.
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if node -e "const s=require('net').connect(6600,'127.0.0.1');s.once('data',()=>{process.exit(0)});s.once('error',()=>process.exit(1));setTimeout(()=>process.exit(1),400);" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+
+# Route the adapter through MPD's Unix socket — TCP clients are blocked from
+# `file://` URIs since MPD 0.22, but socket clients are treated as local.
+export MSTREAM_MPD_HOST=/tmp/mpd.sock
+
+# Run the test; capture exit code so we can clean up MPD regardless.
+node test/cli-audio/test-routing.mjs
+TEST_STATUS=$?
+
+kill $MPD_PID 2>/dev/null || true
+wait $MPD_PID 2>/dev/null || true
+
+exit $TEST_STATUS

--- a/test/cli-audio/mpd.conf
+++ b/test/cli-audio/mpd.conf
@@ -1,0 +1,29 @@
+# Minimal MPD config for the routing test.
+# - music_directory is irrelevant because we feed MPD file:// URIs
+# - null output so MPD doesn't fault on missing ALSA/PulseAudio
+# - listen on all interfaces to make debugging easier from the host
+
+music_directory    "/tmp"
+playlist_directory "/tmp"
+db_file            "/tmp/mpd.db"
+log_file           "/tmp/mpd.log"
+pid_file           "/tmp/mpd.pid"
+state_file         "/tmp/mpd.state"
+sticker_file       "/tmp/mpd.sticker"
+
+# MPD 0.22+ requires a Unix-socket connection to access `file://` URIs (TCP
+# clients are restricted for security). Bind both — TCP so the detection
+# probe works, Unix socket so the adapter can load files.
+bind_to_address    "127.0.0.1"
+bind_to_address    "/tmp/mpd.sock"
+port               "6600"
+
+auto_update        "no"
+
+default_permissions "read,add,control,admin"
+
+audio_output {
+  type     "null"
+  name     "null-sink"
+  mixer_type "software"
+}

--- a/test/cli-audio/test-routing.mjs
+++ b/test/cli-audio/test-routing.mjs
@@ -18,7 +18,12 @@ import { MpvAdapter } from '../../src/api/cli-audio/mpv.js';
 import { VlcAdapter } from '../../src/api/cli-audio/vlc.js';
 import { MplayerAdapter } from '../../src/api/cli-audio/mplayer.js';
 import { MpdAdapter } from '../../src/api/cli-audio/mpd.js';
-import { detectAvailablePlayers } from '../../src/api/cli-audio/index.js';
+import {
+  detectAvailablePlayers,
+  bootCliPlayer,
+  killCliPlayer,
+  getActivePlayerName,
+} from '../../src/api/cli-audio/index.js';
 
 const TEST_FILE = process.env.TEST_FILE || '/tmp/test-tone.mp3';
 
@@ -181,11 +186,32 @@ function formatResult(r) {
   console.log('');
   for (const r of results) { console.log(formatResult(r)); console.log(''); }
 
+  // Preference test: with all four players installed, bootCliPlayer() (no
+  // preference) should pick mpv (top of the default priority list), while
+  // bootCliPlayer('mpd') should pick mpd.
+  console.log('=== preference selection ===');
+  let prefDefaultOk = false;
+  let prefMpdOk = false;
+  try {
+    await killCliPlayer();
+    const def = await bootCliPlayer();
+    prefDefaultOk = def === 'mpv';
+    console.log(`  [${prefDefaultOk ? 'ok' : 'FAIL'}] no preference → ${def} (expected mpv)`);
+    await killCliPlayer();
+    const pref = await bootCliPlayer('mpd');
+    prefMpdOk = pref === 'mpd';
+    console.log(`  [${prefMpdOk ? 'ok' : 'FAIL'}] preferred=mpd → ${pref} (expected mpd)`);
+    await killCliPlayer();
+  } catch (e) {
+    console.log(`  [FAIL] preference test threw: ${e.message}`);
+  }
+  console.log('');
+
   const passed = results.every((r) => {
     if (!r.started || r.routesPassed < r.routesTotal) { return false; }
     const failedAssertions = r.assertions.filter((a) => !a.pass).length;
     return failedAssertions === 0;
-  });
+  }) && prefDefaultOk && prefMpdOk;
 
   console.log(passed ? 'ALL GREEN' : 'SOME FAILURES');
   process.exit(passed ? 0 : 1);

--- a/test/cli-audio/test-routing.mjs
+++ b/test/cli-audio/test-routing.mjs
@@ -17,6 +17,7 @@
 import { MpvAdapter } from '../../src/api/cli-audio/mpv.js';
 import { VlcAdapter } from '../../src/api/cli-audio/vlc.js';
 import { MplayerAdapter } from '../../src/api/cli-audio/mplayer.js';
+import { MpdAdapter } from '../../src/api/cli-audio/mpd.js';
 import { detectAvailablePlayers } from '../../src/api/cli-audio/index.js';
 
 const TEST_FILE = process.env.TEST_FILE || '/tmp/test-tone.mp3';
@@ -168,13 +169,14 @@ function formatResult(r) {
 }
 
 (async () => {
-  console.log('Detected players:', detectAvailablePlayers().join(', ') || '(none)');
+  console.log('Detected players:', (await detectAvailablePlayers()).join(', ') || '(none)');
   console.log('Test file:', TEST_FILE);
 
   const results = [];
   results.push(await runAdapterTests('mpv',     new MpvAdapter()));
   results.push(await runAdapterTests('vlc',     new VlcAdapter()));
   results.push(await runAdapterTests('mplayer', new MplayerAdapter()));
+  results.push(await runAdapterTests('mpd',     new MpdAdapter()));
 
   console.log('');
   for (const r of results) { console.log(formatResult(r)); console.log(''); }

--- a/test/cli-audio/test-routing.mjs
+++ b/test/cli-audio/test-routing.mjs
@@ -1,0 +1,190 @@
+/**
+ * Routing smoke test for the CLI audio adapters.
+ *
+ * For each of mpv / vlc / mplayer this script:
+ *   1. starts the adapter (spawns the process + connects its control channel)
+ *   2. fires every route that server-playback.js proxies, through the
+ *      adapter's `handleRequest` dispatcher (same path the Express layer uses)
+ *   3. makes a handful of state-level assertions (play sets `file`, pause
+ *      flips `paused`, queue/add grows `queue_length`, etc.)
+ *   4. stops the adapter cleanly
+ *
+ * Intended to run inside the Dockerfile at test/cli-audio/Dockerfile which
+ * has mpv, vlc (via cvlc), mplayer and ffmpeg installed and a short test tone
+ * pre-generated at /tmp/test-tone.mp3.
+ */
+
+import { MpvAdapter } from '../../src/api/cli-audio/mpv.js';
+import { VlcAdapter } from '../../src/api/cli-audio/vlc.js';
+import { MplayerAdapter } from '../../src/api/cli-audio/mplayer.js';
+import { detectAvailablePlayers } from '../../src/api/cli-audio/index.js';
+
+const TEST_FILE = process.env.TEST_FILE || '/tmp/test-tone.mp3';
+
+function wait(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+const ROUTES = [
+  { name: 'POST /play',             method: 'POST', path: '/play',            body: () => ({ file: TEST_FILE }) },
+  { name: 'POST /volume',           method: 'POST', path: '/volume',          body: () => ({ volume: 0.5 }) },
+  { name: 'POST /pause',            method: 'POST', path: '/pause',           body: () => ({}) },
+  { name: 'POST /resume',           method: 'POST', path: '/resume',          body: () => ({}) },
+  { name: 'POST /seek',             method: 'POST', path: '/seek',            body: () => ({ position: 1 }) },
+  { name: 'POST /queue/add',        method: 'POST', path: '/queue/add',       body: () => ({ file: TEST_FILE }) },
+  { name: 'POST /queue/add-many',   method: 'POST', path: '/queue/add-many',  body: () => ({ files: [TEST_FILE, TEST_FILE] }) },
+  { name: 'POST /shuffle',          method: 'POST', path: '/shuffle',         body: () => ({ value: true }) },
+  { name: 'POST /loop',             method: 'POST', path: '/loop',            body: () => ({}) },
+  { name: 'POST /queue/play-index', method: 'POST', path: '/queue/play-index',body: () => ({ index: 0 }) },
+  { name: 'POST /queue/remove',     method: 'POST', path: '/queue/remove',    body: () => ({ index: 1 }) },
+  { name: 'GET /status',            method: 'GET',  path: '/status',          body: () => ({}) },
+  { name: 'GET /queue',             method: 'GET',  path: '/queue',           body: () => ({}) },
+  { name: 'POST /next',             method: 'POST', path: '/next',            body: () => ({}) },
+  { name: 'POST /previous',         method: 'POST', path: '/previous',        body: () => ({}) },
+  { name: 'POST /queue/clear',      method: 'POST', path: '/queue/clear',     body: () => ({}) },
+  { name: 'POST /stop',             method: 'POST', path: '/stop',            body: () => ({}) },
+];
+
+async function runAdapterTests(name, adapter) {
+  const result = { name, started: false, routesPassed: 0, routesTotal: ROUTES.length, assertions: [], errors: [] };
+
+  try {
+    await adapter.start();
+    result.started = true;
+  } catch (e) {
+    result.errors.push(`start(): ${e.message}`);
+    return result;
+  }
+
+  // Walk every route through the dispatcher. mpv needs a moment after
+  // `loadfile` before seek/prev work, so we give each call a short breather.
+  for (const r of ROUTES) {
+    try {
+      const res = await adapter.handleRequest(r.method, r.path, r.body());
+      if (res.status === 200) {
+        result.routesPassed += 1;
+      } else {
+        result.errors.push(`${r.name} → ${res.status}: ${JSON.stringify(res.data)}`);
+      }
+    } catch (e) {
+      result.errors.push(`${r.name} → EXCEPTION: ${e.message}`);
+    }
+    await wait(150);
+  }
+
+  // State assertions — we reset + replay a few routes and check the
+  // adapter's internal state reflects what the player should be doing.
+  try {
+    // Reset
+    await adapter.handleRequest('POST', '/queue/clear', {});
+    await wait(150);
+
+    // /play should set file and clear stopped
+    await adapter.handleRequest('POST', '/play', { file: TEST_FILE });
+    await wait(300);
+    let status = (await adapter.handleRequest('GET', '/status', {})).data;
+    result.assertions.push({ name: 'play sets file',        pass: status.file === TEST_FILE });
+    result.assertions.push({ name: 'play sets queue_length=1', pass: status.queue_length === 1 });
+
+    // /pause → paused=true
+    await adapter.handleRequest('POST', '/pause', {});
+    await wait(100);
+    status = (await adapter.handleRequest('GET', '/status', {})).data;
+    result.assertions.push({ name: 'pause flips paused',    pass: status.paused === true });
+
+    // /resume → paused=false
+    await adapter.handleRequest('POST', '/resume', {});
+    await wait(100);
+    status = (await adapter.handleRequest('GET', '/status', {})).data;
+    result.assertions.push({ name: 'resume clears paused',  pass: status.paused === false });
+
+    // /volume 0.25 → status.volume ≈ 0.25
+    await adapter.handleRequest('POST', '/volume', { volume: 0.25 });
+    await wait(100);
+    status = (await adapter.handleRequest('GET', '/status', {})).data;
+    result.assertions.push({ name: 'volume round-trips',    pass: Math.abs(status.volume - 0.25) < 0.01 });
+
+    // /queue/add grows queue
+    await adapter.handleRequest('POST', '/queue/add', { file: TEST_FILE });
+    await wait(100);
+    status = (await adapter.handleRequest('GET', '/status', {})).data;
+    result.assertions.push({ name: 'queue/add grows queue', pass: status.queue_length === 2 });
+
+    // /shuffle true → shuffle reflects
+    await adapter.handleRequest('POST', '/shuffle', { value: true });
+    status = (await adapter.handleRequest('GET', '/status', {})).data;
+    result.assertions.push({ name: 'shuffle round-trips',   pass: status.shuffle === true });
+
+    // /loop cycles through three distinct modes. We don't assume the
+    // adapter's starting loop_mode — just that three successive calls
+    // return three different values from the set { none, one, all } that
+    // eventually land back on the original.
+    await adapter.handleRequest('POST', '/queue/clear', {});
+    await adapter.handleRequest('POST', '/play', { file: TEST_FILE });
+    await wait(100);
+    const seenLoops = new Set();
+    const startLoop = (await adapter.handleRequest('GET', '/status', {})).data.loop_mode;
+    seenLoops.add(startLoop);
+    for (let i = 0; i < 3; i++) {
+      await adapter.handleRequest('POST', '/loop', {});
+      seenLoops.add((await adapter.handleRequest('GET', '/status', {})).data.loop_mode);
+    }
+    const endLoop = (await adapter.handleRequest('GET', '/status', {})).data.loop_mode;
+    result.assertions.push({ name: 'loop cycles 3 modes', pass: seenLoops.size === 3 });
+    result.assertions.push({ name: 'loop returns to start', pass: endLoop === startLoop });
+
+    // /queue (GET) returns array
+    const q = (await adapter.handleRequest('GET', '/queue', {})).data;
+    result.assertions.push({ name: 'queue returns array',   pass: Array.isArray(q.queue) && q.queue.length === 1 });
+  } catch (e) {
+    result.errors.push(`state assertions: ${e.message}`);
+  }
+
+  try { await adapter.stop(); } catch (_) { /* ignore */ }
+  await wait(200);
+  return result;
+}
+
+function formatResult(r) {
+  const passedAssertions = r.assertions.filter((a) => a.pass).length;
+  const totalAssertions = r.assertions.length;
+  const routeLine = `routes: ${r.routesPassed}/${r.routesTotal}`;
+  const stateLine = `state:  ${passedAssertions}/${totalAssertions}`;
+  const startLine = `start:  ${r.started ? 'ok' : 'FAILED'}`;
+  const lines = [
+    `=== ${r.name} ===`,
+    `  ${startLine}`,
+    `  ${routeLine}`,
+    `  ${stateLine}`,
+  ];
+  if (r.assertions.length) {
+    for (const a of r.assertions) {
+      lines.push(`    [${a.pass ? 'ok' : 'FAIL'}] ${a.name}`);
+    }
+  }
+  if (r.errors.length) {
+    lines.push('  errors:');
+    for (const e of r.errors) { lines.push(`    - ${e}`); }
+  }
+  return lines.join('\n');
+}
+
+(async () => {
+  console.log('Detected players:', detectAvailablePlayers().join(', ') || '(none)');
+  console.log('Test file:', TEST_FILE);
+
+  const results = [];
+  results.push(await runAdapterTests('mpv',     new MpvAdapter()));
+  results.push(await runAdapterTests('vlc',     new VlcAdapter()));
+  results.push(await runAdapterTests('mplayer', new MplayerAdapter()));
+
+  console.log('');
+  for (const r of results) { console.log(formatResult(r)); console.log(''); }
+
+  const passed = results.every((r) => {
+    if (!r.started || r.routesPassed < r.routesTotal) { return false; }
+    const failedAssertions = r.assertions.filter((a) => !a.pass).length;
+    return failedAssertions === 0;
+  });
+
+  console.log(passed ? 'ALL GREEN' : 'SOME FAILURES');
+  process.exit(passed ? 0 : 1);
+})();

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -170,6 +170,17 @@ const ADMINDATA = (() => {
     } catch (_err) {}
   }
 
+  // Force a fresh detection probe server-side, then pull the updated info.
+  module.redetectCliPlayers = async () => {
+    try {
+      await API.axios({
+        method: 'POST',
+        url: `${API.url()}/api/v1/admin/server-audio/detect`
+      });
+      await module.getServerAudioInfo();
+    } catch (_err) {}
+  }
+
   module.getTranscodeParams = async () => {
     const res = await API.axios({
       method: 'GET',
@@ -1369,7 +1380,7 @@ const advancedView = Vue.component('advanced-view', {
       });
     },
     refreshServerAudioInfo: function() {
-      ADMINDATA.getServerAudioInfo();
+      ADMINDATA.redetectCliPlayers();
     },
     toggleAutoBootServerAudio: function() {
       iziToast.question({

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -25,6 +25,9 @@ const ADMINDATA = (() => {
   // server settings
   module.serverParams = {};
   module.serverParamsUpdated = { ts: 0 };
+  // server audio backend (rust vs CLI fallback)
+  module.serverAudioInfo = { backend: null, player: null, detectedCliPlayers: [] };
+  module.serverAudioInfoUpdated = { ts: 0 };
   // transcoding
   module.transcodeParams = {};
   module.transcodeParamsUpdated = { ts: 0 };
@@ -152,6 +155,19 @@ const ADMINDATA = (() => {
     });
 
     module.serverParamsUpdated.ts = Date.now();
+  }
+
+  module.getServerAudioInfo = async () => {
+    try {
+      const res = await API.axios({
+        method: 'GET',
+        url: `${API.url()}/api/v1/admin/server-audio/info`
+      });
+      module.serverAudioInfo.backend = res.data.backend;
+      module.serverAudioInfo.player = res.data.player;
+      module.serverAudioInfo.detectedCliPlayers = res.data.detectedCliPlayers || [];
+      module.serverAudioInfoUpdated.ts = Date.now();
+    } catch (_err) {}
   }
 
   module.getTranscodeParams = async () => {
@@ -350,6 +366,7 @@ ADMINDATA.getFolders();
 ADMINDATA.getUsers();
 ADMINDATA.getDbParams();
 ADMINDATA.getServerParams();
+ADMINDATA.getServerAudioInfo();
 ADMINDATA.getFederationParams();
 ADMINDATA.getDlnaParams();
 ADMINDATA.getSubsonicParams();
@@ -938,8 +955,22 @@ const advancedView = Vue.component('advanced-view', {
   data() {
     return {
       params: ADMINDATA.serverParams,
-      paramsTS: ADMINDATA.serverParamsUpdated
+      paramsTS: ADMINDATA.serverParamsUpdated,
+      audioInfo: ADMINDATA.serverAudioInfo,
+      audioInfoTS: ADMINDATA.serverAudioInfoUpdated
     };
+  },
+  computed: {
+    activePlayerLabel: function() {
+      if (!this.audioInfo.backend) { return 'None'; }
+      if (this.audioInfo.backend === 'rust') { return 'rust-server-audio (native)'; }
+      if (this.audioInfo.backend === 'cli') { return (this.audioInfo.player || 'cli') + ' (CLI fallback)'; }
+      return this.audioInfo.player || 'Unknown';
+    },
+    detectedCliPlayersLabel: function() {
+      const d = this.audioInfo.detectedCliPlayers || [];
+      return d.length ? d.join(', ') : 'None';
+    }
   },
   template: `
     <div v-if="paramsTS.ts === 0" class="row">
@@ -1035,6 +1066,16 @@ const advancedView = Vue.component('advanced-view', {
                       <td>
                         [<a v-on:click="openModal('edit-rust-player-port-modal')">{{ t('admin.settings.edit') }}</a>]
                       </td>
+                    </tr>
+                    <tr>
+                      <td><b>Active player:</b> {{ activePlayerLabel }}</td>
+                      <td>
+                        [<a v-on:click="refreshServerAudioInfo()">refresh</a>]
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><b>Detected CLI players:</b> {{ detectedCliPlayersLabel }}</td>
+                      <td></td>
                     </tr>
                   </tbody>
                 </table>
@@ -1321,6 +1362,9 @@ const advancedView = Vue.component('advanced-view', {
         ]
       });
     },
+    refreshServerAudioInfo: function() {
+      ADMINDATA.getServerAudioInfo();
+    },
     toggleAutoBootServerAudio: function() {
       iziToast.question({
         timeout: 20000,
@@ -1344,6 +1388,7 @@ const advancedView = Vue.component('advanced-view', {
               data: { autoBootServerAudio: !this.params.autoBootServerAudio }
             }).then(() => {
               Vue.set(ADMINDATA.serverParams, 'autoBootServerAudio', !this.params.autoBootServerAudio);
+              setTimeout(() => ADMINDATA.getServerAudioInfo(), 500);
               iziToast.success({
                 title: t('admin.settings.updated'),
                 position: 'topCenter',

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -716,6 +716,7 @@ const usersView = Vue.component('users-view', {
       makeAdmin: Object.keys(ADMINDATA.users).length === 0 ? true : false,
       allowMkdir: true,
       allowUpload: true,
+      allowServerAudio: true,
       submitPending: false,
       selectInstance: null
     };
@@ -761,6 +762,10 @@ const usersView = Vue.component('users-view', {
                       <div class="pad-checkbox"><label>
                         <input type="checkbox" v-model="allowUpload"/>
                         <span>{{ t('admin.users.allowUpload') }}</span>
+                      </label></div>
+                      <div class="pad-checkbox"><label>
+                        <input type="checkbox" v-model="allowServerAudio"/>
+                        <span>Allow Server Audio</span>
                       </label></div>
                     </div>
                     <!-- <div class="col s12 m6">
@@ -904,7 +909,8 @@ const usersView = Vue.component('users-view', {
             vpaths: Array.from(selected).map(el => el.value),
             admin: this.makeAdmin,
             allowMkdir: this.allowMkdir,
-            allowUpload: this.allowUpload
+            allowUpload: this.allowUpload,
+            allowServerAudio: this.allowServerAudio
           };
 
           await API.axios({
@@ -913,7 +919,7 @@ const usersView = Vue.component('users-view', {
             data: data
           });
 
-          Vue.set(ADMINDATA.users, this.newUsername, { vpaths: data.vpaths, admin: data.admin, allowMkdir: data.allowMkdir, allowUpload: data.allowUpload });
+          Vue.set(ADMINDATA.users, this.newUsername, { vpaths: data.vpaths, admin: data.admin, allowMkdir: data.allowMkdir, allowUpload: data.allowUpload, allowServerAudio: data.allowServerAudio });
           this.newUsername = '';
           this.newPassword = '';
 
@@ -3631,7 +3637,8 @@ const userAccessView = Vue.component('user-access-view', {
       submitPending: false,
       isAdmin: ADMINDATA.users[ADMINDATA.selectedUser.value].admin,
       allowMkdir: ADMINDATA.users[ADMINDATA.selectedUser.value].allowMkdir !== false,
-      allowUpload: ADMINDATA.users[ADMINDATA.selectedUser.value].allowUpload !== false
+      allowUpload: ADMINDATA.users[ADMINDATA.selectedUser.value].allowUpload !== false,
+      allowServerAudio: ADMINDATA.users[ADMINDATA.selectedUser.value].allowServerAudio !== false
     };
   },
   template: `
@@ -3650,6 +3657,10 @@ const userAccessView = Vue.component('user-access-view', {
         <div class="pad-checkbox"><label>
           <input type="checkbox" v-model="allowUpload"/>
           <span>{{ t('admin.modal.uploadFiles') }}</span>
+        </label></div>
+        <div class="pad-checkbox"><label>
+          <input type="checkbox" v-model="allowServerAudio"/>
+          <span>Allow Server Audio</span>
         </label></div>
       </div>
       <div class="modal-footer">
@@ -3675,7 +3686,8 @@ const userAccessView = Vue.component('user-access-view', {
               username: this.currentUser.value,
               admin: this.isAdmin,
               allowMkdir: this.allowMkdir,
-              allowUpload: this.allowUpload
+              allowUpload: this.allowUpload,
+              allowServerAudio: this.allowServerAudio
             }
           });
 
@@ -3683,6 +3695,7 @@ const userAccessView = Vue.component('user-access-view', {
           Vue.set(ADMINDATA.users[this.currentUser.value], 'admin', this.isAdmin);
           Vue.set(ADMINDATA.users[this.currentUser.value], 'allowMkdir', this.allowMkdir);
           Vue.set(ADMINDATA.users[this.currentUser.value], 'allowUpload', this.allowUpload);
+          Vue.set(ADMINDATA.users[this.currentUser.value], 'allowServerAudio', this.allowServerAudio);
     
           // close & reset the modal
           M.Modal.getInstance(document.getElementById('admin-modal')).close();

--- a/webapp/velvet/admin/index.js
+++ b/webapp/velvet/admin/index.js
@@ -437,6 +437,7 @@ const usersView = Vue.component('users-view', {
       makeAdmin: Object.keys(ADMINDATA.users).length === 0 ? true : false,
       allowMkdir: true,
       allowUpload: true,
+      allowServerAudio: true,
       submitPending: false,
       selectInstance: null
     };
@@ -482,6 +483,10 @@ const usersView = Vue.component('users-view', {
                       <div class="pad-checkbox"><label>
                         <input type="checkbox" v-model="allowUpload"/>
                         <span>Allow Upload</span>
+                      </label></div>
+                      <div class="pad-checkbox"><label>
+                        <input type="checkbox" v-model="allowServerAudio"/>
+                        <span>Allow Server Audio</span>
                       </label></div>
                     </div>
                     <!-- <div class="col s12 m6">
@@ -625,7 +630,8 @@ const usersView = Vue.component('users-view', {
             vpaths: Array.from(selected).map(el => el.value),
             admin: this.makeAdmin,
             allowMkdir: this.allowMkdir,
-            allowUpload: this.allowUpload
+            allowUpload: this.allowUpload,
+            allowServerAudio: this.allowServerAudio
           };
 
           await API.axios({
@@ -634,7 +640,7 @@ const usersView = Vue.component('users-view', {
             data: data
           });
 
-          Vue.set(ADMINDATA.users, this.newUsername, { vpaths: data.vpaths, admin: data.admin, allowMkdir: data.allowMkdir, allowUpload: data.allowUpload });
+          Vue.set(ADMINDATA.users, this.newUsername, { vpaths: data.vpaths, admin: data.admin, allowMkdir: data.allowMkdir, allowUpload: data.allowUpload, allowServerAudio: data.allowServerAudio });
           this.newUsername = '';
           this.newPassword = '';
 
@@ -2668,7 +2674,8 @@ const userAccessView = Vue.component('user-access-view', {
       submitPending: false,
       isAdmin: ADMINDATA.users[ADMINDATA.selectedUser.value].admin,
       allowMkdir: ADMINDATA.users[ADMINDATA.selectedUser.value].allowMkdir !== false,
-      allowUpload: ADMINDATA.users[ADMINDATA.selectedUser.value].allowUpload !== false
+      allowUpload: ADMINDATA.users[ADMINDATA.selectedUser.value].allowUpload !== false,
+      allowServerAudio: ADMINDATA.users[ADMINDATA.selectedUser.value].allowServerAudio !== false
     };
   },
   template: `
@@ -2687,6 +2694,10 @@ const userAccessView = Vue.component('user-access-view', {
         <div class="pad-checkbox"><label>
           <input type="checkbox" v-model="allowUpload"/>
           <span>Upload Files</span>
+        </label></div>
+        <div class="pad-checkbox"><label>
+          <input type="checkbox" v-model="allowServerAudio"/>
+          <span>Allow Server Audio</span>
         </label></div>
       </div>
       <div class="modal-footer">
@@ -2712,7 +2723,8 @@ const userAccessView = Vue.component('user-access-view', {
               username: this.currentUser.value,
               admin: this.isAdmin,
               allowMkdir: this.allowMkdir,
-              allowUpload: this.allowUpload
+              allowUpload: this.allowUpload,
+              allowServerAudio: this.allowServerAudio
             }
           });
 
@@ -2720,6 +2732,7 @@ const userAccessView = Vue.component('user-access-view', {
           Vue.set(ADMINDATA.users[this.currentUser.value], 'admin', this.isAdmin);
           Vue.set(ADMINDATA.users[this.currentUser.value], 'allowMkdir', this.allowMkdir);
           Vue.set(ADMINDATA.users[this.currentUser.value], 'allowUpload', this.allowUpload);
+          Vue.set(ADMINDATA.users[this.currentUser.value], 'allowServerAudio', this.allowServerAudio);
     
           // close & reset the modal
           M.Modal.getInstance(document.getElementById('admin-modal')).close();


### PR DESCRIPTION
## Summary
- When the Rust server-audio binary isn't available, probe the host for an installed CLI player and use it as a drop-in backend.
- Adapters for **mpv** (JSON IPC socket / named pipe), **VLC** (`--intf rc` over TCP), and **mplayer** (`-slave` over stdin). First-available-wins in that priority order — matches what the velvet fork uses for its own mpv-only flow, generalized.
- Admin UI's Server Audio card now shows **Active player** (e.g. `rust-server-audio (native)` or `mpv (CLI fallback)`) and **Detected CLI players**, with a refresh link.

## Why
`autoBootServerAudio` today only works if a prebuilt Rust binary ships for the current arch. This change keeps that as the preferred path but lets users on distros that have mpv / vlc / mplayer installed get server-side playback without a Rust toolchain. The abstraction layer means every existing `/api/v1/server-playback/*` route keeps the same response shape, so [webapp/assets/js/mstream.server-audio.js](webapp/assets/js/mstream.server-audio.js), [/server-remote](src/api/server-playback.js), and any downstream consumers work unchanged.

## What changed
- **`src/api/cli-audio/`** (new)
  - [base.js](src/api/cli-audio/base.js) — `BaseCliAdapter` with shared queue/shuffle/loop state and a dispatcher that mirrors the Rust binary's HTTP routes (`proxyToCli` is a drop-in for `proxyToRust`).
  - [mpv.js](src/api/cli-audio/mpv.js), [vlc.js](src/api/cli-audio/vlc.js), [mplayer.js](src/api/cli-audio/mplayer.js) — per-player process + control-channel implementations.
  - [index.js](src/api/cli-audio/index.js) — player registry, `detectAvailablePlayers()`, `bootCliPlayer()`, `killCliPlayer()`, `proxyToCli()`.
- [src/api/server-playback.js](src/api/server-playback.js) — new `proxyPlayback()` dispatches to Rust when running, else CLI; `bootRustPlayer()` now falls back to CLI probe when the Rust binary is missing; exposes `getActiveBackend` / `getDetectedCliPlayers`; `/status` response gains `backend` + `player` fields.
- [src/api/admin.js](src/api/admin.js) — new `GET /api/v1/admin/server-audio/info` returning `{ backend, player, detectedCliPlayers }`.
- [webapp/admin/index.js](webapp/admin/index.js) — `ADMINDATA.serverAudioInfo` + loader; Server Audio card renders the two new rows.

## Behavior matrix
| Config | Rust binary present | CLI installed | Result |
|---|---|---|---|
| `autoBootServerAudio: false` | — | — | No server audio (unchanged) |
| `autoBootServerAudio: true` | yes | — | Rust backend (unchanged) |
| `autoBootServerAudio: true` | no | mpv/vlc/mplayer | First available CLI player boots |
| `autoBootServerAudio: true` | no | none | Logs warning, no audio (graceful) |

## Test plan
- [x] Lint clean on all new/modified files (only pre-existing `require-await` warnings on abstract-method placeholders).
- [x] Live server on port 3008: toggle auto-boot on → admin shows `rust-server-audio (native)`, toggle off → `None`, move Rust binary aside + toggle on → logs "No CLI audio players detected" (expected on this Windows box).
- [x] Docker-based routing harness — see `test/cli-audio/Dockerfile` + `test-routing.mjs`. Spins up Debian slim with all three players (plus `vlc-plugin-base` for the rc module, null-audio wrappers in `/usr/local/bin`, non-root user because VLC refuses to run as root). Result:
  ```
  Detected players: mpv, vlc, mplayer
  mpv     → start ok, routes 17/17, state 10/10
  vlc     → start ok, routes 17/17, state 10/10
  mplayer → start ok, routes 17/17, state 10/10
  ALL GREEN
  ```
  Run with:
  ```
  docker build -f test/cli-audio/Dockerfile -t mstream-cli-audio-test .
  docker run --rm mstream-cli-audio-test
  ```

## Reviewer notes
- The 17 routes tested are the exact set the Rust binary serves, so the adapter matches the existing contract route-for-route.
- Queue state is managed authoritatively in Node (in `BaseCliAdapter`); each player is fed one track at a time via its native loadfile equivalent. This keeps semantics identical across adapters rather than relying on each player's internal playlist behavior.
- mpv uses named pipes on Windows (`\\.\pipe\mpv-mstream-<pid>`) and Unix sockets elsewhere — `net.connect(path)` handles both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)