### PR TITLE
fix(scanner): data-loss hardening — verify-absence sweep, rollback hygiene, tolerant reads, died-on-arrival fallback

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -1035,6 +1035,12 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
 
     let mut file_count = 0u64;      // new/modified files parsed
     let mut total_processed = 0u64; // all files touched (including unchanged — for progress)
+    let mut error_count = 0u64;     // per-file failures — kept separate so
+                                    // filesUnchanged doesn't absorb errored
+                                    // files (the scanComplete contract is
+                                    // visited = processed + unchanged +
+                                    // errors; mirrors errorCount in
+                                    // src/db/scanner.mjs)
     // Commit cadence: doubles as progress-update cadence and write-lock release.
     // Lower = more responsive API writes during scans but more COMMIT/BEGIN overhead.
     // Admin-configurable via scanCommitInterval; default (25) is a balanced starting point.
@@ -1078,6 +1084,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                 Err(e) => {
                     eprintln!("Warning: failed to process {}: {}", entry.path().display(), e);
                     total_processed += 1;
+                    error_count += 1;
                     continue;
                 }
             };
@@ -1116,6 +1123,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     // a compilation track can CREATE the "Various Artists"
                     // row inside the rolled-back transaction.
                     *various_artists_id.lock().unwrap() = None;
+                    error_count += 1;
                     eprintln!("Warning: failed to commit {}: {}", entry.path().display(), e);
                 }
             }
@@ -1282,9 +1290,12 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 .and_then(|mut stmt| stmt.execute(rusqlite::params![config.scan_id, existing_id]))
                             {
                                 Ok(_) => {}
-                                Err(e) => eprintln!(
-                                    "Warning: scan_id update failed for {}: {}", rel, e
-                                ),
+                                Err(e) => {
+                                    error_count += 1;
+                                    eprintln!(
+                                        "Warning: scan_id update failed for {}: {}", rel, e
+                                    );
+                                }
                             }
                         }
                         Ok(ExtractResult::Extracted(et)) => {
@@ -1322,15 +1333,19 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     // "Various Artists" row inside the
                                     // rolled-back savepoint.
                                     *various_artists_id.lock().unwrap() = None;
+                                    error_count += 1;
                                     eprintln!(
                                         "Warning: failed to commit {}: {}", rel, e
                                     );
                                 }
                             }
                         }
-                        Err(e) => eprintln!(
-                            "Warning: failed to process {}: {}", rel, e
-                        ),
+                        Err(e) => {
+                            error_count += 1;
+                            eprintln!(
+                                "Warning: failed to process {}: {}", rel, e
+                            );
+                        }
                     }
                     total_processed += 1;
                     batch += 1;
@@ -1552,7 +1567,12 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     //                        from cleanup). Surfaced so a permanently
     //                        unreadable subtree is operator-visible in the
     //                        scan summary instead of only a stderr line.
-    let unchanged = total_processed.saturating_sub(file_count);
+    // unchanged excludes errored files: the contract is
+    // visited (filesScanned) = processed + unchanged + errors,
+    // matching the JS emitter. total_processed already counts errors.
+    let unchanged = total_processed
+        .saturating_sub(file_count)
+        .saturating_sub(error_count);
     println!(
         "{{\"event\":\"scanComplete\",\"filesProcessed\":{},\"filesUnchanged\":{},\"filesScanned\":{},\"staleEntriesRemoved\":{},\"walkErrors\":{}}}",
         file_count, unchanged, total_processed, deleted, walk_errors

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -323,11 +323,24 @@ fn load_existing_tracks(
             row.get::<_, String>(0)?,
             ExistingTrack {
                 id: row.get(1)?,
-                modified: row.get(2)?,
+                // TOLERANT reads for modified + lyrics_sidecar_mtime: the
+                // columns have INTEGER affinity, but rows written by older
+                // JS scanners carry fractional stat.mtimeMs stored as REAL
+                // — and rusqlite's strict i64 read rejects REAL with
+                // InvalidColumnType, killing the ENTIRE scan over one
+                // poisoned row (exit 1, no fallback). Read via f64 (accepts
+                // both storage classes) and truncate, matching what the
+                // fixed JS writer now stores. V46 repairs stored rows; this
+                // keeps the scanner alive against any that slip through.
+                // NULL maps to 0 — never a real mtime, so the unchanged
+                // fast-path misses, the file re-extracts, and the UPSERT
+                // writes a proper integer (self-healing instead of
+                // aborting the whole scan over one bad row).
+                modified: row.get::<_, Option<f64>>(2)?.map(|v| v as i64).unwrap_or(0),
                 file_hash: row.get::<_, Option<String>>(3)?,
                 audio_hash: row.get::<_, Option<String>>(4)?,
                 album_id: row.get::<_, Option<i64>>(5)?,
-                lyrics_sidecar_mtime: row.get::<_, Option<i64>>(6)?,
+                lyrics_sidecar_mtime: row.get::<_, Option<f64>>(6)?.map(|v| v as i64),
                 scan_id: row.get::<_, Option<String>>(7)?,
             },
         ))
@@ -470,6 +483,15 @@ fn main() {
         }
     };
 
