### PR TITLE
fix(ffmpeg): harden management subsystem (full audit + smoke-tested)

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -659,6 +659,16 @@ export function setup(mstream) {
 
   // default-algorithm endpoint removed — streaming is now the only mode
 
+  mstream.post("/api/v1/admin/transcode/auto-update", async (req, res) => {
+    const schema = Joi.object({
+      autoUpdate: Joi.boolean().required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editAutoUpdate(req.body.autoUpdate);
+    res.json({});
+  });
+
   mstream.post("/api/v1/admin/transcode/download", async (req, res) => {
     await transcode.downloadedFFmpeg();
     res.json({});

--- a/src/api/album-art.js
+++ b/src/api/album-art.js
@@ -160,16 +160,19 @@ export async function embedArtInFile(audioFilePath, imgBuf) {
   const tmpImg = audioFilePath + '.cover.jpg';
   const tmpOut = audioFilePath + '.tmp_art';
 
+  // Map only the source AUDIO streams (`0:a`) + the new cover (`1:0`) — never
+  // `-map 0`, which also copies any existing embedded cover and stacks a
+  // duplicate art stream on every re-tag.
   let args;
   if (ext === '.mp3') {
     args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
             '-c', 'copy', '-id3v2_version', '3',
             '-metadata:s:v', 'title=Album cover', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
   } else if (ext === '.flac') {
-    args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0', '-map', '1:0',
+    args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
             '-c', 'copy', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
   } else if (ext === '.m4a' || ext === '.aac' || ext === '.m4b') {
-    args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0', '-map', '1:0',
+    args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
             '-c', 'copy', '-disposition:v:0', 'attached_pic', tmpOut];
   } else {
     return; // unsupported container — nothing to embed

--- a/src/api/album-art.js
+++ b/src/api/album-art.js
@@ -158,19 +158,27 @@ export async function embedArtInFile(audioFilePath, imgBuf) {
 
   const ext = path.extname(audioFilePath).toLowerCase();
   const tmpImg = audioFilePath + '.cover.jpg';
-  const tmpOut = audioFilePath + '.tmp_art';
+  // Keep the real extension on the temp output — ffmpeg infers the output
+  // container from it. A bare `.tmp_art` fails with "Unable to choose an
+  // output format", which silently broke art-embedding for every format.
+  const tmpOut = audioFilePath + '.tmp_art' + ext;
 
-  // Map only the source AUDIO streams (`0:a`) + the new cover (`1:0`) — never
-  // `-map 0`, which also copies any existing embedded cover and stacks a
-  // duplicate art stream on every re-tag.
+  // Map only the source AUDIO streams (`0:a`) + the new cover (`1:0`). Using
+  // `-map 0` would also carry over any existing embedded cover, which then
+  // collides with the new one — a hard mux error on M4A ("two mjpeg streams")
+  // or stale, unreplaced art on FLAC. `0:a` drops the old cover so the new one
+  // cleanly replaces it.
   let args;
   if (ext === '.mp3') {
     args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
             '-c', 'copy', '-id3v2_version', '3',
             '-metadata:s:v', 'title=Album cover', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
   } else if (ext === '.flac') {
+    // `-disposition:v:0 attached_pic` is REQUIRED for FLAC — without it the
+    // FLAC muxer drops the mapped image (writes 0 bytes of picture data) and
+    // the cover silently never lands.
     args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
-            '-c', 'copy', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
+            '-c', 'copy', '-disposition:v:0', 'attached_pic', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
   } else if (ext === '.m4a' || ext === '.aac' || ext === '.m4b') {
     args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
             '-c', 'copy', '-disposition:v:0', 'attached_pic', tmpOut];

--- a/src/api/album-art.js
+++ b/src/api/album-art.js
@@ -147,55 +147,51 @@ export async function saveImageToCache(imgBuf, albumArtDir) {
   return filename;
 }
 
-export function embedArtInFile(audioFilePath, imgBuf) {
-  return new Promise(async (resolve, reject) => {
-    const ffmpeg = ffmpegBin();
-    if (!ffmpeg) { return resolve(); }
-    // Only verify existence for absolute paths. When ffmpegBin() returns a
-    // bare command name (system-PATH fallback), leave the check to spawn().
-    if (path.isAbsolute(ffmpeg)) {
-      try { await fsp.access(ffmpeg); } catch { return resolve(); }
-    }
+export async function embedArtInFile(audioFilePath, imgBuf) {
+  const ffmpeg = ffmpegBin();
+  if (!ffmpeg) { return; }
+  // Only verify existence for absolute paths. When ffmpegBin() returns a
+  // bare command name (system-PATH fallback), leave the check to spawn().
+  if (path.isAbsolute(ffmpeg)) {
+    try { await fsp.access(ffmpeg); } catch { return; }
+  }
 
-    const tmpImg = audioFilePath + '.cover.jpg';
-    const tmpOut = audioFilePath + '.tmp_art';
-    await fsp.writeFile(tmpImg, imgBuf);
+  const ext = path.extname(audioFilePath).toLowerCase();
+  const tmpImg = audioFilePath + '.cover.jpg';
+  const tmpOut = audioFilePath + '.tmp_art';
 
-    const ext = path.extname(audioFilePath).toLowerCase();
-    let args;
+  let args;
+  if (ext === '.mp3') {
+    args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
+            '-c', 'copy', '-id3v2_version', '3',
+            '-metadata:s:v', 'title=Album cover', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
+  } else if (ext === '.flac') {
+    args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0', '-map', '1:0',
+            '-c', 'copy', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
+  } else if (ext === '.m4a' || ext === '.aac' || ext === '.m4b') {
+    args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0', '-map', '1:0',
+            '-c', 'copy', '-disposition:v:0', 'attached_pic', tmpOut];
+  } else {
+    return; // unsupported container — nothing to embed
+  }
 
-    if (ext === '.mp3') {
-      args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0:a', '-map', '1:0',
-              '-c', 'copy', '-id3v2_version', '3',
-              '-metadata:s:v', 'title=Album cover', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
-    } else if (ext === '.flac') {
-      args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0', '-map', '1:0',
-              '-c', 'copy', '-metadata:s:v', 'comment=Cover (front)', tmpOut];
-    } else if (ext === '.m4a' || ext === '.aac' || ext === '.m4b') {
-      args = ['-y', '-i', audioFilePath, '-i', tmpImg, '-map', '0', '-map', '1:0',
-              '-c', 'copy', '-disposition:v:0', 'attached_pic', tmpOut];
-    } else {
-      await fsp.unlink(tmpImg).catch(() => {});
-      return resolve();
-    }
-
-    const proc = spawn(ffmpeg, args, { stdio: ['ignore', 'ignore', 'pipe'] });
-    proc.on('close', async (code) => {
-      await fsp.unlink(tmpImg).catch(() => {});
-      if (code === 0) {
-        await fsp.rename(tmpOut, audioFilePath).catch(() => {});
-        resolve();
-      } else {
-        await fsp.unlink(tmpOut).catch(() => {});
-        reject(new Error('ffmpeg embed failed'));
-      }
+  // NOTE: plain async function, NOT `new Promise(async …)`. With an async
+  // executor a throw from writeFile/spawn rejects the executor's inner
+  // promise, never the constructed one, so the caller's `await` hangs forever
+  // and leaks the temp files. Here every failure rejects normally and the
+  // `finally` guarantees cleanup.
+  await fsp.writeFile(tmpImg, imgBuf);
+  try {
+    await new Promise((resolve, reject) => {
+      const proc = spawn(ffmpeg, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      proc.on('error', () => reject(new Error('ffmpeg spawn failed')));
+      proc.on('close', (code) => code === 0 ? resolve() : reject(new Error('ffmpeg embed failed')));
     });
-    proc.on('error', async () => {
-      await fsp.unlink(tmpImg).catch(() => {});
-      await fsp.unlink(tmpOut).catch(() => {});
-      reject(new Error('ffmpeg spawn failed'));
-    });
-  });
+    await fsp.rename(tmpOut, audioFilePath);
+  } finally {
+    await fsp.unlink(tmpImg).catch(() => {});
+    await fsp.unlink(tmpOut).catch(() => {}); // no-op on success (renamed away)
+  }
 }
 
 // ── API setup ───────────────────────────────────────────────────────────────

--- a/src/api/db.js
+++ b/src/api/db.js
@@ -22,6 +22,10 @@ export function renderMetadataObj(row) {
       track: row.track_number || null,
       disk: row.disc_number || null,
       title: row.title || null,
+      // Track length in seconds. The webapp player uses this for the progress
+      // bar and to map a seek-bar click to a time offset — a chunked transcode
+      // stream gives the browser no usable audio.duration to work from.
+      duration: row.duration ?? null,
       year: row.year || null,
       'album-art': row.album_art_file || null,
       rating: row.rating || null,

--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -24,7 +24,7 @@ import * as db from '../../db/manager.js';
 import * as config from '../../state/config.js';
 import * as dbQueue from '../../db/task-queue.js';
 import * as adminUtil from '../../util/admin.js';
-import { ffmpegBin } from '../../util/ffmpeg-bootstrap.js';
+import { ffmpegBin, getResolvedSource } from '../../util/ffmpeg-bootstrap.js';
 import { serveAlbumArtFile } from '../album-art.js';
 import * as serverPlayback from '../server-playback.js';
 import { sendOk, sendError, SubErr } from './response.js';
@@ -908,6 +908,14 @@ function streamTranscoded(req, res, track, codec, bitrateK, timeOffsetSec, estim
     // Don't spawn ffmpeg for a probe — headers-only response is the contract.
     res.status(200).set(headers).end();
     return;
+  }
+
+  // ffmpeg may not have resolved (download failed, no system binary). Without
+  // this, spawn(ffmpegBin()=null) throws a generic TypeError caught as a 500;
+  // a 503 is the honest "unavailable" signal, matching the DLNA/waveform paths.
+  if (!getResolvedSource()) {
+    winston.warn('[subsonic] stream: ffmpeg unavailable');
+    return res.status(503).end();
   }
 
   let ff;

--- a/src/api/transcode.js
+++ b/src/api/transcode.js
@@ -28,16 +28,38 @@ export function getTransCodecs() { return Object.keys(codecMap); }
 let lockInit = false;
 let ffmpegPath = null;
 
+// Background retry for transient boot-time resolution failures (e.g. a brief
+// network blip during the first download). Without this, ffmpeg stays disabled
+// until the next reboot or a manual admin trigger. Bounded so a host that
+// genuinely has no ffmpeg available doesn't retry (and log) forever.
+let retryTimer = null;
+let retryCount = 0;
+const RETRY_DELAY_MS = 5 * 60 * 1000; // 5 minutes between attempts
+const MAX_RETRIES = 6;                // ~30 min, then defer to manual trigger
+
+function scheduleRetry() {
+  if (retryTimer || retryCount >= MAX_RETRIES) { return; }
+  retryCount++;
+  retryTimer = setTimeout(() => {
+    retryTimer = null;
+    winston.info(`Retrying ffmpeg setup (attempt ${retryCount}/${MAX_RETRIES})...`);
+    init().catch(err => winston.error('FFmpeg retry failed', { stack: err }));
+  }, RETRY_DELAY_MS);
+  if (retryTimer.unref) { retryTimer.unref(); }
+}
+
 async function init() {
   winston.info('Checking ffmpeg...');
   await ensureFfmpeg();
 
   // If the resolver found nothing (no bundled binary, no download, no system
-  // PATH fallback), leave lockInit false and return. Downstream consumers
-  // (transcode route, album-art embedding, waveforms, ytdl) will degrade
-  // gracefully. The resolver already logged a detailed error.
+  // PATH fallback), leave lockInit false. Downstream consumers (transcode
+  // route, album-art embedding, waveforms, ytdl) degrade gracefully. The
+  // resolver already logged a detailed error; schedule a retry in case the
+  // failure was transient (ensureFfmpeg no longer caches a failed result).
   if (!getResolvedSource()) {
     winston.warn('FFmpeg unavailable — transcoding, album-art embedding, waveforms, and yt-dlp will be disabled');
+    scheduleRetry();
     return;
   }
 
@@ -55,6 +77,9 @@ async function init() {
     }
   }
 
+  // Resolved — cancel any pending retry and reset the attempt counter.
+  if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
+  retryCount = 0;
   lockInit = true;
   winston.info('FFmpeg OK!');
   startAutoUpdate();
@@ -63,10 +88,17 @@ async function init() {
 export function reset() {
   lockInit = false;
   ffmpegPath = null;
+  if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
+  retryCount = 0;
   stopAutoUpdate();
   resetBootstrap();
 }
 
+/**
+ * True once ffmpeg has been resolved and is ready to use — from ANY source
+ * (a binary we downloaded/manage, OR system ffmpeg on PATH), not strictly
+ * "downloaded". Name retained for backwards compatibility with callers.
+ */
 export function isDownloaded() {
   return lockInit;
 }
@@ -128,7 +160,9 @@ function spawnTranscode(inputPath, codec, bitrate) {
     stdio: ['ignore', 'pipe', 'pipe']
   });
 
-  proc.stderr.on('data', () => {}); // suppress ffmpeg stderr
+  // Surface ffmpeg diagnostics at debug level rather than black-holing them —
+  // a fully-suppressed stderr makes transcode failures impossible to debug.
+  proc.stderr.on('data', d => winston.debug(`[transcode] ${d.toString().trim()}`));
 
   proc.on('error', err => {
     winston.error('Transcoding spawn error', { stack: err });
@@ -165,8 +199,9 @@ export function setup(mstream) {
     // ── Cache hit ────────────────────────────────────────────
     const cached = cacheGet(cacheKey);
     if (cached) {
+      // No Accept-Ranges: this route doesn't honor Range requests, so don't
+      // advertise byte-range seeking we can't actually serve.
       res.header({
-        'Accept-Ranges': 'bytes',
         'Content-Type': codecMap[codec].contentType,
         'Content-Length': cached.contentLength
       });
@@ -190,10 +225,13 @@ export function setup(mstream) {
       : 0;
 
     // ── Set headers ──────────────────────────────────────────
+    // Content-Length here is a best-effort estimate (duration × bitrate) so
+    // clients can render a progress bar — the true size is only known once the
+    // transcode finishes. No Accept-Ranges: a live transcode isn't byte-range
+    // seekable, and advertising it just invites Range requests we'd ignore.
     const headers = { 'Content-Type': codecMap[codec].contentType };
     if (estimatedBytes > 0) {
       headers['Content-Length'] = estimatedBytes;
-      headers['Accept-Ranges'] = 'bytes';
     }
     res.header(headers);
 

--- a/src/api/transcode.js
+++ b/src/api/transcode.js
@@ -3,7 +3,6 @@ import { Readable } from 'stream';
 import winston from 'winston';
 import * as vpath from '../util/vpath.js';
 import * as config from '../state/config.js';
-import * as db from '../db/manager.js';
 import path from 'node:path';
 import {
   ensureFfmpeg,
@@ -209,31 +208,15 @@ export function setup(mstream) {
       return;
     }
 
-    // ── Look up duration for Content-Length estimate ──────────
-    const lib = db.getLibraryByName(pathInfo.vpath);
-    let duration = 0;
-    if (lib) {
-      const track = db.getDB()?.prepare(
-        'SELECT duration FROM tracks WHERE filepath = ? AND library_id = ?'
-      ).get(pathInfo.relativePath, lib.id);
-      duration = track?.duration || 0;
-    }
-
-    const bitrateNum = parseInt(bitrate) * 1000; // '96k' → 96000
-    const estimatedBytes = duration > 0
-      ? Math.ceil(duration * bitrateNum / 8 * 1.05) // 5% container overhead
-      : 0;
-
     // ── Set headers ──────────────────────────────────────────
-    // Content-Length here is a best-effort estimate (duration × bitrate) so
-    // clients can render a progress bar — the true size is only known once the
-    // transcode finishes. No Accept-Ranges: a live transcode isn't byte-range
-    // seekable, and advertising it just invites Range requests we'd ignore.
-    const headers = { 'Content-Type': codecMap[codec].contentType };
-    if (estimatedBytes > 0) {
-      headers['Content-Length'] = estimatedBytes;
-    }
-    res.header(headers);
+    // No Content-Length and no Accept-Ranges on the live path: the true size
+    // isn't known until the transcode finishes, and a *guessed* length is
+    // actively harmful — an over-estimate makes strict HTTP clients (undici/
+    // fetch, some mobile players) abort with "closed before N bytes" when the
+    // real, shorter stream ends. Stream chunked instead; the cache-hit path
+    // above serves the exact length once known, and players show progress from
+    // their own track-duration metadata.
+    res.header({ 'Content-Type': codecMap[codec].contentType });
 
     // ── Stream + collect for cache ───────────────────────────
     const proc = spawnTranscode(pathInfo.fullPath, codec, bitrate);

--- a/src/api/transcode.js
+++ b/src/api/transcode.js
@@ -76,27 +76,39 @@ export async function downloadedFFmpeg() {
 }
 
 // ── Transcode cache ─────────────────────────────────────────────────────────
-// Two-phase: strong reference for (song length + 2 min), then moved to weak.
-// Only one copy in memory at a time. GC can reclaim weak entries under pressure.
+// Bounded LRU keyed by `${fullPath}|${bitrate}|${codec}`. Map iteration order
+// is insertion order, so the first key is the least-recently-used; get()
+// refreshes recency by re-inserting. Capped by BOTH entry count and total
+// bytes so a burst of concurrent transcodes can't grow memory without bound.
+// (The previous strong-ref-then-WeakRef scheme had no ceiling on how many
+// strong entries co-existed, and never pruned its weak-ref keys.)
 
-const strongRefs = new Map();
-const weakRefs = {};
+const CACHE_MAX_ENTRIES = 64;
+const CACHE_MAX_BYTES = 256 * 1024 * 1024; // 256 MB total
+const cache = new Map();
+let cacheBytes = 0;
 
 function cacheGet(key) {
-  const strong = strongRefs.get(key);
-  if (strong) return strong;
-  const weak = weakRefs[key]?.deref();
-  if (!weak) delete weakRefs[key];
-  return weak || null;
+  const entry = cache.get(key);
+  if (!entry) { return null; }
+  cache.delete(key);
+  cache.set(key, entry); // move to most-recently-used
+  return entry;
 }
 
-function cacheSet(key, entry, durationSec) {
-  strongRefs.set(key, entry);
-  const holdMs = (durationSec * 1000) + 120000; // song length + 2 minutes
-  setTimeout(() => {
-    strongRefs.delete(key);
-    weakRefs[key] = new WeakRef(entry);
-  }, holdMs);
+function cacheSet(key, entry) {
+  // Don't evict the whole cache to hold one oversized item.
+  if (entry.contentLength > CACHE_MAX_BYTES) { return; }
+  const prev = cache.get(key);
+  if (prev) { cacheBytes -= prev.contentLength; cache.delete(key); }
+  cache.set(key, entry);
+  cacheBytes += entry.contentLength;
+  while (cache.size > CACHE_MAX_ENTRIES || cacheBytes > CACHE_MAX_BYTES) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined || oldestKey === key) { break; }
+    cacheBytes -= cache.get(oldestKey).contentLength;
+    cache.delete(oldestKey);
+  }
 }
 
 // ── Spawn ffmpeg ────────────────────────────────────────────────────────────
@@ -189,6 +201,11 @@ export function setup(mstream) {
     const proc = spawnTranscode(pathInfo.fullPath, codec, bitrate);
     const bufs = [];
     let contentLength = 0;
+    // Set when the client disconnects (and we SIGTERM ffmpeg as a result). The
+    // collected buffer is then a TRUNCATED prefix of the song and must never be
+    // cached — otherwise the next listener requesting the same track is served
+    // the short version. Skipping a track mid-play is the common trigger.
+    let aborted = false;
 
     proc.stdout.on('data', chunk => {
       bufs.push(chunk);
@@ -199,18 +216,25 @@ export function setup(mstream) {
     proc.stdout.pipe(res);
 
     proc.on('close', code => {
-      if (code !== 0 && code !== null) {
-        winston.error(`FFmpeg exited with code ${code} for ${pathInfo.fullPath}`);
+      // Cache ONLY a clean, complete transcode. A SIGTERM kill reports
+      // code === null and an ffmpeg failure reports a non-zero code; both mean
+      // the output is partial, so cache nothing.
+      if (aborted || code !== 0) {
+        if (code !== 0 && code !== null) {
+          winston.error(`FFmpeg exited with code ${code} for ${pathInfo.fullPath}`);
+        }
         return;
       }
-      // Cache the result — strong for song length + 2 min, then weak
       if (contentLength > 0) {
-        cacheSet(cacheKey, { contentLength, bufs }, duration);
+        cacheSet(cacheKey, { contentLength, bufs });
       }
     });
 
     // Kill ffmpeg if client disconnects mid-stream
     res.on('close', () => {
+      // writableFinished is true only when the full response flushed normally;
+      // if not, the client bailed early and the transcode is incomplete.
+      if (!res.writableFinished) { aborted = true; }
       if (!proc.killed) {
         proc.kill('SIGTERM');
       }

--- a/src/api/transcode.js
+++ b/src/api/transcode.js
@@ -144,16 +144,21 @@ function cacheSet(key, entry) {
 
 // ── Spawn ffmpeg ────────────────────────────────────────────────────────────
 
-function spawnTranscode(inputPath, codec, bitrate) {
+function spawnTranscode(inputPath, codec, bitrate, offsetSec = 0) {
   const entry = codecMap[codec];
-  const args = [
+  const args = [];
+  // Input seek (`-ss` before `-i`): fast, keyframe-aligned — good enough for
+  // lossy transcode targets where sample-accurate seek doesn't matter. Mirrors
+  // the DLNA time-seek and Subsonic stream paths.
+  if (offsetSec > 0) { args.push('-ss', offsetSec.toFixed(3)); }
+  args.push(
     '-i', inputPath,
     '-vn',                          // no video
     '-f', entry.format,             // output container format
     '-acodec', entry.codec,         // audio codec
     '-ab', bitrate,                 // audio bitrate
     'pipe:1'                        // output to stdout
-  ];
+  );
 
   const proc = spawn(ffmpegPath, args, {
     stdio: ['ignore', 'pipe', 'pipe']
@@ -193,10 +198,16 @@ export function setup(mstream) {
       : req.params.filepath;
     const pathInfo = vpath.getVPathInfo(filepath, req.user);
 
+    // Seek offset in seconds (?offset=). A seek re-transcodes from `-ss`, so it
+    // bypasses the cache entirely — caching every scrub position would thrash
+    // it, and only the from-start stream is worth reusing across plays.
+    const offset = parseFloat(req.query.offset);
+    const offsetSec = Number.isFinite(offset) && offset > 0 ? offset : 0;
+
     const cacheKey = `${pathInfo.fullPath}|${bitrate}|${codec}`;
 
-    // ── Cache hit ────────────────────────────────────────────
-    const cached = cacheGet(cacheKey);
+    // ── Cache hit (from-start streams only) ──────────────────
+    const cached = offsetSec === 0 ? cacheGet(cacheKey) : null;
     if (cached) {
       // No Accept-Ranges: this route doesn't honor Range requests, so don't
       // advertise byte-range seeking we can't actually serve.
@@ -218,8 +229,10 @@ export function setup(mstream) {
     // their own track-duration metadata.
     res.header({ 'Content-Type': codecMap[codec].contentType });
 
-    // ── Stream + collect for cache ───────────────────────────
-    const proc = spawnTranscode(pathInfo.fullPath, codec, bitrate);
+    // ── Stream (+ collect for cache on from-start streams) ────
+    const proc = spawnTranscode(pathInfo.fullPath, codec, bitrate, offsetSec);
+    // A seeked stream is a one-off and isn't cached, so don't buffer its bytes.
+    const cacheable = offsetSec === 0;
     const bufs = [];
     let contentLength = 0;
     // Set when the client disconnects (and we SIGTERM ffmpeg as a result). The
@@ -229,24 +242,23 @@ export function setup(mstream) {
     let aborted = false;
 
     proc.stdout.on('data', chunk => {
-      bufs.push(chunk);
-      contentLength += chunk.length;
+      if (cacheable) { bufs.push(chunk); contentLength += chunk.length; }
     });
 
     // Stream to client immediately
     proc.stdout.pipe(res);
 
     proc.on('close', code => {
-      // Cache ONLY a clean, complete transcode. A SIGTERM kill reports
-      // code === null and an ffmpeg failure reports a non-zero code; both mean
-      // the output is partial, so cache nothing.
+      // Cache ONLY a clean, complete from-start transcode. A SIGTERM kill
+      // reports code === null and an ffmpeg failure reports a non-zero code;
+      // both mean the output is partial, so cache nothing.
       if (aborted || code !== 0) {
         if (code !== 0 && code !== null) {
           winston.error(`FFmpeg exited with code ${code} for ${pathInfo.fullPath}`);
         }
         return;
       }
-      if (contentLength > 0) {
+      if (cacheable && contentLength > 0) {
         cacheSet(cacheKey, { contentLength, bufs });
       }
     });

--- a/src/api/ytdl.js
+++ b/src/api/ytdl.js
@@ -121,7 +121,14 @@ export function setup(mstream) {
     const ytdlAudioFormat = formatMap[value.outputCodec] || value.outputCodec;
     const ytdlArgs = ['-f', "ba", "-x", value.url, '-o', downloadDir,
       "--restrict-filenames", "--no-overwrites",
-      "--ffmpeg-location", ffmpegPath, "--audio-format", ytdlAudioFormat, "--embed-metadata"];
+      "--audio-format", ytdlAudioFormat, "--embed-metadata"];
+    // yt-dlp's --ffmpeg-location takes a filesystem path/dir, NOT a PATH-
+    // resolved command name. Only pass it when we manage an on-disk binary;
+    // for the system-PATH fallback (bare 'ffmpeg', e.g. musl/Alpine) omit it
+    // and let yt-dlp find ffmpeg itself — passing 'ffmpeg' makes it look in cwd.
+    if (ffmpegPath && path.isAbsolute(ffmpegPath)) {
+      ytdlArgs.push("--ffmpeg-location", ffmpegPath);
+    }
     const noEmbedThumbnail = ['wav', 'opus', 'ogg'];
     if (!noEmbedThumbnail.includes(value.outputCodec)) {
       ytdlArgs.push("--embed-thumbnail", "--convert-thumbnails", "jpg");
@@ -557,7 +564,12 @@ export function setup(mstream) {
     const formatMap = { 'ogg': 'vorbis', 'm4b': 'm4a' };
     const ytdlAudioFormat = formatMap[outputCodec] || outputCodec;
     const ytdlArgs = ['-f', 'ba', '-x', sanitizedUrl, '-o', downloadDir,
-      '--ffmpeg-location', ffmpegPath, '--audio-format', ytdlAudioFormat, '--embed-metadata'];
+      '--audio-format', ytdlAudioFormat, '--embed-metadata'];
+    // See POST /ytdl/ above: only pass --ffmpeg-location for an on-disk binary;
+    // a bare 'ffmpeg' (system PATH) must be left to yt-dlp's own lookup.
+    if (ffmpegPath && path.isAbsolute(ffmpegPath)) {
+      ytdlArgs.push('--ffmpeg-location', ffmpegPath);
+    }
     const noEmbedThumbnail = ['wav', 'opus', 'ogg'];
     if (!noEmbedThumbnail.includes(outputCodec)) {
       ytdlArgs.push('--embed-thumbnail', '--convert-thumbnails', 'jpg');

--- a/src/api/ytdl.js
+++ b/src/api/ytdl.js
@@ -72,7 +72,7 @@ export function setup(mstream) {
     if (req.user.allow_upload === false || req.user.allow_upload === 0) { throw new WebError('Uploading Disabled', 403); }
 
     if (!transcode.isDownloaded()) {
-      return res.status(500).json({ error: 'FFmpeg not downloaded yet' });
+      return res.status(500).json({ error: 'FFmpeg is not available yet' });
     }
 
     const filesFormats = Object.keys(config.program.supportedAudioFiles).filter((format) => {
@@ -519,7 +519,7 @@ export function setup(mstream) {
       return res.status(403).json({ error: 'Uploading Disabled' });
     }
     if (!transcode.isDownloaded()) {
-      return res.status(500).json({ error: 'FFmpeg not downloaded yet' });
+      return res.status(500).json({ error: 'FFmpeg is not available yet' });
     }
 
     try {

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -99,7 +99,13 @@ const dbOptions = Joi.object({
 const transcodeOptions = Joi.object({
   ffmpegDirectory: Joi.string().default(path.join(__dirname, '../../bin/ffmpeg')),
   defaultCodec: Joi.string().valid(...getTransCodecs()).default('opus'),
-  defaultBitrate: Joi.string().valid(...getTransBitrates()).default('96k')
+  defaultBitrate: Joi.string().valid(...getTransBitrates()).default('96k'),
+  // Auto-update the managed ffmpeg build (BtbN on Linux/Windows, martin-riedl
+  // on macOS) on a weekly check. Default on so codec/security fixes land
+  // without operator action. Set false to pin the current binary — useful when
+  // a rolling upstream build regresses, or for air-gapped / reproducible
+  // installs. No effect when running off system ffmpeg (managed by the OS).
+  autoUpdate: Joi.boolean().default(true)
 });
 
 const rpnOptions = Joi.object({

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -473,6 +473,17 @@ export async function editDefaultBitrate(val) {
   config.program.transcode.defaultBitrate = val;
 }
 
+// Toggle weekly auto-update of the managed ffmpeg build. Persisted to the
+// config file and reflected in the running config immediately — the bootstrap
+// reads config.program.transcode.autoUpdate at each check, so no reboot needed.
+export async function editAutoUpdate(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.transcode) { loadConfig.transcode = {}; }
+  loadConfig.transcode.autoUpdate = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.transcode.autoUpdate = val;
+}
+
 export async function lockAdminApi(val) {
   const loadConfig = await loadFile(config.configFile);
   loadConfig.lockAdmin = val;

--- a/src/util/ffmpeg-bootstrap.js
+++ b/src/util/ffmpeg-bootstrap.js
@@ -14,7 +14,6 @@
 import fsp from 'node:fs/promises';
 import fs from 'node:fs';
 import https from 'node:https';
-import http from 'node:http';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -27,9 +26,14 @@ const binaryExt = process.platform === 'win32' ? '.exe' : '';
 const BUNDLED_FFMPEG_DIR = path.join(__dirname, '../../bin/ffmpeg');
 const MIN_FFMPEG_MAJOR = 6;
 const CHECKSUMS_URL = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256';
+// Download hardening: cap redirect chains and apply a socket-inactivity
+// timeout so a stalled or looping endpoint can't hang the process forever.
+const MAX_REDIRECTS = 5;
+const HTTP_TIMEOUT_MS = 30000;
 
 let _initPromise = null;
 let _updateTimer = null;
+let _bootTimer = null;
 
 // Set by ensureFfmpeg() once the resolver picks a working binary.
 // Source is 'bundled' (we manage it — whether in the default dir or a custom
@@ -114,12 +118,18 @@ function releaseInfo() {
     };
   }
 
-  // macOS: use martin-riedl.de which provides signed static builds for both Intel and Apple Silicon
+  // macOS: martin-riedl.de provides static builds for Intel + Apple Silicon.
+  // Each binary ships as a `.zip` with a sibling `.sha256`. The /redirect/
+  // endpoint 307s to a versioned /download/ path, and the `.sha256` only
+  // exists at that resolved path — so we follow the redirect at download time
+  // and derive the checksum URL from the final location. `release` = tagged
+  // stable build (vs `snapshot` = git master). Arch tokens are amd64/arm64.
   if (process.platform === 'darwin') {
-    const macArch = process.arch === 'arm64' ? 'arm64' : 'x86_64';
+    const macArch = process.arch === 'arm64' ? 'arm64' : 'amd64';
+    const base = `https://ffmpeg.martin-riedl.de/redirect/latest/macos/${macArch}/release`;
     return {
-      url: `https://ffmpeg.martin-riedl.de/packages/latest/macos/${macArch}/ffmpeg`,
-      ffprobeUrl: `https://ffmpeg.martin-riedl.de/packages/latest/macos/${macArch}/ffprobe`,
+      url: `${base}/ffmpeg.zip`,
+      ffprobeUrl: `${base}/ffprobe.zip`,
       asset: `ffmpeg-macos-${macArch}`,
       source: 'martin-riedl'
     };
@@ -132,12 +142,14 @@ function releaseInfo() {
 
 function downloadToBuffer(url) {
   return new Promise((resolve, reject) => {
-    const follow = (u) => {
-      const mod = u.startsWith('https') ? https : http;
-      mod.get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
+    const follow = (u, redirects = 0) => {
+      if (redirects > MAX_REDIRECTS) { return reject(new Error(`Too many redirects for ${url}`)); }
+      if (!u.startsWith('https:')) { return reject(new Error(`Refusing non-HTTPS URL: ${u}`)); }
+      const req = https.get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume();
-          return follow(res.headers.location);
+          // Location may be relative (martin-riedl) — resolve against `u`.
+          return follow(new URL(res.headers.location, u).toString(), redirects + 1);
         }
         if (res.statusCode !== 200) {
           res.resume();
@@ -147,20 +159,25 @@ function downloadToBuffer(url) {
         res.on('data', c => chunks.push(c));
         res.on('end', () => resolve(Buffer.concat(chunks)));
         res.on('error', reject);
-      }).on('error', reject);
+      });
+      req.on('error', reject);
+      req.setTimeout(HTTP_TIMEOUT_MS, () => req.destroy(new Error(`Timeout downloading ${u}`)));
     };
     follow(url);
   });
 }
 
+// Resolves with the final (post-redirect) URL so callers can derive sibling
+// resources — e.g. a `.sha256` that only exists at the resolved download path.
 function downloadToFile(url, destPath) {
   return new Promise((resolve, reject) => {
-    const follow = (u) => {
-      const mod = u.startsWith('https') ? https : http;
-      mod.get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
+    const follow = (u, redirects = 0) => {
+      if (redirects > MAX_REDIRECTS) { return reject(new Error(`Too many redirects for ${url}`)); }
+      if (!u.startsWith('https:')) { return reject(new Error(`Refusing non-HTTPS URL: ${u}`)); }
+      const req = https.get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume();
-          return follow(res.headers.location);
+          return follow(new URL(res.headers.location, u).toString(), redirects + 1);
         }
         if (res.statusCode !== 200) {
           res.resume();
@@ -168,13 +185,17 @@ function downloadToFile(url, destPath) {
         }
         const tmp = destPath + '.tmp';
         const out = fs.createWriteStream(tmp);
-        res.pipe(out);
+        const fail = e => { out.destroy(); fsp.unlink(tmp).catch(() => {}); reject(e); };
+        res.on('error', fail);
+        out.on('error', fail);
         out.on('finish', async () => {
-          try { await fsp.rename(tmp, destPath); resolve(); }
+          try { await fsp.rename(tmp, destPath); resolve(u); }
           catch (e) { fsp.unlink(tmp).catch(() => {}); reject(e); }
         });
-        out.on('error', e => { fsp.unlink(tmp).catch(() => {}); reject(e); });
-      }).on('error', reject);
+        res.pipe(out);
+      });
+      req.on('error', reject);
+      req.setTimeout(HTTP_TIMEOUT_MS, () => req.destroy(new Error(`Timeout downloading ${u}`)));
     };
     follow(url);
   });
@@ -251,6 +272,69 @@ async function extractZip(zipPath, destDir, asset) {
   });
 }
 
+// macOS: extract a single member from a .zip using Info-ZIP `unzip` (present
+// on every macOS). -o overwrite without prompting, -j flatten stored paths.
+function extractZipUnix(zipPath, destDir, member) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('unzip', ['-o', '-j', zipPath, member, '-d', destDir],
+      { stdio: ['ignore', 'ignore', 'pipe'] });
+    let err = '';
+    proc.stderr.on('data', d => { err += d; });
+    proc.on('close', code => code === 0 ? resolve() : reject(new Error(`unzip failed (${code}): ${err.slice(-300)}`)));
+    proc.on('error', reject);
+  });
+}
+
+// Fetch + parse a single-line `<sha256>  <name>` checksum file. Returns the
+// lowercased hex digest, or null on any failure (network, format, etc.).
+async function fetchRemoteSha256(url) {
+  try {
+    const buf = await downloadToBuffer(url);
+    const token = buf.toString('utf8').trim().split('\n')[0].trim().split(/\s+/)[0];
+    return /^[0-9a-f]{64}$/i.test(token) ? token.toLowerCase() : null;
+  } catch (e) {
+    winston.warn(`[ffmpeg-bootstrap] Could not fetch checksum ${url}: ${e.message}`);
+    return null;
+  }
+}
+
+// macOS: download one binary's .zip, verify its sha256 (fetched from the
+// resolved download URL — see downloadToFile's return value), extract, and
+// chmod. Returns false on any failure so the caller refuses to install an
+// unverified binary, matching the BtbN hard-fail policy.
+async function installMacBinary(redirectUrl, dir, member, destBin) {
+  const zipPath = path.join(dir, `${member}.zip`);
+  let finalUrl;
+  try {
+    finalUrl = await downloadToFile(redirectUrl, zipPath);
+  } catch (e) {
+    winston.error(`[ffmpeg-bootstrap] ${member} download failed: ${e.message}`);
+    return false;
+  }
+  const expected = await fetchRemoteSha256(`${finalUrl}.sha256`);
+  if (!expected) {
+    await fsp.unlink(zipPath).catch(() => {});
+    winston.error(`[ffmpeg-bootstrap] No checksum for ${member} (macOS) — refusing unverified binary`);
+    return false;
+  }
+  const actual = await computeFileChecksum(zipPath);
+  if (actual !== expected) {
+    await fsp.unlink(zipPath).catch(() => {});
+    winston.error(`[ffmpeg-bootstrap] Checksum mismatch for ${member} (macOS)! Expected ${expected}, got ${actual}`);
+    return false;
+  }
+  try {
+    await extractZipUnix(zipPath, dir, member);
+  } catch (e) {
+    await fsp.unlink(zipPath).catch(() => {});
+    winston.error(`[ffmpeg-bootstrap] ${member} extract failed: ${e.message}`);
+    return false;
+  }
+  await fsp.chmod(destBin, 0o755).catch(() => {});
+  await fsp.unlink(zipPath).catch(() => {});
+  return true;
+}
+
 // ── Version check ───────────────────────────────────────────────────────────
 
 function getFfmpegVersion(binPath) {
@@ -292,12 +376,11 @@ async function downloadAndInstall() {
   winston.info(`[ffmpeg-bootstrap] Downloading ffmpeg for ${process.platform}/${process.arch}...`);
 
   try {
+    let archiveChecksum = null;
     if (info.source === 'martin-riedl') {
-      // macOS: direct binary downloads (no archive)
-      await downloadToFile(info.url, destFfmpeg);
-      await downloadToFile(info.ffprobeUrl, destFfprobe);
-      await fsp.chmod(destFfmpeg, 0o755).catch(() => {});
-      await fsp.chmod(destFfprobe, 0o755).catch(() => {});
+      // macOS: per-binary .zip downloads, each sha256-verified before extract.
+      if (!(await installMacBinary(info.url, dir, 'ffmpeg', destFfmpeg))) { return false; }
+      if (!(await installMacBinary(info.ffprobeUrl, dir, 'ffprobe', destFfprobe))) { return false; }
     } else {
       // BtbN: archive download with checksum verification
       const archivePath = path.join(dir, info.asset);
@@ -318,6 +401,7 @@ async function downloadAndInstall() {
         winston.error(`[ffmpeg-bootstrap] Checksum mismatch! Expected ${expected}, got ${actual}`);
         return false;
       }
+      archiveChecksum = expected;
       winston.info(`[ffmpeg-bootstrap] Checksum verified`);
 
       // Extract
@@ -344,6 +428,15 @@ async function downloadAndInstall() {
       winston.error(`[ffmpeg-bootstrap] ffprobe verification failed: ${probeCheck.versionLine || '(no output)'}`);
       return false;
     }
+
+    // Persist the verified archive checksum so the daily update check has a
+    // baseline to compare against. Without this the first post-boot check
+    // finds no `.checksum`, assumes "out of date", and re-downloads the exact
+    // build we just installed.
+    if (archiveChecksum) {
+      await fsp.writeFile(path.join(dir, '.checksum'), archiveChecksum, 'utf8').catch(() => {});
+    }
+
     winston.info(`[ffmpeg-bootstrap] ffmpeg ready: ${versionLine || destFfmpeg}`);
     return true;
   } catch (e) {
@@ -502,12 +595,14 @@ export async function checkForUpdate() {
     // concurrent transcode / DLNA seek / yt-dlp call fail with ENOENT.
     _initPromise = null;
 
-    const success = await downloadAndInstall();
-    if (success) {
-      await fsp.writeFile(checksumFile, expected, 'utf8');
-    }
+    // downloadAndInstall() persists the new `.checksum` baseline itself on
+    // success, so there's nothing more to record here.
+    await downloadAndInstall();
   } else {
-    // macOS (martin-riedl): no checksum file — check version instead
+    // macOS (martin-riedl): the `.sha256` lives at the resolved versioned URL,
+    // not a stable path, so a cheap "is there a newer build" check isn't
+    // available here. Fall back to a version-floor check — a tagged stable
+    // release rarely needs refreshing mid-deployment.
     const { major } = await getFfmpegVersion(bin);
     if (major < MIN_FFMPEG_MAJOR) {
       winston.info(`[ffmpeg-bootstrap] ffmpeg outdated, updating...`);
@@ -522,12 +617,19 @@ export async function checkForUpdate() {
  * Start the daily update check timer.
  */
 export function startAutoUpdate() {
-  // Check immediately on boot (after initial ensure)
-  setTimeout(() => {
+  // Idempotent: re-entry (e.g. the admin "download ffmpeg" endpoint re-runs
+  // init() -> startAutoUpdate()) must NOT stack a second interval and orphan
+  // the first — stopAutoUpdate() only knows the latest handle.
+  if (_updateTimer) { return; }
+
+  // Check shortly after boot (after the initial ensure settles)
+  _bootTimer = setTimeout(() => {
+    _bootTimer = null;
     checkForUpdate().catch(e => {
       winston.warn(`[ffmpeg-bootstrap] Update check failed: ${e.message}`);
     });
   }, 30000); // 30 seconds after boot
+  if (_bootTimer.unref) { _bootTimer.unref(); }
 
   // Then every 24 hours
   _updateTimer = setInterval(() => {
@@ -535,12 +637,17 @@ export function startAutoUpdate() {
       winston.warn(`[ffmpeg-bootstrap] Update check failed: ${e.message}`);
     });
   }, 24 * 60 * 60 * 1000);
+  if (_updateTimer.unref) { _updateTimer.unref(); }
 }
 
 /**
  * Stop the auto-update timer.
  */
 export function stopAutoUpdate() {
+  if (_bootTimer) {
+    clearTimeout(_bootTimer);
+    _bootTimer = null;
+  }
   if (_updateTimer) {
     clearInterval(_updateTimer);
     _updateTimer = null;

--- a/src/util/ffmpeg-bootstrap.js
+++ b/src/util/ffmpeg-bootstrap.js
@@ -246,9 +246,8 @@ function extractTarXz(tarPath, destDir, asset) {
   });
 }
 
-async function extractZip(zipPath, destDir, asset) {
-  // Windows: use PowerShell to extract
-  const prefix = asset.replace(/\.zip$/, '');
+function extractZip(zipPath, destDir) {
+  // Windows: use PowerShell to extract ffmpeg.exe + ffprobe.exe by name.
   return new Promise((resolve, reject) => {
     const script = `
       $zip = '${zipPath.replace(/'/g, "''")}';
@@ -344,9 +343,15 @@ function getFfmpegVersion(binPath) {
     p.stdout.on('data', d => { o += d; });
     p.on('close', () => {
       const line = o.split('\n')[0] || '';
-      const stable = line.match(/(?:ffmpeg|ffprobe) version (\d+)/);
-      if (stable) return resolve({ major: parseInt(stable[1], 10), versionLine: line });
-      if (/(?:ffmpeg|ffprobe) version N-\d+/.test(line)) return resolve({ major: 99, versionLine: line });
+      // Git/snapshot builds (BtbN, martin-riedl snapshot) print "version N-<n>"
+      // with no semantic major — treat as newest. Checked first so the stable
+      // matcher below doesn't trip on the leading N.
+      if (/version\s+N-\d+/i.test(line)) { return resolve({ major: 99, versionLine: line }); }
+      // Stable/distro builds: "version 6.1.1", "version n7.0" (Arch),
+      // "version 5.1.4-0+deb…" (Debian). Allow an optional 'n' prefix, match
+      // case-insensitively, and don't require the program-name token.
+      const m = line.match(/version\s+n?(\d+)/i);
+      if (m) { return resolve({ major: parseInt(m[1], 10), versionLine: line }); }
       resolve({ major: 0, versionLine: line });
     });
     p.on('error', () => resolve({ major: 0, versionLine: '' }));
@@ -408,7 +413,7 @@ async function downloadAndInstall() {
       if (info.asset.endsWith('.tar.xz')) {
         await extractTarXz(archivePath, dir, info.asset);
       } else if (info.asset.endsWith('.zip')) {
-        await extractZip(archivePath, dir, info.asset);
+        await extractZip(archivePath, dir);
       }
 
       await fsp.chmod(destFfmpeg, 0o755).catch(() => {});
@@ -498,6 +503,7 @@ export async function ensureFfmpeg() {
         return { ffmpeg: _resolvedFfmpegPath, ffprobe: _resolvedFfprobePath, source: _resolvedSource };
       }
       winston.error('[ffmpeg-bootstrap] No system ffmpeg found. Install with: apk add ffmpeg');
+      _initPromise = null; // don't cache failure — let a later call retry
       return null;
     }
 
@@ -529,6 +535,7 @@ export async function ensureFfmpeg() {
 
     // ── Step 5: Nothing works ────────────────────────────────────────────
     winston.error('[ffmpeg-bootstrap] No working ffmpeg found (download failed and no system binary on PATH)');
+    _initPromise = null; // don't cache failure — let a later call retry
     return null;
   })().catch(e => {
     winston.error(`[ffmpeg-bootstrap] ${e.message}`);
@@ -569,6 +576,9 @@ export function reset() {
  */
 export async function checkForUpdate() {
   if (_resolvedSource === 'system') return;
+  // Operators can pin their current build (config: transcode.autoUpdate=false)
+  // to avoid a rolling upstream build regressing a working install.
+  if (config.program?.transcode?.autoUpdate === false) return;
 
   const info = releaseInfo();
   if (!info) return;
@@ -614,7 +624,7 @@ export async function checkForUpdate() {
 }
 
 /**
- * Start the daily update check timer.
+ * Start the periodic update check timer (weekly, after a short post-boot check).
  */
 export function startAutoUpdate() {
   // Idempotent: re-entry (e.g. the admin "download ffmpeg" endpoint re-runs
@@ -631,12 +641,15 @@ export function startAutoUpdate() {
   }, 30000); // 30 seconds after boot
   if (_bootTimer.unref) { _bootTimer.unref(); }
 
-  // Then every 24 hours
+  // Then weekly. BtbN publishes git-master builds ~daily, so a daily check
+  // meant ~daily churn (and regression exposure); weekly is plenty current for
+  // a media server and cuts that 7×. Operators wanting tighter currency or none
+  // at all can still tune via transcode.autoUpdate.
   _updateTimer = setInterval(() => {
     checkForUpdate().catch(e => {
       winston.warn(`[ffmpeg-bootstrap] Update check failed: ${e.message}`);
     });
-  }, 24 * 60 * 60 * 1000);
+  }, 7 * 24 * 60 * 60 * 1000);
   if (_updateTimer.unref) { _updateTimer.unref(); }
 }
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -2538,6 +2538,12 @@ const transcodeView = Vue.component('transcode-view', {
                       [<a v-on:click="changeBitrate()">{{ t('admin.settings.edit') }}</a>]
                     </td>
                   </tr>
+                  <tr>
+                    <td><b title="Automatically update the managed ffmpeg build on a weekly check. Disable to pin the current binary — useful if a rolling upstream build regresses, or for reproducible/air-gapped installs. No effect when running off system ffmpeg.">Auto-Update FFmpeg:</b> {{params.autoUpdate ? 'on' : 'off'}}</td>
+                    <td>
+                      [<a v-on:click="toggleAutoUpdate()">{{ params.autoUpdate ? 'disable' : 'enable' }}</a>]
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>
@@ -2553,6 +2559,28 @@ const transcodeView = Vue.component('transcode-view', {
     changeBitrate: function() {
       modVM.currentViewModal = 'edit-transcode-bitrate-modal';
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
+    },
+    toggleAutoUpdate: async function() {
+      const next = !this.params.autoUpdate;
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/transcode/auto-update`,
+          data: { autoUpdate: next }
+        });
+        Vue.set(ADMINDATA.transcodeParams, 'autoUpdate', next);
+        iziToast.success({
+          title: next ? 'FFmpeg auto-update enabled' : 'FFmpeg auto-update disabled',
+          position: 'topCenter',
+          timeout: 2500
+        });
+      } catch (err) {
+        iziToast.error({
+          title: 'Failed to change auto-update setting',
+          position: 'topCenter',
+          timeout: 3500
+        });
+      }
     },
     downloadFFMpeg: async function() {
       if (this.downloadPending.val === true) {

--- a/webapp/assets/js/mstream.player.js
+++ b/webapp/assets/js/mstream.player.js
@@ -1038,9 +1038,26 @@ const MSTREAMPLAYER = (() => {
       }
     });
 
-    playerObj.playerObject.addEventListener('timeupdate', err => {
-      mstreamModule.playerStats.currentTime = getCurrentPlayer().playerObject.currentTime;
-      mstreamModule.playerStats.duration = getCurrentPlayer().playerObject.duration;
+    playerObj.playerObject.addEventListener('timeupdate', () => {
+      const cur = getCurrentPlayer();
+      // Virtual playhead: a server-side seek reloads the stream from `-ss
+      // offset`, so the element's own currentTime restarts at 0. Add the
+      // offset back to report the true position.
+      mstreamModule.playerStats.currentTime = (cur.seekOffset || 0) + cur.playerObject.currentTime;
+
+      // Duration: a chunked transcode stream has no usable audio.duration
+      // (Infinity until fully buffered, and a seeked stream only spans the
+      // remainder), so trust the track's metadata duration there. Direct files
+      // report an exact audio.duration.
+      const adur = cur.playerObject.duration;
+      const metaDur = cur.songObject && cur.songObject.metadata ? Number(cur.songObject.metadata.duration) : NaN;
+      if (isTranscoding()) {
+        mstreamModule.playerStats.duration = (Number.isFinite(metaDur) && metaDur > 0)
+          ? metaDur : (Number.isFinite(adur) ? adur : 0);
+      } else {
+        mstreamModule.playerStats.duration = (Number.isFinite(adur) && adur > 0)
+          ? adur : (Number.isFinite(metaDur) ? metaDur : 0);
+      }
     });
   }
 
@@ -1058,22 +1075,38 @@ const MSTREAMPLAYER = (() => {
 
   var curP = 'A';
 
-  function setMedia(song, player, play) {
+  // True when playback goes through the server transcoder (a chunked stream
+  // that is NOT byte-range seekable) rather than a direct /media file.
+  function isTranscoding() {
+    return mstreamModule.transcodeOptions.serverEnabled === true
+      && mstreamModule.transcodeOptions.frontendEnabled === true;
+  }
+
+  // Build the stream URL for a song: transcode bitrate/codec plus an optional
+  // server-side seek offset (seconds). song.url already ends with `?token=…`
+  // (or just `?`), so every extra param is appended with `&`.
+  function buildStreamUrl(song, offsetSec = 0) {
     let url = song.url;
-    if(mstreamModule.transcodeOptions.serverEnabled === true && mstreamModule.transcodeOptions.frontendEnabled === true) {
+    if (isTranscoding()) {
       if (mstreamModule.transcodeOptions.selectedBitrate !== null) {
         url += `&bitrate=${mstreamModule.transcodeOptions.selectedBitrate}`;
       }
       if (mstreamModule.transcodeOptions.selectedCodec !== null) {
         url += `&codec=${mstreamModule.transcodeOptions.selectedCodec}`;
       }
+      // Only the transcode route understands ?offset= (re-encode from -ss).
+      if (offsetSec > 0) { url += `&offset=${offsetSec}`; }
     }
+    return url;
+  }
 
-    player.playerObject.src = url;
+  function setMedia(song, player, play) {
+    player.seekOffset = 0; // a fresh song starts at the beginning
+    player.playerObject.src = buildStreamUrl(song, 0);
     player.songObject = song;
     player.playerObject.load();
     player.playerObject.playbackRate = mstreamModule.playerStats.playbackRate;
-    
+
     player.playerObject.onended = () => {
       callMeOnStreamEnd();
     }
@@ -1092,49 +1125,56 @@ const MSTREAMPLAYER = (() => {
     goToNextSong();
   }
 
-  mstreamModule.goBackSeek = (backBy) => {
+  // Seek to an absolute position (seconds). Direct /media files seek natively
+  // (byte ranges); a transcoded stream isn't seekable in the browser, so we
+  // re-request it from the server with ?offset= and reload — see transcodeSeek.
+  function seekToAbsolute(targetSec) {
     const lPlayer = getCurrentPlayer();
-    var seekTo = lPlayer.playerObject.currentTime - backBy;
-    if (seekTo < 0) {
-      seekTo = 0;
-    }
+    if (!lPlayer.songObject) { return; }
+    const dur = mstreamModule.playerStats.duration;
+    if (!(targetSec >= 0)) { targetSec = 0; }
+    if (Number.isFinite(dur) && dur > 0 && targetSec > dur) { targetSec = dur; }
 
-    lPlayer.playerObject.currentTime = seekTo;
+    if (isTranscoding()) {
+      transcodeSeek(targetSec);
+    } else {
+      lPlayer.seekOffset = 0;
+      lPlayer.playerObject.currentTime = targetSec;
+    }
+  }
+
+  // Server-side seek for transcoded playback: reload the stream from `-ss
+  // targetSec`, remember the offset so the playhead reads correctly, and
+  // resume playback if it was playing.
+  function transcodeSeek(targetSec) {
+    const lPlayer = getCurrentPlayer();
+    const wasPlaying = mstreamModule.playerStats.playing === true;
+    lPlayer.seekOffset = targetSec;
+    lPlayer.playerObject.src = buildStreamUrl(lPlayer.songObject, targetSec);
+    lPlayer.playerObject.load();
+    lPlayer.playerObject.playbackRate = mstreamModule.playerStats.playbackRate;
+    mstreamModule.playerStats.currentTime = targetSec; // reflect immediately
+    if (wasPlaying) { lPlayer.playerObject.play(); }
+  }
+
+  mstreamModule.goBackSeek = (backBy) => {
+    seekToAbsolute(mstreamModule.playerStats.currentTime - backBy);
   }
 
   mstreamModule.goForwardSeek = (forwardBy) => {
-    const lPlayer = getCurrentPlayer();
-    if (lPlayer.playerObject.currentTime > (lPlayer.playerObject.duration - 5) ) {
-      return;
-    }
-
-    let seekTo = lPlayer.playerObject.currentTime + forwardBy;
-    if (seekTo >  (lPlayer.playerObject.duration - 5)) {
-      seekTo = lPlayer.playerObject.duration - 5;
-    }
-
-    lPlayer.playerObject.currentTime = seekTo;
+    seekToAbsolute(mstreamModule.playerStats.currentTime + forwardBy);
   }
 
-  // NOTE: Seektime is in seconds
+  // NOTE: seekTime is in seconds
   mstreamModule.seek = (seekTime) => {
-    const lPlayer = getCurrentPlayer();
-    // Check that the seek number is less than the duration
-    if (seekTime < 0 || seekTime > lPlayer.playerObject.duration) {
-      return false;
-    }
-    lPlayer.playerObject.currentTime = seektime;
+    seekToAbsolute(seekTime);
   }
 
   mstreamModule.seekByPercentage = (percentage) => {
-    if (percentage < 0 || percentage > 99) {
-      return false;
-    }
-
-    const lPlayer = getCurrentPlayer();
-    if (!lPlayer.songObject) { return; }
-    const seektime = (percentage * lPlayer.playerObject.duration) / 100;
-    lPlayer.playerObject.currentTime = seektime;
+    if (percentage < 0 || percentage > 99) { return false; }
+    const dur = mstreamModule.playerStats.duration;
+    if (!Number.isFinite(dur) || dur <= 0) { return false; }
+    seekToAbsolute((percentage * dur) / 100);
   }
 
   // Timer for caching.  Helps prevent excess caching due to button mashing


### PR DESCRIPTION
## Summary

Full audit of the ffmpeg management code (`src/util/ffmpeg-bootstrap.js` + every consumer), low-priority cleanups, three bugs found by cross-platform smoke testing, a new `/transcode?offset=` seek param, the alpha player wired to use it, and an admin toggle for the auto-update setting. Only **L4** (velvet ytdl filename hardening) is intentionally deferred.

## Commits
1. **High/Medium audit fixes (1–8)** — truncated-cache-on-disconnect, idempotent auto-update, `.checksum` baseline, async-executor embed, ytdl `--ffmpeg-location` on musl, download hardening (timeout/redirect/HTTPS/relative), macOS path repair + sha256, bounded LRU cache.
2. **Low-priority cleanups (L1–L3, L5–L9)** — version parser, drop `Accept-Ranges`, `-map 0:a`, stderr/503, `autoUpdate` config + weekly cadence, boot retry, `isDownloaded()` docs, dead `prefix`.
3. **Bugs found by smoke testing** — album-art `.tmp_art` (broke embed for all formats), FLAC missing `attached_pic`, live `Content-Length` over-estimate breaking strict clients (now chunked).
4. **`/transcode?offset=` time-seek** — input-seek via `-ss`; seeked requests bypass the cache.
5. **Alpha player server-side seek** — exposes track `duration` in `/api/v1/db/*`; engine uses it for the progress bar + maps seek→time, reloads from `?offset=` on seek, virtual playhead. Native `/media` seeks directly.
6. **Admin toggle for `autoUpdate`** — `POST /api/v1/admin/transcode/auto-update` (validated, persisted, applied at runtime) + an "Auto-Update FFmpeg" row in the admin Transcode panel, so the L6 setting is usable from the UI rather than config.json only.

## Cross-platform smoke testing

| Harness | Exercises | Result |
|---|---|---|
| **Windows** (bundled ffmpeg) | resolve, transcode mp3/opus/aac, art embed | **10/10** |
| **Debian/glibc** (Docker) | real BtbN download + checksum + `.checksum`, no-op re-check, `autoUpdate` gate, codecs, version parsing, embed | **24/24** |
| **Alpine/musl** (Docker) | musl detect, graceful no-ffmpeg, L7 retry, system fallback, transcode | **9/9** |
| **`/transcode` route** (server) | #1 truncation end-to-end, cache round-trip | **7/7** |
| **`/transcode?offset=`** (server) | seek lands at right decoded duration (mp3/opus/aac), edge cases, cache isolation, mid-seek disconnect | **16/16** |
| **musl `-ss`** (Docker) | system ffmpeg 8.0.1 honors the seek args | ✓ |
| **alpha player engine** (real code, mock `<audio>`) | native vs transcode `?offset=` reload, virtual playhead, metadata-duration fallback, guards | **19/19** |
| **server duration / admin auto-update** | `duration` in metadata; auto-update toggle persists + validates | ✓ |
| Existing suites | dlna, subsonic, waveform, ytdl | **211/211** |

No new lint problems. macOS *execution* still can't be tested off-Mac (Docker is Linux); that branch only runs on `darwin` and its download/verify/extract was validated against martin-riedl.de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)