### PR TITLE
build(mac): produce both x64 and arm64 macOS builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,15 @@
       "category": "public.app-category.music",
       "binaries": [
         "bin/syncthing/syncthing-osx"
+      ],
+      "target": [
+        {
+          "target": "default",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ]
     },
     "win": {


### PR DESCRIPTION
## Summary
- macOS-latest GitHub Actions runners switched to Apple Silicon (arm64) sometime in 2024. Because `package.json`'s `mac` config didn't specify `arch`, electron-builder defaulted to host arch — meaning recent releases (including v6.6.0) only shipped `mStream-Server-{version}-arm64.dmg`. Intel Mac users have had no working download.
- Add explicit `mac.target.default` with both `x64` and `arm64` archs so the next release produces:
  - `mStream-Server-{version}-x64.dmg` + zip
  - `mStream-Server-{version}-arm64.dmg` + zip

## Why this works
- Pre-built Rust binaries for both Mac archs already exist in [bin/rust-parser/](bin/rust-parser/) (`rust-parser-darwin-x64` + `-arm64`) and [bin/rust-server-audio/](bin/rust-server-audio/), so the scanner side needs no changes.
- The `bin/rust-parser/rust-parser-darwin-*` glob in `mac.files` will keep both archs in both DMGs (slight overhead — runtime arch selection picks the right one). Slimming this is a follow-up.
- Cross-compilation x64-on-arm64 works fine for pure-JS Electron apps; no native node modules to worry about (we use `node:sqlite` which is bundled with Node).

## Review checklist
- [ ] Confirm a release tag (e.g. `v6.7.0-test`) actually produces both DMG/zip pairs in the GitHub release
- [ ] Confirm the Intel DMG launches on an Intel Mac (or via Rosetta-disabled launch on Apple Silicon)
- [ ] Sanity-check that both rust-parser binaries get bundled and the correct one runs (look for "rust-parser failed, falling back to JS scanner" in logs — should NOT appear on Intel Mac)

## Companion website change
The website's [server download page](https://mstream.io/server) is being updated in a separate PR on `IrosTheBeggar/mstream-website` (branch `claude/mac-builds-and-version-bump`) to bump versions from the stale 5.11.4 → 6.6.0 and add Apple Silicon + Intel Mac rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)