### PR TITLE
docs(readme): rewrite to lead with differentiators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mStream Music
 
-mStream is a personal music streaming server.  You can use mStream to stream your music from your home computer to any device, anywhere.
+**The music server that's also a file manager.**
+Drop a file in your folder, upload one through the web UI, or paste a YouTube link — it plays. No accounts to set up, no scan to wait for.
 
 Main|Shared|Admin
 ---|---|---
@@ -14,16 +15,43 @@ Main|Shared|Admin
 
 #### [Website](https://mstream.io)
 
+## Why mStream?
+
+Most self-hosted music servers — Navidrome, Jellyfin, Plex, Airsonic — scan your files into a database and show you *their* version of your library: virtual albums, hidden paths, files invisible until the next index run. Useful, but it means giving up the folder structure you built.
+
+mStream's native API takes the opposite approach. The file browser **is** the music browser. The `/media/<library>/` route streams files directly from disk via `express.static` — no per-request database lookup. Add a file to a watched folder and it's available immediately, on the next page refresh. The same web UI lets you upload, mkdir, rename, and download from YouTube — no SFTP or Docker volume gymnastics required.
+
+|                                  | mStream                 | Navidrome / Jellyfin / Plex |
+|----------------------------------|-------------------------|------------------------------|
+| User account required to start   | Optional (public mode)  | Required                     |
+| Upload via web UI                | Yes (file explorer)     | No (Funkwhale has it)        |
+| YouTube → library                | Yes (yt-dlp wrapper)    | No                           |
+| New file appears in browser      | Immediately             | After scan                   |
+| Folder hierarchy preserved       | Yes                     | Hidden behind virtual library |
+| First-party desktop apps         | Server + Player         | Plex yes; FOSS servers no    |
+| Open source                      | Yes (GPL-3.0)           | Plex no, others yes          |
+
+**Public mode** is the "trusted local network" config: no user accounts required, every client gets full library access. It's the fastest path from `git clone` to playing music — point mStream at a folder, run it, browse, play. Add real users when you actually need them. For wider exposure, the admin API exposes `lockAdmin` to disable all writes server-wide, plus independent `noUpload` / `noMkdir` / `noFileModify` toggles for granular control.
+
+**Polished on both ends.** mStream ships as two distinct desktop apps: **mStream Server**, a tray-resident server with auto-update and boot-on-startup, and **mStream Desktop Player**, a native window for the web UI on machines where you'd rather not have a browser tab open. For headless deployment, the [official LinuxServer.io Docker image](https://github.com/linuxserver/docker-mstream) and `npm install` from source are first-class alternatives.
+
+**The Subsonic API caveat:** third-party Subsonic clients (DSub, Symfonium, Substreamer) require the index to be populated for metadata-driven features — that's a Subsonic protocol limitation, not an mStream limitation. The "drop and play" experience is in the native UI; Subsonic clients still need a scan first.
+
 ### Server Features
-* Cross Platform. Works on Windows, OSX, Linux, & FreeBSD and ARM CPUs
-* Light on memory and CPU
-* Tested on multi-terabyte libraries
-* Metadata parser written in Rust for fast indexing - JS fallback included for maximum compatibility
-* Multi-user accounts with per-library access control
-* DLNA / UPnP server for casting to TVs and stereos
-* [Subsonic / OpenSubsonic API](https://opensubsonic.netlify.app/) — works with DSub, play:Sub, Symfonium, Feishin, Supersonic, and other Subsonic clients
-* On-the-fly transcoding via ffmpeg (opus, mp3, aac)
-* Server-side audio playback for headless boxes (Rust audio engine + CLI fallback)
+* **Folder-faithful library** — files stream from `/media/<library>/` via `express.static`; no per-request database lookup, no scan required to play
+* **Manage music from the music server** — upload, mkdir, rename via the file explorer; download from YouTube via `yt-dlp` integration. The web UI doubles as a file manager
+* **Public mode** — run with no user accounts on a trusted network; configure libraries and start streaming in one command
+* **Granular write permissions** — `lockAdmin` panic-button plus independent `noUpload` / `noMkdir` / `noFileModify` toggles. Tune live from the admin UI
+* **Server runs as a desktop app** — Windows (NSIS) / macOS (DMG) / Linux (AppImage) installers with system tray, auto-update, boot-on-startup. Or use the [official LSIO Docker image](https://github.com/linuxserver/docker-mstream) for headless deployment
+* **mStream Desktop Player** — the mStream UI delivered as a native desktop app on Windows / macOS / Linux instead of a browser tab. Requires a running mStream server (local or remote)
+* **[Subsonic / OpenSubsonic API](https://opensubsonic.netlify.app/)** — works with DSub, play:Sub, Symfonium, Feishin, Supersonic, and other Subsonic clients
+* **Multi-user accounts** with per-library access control (when you need them)
+* **DLNA / UPnP** for casting to TVs and stereos
+* **On-the-fly transcoding** via ffmpeg (opus, mp3, aac)
+* **Server-side audio playback** for headless boxes (Rust audio engine + CLI fallback)
+* **Multi-threaded Rust scanner** — file-level parallelism via rayon, cgroup-aware thread sizing (Docker / k8s CPU quotas honored), backpressured pipeline. Generates 800-bar waveform previews during scan. JS fallback for max compatibility
+* **Cross platform** — Windows, OSX, Linux, FreeBSD, ARM
+* **Light on memory and CPU**, tested on multi-terabyte libraries
 
 ### WebApp Features
 * Gapless Playback


### PR DESCRIPTION
## Summary
- Replace the generic tagline ("personal music streaming server…") with copy that leads with what makes mStream different: folder-faithful native API, file-manager-via-web-UI, public mode, dual desktop apps.
- Insert a new "Why mStream?" section with a comparison table vs Navidrome / Jellyfin / Plex, public-mode safeguard prose, dual-app install story, and an honest Subsonic API caveat.
- Reorder Server Features list so differentiators lead and table-stakes items drop to the bottom. Federation deliberately omitted — partially usable today, will be promoted when v7 rewrite lands.

## Review checklist
- [ ] Load-bearing technical claims accurate:
  - `/media/<library>/` streams via `express.static`, no per-request DB lookup → `src/server.js:303-307`
  - Public mode (no user accounts) → `src/db/manager.js:277` `isPublicMode()`, tested in `test/public-mode-privacy.test.mjs`
  - Granular write toggles (`lockAdmin` / `noUpload` / `noMkdir` / `noFileModify`) → `src/api/auth.js:14`, `src/api/admin.js:459-489`
  - Dual Electron builds → root `package.json` (`io.mstream.server`) + `webapp/package.json` (`io.mstream.desktop`)
- [ ] Comparison table is fair to Navidrome / Jellyfin / Plex / Funkwhale (flag any rows that look wrong or overclaim)
- [ ] Subsonic caveat phrasing OK — intentional honesty that "drop and play" is the native-UI experience; third-party Subsonic clients still need an index first

## Not changed
Screenshots, demo / Discord / website links, mobile apps section, install instructions, technical details, credits. Existing screenshots are stale and need re-shooting as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)