### PR TITLE
feat(server): surface fatal listen errors as an electron dialog (not just a log)

### DIFF
--- a/build/electron.js
+++ b/build/electron.js
@@ -75,6 +75,15 @@ function handleFatalError(error) {
 process.on('uncaughtException', handleFatalError);
 process.on('unhandledRejection', handleFatalError);
 
+// serveIt() catches its own fatal boot errors (e.g. a failed server.listen),
+// logs them with an actionable hint, then calls this hook so the desktop build
+// can show the user a dialog instead of failing silently. `message` is the same
+// text serveIt already wrote to the log.
+server.setFatalErrorHandler((err, message) => {
+  dialog.showErrorBox("Server Boot Error", message || `Server failed to start: ${err.message}`);
+  app.quit();
+});
+
 app.whenReady().then(bootServer).catch(handleFatalError);
 
 function bootServer() {

--- a/src/server.js
+++ b/src/server.js
@@ -60,6 +60,13 @@ const packageJson = require('../package.json');
 let mstream;
 let server;
 
+// Optional platform hook for surfacing a fatal boot error to the user before
+// the process ends. The electron build registers one that shows a dialog; with
+// no hook (CLI / library use) serveIt just logs and exits. The error is always
+// logged BEFORE this runs, so the handler only needs to deal with UX + exit.
+let fatalErrorHandler = null;
+export function setFatalErrorHandler(fn) { fatalErrorHandler = fn; }
+
 export async function serveIt(configFile) {
   mstream = express();
 
@@ -449,9 +456,17 @@ export async function serveIt(configFile) {
     } else if (err.code === 'EACCES') {
       hint = `Permission denied binding port ${config.program.port} (${err.code}) — ports below 1024 require elevated privileges; choose a higher port.`;
     }
-    winston.error(`Server failed to start (${err.code || 'unknown error'}): ${err.message}. ${hint}`, { stack: err });
-    // Give the file logger a moment to flush this line before we exit.
-    setTimeout(() => process.exit(1), 500);
+    const message = `Server failed to start (${err.code || 'unknown error'}): ${err.message}. ${hint}`;
+    winston.error(message, { stack: err });
+    if (fatalErrorHandler) {
+      // Platform hook (e.g. the electron build's dialog) — it owns surfacing
+      // the error to the user and terminating. Already logged above.
+      fatalErrorHandler(err, message);
+    } else {
+      // No hook (CLI / library use): give the file logger a moment to flush
+      // this line, then exit.
+      setTimeout(() => process.exit(1), 500);
+    }
   });
 
   // Start the server!


### PR DESCRIPTION
**Stacked on #617** (base is that branch — retarget to `master` once #617 merges).

## Why

In #617 a fatal `server.listen` error logs an actionable message and then `process.exit(1)`s. That's great for headless/CLI, but on the **desktop electron build** it means the error dialog is gone — the app just disappears. This restores the dialog **and** keeps the log, without coupling shared server code to electron.

## How

A tiny platform hook:

- **`src/server.js`** exposes `setFatalErrorHandler(fn)`. `serveIt`'s `server.on('error')` still logs the actionable, code-specific message first (so CLI *and* electron both get the on-disk line), then — if a handler is registered — hands it `(err, message)` to own the user-facing surfacing + termination; with no handler it flushes and exits exactly as before.
- **`build/electron.js`** registers a handler that shows that same `message` in a `showErrorBox` and `app.quit()`s.

Result: a listen failure is now **both logged and shown to the user**, with no duplicate logging and no `electron` import leaking into `src/`.

The dialog now carries the real hint instead of a generic "Unknown Error":
> Server failed to start (EADDRNOTAVAIL): listen EADDRNOTAVAIL … Address "::" is not available on this host (EADDRNOTAVAIL). Try setting "address": "0.0.0.0" in your config.

## Verification

- `node --check` + lint clean on both files (no new problems vs the #617 base).
- Dispatch contract tested: with a handler registered → the hook receives `(err, message)`, the dialog shows the actionable text, and the silent-exit path is **not** taken; EADDRINUSE surfaces the "port already in use" hint; with no handler (CLI) → the exit path is taken (still logged upstream).

## Note
`handleFatalError` (the `uncaughtException`/`unhandledRejection` path from #615) is unchanged and still covers errors `serveIt` doesn't catch itself; listen errors now flow through this dedicated hook instead, so there's no double dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)