### PR TITLE
Drop 6 prod deps to shrink Electron installers (~6 MB)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,8 @@
       "version": "6.5.7",
       "license": "GPL-3.0",
       "dependencies": {
-        "archiver": "^7.0.1",
         "busboy": "^1.6.0",
         "command-exists": "^1.2.9",
-        "cookie-parser": "^1.4.7",
         "electron-updater": "^6.7.3",
         "express": "^5.0.1",
         "fast-xml-parser": "^5.3.6",
@@ -20,14 +18,11 @@
         "jimp": "^1.6.0",
         "joi": "^18.0.2",
         "jsonwebtoken": "^9.0.3",
-        "m3u8-parser": "^7.2.0",
-        "mime-types": "^3.0.2",
         "music-metadata": "^11.11.1",
-        "nanoid": "^5.0.9",
         "tree-kill": "^1.2.2",
-        "undici": "^7.0.0",
         "winston": "^3.19.0",
-        "ws": "^8.19.0"
+        "ws": "^8.19.0",
+        "yazl": "^3.3.1"
       },
       "bin": {
         "mstream": "cli-boot-wrapper.js"
@@ -72,6 +67,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -814,102 +810,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -1638,16 +1538,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2084,20 +1974,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@videojs/vhs-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
-      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -2129,6 +2005,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -2225,6 +2102,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2234,6 +2112,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2326,115 +2205,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2505,20 +2275,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2529,102 +2285,11 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
-      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
-      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
-      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3037,6 +2702,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3049,6 +2715,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -3139,22 +2806,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3193,25 +2844,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/cookie-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
-      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
-    },
     "node_modules/core-js": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
@@ -3229,7 +2861,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/crc": {
       "version": "3.8.0",
@@ -3240,31 +2874,6 @@
       "optional": true,
       "dependencies": {
         "buffer": "^5.1.0"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/cross-dirname": {
@@ -3279,6 +2888,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3293,12 +2903,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3586,11 +3198,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
     "node_modules/dompurify": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
@@ -3643,12 +3250,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3857,6 +3458,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
@@ -4181,6 +3783,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4191,24 +3794,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
     },
     "node_modules/exif-parser": {
       "version": "0.1.12",
@@ -4290,12 +3875,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4559,34 +4138,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -4777,16 +4328,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "license": "MIT",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
       }
     },
     "node_modules/global-agent": {
@@ -5199,6 +4740,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5235,12 +4777,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
@@ -5262,21 +4798,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jake": {
@@ -5562,48 +5083,6 @@
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
       "license": "MIT"
     },
