### PR TITLE
add config option to set the expressjs "trust proxy" setting when running behind a reverse proxy

### DIFF
--- a/docs/json_config.md
+++ b/docs/json_config.md
@@ -14,7 +14,7 @@ All config params have default values. A newly generated config will be empty js
 { }
 ```
 
-A heavily edited config would look like: 
+A heavily edited config would look like:
 
 ```json
 {
@@ -87,7 +87,7 @@ If this is not set, the cwd will be used
 
 If there is no users object, the login system will not be enabled and anyone will be abe to access the server.  All folders will be accessible
 
-A basic user example.  
+A basic user example.
 
 Note that the hashed password and salt can be generated automatically by creating a new user via the admin ui.
 
@@ -162,7 +162,7 @@ The `defaultCodec` accepts the values `aac`, `mp3`, `opus`.
 
 The `defaultBitrate` accepts the values, `192k` `128k`, `96k`, `64k`
 
-## Secret 
+## Secret
 
 Sets the secret key used for the login system.  If this is not set, mStream will generate a different secret key on each boot and all previous login sessions will be voided
 
@@ -235,7 +235,7 @@ Each user can have their own lastFM credentials
 
 mStream will write, logs, DB files, and album art to the filesystem.  By default these will be written in the mStream project folder tothe `save` and `image-cache` folders.  Use the `storage` object to choose where to save these files
 
-The `albumArtDirectory` will be publicly available 
+The `albumArtDirectory` will be publicly available
 
 ```json
 {
@@ -273,3 +273,11 @@ Folder that contains the frontend for mStream.  Defaults to `public` if not set
 The object key is the file extension and the value is true/false.
 
 If true, the file will be scanned and saved the db as an audio file. If false, the file will not be scanned but still be viewable in the file explorer
+
+## Trust Proxy
+
+Set `trustProxy` to `true` to get correct client IPs in logs when behind a reverse proxy. This defaults to `false`.  It should be `false` on directly exposed instances to prevent trivial spoofing.
+
+```
+  "trustProxy": true,
+```

--- a/src/server.js
+++ b/src/server.js
@@ -92,6 +92,10 @@ export async function serveIt(configFile) {
     );
     next();
   });
+  // Trust Proxy
+  if (config.program.trustProxy) {
+    mstream.set("trust proxy", true);
+  }
 
   // Setup DB
   dbManager.initDB();

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -188,6 +188,9 @@ const schema = Joi.object({
   subsonic: subsonicOptions.default(subsonicOptions.validate({}).value),
   autoBootServerAudio: Joi.boolean().default(false),
   rustPlayerPort: Joi.number().integer().min(1).max(65535).default(3333),
+  // true  - trust X-Forwarded-For header for client IP address
+  // false - default behavior
+  trustProxy: Joi.boolean().default(false),
 });
 
 export let program;


### PR DESCRIPTION
When running behind a reverse proxy, the logs always show the reverse proxy's IP when logins fail.  The logs should show the original client IP by looking at the `X-Forwarded-For` header set by the proxy.  This is something that expressjs can already do with a small application code change [More details](https://expressjs.com/en/guide/behind-proxies.html).

I intend to use this with fail2ban scanning the logs for failed logins for blocking IPs, but the logs need to show the real client IP, not my proxy's IP.

The new option should be left false when _**not**_ running behind a trusted reverse proxy to prevent a trivial client IP spoof.
