### PR TITLE
fix(db): BEGIN IMMEDIATE server transactions + unbreak the JS fallback scanner launch

### DIFF
--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -189,7 +189,15 @@ function runMigrations() {
       // migration loop can't self-heal (e.g. ALTER TABLE ADD COLUMN has no
       // IF NOT EXISTS, so re-running after a mid-migration failure would
       // error with "duplicate column").
-      db.exec('BEGIN');
+      //
+      // IMMEDIATE for the same SQLITE_BUSY_SNAPSHOT reason as transaction()
+      // above. Migrations are not guaranteed write-first against the MAIN
+      // db: V24 opens with CREATE TEMP TABLE ... AS SELECT, which writes
+      // only the per-connection temp db and READS main — and an orphaned
+      // scanner from a previous server instance can still be committing
+      // while this boot migrates. A migration aborts boot on failure, so
+      // it should wait out busy_timeout, not die on an instant 517.
+      db.exec('BEGIN IMMEDIATE');
       try {
         db.exec(migration.sql);
         setSchemaVersion(migration.version);

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -126,8 +126,20 @@ export function getDB() {
 // playlist mutations) don't pay a per-statement commit, and a concurrent reader
 // never sees a half-applied batch. SQLite has no nested transactions — don't
 // call this inside another transaction.
+//
+// BEGIN IMMEDIATE, not a deferred BEGIN: the scanner runs as a separate
+// process that commits write batches continuously during a scan. With a
+// deferred BEGIN, a body whose FIRST statement is a read (e.g. Subsonic
+// updatePlaylist SELECTs playlist positions before writing) pins a read
+// snapshot; when the scanner commits before the body's first write, the
+// lock upgrade fails with SQLITE_BUSY_SNAPSHOT — which does NOT invoke the
+// busy handler, so the 5s busy_timeout above never applies and the caller
+// gets an instant non-retryable "database is locked". IMMEDIATE takes the
+// write lock at BEGIN, where the busy handler IS honored, making that
+// failure class impossible. Behavior-neutral for write-first bodies (they
+// acquire the same lock one statement later anyway).
 export function transaction(fn) {
-  db.exec('BEGIN');
+  db.exec('BEGIN IMMEDIATE');
   try {
     const result = fn();
     db.exec('COMMIT');
@@ -548,8 +560,11 @@ export function setTrackGenres(trackId, genreStr) {
 // missing upnp:genre. The scanner runs in a separate process so
 // this matters in practice — the backup worker, scanner, and HTTP
 // handlers all share the same DB file.
+// BEGIN IMMEDIATE for the same reason as transaction() above — the body
+// is write-first today, but IMMEDIATE keeps it immune to the
+// SQLITE_BUSY_SNAPSHOT trap if a read is ever added before the DELETE.
 export function replaceTrackGenres(trackId, genreStr) {
-  db.exec('BEGIN');
+  db.exec('BEGIN IMMEDIATE');
   try {
     db.prepare('DELETE FROM track_genres WHERE track_id = ?').run(trackId);
     setTrackGenres(trackId, genreStr);

--- a/src/db/migrate-from-loki.js
+++ b/src/db/migrate-from-loki.js
@@ -47,8 +47,10 @@ export function migrate(db) {
   // retry duplicated every playlist's tracks — compounding each boot, and
   // unbounded if the failing step never succeeds. All-or-nothing makes a
   // retry start from a clean slate. Mirrors the per-migration transaction
-  // in manager.js runMigrations().
-  db.exec('BEGIN');
+  // in manager.js runMigrations() — including BEGIN IMMEDIATE, so the
+  // busy handler (not an instant SQLITE_BUSY_SNAPSHOT) decides the
+  // outcome if anything else holds the write lock during boot.
+  db.exec('BEGIN IMMEDIATE');
   try {
     migrateUsersAndFolders(db);
     migratePlaylists(db, dbDir);

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -68,7 +68,22 @@ const schema = Joi.object({
   // (tracks outside the subtree would otherwise be deleted as "not
   // seen this scan"). See the matching field in rust-parser/src/main.rs.
   subtree: Joi.string().allow('').default(''),
-});
+  // Rust-only: directory the Rust scanner writes waveform .bin files to.
+  // task-queue.js sends this to BOTH scanners (it stopped sending the
+  // older `generateWaveforms` boolean). The JS fallback doesn't generate
+  // waveforms, so it ignores the value — but it MUST accept the field or
+  // Joi rejects the whole jsonLoad. This omission previously made the JS
+  // fallback fail with "Invalid JSON Input" on every real launch.
+  waveformCacheDir: Joi.string().allow('').optional(),
+})
+  // Tolerate unknown keys. The Rust scanner gains config fields over
+  // time (each one a separate addition to task-queue.js's jsonLoad);
+  // enumerating every Rust-only field here by hand is what let
+  // `waveformCacheDir` slip through and break the fallback. Accepting
+  // unknowns keeps the JS fallback launchable no matter what Rust-only
+  // field is added next — the fields the JS scanner actually reads are
+  // still validated above.
+  .unknown(true);
 
 const { error: validationError } = schema.validate(loadJson);
 if (validationError) {


### PR DESCRIPTION
Two small, independent fixes from the June 2026 scanner audit — the "step 1" items that shrink the *writes fail during scans* symptom immediately, without touching the scanner PRs (#623, #603) in flight.

## 1. `BEGIN IMMEDIATE` in server transactions (`src/db/manager.js`)

`manager.transaction()` opened a **deferred** `BEGIN`. The scanner is a separate process committing write batches continuously during a scan, so any transaction body whose *first* statement is a read pins a stale-able read snapshot — and when the body then writes, the lock upgrade fails with **`SQLITE_BUSY_SNAPSHOT` (errcode 517)**, which *skips the busy handler entirely*: the 5s `busy_timeout` never applies, and the client gets an instant, non-retryable "database is locked".

Subsonic `updatePlaylist` hits this today: the standard add-song / remove-song calls from DSub/Symfonium/Ultrasonic execute no UPDATE before the body's SELECTs, so during heavy scan phases the endpoint fails near-deterministically — the scanner's COMMIT (its only way of releasing the lock) is precisely what invalidates the waiting snapshot.

`BEGIN IMMEDIATE` takes the write lock up front, where the busy handler **is** honored — the transaction waits up to `busy_timeout` like callers expect, and the snapshot-staleness failure class becomes impossible. Behavior-neutral for the nine write-first call sites (they acquired the same lock one statement later anyway). `replaceTrackGenres()` gets the same one-word change for uniformity.

The third commit extends this to the boot-time migration loop and the LokiJS importer — notably, V24's first statement (`CREATE TEMP TABLE ... AS SELECT`) only *reads* the main DB, so the migration loop was quietly relying on the same unenforced write-first invariant, and an orphaned scanner from a previous server instance can still be committing during boot. With that, every explicit transaction in the server process is `IMMEDIATE` and statement order inside a body is never load-bearing.

Reproduced before/after on this runtime (Node 24.13, `node:sqlite`, WAL, `busy_timeout=5000`):

```
deferred BEGIN: write failed INSTANTLY -> errcode=517 (SQLITE_BUSY_SNAPSHOT) — busy_timeout never applied
BEGIN IMMEDIATE: read-then-write committed fine (snapshot taken with the lock held)
competitor with IMMEDIATE: waited its full busy_timeout then errcode=5 (SQLITE_BUSY) — normal, retryable
```

## 2. Unbreak the JS fallback scanner launch (`src/db/scanner.mjs`)

`task-queue.js` sends one `jsonLoad` to both scanners, and it includes `waveformCacheDir` (it stopped sending the older `generateWaveforms` boolean). The JS fallback's Joi schema never listed that field, and Joi rejects unknown keys by default — so **every real launch of the JS fallback dies instantly** with `Invalid JSON Input` / exit 1. Any install without a working Rust binary currently has a scanner that cannot run at all.

CI never caught it because the parity tests hand-build their own `jsonLoad` (without `waveformCacheDir`) instead of going through task-queue.

Fix: accept the field, plus `.unknown(true)` so the next Rust-only field added to the payload can't re-break the fallback the same way. The hunk is **verbatim identical to PR #603's**, so the eventual rebase of #603 over this auto-merges.

Verified by forking `scanner.mjs` with a task-queue-shaped payload against a fresh fully-migrated DB:

```
[master-BEFORE] exit=1  "waveformCacheDir" is not allowed
[fixed-AFTER]   exit=0  {"event":"scanComplete","filesProcessed":0,...}
```

## Testing

- Full suite: **1154/1156 pass** — the 2 failures (`dlna.test.mjs:605`, `subsonic-phase3.test.mjs:205`, both 503-vs-200 on ffmpeg-transcode endpoints) reproduce identically on a clean `master` checkout in the same environment, i.e. pre-existing and unrelated.
- Migration-path tests (`migrate-from-loki`, `hash-migration`, `db-fts5-schema`, `db-v34-drop-genre`, `orphan-cleanup`) re-run green after the third commit.
- Both empirical repros above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