-    "node_modules/lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5648,6 +5127,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
@@ -5772,17 +5252,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/m3u8-parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz",
-      "integrity": "sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^4.1.1",
-        "global": "^4.4.0"
-      }
-    },
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
@@ -5895,15 +5364,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/min-document": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
-      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
-      "license": "MIT",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -5934,6 +5394,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6064,24 +5525,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -6257,15 +5700,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-url": {
@@ -6504,12 +5938,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -6593,6 +6021,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6858,21 +6287,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -7136,82 +6550,6 @@
       },
       "bin": {
         "read-binary-file-arch": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readable-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/redoc": {
@@ -7691,6 +7029,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7703,6 +7042,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8053,17 +7393,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -8077,21 +7406,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8106,19 +7421,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8268,18 +7571,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -8288,15 +7579,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp": {
@@ -8322,15 +7604,6 @@
       "dependencies": {
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-hex": {
@@ -8559,15 +7832,6 @@
       "license": "MIT",
       "bin": {
         "ulid": "dist/cli.js"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8815,24 +8079,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8961,6 +8207,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -8972,20 +8227,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build-rust": "cd rust-parser && cargo build --release",
     "docs:api": "redocly build-docs docs/openapi.yaml -o docs/api.html",
     "docs:api:validate": "redocly lint docs/openapi.yaml",
-    "test": "node --test --test-reporter=spec test/dlna.test.mjs test/subsonic.test.mjs test/subsonic-modes.test.mjs test/subsonic-phase3.test.mjs test/subsonic-jukebox.test.mjs test/subsonic-polish.test.mjs test/subsonic-multi-artist.test.mjs test/subsonic-client-flow.test.mjs test/subsonic-info-endpoints.test.mjs test/subsonic-lyrics.test.mjs test/subsonic-lyrics-lrclib.test.mjs test/subsonic-ui.test.mjs test/admin-subsonic-ui.test.mjs test/public-mode-library-filter.test.mjs test/public-mode-privacy.test.mjs test/hash-migration.test.mjs test/scanner-follow-symlinks.test.mjs test/audio-hash-parity.test.mjs test/lyrics-parity.test.mjs test/waveform.test.mjs",
+    "test": "node --test --test-reporter=spec test/dlna.test.mjs test/subsonic.test.mjs test/subsonic-modes.test.mjs test/subsonic-phase3.test.mjs test/subsonic-jukebox.test.mjs test/subsonic-polish.test.mjs test/subsonic-multi-artist.test.mjs test/subsonic-client-flow.test.mjs test/subsonic-info-endpoints.test.mjs test/subsonic-lyrics.test.mjs test/subsonic-lyrics-lrclib.test.mjs test/subsonic-ui.test.mjs test/admin-subsonic-ui.test.mjs test/public-mode-library-filter.test.mjs test/public-mode-privacy.test.mjs test/hash-migration.test.mjs test/scanner-follow-symlinks.test.mjs test/audio-hash-parity.test.mjs test/lyrics-parity.test.mjs test/waveform.test.mjs test/cookie-middleware-parity.test.mjs",
     "test:dlna": "node --test --test-reporter=spec test/dlna.test.mjs",
     "test:subsonic": "node --test --test-reporter=spec test/subsonic.test.mjs test/subsonic-modes.test.mjs test/subsonic-phase3.test.mjs test/subsonic-jukebox.test.mjs test/subsonic-polish.test.mjs test/subsonic-multi-artist.test.mjs test/subsonic-client-flow.test.mjs test/subsonic-info-endpoints.test.mjs test/subsonic-lyrics.test.mjs test/subsonic-lyrics-lrclib.test.mjs test/subsonic-ui.test.mjs test/admin-subsonic-ui.test.mjs"
   },
@@ -107,10 +107,8 @@
     }
   },
   "dependencies": {
-    "archiver": "^7.0.1",
     "busboy": "^1.6.0",
     "command-exists": "^1.2.9",
-    "cookie-parser": "^1.4.7",
     "electron-updater": "^6.7.3",
     "express": "^5.0.1",
     "fast-xml-parser": "^5.3.6",
@@ -118,14 +116,11 @@
     "jimp": "^1.6.0",
     "joi": "^18.0.2",
     "jsonwebtoken": "^9.0.3",
-    "m3u8-parser": "^7.2.0",
-    "mime-types": "^3.0.2",
     "music-metadata": "^11.11.1",
-    "nanoid": "^5.0.9",
     "tree-kill": "^1.2.2",
-    "undici": "^7.0.0",
     "winston": "^3.19.0",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "yazl": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -3,7 +3,7 @@ import child from 'child_process';
 import os from 'os';
 import Joi from 'joi';
 import winston from 'winston';
-import archiver from 'archiver';
+import { createZipForResponse, addDirectoryRecursive } from '../util/zip-stream.js';
 import * as fileExplorer from '../util/file-explorer.js';
 import * as admin from '../util/admin.js';
 import * as config from '../state/config.js';
@@ -554,19 +554,10 @@ export function setup(mstream) {
     res.json({});
   });
 
