### PR TITLE
perf(scanner): cut DB-writer-lock contention + speed up decode

### DIFF
--- a/rust-parser/Cargo.lock
+++ b/rust-parser/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "bytemuck",
  "lazy_static",
  "log",
+ "rustfft",
 ]
 
 [[package]]

--- a/rust-parser/Cargo.toml
+++ b/rust-parser/Cargo.toml
@@ -37,6 +37,16 @@ symphonia = { version = "0.5", default-features = false, features = [
     "isomp4",
     "ogg",
     "wav",
+    # opt-simd gates the rustfft-backed (SSE/AVX/NEON) inverse-MDCT path
+    # used by the transform codecs (MP3 hybrid filterbank, Vorbis, AAC) —
+    # the per-packet hot loop that dominates waveform/BPM decode, which is
+    # ~90% of scan wall-time. Without it those decode on rustfft's scalar
+    # fallback. rustfft does runtime CPU detection, so AVX is used only
+    # when present and otherwise falls back — safe for the generic
+    # prebuilt binaries. (Do NOT pair this with `-C target-cpu=native`:
+    # the committed binaries must run on older CPUs.) FLAC/WAV are integer
+    # codecs and don't touch the MDCT, so the win is codec-mix-dependent.
+    "opt-simd",
 ] }
 # File-level parallelism for the scan loop. Pure Rust, no C deps —
 # fits the same philosophy as md-5 / image-rs above. Workers run
@@ -61,3 +71,12 @@ stratum-dsp = "=1.0.0"
 
 [profile.release]
 strip = true
