### PR TITLE
fix(server): log listen() failures + fall back to IPv4 when IPv6 (::) can't bind

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -386,9 +386,9 @@ export async function serveIt(configFile) {
     res.status(500).json({ error: 'Server Error' });
   });
 
-  // Start the server!
-  server.on('request', mstream);
-  server.listen(config.program.port, config.program.address, async () => {
+  // Runs once the listening socket is bound. Logs the address and kicks off
+  // the post-boot hooks (scan, watchers, DLNA/Subsonic side-servers).
+  async function onListening() {
     const protocol = config.program.ssl && config.program.ssl.cert && config.program.ssl.key ? 'https' : 'http';
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
 
@@ -416,7 +416,47 @@ export async function serveIt(configFile) {
     // Boot server audio (Rust preferred, CLI fallback) — runs CLI detection
     // eagerly so the admin endpoint has fresh data by the time it's called.
     serverPlaybackApi.bootRustPlayer().catch(() => {});
+  }
+
+  // Surface — and where possible recover from — listen() failures. Without a
+  // handler, a failed bind emits an unhandled 'error' event: the CLI crashes
+  // and the packaged build only flashes a dialog, leaving NOTHING in the log
+  // to explain why the server never came up (the boot just stops after the
+  // ffmpeg lines). Now we log an actionable message with the OS error code.
+  //
+  // mStream defaults to the IPv6 wildcard `::`. On hosts where IPv6 is
+  // disabled, binding `::` fails with EADDRNOTAVAIL/EAFNOSUPPORT and the
+  // server never starts — so for the default address we transparently retry
+  // once on IPv4 `0.0.0.0` instead of dying.
+  let ipv4FallbackTried = false;
+  server.on('error', (err) => {
+    if (
+      (err.code === 'EADDRNOTAVAIL' || err.code === 'EAFNOSUPPORT')
+      && config.program.address === '::'
+      && !ipv4FallbackTried
+    ) {
+      ipv4FallbackTried = true;
+      winston.warn(`Could not bind IPv6 address :: (${err.code}); retrying on IPv4 0.0.0.0. Set "address": "0.0.0.0" in your config to make this the default.`);
+      server.listen(config.program.port, '0.0.0.0', onListening);
+      return;
+    }
+
+    let hint = `Failed to start the server on ${config.program.address}:${config.program.port}.`;
+    if (err.code === 'EADDRINUSE') {
+      hint = `Port ${config.program.port} is already in use — stop whatever is bound to it (often a previous mStream instance) or set a different "port" in your config.`;
+    } else if (err.code === 'EADDRNOTAVAIL' || err.code === 'EAFNOSUPPORT') {
+      hint = `Address "${config.program.address}" is not available on this host (${err.code}). Try setting "address": "0.0.0.0" in your config.`;
+    } else if (err.code === 'EACCES') {
+      hint = `Permission denied binding port ${config.program.port} (${err.code}) — ports below 1024 require elevated privileges; choose a higher port.`;
+    }
+    winston.error(`Server failed to start (${err.code || 'unknown error'}): ${err.message}. ${hint}`, { stack: err });
+    // Give the file logger a moment to flush this line before we exit.
+    setTimeout(() => process.exit(1), 500);
   });
+
+  // Start the server!
+  server.on('request', mstream);
+  server.listen(config.program.port, config.program.address, onListening);
 }
 
 export function reboot() {


### PR DESCRIPTION
## Problem

A user's server "won't boot" — the on-disk log just stops after the ffmpeg lines, with no error:

```
... FFmpeg OK!
(nothing)
```

Tracing it: this is a **fresh DB with no libraries** (so it's *not* the media-mount issue from #616), it's the **default UI** (so there are no `await`s between ffmpeg and `server.listen`), and the process stays alive (the ffmpeg auto-update timer keeps firing). A literal-IP bind can't *hang* — so the boot is **erroring at `server.listen`**, and `serveIt()` has **no `server.on('error')` handler**. The bind error escapes as an unhandled `'error'` event: the CLI crashes, the packaged electron build only flashes a dialog, and **nothing reaches the log**.

mStream defaults to the IPv6 wildcard `address: '::'`. The most likely trigger for a consistent every-boot failure on a fresh install is **IPv6 being disabled on the host** (`EADDRNOTAVAIL`), with a port-3000 conflict (`EADDRINUSE`) as the other candidate.

## Fix

In `serveIt()`, add `server.on('error')` before `server.listen`:

- **Log it.** An actionable message with the OS error code — `EADDRINUSE` (port in use), `EADDRNOTAVAIL`/`EAFNOSUPPORT` (address unavailable), `EACCES` (privileged port) — so the failure is finally visible in the log file (and, with #615 on master, with a readable stack).
- **Recover from the IPv6 case.** For the default `::` address, transparently retry once on IPv4 `0.0.0.0` instead of dying — so mStream just boots on IPv6-disabled hosts.
- Extracted the listen success callback into a named `onListening()` so the retry reuses it.

## Verification

- `node --check` + lint clean (no new problems vs `origin/master`).
- Behavior test with **real OS errors**:
  - Induced `EADDRNOTAVAIL` (bind to TEST-NET `192.0.2.1`) → handler re-`listen`s on `0.0.0.0` → server ends up listening. Confirms the re-listen-after-error mechanism the fallback depends on actually works.
  - Induced `EADDRINUSE` (occupied port) → clear "already in use" message logged.

## Notes
- This is the missing piece even after #615: #615 routes boot errors to the log, but a listen error would still surface as a generic "Unknown Error"; this gives a specific, actionable message **and** auto-recovers the common IPv6 case.
- On unrecoverable errors it logs then `process.exit(1)` (after a short flush delay) — consistent with the existing config-validation failure path. The electron desktop dialog is no longer shown for listen errors; the log message replaces it (most deployments, including the reporting user's, are headless).
- Immediate workaround for affected users without rebuilding: set `"address": "0.0.0.0"` (and/or a different `"port"`) in the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)