### PR TITLE
fix(electron): write boot/fatal errors to the log file

### DIFF
--- a/build/electron.js
+++ b/build/electron.js
@@ -3,7 +3,9 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import os from 'os';
+import winston from 'winston';
 import * as server from '../src/server.js';
+import * as logger from '../src/logger.js';
 import pkg from 'electron-updater';
 const { autoUpdater } = pkg;
 
@@ -40,21 +42,40 @@ if (!fs.existsSync(path.join(app.getPath('userData'), 'ffmpeg'))) {
   fs.mkdirSync(path.join(app.getPath('userData'), 'ffmpeg'), { recursive: true });
 }
 
-process.on('uncaughtException', (error) => {
-  if (error.code === 'EADDRINUSE') {
-    // Handle the error
+let fatalHandled = false;
+function handleFatalError(error) {
+  // Boot/runtime failures used to only reach console.log here, which is
+  // invisible in a packaged AppImage/NSIS build — so users saw the server fail
+  // to start with nothing in the log file explaining why. Route the error
+  // through winston FIRST so it lands in the on-disk log (file transport is
+  // attached early in bootServer) and the admin live-log buffer, then surface
+  // a dialog and quit. Guarded so a cascade during shutdown shows one dialog.
+  if (fatalHandled) { return; }
+  fatalHandled = true;
+
+  const err = error instanceof Error ? error : new Error(String(error));
+  try {
+    winston.error('Fatal error — server did not finish booting', { stack: err });
+  } catch (_logErr) { /* logging must never mask the original failure */ }
+
+  if (err.code === 'EADDRINUSE') {
     dialog.showErrorBox("Server Boot Error", "The port you selected is already in use.  Please choose another");
-  } else if (error.code === 'BAD CERTS') {
-    dialog.showErrorBox("Server Boot Error", "Failed to create HTTPS server.  Please check your certs and try again. " + os.EOL + os.EOL + os.EOL + "ERROR MESSAGE: " + error.message);
+  } else if (err.code === 'BAD CERTS') {
+    dialog.showErrorBox("Server Boot Error", "Failed to create HTTPS server.  Please check your certs and try again. " + os.EOL + os.EOL + os.EOL + "ERROR MESSAGE: " + err.message);
   } else {
-    dialog.showErrorBox("Unknown Error", "Unknown Error with code: " + error.code + os.EOL + os.EOL + os.EOL + "ERROR MESSAGE: " + error.message);
-    console.log(error);
+    dialog.showErrorBox("Unknown Error", "Unknown Error with code: " + err.code + os.EOL + os.EOL + os.EOL + "ERROR MESSAGE: " + err.message);
   }
 
   app.quit();
-});
+}
 
-app.whenReady().then(bootServer);
+// serveIt() is async and its rejection would otherwise become an unhandled
+// rejection; non-promise throws (e.g. the server's EADDRINUSE 'error' event with
+// no listener) surface as uncaughtException. Capture both.
+process.on('uncaughtException', handleFatalError);
+process.on('unhandledRejection', handleFatalError);
+
+app.whenReady().then(bootServer).catch(handleFatalError);
 
 function bootServer() {
   let program;
@@ -144,7 +165,19 @@ function bootServer() {
 
   getLoginAtBoot();
 
-  server.serveIt(configFile);
+  // Attach the on-disk logger BEFORE booting so any failure during boot —
+  // config validation, port-in-use, bad certs, a throwing setup step — is
+  // written to the log file. serveIt() attaches its own file logger after it
+  // validates the config (server.js), but errors thrown before that point would
+  // otherwise never reach disk. addFileLogger() resets any existing transport,
+  // so serveIt re-pointing to the same directory is a no-op, not a duplicate.
+  if (program.writeLogs) {
+    try {
+      logger.addFileLogger(program.storage.logsDirectory);
+    } catch (_err) { /* fall back to console/live-buffer logging */ }
+  }
+
+  server.serveIt(configFile).catch(handleFatalError);
 }
 
 let bootBol;

--- a/src/api/discogs.js
+++ b/src/api/discogs.js
@@ -145,7 +145,7 @@ export function setup(mstream) {
 
       res.json({ choices });
     } catch (e) {
-      winston.error('[discogs] Search failed:', e.message);
+      winston.error('[discogs] Search failed', { stack: e });
       res.status(500).json({ error: 'Discogs search failed' });
     }
   });