+    // Liveness banner — the FIRST stdout write, before any environment-
+    // dependent work (mount checks, DB open, prefetch). task-queue's
+    // died-on-arrival fallback keys on "exited non-zero with zero stdout";
+    // this line makes that signature mean what it says: the binary itself
+    // never ran. Without it, a transiently-unplugged mount or a busy DB at
+    // open would be indistinguishable from a dynamic-linker abort and
+    // would wrongly disable the Rust scanner for the process lifetime.
+    println!("{{\"event\":\"scanStart\"}}");
+
     if let Err(e) = run_scan(&config) {
         eprintln!("Scan Failed\n{}", e);
         // Exit 3 mirrors scanner.mjs's schema-version-guard exit code so
@@ -507,15 +529,26 @@ const ORPHAN_CHUNK_SIZE: usize = 500;
 // a single DELETE that handles everything plus one trivial no-op
 // confirmation; on a large one it's many small DELETEs that cooperate
 // with concurrent writers instead of starving them.
+// `expected_schema_version` re-verifies PRAGMA user_version before every
+// chunk, exactly like chunked_delete_stale_tracks: these yielding loops
+// are the widest mid-scan windows for a migration by another instance to
+// land in. Mirrors the guard the JS twin gained in orphan-cleanup.js.
 fn chunked_orphan_delete(
-    conn: &Connection, table: &str, select_ids_sql: &str,
-) -> rusqlite::Result<()> {
+    conn: &Connection, table: &str, select_ids_sql: &str, expected_schema_version: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
     let sql = format!(
         "DELETE FROM {} WHERE id IN ({} LIMIT {})",
         table, select_ids_sql, ORPHAN_CHUNK_SIZE,
     );
     let mut stmt = conn.prepare(&sql)?;
     loop {
+        let v: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        if v != expected_schema_version {
+            return Err(format!(
+                "{}DB schema changed mid-cleanup (V{} -> V{}) — aborting orphan cleanup of {}",
+                SCHEMA_GUARD_ERROR_PREFIX, expected_schema_version, v, table,
+            ).into());
+        }
         let changes = stmt.execute([])?;
         if changes == 0 { break; }
         // Back-to-back chunks free the writer lock for only microseconds
@@ -570,16 +603,63 @@ const STALE_TRACK_CHUNK_SIZE: usize = 500;
 // change what `scan_id != ?` selects. The PRAGMA read is trivial next
 // to a 500-row cascade delete. Errors carry the schema-guard sentinel
 // so main() maps them to exit 3.
+// VERIFY-ABSENCE: a row is only deleted after a fresh filesystem check
+// proves its file is really gone. An unstamped scan_id is NOT proof of
+// deletion — every swallowed per-file error (transient SQLITE_BUSY on the
+// stamp, a sharing violation, a decode crash) and every unreadable walk
+// subtree leaves LIVE tracks unstamped, and the old sweep deleted them,
+// cascading user_album_stars/user_artist_stars away permanently.
+//
+// Presence is decided from the PARENT DIRECTORY LISTING, not a per-file
+// stat, because the obvious stat has three failure modes that all bite:
+//  - a stat error is NOT proof of absence (EACCES/EIO on a degraded mount
+//    must keep data, only NotFound proves deletion) — fail closed;
+//  - stats are case-insensitive on Windows/macOS, so a case-only rename
+//    would keep resurrecting the old-casing row forever; the listing
+//    gives exact on-disk names to compare;
+//  - one stat per gone file is a network round-trip each on CIFS/NFS;
+//    one read_dir per directory amortises a mass deletion.
+//
+// Outcomes per candidate:
+//  - under a failed-walk prefix → SKIPPED untouched (we couldn't see that
+//    subtree this scan; neither delete nor claim it was seen);
+//  - listing readable, exact-case name present as a regular file (or a
+//    symlink resolving to one under follow_symlinks) → KEPT, re-stamped
+//    with the "<scan_id>-kept" sentinel: it leaves this sweep's candidate
+//    set but stays != every real scan id, so the next scan re-examines it
+//    and a resumable boot-rescan epoch does NOT mistake it for re-parsed;
+//  - listing readable, name absent (or not a file) → DELETED;
+//  - listing's directory NotFound → DELETED (the whole folder is gone);
+//  - listing unreadable for any other reason → SKIPPED untouched.
+//
+// Keyset pagination (id > cursor) guarantees termination even though
+// skipped candidates remain unstamped. The library root is re-verified
+// every chunk: if the mount vanished mid-sweep, every listing would
+// suddenly read NotFound and the sweep would happily erase the library —
+// the root check aborts instead (matching the vanished-mount walk guard).
 fn chunked_delete_stale_tracks(
     conn: &Connection, library_id: i64, scan_id: &str, expected_schema_version: i64,
+    library_root: &str, follow_symlinks: bool, failed_walk_prefixes: &[String],
 ) -> Result<usize, Box<dyn std::error::Error>> {
-    let sql = format!(
-        "DELETE FROM tracks WHERE id IN \
-         (SELECT id FROM tracks WHERE library_id = ?1 AND scan_id != ?2 LIMIT {})",
+    let select_sql = format!(
+        "SELECT id, filepath FROM tracks \
+          WHERE library_id = ?1 AND scan_id != ?2 AND id > ?3 \
+          ORDER BY id LIMIT {}",
         STALE_TRACK_CHUNK_SIZE,
     );
-    let mut stmt = conn.prepare(&sql)?;
+    let mut select = conn.prepare(&select_sql)?;
+    let kept_stamp = format!("{}-kept", scan_id);
+    let root = Path::new(library_root);
+
+    // Per-sweep listing cache: rel dir (fwd slashes) → Some(name → kind)
+    // or None when the directory itself was unreadable (≠ NotFound).
+    #[derive(Clone, Copy, PartialEq)]
+    enum Kind { RegularFile, Symlink, Other }
+    let mut listings: HashMap<String, Option<HashMap<String, Kind>>> = HashMap::new();
+
     let mut total = 0usize;
+    let mut skipped = 0usize;
+    let mut cursor: i64 = 0;
     loop {
         let v: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         if v != expected_schema_version {
@@ -589,12 +669,109 @@ fn chunked_delete_stale_tracks(
                 SCHEMA_GUARD_ERROR_PREFIX, expected_schema_version, v, total,
             ).into());
         }
-        let changes = stmt.execute(rusqlite::params![library_id, scan_id])?;
-        total += changes;
-        if changes == 0 { break; }
-        if changes == STALE_TRACK_CHUNK_SIZE {
-            chunk_yield();
+        if !root.is_dir() {
+            eprintln!(
+                "Warning: library root became inaccessible mid-sweep ({}) — aborting \
+                 stale-track cleanup after {} rows to avoid wiping the library",
+                library_root, total,
+            );
+            break;
         }
+        let candidates: Vec<(i64, String)> = select
+            .query_map(rusqlite::params![library_id, scan_id, cursor], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<_, _>>()?;
+        if candidates.is_empty() { break; }
+        let full_chunk = candidates.len() == STALE_TRACK_CHUNK_SIZE;
+        cursor = candidates.last().map(|(id, _)| *id).unwrap_or(cursor);
+
+        let mut doomed: Vec<i64> = Vec::new();
+        let mut survivors: Vec<i64> = Vec::new();
+        for (id, rel) in &candidates {
+            // A failed prefix shields its exact path and everything below
+            // it (slash boundary — "Artist/Bad" must not shield
+            // "Artist/Bad2"). The empty prefix (unattributable error)
+            // shields everything.
+            let shielded = failed_walk_prefixes.iter().any(|p| {
+                p.is_empty()
+                    || rel == p
+                    || (rel.len() > p.len()
+                        && rel.starts_with(p.as_str())
+                        && rel.as_bytes()[p.len()] == b'/')
+            });
+            if shielded {
+                skipped += 1;
+                continue;
+            }
+            let (dir_rel, name) = match rel.rfind('/') {
+                Some(i) => (&rel[..i], &rel[i + 1..]),
+                None => ("", rel.as_str()),
+            };
+            let listing = listings.entry(dir_rel.to_string()).or_insert_with(|| {
+                match fs::read_dir(root.join(dir_rel)) {
+                    Ok(entries) => Some(entries.filter_map(|e| e.ok()).map(|e| {
+                        let kind = match e.file_type() {
+                            Ok(t) if t.is_file() => Kind::RegularFile,
+                            Ok(t) if t.is_symlink() => Kind::Symlink,
+                            _ => Kind::Other,
+                        };
+                        (e.file_name().to_string_lossy().into_owned(), kind)
+                    }).collect()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Some(HashMap::new()),
+                    Err(_) => None, // unreadable — fail closed, skip its rows
+                }
+            });
+            match listing {
+                None => { skipped += 1; }
+                Some(names) => match names.get(name) {
+                    Some(Kind::RegularFile) => survivors.push(*id),
+                    Some(Kind::Symlink) if follow_symlinks => {
+                        // Walk-faithful: a symlink the walk would have
+                        // followed counts as present only if its target
+                        // resolves to a regular file right now.
+                        match fs::metadata(root.join(rel)) {
+                            Ok(m) if m.is_file() => survivors.push(*id),
+                            Ok(_) => doomed.push(*id),
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => doomed.push(*id),
+                            Err(_) => { skipped += 1; }
+                        }
+                    }
+                    // Exact-case name missing, a non-file, or a symlink the
+                    // no-follow walk would not index — the walk's reality
+                    // says this row's file is gone.
+                    _ => doomed.push(*id),
+                },
+            }
+        }
+        if !survivors.is_empty() {
+            eprintln!(
+                "Warning: {} track(s) missed their scan stamp but still exist on disk — \
+                 keeping them (re-stamped '-kept'); a swallowed per-file error likely occurred",
+                survivors.len(),
+            );
+            let placeholders = vec!["?"; survivors.len()].join(",");
+            let restamp_sql = format!(
+                "UPDATE tracks SET scan_id = ? WHERE id IN ({})", placeholders,
+            );
+            let mut params: Vec<&dyn rusqlite::ToSql> = vec![&kept_stamp];
+            params.extend(survivors.iter().map(|id| id as &dyn rusqlite::ToSql));
+            conn.prepare(&restamp_sql)?.execute(params.as_slice())?;
+        }
+        if !doomed.is_empty() {
+            let placeholders = vec!["?"; doomed.len()].join(",");
+            let del_sql = format!("DELETE FROM tracks WHERE id IN ({})", placeholders);
+            total += conn.prepare(&del_sql)?
+                .execute(rusqlite::params_from_iter(doomed.iter()))?;
+        }
+        if full_chunk { chunk_yield(); }
+    }
+    if skipped > 0 {
+        eprintln!(
+            "Warning: {} stale-candidate row(s) left untouched because their subtree \
+             could not be verified this scan (walk errors or unreadable directories)",
+            skipped,
+        );
     }
     Ok(total)
 }
@@ -788,10 +965,53 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // over the list and no throwaway String allocation per file. File
     // extensions are ASCII by convention, so `to_ascii_lowercase` skips the
     // Unicode mapping table `to_lowercase` would apply.
+    // Walk errors are RECORDED, not silently dropped: an unreadable
+    // subdirectory (permissions flip, antivirus lock, CIFS/NFS mount dying
+    // mid-walk) means every file under it is absent from `entries`, their
+    // rows keep their old scan_id, and the stale sweep would treat them as
+    // deleted. Each failed path becomes a sweep-skip prefix — rows under
+    // it are neither deleted nor re-stamped this scan — so the rest of the
+    // library still cleans normally even when one #recycle-style dir is
+    // permanently unreadable. Benign per-entry errors (dangling symlinks,
+    // symlink loops under follow_links) are library CONTENT, not lost
+    // subtrees: they're logged but don't shield anything — the sweep's
+    // listing check handles their rows faithfully. An error walkdir can't
+    // attribute to a path records the EMPTY prefix, shielding everything
+    // (fail closed). Detail logging is capped; the count always reports.
+    let mut failed_walk_prefixes: Vec<String> = Vec::new();
+    let mut walk_errors = 0usize;
+    let mut walk_error_logs = 0usize;
     let entries: Vec<(walkdir::DirEntry, String)> = WalkDir::new(&scan_root)
         .follow_links(config.follow_symlinks)
         .into_iter()
-        .filter_map(|e| e.ok())
+        .filter_map(|e| match e {
+            Ok(entry) => Some(entry),
+            Err(err) => {
+                let benign = err.loop_ancestor().is_some()
+                    || err.io_error()
+                        .map(|io| io.kind() == std::io::ErrorKind::NotFound)
+                        .unwrap_or(false);
+                if walk_error_logs < 20 {
+                    eprintln!(
+                        "Warning: directory walk error ({}): {}",
+                        if benign { "dangling symlink/loop, entry skipped" } else { "subtree shielded from cleanup" },
+                        err,
+                    );
+                } else if walk_error_logs == 20 {
+                    eprintln!("Warning: suppressing further walk-error detail (count continues)");
+                }
+                walk_error_logs += 1;
+                if !benign {
+                    walk_errors += 1;
+                    let rel = err.path()
+                        .and_then(|p| p.strip_prefix(&config.directory).ok())
+                        .map(|p| p.to_string_lossy().replace('\\', "/"))
+                        .unwrap_or_default();
+                    failed_walk_prefixes.push(rel);
+                }
+                None
+            }
+        })
         .filter(|e| e.file_type().is_file())
         .filter_map(|e| {
             let ext = file_ext(e.path()).to_ascii_lowercase();
@@ -875,13 +1095,30 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                 &conn, config, result,
                 &artist_cache, &album_cache, &genre_cache, &various_artists_id,
             ) {
-                Ok(true)  => { file_count += 1; }
-                Ok(false) => {} // skipped (unchanged)
+                Ok(true)  => { conn.execute("COMMIT", [])?; file_count += 1; }
+                Ok(false) => { conn.execute("COMMIT", [])?; } // skipped (unchanged)
                 Err(e) => {
+                    // ROLLBACK, not COMMIT: this previously fell through to
+                    // COMMIT and persisted whatever half of the track had
+                    // been written before the failure. And the rollback
+                    // un-creates any artists/albums/genres inserted inside
+                    // this transaction, so the memo caches must be evicted —
+                    // a cached id may now be dangling, or (sqlite_sequence
+                    // rolls back too) get reassigned to a DIFFERENT name by
+                    // the next insert, silently misattributing every later
+                    // track of that artist. Clearing all three is cheap:
+                    // repopulation costs one SELECT per name.
+                    let _ = conn.execute("ROLLBACK", []);
+                    artist_cache.lock().unwrap().clear();
+                    album_cache.lock().unwrap().clear();
+                    genre_cache.lock().unwrap().clear();
+                    // The VA memo is a fourth cache with the same hazard:
+                    // a compilation track can CREATE the "Various Artists"
+                    // row inside the rolled-back transaction.
+                    *various_artists_id.lock().unwrap() = None;
                     eprintln!("Warning: failed to commit {}: {}", entry.path().display(), e);
                 }
             }
-            conn.execute("COMMIT", [])?;
 
             total_processed += 1;
 
@@ -1067,6 +1304,24 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 Err(e) => {
                                     let _ = conn.execute("ROLLBACK TO sp", []);
                                     let _ = conn.execute("RELEASE sp", []);
+                                    // The rollback un-created any artists/
+                                    // albums/genres inserted inside this
+                                    // song's savepoint, but the memo caches
+                                    // still hold their ids — dangling at
+                                    // best, reassigned to a DIFFERENT name
+                                    // at worst (sqlite_sequence rolls back
+                                    // too), which silently misattributes
+                                    // every later track of that name. Evict
+                                    // all three; repopulation is one SELECT
+                                    // per name.
+                                    artist_cache.lock().unwrap().clear();
+                                    album_cache.lock().unwrap().clear();
+                                    genre_cache.lock().unwrap().clear();
+                                    // Fourth cache, same hazard: a
+                                    // compilation track can CREATE the
+                                    // "Various Artists" row inside the
+                                    // rolled-back savepoint.
+                                    *various_artists_id.lock().unwrap() = None;
                                     eprintln!(
                                         "Warning: failed to commit {}: {}", rel, e
                                     );
@@ -1208,6 +1463,19 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // scan can ONLY add/update tracks under its root, never delete
     // anything outside it. Stale-track cleanup for the rest of the
     // library will run on the next whole-library scan.
+    // Walk errors no longer veto the whole destructive phase: the sweep
+    // shields candidates under the failed-walk prefixes individually and
+    // its listing-based presence check fails closed for everything else,
+    // so a permanently unreadable #recycle dir can't freeze cleanup for
+    // the rest of the library forever.
+    if walk_errors > 0 && !subtree_mode {
+        eprintln!(
+            "Warning: {} directory enumeration error(s) during the walk — rows under \
+             the affected subtrees are shielded from this scan's cleanup",
+            walk_errors,
+        );
+    }
+
     let deleted = if subtree_mode {
         0
     } else {
@@ -1215,8 +1483,12 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // track_genres / track_artists and fires the per-row FTS5 AFTER
         // DELETE trigger, so on a large-deletion scan a single statement
         // would hold the writer lock past busy_timeout. See
-        // chunked_delete_stale_tracks.
-        chunked_delete_stale_tracks(&conn, config.library_id, &config.scan_id, schema_version_at_open)?
+        // chunked_delete_stale_tracks (which also verifies each candidate
+        // against its parent-directory listing before deleting its row).
+        chunked_delete_stale_tracks(
+            &conn, config.library_id, &config.scan_id, schema_version_at_open,
+            &config.directory, config.follow_symlinks, &failed_walk_prefixes,
+        )?
     };
 
     // Clean up orphaned artists and albums. An artist is kept if ANY of:
@@ -1249,15 +1521,18 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // src/db/orphan-cleanup.js.
     if !subtree_mode {
         chunked_orphan_delete(&conn, "albums",
-            "SELECT id FROM albums WHERE NOT EXISTS (SELECT 1 FROM tracks WHERE tracks.album_id = albums.id)")?;
+            "SELECT id FROM albums WHERE NOT EXISTS (SELECT 1 FROM tracks WHERE tracks.album_id = albums.id)",
+            schema_version_at_open)?;
         chunked_orphan_delete(&conn, "artists",
             "SELECT id FROM artists \
              WHERE NOT EXISTS (SELECT 1 FROM tracks        WHERE tracks.artist_id        = artists.id) \
                AND NOT EXISTS (SELECT 1 FROM albums        WHERE albums.artist_id        = artists.id) \
                AND NOT EXISTS (SELECT 1 FROM track_artists WHERE track_artists.artist_id = artists.id) \
-               AND NOT EXISTS (SELECT 1 FROM album_artists WHERE album_artists.artist_id = artists.id)")?;
+               AND NOT EXISTS (SELECT 1 FROM album_artists WHERE album_artists.artist_id = artists.id)",
+            schema_version_at_open)?;
         chunked_orphan_delete(&conn, "genres",
-            "SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM track_genres WHERE track_genres.genre_id = genres.id)")?;
+            "SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM track_genres WHERE track_genres.genre_id = genres.id)",
+            schema_version_at_open)?;
     }
 
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
@@ -1272,10 +1547,15 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     //                      sanity-check 'is the scanner actually seeing my
     //                      library' even on a no-op subsequent run.
     //   staleEntriesRemoved  Tracks deleted because the file disappeared.
+    //   walkErrors           Directory enumeration failures (subtrees the
+    //                        scan could not see — their rows were shielded
+    //                        from cleanup). Surfaced so a permanently
+    //                        unreadable subtree is operator-visible in the
+    //                        scan summary instead of only a stderr line.
     let unchanged = total_processed.saturating_sub(file_count);
     println!(
-        "{{\"event\":\"scanComplete\",\"filesProcessed\":{},\"filesUnchanged\":{},\"filesScanned\":{},\"staleEntriesRemoved\":{}}}",
-        file_count, unchanged, total_processed, deleted
+        "{{\"event\":\"scanComplete\",\"filesProcessed\":{},\"filesUnchanged\":{},\"filesScanned\":{},\"staleEntriesRemoved\":{},\"walkErrors\":{}}}",
+        file_count, unchanged, total_processed, deleted, walk_errors
     );
     Ok(())
 }
@@ -3418,7 +3698,11 @@ fn check_directory_for_album_art(
             .unwrap_or(&images[0]);
 
         let data = match fs::read(chosen) { Ok(d) => d, Err(_) => return None };
-        let pic_ext = file_ext(chosen);
+        // Lowercase the extension so a `Folder.JPG` cover gets the same
+        // cache filename from both scanners (the JS twin lowercases too)
+        // and from any future rescan — the name is content-addressed, so
+        // case drift just wastes a duplicate cache file.
+        let pic_ext = file_ext(chosen).to_ascii_lowercase();
         let hash = hex_lower(Md5::digest(&data));
         let filename = format!("{}.{}", hash, pic_ext);
         let art_path = Path::new(&config.album_art_directory).join(&filename);

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -640,6 +640,7 @@ const STALE_TRACK_CHUNK_SIZE: usize = 500;
 fn chunked_delete_stale_tracks(
     conn: &Connection, library_id: i64, scan_id: &str, expected_schema_version: i64,
     library_root: &str, follow_symlinks: bool, failed_walk_prefixes: &[String],
+    supported_files: &HashMap<String, bool>,
 ) -> Result<usize, Box<dyn std::error::Error>> {
     let select_sql = format!(
         "SELECT id, filepath FROM tracks \
@@ -652,9 +653,63 @@ fn chunked_delete_stale_tracks(
     let root = Path::new(library_root);
 
     // Per-sweep listing cache: rel dir (fwd slashes) → Some(name → kind)
-    // or None when the directory itself was unreadable (≠ NotFound).
+    // or None when the directory could not be FULLY and TRUSTWORTHILY
+    // listed. Fail-closed details:
+    //  - any per-entry read_dir error poisons the whole listing to None
+    //    (a partial listing would doom the unlisted live files);
+    //  - a file_type() failure maps to Kind::Unknown → that row skips
+    //    (DT_UNKNOWN filesystems must not have rows deleted as "not a
+    //    regular file");
+    //  - a NotFound/NotADirectory listing is "provably gone" ONLY after
+    //    re-checking the library root still exists (mount-vanish TOCTOU
+    //    inside a chunk) and — under follow_symlinks — that no ancestor
+    //    of the directory is a symlink whose target is merely unreachable
+    //    right now (a symlinked mountpoint that is down is unverifiable,
+    //    not deleted).
     #[derive(Clone, Copy, PartialEq)]
-    enum Kind { RegularFile, Symlink, Other }
+    enum Kind { RegularFile, Symlink, Other, Unknown }
+    fn build_listing(
+        root: &Path, dir_rel: &str, follow_symlinks: bool,
+    ) -> Option<HashMap<String, Kind>> {
+        match fs::read_dir(root.join(dir_rel)) {
+            Ok(entries) => {
+                let mut names = HashMap::new();
+                for entry in entries {
+                    let Ok(e) = entry else { return None; }; // partial listing — poison
+                    let kind = match e.file_type() {
+                        Ok(t) if t.is_file() => Kind::RegularFile,
+                        Ok(t) if t.is_symlink() => Kind::Symlink,
+                        Ok(_) => Kind::Other,
+                        Err(_) => Kind::Unknown,
+                    };
+                    names.insert(e.file_name().to_string_lossy().into_owned(), kind);
+                }
+                Some(names)
+            }
+            Err(e) if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+            ) => {
+                if !root.is_dir() { return None; } // the whole mount vanished
+                if follow_symlinks {
+                    // An ancestor that still lstat's as a symlink means the
+                    // subtree hangs off a link whose target is unreachable —
+                    // a down mountpoint, not a deletion.
+                    let mut anc = PathBuf::from(root);
+                    for seg in dir_rel.split('/').filter(|s| !s.is_empty()) {
+                        anc.push(seg);
+                        match fs::symlink_metadata(&anc) {
+                            Ok(m) if m.is_symlink() && fs::metadata(&anc).is_err() => return None,
+                            Ok(_) => {}
+                            Err(_) => break, // first missing segment — genuinely gone
+                        }
+                    }
+                }
+                Some(HashMap::new()) // directory provably gone → its files too
+            }
+            Err(_) => None, // unreadable — fail closed, skip its rows
+        }
+    }
     let mut listings: HashMap<String, Option<HashMap<String, Kind>>> = HashMap::new();
 
     let mut total = 0usize;
@@ -709,23 +764,24 @@ fn chunked_delete_stale_tracks(
                 None => ("", rel.as_str()),
             };
             let listing = listings.entry(dir_rel.to_string()).or_insert_with(|| {
-                match fs::read_dir(root.join(dir_rel)) {
-                    Ok(entries) => Some(entries.filter_map(|e| e.ok()).map(|e| {
-                        let kind = match e.file_type() {
-                            Ok(t) if t.is_file() => Kind::RegularFile,
-                            Ok(t) if t.is_symlink() => Kind::Symlink,
-                            _ => Kind::Other,
-                        };
-                        (e.file_name().to_string_lossy().into_owned(), kind)
-                    }).collect()),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Some(HashMap::new()),
-                    Err(_) => None, // unreadable — fail closed, skip its rows
-                }
+                build_listing(root, dir_rel, follow_symlinks)
             });
+            // Walk-faithful presence includes the EXTENSION filter: a file
+            // whose extension is no longer in supportedFiles would never
+            // be indexed by the walk, so its row converges out of the
+            // index (matching pre-hardening behaviour when an extension is
+            // removed from config) instead of becoming an immortal '-kept'
+            // row with a misleading swallowed-error warning every scan.
+            let ext_supported = supported_files
+                .get(&file_ext(Path::new(rel)).to_ascii_lowercase())
+                .copied()
+                .unwrap_or(false);
             match listing {
                 None => { skipped += 1; }
+                Some(_) if !ext_supported => doomed.push(*id),
                 Some(names) => match names.get(name) {
                     Some(Kind::RegularFile) => survivors.push(*id),
+                    Some(Kind::Unknown) => { skipped += 1; } // DT_UNKNOWN — unverifiable
                     Some(Kind::Symlink) if follow_symlinks => {
                         // Walk-faithful: a symlink the walk would have
                         // followed counts as present only if its target
@@ -733,7 +789,10 @@ fn chunked_delete_stale_tracks(
                         match fs::metadata(root.join(rel)) {
                             Ok(m) if m.is_file() => survivors.push(*id),
                             Ok(_) => doomed.push(*id),
-                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => doomed.push(*id),
+                            Err(e) if matches!(
+                                e.kind(),
+                                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                            ) => doomed.push(*id),
                             Err(_) => { skipped += 1; }
                         }
                     }
@@ -1503,6 +1562,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         chunked_delete_stale_tracks(
             &conn, config.library_id, &config.scan_id, schema_version_at_open,
             &config.directory, config.follow_symlinks, &failed_walk_prefixes,
+            &config.supported_files,
         )?
     };
 

--- a/src/db/lyrics-extraction.js
+++ b/src/db/lyrics-extraction.js
@@ -108,7 +108,13 @@ function readIfExists(filePath) {
     // Strip BOM — Windows LRC editors love to add one and it breaks
     // the first-line timestamp parse.
     const clean = text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
-    return { text: clean, mtimeMs: stat.mtimeMs };
+    // Math.trunc: stat.mtimeMs is fractional on NTFS/ext4. Stored raw it
+    // lands in the INTEGER-affinity lyrics_sidecar_mtime column as REAL,
+    // which the Rust scanner's typed read used to reject — one fractional
+    // row aborted every subsequent Rust scan of the library. Whole ms
+    // also matches what Rust stores (as_millis), so the drift comparison
+    // agrees across scanners. Same truncation in both probes below.
+    return { text: clean, mtimeMs: Math.trunc(stat.mtimeMs) };
   } catch (_) {
     return null;
   }
@@ -138,16 +144,18 @@ export function sidecarMtime(absPath) {
     const name = suffix ? `${base}.${suffix}.lrc` : `${base}.lrc`;
     try {
       const st = fs.statSync(path.join(dir, name));
-      if (st.isFile() && (newest == null || st.mtimeMs > newest)) {
-        newest = st.mtimeMs;
+      const m = Math.trunc(st.mtimeMs); // whole ms — see readIfExists
+      if (st.isFile() && (newest == null || m > newest)) {
+        newest = m;
       }
     } catch (_) { /* no such file — expected */ }
   }
   // `.txt` sidecar matters too for the "no embedded lyrics at all" case.
   try {
     const st = fs.statSync(path.join(dir, `${base}.txt`));
-    if (st.isFile() && (newest == null || st.mtimeMs > newest)) {
-      newest = st.mtimeMs;
+    const m = Math.trunc(st.mtimeMs); // whole ms — see readIfExists
+    if (st.isFile() && (newest == null || m > newest)) {
+      newest = m;
     }
   } catch (_) { /* expected */ }
   return newest;
@@ -204,7 +212,8 @@ export function sidecarMtimeCached(absPath, cache) {
     if (!listing.names.has(name.toLowerCase())) { return; }
     try {
       const st = fs.statSync(path.join(dir, name));
-      if (st.isFile() && (newest == null || st.mtimeMs > newest)) { newest = st.mtimeMs; }
+      const m = Math.trunc(st.mtimeMs); // whole ms — see readIfExists
+      if (st.isFile() && (newest == null || m > newest)) { newest = m; }
     } catch (_) { /* listed but vanished — treat as absent */ }
   };
   for (const suffix of LANG_PROBE_ORDER) {

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -175,7 +175,8 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 // libraryRoot null (no caller does this today) the sweep degrades to
 // the legacy delete-by-stamp behaviour.
 export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion = null,
-  { libraryRoot = null, followSymlinks = false, failedWalkPrefixes = [] } = {}) {
+  { libraryRoot = null, followSymlinks = false, failedWalkPrefixes = [],
+    supportedFiles = null } = {}) {
   const select = db.prepare(
     `SELECT id, filepath FROM tracks
       WHERE library_id = ? AND scan_id != ? AND id > ?
@@ -196,9 +197,32 @@ export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion =
       }
       result = m;
     } catch (err) {
-      // ENOENT/ENOTDIR: the directory itself is gone — its files are
-      // provably gone with it. Anything else: unverifiable, fail closed.
-      result = (err.code === 'ENOENT' || err.code === 'ENOTDIR') ? new Map() : null;
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+        // The directory itself is gone — its files are provably gone
+        // with it. But first rule out two unverifiable look-alikes:
+        // (a) the whole mount vanished inside this chunk (root re-check
+        // TOCTOU), (b) under followSymlinks, an ancestor that still
+        // lstat's as a symlink whose target is unreachable — a down
+        // mountpoint, not a deletion.
+        result = new Map();
+        try { if (!fs.statSync(libraryRoot).isDirectory()) { result = null; } }
+        catch (_e) { result = null; }
+        if (result !== null && followSymlinks) {
+          let anc = libraryRoot;
+          for (const seg of relDir.split('/').filter(Boolean)) {
+            anc = path.join(anc, seg);
+            let lst;
+            try { lst = fs.lstatSync(anc); } catch (_e) { break; } // first missing — genuinely gone
+            if (lst.isSymbolicLink()) {
+              let resolvable = true;
+              try { fs.statSync(anc); } catch (_e) { resolvable = false; }
+              if (!resolvable) { result = null; break; } // down mountpoint
+            }
+          }
+        }
+      } else {
+        result = null; // unreadable — fail closed
+      }
     }
     listings.set(relDir, result);
     return result;
@@ -243,6 +267,15 @@ export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion =
       const name = i === -1 ? c.filepath : c.filepath.slice(i + 1);
       const listing = getListing(dirRel);
       if (listing === null) { skipped++; continue; }
+      // Walk-faithful presence includes the EXTENSION filter: a file whose
+      // extension left supportedFiles would never be indexed by the walk,
+      // so its row converges out of the index instead of becoming an
+      // immortal '-kept' row with a misleading warning every scan.
+      if (supportedFiles !== null
+          && !supportedFiles[name.split('.').pop().toLowerCase()]) {
+        doomed.push(c.id);
+        continue;
+      }
       const kind = listing.get(name);
       if (kind === KIND_FILE) {
         survivors.push(c.id);

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -26,6 +26,9 @@
 // it's a separate process in a different language; the comments stay
 // in lockstep with this file's design choices.
 
+import fs from 'fs';
+import path from 'path';
+
 // Per-chunk row cap. Balances per-chunk lock duration (well under
 // SQLite's 5s busy_timeout) against per-iteration overhead — each
 // iteration re-runs the candidate-id subselect, which is the slow
@@ -138,14 +141,78 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 // cascade delete. Throws a "schema-version guard:" error so the caller
 // can map it to the guard exit code. Only called from the scanner
 // process, so the inter-chunk yield is unconditional here.
-export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion = null) {
-  const stmt = db.prepare(
-    `DELETE FROM tracks WHERE id IN (
-       SELECT id FROM tracks WHERE library_id = ? AND scan_id != ? LIMIT ${ORPHAN_CHUNK_SIZE}
-     )`,
+//
+// VERIFY-ABSENCE: a row is only deleted after a fresh filesystem check
+// proves its file is really gone. An unstamped scan_id is NOT proof of
+// deletion — a swallowed per-file error (decode crash, EBUSY lock, a
+// transient stamp failure) leaves a LIVE track unstamped, and the old
+// sweep deleted it, cascading the user's album/artist stars away
+// permanently.
+//
+// Presence is decided from the PARENT DIRECTORY LISTING, not a per-file
+// stat: a stat error is NOT proof of absence (EACCES/EIO on a degraded
+// mount must keep data — fail closed), stats are case-insensitive on
+// Windows/macOS (a case-only rename would resurrect the old-casing row
+// forever; the listing gives exact on-disk names), and one readdir per
+// directory beats one network round-trip per gone file on CIFS/NFS.
+//
+// Outcomes per candidate:
+//  - under a failed-walk prefix → SKIPPED untouched (that subtree was
+//    invisible this scan; neither delete nor claim it was seen);
+//  - exact-case name present as a regular file (or a symlink resolving
+//    to one under followSymlinks) → KEPT, re-stamped "<scanId>-kept":
+//    leaves this sweep's candidate set but stays != every real scan id,
+//    so the next scan re-examines it and a resumable boot-rescan epoch
+//    does NOT mistake it for already-re-parsed;
+//  - name absent / not a file / directory listing ENOENT → DELETED;
+//  - listing unreadable for any other reason → SKIPPED untouched.
+//
+// Keyset pagination (id > cursor) guarantees termination even though
+// skipped candidates stay unstamped. The library root is re-verified
+// every chunk: a mount that vanishes mid-sweep would otherwise make
+// every listing read ENOENT and erase the library. Mirrors
+// chunked_delete_stale_tracks in rust-parser/src/main.rs. With
+// libraryRoot null (no caller does this today) the sweep degrades to
+// the legacy delete-by-stamp behaviour.
+export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion = null,
+  { libraryRoot = null, followSymlinks = false, failedWalkPrefixes = [] } = {}) {
+  const select = db.prepare(
+    `SELECT id, filepath FROM tracks
+      WHERE library_id = ? AND scan_id != ? AND id > ?
+      ORDER BY id LIMIT ${ORPHAN_CHUNK_SIZE}`,
   );
   const versionStmt = db.prepare('PRAGMA user_version');
+  const keptStamp = `${scanId}-kept`;
+  const KIND_FILE = 1; const KIND_SYMLINK = 2; const KIND_OTHER = 3;
+  const listings = new Map(); // relDir -> Map(name -> kind) | null (unreadable)
+  const getListing = (relDir) => {
+    if (listings.has(relDir)) { return listings.get(relDir); }
+    let result;
+    try {
+      const m = new Map();
+      for (const ent of fs.readdirSync(path.join(libraryRoot, relDir), { withFileTypes: true })) {
+        m.set(ent.name,
+          ent.isFile() ? KIND_FILE : ent.isSymbolicLink() ? KIND_SYMLINK : KIND_OTHER);
+      }
+      result = m;
+    } catch (err) {
+      // ENOENT/ENOTDIR: the directory itself is gone — its files are
+      // provably gone with it. Anything else: unverifiable, fail closed.
+      result = (err.code === 'ENOENT' || err.code === 'ENOTDIR') ? new Map() : null;
+    }
+    listings.set(relDir, result);
+    return result;
+  };
+  const isShielded = (rel) => failedWalkPrefixes.some(p =>
+    p === '' || rel === p
+    || (rel.length > p.length && rel.startsWith(p) && rel[p.length] === '/'));
+  const rootAccessible = () => {
+    try { return fs.statSync(libraryRoot).isDirectory(); } catch (_err) { return false; }
+  };
+
   let total = 0;
+  let skipped = 0;
+  let cursor = 0;
   while (true) {
     if (expectedSchemaVersion !== null) {
       const v = versionStmt.get().user_version;
@@ -155,10 +222,68 @@ export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion =
           `(V${expectedSchemaVersion} -> V${v}) — aborting stale-track cleanup`);
       }
     }
-    const r = stmt.run(libraryId, scanId);
-    total += r.changes;
-    if (r.changes === 0) { break; }
-    if (r.changes === ORPHAN_CHUNK_SIZE) { chunkYield(); }
+    if (libraryRoot !== null && !rootAccessible()) {
+      console.error(
+        `Warning: library root became inaccessible mid-sweep (${libraryRoot}) — ` +
+        `aborting stale-track cleanup after ${total} rows to avoid wiping the library`);
+      break;
+    }
+    const candidates = select.all(libraryId, scanId, cursor);
+    if (candidates.length === 0) { break; }
+    const fullChunk = candidates.length === ORPHAN_CHUNK_SIZE;
+    cursor = candidates[candidates.length - 1].id;
+
+    const survivors = [];
+    const doomed = [];
+    for (const c of candidates) {
+      if (libraryRoot === null) { doomed.push(c.id); continue; } // legacy delete-by-stamp
+      if (isShielded(c.filepath)) { skipped++; continue; }
+      const i = c.filepath.lastIndexOf('/');
+      const dirRel = i === -1 ? '' : c.filepath.slice(0, i);
+      const name = i === -1 ? c.filepath : c.filepath.slice(i + 1);
+      const listing = getListing(dirRel);
+      if (listing === null) { skipped++; continue; }
+      const kind = listing.get(name);
+      if (kind === KIND_FILE) {
+        survivors.push(c.id);
+      } else if (kind === KIND_SYMLINK && followSymlinks) {
+        // Walk-faithful: a symlink the walk would follow counts as
+        // present only if its target resolves to a regular file now.
+        let present;
+        try { present = fs.statSync(path.join(libraryRoot, c.filepath)).isFile(); }
+        catch (err) {
+          present = (err.code === 'ENOENT' || err.code === 'ENOTDIR') ? false : null;
+        }
+        if (present === null) { skipped++; }
+        else if (present) { survivors.push(c.id); }
+        else { doomed.push(c.id); }
+      } else {
+        // Exact-case name missing, a non-file, or a symlink the
+        // no-follow walk would not index.
+        doomed.push(c.id);
+      }
+    }
+    if (survivors.length > 0) {
+      console.error(
+        `Warning: ${survivors.length} track(s) missed their scan stamp but still ` +
+        'exist on disk — keeping them (re-stamped \'-kept\'); a swallowed per-file ' +
+        'error likely occurred');
+      db.prepare(
+        `UPDATE tracks SET scan_id = ? WHERE id IN (${survivors.map(() => '?').join(',')})`,
+      ).run(keptStamp, ...survivors);
+    }
+    if (doomed.length > 0) {
+      const r = db.prepare(
+        `DELETE FROM tracks WHERE id IN (${doomed.map(() => '?').join(',')})`,
+      ).run(...doomed);
+      total += r.changes;
+    }
+    if (fullChunk) { chunkYield(); }
+  }
+  if (skipped > 0) {
+    console.error(
+      `Warning: ${skipped} stale-candidate row(s) left untouched because their ` +
+      'subtree could not be verified this scan (walk errors or unreadable directories)');
   }
   return total;
 }

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -841,7 +841,12 @@ function collectFiles(dir, out) {
     if (stat.isDirectory()) {
       collectFiles(filepath, out);
     } else if (stat.isFile() && loadJson.supportedFiles[getFileType(file).toLowerCase()]) {
-      out.push({ filepath, mtime: stat.mtime.getTime() });
+      // Math.trunc(mtimeMs), NOT stat.mtime.getTime(): Node builds the
+      // Date by ROUNDING the fractional ms (dateFromMs adds 0.5) while
+      // the Rust scanner's as_millis() TRUNCATES — so getTime() disagrees
+      // with Rust by 1ms on ~half of all files, and every Rust↔JS scanner
+      // alternation re-parsed half the library off that phantom drift.
+      out.push({ filepath, mtime: Math.trunc(stat.mtimeMs) });
     }
   }
 }
@@ -1105,7 +1110,7 @@ async function run() {
       ? { changes: 0 }
       : { changes: deleteStaleTracks(db, loadJson.libraryId, loadJson.scanId, schemaVersionAtOpen,
           { libraryRoot: loadJson.directory, followSymlinks: !!loadJson.followSymlinks,
-            failedWalkPrefixes }) };
+            failedWalkPrefixes, supportedFiles: loadJson.supportedFiles }) };
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
     // to run the waveform post-processor and to print a human-readable summary.
     // Field shapes mirror the rust-parser's emitter:

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -430,14 +430,17 @@ function checkDirectoryForAlbumArt(songInfo) {
     const imgMod = imageArray[i].toLowerCase();
     if (['folder.jpg', 'cover.jpg', 'album.jpg', 'folder.png', 'cover.png', 'album.png'].includes(imgMod)) {
       imageBuffer = fs.readFileSync(path.join(directory, imageArray[i]));
-      picFormat = getFileType(imageArray[i]);
+      // Lowercased so a `Folder.JPG` cover gets the same cache filename
+      // from both scanners (rust lowercases too) — the name is content-
+      // addressed, so case drift just wastes a duplicate cache file.
+      picFormat = getFileType(imageArray[i]).toLowerCase();
       break;
     }
   }
 
   if (!imageBuffer) {
     imageBuffer = fs.readFileSync(path.join(directory, imageArray[0]));
-    picFormat = getFileType(imageArray[0]);
+    picFormat = getFileType(imageArray[0]).toLowerCase();
   }
 
   // Raw bytes — see the note in getAlbumArt on why .toString() was wrong.
@@ -789,15 +792,45 @@ const visitedDirs = loadJson.followSymlinks ? new Set() : null;
 // (countSupportedFiles to size the progress bar, then a second walk to
 // scan), which stat'd the whole tree twice — costly on network mounts.
 // The Rust scanner likewise collects its entries once and reuses them.
+//
+// Walk errors are RECORDED, not silently dropped: an unreadable
+// subdirectory (permissions flip, antivirus lock, a mount dying
+// mid-walk) means every file under it never reaches `out`, their rows
+// keep their old scan_id, and the stale sweep would treat them as
+// deleted. Each failed directory becomes a sweep-skip prefix — its rows
+// are neither deleted nor re-stamped this scan — so one permanently
+// unreadable #recycle-style dir can't freeze cleanup for the rest of
+// the library forever. ENOENT failures are benign races (the dir was
+// deleted mid-walk; its rows SHOULD sweep) and are not recorded. Detail
+// logging is capped; the count always reports. Mirrors the Rust
+// scanner's walk-error classification.
+let walkErrors = 0;
+let walkErrorLogs = 0;
+const failedWalkPrefixes = [];
+function recordWalkError(dir, err) {
+  if (err.code === 'ENOENT' || err.code === 'ENOTDIR') { return; } // deletion race — sweepable
+  walkErrors++;
+  failedWalkPrefixes.push(
+    path.relative(loadJson.directory, dir).replace(/\\/g, '/'));
+  if (walkErrorLogs < 20) {
+    console.error(`Warning: directory walk error (subtree shielded from cleanup): ${dir}: ${err.message}`);
+  } else if (walkErrorLogs === 20) {
+    console.error('Warning: suppressing further walk-error detail (count continues)');
+  }
+  walkErrorLogs++;
+}
 function collectFiles(dir, out) {
   if (visitedDirs) {
     let real;
-    try { real = fs.realpathSync(dir); } catch (_e) { return; }
+    try { real = fs.realpathSync(dir); } catch (err) { recordWalkError(dir, err); return; }
     if (visitedDirs.has(real)) { return; }   // symlink cycle — already walked
     visitedDirs.add(real);
   }
   let files;
-  try { files = fs.readdirSync(dir); } catch (_err) { return; }
+  try { files = fs.readdirSync(dir); } catch (err) {
+    recordWalkError(dir, err);
+    return;
+  }
   for (const file of files) {
     const filepath = path.join(dir, file);
     let stat;
@@ -1044,6 +1077,17 @@ async function run() {
       return;
     }
 
+    // (c) Walk errors no longer veto the whole destructive phase: the
+    // sweep shields candidates under the failed-walk prefixes
+    // individually, and its listing-based presence check fails closed
+    // for everything else — so one permanently unreadable directory
+    // can't freeze cleanup for the rest of the library forever.
+    if (walkErrors > 0 && !subtreeMode) {
+      console.error(
+        `Warning: ${walkErrors} directory enumeration error(s) during the walk — ` +
+        'rows under the affected subtrees are shielded from this scan\'s cleanup');
+    }
+
     // Remove tracks that weren't seen in this scan (deleted files).
     // SKIPPED in subtree mode — tracks outside the subtree share the
     // library_id but have an older scan_id, and wiping them would be a
@@ -1053,10 +1097,15 @@ async function run() {
     // is released — with a real 10-20ms yield — between batches instead of
     // held for the whole cascade + FTS delete-trigger run. Runs in
     // autocommit here (the fast-path batch was flushed above), so each
-    // chunk is its own transaction.
+    // chunk is its own transaction. libraryRoot/followSymlinks/
+    // failedWalkPrefixes feed the verify-absence check: only rows whose
+    // file is provably gone get deleted; unstamped-but-alive rows are
+    // re-stamped '-kept'; unverifiable rows are left untouched.
     const deleted = subtreeMode
       ? { changes: 0 }
-      : { changes: deleteStaleTracks(db, loadJson.libraryId, loadJson.scanId, schemaVersionAtOpen) };
+      : { changes: deleteStaleTracks(db, loadJson.libraryId, loadJson.scanId, schemaVersionAtOpen,
+          { libraryRoot: loadJson.directory, followSymlinks: !!loadJson.followSymlinks,
+            failedWalkPrefixes }) };
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
     // to run the waveform post-processor and to print a human-readable summary.
     // Field shapes mirror the rust-parser's emitter:
@@ -1074,7 +1123,11 @@ async function run() {
       // as the Rust emitter, whose total_processed increments on the Err
       // arm too.
       filesScanned: totalProcessed + errorCount,
-      staleEntriesRemoved: deleted.changes
+      staleEntriesRemoved: deleted.changes,
+      // Subtrees the scan could not see (their rows were shielded from
+      // cleanup) — surfaced so a permanently unreadable directory is
+      // operator-visible in the scan summary, not just a stderr line.
+      walkErrors
     }));
 
     // Clean up orphaned artists, albums, and genres. SKIPPED in

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -23,7 +23,7 @@
 //   V39 (torrent_client_vpath_access)      → V40
 //   V40 (managed_torrents.download_path)   → V41
 //   V41 (libraries.torrent_path_template)  → V42
-export const SCHEMA_VERSION = 45;
+export const SCHEMA_VERSION = 46;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -1405,6 +1405,26 @@ export const SCHEMA_V45 = `
   ALTER TABLE tracks ADD COLUMN disc_total  INTEGER;
 `;
 
+// V46: one-shot repair of REAL values in INTEGER-affinity columns. The JS
+// scanner used to store raw stat.mtimeMs — fractional on NTFS/ext4 — into
+// lyrics_sidecar_mtime (and could in principle into modified), where
+// SQLite keeps it as REAL. The Rust scanner's typed reads rejected REAL
+// with InvalidColumnType, so ONE poisoned row aborted every subsequent
+// Rust scan of that library (exit 1, and the JS fallback only triggers on
+// spawn errors — scans stayed dead until manual intervention). The
+// writers now truncate (lyrics-extraction.js) and the Rust reads are
+// tolerant (load_existing_tracks reads via f64), but already-poisoned
+// rows still cause permanent sidecar re-parse loops (fractional stored
+// value never equals the truncated probe) — CAST them once. typeof()
+// guards make this a no-op table scan on healthy DBs. Index-only-style
+// data fix: no rescan required.
+export const SCHEMA_V46 = `
+  UPDATE tracks SET lyrics_sidecar_mtime = CAST(lyrics_sidecar_mtime AS INTEGER)
+   WHERE typeof(lyrics_sidecar_mtime) = 'real';
+  UPDATE tracks SET modified = CAST(modified AS INTEGER)
+   WHERE typeof(modified) = 'real';
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -1555,4 +1575,9 @@ export const MIGRATIONS = [
   // the V16 audio-format columns. Renumbered from the PR's original V43 —
   // see SCHEMA_V45.
   { version: 45, sql: SCHEMA_V45, rescanRequired: true },
+  // V46 CASTs stray REAL values out of lyrics_sidecar_mtime / modified —
+  // the rows older JS scanners poisoned (they killed Rust scans outright
+  // and caused permanent sidecar re-parse loops). Data-only, no rescan.
+  // See SCHEMA_V46.
+  { version: 46, sql: SCHEMA_V46 },
 ];

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -526,7 +526,24 @@ function launchJsScanner(scanObj, jsonLoad, library, { isFallback = false } = {}
       process.execPath, 'js', path.join(__dirname, './scanner.mjs'));
   }
   attachScanHandlers(forkedScan, scanObj);
-  forkedScan.on('close', (code) => onScanClose(forkedScan, scanObj, code));
+  // Latched close-or-error: a fork that fails to start (ENOMEM, exec
+  // policy) emits 'error', and with no listener that is an unhandled
+  // EventEmitter error that tears down the whole server — while the
+  // activeTask claim and kill-queue entry leak, wedging the serial task
+  // queue forever. Route it through onScanClose exactly once (code -1 →
+  // error-level FAILED log + normal queue accounting), mirroring the
+  // backup worker's guard.
+  let scanClosed = false;
+  const closeOnce = (code) => {
+    if (scanClosed) { return; }
+    scanClosed = true;
+    onScanClose(forkedScan, scanObj, code);
+  };
+  forkedScan.on('error', (err) => {
+    winston.error(`JS scanner failed to start: ${err.message}`);
+    closeOnce(-1);
+  });
+  forkedScan.on('close', (code) => closeOnce(code));
   return forkedScan;
 }
 

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -352,11 +352,23 @@ function rescanAll(scanId = null) {
 
 function handleScannerLine(scanObj, line) {
   if (!line) { return; }
+  // Any stdout at all proves the binary launched and ran real code —
+  // read by the rust close handler to tell "scanned and failed" from
+  // "died on arrival" (dynamic-linker abort, stale arg format, instant
+  // panic), which is the case that warrants the JS fallback.
+  scanObj.sawOutput = true;
   // Structured events from the scanner are emitted as single-line JSON;
   // see scanner.mjs and rust-parser/src/main.rs for the event shapes.
   if (line[0] === '{') {
     try {
       const evt = JSON.parse(line);
+      if (evt?.event === 'scanStart') {
+        // Liveness banner — the rust binary's first stdout line, emitted
+        // before any environment-dependent work. Its only job is setting
+        // sawOutput (above) so died-on-arrival detection can't misfire on
+        // pre-walk environment failures. Nothing to log.
+        return;
+      }
       if (evt?.event === 'scanComplete') {
         // A clean end-of-scan event means the scanner finished its walk
         // (vs. dying mid-way). onScanClose reads this to tell a completed
@@ -373,6 +385,15 @@ function handleScannerLine(scanObj, line) {
         parts.push(`${evt.staleEntriesRemoved} stale entries removed`);
         const tail = evt.filesScanned != null ? ` (${evt.filesScanned} scanned)` : '';
         winston.info(`Scan complete: ${parts.join(', ')}${tail}`);
+        if (evt.walkErrors > 0) {
+          // Cleanup was partially shielded — deleted files under the
+          // affected subtrees stay in the index until a clean scan.
+          // Surface it at warn level so a permanently unreadable
+          // directory doesn't hide behind healthy-looking summaries.
+          winston.warn(
+            `Scan saw ${evt.walkErrors} directory enumeration error(s) — ` +
+            'rows under the affected subtrees were shielded from cleanup');
+        }
         if (evt.filesProcessed > 0 || evt.staleEntriesRemoved > 0) {
           anyScansChanged = true;
           // Per-scan flag, read in onScanClose to decide whether to run
@@ -614,8 +635,46 @@ function runScan(scanObj) {
   });
 
   attachScanHandlers(rustScan, scanObj);
-  rustScan.on('close', (code) => {
+  rustScan.on('close', (code, signal) => {
     if (fellBack) { return; }
+    // Died-on-arrival fallback: the spawn 'error' event only fires when
+    // the OS can't exec the binary at all (ENOENT/EACCES). The far more
+    // common real-world breakage — the dynamic linker aborting ("GLIBC
+    // not found", exit 127), a stale binary rejecting the arg format, an
+    // instant panic — execs fine, prints NOTHING to stdout, and exits
+    // non-zero. That used to log "completed with code N" and re-spawn
+    // the same dead binary every scheduled scan, leaving the library
+    // unindexed forever. Treat "really exited non-zero + zero stdout +
+    // never completed" as a launch failure: disable Rust for this
+    // process lifetime (a dead binary doesn't heal between scans) and
+    // run the JS fallback for this scan.
+    //
+    // The signature is precise, not inferential:
+    //  - the binary prints a {"event":"scanStart"} banner as its FIRST
+    //    statement, before any environment-dependent work — so a downed
+    //    mount, a busy DB, or a poisoned row (all transient, all stderr-
+    //    only) sets sawOutput and can never be mistaken for a dead
+    //    binary;
+    //  - signal === null excludes kills (shutdown via the kill queue,
+    //    OOM, operator) — close reports (null, 'SIGTERM')-style pairs
+    //    for those, and spawning a fallback after a deliberate kill
+    //    would orphan a scanner the kill queue no longer tracks;
+    //  - exit 3 (schema-version guard) is excluded as belt-and-braces:
+    //    a deliberate refusal the JS scanner would simply repeat.
+    if (signal === null && code !== null && code !== 0 && code !== 3
+        && !scanObj.completed && !scanObj.sawOutput) {
+      winston.error(
+        `Rust parser died on arrival (exit ${code}, no output) — disabling it ` +
+        'for this run and falling back to the JS scanner');
+      rustParserDisabled = true;
+      if (activeTask?.child === rustScan) {
+        removeFromKillQueue(activeTask.killFn);
+        activeTask = null;
+      }
+      clearScannerPidfile(config.program.storage.dbDirectory);
+      launchJsScanner(scanObj, jsonLoad, library, { isFallback: true });
+      return;
+    }
     onScanClose(rustScan, scanObj, code);
   });
 }

--- a/test/scanner-schema-guard.test.mjs
+++ b/test/scanner-schema-guard.test.mjs
@@ -92,6 +92,161 @@ async function waitFor(predicate, ms) {
   return predicate();
 }
 
+describe('stale sweep verify-absence (deleteStaleTracks)', () => {
+  // The sweep must only delete rows whose file is PROVABLY gone — an
+  // unstamped scan_id alone is not proof (swallowed per-file errors leave
+  // live tracks unstamped). Rows with a living file get re-stamped.
+  test('keeps and re-stamps unstamped rows whose file still exists; deletes only truly-gone files', async () => {
+    const { deleteStaleTracks } = await import('../src/db/orphan-cleanup.js');
+    const tmp = makeTmp('verify-absence');
+    const lib = path.join(tmp, 'music');
+    fs.mkdirSync(lib, { recursive: true });
+    fs.writeFileSync(path.join(lib, 'alive.mp3'), 'x');
+    // 'gone.mp3' intentionally not created.
+    const { db, dbPath } = makeDb(tmp);
+    db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
+    const ins = db.prepare(
+      'INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)');
+    ins.run('alive.mp3', 'ancient'); // unstamped but file exists — a swallowed error victim
+    ins.run('gone.mp3', 'ancient');  // unstamped and file gone — genuinely stale
+
+    const deleted = deleteStaleTracks(db, 1, 'current-scan', SCHEMA_VERSION,
+      { libraryRoot: lib, followSymlinks: false });
+    assert.strictEqual(deleted, 1, 'only the file that is really gone gets deleted');
+    // Spread into plain objects: node:sqlite rows have a null prototype,
+    // which deepStrictEqual treats as a mismatch against object literals.
+    const rows = db.prepare('SELECT filepath, scan_id FROM tracks ORDER BY filepath')
+      .all().map(r => ({ ...r }));
+    db.close();
+    // The '-kept' sentinel: out of THIS sweep's way, but != any real scan
+    // id, so the next scan re-examines it and a resumable boot-rescan
+    // epoch doesn't mistake it for already-re-parsed.
+    assert.deepStrictEqual(rows, [{ filepath: 'alive.mp3', scan_id: 'current-scan-kept' }],
+      'the living file survives, re-stamped with the kept sentinel');
+
+    // A second sweep re-examines the kept row (still a candidate) but
+    // keeps it again and deletes nothing.
+    const check = new DatabaseSync(dbPath);
+    const again = deleteStaleTracks(check, 1, 'current-scan', SCHEMA_VERSION,
+      { libraryRoot: lib, followSymlinks: false });
+    check.close();
+    assert.strictEqual(again, 0);
+  });
+
+  test('failed-walk prefixes shield rows; unverifiable listings are left untouched', async () => {
+    const { deleteStaleTracks } = await import('../src/db/orphan-cleanup.js');
+    const tmp = makeTmp('shield');
+    const lib = path.join(tmp, 'music');
+    fs.mkdirSync(path.join(lib, 'ok'), { recursive: true });
+    // 'broken' dir intentionally NOT created — but its rows are shielded
+    // by the walk-error prefix, so they must survive even though a
+    // listing would say the directory is gone.
+    const { db } = makeDb(tmp);
+    db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
+    const ins = db.prepare(
+      'INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)');
+    ins.run('broken/one.mp3', 'ancient');
+    ins.run('broken/two.mp3', 'ancient');
+    ins.run('ok/gone.mp3', 'ancient'); // dir exists, file doesn't — genuinely stale
+
+    const deleted = deleteStaleTracks(db, 1, 'scan-x', SCHEMA_VERSION,
+      { libraryRoot: lib, followSymlinks: false, failedWalkPrefixes: ['broken'] });
+    assert.strictEqual(deleted, 1, 'only the verifiable-and-gone row is deleted');
+    const rows = db.prepare('SELECT filepath, scan_id FROM tracks ORDER BY filepath')
+      .all().map(r => ({ ...r }));
+    db.close();
+    assert.deepStrictEqual(rows, [
+      // Shielded rows keep their ORIGINAL stamp — untouched, not re-stamped.
+      { filepath: 'broken/one.mp3', scan_id: 'ancient' },
+      { filepath: 'broken/two.mp3', scan_id: 'ancient' },
+    ]);
+  });
+
+  test('case-only rename converges: old-casing row is deleted (exact-name listing match)', async () => {
+    const { deleteStaleTracks } = await import('../src/db/orphan-cleanup.js');
+    const tmp = makeTmp('case');
+    const lib = path.join(tmp, 'music');
+    fs.mkdirSync(lib, { recursive: true });
+    fs.writeFileSync(path.join(lib, 'Track.mp3'), 'x'); // on-disk casing
+    const { db } = makeDb(tmp);
+    db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
+    db.prepare('INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)')
+      .run('TRACK.mp3', 'ancient'); // stale row under the OLD casing
+    // A per-file stat would hit case-insensitively on Windows and keep
+    // resurrecting this row forever; the listing compares exact names.
+    const deleted = deleteStaleTracks(db, 1, 'scan-y', SCHEMA_VERSION,
+      { libraryRoot: lib, followSymlinks: false });
+    const n = db.prepare('SELECT COUNT(*) AS n FROM tracks').get().n;
+    db.close();
+    assert.strictEqual(deleted, 1);
+    assert.strictEqual(n, 0);
+  });
+
+  test('symlink semantics: under followSymlinks=false a symlinked file counts as absent', async (t) => {
+    const { deleteStaleTracks } = await import('../src/db/orphan-cleanup.js');
+    const tmp = makeTmp('symlink-absence');
+    const lib = path.join(tmp, 'music');
+    fs.mkdirSync(lib, { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'target.mp3'), 'x');
+    try {
+      fs.symlinkSync(path.join(tmp, 'target.mp3'), path.join(lib, 'linked.mp3'), 'file');
+    } catch (_err) {
+      t.skip('symlink creation not permitted (needs Windows Developer Mode or admin)');
+      return;
+    }
+    const { db } = makeDb(tmp);
+    db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
+    db.prepare('INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)')
+      .run('linked.mp3', 'ancient');
+    // followSymlinks=false: the walk would not index this entry, so the
+    // sweep must agree it is "absent" and delete the row...
+    const deletedNoFollow = deleteStaleTracks(db, 1, 's1', SCHEMA_VERSION,
+      { libraryRoot: lib, followSymlinks: false });
+    assert.strictEqual(deletedNoFollow, 1);
+    // ...while followSymlinks=true treats it as present (re-stamp).
+    db.prepare('INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)')
+      .run('linked.mp3', 'ancient');
+    const deletedFollow = deleteStaleTracks(db, 1, 's2', SCHEMA_VERSION,
+      { libraryRoot: lib, followSymlinks: true });
+    assert.strictEqual(deletedFollow, 0);
+    const row = db.prepare('SELECT scan_id FROM tracks WHERE filepath = ?').get('linked.mp3');
+    db.close();
+    assert.strictEqual(row.scan_id, 's2-kept');
+  });
+
+  test('V46 repairs REAL-poisoned mtime columns exactly, leaves healthy rows alone', () => {
+    const tmp = makeTmp('v46');
+    const dbPath = path.join(tmp, 't.db');
+    const db = new DatabaseSync(dbPath);
+    db.exec('PRAGMA journal_mode = WAL');
+    // Build the world as it was BEFORE the repair migration...
+    for (const m of MIGRATIONS.filter(m => m.version <= 45)) {
+      db.exec(m.sql);
+      db.exec(`PRAGMA user_version = ${m.version}`);
+    }
+    db.prepare("INSERT INTO libraries (id, name, root_path) VALUES (1, 'l', 'x')").run();
+    // ...poison it the way old JS scanners did (fractional mtimeMs → REAL)...
+    db.exec(`INSERT INTO tracks (filepath, library_id, scan_id, modified, lyrics_sidecar_mtime)
+             VALUES ('poisoned.mp3', 1, 's', 1781126455012.999, 1781126455012.123)`);
+    db.exec(`INSERT INTO tracks (filepath, library_id, scan_id, modified, lyrics_sidecar_mtime)
+             VALUES ('healthy.mp3', 1, 's', 1781126455012, NULL)`);
+    // ...then apply the rest of the migrations (V46).
+    for (const m of MIGRATIONS.filter(m => m.version > 45)) {
+      db.exec(m.sql);
+      db.exec(`PRAGMA user_version = ${m.version}`);
+    }
+    const rows = db.prepare(
+      `SELECT filepath, modified, typeof(modified) AS tm,
+              lyrics_sidecar_mtime AS lsm, typeof(lyrics_sidecar_mtime) AS tl
+         FROM tracks ORDER BY filepath`).all().map(r => ({ ...r }));
+    db.close();
+    assert.deepStrictEqual(rows, [
+      { filepath: 'healthy.mp3', modified: 1781126455012, tm: 'integer', lsm: null, tl: 'null' },
+      { filepath: 'poisoned.mp3', modified: 1781126455012, tm: 'integer', lsm: 1781126455012, tl: 'integer' },
+    ]);
+  });
+});
+
 describe('scanner schema-version guard', () => {
   test('refuses to scan when user_version differs — and writes nothing', async () => {
     const tmp = makeTmp('mismatch');

--- a/test/scanner-schema-guard.test.mjs
+++ b/test/scanner-schema-guard.test.mjs
@@ -247,6 +247,93 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
   });
 });
 
+// ── Symlink-cycle termination ───────────────────────────────────────────────
+// With followSymlinks on, a directory symlink pointing at an ancestor is an
+// infinite walk without protection. The JS scanner breaks cycles via a
+// visited-realpath set (collectFiles); the Rust scanner gets ancestor-loop
+// detection from walkdir. Neither had a regression test — a removed guard
+// would only show up as a stack overflow in production.
+describe('symlink cycle termination (followSymlinks=true)', () => {
+  function buildCycleLib(tmp) {
+    const lib = path.join(tmp, 'music');
+    fs.mkdirSync(path.join(lib, 'a'), { recursive: true });
+    fs.mkdirSync(path.join(lib, 'b'), { recursive: true });
+    // Corrupt-but-walkable "mp3"s: the walk visits and indexes them with
+    // null tags, which is all a termination + exactly-once test needs.
+    fs.writeFileSync(path.join(lib, 'a', 'one.mp3'), Buffer.alloc(64, 1));
+    fs.writeFileSync(path.join(lib, 'a', 'two.mp3'), Buffer.alloc(64, 2));
+    fs.writeFileSync(path.join(lib, 'b', 'three.mp3'), Buffer.alloc(64, 3));
+    // The cycle: lib/a/loop -> lib (an ANCESTOR). Directory symlinks need
+    // Developer Mode on Windows; junctions don't — Node and walkdir both
+    // treat junctions as symlinks, so fall back to one.
+    const loop = path.join(lib, 'a', 'loop');
+    try {
+      fs.symlinkSync(lib, loop, 'dir');
+    } catch (_err) {
+      try { fs.symlinkSync(lib, loop, 'junction'); }
+      catch (_err2) { return null; }
+    }
+    return lib;
+  }
+
+  test('JS scanner terminates and indexes each file exactly once', { timeout: 60000 }, async (t) => {
+    const tmp = makeTmp('cycle-js');
+    const lib = buildCycleLib(tmp);
+    if (lib === null) { t.skip('symlink/junction creation not permitted'); return; }
+    const { db, dbPath } = makeDb(tmp);
+    db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
+    db.close();
+    const r = await runScanner(scanPayload(tmp, dbPath, {
+      directory: lib,
+      followSymlinks: true,
+    }));
+    // The real assertion is that we get here at all: a regressed cycle
+    // guard recurses until stack exhaustion (non-zero exit) or hangs
+    // (test timeout).
+    assert.strictEqual(r.code, 0, `expected termination with exit 0, got ${r.code}\n${r.errOut}`);
+    const check = new DatabaseSync(dbPath);
+    const rows = check.prepare('SELECT filepath FROM tracks ORDER BY filepath').all().map(x => x.filepath);
+    check.close();
+    assert.strictEqual(rows.length, 3,
+      `each file indexed exactly once (no loop-path duplicates); got ${JSON.stringify(rows)}`);
+    assert.strictEqual(new Set(rows).size, 3);
+  });
+
+  test('Rust scanner terminates and indexes each file exactly once', { timeout: 60000 }, async (t) => {
+    const ext = process.platform === 'win32' ? '.exe' : '';
+    const rustBin = [
+      path.resolve(__dirname, `../rust-parser/target/release/rust-parser${ext}`),
+      path.resolve(__dirname, `../bin/rust-parser/rust-parser-${process.platform}-${process.arch}${ext}`),
+    ].find(p => fs.existsSync(p));
+    if (!rustBin) { t.skip('no rust-parser binary available'); return; }
+    const tmp = makeTmp('cycle-rust');
+    const lib = buildCycleLib(tmp);
+    if (lib === null) { t.skip('symlink/junction creation not permitted'); return; }
+    const { db, dbPath } = makeDb(tmp);
+    db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
+    db.close();
+    const payload = scanPayload(tmp, dbPath, {
+      directory: lib,
+      followSymlinks: true,
+      scanThreads: 1,
+      analyzeBpm: false,
+    });
+    const r = await new Promise((resolve) => {
+      const p = child.spawn(rustBin, [JSON.stringify(payload)], { stdio: ['ignore', 'pipe', 'pipe'] });
+      let out = ''; let errOut = '';
+      p.stdout.on('data', d => { out += d.toString(); });
+      p.stderr.on('data', d => { errOut += d.toString(); });
+      p.on('close', code => resolve({ code, out, errOut }));
+    });
+    assert.strictEqual(r.code, 0, `expected termination with exit 0, got ${r.code}\n${r.errOut}`);
+    const check = new DatabaseSync(dbPath);
+    const rows = check.prepare('SELECT filepath FROM tracks').all();
+    check.close();
+    assert.strictEqual(rows.length, 3,
+      `each file indexed exactly once; got ${JSON.stringify(rows.map(x => x.filepath))}`);
+  });
+});
+
 describe('scanner schema-version guard', () => {
   test('refuses to scan when user_version differs — and writes nothing', async () => {
     const tmp = makeTmp('mismatch');


### PR DESCRIPTION
The scanner audit's data-loss cluster, fixed: every swallowed error used to feed the stale sweep, and the sweep deleted on circumstantial evidence (an unstamped `scan_id`). The theme of this PR: **a row is deleted only on proof its file is gone, and every ambiguity resolves toward keeping data.**

## What changed

**1. Verify-absence stale sweep (both scanners).** Presence is decided from the candidate's **parent-directory listing**, not a per-file stat: exact-case name present as a regular file (or a symlink resolving to one under `followSymlinks`) → kept and re-stamped `"<scanId>-kept"`; name absent or directory ENOENT → deleted; listing unreadable for any other reason → left untouched (**fail closed** — EACCES/EIO on a degraded mount is not proof of deletion). The listing approach simultaneously fixes the case-insensitive-stat trap (a case-only rename now converges instead of resurrecting the old-casing row forever) and amortizes mass deletions to one `readdir` per directory instead of a network round-trip per gone file. Keyset pagination guarantees termination; the library root is re-verified every chunk so a mount vanishing mid-sweep aborts instead of erasing the library.

**2. Walk errors shield, not veto.** Enumeration failures are classified (dangling symlinks/loops are content, not lost subtrees) and recorded as per-path shield prefixes: rows under a failed subtree are untouched this scan while the rest of the library cleans normally — so one permanently unreadable `#recycle`-style dir can't freeze cleanup forever. `walkErrors` rides the `scanComplete` event and surfaces at warn level in the server log.

**3. Rollback hygiene (rust).** The serial path's write failure used to fall through to **COMMIT**, persisting half-written tracks — now it rolls back. Both rollback paths evict all four memo caches (artists, albums, genres, `various_artists_id`): a rolled-back insert leaves cached ids dangling, or reassigned to a *different name* (`sqlite_sequence` rolls back too), silently misattributing every later track.

**4. Tolerant reads + V46 repair.** One REAL-poisoned `lyrics_sidecar_mtime`/`modified` row (fractional `stat.mtimeMs` from older JS scanners) used to abort the **entire** rust scan. The rust reads are now type-tolerant (NULL `modified` maps to a forced re-parse), the JS writers truncate, and migration **V46** (no rescan) CASTs already-poisoned rows clean.

**5. Died-on-arrival fallback (task-queue).** A rust binary that execs but dies instantly (linker abort, stale arg format, instant panic) used to log "completed with code N" at INFO and be re-spawned forever, leaving the library unindexed. Now: `signal === null && exit ∉ {0, 3} && zero stdout && never completed` → error log, rust disabled for the process lifetime, JS fallback runs the scan. The signature is precise, not inferential — the binary emits a `{"event":"scanStart"}` banner as its *first* statement, so a downed mount, busy DB, or poisoned row (all stderr-only, transient) can never be mistaken for a dead binary, and signal-kills are excluded.

**6. Parity items:** rust's orphan-delete loops gain the per-chunk schema guard; directory-art extensions lowercase in both scanners.

## Review + smoke

The first draft of verify-absence went through a 4-lens adversarial review that confirmed 23 findings — most importantly that it treated *every* stat error as proof of absence, which would have defeated the protection under exactly the degraded-mount conditions it exists for. The listing-based fail-closed design above is the result.

Fault-injection smoke (all PASS, exact evidence in the scenario logs):

| Fault injected | Expected & observed |
|---|---|
| 3 files exclusively locked (FileShare.None) during a rescan, 5 others deleted | Locked rows survive as `"<scanId>-kept"` with warnings; exactly the 5 deleted rows swept; after unlock, next scan re-parses the 3 back to normal. Same behavior in the JS scanner (EBUSY path) |
| `icacls`-denied artist directory | `walkErrors: 1`, its 7 rows completely untouched (original stamps), rest of library cleans; after ACL restore, full convergence. **Zero shielded rows were ever deleted** |
| REAL-poisoned `modified`/`lyrics_sidecar_mtime` + NULL `modified` on a V45 DB | Rust rescan exits 0 (old binary died with InvalidColumnType), poisoned rows re-parse to clean integers, nothing deleted; server boot applies V46 exactly once, `1781126455012.5 → 1781126455012` exact, no rescan marker |
| `whoami.exe` masquerading as the rust binary | `Rust parser died on arrival (exit 1, no output)` at ERROR, JS fallback completes the 60-file scan, second scan goes straight to JS with no second DOA |
| `taskkill /F` on the rust child mid-scan (healthy binary) | No fallback, no disable — banner-based `sawOutput` carries the exclusion on Windows (where kills surface as `code=1, signal=null`); next scan uses Rust again |

The smoke also caught the rust emitter absorbing errored files into `filesUnchanged` (contract skew vs the JS scanner) — fixed in the second commit.

**Tests:** 1186/1186 full suite; 5 new unit tests (verify-absence keep/delete/sentinel, prefix shielding, case-rename convergence, symlink walk-fidelity, V46 exact repair).

## Notes

- The `-kept` sentinel intentionally keeps rescued rows in the next scan's candidate set, and a resumable boot-rescan epoch does **not** mistake them for already-re-parsed.
- Known minor follow-up (benign, one-time): switching scanners can re-parse files whose stored `modified` differs by ~1ms between rust and JS (truncation-vs-rounding of NTFS fractional timestamps); the scan after that is stable.
- The rust half ships once CI rebuilds `bin/rust-parser/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
