### PR TITLE
Fix garbled non-latin filename of uploaded files

### DIFF
--- a/src/api/file-explorer.js
+++ b/src/api/file-explorer.js
@@ -125,7 +125,7 @@ export function setup(mstream) {
     const bb = busboy({ headers: req.headers });
     bb.on('file', (fieldname, file, info) => {
       // Sanitize filename — strip path separators and traversal sequences
-      const rawName = info.filename || 'upload';
+      const rawName = Buffer.from(info.filename, "latin1").toString("utf8") || 'upload';
       const safeName = path.basename(rawName.replace(/\\/g, '/'));
       if (!safeName || safeName === '.' || safeName === '..') {
         file.resume(); // drain the stream

--- a/src/api/file-explorer.js
+++ b/src/api/file-explorer.js
@@ -122,10 +122,10 @@ export function setup(mstream) {
     const pathInfo = vpath.getVPathInfo(decodeURI(req.headers['data-location']), req.user);
     fsOld.mkdirSync(pathInfo.fullPath, { recursive: true });
 
-    const bb = busboy({ headers: req.headers });
+    const bb = busboy({ headers: req.headers, defParamCharset: 'utf8' });
     bb.on('file', (fieldname, file, info) => {
       // Sanitize filename — strip path separators and traversal sequences
-      const rawName = Buffer.from(info.filename, "latin1").toString("utf8") || 'upload';
+      const rawName = info.filename || 'upload';
       const safeName = path.basename(rawName.replace(/\\/g, '/'));
       if (!safeName || safeName === '.' || safeName === '..') {
         file.resume(); // drain the stream


### PR DESCRIPTION
Filenames with non-latin characters gets garbled when uploaded to mStream. This patch fixes it by recreating the string with utf-8.