@@ -270,7 +270,7 @@ export function setup(mstream) {
 
       res.json({ aaFile: filename });
     } catch (e) {
-      winston.error('[discogs] Embed failed:', e.message);
+      winston.error('[discogs] Embed failed', { stack: e });
       res.status(500).json({ error: 'Failed to apply album art' });
     }
   });

--- a/src/api/download.js
+++ b/src/api/download.js
@@ -103,8 +103,7 @@ export function setup(mstream) {
         await fs.access(pathInfo.fullPath);
         archive.file(pathInfo.fullPath, { name: path.basename(file) });
       } catch (err) {
-        winston.warn(`Failed to access file ${file} for download, skipping.`);
-        winston.warn(err);
+        winston.warn(`Failed to access file ${file} for download, skipping.`, { stack: err });
         continue;
       }
     }

--- a/src/api/file-explorer.js
+++ b/src/api/file-explorer.js
@@ -68,8 +68,7 @@ export function setup(mstream) {
         stat = await fs.stat(path.join(directory, file));
       } catch (err) {
         /* Bad file or permission error, ignore and continue */
-        winston.warn(`Failed to access file ${file} in directory ${directory}, skipping.`);
-        winston.warn(err);
+        winston.warn(`Failed to access file ${file} in directory ${directory}, skipping.`, { stack: err });
         continue;
       }
 

