### PR TITLE
fix(velvet): throttle queue position-sync to 60s + harden settings endpoint

### DIFF
--- a/src/api/user-settings.js
+++ b/src/api/user-settings.js
@@ -2,6 +2,7 @@
 // Stores key-value pairs in user_settings table.
 // Also handles queue save/restore for session continuity.
 
+import winston from 'winston';
 import * as db from '../db/manager.js';
 
 const d = () => db.getDB();
@@ -26,7 +27,7 @@ export function setup(mstream) {
     let queue = null;
     for (const row of rows) {
       if (row.key === '__queue__') {
-        try { queue = JSON.parse(row.value); } catch (_) {}
+        try { queue = JSON.parse(row.value); } catch (_) { /* corrupt queue JSON — ignore */ }
       } else {
         prefs[row.key] = row.value;
       }
@@ -43,25 +44,40 @@ export function setup(mstream) {
 
     const { prefs, queue } = req.body;
 
-    const upsert = d().prepare(`
-      INSERT INTO user_settings (user_id, key, value)
-      VALUES (?, ?, ?)
-      ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value
-    `);
+    try {
+      const upsert = d().prepare(`
+        INSERT INTO user_settings (user_id, key, value)
+        VALUES (?, ?, ?)
+        ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value
+      `);
 
-    // Save preferences (individual upserts — no explicit transaction needed)
-    if (prefs && typeof prefs === 'object') {
-      for (const [key, value] of Object.entries(prefs)) {
-        if (key === '__queue__') continue; // reserved key
-        upsert.run(req.user.id, key, value != null ? String(value) : null);
+      // Save preferences (individual upserts — no explicit transaction needed)
+      if (prefs && typeof prefs === 'object') {
+        for (const [key, value] of Object.entries(prefs)) {
+          if (key === '__queue__') continue; // reserved key
+          upsert.run(req.user.id, key, value != null ? String(value) : null);
+        }
       }
-    }
 
-    // Save queue state
-    if (queue && typeof queue === 'object') {
-      upsert.run(req.user.id, '__queue__', JSON.stringify(queue));
-    }
+      // Save queue state
+      if (queue && typeof queue === 'object') {
+        upsert.run(req.user.id, '__queue__', JSON.stringify(queue));
+      }
 
-    res.json({ ok: true });
+      res.json({ ok: true });
+    } catch (err) {
+      // node:sqlite writes are synchronous and serialise against the
+      // scanner's single SQLite writer. Under sustained scan load a write
+      // can exceed busy_timeout (5s) and throw SQLITE_BUSY. This endpoint
+      // is best-effort — the velvet client re-syncs the queue on its next
+      // tick — so degrade to a soft 503 instead of letting the throw
+      // bubble up to a 500. SQLITE_BUSY / "database is locked" is the
+      // expected transient and is not logged; anything else is surfaced.
+      const msg = String(err?.message || err);
+      if (!/SQLITE_BUSY|database is locked/i.test(msg)) {
+        winston.warn(`Failed to save user settings for user ${req.user.id}: ${msg}`);
+      }
+      res.status(503).json({ ok: false, error: 'settings store busy' });
+    }
   });
 }

--- a/webapp/velvet/app.js
+++ b/webapp/velvet/app.js
@@ -12701,8 +12701,13 @@ function _onAudioSeeked() {
   _seekSyncTimer = setTimeout(() => _syncQueueToDb(), 1000);
 }
 
-// Periodic position-only DB sync every 60 s during playback — keeps the
-// position reasonably fresh for cross-device resume without hammering the DB.
+// Periodic queue/position DB sync during playback — keeps the saved
+// position reasonably fresh for cross-device resume. Deliberately 60 s,
+// NOT faster: each tick is a synchronous SQLite write that serialises
+// against the scanner's single writer, so a tighter cadence stalls the
+// server's event loop under scan load (was 15 s, which did exactly that).
+// localStorage is mirrored far more often via the 5 s timeupdate persist;
+// this is only the cross-device DB copy.
 let _positionSyncInterval = null;
 function _startPositionSync() {
   if (_positionSyncInterval) return;
@@ -12720,7 +12725,7 @@ function _startPositionSync() {
         .then(() => localStorage.setItem('ms2_settings_pushed_' + S.username, new Date().toISOString()))
         .catch(() => {});
     }
-  }, 15000);
+  }, 60000);
 }
 function _stopPositionSync() {
   clearInterval(_positionSyncInterval);


### PR DESCRIPTION
## Symptom

A user reported the `__queue__` entry in `user_settings` being saved **every 15 seconds**, causing issues during library scans.

## Root cause

The velvet player's `_startPositionSync` ([`webapp/velvet/app.js`](webapp/velvet/app.js)) runs a `setInterval` whose own comment says *"every 60 s"* but whose value is `15000`. During playback it POSTs the **entire** play queue into `user_settings.__queue__` on every tick. It's been 15 s since velvet was first added (commit `b24fdd2e`) — the `15000` is the bug, the `60 s` comment is the intent. (This is velvet-only; the default `alpha` UI has no periodic queue→DB sync.)

Why that hurts scans: the save is stored by a **synchronous** `node:sqlite` write ([`user-settings.js`](src/api/user-settings.js) → `upsert.run()` on the main `DatabaseSync` connection, `busy_timeout = 5000`). SQLite WAL allows many readers but only one **writer**, and the scanner is a writer. While the scanner holds the write lock, the queue upsert:

- can't proceed, and because the write is synchronous it **blocks the entire Node event loop** for up to `busy_timeout` (5 s) — stalling *all* HTTP/streaming, not just this request;
- at a 15 s cadence that's up to ~4 stall windows/minute for the whole scan;
- if it ever exceeds 5 s it throws `SQLITE_BUSY`, and the handler had **no try/catch**, so it 500s (the client silently `.catch()`es it).

## Fix

1. **`webapp/velvet/app.js`** — interval `15000 → 60000` to match the documented intent (4× fewer DB writes during playback), plus a comment explaining why the cadence must not be lowered again.
2. **`src/api/user-settings.js`** — wrap the POST upserts in `try/catch`: a transient `SQLITE_BUSY` under scan load now degrades to a soft `503` (the client re-syncs on its next tick) instead of an unhandled `500`. `SQLITE_BUSY`/"database is locked" is treated as the expected transient and not logged; anything else is surfaced via `winston.warn`. Also annotated the pre-existing empty `catch` in the GET handler, clearing the file's lone lint error.

## Notes
- Scoped to the velvet UI + the settings endpoint; the scanner and `task-queue` are untouched.
- No automated test added: the velvet change is a browser-side interval constant (no e2e harness), and `user-settings.js` has no existing test scaffold. Validated with `node --check` (both files) and `eslint` (clean, 0 errors on the changed server file).
- Deliberately did **not** add a "pause sync while scanning" client check (the heavier option) — 60 s + the endpoint guard resolves the reported contention without coupling the player to scan state. Easy follow-up if it's still noticeable on very long scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