-  mstream.get("/api/v1/admin/logs/download", (req, res) => {
-    const archive = archiver('zip');
-    archive.on('error', err => {
-      winston.error('Download Error', { stack: err });
-      res.status(500).json({ error: err.message });
-    });
-
-    res.attachment(`mstream-logs.zip`);
-
-    //streaming magic
-    archive.pipe(res);
-    archive.directory(config.program.storage.logsDirectory, false)
-    archive.finalize();
+  mstream.get("/api/v1/admin/logs/download", async (req, res) => {
+    const zipFile = createZipForResponse(res, 'mstream-logs.zip', 'Download Error');
+    await addDirectoryRecursive(zipFile, config.program.storage.logsDirectory);
+    zipFile.end();
   });
 
   mstream.get("/api/v1/admin/db/shared", (req, res) => {

--- a/src/api/download.js
+++ b/src/api/download.js
@@ -1,4 +1,3 @@
-import archiver from 'archiver';
 import path from 'path';
 import fs from 'fs/promises';
 import winston from 'winston';
@@ -6,10 +5,10 @@ import * as vpath from '../util/vpath.js';
 import * as shared from '../api/shared.js';
 import * as m3u from '../util/m3u.js';
 import WebError from '../util/web-error.js';
+import { createZipForResponse, addDirectoryRecursive } from '../util/zip-stream.js';
 
 export function setup(mstream) {
   mstream.post('/api/v1/download/m3u', (req, res) => {
-    // custom wrap download functions to avoid an error with the archiver module
     downloadM3U(req, res).catch(err  => {
       throw err;
     })
@@ -21,14 +20,12 @@ export function setup(mstream) {
     const playlistParentDir = path.dirname(pathInfo.fullPath);
     const songs = await m3u.readPlaylistSongs(pathInfo.fullPath);
 
-    const archive = archiver('zip');
-    archive.on('error', function (err) {
-      winston.error('Download Error', { stack: err });
-      res.status(500).json({ error: err.message });
-    });
+    const zipFile = createZipForResponse(
+      res,
+      `${path.basename(req.body.path)}.zip`,
+      'Download Error',
+    );
 
-    res.attachment(`${path.basename(req.body.path)}.zip`);
-    archive.pipe(res);
     for (const song of songs) {
       const songPath = path.resolve(playlistParentDir, song);
       // Verify resolved path stays within the library root
@@ -36,11 +33,11 @@ export function setup(mstream) {
         winston.warn(`M3U entry escaped library root: ${song}`);
         continue;
       }
-      archive.file(songPath, { name: path.basename(song) });
+      zipFile.addFile(songPath, path.basename(song));
     }
 
-    archive.file(pathInfo.fullPath, { name: path.basename(pathInfo.fullPath) });
-    archive.finalize();
+    zipFile.addFile(pathInfo.fullPath, path.basename(pathInfo.fullPath));
+    zipFile.end();
   }
 
   mstream.post('/api/v1/download/directory',  (req, res) => {
@@ -55,18 +52,9 @@ export function setup(mstream) {
     const pathInfo = vpath.getVPathInfo(req.body.directory, req.user);
     if (!(await fs.stat(pathInfo.fullPath)).isDirectory()) { throw new Error('Not A Directory'); }
 
-    const archive = archiver('zip');
-    archive.on('error', (err) => {
-      winston.error('Download Error', { stack: err })
-      res.status(500).json({ error: 'Download Error' });
-    });
-
-    res.attachment('mstream-directory.zip');
-
-    archive.pipe(res);
-
-    archive.directory(pathInfo.fullPath, false);
-    archive.finalize();
+    const zipFile = createZipForResponse(res, 'mstream-directory.zip', 'Download Error');
+    await addDirectoryRecursive(zipFile, pathInfo.fullPath);
+    zipFile.end();
   }
 
   mstream.get('/api/v1/download/shared', (req, res) => {
@@ -85,23 +73,13 @@ export function setup(mstream) {
   });
 
   async function download(req, res, fileArray) {
-    const archive = archiver('zip');
-
-    archive.on('error', err => {
-      winston.error('Download Error', { stack: err })
-      res.status(500).json({ error: typeof err === 'string' ? err : 'Unknown Error' });
-    });
-
-    res.attachment(`mstream-playlist.zip`);
-
-    //streaming magic
-    archive.pipe(res);
+    const zipFile = createZipForResponse(res, 'mstream-playlist.zip', 'Download Error');
 
     for(const file of fileArray) {
       try {
         const pathInfo = vpath.getVPathInfo(file, req.user);
         await fs.access(pathInfo.fullPath);
-        archive.file(pathInfo.fullPath, { name: path.basename(file) });
+        zipFile.addFile(pathInfo.fullPath, path.basename(file));
       } catch (err) {
         winston.warn(`Failed to access file ${file} for download, skipping.`);
         winston.warn(err);
@@ -109,6 +87,6 @@ export function setup(mstream) {
       }
     }
 
-    archive.finalize();
+    zipFile.end();
   }
 }

--- a/src/api/remote.js
+++ b/src/api/remote.js
@@ -2,7 +2,7 @@ import url from 'url';
 import path from 'path';
 import fs from 'fs/promises';
 import Joi from 'joi';
-import { nanoid } from 'nanoid';
+import { newId } from '../util/ids.js';
 import jwt from 'jsonwebtoken';
 import { WebSocketServer } from 'ws';
 import winston from 'winston';
@@ -78,7 +78,7 @@ export function setupAfterAuth(mstream, server) {
   }});
 
   wss.on('connection', (connection, req) => {
-    const code = nanoid(8);
+    const code = newId(8);
     winston.info(`Websocket Connection Accepted With Code: ${code}`);
     clients[code] = connection;
 

--- a/src/api/shared.js
+++ b/src/api/shared.js
@@ -1,4 +1,4 @@
-import { nanoid } from 'nanoid';
+import { newId } from '../util/ids.js';
 import jwt from 'jsonwebtoken';
 import path from 'path';
 import fs from 'fs/promises';
@@ -62,7 +62,7 @@ export function setupAfterSecurity(mstream) {
     });
     joiValidate(schema, req.body);
 
-    const shareId = nanoid(10);
+    const shareId = newId(10);
 
     const tokenData = {
       playlistId: shareId,

--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -18,7 +18,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import winston from 'winston';
-import { nanoid } from 'nanoid';
+import { newId } from '../../util/ids.js';
 import jwt from 'jsonwebtoken';
 import * as db from '../../db/manager.js';
 import * as config from '../../state/config.js';
@@ -2086,7 +2086,7 @@ export function createShare(req, res) {
   const hasExpiry = Number.isFinite(expiresMs) && expiresMs > Date.now();
   const expires = hasExpiry ? Math.floor(expiresMs / 1000) : null;
   const description = req.query.description ? String(req.query.description) : null;
-  const shareId = nanoid(10);
+  const shareId = newId(10);
 
   // The webapp share-viewer (src/api/shared.js) verifies this JWT on every
   // lookup — an empty string here would throw "jwt must be provided" and

--- a/src/api/ytdl.js
+++ b/src/api/ytdl.js
@@ -11,7 +11,7 @@ import * as db from '../db/manager.js';
 import { ffmpegBin } from '../util/ffmpeg-bootstrap.js';
 import { parseFile } from 'music-metadata';
 import { Jimp } from 'jimp';
-import mime from 'mime-types';
+import { extFromImageMime } from '../util/image-mime.js';
 import crypto from 'crypto';
 import fs from 'fs/promises';
 
@@ -347,7 +347,7 @@ export function setup(mstream) {
           try {
             const picData = metadata.picture[0].data;
             const picHashString = crypto.createHash('md5').update(picData.toString('utf-8')).digest('hex');
-            const extension = mime.extension(metadata.picture[0].format) || 'jpg';
+            const extension = extFromImageMime(metadata.picture[0].format) || 'jpg';
             data.aaFile = picHashString + '.' + extension;
 
             const aaDir = config.program.storage.albumArtDirectory;
@@ -630,7 +630,7 @@ export function setup(mstream) {
       try {
         const picData = metadata.picture[0].data;
         const picHash = crypto.createHash('md5').update(picData.toString('utf-8')).digest('hex');
-        const extension = mime.extension(metadata.picture[0].format) || 'jpg';
+        const extension = extFromImageMime(metadata.picture[0].format) || 'jpg';
         aaFile = picHash + '.' + extension;
 
         const aaDir = config.program.storage.albumArtDirectory;

--- a/src/db/image-compress-script.js
+++ b/src/db/image-compress-script.js
@@ -2,7 +2,7 @@ import { Jimp } from 'jimp';
 import Joi from 'joi';
 import fs from 'fs/promises';
 import path from 'path';
-import mime from 'mime-types';
+import { isImageExtension } from '../util/image-mime.js';
 
 let loadJson;
 try {
@@ -41,8 +41,7 @@ async function run() {
       filepath = path.join(loadJson.albumArtDirectory, file);
       const stat = await fs.stat(filepath);
       if (stat.isDirectory()) { continue; }
-      const mimeType = mime.lookup(path.extname(file));
-      if (!mimeType.startsWith('image')) { continue; }
+      if (!isImageExtension(path.extname(file))) { continue; }
       if (file.startsWith('zs-') || file.startsWith('zl-') || file.startsWith('zm-')) { continue; }
 
       const img = await Jimp.read(filepath);

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -9,7 +9,7 @@ import path from 'path';
 import crypto from 'crypto';
 import Joi from 'joi';
 import { Jimp } from 'jimp';
-import mime from 'mime-types';
+import { extFromImageMime } from '../util/image-mime.js';
 import { migrateHashReferences as migrateHashRefsShared } from './hash-migration.js';
 import { extractLyrics, sidecarMtime as probeLyricsSidecarMtime } from './lyrics-extraction.js';
 import { computeHashes } from './audio-hash.js';
@@ -211,7 +211,7 @@ async function getAlbumArt(songInfo) {
     const picHashString = crypto.createHash('md5')
       .update(songInfo.picture[0].data.toString('utf-8'))
       .digest('hex');
-    songInfo.aaFile = picHashString + '.' + mime.extension(songInfo.picture[0].format);
+    songInfo.aaFile = picHashString + '.' + (extFromImageMime(songInfo.picture[0].format) || 'jpg');
 
     if (!fs.existsSync(path.join(loadJson.albumArtDirectory, songInfo.aaFile))) {
       fs.writeFileSync(path.join(loadJson.albumArtDirectory, songInfo.aaFile), songInfo.picture[0].data);

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -2,7 +2,7 @@ import child from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import winston from 'winston';
-import { nanoid } from 'nanoid';
+import { newId } from '../util/ids.js';
 import * as config from '../state/config.js';
 import * as db from './manager.js';
 import { addToKillQueue, removeFromKillQueue } from '../state/kill-list.js';
@@ -95,7 +95,7 @@ function findRustParser() {
 // ── Scan task management ────────────────────────────────────────────────────
 
 function addScanTask(vpath, forceRescan = false) {
-  const scanObj = { task: 'scan', vpath: vpath, id: nanoid(8), forceRescan };
+  const scanObj = { task: 'scan', vpath: vpath, id: newId(8), forceRescan };
   if (runningTasks.size < config.program.scanOptions.maxConcurrentTasks) {
     runScan(scanObj);
   } else {

--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,6 @@ import express from 'express';
 import fs from 'fs';
 import path from 'path';
 import Joi from 'joi';
-import cookieParser from 'cookie-parser';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import https from 'https';
@@ -81,7 +80,39 @@ export async function serveIt(configFile) {
   }
 
   // Magic Middleware Things
-  mstream.use(cookieParser());
+  mstream.use((req, _res, next) => {
+    // Cookie parser (replaces the cookie-parser package). Reads the Cookie
+    // header, populates req.cookies. Mirrors cookie-parser's behaviour
+    // closely enough for mStream's JWT-in-cookie auth flow:
+    //   - idempotent (skip if already populated by upstream middleware)
+    //   - null-prototype object (no prototype-pollution surprises if a
+    //     cookie name collides with Object.prototype keys)
+    //   - first-occurrence wins on duplicate names
+    //   - strips matching surrounding double-quotes per RFC 6265
+    //   - URL-decodes only when a percent sign is present
+    //   - falls back to the raw value if decodeURIComponent throws
+    if (!req.cookies) {
+      req.cookies = Object.create(null);
+      const header = req.headers.cookie;
+      if (header) {
+        for (const part of header.split(';')) {
+          const eq = part.indexOf('=');
+          if (eq < 0) continue;
+          const k = part.slice(0, eq).trim();
+          if (!k || k in req.cookies) continue;
+          let v = part.slice(eq + 1).trim();
+          if (v.length >= 2 && v.charCodeAt(0) === 0x22 && v.charCodeAt(v.length - 1) === 0x22) {
+            v = v.slice(1, -1);
+          }
+          if (v.indexOf('%') !== -1) {
+            try { v = decodeURIComponent(v); } catch { /* keep raw */ }
+          }
+          req.cookies[k] = v;
+        }
+      }
+    }
+    next();
+  });
   mstream.use(express.json({ limit: config.program.maxRequestSize }));
   mstream.use(express.urlencoded({ extended: true }));
   mstream.use((req, res, next) => {

--- a/src/state/syncthing.js
+++ b/src/state/syncthing.js
@@ -1,16 +1,16 @@
 import os from 'os';
 import fs from 'fs';
-import { nanoid } from 'nanoid';
+import https from 'node:https';
 import winston from 'winston';
 import path from 'path';
 import { spawn } from 'child_process';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
-import { Agent } from 'undici';
 import kill from 'tree-kill';
 import * as killQueue from './kill-list.js';
 import * as config from './config.js';
 import * as db from '../db/manager.js';
 import { getDirname } from '../util/esm-helpers.js';
+import { newId } from '../util/ids.js';
 
 const __dirname = getDirname(import.meta.url);
 
@@ -195,11 +195,11 @@ function addFoldersToConfig() {
       const key = lib.name;
       const value = { root: lib.root_path };
       if (!xmlFolderMapper[key]) {
-        const newId = nanoid();
-        cacheObj[key] = newId;
+        const folderId = newId();
+        cacheObj[key] = folderId;
 
         xmlObj.configuration.folder.push({
-          '@_id': newId,
+          '@_id': folderId,
           '@_label': key,
           '@_path': value.root,
           '@_type': 'sendreceive',
@@ -258,7 +258,7 @@ export function addDevice(deviceId, directories) {
   if (flag1) {
     xmlObj.configuration.device.push({
       '@_id': deviceId,
-      '@_name': nanoid(),
+      '@_name': newId(),
       '@_compression': 'metadata',
       '@_introducer': 'false',
       '@_skipIntroductionRemovals': 'false',
@@ -378,10 +378,22 @@ function saveIt() {
 
 async function rebootSyncThing() {
   try {
-    await fetch(`https://${xmlObj.configuration.gui.address}/rest/system/restart`, {
-      method: 'POST',
-      headers: { 'X-API-Key': xmlObj.configuration.gui.apikey },
-      dispatcher: new Agent({ connect: { rejectUnauthorized: false } })
+    const u = new URL(`https://${xmlObj.configuration.gui.address}/rest/system/restart`);
+    await new Promise((resolve, reject) => {
+      const req = https.request({
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname,
+        method: 'POST',
+        headers: { 'X-API-Key': xmlObj.configuration.gui.apikey },
+        rejectUnauthorized: false,
+      }, res => {
+        res.resume();
+        res.on('end', resolve);
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.end();
     });
   } catch(err) {
     winston.error('Syncthing Reboot Failed', { stack: err });

--- a/src/util/ids.js
+++ b/src/util/ids.js
@@ -1,0 +1,5 @@
+import { randomBytes } from 'node:crypto';
+
+export function newId(len = 21) {
+  return randomBytes(len).toString('base64url').slice(0, len);
+}

--- a/src/util/image-mime.js
+++ b/src/util/image-mime.js
@@ -1,0 +1,23 @@
+const MIME_TO_EXT = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/bmp': 'bmp',
+  'image/tiff': 'tiff',
+  'image/svg+xml': 'svg',
+};
+
+const IMAGE_EXTS = new Set([
+  '.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.tiff', '.tif', '.svg',
+]);
+
+export function extFromImageMime(mimeStr) {
+  if (typeof mimeStr !== 'string') return null;
+  return MIME_TO_EXT[mimeStr.toLowerCase()] ?? null;
+}
+
+export function isImageExtension(extWithDot) {
+  if (typeof extWithDot !== 'string') return false;
+  return IMAGE_EXTS.has(extWithDot.toLowerCase());
+}

--- a/src/util/m3u.js
+++ b/src/util/m3u.js
@@ -1,17 +1,12 @@
 import fs from 'fs/promises';
-import * as m3u8Parser from 'm3u8-parser';
 
 export async function readPlaylistSongs(filePath) {
   const fileContents = (await fs.readFile(filePath)).toString();
 
-  const parser = new m3u8Parser.Parser();
-  parser.push(fileContents);
-  parser.end();
-
-  let items = parser.manifest.segments.map(segment => { return segment.uri; });
-  if (items.length === 0) {
-    items = fileContents.split(/\r?\n/).filter(Boolean);
-  }
+  const items = fileContents
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith('#'));
 
   return items
     .map(item => item.replace(/\\/g, "/"))

--- a/src/util/zip-stream.js
+++ b/src/util/zip-stream.js
@@ -1,0 +1,27 @@
+import yazl from 'yazl';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import winston from 'winston';
+
+export function createZipForResponse(res, downloadFilename, errorLabel) {
+  res.attachment(downloadFilename);
+  const zipFile = new yazl.ZipFile();
+  zipFile.outputStream.on('error', err => {
+    winston.error(errorLabel, { stack: err });
+    if (!res.headersSent) {
+      res.status(500).json({ error: errorLabel });
+    }
+  });
+  zipFile.outputStream.pipe(res);
+  return zipFile;
+}
+
+export async function addDirectoryRecursive(zipFile, srcDir) {
+  const entries = await fs.readdir(srcDir, { recursive: true, withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const full = path.join(entry.parentPath, entry.name);
+    const rel = path.relative(srcDir, full).replace(/\\/g, '/');
+    zipFile.addFile(full, rel);
+  }
+}

--- a/test/cookie-middleware-parity.test.mjs
+++ b/test/cookie-middleware-parity.test.mjs
@@ -1,0 +1,101 @@
+// Behaviour tests for the inline cookie middleware in src/server.js.
+// We can't import the middleware directly (it's defined inline inside
+// serveIt), so we re-implement the parser as a pure function here. The
+// test cases lock in the behaviour we audited against cookie-parser
+// 1.4.7 for the cases mStream cares about. Any change to the inline
+// middleware should be mirrored in `parseInline` below.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+function parseInline(header) {
+  const cookies = Object.create(null);
+  if (!header) return cookies;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const k = part.slice(0, eq).trim();
+    if (!k || k in cookies) continue;
+    let v = part.slice(eq + 1).trim();
+    if (v.length >= 2 && v.charCodeAt(0) === 0x22 && v.charCodeAt(v.length - 1) === 0x22) {
+      v = v.slice(1, -1);
+    }
+    if (v.indexOf('%') !== -1) {
+      try { v = decodeURIComponent(v); } catch { /* keep raw */ }
+    }
+    cookies[k] = v;
+  }
+  return cookies;
+}
+
+// Each case is [header, expected]. Expected values match cookie-parser
+// 1.4.7's output for the same input, audited against its source on
+// 2026-04-28.
+const cases = [
+  ['empty header',                undefined,                                              {}],
+  ['empty string',                '',                                                     {}],
+  ['single cookie',               'x-access-token=eyJhbGciOiJIUzI1NiJ9.payload.sig',      { 'x-access-token': 'eyJhbGciOiJIUzI1NiJ9.payload.sig' }],
+  ['JWT with == padding',         'token=abc.def.ghi==',                                  { token: 'abc.def.ghi==' }],
+  ['multiple cookies',            'a=1; b=2; c=3',                                        { a: '1', b: '2', c: '3' }],
+  ['extra whitespace + tabs',     '  a = 1 ;\tb=2 ; c =3',                                { a: '1', b: '2', c: '3' }],
+  ['leading semicolon',           ';a=1;b=2',                                             { a: '1', b: '2' }],
+  ['trailing semicolon',          'a=1;b=2;',                                             { a: '1', b: '2' }],
+  ['duplicate key (first wins)',  'a=first; a=second',                                    { a: 'first' }],
+  ['quoted value',                'a="hello"',                                            { a: 'hello' }],
+  ['quoted with spaces',          'a="hello world"',                                      { a: 'hello world' }],
+  ['percent-encoded value',       'a=hello%20world',                                      { a: 'hello world' }],
+  ['no equals',                   'foo',                                                  {}],
+  ['empty value',                 'a=',                                                   { a: '' }],
+  ['equals in value',             'a=b=c=d',                                              { a: 'b=c=d' }],
+  ['plus sign not decoded',       'a=b+c',                                                { a: 'b+c' }],
+  ['dotted cookie name',          'a.b.c=value',                                          { 'a.b.c': 'value' }],
+  ['real JWT cookie',             'x-access-token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InBhdWwiLCJpYXQiOjE3NzczNzc4ODd9.OyNpSiWYHaEPUSIaPfnGbyDM_dB_OKerrUndYJmJU2I',
+                                  { 'x-access-token': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InBhdWwiLCJpYXQiOjE3NzczNzc4ODd9.OyNpSiWYHaEPUSIaPfnGbyDM_dB_OKerrUndYJmJU2I' }],
+  ['empty-name part is skipped', '=orphan;a=1',                                           { a: '1' }],
+];
+
+test('inline cookie middleware: parser cases', async (t) => {
+  for (const [label, header, expected] of cases) {
+    await t.test(label, () => {
+      const got = parseInline(header);
+      const gotKeys = Object.keys(got).sort();
+      const expectedKeys = Object.keys(expected).sort();
+      assert.deepEqual(gotKeys, expectedKeys,
+        `key set: got=${JSON.stringify(gotKeys)} expected=${JSON.stringify(expectedKeys)}`);
+      for (const k of gotKeys) {
+        assert.equal(got[k], expected[k],
+          `value for "${k}": got=${JSON.stringify(got[k])} expected=${JSON.stringify(expected[k])}`);
+      }
+    });
+  }
+});
+
+test('malformed percent-encoding falls back to raw value', () => {
+  // %E0%A4%A is an incomplete UTF-8 sequence; decodeURIComponent throws
+  // URIError. cookie-parser swallows the error and returns the raw
+  // value. Our middleware does the same.
+  const got = parseInline('a=%E0%A4%A');
+  assert.equal(got.a, '%E0%A4%A');
+});
+
+test('null-prototype object: Object.prototype keys not inherited', () => {
+  const cookies = parseInline('a=1');
+  assert.equal(Object.getPrototypeOf(cookies), null);
+  // 'toString' is on Object.prototype but not on a null-proto object,
+  // so it is NOT considered "in cookies" until explicitly set.
+  assert.equal('toString' in cookies, false);
+});
+
+test('cookie name colliding with Object.prototype gets stored normally', () => {
+  // With a plain `{}`, parsing `toString=foo` would have hit the
+  // `k in cookies` guard and silently dropped the cookie because
+  // 'toString' is inherited. Object.create(null) prevents that.
+  const cookies = parseInline('toString=foo');
+  assert.equal(cookies.toString, 'foo');
+});
+
+test('JWT base64url chars survive round-trip', () => {
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJ1IjoicCJ9.A_B-C.signature==';
+  const cookies = parseInline(`x-access-token=${jwt}`);
+  assert.equal(cookies['x-access-token'], jwt);
+});


### PR DESCRIPTION
## Summary

Replace 6 runtime dependencies with small, self-contained equivalents. Because `package.json` builds the Electron app with `asar: false`, every file in `node_modules` ships unpacked into the installer — a smaller dependency graph translates directly to faster downloads and extracts. Net savings: **~6 MB** off the production node_modules tree.

## What changed

| Removed | Replaced with | Saves | Sites |
|---|---|---|---|
| `archiver` | `yazl` + new helper at [`src/util/zip-stream.js`](src/util/zip-stream.js) | ~4.2 MB transitive (archiver-utils, tar-stream, zip-stream, compress-commons, lazystream, readdir-glob, glob, async) | 4 ZIP-producing endpoints |
| `undici` | `node:https.request` | ~1.5 MB | 1 (Syncthing TLS-ignore POST) |
| `m3u8-parser` | inline line parser | ~518 KB | 1 (m3u song extraction) |
| `mime-types` | static map at [`src/util/image-mime.js`](src/util/image-mime.js) | ~250 KB transitive (mime-db) — note: stays as Express transitive | 3 (album art ext lookup) |
| `nanoid` | `crypto.randomBytes` helper at [`src/util/ids.js`](src/util/ids.js) | ~13 KB | 6 (id generation) |
| `cookie-parser` | inline middleware in [`src/server.js`](src/server.js) | ~13 KB | 1 (read-only `x-access-token` cookie) |

## What was kept (and why)

- **`tree-kill`** — handles cross-platform process-tree termination: `taskkill /T /F` on Windows, recursive `pgrep`/`ps` on Unix. Re-implementing this correctly is ~80 lines for 8 KB savings.
- **`command-exists`** — handles input sanitization + file-path-vs-PATH-name detection. Savings (13 KB) too small to justify any replacement.
- **`joi`**, **`winston`**, **`electron-updater`** — discussed; kept.

## Side-effect bug fixes uncovered during the audit

- [`src/util/m3u.js`](src/util/m3u.js): the existing fallback path returned `#EXTM3U` as a track URI when the parser yielded zero segments. Inline parser filters `#`-prefixed lines correctly.
- [`src/db/scanner.mjs`](src/db/scanner.mjs): used to produce filenames like `<hash>.false` when `music-metadata` returned an unrecognized picture format (`mime.extension(...)` returns boolean `false`). Now falls back to `.jpg` like [`src/api/ytdl.js`](src/api/ytdl.js) already did.
- [`src/db/image-compress-script.js`](src/db/image-compress-script.js): existing `mime.lookup(ext).startsWith('image')` could throw `Cannot read property 'startsWith' of false` on unknown extensions. New helper returns a clean boolean.

## Cookie-parser swap: hardening + parity tests

After the initial inline-middleware swap, the audit against `cookie-parser` 1.4.7's source surfaced four small differences worth closing. The middleware now uses:

- `Object.create(null)` for `req.cookies` (no prototype-pollution surprises if a cookie name collides with `Object.prototype` keys like `toString`)
- Idempotency guard (`if (!req.cookies)`) — matches cookie-parser when middleware is mounted twice
- RFC 6265 surrounding-quote stripping (`"value"` → `value`)
- `%`-presence check before `decodeURIComponent` (cheap perf parity)

Behavior is locked in by **24 parity tests** at [`test/cookie-middleware-parity.test.mjs`](test/cookie-middleware-parity.test.mjs) covering empty headers, JWT-with-`==`-padding, multi-cookie headers, whitespace+tabs, leading/trailing semicolons, duplicate keys (first wins), quoted values, percent-encoding, malformed percent-encoding, no-equals, equals-in-value, and Object.prototype-collision names. Each expected value is validated against cookie-parser 1.4.7's audited output.

## Verification

- **`npm test`**: **450/450 pass** (24 new cookie parity tests; baseline 426 unchanged for Subsonic / DLNA / scanner / lyrics / waveform suites)
- **`npm run lint`**: 82 problems before / 82 after — zero new lint issues
- **Live server smoke test** with the worktree's test fixture music:
  - Logged in via `x-access-token` header **and** via cookie — both work
  - `POST /api/v1/download/m3u` → 23 KB ZIP, 3 mp3s + the m3u file ✅
  - `POST /api/v1/download/directory` (flat) → 22 KB, 3 files ✅
  - `POST /api/v1/download/directory` (recursive, 2 subdirs) → 30 KB, 4 files preserving structure ✅
  - `POST /api/v1/download/zip` (file array) → 22 KB ✅
  - `POST /api/v1/download/zip` with UTF-8 filename `café_日本語.mp3` → round-trips correctly ✅
  - `GET /api/v1/admin/logs/download` → valid ZIP ✅
  - All ZIPs pass `zipfile.testzip()` integrity check

## Test plan

- [ ] CI green
- [ ] `npm install` produces a smaller `node_modules` (`archiver`, `undici`, `m3u8-parser`, `nanoid`, `cookie-parser` should be gone from prod tree; `mime-types` stays as Express transitive)
- [ ] Smoke-test downloads against your real library: an album folder, an `.m3u` playlist, a multi-album zip, and `admin/logs/download`
- [ ] Confirm Syncthing reboot still works (the undici → `https.request` swap is the only Syncthing-touching change)
- [ ] Confirm share-link generation produces URL-safe IDs (the `nanoid` → `crypto.randomBytes('base64url')` swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)