--- a/src/api/ytdl.js
+++ b/src/api/ytdl.js
@@ -46,7 +46,7 @@ function lookupMetadata(url) {
 
     proc.on('close', (code) => {
       if (code !== 0) {
-        winston.error('yt-dlp metadata lookup failed:', stderr);
+        winston.error(`yt-dlp metadata lookup failed: ${stderr}`);
         return reject(new Error('Failed to lookup metadata'));
       }
 
@@ -143,8 +143,8 @@ export function setup(mstream) {
     });
 
     ytdl.stderr.on('data', (data) => {
-      winston.error('yt-dlp error: failed to download file - ', value.url);
-      winston.error('yt-dlp error:', data.toString());
+      winston.error(`yt-dlp error: failed to download file - ${value.url}`);
+      winston.error(`yt-dlp error: ${data.toString()}`);
     });
 
     ytdl.on('close', async (code) => {

--- a/src/logger.js
+++ b/src/logger.js
@@ -19,6 +19,21 @@ const myFormat = winston.format.printf(info => {
   return msg + os.EOL + stackStr.stack;
 });
 
+// Callers across the codebase log errors as `winston.error('msg', { stack: err })`,
+// passing the Error OBJECT. winston's json() serializer (used by the file
+// transport) calls JSON.stringify, which drops Error's non-enumerable `message`
+// and `stack` — so a raw `{ stack: err }` lands on disk as `"stack":{}` (or just
+// the enumerable `.code`), hiding the actual cause from anyone reading the log
+// file. Normalize a non-string stack to its text form BEFORE json() so on-disk
+// logs stay useful. The Console (myFormat) and live-buffer transports already do
+// this themselves, so this only needs to feed the file transport.
+const normalizeStack = winston.format(info => {
+  if (info.stack && typeof info.stack !== 'string') {
+    info.stack = info.stack.stack || info.stack.message || String(info.stack);
+  }
+  return info;
+});
+
 // ── In-memory ring buffer for the admin live-log viewer ─────────────────────
 // A fixed-capacity circular buffer of the most recent log entries, fed by a
 // winston transport that is ALWAYS attached — independent of the on-disk file
@@ -137,6 +152,7 @@ function buildFileTransport(dirname, key) {
     filename: path.join(dirname, `mstream-${key}.log`),
     maxsize: 20 * 1024 * 1024,
     format: winston.format.combine(
+      normalizeStack(),
       winston.format.timestamp(),
       winston.format.json()
     ),

--- a/src/util/file-explorer.js
+++ b/src/util/file-explorer.js
@@ -15,8 +15,7 @@ export async function getDirectoryContents(directory, fileTypeFilter, sort, pm, 
       stat = await fs.stat(path.join(directory, file));
     } catch (error) {
       // Bad file or permission error, ignore and continue
-      winston.warn(`Failed to access file ${file} in directory ${directory}, skipping.`);
-      winston.warn(error);
+      winston.warn(`Failed to access file ${file} in directory ${directory}, skipping.`, { stack: error });
       continue;
     }
 


### PR DESCRIPTION
## Problem

A user on the electron build reported their server "did not fully boot and logs didn't show why." Their shared log ended at `FFmpeg OK!` with no error line.

Tracing the boot: `transcode.setup()` fires ffmpeg init as fire-and-forget, so those ffmpeg lines log async, in parallel with the rest of boot. The main `serveIt` flow ran past that point but never logged `Access mStream locally` — meaning it threw/rejected somewhere before `server.listen` — yet nothing landed in the log file.

## Root cause — two defects hid the error from disk

1. **`build/electron.js` never routed boot errors to winston.** The `uncaughtException` handler only did `console.log(error)`, which is invisible in a packaged AppImage/NSIS app. It also had no `unhandledRejection` handler and called the async `serveIt()` without a `.catch`, so most boot-time rejections never reached the handler at all.

2. **`src/logger.js`'s file transport mangled errors.** The house convention `winston.error('msg', { stack: err })` (used at `server.js:69`, `server.js:351`, `transcode.js:122/134`, …) passes the **Error object**, but the file transport's `json()` calls `JSON.stringify`, which drops Error's non-enumerable `message`/`stack`. Verified empirically: it writes `"stack":{}` to disk. So even *with* a winston call, the cause stayed hidden in the on-disk log.

## Changes

**`build/electron.js`**
- Extracted a shared `handleFatalError` that logs through winston **first** (→ file + admin live-log buffer), then shows the dialog and quits (guarded against shutdown cascades).
- Registered it for both `uncaughtException` **and** `unhandledRejection`, and `.catch`'d the `serveIt()` / `whenReady()` chains.
- Attach the file logger **early in `bootServer`** (before `serveIt`), so failures that occur before `serveIt` wires up its own logger — config validation, port-in-use, bad certs — still reach disk. `addFileLogger()` resets any existing transport, so `serveIt` re-pointing to the same directory is a no-op, not a duplicate.

**`src/logger.js`**
- Added a `normalizeStack` format step to the file transport that converts a non-string `stack` to its text form **before** `json()`. Now `{ stack: err }` writes the full stack to disk. This fixes on-disk error logging for **every** call site, not just electron.

## Verification

- Both files pass `node --check` and lint clean (`eslint`, no new problems).
- End-to-end test through the real modified `logger.js`: a simulated `EADDRINUSE` boot crash now writes a full, readable stack to the log file (previously: nothing / `"stack":{}`).

## Notes for reviewers

- **No CI change needed.** `.github/workflows/build.yml` just runs `electron-builder`; runtime error logging is app-code. Both files ship in the build (`src/**` and `build/**` are in the `files` glob; `winston` is a prod dependency).
- Crash behavior is unchanged (an unhandled rejection already quit the app before, via Node's throw→uncaughtException escalation) — this only **adds logging**.
- The reporting user's exact crash predates this fix, but the leading suspect is a `server.listen` bind failure (`serveIt` has no `server.on('error')` listener). The next occurrence will now be captured verbatim.

### Optional follow-ups (scoped out to keep this focused)
- Add `server.on('error', …)` in `serveIt` so port-bind failures log a clean message instead of relying on the process-level handler (helps electron **and** CLI).
- Mirror the `.catch` + winston routing in `cli-boot-wrapper.js` for parity.


## Follow-on commit: repair sites that bypass the convention

A survey of all 153 `winston.error/warn` call sites found the transport fix covers the large majority (the `{ stack: err }` convention) automatically. But ~8 sites pass the error in a way winston can't serialize, so they lose it on disk *even after* the transport fix:

- **`winston.warn(err)`** (bare Error as the message) → serializes to `{"code":...}` with **message and stack both gone**. Folded into the preceding context line as `{ stack: err }`: `util/file-explorer.js`, `api/file-explorer.js`, `api/download.js`.
- **`winston.error('label:', str)`** → the 2nd positional string is **dropped** (no `%s`), leaving just `"label:"`. Fixed by interpolation: `discogs.js` (×2, upgraded to `{ stack: e }` since these are caught exceptions) and `ytdl.js` (×3, subprocess output strings).

Deliberately left as-is: the ~90 sites that log `err.message` only for expected/operational conditions (full stacks there would be noise), and `winston.error('msg', err)` (e.g. `ytdl.js:111`) which already serializes correctly. Verified each fixed site writes the error detail to disk; no new lint problems (baseline lint counts unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