+# thin-LTO inlines across the symphonia/rustfft/md-5 crate boundaries into
+# the per-sample downmix + hashing hot loops (full LTO buys little more here
+# but costs much longer CI builds); codegen-units = 1 lets the optimizer see
+# each crate whole. Together ~5-15% across the decode + hash pass on top of
+# the opt-simd MDCT win above. panic stays at the default 'unwind' — NOT
+# 'abort' — because the parallel writer relies on std::thread::scope unwinding
+# a worker panic rather than killing the process mid-transaction.
+lto = "thin"
+codegen-units = 1

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -203,7 +203,9 @@ struct ExtractedTrack {
 
     // Captured from the prior tracks row (when one existed) so the
     // writer can run user_*-row + album-stars migrations after the
-    // INSERT OR REPLACE swaps the canonical identity.
+    // UPSERT in commit_track refreshes the canonical identity (the row
+    // is updated in place — same rowid — so these pre-images are the
+    // only record of what the identity used to be).
     old_hash: Option<String>,
     old_audio_hash: Option<String>,
     old_album_id: Option<i64>,
@@ -509,8 +511,30 @@ fn chunked_orphan_delete(
     loop {
         let changes = stmt.execute([])?;
         if changes == 0 { break; }
+        // Back-to-back chunks free the writer lock for only microseconds
+        // — useless to the server's busy handler (one poll per 100ms in
+        // its tail). A full chunk means more work likely remains, so
+        // open a real window. Same rationale + width as WRITER_YIELD.
+        if changes == ORPHAN_CHUNK_SIZE {
+            chunk_yield();
+        }
     }
     Ok(())
+}
+
+// Inter-chunk writer yield shared by the chunked delete loops: 10-20ms,
+// jittered so the cadence can't phase-lock with the server's 100ms
+// busy-retry tail. See the WRITER_YIELD comment block for the model.
+// Wall-clock subsecond nanos as the entropy source — Instant is an
+// opaque monotonic point (elapsed-since-now is always ~0), and pulling
+// in a rand dependency for one modulus would be overkill.
+fn chunk_yield() {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let jitter = u64::from(nanos) % WRITER_YIELD_JITTER_MS;
+    std::thread::sleep(Duration::from_millis(WRITER_YIELD_MIN_MS + jitter));
 }
 
 // Per-chunk row cap for the end-of-scan stale-track sweep. Same value as
@@ -531,9 +555,17 @@ const STALE_TRACK_CHUNK_SIZE: usize = 500;
 // from the main server. Chunking is the same cooperate-with-writers
 // pattern chunked_orphan_delete already uses. Returns the total rows
 // deleted (sum across chunks) so the scanComplete count stays accurate.
+//
+// `expected_schema_version` re-arms the mid-scan schema guard on EVERY
+// chunk: the sweep is no longer one atomic DELETE but an unbounded
+// sequence of autocommit transactions (with deliberate yields between
+// them), and a migration by another instance could land mid-sweep and
+// change what `scan_id != ?` selects. The PRAGMA read is trivial next
+// to a 500-row cascade delete. Errors carry the schema-guard sentinel
+// so main() maps them to exit 3.
 fn chunked_delete_stale_tracks(
-    conn: &Connection, library_id: i64, scan_id: &str,
-) -> rusqlite::Result<usize> {
+    conn: &Connection, library_id: i64, scan_id: &str, expected_schema_version: i64,
+) -> Result<usize, Box<dyn std::error::Error>> {
     let sql = format!(
         "DELETE FROM tracks WHERE id IN \
          (SELECT id FROM tracks WHERE library_id = ?1 AND scan_id != ?2 LIMIT {})",
@@ -542,9 +574,20 @@ fn chunked_delete_stale_tracks(
     let mut stmt = conn.prepare(&sql)?;
     let mut total = 0usize;
     loop {
+        let v: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        if v != expected_schema_version {
+            return Err(format!(
+                "{}DB schema changed mid-sweep (V{} -> V{}) — aborting stale-track cleanup \
+                 after {} rows",
+                SCHEMA_GUARD_ERROR_PREFIX, expected_schema_version, v, total,
+            ).into());
+        }
         let changes = stmt.execute(rusqlite::params![library_id, scan_id])?;
         total += changes;
         if changes == 0 { break; }
+        if changes == STALE_TRACK_CHUNK_SIZE {
+            chunk_yield();
+        }
     }
     Ok(total)
 }
@@ -561,15 +604,29 @@ fn chunked_delete_stale_tracks(
 // with FTS + M2M fan-out), so a pure row count under-bounds the hold on
 // heavy initial/force rescans.
 //
-// WRITER_YIELD_MS: after a batch that hit the cap (the channel still had
+// WRITER_YIELD: after a batch that hit the cap (the channel still had
 // work queued — i.e. we're writer-bound), sleep briefly with NO
 // transaction open so a waiting server writer can win the lock. SQLite's
 // busy handler is not fair; without a deliberate gap the hot writer
 // thread re-acquires almost instantly and the server write can exhaust
 // its 5s timeout. The yield is skipped when the channel drains naturally
 // (not writer-bound), so quiet rescans pay nothing.
+//
+// Why 10-20ms and jittered, not a small fixed value: the server's busy
+// handler (no SQLITE_ENABLE_SETLK_TIMEOUT in node's bundled build) polls
+// the lock at fixed offsets — densely for the first ~330ms, then once
+// every 100ms. A short fixed yield (e.g. 3ms) leaves the lock free ~3ms
+// out of every ~53ms cycle (~6% duty): modeled against the real retry
+// schedule that still gives waiting writes p90 waits of seconds and a
+// few-percent chance of exhausting the full 5s timeout — and a fixed
+// period can phase-lock with the 100ms tail so the same write loses
+// every round. A 10-20ms jittered window overlaps enough retry offsets
+// that the timeout probability drops to ~zero (p99 wait ~200ms), costing
+// ~20% writer-bound throughput and nothing at all when decode-bound or
+// quiet. Jitter is derived from the batch-start clock — no rand dep.
 const COMMIT_BUDGET_MS: u64 = 50;
-const WRITER_YIELD_MS: u64 = 3;
+const WRITER_YIELD_MIN_MS: u64 = 10;
+const WRITER_YIELD_JITTER_MS: u64 = 11; // yield = 10..=20ms
 
 // ── Main scan ───────────────────────────────────────────────────────────────
 
@@ -799,7 +856,14 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             };
 
             // Tight per-song transaction around just the DB write.
-            conn.execute("BEGIN", [])?;
+            // IMMEDIATE, not deferred: a cache-miss find_or_create_artist/
+            // album makes the first statement a SELECT, pinning a read
+            // snapshot before the first write — if the server commits in
+            // that window the lock upgrade dies with SQLITE_BUSY_SNAPSHOT,
+            // which bypasses the busy handler entirely (the same class
+            // src/db/manager.js transaction() fixed). IMMEDIATE takes the
+            // write lock up front where busy_timeout IS honored.
+            conn.execute("BEGIN IMMEDIATE", [])?;
             match write_extract_result(
                 &conn, config, result,
                 &artist_cache, &album_cache, &genre_cache, &various_artists_id,
@@ -937,7 +1001,17 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                 // the bounded channel never blocks a worker; do no DB work.
                 if err.is_some() { continue; }
 
-                if let Err(e) = conn.execute("BEGIN", []) {
+                // IMMEDIATE, not deferred: a batch whose first row needs a
+                // cache-miss artist/album lookup opens with a SELECT, which
+                // pins a read snapshot before the batch's first write. A
+                // server commit landing in that window — MORE likely now
+                // that the post-batch yield lets server writes win the lock
+                // — would fail the upgrade with SQLITE_BUSY_SNAPSHOT (no
+                // busy-handler retry, instant error) and poison the whole
+                // batch. IMMEDIATE takes the write lock at BEGIN, where the
+                // 5s busy_timeout applies. Same convention as
+                // src/db/manager.js transaction().
+                if let Err(e) = conn.execute("BEGIN IMMEDIATE", []) {
                     err = Some(Box::new(e));
                     stop.store(true, Ordering::Relaxed);
                     continue;
@@ -1017,19 +1091,40 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
+                // Progress row rides INSIDE the batch transaction. As its
+                // own autocommit statement after COMMIT it took and released
+                // the writer lock a second time per progress interval, right
+                // at the head of the post-COMMIT lock-free gap — and could
+                // itself stall on the busy handler whenever a waiting API
+                // write won the lock at COMMIT. Riding in the batch txn
+                // costs nothing extra and makes progress atomic with the
+                // rows it describes. The coupling cuts both ways: it shares
+                // the batch's fate on a rollback (one batch of display lag),
+                // and an UPDATE failure here must abort the batch like a
+                // COMMIT failure would — an auto-rollback-class error
+                // (FULL/IOERR/NOMEM) silently rolls back the whole
+                // transaction, after which issuing COMMIT would just mask
+                // the root cause with "cannot commit - no transaction is
+                // active".
+                if total_processed - last_progress_at >= commit_interval {
+                    if let Err(e) = conn.execute(
+                        "UPDATE scan_progress SET scanned = ?1, current_file = ?2 WHERE scan_id = ?3",
+                        rusqlite::params![total_processed, last_rel, config.scan_id],
+                    ) {
+                        err = Some(Box::new(e));
+                        stop.store(true, Ordering::Relaxed);
+                        let _ = conn.execute("ROLLBACK", []);
+                        continue;
+                    }
+                    last_progress_at = total_processed;
+                }
+
                 // Commit the batch and release the write lock before going
                 // back to the blocking recv() above.
                 if let Err(e) = conn.execute("COMMIT", []) {
                     err = Some(Box::new(e));
                     stop.store(true, Ordering::Relaxed);
                     continue;
-                }
-                if total_processed - last_progress_at >= commit_interval {
-                    let _ = conn.execute(
-                        "UPDATE scan_progress SET scanned = ?1, current_file = ?2 WHERE scan_id = ?3",
-                        rusqlite::params![total_processed, last_rel, config.scan_id],
-                    );
-                    last_progress_at = total_processed;
                 }
 
                 // Writer-bound backoff: when the batch hit the row/time cap
@@ -1038,9 +1133,14 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                 // free here, between COMMIT and the next BEGIN) so a waiting
                 // API write can win the writer lock instead of losing repeated
                 // busy-handler retries. Skipped when the channel drained
-                // naturally — a quiet rescan never pauses.
+                // naturally — a quiet rescan never pauses. Duration is
+                // 10-20ms, jittered off the batch clock so the yield cadence
+                // can't phase-lock with the server's 100ms busy-retry tail
+                // (see the WRITER_YIELD comment above the constants).
                 if hit_cap {
-                    std::thread::sleep(Duration::from_millis(WRITER_YIELD_MS));
+                    let jitter = u64::from(batch_start.elapsed().subsec_nanos())
+                        % WRITER_YIELD_JITTER_MS;
+                    std::thread::sleep(Duration::from_millis(WRITER_YIELD_MIN_MS + jitter));
                 }
             }
             err
@@ -1109,7 +1209,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // DELETE trigger, so on a large-deletion scan a single statement
         // would hold the writer lock past busy_timeout. See
         // chunked_delete_stale_tracks.
-        chunked_delete_stale_tracks(&conn, config.library_id, &config.scan_id)?
+        chunked_delete_stale_tracks(&conn, config.library_id, &config.scan_id, schema_version_at_open)?
     };
 
     // Clean up orphaned artists and albums. An artist is kept if ANY of:
@@ -1288,10 +1388,11 @@ fn extract_track(
     // tag parsing. A mid-parse failure used to leave the DELETE
     // committed without a matching INSERT on the next batch flush,
     // orphaning user_metadata / bookmarks / play-queue rows keyed off
-    // the old hash. The INSERT OR REPLACE in commit_track handles the
-    // row swap atomically — the old row (and its cascaded
-    // track_artists / track_genres) only disappears when the new one
-    // is ready to take its place.
+    // the old hash. The UPSERT in commit_track updates the old row in
+    // place (same rowid and created_at; stale track_artists /
+    // track_genres are removed by its explicit DELETEs, not a REPLACE
+    // cascade) and runs only once extraction has produced a complete
+    // result — until then no write touches the row at all.
     let (old_hash, old_audio_hash, old_album_id): (Option<String>, Option<String>, Option<i64>) =
         if let Some(e) = existing {
             let audio_unchanged = e.modified == mod_time;

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -4,6 +4,7 @@ use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use rayon::prelude::*;
 
@@ -512,6 +513,64 @@ fn chunked_orphan_delete(
     Ok(())
 }
 
+// Per-chunk row cap for the end-of-scan stale-track sweep. Same value as
+// ORPHAN_CHUNK_SIZE: each deleted tracks row is heavier than an orphan
+// (it fires the FTS5 AFTER DELETE trigger and cascades to track_genres /
+// track_artists), but 500 still keeps the per-chunk writer-lock hold well
+// under the 5s busy_timeout while bounding the per-iteration overhead of
+// re-running the candidate subselect. Mirrors ORPHAN_CHUNK_SIZE in
+// src/db/orphan-cleanup.js (deleteStaleTracks).
+const STALE_TRACK_CHUNK_SIZE: usize = 500;
+
+// Delete tracks not seen in this scan (file removed on disk), in chunks
+// so the single WAL writer lock is RELEASED between batches. Run as one
+// big `DELETE FROM tracks WHERE library_id=? AND scan_id!=?` it holds the
+// writer for the whole cascade + per-row FTS delete trigger — on a
+// large-deletion scan (moved/renamed top folder, migration force-rescan)
+// that can run past the 5s busy_timeout and stall concurrent API writes
+// from the main server. Chunking is the same cooperate-with-writers
+// pattern chunked_orphan_delete already uses. Returns the total rows
+// deleted (sum across chunks) so the scanComplete count stays accurate.
+fn chunked_delete_stale_tracks(
+    conn: &Connection, library_id: i64, scan_id: &str,
+) -> rusqlite::Result<usize> {
+    let sql = format!(
+        "DELETE FROM tracks WHERE id IN \
+         (SELECT id FROM tracks WHERE library_id = ?1 AND scan_id != ?2 LIMIT {})",
+        STALE_TRACK_CHUNK_SIZE,
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut total = 0usize;
+    loop {
+        let changes = stmt.execute(rusqlite::params![library_id, scan_id])?;
+        total += changes;
+        if changes == 0 { break; }
+    }
+    Ok(total)
+}
+
+// Parallel-writer batch tuning. The greedy-drain writer holds the single
+// WAL writer lock for one BEGIN..COMMIT span; these two knobs bound how
+// long it holds it and how aggressively it re-grabs it, so a concurrent
+// server write (scrobble/star/playlist) gets a turn instead of losing
+// repeated busy-handler retries until busy_timeout expires.
+//
+// COMMIT_BUDGET_MS: also break a batch once it has held the lock this
+// long in wall-clock, not just at commit_interval rows. A row's write
+// cost is wildly variable (a no-op scan_id bump vs. a full commit_track
+// with FTS + M2M fan-out), so a pure row count under-bounds the hold on
+// heavy initial/force rescans.
+//
+// WRITER_YIELD_MS: after a batch that hit the cap (the channel still had
+// work queued — i.e. we're writer-bound), sleep briefly with NO
+// transaction open so a waiting server writer can win the lock. SQLite's
+// busy handler is not fair; without a deliberate gap the hot writer
+// thread re-acquires almost instantly and the server write can exhaust
+// its 5s timeout. The yield is skipped when the channel drains naturally
+// (not writer-bound), so quiet rescans pay nothing.
+const COMMIT_BUDGET_MS: u64 = 50;
+const WRITER_YIELD_MS: u64 = 3;
+
 // ── Main scan ───────────────────────────────────────────────────────────────
 
 fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -606,6 +665,14 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             load_waveform_cache_names(Path::new(&config.waveform_cache_dir))
         }
     );
+    // Ensure the waveform cache dir exists ONCE up front, not per-track.
+    // The per-track .bin write previously called fs::create_dir_all on
+    // every changed file (an mkdir/stat syscall storm on a fresh scan);
+    // all .bin files live flat in this single dir, so one create here
+    // covers every later write_atomic.
+    if !config.waveform_cache_dir.is_empty() {
+        let _ = fs::create_dir_all(&config.waveform_cache_dir);
+    }
 
     // Bulk-prefetch every tracks row for this library into memory. The
     // per-file fast-path then lives off this HashMap instead of issuing
@@ -876,9 +943,15 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     continue;
                 }
 
+                let batch_start = Instant::now();
                 let mut msg = first;
                 let mut batch: u64 = 0;
                 let mut last_rel; // rel of the last processed msg, for progress
+                // True when we stopped draining because the batch was full
+                // or over its wall-clock budget (vs. the channel running
+                // dry). Signals we're writer-bound, so we yield the lock
+                // after COMMIT to let a waiting server writer in.
+                let mut hit_cap = false;
                 loop {
                     // Take the progress path before the match consumes
                     // msg.result (leaves msg fully moved, ready to reassign).
@@ -927,7 +1000,17 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     batch += 1;
                     last_rel = rel;
 
-                    if batch >= commit_interval { break; } // cap the lock-hold
+                    // Cap the lock-hold by row count OR wall-clock budget,
+                    // whichever trips first. The time bound matters because
+                    // a batch of heavy commit_track rows (FTS + M2M fan-out)
+                    // holds the lock far longer than the same count of cheap
+                    // scan_id bumps.
+                    if batch >= commit_interval
+                        || batch_start.elapsed() >= Duration::from_millis(COMMIT_BUDGET_MS)
+                    {
+                        hit_cap = true;
+                        break;
+                    }
                     match rx.try_recv() {
                         Ok(next) => msg = next,   // more queued → keep draining
                         Err(_) => break,          // empty or disconnected → commit & release
@@ -947,6 +1030,17 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                         rusqlite::params![total_processed, last_rel, config.scan_id],
                     );
                     last_progress_at = total_processed;
+                }
+
+                // Writer-bound backoff: when the batch hit the row/time cap
+                // the channel still had work queued, so we're outrunning the
+                // server. Sleep briefly with NO transaction open (the lock is
+                // free here, between COMMIT and the next BEGIN) so a waiting
+                // API write can win the writer lock instead of losing repeated
+                // busy-handler retries. Skipped when the channel drained
+                // naturally — a quiet rescan never pauses.
+                if hit_cap {
+                    std::thread::sleep(Duration::from_millis(WRITER_YIELD_MS));
                 }
             }
             err
@@ -1010,10 +1104,12 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     let deleted = if subtree_mode {
         0
     } else {
-        conn.execute(
-            "DELETE FROM tracks WHERE library_id = ? AND scan_id != ?",
-            rusqlite::params![config.library_id, config.scan_id],
-        )?
+        // CHUNKED, not one big DELETE: the stale-track sweep cascades to
+        // track_genres / track_artists and fires the per-row FTS5 AFTER
+        // DELETE trigger, so on a large-deletion scan a single statement
+        // would hold the writer lock past busy_timeout. See
+        // chunked_delete_stale_tracks.
+        chunked_delete_stale_tracks(&conn, config.library_id, &config.scan_id)?
     };
 
     // Clean up orphaned artists and albums. An artist is kept if ANY of:
@@ -1528,10 +1624,9 @@ fn extract_track(
                 // configured to and (b) this audio_hash hasn't already
                 // been written by another worker in the same scan.
                 if need_waveform {
+                    // Cache dir was created once at run_scan start — no
+                    // per-track create_dir_all here.
                     let wf_path = PathBuf::from(&config.waveform_cache_dir).join(&wf_filename);
-                    if let Some(dir) = wf_path.parent() {
-                        let _ = fs::create_dir_all(dir);
-                    }
                     // Atomic write via temp+rename. The unique sequence in
                     // write_atomic's temp filename is essential here: two
                     // workers can race on the same `wf_key` whenever two
@@ -1682,28 +1777,58 @@ fn commit_track(
 
     // Insert track. Hottest statement in the scanner — prepared once
     // per connection and reused for every changed file.
-    // V34 dropped tracks.genre — the canonical store is the track_genres
-    // M2M, populated below via set_track_genres. V36 added tracks.source
-    // (open-enum provenance) — extracted from custom tags in extract_track.
-    // Keep the column list in lock-step with src/db/scanner.mjs.
-    conn.prepare_cached(
-        "INSERT OR REPLACE INTO tracks (filepath, library_id, title, artist_id, album_id, track_number,
+    //
+    // UPSERT (ON CONFLICT … DO UPDATE) rather than INSERT OR REPLACE: a
+    // REPLACE on the UNIQUE(filepath, library_id) conflict is a DELETE +
+    // INSERT, which (a) fires BOTH the FTS5 AFTER DELETE and AFTER INSERT
+    // triggers per changed row, (b) cascade-deletes the row's track_genres
+    // / track_artists, and (c) allocates a brand-new rowid and re-stamps
+    // created_at — so the V43 "recently added" sort would reset on every
+    // tag edit. DO UPDATE keeps the same rowid + created_at and fires only
+    // the column-scoped AFTER UPDATE trigger (and only when title/artist/
+    // album/filepath actually changed), cutting the per-row writer-lock
+    // work that concurrent API writes wait on. RETURNING id covers both
+    // the insert and the update branch (last_insert_rowid is NOT updated
+    // on the DO UPDATE path). The migration inputs (old_*) were snapshotted
+    // before the write, so they don't depend on the pre-image surviving.
+    // V34 dropped tracks.genre — canonical store is the track_genres M2M,
+    // populated below. V36 added tracks.source. Keep the column list AND
+    // the DO UPDATE SET list in lock-step with src/db/scanner.mjs.
+    let track_id: i64 = conn.prepare_cached(
+        "INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, track_number,
          disc_number, year, duration, format, file_hash, audio_hash, album_art_file,
          replaygain_track_db, sample_rate, channels, bit_depth,
          lyrics_embedded, lyrics_synced_lrc, lyrics_lang, lyrics_sidecar_mtime,
          bpm, musical_key, bpm_source,
          modified, scan_id, source)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )?.execute(rusqlite::params![
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(filepath, library_id) DO UPDATE SET
+           title=excluded.title, artist_id=excluded.artist_id, album_id=excluded.album_id,
+           track_number=excluded.track_number, disc_number=excluded.disc_number, year=excluded.year,
+           duration=excluded.duration, format=excluded.format, file_hash=excluded.file_hash,
+           audio_hash=excluded.audio_hash, album_art_file=excluded.album_art_file,
+           replaygain_track_db=excluded.replaygain_track_db, sample_rate=excluded.sample_rate,
+           channels=excluded.channels, bit_depth=excluded.bit_depth,
+           lyrics_embedded=excluded.lyrics_embedded, lyrics_synced_lrc=excluded.lyrics_synced_lrc,
+           lyrics_lang=excluded.lyrics_lang, lyrics_sidecar_mtime=excluded.lyrics_sidecar_mtime,
+           bpm=excluded.bpm, musical_key=excluded.musical_key, bpm_source=excluded.bpm_source,
+           modified=excluded.modified, scan_id=excluded.scan_id, source=excluded.source
+         RETURNING id",
+    )?.query_row(rusqlite::params![
         et.rel_path, config.library_id, et.title, primary_track_artist_id, album_id,
         et.track_num, et.disc_num, et.year, et.duration_sec, et.ext, et.file_hash, et.audio_hash,
         et.aa_file, et.rg_track_db, et.sample_rate, et.channels, et.bit_depth,
         et.lyrics_embedded, et.lyrics_synced_lrc, et.lyrics_lang, et.current_sidecar_mtime,
         et.bpm, et.musical_key, et.bpm_source,
         et.mod_time, config.scan_id, et.source
-    ])?;
+    ], |row| row.get(0))?;
 
-    let track_id = conn.last_insert_rowid();
+    // Clear track_genres first. Under the old INSERT OR REPLACE the row's
+    // genres were cascade-dropped by the REPLACE; UPSERT keeps the same
+    // track_id, so a tag edit that REMOVES a genre would otherwise leak the
+    // stale row (set_track_genres only INSERTs OR IGNOREs). Mirror in scanner.mjs.
+    conn.prepare_cached("DELETE FROM track_genres WHERE track_id = ?")?
+        .execute(rusqlite::params![track_id])?;
     set_track_genres(conn, genre_cache, track_id, et.genre.as_deref())?;
 
     // V17: populate M2M. Album-artists — INSERT OR IGNORE across multiple
@@ -1728,8 +1853,9 @@ fn commit_track(
         }
     }
 
-    // Track-artists — clear first (defensive; REPLACE above should have
-    // cascaded, but a partial-run rescan could leave orphans). Primary is
+    // Track-artists — clear first, then repopulate. Load-bearing under the
+    // UPSERT above (which keeps the same track_id and so does NOT cascade-
+    // drop these the way the old INSERT OR REPLACE did). Primary is
     // role='main'; any additional collaborators are 'featured' in tag order.
     conn.prepare_cached("DELETE FROM track_artists WHERE track_id = ?")?
         .execute(rusqlite::params![track_id])?;

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -32,6 +32,24 @@
 // part on big libraries.
 const ORPHAN_CHUNK_SIZE = 500;
 
+// Between full chunks the writer lock is otherwise free for only
+// microseconds — far too narrow for the server's busy handler, which
+// polls densely for ~330ms and then only once per 100ms (see the
+// WRITER_YIELD comment in rust-parser/src/main.rs). 10-20ms jittered
+// gives a waiting API write a real window and can't phase-lock with
+// the 100ms retry cadence. The sleep is synchronous (Atomics.wait is
+// allowed on Node's main thread), which is why it is OPT-IN: fine in
+// the scanner (a dedicated child process), but it would pointlessly
+// block the event loop when the SERVER runs these helpers
+// (admin.js removeDirectory) — there is nobody to yield to when the
+// would-be beneficiary is the sleeping process itself.
+const YIELD_MIN_MS = 10;
+const YIELD_JITTER_MS = 11; // yield = 10..=20ms
+function chunkYield() {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0,
+    YIELD_MIN_MS + Math.floor(Math.random() * YIELD_JITTER_MS));
+}
+
 // Repeatedly DELETE up to ORPHAN_CHUNK_SIZE rows from `table` whose
 // ids match `selectIdsSql`, until no rows remain. SQLite's bundled
 // build doesn't ship with SQLITE_ENABLE_UPDATE_DELETE_LIMIT, so the
@@ -44,13 +62,17 @@ const ORPHAN_CHUNK_SIZE = 500;
 //
 // `table` and `selectIdsSql` are interpolated into the SQL string —
 // callers are responsible for passing trusted (non-user-input) values.
-function chunkedDelete(db, table, selectIdsSql) {
+function chunkedDelete(db, table, selectIdsSql, { yieldBetweenChunks = false } = {}) {
   const stmt = db.prepare(
     `DELETE FROM ${table} WHERE id IN (${selectIdsSql} LIMIT ${ORPHAN_CHUNK_SIZE})`,
   );
   while (true) {
     const r = stmt.run();
     if (r.changes === 0) { break; }
+    // A full chunk means more work likely remains — give a waiting
+    // server write a real window before re-taking the lock. Partial
+    // chunks fall through to the terminating zero-changes pass.
+    if (yieldBetweenChunks && r.changes === ORPHAN_CHUNK_SIZE) { chunkYield(); }
   }
 }
 
@@ -89,17 +111,35 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 // (500) keeps each chunk well under busy_timeout. Returns the total rows
 // deleted so the caller's scanComplete count stays accurate. Mirrors
 // chunked_delete_stale_tracks in rust-parser/src/main.rs.
-export function deleteStaleTracks(db, libraryId, scanId) {
+// `expectedSchemaVersion` (when given) re-arms the scanner's mid-scan
+// schema guard on EVERY chunk: the sweep is no longer one atomic DELETE
+// but an unbounded sequence of autocommit transactions, and a migration
+// by another instance could land between chunks and change what
+// `scan_id != ?` means. The PRAGMA read is trivial next to a 500-row
+// cascade delete. Throws a "schema-version guard:" error so the caller
+// can map it to the guard exit code. Only called from the scanner
+// process, so the inter-chunk yield is unconditional here.
+export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion = null) {
   const stmt = db.prepare(
     `DELETE FROM tracks WHERE id IN (
        SELECT id FROM tracks WHERE library_id = ? AND scan_id != ? LIMIT ${ORPHAN_CHUNK_SIZE}
      )`,
   );
+  const versionStmt = db.prepare('PRAGMA user_version');
   let total = 0;
   while (true) {
+    if (expectedSchemaVersion !== null) {
+      const v = versionStmt.get().user_version;
+      if (v !== expectedSchemaVersion) {
+        throw new Error(
+          `schema-version guard: DB schema changed mid-sweep ` +
+          `(V${expectedSchemaVersion} -> V${v}) — aborting stale-track cleanup`);
+      }
+    }
     const r = stmt.run(libraryId, scanId);
     total += r.changes;
     if (r.changes === 0) { break; }
+    if (r.changes === ORPHAN_CHUNK_SIZE) { chunkYield(); }
   }
   return total;
 }
@@ -108,8 +148,8 @@ export function deleteStaleTracks(db, libraryId, scanId) {
 // then artists (so artists referenced ONLY by orphaned albums become
 // eligible for deletion via the artists-NOT-IN-albums clause), then
 // genres (independent of the other two).
-export function cleanupOrphans(db) {
-  chunkedDelete(db, 'albums',  ORPHAN_ALBUMS_SQL);
-  chunkedDelete(db, 'artists', ORPHAN_ARTISTS_SQL);
-  chunkedDelete(db, 'genres',  ORPHAN_GENRES_SQL);
+export function cleanupOrphans(db, { yieldBetweenChunks = false } = {}) {
+  chunkedDelete(db, 'albums',  ORPHAN_ALBUMS_SQL,  { yieldBetweenChunks });
+  chunkedDelete(db, 'artists', ORPHAN_ARTISTS_SQL, { yieldBetweenChunks });
+  chunkedDelete(db, 'genres',  ORPHAN_GENRES_SQL,  { yieldBetweenChunks });
 }

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -78,6 +78,32 @@ const ORPHAN_ARTISTS_SQL = `SELECT id FROM artists
     AND NOT EXISTS (SELECT 1 FROM album_artists WHERE album_artists.artist_id = artists.id)`;
 const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM track_genres WHERE track_genres.genre_id = genres.id)';
 
+// Delete tracks not seen in the just-finished scan (file removed on disk),
+// CHUNKED so the single WAL writer lock is released between batches. Run as
+// one `DELETE FROM tracks WHERE library_id=? AND scan_id!=?` it holds the
+// writer for the entire cascade (track_genres / track_artists) + the per-row
+// FTS5 AFTER DELETE trigger — on a large-deletion scan (moved/renamed top
+// folder, migration force-rescan, emptied library) that can run past the 5s
+// busy_timeout and stall concurrent API writes from the main server. Same
+// cooperate-with-writers pattern as chunkedDelete above; ORPHAN_CHUNK_SIZE
+// (500) keeps each chunk well under busy_timeout. Returns the total rows
+// deleted so the caller's scanComplete count stays accurate. Mirrors
+// chunked_delete_stale_tracks in rust-parser/src/main.rs.
+export function deleteStaleTracks(db, libraryId, scanId) {
+  const stmt = db.prepare(
+    `DELETE FROM tracks WHERE id IN (
+       SELECT id FROM tracks WHERE library_id = ? AND scan_id != ? LIMIT ${ORPHAN_CHUNK_SIZE}
+     )`,
+  );
+  let total = 0;
+  while (true) {
+    const r = stmt.run(libraryId, scanId);
+    total += r.changes;
+    if (r.changes === 0) { break; }
+  }
+  return total;
+}
+
 // Run all three orphan DELETEs in sequence. Order matters: albums first,
 // then artists (so artists referenced ONLY by orphaned albums become
 // eligible for deletion via the artists-NOT-IN-albums clause), then

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -15,7 +15,7 @@ import { extractLyrics, sidecarMtime as probeLyricsSidecarMtime } from './lyrics
 import { computeHashes } from './audio-hash.js';
 import { extractArtists, chooseAlbumArtistId } from './artist-extraction.js';
 import { migrateAlbumStars } from './album-migration.js';
-import { cleanupOrphans } from './orphan-cleanup.js';
+import { cleanupOrphans, deleteStaleTracks } from './orphan-cleanup.js';
 import { detectSource } from './source-detect.js';
 
 // ── Parse CLI input ─────────────────────────────────────────────────────────
@@ -180,30 +180,58 @@ const stmts = {
   ),
   // V34 dropped tracks.genre — the canonical store is the track_genres
   // M2M (populated below via setTrackGenres at L470). Keep the column
-  // list in lock-step with the schema.js V1+V24 definitions.
+  // list AND the DO UPDATE SET list in lock-step with rust-parser's
+  // commit_track and the schema.js V1+V24 definitions.
   // V36: tracks.source records provenance (e.g. 'ytdl'). Extracted from
   // embedded tags by detectSource() in parseMyFile. NULL when no marker
   // is present.
+  //
+  // UPSERT (ON CONFLICT … DO UPDATE), not INSERT OR REPLACE: a REPLACE on
+  // the UNIQUE(filepath, library_id) conflict is a DELETE + INSERT, which
+  // fires both the FTS5 AFTER DELETE and AFTER INSERT triggers, cascade-
+  // deletes track_genres/track_artists, allocates a new rowid, and resets
+  // created_at (breaking the V43 "recently added" sort on every tag edit).
+  // DO UPDATE keeps the same rowid + created_at and fires only the
+  // column-scoped AFTER UPDATE trigger — less per-row work under the
+  // writer lock. RETURNING id covers both branches (lastInsertRowid is not
+  // updated on the UPDATE path), so insertTrack() reads it via .get().
   insertTrack: db.prepare(
-    `INSERT OR REPLACE INTO tracks (filepath, library_id, title, artist_id, album_id, track_number,
+    `INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, track_number,
      disc_number, year, duration, format, file_hash, audio_hash, album_art_file,
      replaygain_track_db, sample_rate, channels, bit_depth,
      lyrics_embedded, lyrics_synced_lrc, lyrics_lang, lyrics_sidecar_mtime,
      bpm, musical_key, bpm_source,
      modified, scan_id, source)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(filepath, library_id) DO UPDATE SET
+       title=excluded.title, artist_id=excluded.artist_id, album_id=excluded.album_id,
+       track_number=excluded.track_number, disc_number=excluded.disc_number, year=excluded.year,
+       duration=excluded.duration, format=excluded.format, file_hash=excluded.file_hash,
+       audio_hash=excluded.audio_hash, album_art_file=excluded.album_art_file,
+       replaygain_track_db=excluded.replaygain_track_db, sample_rate=excluded.sample_rate,
+       channels=excluded.channels, bit_depth=excluded.bit_depth,
+       lyrics_embedded=excluded.lyrics_embedded, lyrics_synced_lrc=excluded.lyrics_synced_lrc,
+       lyrics_lang=excluded.lyrics_lang, lyrics_sidecar_mtime=excluded.lyrics_sidecar_mtime,
+       bpm=excluded.bpm, musical_key=excluded.musical_key, bpm_source=excluded.bpm_source,
+       modified=excluded.modified, scan_id=excluded.scan_id, source=excluded.source
+     RETURNING id`
   ),
   // V17: M2M artist-link maintenance. Album-artists use INSERT OR IGNORE
   // so the same album getting re-walked by multiple tracks doesn't pile
-  // up duplicate rows. Track-artists are cleared first (track_id was
-  // just re-INSERTed so any stale CASCADE-dropped rows are already gone
-  // — this DELETE is a belt-and-braces for partial-run edge cases).
+  // up duplicate rows. Track-artists AND track-genres are cleared first
+  // and repopulated — this is load-bearing under the UPSERT insertTrack
+  // (which keeps the same track_id and so does NOT cascade-drop them the
+  // way the old INSERT OR REPLACE did); without the explicit DELETEs a
+  // tag edit that drops an artist/genre would leak the stale M2M row.
   insertAlbumArtist: db.prepare(
     `INSERT OR IGNORE INTO album_artists (album_id, artist_id, role, position)
      VALUES (?, ?, ?, ?)`
   ),
   deleteTrackArtists: db.prepare(
     'DELETE FROM track_artists WHERE track_id = ?'
+  ),
+  deleteTrackGenres: db.prepare(
+    'DELETE FROM track_genres WHERE track_id = ?'
   ),
   insertTrackArtist: db.prepare(
     `INSERT OR IGNORE INTO track_artists (track_id, artist_id, role, position)
@@ -213,9 +241,6 @@ const stmts = {
   // the album-artist fallback chain hits the compilation branch.
   findVariousArtists: db.prepare(
     `SELECT id FROM artists WHERE name = 'Various Artists' LIMIT 1`
-  ),
-  deleteOldTracks: db.prepare(
-    'DELETE FROM tracks WHERE library_id = ? AND scan_id != ?'
   ),
   findGenre: db.prepare(
     'SELECT id FROM genres WHERE name = ?'
@@ -532,7 +557,10 @@ function insertTrack(song) {
     lyricsEmbedded: null, lyricsSyncedLrc: null,
     lyricsLang: null, lyricsSidecarMtime: null,
   };
-  const result = stmts.insertTrack.run(
+  // .get() (not .run()) because the UPSERT carries `RETURNING id` — that's
+  // the only branch-agnostic way to get the rowid (lastInsertRowid is not
+  // updated on the DO UPDATE path).
+  const row = stmts.insertTrack.get(
     song.filePath,
     loadJson.libraryId,
     song.title ? String(song.title) : null,
@@ -562,8 +590,12 @@ function insertTrack(song) {
     loadJson.scanId,
     song.source ?? null
   );
-  const trackId = Number(result.lastInsertRowid);
+  const trackId = Number(row.id);
 
+  // Clear track_genres first — load-bearing under UPSERT (same track_id is
+  // kept, so the old genres are NOT cascade-dropped). setTrackGenres only
+  // INSERTs OR IGNOREs, so a removed genre would otherwise leak.
+  stmts.deleteTrackGenres.run(trackId);
   setTrackGenres(trackId, song.genre);
 
   // ── V17 M2M population ──────────────────────────────────────────────
@@ -577,9 +609,9 @@ function insertTrack(song) {
     stmts.insertAlbumArtist.run(albumId, albumArtistsForM2M[i], 'main', i);
   }
 
-  // track_artists: the track row was just (INSERT OR REPLACE)'d so any
-  // prior rows CASCADE-dropped. But the REPLACE path keeps the same id
-  // when (filepath, library_id) collides — clear first to be safe.
+  // track_artists: clear first, then repopulate. Load-bearing under the
+  // UPSERT (same track_id kept, so prior rows are NOT cascade-dropped the
+  // way the old INSERT OR REPLACE did).
   stmts.deleteTrackArtists.run(trackId);
   const trackArtistIds = ai.trackArtists.map(n => findOrCreateArtist(n)).filter(Number.isFinite);
   // Fall back to the primary track artist if the extractor returned
@@ -800,9 +832,13 @@ async function run() {
     // library_id but have an older scan_id, and wiping them would be a
     // data-loss bug. Stale cleanup runs only when we've actually
     // walked the whole library.
+    // CHUNKED stale-track sweep (see deleteStaleTracks) so the writer lock
+    // is released between batches instead of held for the whole cascade +
+    // FTS delete-trigger run. Runs in autocommit here (after the COMMIT
+    // above), so each chunk is its own transaction.
     const deleted = subtreeMode
       ? { changes: 0 }
-      : stmts.deleteOldTracks.run(loadJson.libraryId, loadJson.scanId);
+      : { changes: deleteStaleTracks(db, loadJson.libraryId, loadJson.scanId) };
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
     // to run the waveform post-processor and to print a human-readable summary.
     // Field shapes mirror the rust-parser's emitter:

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -730,14 +730,16 @@ async function recursiveScan(dir) {
           // before calling parseMyFile. If the parse throws (malformed
           // tags, disk error, locked file), the old row stays intact
           // and the user's user_metadata / bookmarks / play-queue
-          // entries keyed off the old hash are preserved. The INSERT
-          // below uses `INSERT OR REPLACE`, which atomically drops the
-          // old row (cascading track_artists/track_genres) and inserts
-          // the new one only after parseMyFile has returned a complete
-          // songInfo. Earlier revisions pre-DELETEd here; inside the
-          // scanner's batch transaction a mid-parse throw would commit
-          // the DELETE without a matching INSERT on the next 25-file
-          // flush, orphaning user state on the next scan.
+          // entries keyed off the old hash are preserved. The UPSERT in
+          // insertTrack updates the old row in place (same rowid and
+          // created_at; stale track_artists/track_genres rows are
+          // removed by its explicit DELETEs, not a REPLACE cascade) and
+          // only runs after parseMyFile has returned a complete
+          // songInfo — until then, no write touches the row at all.
+          // Earlier revisions pre-DELETEd here; inside the scanner's
+          // batch transaction a mid-parse throw would commit the DELETE
+          // without a matching INSERT on the next 25-file flush,
+          // orphaning user state on the next scan.
           const oldFileHash  = existing ? existing.file_hash  : null;
           const oldAudioHash = existing ? existing.audio_hash : null;
           const oldAlbumId   = existing ? existing.album_id   : null;
@@ -773,7 +775,10 @@ async function recursiveScan(dir) {
         if (totalProcessed % COMMIT_INTERVAL === 0) {
           db.exec('COMMIT');
           try { progressStmts.update.run(totalProcessed, relativePath, loadJson.scanId); } catch (_) {}
-          db.exec('BEGIN');
+          // IMMEDIATE — see the comment at the outer BEGIN in run();
+          // every batch here opens with getTrack reads, so a deferred
+          // BEGIN risks SQLITE_BUSY_SNAPSHOT.
+          db.exec('BEGIN IMMEDIATE');
         }
       } catch (err) {
         console.error(`Warning: failed to process ${filepath}: ${err.message}`);
@@ -809,7 +814,19 @@ async function run() {
     // Use explicit transactions for batch performance.
     // Without this, SQLite does a disk fsync per INSERT (~50 files/sec).
     // With transactions, it batches fsyncs (~5000+ files/sec).
-    db.exec('BEGIN');
+    //
+    // BEGIN IMMEDIATE, not deferred: the first statement of every batch
+    // is a READ (stmts.getTrack), which under a deferred BEGIN pins a
+    // read snapshot before the batch's first write. If the server
+    // commits in that window the eventual lock upgrade fails with
+    // SQLITE_BUSY_SNAPSHOT — instantly, bypassing the 5s busy_timeout
+    // (the same failure class src/db/manager.js transaction() was
+    // converted to IMMEDIATE for). The per-file catch would swallow the
+    // poisoned batch's errors file by file, those rows would miss their
+    // scan_id stamp, and the stale sweep below would delete live tracks.
+    // IMMEDIATE takes the write lock up front where the busy handler IS
+    // honored.
+    db.exec('BEGIN IMMEDIATE');
     await recursiveScan(scanRoot);
     db.exec('COMMIT');
 
@@ -838,7 +855,7 @@ async function run() {
     // above), so each chunk is its own transaction.
     const deleted = subtreeMode
       ? { changes: 0 }
-      : { changes: deleteStaleTracks(db, loadJson.libraryId, loadJson.scanId) };
+      : { changes: deleteStaleTracks(db, loadJson.libraryId, loadJson.scanId, schemaVersionAtOpen) };
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
     // to run the waveform post-processor and to print a human-readable summary.
     // Field shapes mirror the rust-parser's emitter:
@@ -859,8 +876,11 @@ async function run() {
     // Clean up orphaned artists, albums, and genres. SKIPPED in
     // subtree mode (we didn't delete any tracks, so nothing newly
     // orphaned). Whole-library scans still perform this cleanup.
+    // yieldBetweenChunks: we are a dedicated scanner process, so the
+    // inter-chunk sleep costs nothing and gives concurrent server
+    // writes a real window during big cleanups.
     if (!subtreeMode) {
-      cleanupOrphans(db);
+      cleanupOrphans(db, { yieldBetweenChunks: true });
     }
   } catch (err) {
     console.error('Scan failed');
@@ -869,7 +889,9 @@ async function run() {
     try { db.exec('ROLLBACK'); } catch (_) {}
     // A failed scan must not exit 0 — task-queue's close handler keys its
     // failure logging (and the boot-rescan resume marker) off the code.
-    process.exitCode = 1;
+    // The schema guard's mid-sweep abort maps to exit 3, matching the
+    // at-open guard and the rust scanner.
+    process.exitCode = String(err.message).startsWith('schema-version guard') ? 3 : 1;
   } finally {
     // Always clean up progress row, even on error
     try { progressStmts.remove.run(loadJson.scanId); } catch (_) {}

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -23,7 +23,7 @@
 //   V39 (torrent_client_vpath_access)      → V40
 //   V40 (managed_torrents.download_path)   → V41
 //   V41 (libraries.torrent_path_template)  → V42
-export const SCHEMA_VERSION = 43;
+export const SCHEMA_VERSION = 44;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -1368,6 +1368,19 @@ export const SCHEMA_V43 = `
   DROP INDEX IF EXISTS idx_user_bookmarks_user;
 `;
 
+// V44 drops idx_tracks_filepath. It indexes tracks(filepath, library_id) —
+// the exact same columns, in the same order, as the UNIQUE(filepath,
+// library_id) constraint, whose auto-index (sqlite_autoindex_tracks_1)
+// already serves every lookup the explicit index did (the getTrack
+// equality probe and the UPSERT conflict resolution). The duplicate just
+// doubled the filepath b-tree maintenance on every track INSERT/UPSERT —
+// pure write-amplification on the scanner's hottest path. Index-only, no
+// rescan. The base-schema CREATE is left in place (immutable migration
+// history); this DROP runs after it on both fresh and existing DBs.
+export const SCHEMA_V44 = `
+  DROP INDEX IF EXISTS idx_tracks_filepath;
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -1507,4 +1520,9 @@ export const MIGRATIONS = [
   // redundant single-column user_id indexes that duplicate each table's
   // PK/UNIQUE composite. Index-only, no rescan. See SCHEMA_V43.
   { version: 43, sql: SCHEMA_V43 },
+  // V44 drops the redundant idx_tracks_filepath (duplicate of the
+  // UNIQUE(filepath, library_id) auto-index) to cut b-tree write
+  // amplification on the scanner's hottest INSERT/UPSERT path. Index-only,
+  // no rescan. See SCHEMA_V44.
+  { version: 44, sql: SCHEMA_V44 },
 ];


### PR DESCRIPTION
## Why

Audit of the Rust scanner (and its JS twin `src/db/scanner.mjs`) targeting the intermittent **"server DB writes hang during a scan"** symptom — the scanner holds the single WAL writer lock long enough that concurrent API writes (scrobble / star / playlist save / play-queue) exhaust the 5 s `busy_timeout` — plus raw scan throughput. A multi-agent review surfaced the findings; each was adversarially verified against the code before landing here.

## What changed

### Contention (the hang)
- **Time-bounded commit + writer yield** — the parallel writer now ends a batch on `scanCommitInterval` rows **or** ~50 ms wall-clock (a heavy `commit_track` row costs far more under the lock than a cheap `scan_id` bump), and sleeps ~3 ms after a *capped* batch so a waiting API write can win the lock (SQLite's busy handler isn't fair). Skipped when the channel drains naturally → quiet rescans pay nothing.
- **Chunked stale-track DELETE** — `DELETE FROM tracks WHERE scan_id != ?` was a single unchunked statement that held the lock through the whole cascade + per-row FTS delete trigger. Now 500-row autocommit batches in both scanners (new `deleteStaleTracks` in `orphan-cleanup.js`), matching the orphan cleanup that was already chunked.
- **`INSERT OR REPLACE` → `ON CONFLICT … DO UPDATE … RETURNING id`** — one column-scoped FTS update per changed track instead of delete+insert (2 FTS ops + cascade churn + rowid churn).

### Speed
- **`opt-simd` + thin-LTO + `codegen-units=1`** in `Cargo.toml` — enables rustfft's SSE/AVX/NEON inverse-MDCT for the MP3/Vorbis/AAC decode that is ~90 % of scan wall-time, plus cross-crate inlining of the downmix/hash loops. `panic` stays `unwind` (`abort` would break the parallel writer's `std::thread::scope` worker-panic handling). rustfft does runtime CPU detection, so the generic prebuilt binaries stay safe on older CPUs.

### Hygiene
- **Schema V44** drops the redundant `idx_tracks_filepath` (duplicate of the `UNIQUE(filepath, library_id)` auto-index) — pure write-amplification on the hottest INSERT/UPSERT path.
- Hoisted `fs::create_dir_all` out of the per-track waveform write to once at scan start.

## Behavior improvements from the UPSERT
- **`created_at` is now preserved across rescans.** The old `INSERT OR REPLACE` silently reset it on every rescan of a *changed* file, so the V43 "recently added" sort was effectively "recently modified". Fixed.
- **Track ids are now stable across rescans.**

The UPSERT made `DELETE FROM track_artists` load-bearing (kept) and required an explicit `DELETE FROM track_genres` before repopulating, since the row no longer gets cascade-cleared.

## Testing
- **Scanner parity / determinism** (`scanner-parity.test.mjs`): two-scan determinism, `scanThreads=1` vs `=4` parity, parallel rescan with mixed changed/unchanged files, resume/no-op fast paths — all green.
- **audio-hash / lyrics / waveform** parity suites green (waveform determinism confirms `opt-simd` is reproducible within a build).
- **FTS5 / orphan-cleanup / schema** suites green, incl. "SCHEMA_VERSION is the latest migration" and "applying all migrations leaves user_version = SCHEMA_VERSION" (V44 applies cleanly).

## Note for release
The DB-contention fixes and decode speedups live in the **Rust binary**, so production installs get them only once CI (`build-rust-parser.yml`) rebuilds and re-commits the prebuilt binaries in `bin/rust-parser/`; local dev builds (`npm run build-rust`) pick them up immediately. The JS-fallback half (chunked delete, UPSERT) is live on merge.

## Not in this PR (audited backlog)
Defer waveform/BPM decode out of the DB-holding scan (~10× faster initial-scan library availability), raise the half-cores worker cap on decode-bound initial scans, WAL-checkpoint management (`wal_autocheckpoint` + end-of-scan `wal_checkpoint(TRUNCATE)`), merge the two `read_dir`-per-directory caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
