### PR TITLE
feat(subsonic): cross-field song search in search3/search2

### DIFF
--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -1354,15 +1354,17 @@ function _ftsAlbumsRowsSubsonic(scope, parsed, limit, offset) {
   `).all(expr, ...scope.params, limit, offset);
 }
 
-// Song match scopes to fts_tracks.{title}. The cross-field denormalised
-// columns (artist_name, album_name) are also indexed by V31; we could
-// expose an unscoped multi-word search here, but the per-category UI
-// in Subsonic clients (artists tab + songs tab + albums tab) means
-// users expect "songs" results to be title-keyed. Cross-field smart
-// search lands in PR3's webapp /api/v1/db/search instead.
+// Song match is cross-field: a query matches a song by its title OR its
+// (denormalised) artist_name / album_name — all three indexed in
+// fts_tracks since V31. This mirrors Navidrome and matches what
+// single-search-box Subsonic clients (Symfonium, DSub, substreamer)
+// expect: searching an artist surfaces that artist's songs. The album
+// *category* of search3 stays name-only for now — cross-entity album
+// matching is the open half of divergences.yaml
+// search3/no-cross-entity-fields.
 function _ftsSongsRowsSubsonic(scope, parsed, limit, offset) {
   const expr = buildFtsExpression({
-    column: 'title',
+    column: ['title', 'artist_name', 'album_name'],
     positive: parsed.positive,
     negative: parsed.negative,
   });
@@ -1444,10 +1446,14 @@ function _likeSongsRowsSubsonic(scope, q, limit, offset) {
     FROM tracks t
     LEFT JOIN artists a  ON a.id = t.artist_id
     LEFT JOIN albums  al ON al.id = t.album_id
-    WHERE ${scope.clause} AND LOWER(t.title) LIKE ?
+    WHERE ${scope.clause} AND (
+      LOWER(t.title) LIKE ?
+      OR LOWER(a.name) LIKE ?
+      OR LOWER(al.name) LIKE ?
+    )
     ORDER BY t.title COLLATE NOCASE
     LIMIT ? OFFSET ?
-  `).all(...scope.params, like, limit, offset);
+  `).all(...scope.params, like, like, like, limit, offset);
 }
 
 export function search3(req, res) {

--- a/src/util/search-query.js
+++ b/src/util/search-query.js
@@ -73,11 +73,13 @@ export function escapeFts(term) {
  * should fall back (LIKE in combo mode, empty in strict mode).
  *
  * Inputs:
- *   column   - optional FTS5 column name. When given, each
- *              positive term is wrapped as `{column} : "term"*`.
- *              Negatives are always unscoped — they exclude rows
- *              that match the term anywhere, which is what users
- *              expect from `-word`.
+ *   column   - optional FTS5 column scope. A string scopes each
+ *              positive term to that one column (`{col} : "term"*`).
+ *              An array scopes to a column-filter SET, matching the
+ *              term in ANY listed column (`{a b c} : "term"*`) — used
+ *              for cross-field song search. Negatives are always
+ *              unscoped — they exclude rows that match the term
+ *              anywhere, which is what users expect from `-word`.
  *   positive - required array of positive terms.
  *   negative - optional array of negative terms (default []).
  *   mode     - 'single' or 'all-words'. Optional; inferred from
@@ -105,8 +107,11 @@ export function buildFtsExpression({ column, positive, negative, mode } = {}) {
 
   const NEG = Array.isArray(negative) ? negative : [];
 
+  // A string scopes to one column; a (non-empty) array scopes to an
+  // FTS5 column-filter set {a b c}, matching the term in ANY of them.
+  const colSet = Array.isArray(column) ? column.join(' ') : column;
   const scoped = (term) =>
-    column ? `{${column}} : "${escapeFts(term)}"*` : `"${escapeFts(term)}"*`;
+    colSet ? `{${colSet}} : "${escapeFts(term)}"*` : `"${escapeFts(term)}"*`;
 
   let expr;
   if (resolvedMode === 'single') {

--- a/test/subsonic/subsonic-search.test.mjs
+++ b/test/subsonic/subsonic-search.test.mjs
@@ -306,6 +306,56 @@ describe('Subsonic search3/search2 with FTS5 (PR3)', () => {
       'empty-listing search3 should also not surface OrphanArtist — parity with named search');
   });
 
+  // ── Cross-field song search (divergences: search3/no-cross-entity-fields, song half) ──
+  //
+  // Songs match on title OR (denormalised) artist_name OR album_name.
+  // Pre-fix, song search was title-only, so an artist/album query
+  // returned 0 songs — the gap vs Navidrome. These pin the new
+  // behaviour; the album *category* stays name-only (see last test).
+
+  test('cross-field: searching an artist name surfaces that artist\'s songs', async () => {
+    // "Floyd" appears in artist "Pink Floyd" but in no song title.
+    // Title-only search would return 0 songs; cross-field returns the
+    // artist's track "Comfortably Numb".
+    const env = await call(server.baseUrl, 'search3', { query: 'Floyd' });
+    assert.equal(env.status, 'ok');
+    const titles = (env.searchResult3.song || []).map(s => s.title);
+    assert.ok(titles.includes('Comfortably Numb'),
+      `expected song "Comfortably Numb" via artist-name match, got ${JSON.stringify(titles)}`);
+  });
+
+  test('cross-field: searching an album name surfaces that album\'s songs', async () => {
+    // "Wall" appears in album "The Wall" but in no song title.
+    const env = await call(server.baseUrl, 'search3', { query: 'Wall' });
+    assert.equal(env.status, 'ok');
+    const titles = (env.searchResult3.song || []).map(s => s.title);
+    assert.ok(titles.includes('Comfortably Numb'),
+      `expected song "Comfortably Numb" via album-name match, got ${JSON.stringify(titles)}`);
+  });
+
+  test('cross-field: plain title search still works (regression)', async () => {
+    // "Numb" is a title token — must still match after the column set widened.
+    const env = await call(server.baseUrl, 'search3', { query: 'Numb' });
+    assert.equal(env.status, 'ok');
+    const titles = (env.searchResult3.song || []).map(s => s.title);
+    assert.ok(titles.includes('Comfortably Numb'),
+      `title search regressed: got ${JSON.stringify(titles)}`);
+  });
+
+  test('album category stays name-only (open half of the divergence)', async () => {
+    // The song side is cross-field now, but the ALBUM category is still
+    // matched by album name only. "Floyd" (artist) must NOT pull in
+    // "The Wall" as an album result — that's the still-deferred half.
+    const env = await call(server.baseUrl, 'search3', { query: 'Floyd' });
+    assert.equal(env.status, 'ok');
+    const albums = (env.searchResult3.album || []).map(a => a.name);
+    assert.equal(albums.includes('The Wall'), false,
+      `album category should still be name-only; got ${JSON.stringify(albums)}`);
+    // Sanity: the artist itself still surfaces in the artist category.
+    assert.ok((env.searchResult3.artist || []).some(a => a.name === 'Pink Floyd'),
+      'artist "Pink Floyd" should still surface in the artist category');
+  });
+
   // ── Empty-query semantics: search3 vs search2 ─────────────────────
 
   test("search3 empty query returns paginated listing (OpenSubsonic 'A blank query will return everything')", async () => {


### PR DESCRIPTION
## What

Make Subsonic `search3` / `search2` **cross-reference artist and album names into the song results**. Searching an artist (or album) name now surfaces that artist's songs — instead of returning the artist but **zero songs**.

Before:
```
search3?query=Beatles  ->  artist: The Beatles | albums: 0 | songs: 0
```
After (matches Navidrome's song behavior):
```
search3?query=Beatles  ->  artist: The Beatles | albums: 0 | songs: 5
```

## Why

Songs were matched **title-only**. But virtually every Subsonic client (Symfonium, DSub, substreamer, …) is written and tested against Navidrome, which cross-references — so a single-search-box client that searches an artist and gets an empty Songs tab reads as broken. The prior title-only choice optimized for a per-category-tab mental model that real clients don't actually impose.

## How

- The denormalised `artist_name` / `album_name` columns are **already indexed in `fts_tracks`** (since V31), so the FTS path just widens the column scope from `{title}` to the column-filter set `{title artist_name album_name}`. The LIKE fallback gains matching `OR` clauses on artist + album name.
- `buildFtsExpression` (`src/util/search-query.js`) now accepts an **array** `column` → FTS5 column-filter set. This is **additive**: every existing string caller (artists, albums, webapp title/filepath search) is byte-for-byte unchanged.
- `search2` shares the same payload builder, so it inherits the fix.

## Scope / what's deliberately *not* here

The **album category** of `search3` stays name-only. Cross-entity album matching needs either a schema migration (`fts_albums.artist_name`) or a query-side orchestration change — tracked as the open half of the `subsonic-conformance` divergence `search3/no-cross-entity-fields`. This PR is the low-risk song half only.

## Testing

- `test/subsonic-search.test.mjs`: **+4 tests** — artist→songs, album→songs, plain-title regression, and album-category-stays-name-only.
- `test/search-query-parser.test.mjs` (32), `test/search-route.test.mjs` (14), FTS5 schema/backfill/trigger suites: all green — no regression to the shared util or the webapp `/api/v1/db/search`.
- **subsonic-conformance harness** (vs Navidrome 0.55.2): song-side cross-server set now matches; album side still asserts the remaining divergence. Verified through the harness's own client **and** the real `subsonic-api` (JS) + `opensubsonic_api` (Dart) libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
