### PR TITLE
fix(ci): bump electron 37 -> 41.3.0 to unbreak Build Desktop Player

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "build": {
     "appId": "io.mstream.server",
     "productName": "mStream Server",
-    "electronVersion": "37.0.0",
+    "electronVersion": "41.3.0",
     "asar": false,
     "files": [
       "**/*",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0",
       "license": "GPL-3.0",
       "devDependencies": {
-        "electron": "^37.0.0",
+        "electron": "^41.3.0",
         "electron-builder": "^26.7.0"
       },
       "engines": {
@@ -818,13 +818,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/plist": {
@@ -1949,6 +1949,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -2093,15 +2094,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "37.10.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
-      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
+      "version": "41.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
+      "integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -4653,9 +4654,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -62,7 +62,7 @@
     }
   },
   "devDependencies": {
-    "electron": "^37.0.0",
+    "electron": "^41.3.0",
     "electron-builder": "^26.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `electron` in `webapp/` from `^37.0.0` to `^41.3.0` (latest stable, published 2026-04-22) to fix the `Build Desktop Player` workflow, which started failing 2026-04-25 with a 404 from electron's postinstall (`node install.js`) when fetching prebuilt binaries from GitHub release assets.
- Also bumps the root `package.json` `electronVersion` `37.0.0` → `41.3.0` so the separate `Build Server` workflow doesn't hit the same class of failure on the next tag push.
- Supersedes dependabot PR #548 (`^39.8.5`) — going to current stable instead avoids re-hitting the same EOL-induced 404 in a few months.

## Why electron 37 broke
`webapp/package.json` pinned `^37.0.0`, lockfile resolved `37.10.3`. Between v6.5.3 (success at 2026-04-25 03:22 UTC) and v6.5.5 (failure at 2026-04-25 19:09 UTC), no webapp-side code changed — git log shows only server-side commits in that window — so the trigger is external to the repo. Electron 37 has reached EOL; the postinstall script's request for some artifact (likely a checksum or platform asset that's no longer reliably served) now returns 404. The primary `electron-v37.10.3-darwin-{arm64,x64}.zip` files still exist (verified via curl), so it's a secondary fetch failing.

## Test plan
- [x] `cd webapp && rm -rf node_modules && npm install` — completes without 404 (electron 41.3.0 binary downloaded successfully).
- [x] `cd webapp && npx electron-builder --publish never` — produces `dist/mStream Desktop Setup 6.0.0.exe` on Windows; builder log confirms it fetched `electron-v41.3.0-win32-x64.zip` from GitHub in ~7s.
- [ ] `Build Desktop Player` workflow goes green for `macos-latest`, `ubuntu-latest`, `windows-latest` after merge / re-run of run id `25081863611`.
- [ ] `Build Server` workflow goes green on next tag push with the new `electronVersion: 41.3.0`.

## Follow-up
Close dependabot PR #548 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)