### PR TITLE
perf(scanner): in-memory seen-set ends per-row writes on no-op rescans (V47)

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -94,8 +94,9 @@ struct ScanConfig {
     // When set, the scan:
     //   - Walks {directory}/{subtree} instead of {directory}
     //   - SKIPS the "remove tracks not seen in this scan" cleanup pass
-    //     because tracks outside the subtree have an older scan_id but
-    //     are still on disk — wiping them would be a data-loss bug
+    //     because tracks outside the subtree were never walked (so they
+    //     are absent from the seen-set) but are still on disk — wiping
+    //     them would be a data-loss bug
     //   - SKIPS the orphan artists/albums/genres cleanup for the same
     //     reason (no tracks were deleted, so nothing newly orphaned)
     //
@@ -151,7 +152,7 @@ struct ExistingTrack {
 // path runs extract_track across a rayon worker pool and pushes
 // ExtractedTrack values over an mpsc channel to a single writer thread
 // that calls commit_track; the serial path (scanThreads=1 / ≤2-core
-// hosts) runs extract_track then write_extract_result inline, one tight
+// hosts) runs extract_track then commit_track inline, one tight
 // per-song transaction each. Both produce byte-identical output, locked
 // in by the determinism test (test/scanner-parity.test.mjs).
 #[derive(Debug)]
@@ -216,13 +217,21 @@ struct ExtractedTrack {
     old_hash: Option<String>,
     old_audio_hash: Option<String>,
     old_album_id: Option<i64>,
+    // The prior tracks-row id (None for a brand-new file). The writer
+    // adds it to the in-memory seen-set on a successful commit so the
+    // stale sweep knows this pre-existing row was accounted for — the
+    // row itself no longer carries a per-scan marker (the per-row
+    // scan_id bump was the dominant write cost of a no-op rescan).
+    existing_id: Option<i64>,
 }
 
 enum ExtractResult {
     // The fast-path: file mtime matched and no sidecar drift, so the
-    // existing tracks row only needs its scan_id bumped. Carries the
-    // row id so the writer can issue a one-shot UPDATE without
-    // re-querying.
+    // existing tracks row needs NO write at all — the writer just adds
+    // the row id to the in-memory seen-set the stale sweep consults.
+    // (This used to bump tracks.scan_id per file, which made a no-op
+    // rescan rewrite every row in the library through the single WAL
+    // writer; seen-ness now lives in RAM for the scan's lifetime.)
     Unchanged { existing_id: i64 },
     // New / modified file: full extraction succeeded. Boxed because
     // the struct is large (~500 bytes with strings) and we want the
@@ -581,34 +590,45 @@ fn chunk_yield() {
 // ORPHAN_CHUNK_SIZE: each deleted tracks row is heavier than an orphan
 // (it fires the FTS5 AFTER DELETE trigger and cascades to track_genres /
 // track_artists), but 500 still keeps the per-chunk writer-lock hold well
-// under the 5s busy_timeout while bounding the per-iteration overhead of
-// re-running the candidate subselect. Mirrors ORPHAN_CHUNK_SIZE in
+// under the 5s busy_timeout. Mirrors ORPHAN_CHUNK_SIZE in
 // src/db/orphan-cleanup.js (deleteStaleTracks).
 const STALE_TRACK_CHUNK_SIZE: usize = 500;
 
 // Delete tracks not seen in this scan (file removed on disk), in chunks
 // so the single WAL writer lock is RELEASED between batches. Run as one
-// big `DELETE FROM tracks WHERE library_id=? AND scan_id!=?` it holds the
-// writer for the whole cascade + per-row FTS delete trigger — on a
-// large-deletion scan (moved/renamed top folder, migration force-rescan)
-// that can run past the 5s busy_timeout and stall concurrent API writes
-// from the main server. Chunking is the same cooperate-with-writers
-// pattern chunked_orphan_delete already uses. Returns the total rows
-// deleted (sum across chunks) so the scanComplete count stays accurate.
+// big DELETE it holds the writer for the whole cascade + per-row FTS
+// delete trigger — on a large-deletion scan (moved/renamed top folder,
+// migration force-rescan) that can run past the 5s busy_timeout and
+// stall concurrent API writes from the main server. Chunking is the same
+// cooperate-with-writers pattern chunked_orphan_delete already uses.
+// Returns the total rows deleted (sum across chunks) so the scanComplete
+// count stays accurate.
+//
+// `candidates` is computed by the caller as (rows that existed when the
+// scan started) − (rows the walk accounted for), sorted by id — the
+// in-memory seen-set replaced the old per-row `UPDATE tracks SET
+// scan_id = ?` marker, so "not seen" is no longer a DB predicate. Rows
+// inserted mid-scan by other writers (ytdl downloads land with scan_id
+// NULL) are not in the scan-start snapshot and therefore can never be
+// candidates. NOTE one deliberate delta from the old `scan_id != ?`
+// predicate: a PRE-existing row with scan_id NULL (a ytdl download from
+// before this scan) used to be unsweepable forever — NULL never matched
+// `!=` — even after its file was deleted from disk. Such rows are
+// ordinary candidates now and converge out of the index once
+// verify-absence proves the file gone.
 //
 // `expected_schema_version` re-arms the mid-scan schema guard on EVERY
-// chunk: the sweep is no longer one atomic DELETE but an unbounded
-// sequence of autocommit transactions (with deliberate yields between
-// them), and a migration by another instance could land mid-sweep and
-// change what `scan_id != ?` selects. The PRAGMA read is trivial next
+// chunk: the sweep is not one atomic DELETE but a sequence of autocommit
+// transactions (with deliberate yields between them), and a migration by
+// another instance could land mid-sweep. The PRAGMA read is trivial next
 // to a 500-row cascade delete. Errors carry the schema-guard sentinel
 // so main() maps them to exit 3.
 // VERIFY-ABSENCE: a row is only deleted after a fresh filesystem check
-// proves its file is really gone. An unstamped scan_id is NOT proof of
-// deletion — every swallowed per-file error (transient SQLITE_BUSY on the
-// stamp, a sharing violation, a decode crash) and every unreadable walk
-// subtree leaves LIVE tracks unstamped, and the old sweep deleted them,
-// cascading user_album_stars/user_artist_stars away permanently.
+// proves its file is really gone. An unseen row is NOT proof of
+// deletion — every swallowed per-file error (a sharing violation, a
+// decode crash) and every unreadable walk subtree leaves LIVE tracks
+// unseen, and the pre-hardening sweep deleted them, cascading
+// user_album_stars/user_artist_stars away permanently.
 //
 // Presence is decided from the PARENT DIRECTORY LISTING, not a per-file
 // stat, because the obvious stat has three failure modes that all bite:
@@ -624,32 +644,23 @@ const STALE_TRACK_CHUNK_SIZE: usize = 500;
 //  - under a failed-walk prefix → SKIPPED untouched (we couldn't see that
 //    subtree this scan; neither delete nor claim it was seen);
 //  - listing readable, exact-case name present as a regular file (or a
-//    symlink resolving to one under follow_symlinks) → KEPT, re-stamped
-//    with the "<scan_id>-kept" sentinel: it leaves this sweep's candidate
-//    set but stays != every real scan id, so the next scan re-examines it
-//    and a resumable boot-rescan epoch does NOT mistake it for re-parsed;
+//    symlink resolving to one under follow_symlinks) → KEPT untouched —
+//    a swallowed per-file error left it unaccounted for; the next scan
+//    simply re-examines it (no row marker needed: the candidate list
+//    lives in this process's memory and dies with the scan);
 //  - listing readable, name absent (or not a file) → DELETED;
 //  - listing's directory NotFound → DELETED (the whole folder is gone);
 //  - listing unreadable for any other reason → SKIPPED untouched.
 //
-// Keyset pagination (id > cursor) guarantees termination even though
-// skipped candidates remain unstamped. The library root is re-verified
-// every chunk: if the mount vanished mid-sweep, every listing would
-// suddenly read NotFound and the sweep would happily erase the library —
-// the root check aborts instead (matching the vanished-mount walk guard).
+// The library root is re-verified every chunk: if the mount vanished
+// mid-sweep, every listing would suddenly read NotFound and the sweep
+// would happily erase the library — the root check aborts instead
+// (matching the vanished-mount walk guard).
 fn chunked_delete_stale_tracks(
-    conn: &Connection, library_id: i64, scan_id: &str, expected_schema_version: i64,
+    conn: &Connection, candidates: &[(i64, String)], expected_schema_version: i64,
     library_root: &str, follow_symlinks: bool, failed_walk_prefixes: &[String],
     supported_files: &HashMap<String, bool>,
 ) -> Result<usize, Box<dyn std::error::Error>> {
-    let select_sql = format!(
-        "SELECT id, filepath FROM tracks \
-          WHERE library_id = ?1 AND scan_id != ?2 AND id > ?3 \
-          ORDER BY id LIMIT {}",
-        STALE_TRACK_CHUNK_SIZE,
-    );
-    let mut select = conn.prepare(&select_sql)?;
-    let kept_stamp = format!("{}-kept", scan_id);
     let root = Path::new(library_root);
 
     // Per-sweep listing cache: rel dir (fwd slashes) → Some(name → kind)
@@ -714,8 +725,7 @@ fn chunked_delete_stale_tracks(
 
     let mut total = 0usize;
     let mut skipped = 0usize;
-    let mut cursor: i64 = 0;
-    loop {
+    for chunk in candidates.chunks(STALE_TRACK_CHUNK_SIZE) {
         let v: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         if v != expected_schema_version {
             return Err(format!(
@@ -732,18 +742,11 @@ fn chunked_delete_stale_tracks(
             );
             break;
         }
-        let candidates: Vec<(i64, String)> = select
-            .query_map(rusqlite::params![library_id, scan_id, cursor], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-            })?
-            .collect::<Result<_, _>>()?;
-        if candidates.is_empty() { break; }
-        let full_chunk = candidates.len() == STALE_TRACK_CHUNK_SIZE;
-        cursor = candidates.last().map(|(id, _)| *id).unwrap_or(cursor);
+        let full_chunk = chunk.len() == STALE_TRACK_CHUNK_SIZE;
 
-        let mut doomed: Vec<i64> = Vec::new();
-        let mut survivors: Vec<i64> = Vec::new();
-        for (id, rel) in &candidates {
+        let mut doomed: Vec<(i64, &str)> = Vec::new();
+        let mut survivors = 0usize;
+        for (id, rel) in chunk {
             // A failed prefix shields its exact path and everything below
             // it (slash boundary — "Artist/Bad" must not shield
             // "Artist/Bad2"). The empty prefix (unattributable error)
@@ -770,58 +773,71 @@ fn chunked_delete_stale_tracks(
             // whose extension is no longer in supportedFiles would never
             // be indexed by the walk, so its row converges out of the
             // index (matching pre-hardening behaviour when an extension is
-            // removed from config) instead of becoming an immortal '-kept'
-            // row with a misleading swallowed-error warning every scan.
+            // removed from config) instead of becoming an immortal
+            // candidate warned about on every scan.
             let ext_supported = supported_files
                 .get(&file_ext(Path::new(rel)).to_ascii_lowercase())
                 .copied()
                 .unwrap_or(false);
             match listing {
                 None => { skipped += 1; }
-                Some(_) if !ext_supported => doomed.push(*id),
+                Some(_) if !ext_supported => doomed.push((*id, rel.as_str())),
                 Some(names) => match names.get(name) {
-                    Some(Kind::RegularFile) => survivors.push(*id),
+                    Some(Kind::RegularFile) => survivors += 1,
                     Some(Kind::Unknown) => { skipped += 1; } // DT_UNKNOWN — unverifiable
                     Some(Kind::Symlink) if follow_symlinks => {
                         // Walk-faithful: a symlink the walk would have
                         // followed counts as present only if its target
                         // resolves to a regular file right now.
                         match fs::metadata(root.join(rel)) {
-                            Ok(m) if m.is_file() => survivors.push(*id),
-                            Ok(_) => doomed.push(*id),
+                            Ok(m) if m.is_file() => survivors += 1,
+                            Ok(_) => doomed.push((*id, rel.as_str())),
                             Err(e) if matches!(
                                 e.kind(),
                                 std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
-                            ) => doomed.push(*id),
+                            ) => doomed.push((*id, rel.as_str())),
                             Err(_) => { skipped += 1; }
                         }
                     }
                     // Exact-case name missing, a non-file, or a symlink the
                     // no-follow walk would not index — the walk's reality
                     // says this row's file is gone.
-                    _ => doomed.push(*id),
+                    _ => doomed.push((*id, rel.as_str())),
                 },
             }
         }
-        if !survivors.is_empty() {
+        if survivors > 0 {
+            // No row write needed to "keep" them — the candidate list is
+            // in-memory and dies with this scan; the next scan just
+            // re-derives it. Warn so a chronic swallowed-error subtree is
+            // operator-visible.
             eprintln!(
-                "Warning: {} track(s) missed their scan stamp but still exist on disk — \
-                 keeping them (re-stamped '-kept'); a swallowed per-file error likely occurred",
-                survivors.len(),
+                "Warning: {} track(s) missed by this scan still exist on disk — \
+                 keeping them; a swallowed per-file error likely occurred",
+                survivors,
             );
-            let placeholders = vec!["?"; survivors.len()].join(",");
-            let restamp_sql = format!(
-                "UPDATE tracks SET scan_id = ? WHERE id IN ({})", placeholders,
-            );
-            let mut params: Vec<&dyn rusqlite::ToSql> = vec![&kept_stamp];
-            params.extend(survivors.iter().map(|id| id as &dyn rusqlite::ToSql));
-            conn.prepare(&restamp_sql)?.execute(params.as_slice())?;
         }
         if !doomed.is_empty() {
-            let placeholders = vec!["?"; doomed.len()].join(",");
-            let del_sql = format!("DELETE FROM tracks WHERE id IN ({})", placeholders);
-            total += conn.prepare(&del_sql)?
-                .execute(rusqlite::params_from_iter(doomed.iter()))?;
+            // Row-value guard (id AND filepath, both from the scan-start
+            // snapshot): the absence check ran against the snapshot path,
+            // so a row whose filepath were ever rewritten mid-scan by
+            // some future rename/move API would fall out of the doomed
+            // set instead of being deleted off a stale verdict. (No such
+            // writer exists today; the old per-chunk re-SELECT was immune
+            // by construction — this keeps the property.) AUTOINCREMENT
+            // already guarantees ids are never reused, so the pair is
+            // stable evidence.
+            let placeholders = vec!["(?, ?)"; doomed.len()].join(",");
+            let del_sql = format!(
+                "DELETE FROM tracks WHERE (id, filepath) IN (VALUES {})", placeholders,
+            );
+            let mut params: Vec<&dyn rusqlite::ToSql> =
+                Vec::with_capacity(doomed.len() * 2);
+            for (id, rel) in &doomed {
+                params.push(id);
+                params.push(rel);
+            }
+            total += conn.prepare(&del_sql)?.execute(params.as_slice())?;
         }
         if full_chunk { chunk_yield(); }
     }
@@ -841,11 +857,11 @@ fn chunked_delete_stale_tracks(
 // server write (scrobble/star/playlist) gets a turn instead of losing
 // repeated busy-handler retries until busy_timeout expires.
 //
-// COMMIT_BUDGET_MS: also break a batch once it has held the lock this
-// long in wall-clock, not just at commit_interval rows. A row's write
-// cost is wildly variable (a no-op scan_id bump vs. a full commit_track
-// with FTS + M2M fan-out), so a pure row count under-bounds the hold on
-// heavy initial/force rescans.
+// COMMIT_BUDGET_MS: also break a batch once it has run this long in
+// wall-clock, not just at commit_interval rows. A row's write cost is
+// wildly variable (a free seen-set insert for an unchanged file vs. a
+// full commit_track with FTS + M2M fan-out), so a pure row count
+// under-bounds the lock hold on heavy initial/force rescans.
 //
 // WRITER_YIELD: after a batch that hit the cap (the channel still had
 // work queued — i.e. we're writer-bound), sleep briefly with NO
@@ -876,11 +892,12 @@ const WRITER_YIELD_JITTER_MS: u64 = 11; // yield = 10..=20ms
 fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // Fail fast if the library root isn't accessible. Without this check,
     // `WalkDir` yields zero entries on a missing mount — main-loop runs
-    // over an empty set — the final `DELETE FROM tracks WHERE scan_id != ?`
-    // then wipes *every* track for this library, cascading through
-    // albums / artists / user_album_stars. A transient CIFS or NFS outage
-    // would silently erase the DB. Erroring out before any DB writes is
-    // safer than trying to reason about partial-processed states.
+    // over an empty set, nothing lands in the seen-set — and the stale
+    // sweep would then consider *every* track of this library a candidate,
+    // cascading deletions through albums / artists / user_album_stars. A
+    // transient CIFS or NFS outage would silently erase the DB. Erroring
+    // out before any DB writes is safer than trying to reason about
+    // partial-processed states.
     if !Path::new(&config.directory).is_dir() {
         return Err(format!(
             "library directory not accessible: {}", config.directory
@@ -896,11 +913,9 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // synchronous = NORMAL: in WAL mode this is crash-safe — the DB can never
     // corrupt; a power loss can only lose recently-committed transactions
     // (those in the WAL since the last checkpoint), which the next scan
-    // re-derives via the mtime/scan_id fast-path — and it drops the per-COMMIT
-    // fsync. That fsync
-    // is otherwise on the critical path of EVERY batch — including the
-    // per-file scan_id bumps a no-op re-scan does over the whole library — so
-    // removing it is a large win on the HDD/NAS storage mStream often runs on.
+    // re-derives via the mtime fast-path — and it drops the per-COMMIT
+    // fsync, otherwise on the critical path of EVERY batch, a large win on
+    // the HDD/NAS storage mStream often runs on.
     // We scope it to the scanner connection only; the main server (manager.js)
     // keeps the FULL default so user data stays maximally durable.
     //
@@ -1027,9 +1042,9 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // Walk errors are RECORDED, not silently dropped: an unreadable
     // subdirectory (permissions flip, antivirus lock, CIFS/NFS mount dying
     // mid-walk) means every file under it is absent from `entries`, their
-    // rows keep their old scan_id, and the stale sweep would treat them as
-    // deleted. Each failed path becomes a sweep-skip prefix — rows under
-    // it are neither deleted nor re-stamped this scan — so the rest of the
+    // rows never land in the seen-set, and the stale sweep would treat
+    // them as deleted. Each failed path becomes a sweep-skip prefix — rows
+    // under it are exempt from this scan's cleanup — so the rest of the
     // library still cleans normally even when one #recycle-style dir is
     // permanently unreadable. Benign per-entry errors (dangling symlinks,
     // symlink loops under follow_links) are library CONTENT, not lost
@@ -1100,6 +1115,17 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     // visited = processed + unchanged +
                                     // errors; mirrors errorCount in
                                     // src/db/scanner.mjs)
+    // Row ids of pre-existing tracks this scan accounted for: unchanged
+    // fast-path hits plus successfully re-committed (modified) rows. The
+    // stale sweep's candidates are (existing_tracks − seen_ids) — replacing
+    // the old per-row `UPDATE tracks SET scan_id = ?` marker, which made a
+    // no-op rescan of a stable library rewrite EVERY tracks row (plus its
+    // index maintenance) through the single WAL writer just to mark
+    // "seen". 8 bytes of RAM per row instead. Errored files are
+    // deliberately NOT marked seen: their rows fall to the sweep, whose
+    // verify-absence check finds the file on disk and keeps them — same
+    // outcome as the old unstamped-row path, warning included.
+    let mut seen_ids: HashSet<i64> = HashSet::with_capacity(existing_tracks.len());
     // Commit cadence: doubles as progress-update cadence and write-lock release.
     // Lower = more responsive API writes during scans but more COMMIT/BEGIN overhead.
     // Admin-configurable via scanCommitInterval; default (25) is a balanced starting point.
@@ -1123,7 +1149,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // Extraction (file read, tag parse, hash, waveform decode) runs
         // with NO transaction open, so the single SQLite write lock stays
         // free during the slow per-file work; only the quick
-        // commit_track / scan_id write is wrapped in a short per-song
+        // commit_track write is wrapped in a short per-song
         // transaction. This stops a concurrent API write (e.g. a playlist
         // save) from being blocked for the length of a decode — the worst
         // it can wait is one song's writes. (Multi-core hosts take the
@@ -1148,42 +1174,59 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
 
-            // Tight per-song transaction around just the DB write.
-            // IMMEDIATE, not deferred: a cache-miss find_or_create_artist/
-            // album makes the first statement a SELECT, pinning a read
-            // snapshot before the first write — if the server commits in
-            // that window the lock upgrade dies with SQLITE_BUSY_SNAPSHOT,
-            // which bypasses the busy handler entirely (the same class
-            // src/db/manager.js transaction() fixed). IMMEDIATE takes the
-            // write lock up front where busy_timeout IS honored.
-            conn.execute("BEGIN IMMEDIATE", [])?;
-            match write_extract_result(
-                &conn, config, result,
-                &artist_cache, &album_cache, &genre_cache, &various_artists_id,
-            ) {
-                Ok(true)  => { conn.execute("COMMIT", [])?; file_count += 1; }
-                Ok(false) => { conn.execute("COMMIT", [])?; } // skipped (unchanged)
-                Err(e) => {
-                    // ROLLBACK, not COMMIT: this previously fell through to
-                    // COMMIT and persisted whatever half of the track had
-                    // been written before the failure. And the rollback
-                    // un-creates any artists/albums/genres inserted inside
-                    // this transaction, so the memo caches must be evicted —
-                    // a cached id may now be dangling, or (sqlite_sequence
-                    // rolls back too) get reassigned to a DIFFERENT name by
-                    // the next insert, silently misattributing every later
-                    // track of that artist. Clearing all three is cheap:
-                    // repopulation costs one SELECT per name.
-                    let _ = conn.execute("ROLLBACK", []);
-                    artist_cache.lock().unwrap().clear();
-                    album_cache.lock().unwrap().clear();
-                    genre_cache.lock().unwrap().clear();
-                    // The VA memo is a fourth cache with the same hazard:
-                    // a compilation track can CREATE the "Various Artists"
-                    // row inside the rolled-back transaction.
-                    *various_artists_id.lock().unwrap() = None;
-                    error_count += 1;
-                    eprintln!("Warning: failed to commit {}: {}", entry.path().display(), e);
+            match result {
+                ExtractResult::Unchanged { existing_id } => {
+                    // No DB write at all for an unchanged file — seen-ness
+                    // lives in the in-memory set the stale sweep consults.
+                    // A no-op rescan on this path never takes the writer
+                    // lock except for the periodic progress updates below.
+                    seen_ids.insert(existing_id);
+                }
+                ExtractResult::Extracted(et) => {
+                    // Tight per-song transaction around just the DB write.
+                    // IMMEDIATE, not deferred: a cache-miss find_or_create_artist/
+                    // album makes the first statement a SELECT, pinning a read
+                    // snapshot before the first write — if the server commits in
+                    // that window the lock upgrade dies with SQLITE_BUSY_SNAPSHOT,
+                    // which bypasses the busy handler entirely (the same class
+                    // src/db/manager.js transaction() fixed). IMMEDIATE takes the
+                    // write lock up front where busy_timeout IS honored.
+                    conn.execute("BEGIN IMMEDIATE", [])?;
+                    match commit_track(
+                        &conn, config, &et,
+                        &artist_cache, &album_cache, &genre_cache, &various_artists_id,
+                    ) {
+                        Ok(()) => {
+                            conn.execute("COMMIT", [])?;
+                            file_count += 1;
+                            // A re-committed pre-existing row is accounted
+                            // for; without this the sweep would re-list its
+                            // directory and warn about a "missed" stamp.
+                            if let Some(id) = et.existing_id { seen_ids.insert(id); }
+                        }
+                        Err(e) => {
+                            // ROLLBACK, not COMMIT: this previously fell through to
+                            // COMMIT and persisted whatever half of the track had
+                            // been written before the failure. And the rollback
+                            // un-creates any artists/albums/genres inserted inside
+                            // this transaction, so the memo caches must be evicted —
+                            // a cached id may now be dangling, or (sqlite_sequence
+                            // rolls back too) get reassigned to a DIFFERENT name by
+                            // the next insert, silently misattributing every later
+                            // track of that artist. Clearing all three is cheap:
+                            // repopulation costs one SELECT per name.
+                            let _ = conn.execute("ROLLBACK", []);
+                            artist_cache.lock().unwrap().clear();
+                            album_cache.lock().unwrap().clear();
+                            genre_cache.lock().unwrap().clear();
+                            // The VA memo is a fourth cache with the same hazard:
+                            // a compilation track can CREATE the "Various Artists"
+                            // row inside the rolled-back transaction.
+                            *various_artists_id.lock().unwrap() = None;
+                            error_count += 1;
+                            eprintln!("Warning: failed to commit {}: {}", entry.path().display(), e);
+                        }
+                    }
                 }
             }
 
@@ -1212,7 +1255,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // concurrently and pipe ExtractResult values across a bounded
         // mpsc channel to the writer thread (this thread). The writer
         // owns the SQLite Connection and drains every result through
-        // commit_track / scan_id UPDATE.
+        // commit_track (or a seen-set insert for unchanged files).
         //
         // Bounded channel caps memory: workers can run at most 2×N
         // files ahead of the writer. With the in-process buffer cap
@@ -1293,10 +1336,17 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             // Block for the first message of a batch with NO transaction
             // open, so the write lock is free while we wait — a worker
             // stuck on a slow read/decode can't extend the lock-hold. Once
-            // a message arrives, BEGIN, drain everything already queued via
+            // a message arrives, drain everything already queued via
             // try_recv, and COMMIT the instant the channel runs dry.
             // commit_interval caps the batch so the lock is still released
             // periodically if the channel never goes idle (writer-bound).
+            //
+            // The transaction opens LAZILY on the batch's first Extracted
+            // row: an unchanged file now costs no DB work at all (one
+            // seen-set insert), so a batch that drains only unchanged
+            // results never takes the writer lock — on a no-op rescan of a
+            // stable library the writer touches the DB only for the
+            // periodic progress updates instead of rewriting every row.
             let mut err: Option<Box<dyn std::error::Error>> = None;
             // Throttle the scan_progress write to ~once per commit_interval
             // files, decoupled from the now variable-size commit cadence.
@@ -1312,26 +1362,21 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                 // the bounded channel never blocks a worker; do no DB work.
                 if err.is_some() { continue; }
 
-                // IMMEDIATE, not deferred: a batch whose first row needs a
-                // cache-miss artist/album lookup opens with a SELECT, which
-                // pins a read snapshot before the batch's first write. A
-                // server commit landing in that window — MORE likely now
-                // that the post-batch yield lets server writes win the lock
-                // — would fail the upgrade with SQLITE_BUSY_SNAPSHOT (no
-                // busy-handler retry, instant error) and poison the whole
-                // batch. IMMEDIATE takes the write lock at BEGIN, where the
-                // 5s busy_timeout applies. Same convention as
-                // src/db/manager.js transaction().
-                if let Err(e) = conn.execute("BEGIN IMMEDIATE", []) {
-                    err = Some(Box::new(e));
-                    stop.store(true, Ordering::Relaxed);
-                    continue;
-                }
+                // Set true once this batch's first Extracted row opens the
+                // transaction (see the lazy-BEGIN note above). Stays false
+                // for batches of only unchanged/errored results, in which
+                // case there is nothing to COMMIT and no lock to yield.
+                let mut txn_open = false;
 
                 let batch_start = Instant::now();
                 let mut msg = first;
                 let mut batch: u64 = 0;
-                let mut last_rel; // rel of the last processed msg, for progress
+                // rel of the last processed msg, for progress. Initialized
+                // because a lazy-BEGIN failure breaks out of the drain loop
+                // before the first `last_rel = rel` — that path skips the
+                // progress write via the err check below, but the compiler
+                // can't prove it.
+                let mut last_rel = String::new();
                 // True when we stopped draining because the batch was full
                 // or over its wall-clock budget (vs. the channel running
                 // dry). Signals we're writer-bound, so we yield the lock
@@ -1343,21 +1388,33 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     let rel = msg.rel_path_progress;
                     match msg.result {
                         Ok(ExtractResult::Unchanged { existing_id }) => {
-                            // Single statement — atomic on its own, no savepoint.
-                            match conn
-                                .prepare_cached("UPDATE tracks SET scan_id = ? WHERE id = ?")
-                                .and_then(|mut stmt| stmt.execute(rusqlite::params![config.scan_id, existing_id]))
-                            {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    error_count += 1;
-                                    eprintln!(
-                                        "Warning: scan_id update failed for {}: {}", rel, e
-                                    );
-                                }
-                            }
+                            // No DB write — seen-ness lives in RAM for the
+                            // sweep. (This used to be a per-row scan_id
+                            // UPDATE: the dominant write cost of a no-op
+                            // rescan, one row rewrite + index maintenance
+                            // per unchanged file through the WAL writer.)
+                            seen_ids.insert(existing_id);
                         }
                         Ok(ExtractResult::Extracted(et)) => {
+                            // First write of this batch opens its
+                            // transaction. IMMEDIATE, not deferred: a
+                            // cache-miss artist/album lookup makes the
+                            // first statement a SELECT, which would pin a
+                            // read snapshot before the batch's first write
+                            // — a server commit landing in that window
+                            // fails the upgrade with SQLITE_BUSY_SNAPSHOT
+                            // (no busy-handler retry, instant error).
+                            // IMMEDIATE takes the write lock at BEGIN,
+                            // where the 5s busy_timeout applies. Same
+                            // convention as src/db/manager.js transaction().
+                            if !txn_open {
+                                if let Err(e) = conn.execute("BEGIN IMMEDIATE", []) {
+                                    err = Some(Box::new(e));
+                                    stop.store(true, Ordering::Relaxed);
+                                    break;
+                                }
+                                txn_open = true;
+                            }
                             // Per-song savepoint: commit_track runs several
                             // statements, so on a mid-way failure we roll
                             // back just this song (no half-written row) and
@@ -1370,6 +1427,13 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 Ok(()) => {
                                     let _ = conn.execute("RELEASE sp", []);
                                     file_count += 1;
+                                    // A re-committed pre-existing row is
+                                    // accounted for; without this the sweep
+                                    // would re-list its directory and warn
+                                    // about a "missed" stamp.
+                                    if let Some(id) = et.existing_id {
+                                        seen_ids.insert(id);
+                                    }
                                 }
                                 Err(e) => {
                                     let _ = conn.execute("ROLLBACK TO sp", []);
@@ -1410,11 +1474,11 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     batch += 1;
                     last_rel = rel;
 
-                    // Cap the lock-hold by row count OR wall-clock budget,
+                    // Cap the batch by row count OR wall-clock budget,
                     // whichever trips first. The time bound matters because
                     // a batch of heavy commit_track rows (FTS + M2M fan-out)
-                    // holds the lock far longer than the same count of cheap
-                    // scan_id bumps.
+                    // holds the lock far longer than the same count of free
+                    // seen-set inserts.
                     if batch >= commit_interval
                         || batch_start.elapsed() >= Duration::from_millis(COMMIT_BUDGET_MS)
                     {
@@ -1427,21 +1491,31 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                // Progress row rides INSIDE the batch transaction. As its
-                // own autocommit statement after COMMIT it took and released
-                // the writer lock a second time per progress interval, right
-                // at the head of the post-COMMIT lock-free gap — and could
-                // itself stall on the busy handler whenever a waiting API
-                // write won the lock at COMMIT. Riding in the batch txn
-                // costs nothing extra and makes progress atomic with the
-                // rows it describes. The coupling cuts both ways: it shares
-                // the batch's fate on a rollback (one batch of display lag),
-                // and an UPDATE failure here must abort the batch like a
-                // COMMIT failure would — an auto-rollback-class error
-                // (FULL/IOERR/NOMEM) silently rolls back the whole
-                // transaction, after which issuing COMMIT would just mask
-                // the root cause with "cannot commit - no transaction is
-                // active".
+                // A lazy BEGIN failed mid-drain: no transaction is open and
+                // the scan is already marked failed — skip the progress/
+                // COMMIT tail and fall back to drain-and-discard.
+                if err.is_some() { continue; }
+
+                // Progress row rides INSIDE the batch transaction when one
+                // is open: as its own autocommit statement after COMMIT it
+                // took and released the writer lock a second time per
+                // progress interval, right at the head of the post-COMMIT
+                // lock-free gap — and could itself stall on the busy
+                // handler whenever a waiting API write won the lock at
+                // COMMIT. Riding in the batch txn costs nothing extra and
+                // makes progress atomic with the rows it describes. The
+                // coupling cuts both ways: it shares the batch's fate on a
+                // rollback (one batch of display lag), and an UPDATE
+                // failure here must abort the batch like a COMMIT failure
+                // would — an auto-rollback-class error (FULL/IOERR/NOMEM)
+                // silently rolls back the whole transaction, after which
+                // issuing COMMIT would just mask the root cause with
+                // "cannot commit - no transaction is active".
+                //
+                // With NO transaction open (an all-unchanged batch) the
+                // UPDATE runs as its own autocommit statement — on a no-op
+                // rescan that is the writer's ONLY lock acquisition, once
+                // per commit_interval files.
                 if total_processed - last_progress_at >= commit_interval {
                     if let Err(e) = conn.execute(
                         "UPDATE scan_progress SET scanned = ?1, current_file = ?2 WHERE scan_id = ?3",
@@ -1449,7 +1523,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     ) {
                         err = Some(Box::new(e));
                         stop.store(true, Ordering::Relaxed);
-                        let _ = conn.execute("ROLLBACK", []);
+                        if txn_open { let _ = conn.execute("ROLLBACK", []); }
                         continue;
                     }
                     last_progress_at = total_processed;
@@ -1457,10 +1531,12 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
 
                 // Commit the batch and release the write lock before going
                 // back to the blocking recv() above.
-                if let Err(e) = conn.execute("COMMIT", []) {
-                    err = Some(Box::new(e));
-                    stop.store(true, Ordering::Relaxed);
-                    continue;
+                if txn_open {
+                    if let Err(e) = conn.execute("COMMIT", []) {
+                        err = Some(Box::new(e));
+                        stop.store(true, Ordering::Relaxed);
+                        continue;
+                    }
                 }
 
                 // Writer-bound backoff: when the batch hit the row/time cap
@@ -1469,11 +1545,14 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                 // free here, between COMMIT and the next BEGIN) so a waiting
                 // API write can win the writer lock instead of losing repeated
                 // busy-handler retries. Skipped when the channel drained
-                // naturally — a quiet rescan never pauses. Duration is
-                // 10-20ms, jittered off the batch clock so the yield cadence
-                // can't phase-lock with the server's 100ms busy-retry tail
-                // (see the WRITER_YIELD comment above the constants).
-                if hit_cap {
+                // naturally — a quiet rescan never pauses — and when this
+                // batch never opened a transaction (all-unchanged: no lock
+                // was held, so there is nothing to yield and sleeping would
+                // only slow the no-op rescan down). Duration is 10-20ms,
+                // jittered off the batch clock so the yield cadence can't
+                // phase-lock with the server's 100ms busy-retry tail (see
+                // the WRITER_YIELD comment above the constants).
+                if hit_cap && txn_open {
                     let jitter = u64::from(batch_start.elapsed().subsec_nanos())
                         % WRITER_YIELD_JITTER_MS;
                     std::thread::sleep(Duration::from_millis(WRITER_YIELD_MIN_MS + jitter));
@@ -1519,9 +1598,10 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
 
     // Re-check the schema version before the scan's only destructive
     // phase. If a migration ran mid-scan (a second server instance, or a
-    // boot racing this scanner after its parent died), what `scan_id != ?`
-    // selects may have changed under us — bail without sweeping rather
-    // than delete rows under stale assumptions.
+    // boot racing this scanner after its parent died), the table contents
+    // our scan-start snapshot was read from may have changed under us —
+    // bail without sweeping rather than delete rows under stale
+    // assumptions.
     let schema_version_now: i64 =
         conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if schema_version_now != schema_version_at_open {
@@ -1532,11 +1612,11 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Remove tracks not seen in this scan (deleted files). SKIPPED in
-    // subtree mode: tracks OUTSIDE the subtree have an older scan_id
-    // but are still on disk; the cleanup would wipe them. A subtree
-    // scan can ONLY add/update tracks under its root, never delete
-    // anything outside it. Stale-track cleanup for the rest of the
-    // library will run on the next whole-library scan.
+    // subtree mode: tracks OUTSIDE the subtree were never walked (absent
+    // from the seen-set) but are still on disk; the cleanup would wipe
+    // them. A subtree scan can ONLY add/update tracks under its root,
+    // never delete anything outside it. Stale-track cleanup for the rest
+    // of the library will run on the next whole-library scan.
     // Walk errors no longer veto the whole destructive phase: the sweep
     // shields candidates under the failed-walk prefixes individually and
     // its listing-based presence check fails closed for everything else,
@@ -1553,6 +1633,20 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     let deleted = if subtree_mode {
         0
     } else {
+        // Sweep candidates = (rows that existed when the scan started) −
+        // (rows the walk accounted for), in id order so chunk boundaries
+        // are deterministic. On a no-op rescan of a stable library this
+        // set is EMPTY and the sweep does no DB work at all — replacing
+        // the old scheme where every unchanged row was rewritten with a
+        // fresh scan_id just so a `scan_id != ?` DELETE could find the
+        // leftovers. Rows other writers insert mid-scan (ytdl) are not in
+        // the scan-start snapshot, so they can never be candidates.
+        let mut candidates: Vec<(i64, String)> = existing_tracks
+            .iter()
+            .filter(|(_, t)| !seen_ids.contains(&t.id))
+            .map(|(path, t)| (t.id, path.clone()))
+            .collect();
+        candidates.sort_unstable_by_key(|&(id, _)| id);
         // CHUNKED, not one big DELETE: the stale-track sweep cascades to
         // track_genres / track_artists and fires the per-row FTS5 AFTER
         // DELETE trigger, so on a large-deletion scan a single statement
@@ -1560,7 +1654,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // chunked_delete_stale_tracks (which also verifies each candidate
         // against its parent-directory listing before deleting its row).
         chunked_delete_stale_tracks(
-            &conn, config.library_id, &config.scan_id, schema_version_at_open,
+            &conn, &candidates, schema_version_at_open,
             &config.directory, config.follow_symlinks, &failed_walk_prefixes,
             &config.supported_files,
         )?
@@ -1616,7 +1710,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     //
     //   filesProcessed     New / modified — DB rows actually written by this scan.
     //   filesUnchanged     Cache-hit fast-path skips — file existed in DB and
-    //                      mtime matched, only scan_id was bumped.
+    //                      mtime matched; no row was written.
     //   filesScanned       Total supported-extension files visited (sum of the
     //                      above plus any per-file errors). Lets the operator
     //                      sanity-check 'is the scanner actually seeing my
@@ -1642,44 +1736,10 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
 
 // ── Per-file processing ─────────────────────────────────────────────────────
 
-// Write one already-extracted result. The serial main loop calls this
-// inside its own short per-song transaction (extraction having already
-// happened OUTSIDE any transaction, so the write lock isn't held during
-// the decode); the parallel writer thread inlines the same two-arm logic.
-// Returns Ok(true) for a newly written/replaced track, Ok(false) for the
-// scan_id-only fast-path bump on an unchanged file.
-#[allow(clippy::too_many_arguments)]
-fn write_extract_result(
-    conn: &Connection,
-    config: &ScanConfig,
-    result: ExtractResult,
-    artist_cache: &Mutex<HashMap<String, i64>>,
-    album_cache: &Mutex<HashMap<(String, Option<i64>, Option<i64>), i64>>,
-    genre_cache: &Mutex<HashMap<String, i64>>,
-    various_artists_id: &Mutex<Option<i64>>,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    match result {
-        ExtractResult::Unchanged { existing_id } => {
-            // Hot path for any rescan of a stable library; keep the
-            // statement prepared so the cache hit is the only cost.
-            conn.prepare_cached("UPDATE tracks SET scan_id = ? WHERE id = ?")?
-                .execute(rusqlite::params![config.scan_id, existing_id])?;
-            Ok(false)
-        }
-        ExtractResult::Extracted(et) => {
-            commit_track(
-                conn, config, &et,
-                artist_cache, album_cache, genre_cache, various_artists_id,
-            )?;
-            Ok(true)
-        }
-    }
-}
-
 // Per-file CPU + I/O work. No SQLite access; safe to call from any
-// thread. Returns Unchanged for the mtime fast-path (so the writer
-// only has to bump scan_id) or a fully-populated ExtractedTrack
-// payload the writer will INSERT.
+// thread. Returns Unchanged for the mtime fast-path (the writer just
+// records the row id in the in-memory seen-set) or a fully-populated
+// ExtractedTrack payload the writer will INSERT.
 //
 // Side effects worth knowing about:
 //   - Reads `fs::metadata`, `fs::read`, walks lyric sidecars.
@@ -1724,7 +1784,7 @@ fn extract_track(
     // a per-file SELECT. See `load_existing_tracks` at the top of
     // run_scan. The row (if any) carries everything the fast-path
     // check and the downstream migration logic need:
-    //   - id            — for the scan_id UPDATE
+    //   - id            — for the sweep's seen-set
     //   - modified      — mtime equality check for fast path
     //   - file_hash /
     //     audio_hash    — migrate user-facing rows (stars, bookmarks,
@@ -1760,6 +1820,7 @@ fn extract_track(
     // track_genres are removed by its explicit DELETEs, not a REPLACE
     // cascade) and runs only once extraction has produced a complete
     // result — until then no write touches the row at all.
+    let existing_id = existing.map(|e| e.id);
     let (old_hash, old_audio_hash, old_album_id): (Option<String>, Option<String>, Option<i64>) =
         if let Some(e) = existing {
             let audio_unchanged = e.modified == mod_time;
@@ -2197,6 +2258,7 @@ fn extract_track(
         old_hash,
         old_audio_hash,
         old_album_id,
+        existing_id,
     })))
 }
 

--- a/src/api/ytdl.js
+++ b/src/api/ytdl.js
@@ -369,9 +369,11 @@ export function setup(mstream) {
           aaFile: null,
           vpath: pathInfo.vpath,
           ts: Math.floor(Date.now() / 1000),
-          // scan_id is the scanner's sweep marker — leave NULL here so the
-          // first scan that touches this file claims the row normally. The
-          // 'ytdl' provenance signal lives in tracks.source (V36) instead.
+          // Leave scan_id NULL: the scanner stamps it only when it
+          // rewrites a row, and the first scan that walks this file
+          // claims the row normally (the stale sweep keys on the
+          // scanner's in-memory seen tracking, not this column). The
+          // 'ytdl' provenance signal lives in tracks.source (V36).
           sID: null,
           replaygainTrackDb: metadata.replaygain_track_gain ? metadata.replaygain_track_gain.dB : null,
         };

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -553,9 +553,9 @@ export function setTrackGenres(trackId, genreStr) {
 // new genre string. Used by the file-edit / tag-write handler, which
 // needs to reflect user edits to the genre tag (where the new tag may
 // have FEWER genres than the old one — pure-INSERT would leak the old
-// ones). The scanner doesn't need this because its scan_id rotation
-// already deletes old tracks (and CASCADE drops their track_genres
-// rows) before re-inserting fresh.
+// ones). The scanner doesn't need this because it clears track_genres
+// itself before re-inserting on every re-parse, and its stale sweep
+// deletes removed tracks (CASCADE drops their track_genres rows).
 //
 // Empty / null genreStr clears the link list entirely (matches the
 // "user removed all genres from the tag" case).

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -124,30 +124,43 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 
 // Delete tracks not seen in the just-finished scan (file removed on disk),
 // CHUNKED so the single WAL writer lock is released between batches. Run as
-// one `DELETE FROM tracks WHERE library_id=? AND scan_id!=?` it holds the
-// writer for the entire cascade (track_genres / track_artists) + the per-row
-// FTS5 AFTER DELETE trigger — on a large-deletion scan (moved/renamed top
-// folder, migration force-rescan, emptied library) that can run past the 5s
-// busy_timeout and stall concurrent API writes from the main server. Same
-// cooperate-with-writers pattern as chunkedDelete above; ORPHAN_CHUNK_SIZE
-// (500) keeps each chunk well under busy_timeout. Returns the total rows
-// deleted so the caller's scanComplete count stays accurate. Mirrors
-// chunked_delete_stale_tracks in rust-parser/src/main.rs.
+// one big DELETE it holds the writer for the entire cascade (track_genres /
+// track_artists) + the per-row FTS5 AFTER DELETE trigger — on a
+// large-deletion scan (moved/renamed top folder, migration force-rescan,
+// emptied library) that can run past the 5s busy_timeout and stall
+// concurrent API writes from the main server. Same cooperate-with-writers
+// pattern as chunkedDelete above; ORPHAN_CHUNK_SIZE (500) keeps each chunk
+// well under busy_timeout. Returns the total rows deleted so the caller's
+// scanComplete count stays accurate. Mirrors chunked_delete_stale_tracks
+// in rust-parser/src/main.rs.
+//
+// `candidates` is an array of {id, filepath} rows the caller computed as
+// (rows that existed when the scan started) − (rows the walk accounted
+// for), sorted by id — the scanner's in-memory seen tracking replaced the
+// old per-row `UPDATE tracks SET scan_id = ?` marker (one row rewrite per
+// unchanged file, the dominant write cost of a no-op rescan), so "not
+// seen" is no longer a DB predicate. Rows inserted mid-scan by other
+// writers (ytdl downloads land with scan_id NULL) are not in the
+// scan-start snapshot and can never be candidates. NOTE one deliberate
+// delta from the old `scan_id != ?` predicate: a PRE-existing row with
+// scan_id NULL (a ytdl download from before this scan) used to be
+// unsweepable forever — NULL never matched `!=` — even after its file
+// was deleted from disk. Such rows are ordinary candidates now and
+// converge out of the index once verify-absence proves the file gone.
+//
 // `expectedSchemaVersion` (when given) re-arms the scanner's mid-scan
-// schema guard on EVERY chunk: the sweep is no longer one atomic DELETE
-// but an unbounded sequence of autocommit transactions, and a migration
-// by another instance could land between chunks and change what
-// `scan_id != ?` means. The PRAGMA read is trivial next to a 500-row
-// cascade delete. Throws a "schema-version guard:" error so the caller
-// can map it to the guard exit code. Only called from the scanner
-// process, so the inter-chunk yield is unconditional here.
+// schema guard on EVERY chunk: the sweep is not one atomic DELETE but a
+// sequence of autocommit transactions, and a migration by another
+// instance could land between chunks. The PRAGMA read is trivial next to
+// a 500-row cascade delete. Throws a "schema-version guard:" error so
+// the caller can map it to the guard exit code. Only called from the
+// scanner process, so the inter-chunk yield is unconditional here.
 //
 // VERIFY-ABSENCE: a row is only deleted after a fresh filesystem check
-// proves its file is really gone. An unstamped scan_id is NOT proof of
-// deletion — a swallowed per-file error (decode crash, EBUSY lock, a
-// transient stamp failure) leaves a LIVE track unstamped, and the old
-// sweep deleted it, cascading the user's album/artist stars away
-// permanently.
+// proves its file is really gone. An unseen row is NOT proof of
+// deletion — a swallowed per-file error (decode crash, EBUSY lock)
+// leaves a LIVE track unseen, and the pre-hardening sweep deleted it,
+// cascading the user's album/artist stars away permanently.
 //
 // Presence is decided from the PARENT DIRECTORY LISTING, not a per-file
 // stat: a stat error is NOT proof of absence (EACCES/EIO on a degraded
@@ -160,30 +173,22 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 //  - under a failed-walk prefix → SKIPPED untouched (that subtree was
 //    invisible this scan; neither delete nor claim it was seen);
 //  - exact-case name present as a regular file (or a symlink resolving
-//    to one under followSymlinks) → KEPT, re-stamped "<scanId>-kept":
-//    leaves this sweep's candidate set but stays != every real scan id,
-//    so the next scan re-examines it and a resumable boot-rescan epoch
-//    does NOT mistake it for already-re-parsed;
+//    to one under followSymlinks) → KEPT untouched — a swallowed
+//    per-file error left it unaccounted for; the next scan simply
+//    re-examines it (no row marker needed: the candidate list lives in
+//    the scanner's memory and dies with the scan);
 //  - name absent / not a file / directory listing ENOENT → DELETED;
 //  - listing unreadable for any other reason → SKIPPED untouched.
 //
-// Keyset pagination (id > cursor) guarantees termination even though
-// skipped candidates stay unstamped. The library root is re-verified
-// every chunk: a mount that vanishes mid-sweep would otherwise make
-// every listing read ENOENT and erase the library. Mirrors
-// chunked_delete_stale_tracks in rust-parser/src/main.rs. With
-// libraryRoot null (no caller does this today) the sweep degrades to
-// the legacy delete-by-stamp behaviour.
-export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion = null,
+// The library root is re-verified every chunk: a mount that vanishes
+// mid-sweep would otherwise make every listing read ENOENT and erase
+// the library. Mirrors chunked_delete_stale_tracks in
+// rust-parser/src/main.rs. With libraryRoot null (no caller does this
+// today) the sweep degrades to deleting every candidate unverified.
+export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
   { libraryRoot = null, followSymlinks = false, failedWalkPrefixes = [],
     supportedFiles = null } = {}) {
-  const select = db.prepare(
-    `SELECT id, filepath FROM tracks
-      WHERE library_id = ? AND scan_id != ? AND id > ?
-      ORDER BY id LIMIT ${ORPHAN_CHUNK_SIZE}`,
-  );
   const versionStmt = db.prepare('PRAGMA user_version');
-  const keptStamp = `${scanId}-kept`;
   const KIND_FILE = 1; const KIND_SYMLINK = 2; const KIND_OTHER = 3;
   const listings = new Map(); // relDir -> Map(name -> kind) | null (unreadable)
   const getListing = (relDir) => {
@@ -236,8 +241,7 @@ export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion =
 
   let total = 0;
   let skipped = 0;
-  let cursor = 0;
-  while (true) {
+  for (let offset = 0; offset < candidates.length; offset += ORPHAN_CHUNK_SIZE) {
     if (expectedSchemaVersion !== null) {
       const v = versionStmt.get().user_version;
       if (v !== expectedSchemaVersion) {
@@ -252,15 +256,13 @@ export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion =
         `aborting stale-track cleanup after ${total} rows to avoid wiping the library`);
       break;
     }
-    const candidates = select.all(libraryId, scanId, cursor);
-    if (candidates.length === 0) { break; }
-    const fullChunk = candidates.length === ORPHAN_CHUNK_SIZE;
-    cursor = candidates[candidates.length - 1].id;
+    const chunk = candidates.slice(offset, offset + ORPHAN_CHUNK_SIZE);
+    const fullChunk = chunk.length === ORPHAN_CHUNK_SIZE;
 
-    const survivors = [];
+    let survivors = 0;
     const doomed = [];
-    for (const c of candidates) {
-      if (libraryRoot === null) { doomed.push(c.id); continue; } // legacy delete-by-stamp
+    for (const c of chunk) {
+      if (libraryRoot === null) { doomed.push(c); continue; } // delete unverified
       if (isShielded(c.filepath)) { skipped++; continue; }
       const i = c.filepath.lastIndexOf('/');
       const dirRel = i === -1 ? '' : c.filepath.slice(0, i);
@@ -270,15 +272,15 @@ export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion =
       // Walk-faithful presence includes the EXTENSION filter: a file whose
       // extension left supportedFiles would never be indexed by the walk,
       // so its row converges out of the index instead of becoming an
-      // immortal '-kept' row with a misleading warning every scan.
+      // immortal candidate warned about on every scan.
       if (supportedFiles !== null
           && !supportedFiles[name.split('.').pop().toLowerCase()]) {
-        doomed.push(c.id);
+        doomed.push(c);
         continue;
       }
       const kind = listing.get(name);
       if (kind === KIND_FILE) {
-        survivors.push(c.id);
+        survivors++;
       } else if (kind === KIND_SYMLINK && followSymlinks) {
         // Walk-faithful: a symlink the walk would follow counts as
         // present only if its target resolves to a regular file now.
@@ -288,27 +290,36 @@ export function deleteStaleTracks(db, libraryId, scanId, expectedSchemaVersion =
           present = (err.code === 'ENOENT' || err.code === 'ENOTDIR') ? false : null;
         }
         if (present === null) { skipped++; }
-        else if (present) { survivors.push(c.id); }
-        else { doomed.push(c.id); }
+        else if (present) { survivors++; }
+        else { doomed.push(c); }
       } else {
         // Exact-case name missing, a non-file, or a symlink the
         // no-follow walk would not index.
-        doomed.push(c.id);
+        doomed.push(c);
       }
     }
-    if (survivors.length > 0) {
+    if (survivors > 0) {
+      // No row write needed to "keep" them — the candidate list is
+      // in-memory and dies with this scan; the next scan just re-derives
+      // it. Warn so a chronic swallowed-error subtree stays
+      // operator-visible.
       console.error(
-        `Warning: ${survivors.length} track(s) missed their scan stamp but still ` +
-        'exist on disk — keeping them (re-stamped \'-kept\'); a swallowed per-file ' +
-        'error likely occurred');
-      db.prepare(
-        `UPDATE tracks SET scan_id = ? WHERE id IN (${survivors.map(() => '?').join(',')})`,
-      ).run(keptStamp, ...survivors);
+        `Warning: ${survivors} track(s) missed by this scan still exist on ` +
+        'disk — keeping them; a swallowed per-file error likely occurred');
     }
     if (doomed.length > 0) {
+      // Row-value guard (id AND filepath, both from the scan-start
+      // snapshot): the absence check ran against the snapshot path, so a
+      // row whose filepath were ever rewritten mid-scan by some future
+      // rename/move API would fall out of the doomed set instead of
+      // being deleted off a stale verdict. (No such writer exists today;
+      // the old per-chunk re-SELECT was immune by construction — this
+      // keeps the property.) AUTOINCREMENT already guarantees ids are
+      // never reused, so the pair is stable evidence.
       const r = db.prepare(
-        `DELETE FROM tracks WHERE id IN (${doomed.map(() => '?').join(',')})`,
-      ).run(...doomed);
+        `DELETE FROM tracks WHERE (id, filepath) IN (VALUES ${
+          doomed.map(() => '(?, ?)').join(',')})`,
+      ).run(...doomed.flatMap(d => [d.id, d.filepath]));
       total += r.changes;
     }
     if (fullChunk) { chunkYield(); }

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -112,9 +112,8 @@ db.exec('PRAGMA busy_timeout = 5000');
 db.exec('PRAGMA recursive_triggers = ON');
 // synchronous = NORMAL: crash-safe in WAL — the DB never corrupts; a power
 // loss can only lose recently-committed transactions (those in the WAL since
-// the last checkpoint), which the next scan re-derives via the mtime/scan_id
-// fast-path — and skips the per-COMMIT fsync — a big win for bulk inserts
-// and the per-file scan_id bumps a re-scan does over the whole library,
+// the last checkpoint), which the next scan re-derives via the mtime
+// fast-path — and skips the per-COMMIT fsync — a big win for bulk inserts,
 // especially on the HDD/NAS storage this often runs on. Safe here because
 // scanner data is re-derivable; the main server connection (manager.js)
 // stays on the FULL default for user-data durability.
@@ -149,9 +148,6 @@ const stmts = {
   getTrack: db.prepare(
     `SELECT id, modified, file_hash, audio_hash, album_id, lyrics_sidecar_mtime, scan_id
        FROM tracks WHERE filepath = ? AND library_id = ?`
-  ),
-  updateScanId: db.prepare(
-    'UPDATE tracks SET scan_id = ? WHERE id = ?'
   ),
   findArtist: db.prepare(
     'SELECT id FROM artists WHERE name = ?'
@@ -708,61 +704,37 @@ let errorCount = 0;     // per-file failures — counted separately so the
                         // contract (visited = processed + unchanged +
                         // errors) while totalProcessed stays success-only
                         // for the zero-successful-files data-loss guard.
-// Cadence (in files) for flushing the unchanged-file batch and refreshing
-// the progress row. Lower = more responsive API writes during scans but more
-// COMMIT overhead. Admin-configurable via scanCommitInterval; default (25)
-// is a balanced starting point.
+// Cadence (in files) for refreshing the progress row. Lower = more
+// frequent progress updates but more write overhead. Admin-configurable
+// via scanCommitInterval; default (25) is a balanced starting point.
 const COMMIT_INTERVAL = loadJson.scanCommitInterval || 25;
 
-// Write-batch state. The cheap scan_id bumps for unchanged files are batched
-// under one transaction (flushed every COMMIT_INTERVAL files) for
-// throughput. A changed file's parseMyFile (read + tag parse + hash +
-// album-art I/O) is slow, so processFile flushes the batch — releasing the
-// single SQLite write lock — BEFORE parsing it, then writes that one track
-// in its own tight transaction. This keeps the write lock free during every
-// decode so a concurrent API write can't block for the length of one.
-// Mirrors the Rust scanner's extract-outside-the-transaction restructure.
-// BEGIN IMMEDIATE, not deferred: a batch's first statement can be a read
-// (getTrack runs before the batch's first write on some paths), and a
-// deferred BEGIN would pin a read snapshot that a server commit landing
-// before our first write invalidates — the lock upgrade then fails with
-// SQLITE_BUSY_SNAPSHOT, which bypasses the 5s busy_timeout entirely (the
-// same failure class src/db/manager.js transaction() was converted to
-// IMMEDIATE for). IMMEDIATE takes the write lock up front where the busy
-// handler IS honored.
-let batchOpen = false;
-let batchStartMs = 0;
-function ensureBatch() {
-  if (!batchOpen) {
-    db.exec('BEGIN IMMEDIATE');
-    batchOpen = true;
-    batchStartMs = Date.now();
-  }
-}
-// A COMMIT failure here means the transaction is gone (SQLite auto-rolls
-// back on FULL/IOERR/NOMEM) or unusable — either way batchOpen must NOT
-// stay true, or every later flush throws "no transaction active" and the
-// real cause gets buried under per-file warnings. Reset the flag, attempt
-// a defensive ROLLBACK, and rethrow marked fatal so processFile's
-// per-file catch lets it bubble to run()'s scan-failure path instead of
-// swallowing it file by file.
-function flushBatch() {
-  if (!batchOpen) { return; }
-  try {
-    db.exec('COMMIT');
-  } catch (e) {
-    try { db.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
-    batchOpen = false;
-    e.fatalScanError = true;
-    throw e;
-  }
-  batchOpen = false;
-}
-// Wall-clock cap on how long the fast-path batch may hold the write lock:
-// getTrack + the cached sidecar probe run inside the open transaction, and
-// on a degraded NAS a cold readdirSync can block for seconds per directory
-// while the lock is held. Mirrors the Rust writer's COMMIT_BUDGET_MS.
-const COMMIT_BUDGET_MS = 50;
+// Library-relative paths of files this scan accounted for: unchanged
+// fast-path hits plus successfully committed (new/modified) files. The
+// stale sweep's candidates are the scan-start snapshot rows whose
+// filepath is NOT in this set — replacing the old per-row `UPDATE
+// tracks SET scan_id = ?` marker, which made a no-op rescan of a
+// stable library rewrite EVERY tracks row through the single WAL
+// writer just to mark "seen" (and dragged a whole write-batching
+// machinery along to make those useless writes cheap enough). With the
+// batch gone, an unchanged file's getTrack + sidecar probes run with
+// no transaction open and take no writer lock at all.
+//
+// Keyed by PATH, not row id: processFile reads its row LIVE (getTrack)
+// while the sweep candidates come from the scan-start snapshot, and a
+// row REPLACEd mid-scan by another writer (a ytdl re-download of an
+// existing file) gets a fresh rowid — id-keying would orphan the
+// snapshot id and emit a spurious missed-but-alive warning. filepath
+// is UNIQUE per library and is the identity the walk actually visits.
+// (The rust scanner's seen_ids is id-keyed because its fast-path reads
+// from the SAME snapshot map its candidates derive from — ids there
+// are consistent by construction.)
+//
+// Errored files are deliberately NOT marked seen: their rows fall to
+// the sweep, whose verify-absence check finds the file on disk and
+// keeps them — same outcome as the old unstamped-row path, warning
+// included.
+const seenPaths = new Set();
 
 // Per-scan, per-directory filename listing cache for sidecar probing.
 // The fast-path probes sidecar mtime for every file on every scan; this
@@ -796,11 +768,11 @@ const visitedDirs = loadJson.followSymlinks ? new Set() : null;
 // Walk errors are RECORDED, not silently dropped: an unreadable
 // subdirectory (permissions flip, antivirus lock, a mount dying
 // mid-walk) means every file under it never reaches `out`, their rows
-// keep their old scan_id, and the stale sweep would treat them as
+// never land in the seen-set, and the stale sweep would treat them as
 // deleted. Each failed directory becomes a sweep-skip prefix — its rows
-// are neither deleted nor re-stamped this scan — so one permanently
-// unreadable #recycle-style dir can't freeze cleanup for the rest of
-// the library forever. ENOENT failures are benign races (the dir was
+// are exempt from this scan's cleanup — so one permanently unreadable
+// #recycle-style dir can't freeze cleanup for the rest of the library
+// forever. ENOENT failures are benign races (the dir was
 // deleted mid-walk; its rows SHOULD sweep) and are not recorded. Detail
 // logging is capped; the count always reports. Mirrors the Rust
 // scanner's walk-error classification.
@@ -895,19 +867,15 @@ async function processFile(filepath, fileMtime) {
       : (existing?.lyrics_sidecar_mtime || null) !== (sidecarMtimeCached(filepath, dirListingCache) || null);
 
     if (existing && (alreadyThisEpoch || (existing.modified === fileMtime && !loadJson.forceRescan && !sidecarDrifted))) {
-      // Unchanged (mtime fast-path) or already re-parsed this epoch — just
-      // (re)assert the scan id (a no-op write when it already carries it).
-      // No extraction here, so batch these cheap writes for throughput —
-      // but flush first if the open batch has held the lock past its
-      // wall-clock budget (the sidecar probes above run inside it, and a
-      // cold directory listing on slow storage isn't microseconds).
-      if (batchOpen && Date.now() - batchStartMs > COMMIT_BUDGET_MS) { flushBatch(); }
-      ensureBatch();
-      stmts.updateScanId.run(loadJson.scanId, existing.id);
+      // Unchanged (mtime fast-path) or already re-parsed this epoch — no
+      // DB write at all: seen-ness lives in the in-memory set the stale
+      // sweep consults, so a no-op rescan never takes the writer lock
+      // except for the periodic progress updates below.
+      seenPaths.add(relativePath);
     } else {
-      // New or modified file. Capture the prior identity, then FLUSH the
-      // fast-path batch so the write lock is released BEFORE the slow parse
-      // below — a concurrent API write must not block for a decode's length.
+      // New or modified file. Capture the prior identity before the slow
+      // parse below — which runs with no transaction open, so a
+      // concurrent API write never blocks for a decode's length.
       //
       // NOTE: we intentionally do NOT DELETE the old tracks row before
       // calling parseMyFile. If the parse throws (malformed tags, disk
@@ -922,15 +890,17 @@ async function processFile(filepath, fileMtime) {
       const oldAudioHash = existing ? existing.audio_hash : null;
       const oldAlbumId   = existing ? existing.album_id   : null;
 
-      flushBatch();
       const songInfo = await parseMyFile(filepath, fileMtime);   // no txn held
 
       // Write this one track in its own tight transaction: the lock is held
       // only for the synchronous DB writes, and a mid-write failure rolls
       // back just this track (no half-written row) — the JS analogue of the
-      // Rust writer's per-song savepoint. IMMEDIATE for the same
-      // SQLITE_BUSY_SNAPSHOT reason as ensureBatch above (insertTrack's
-      // first statement is a cache-miss artist SELECT on many paths).
+      // Rust writer's per-song savepoint. IMMEDIATE, not deferred:
+      // insertTrack's first statement is a cache-miss artist SELECT on
+      // many paths, which would pin a read snapshot before the first
+      // write — a server commit landing in that window fails the lock
+      // upgrade with SQLITE_BUSY_SNAPSHOT, bypassing the 5s busy_timeout
+      // entirely. Same convention as src/db/manager.js transaction().
       db.exec('BEGIN IMMEDIATE');
       try {
         const { albumId: newAlbumId } = insertTrack(songInfo);
@@ -953,24 +923,23 @@ async function processFile(filepath, fileMtime) {
         try { db.exec('ROLLBACK'); } catch (_) {}
         throw e;
       }
+      // A successfully committed file is accounted for; without this the
+      // sweep would re-list its directory and warn about a "missed" row.
+      // (For brand-new files this is a no-op against the snapshot —
+      // unless the snapshot held a REPLACEd row for the same path.)
+      seenPaths.add(relativePath);
       fileCount++;
     }
 
     // Track all files (including unchanged) for progress
     totalProcessed++;
 
-    // Periodically flush the fast-path batch (bounding how long it holds the
-    // write lock) and refresh the progress row.
+    // Periodically refresh the progress row — on a no-op rescan this
+    // autocommit UPDATE is the scan's only writer-lock acquisition.
     if (totalProcessed % COMMIT_INTERVAL === 0) {
-      flushBatch();
       try { progressStmts.update.run(totalProcessed, relativePath, loadJson.scanId); } catch (_) {}
     }
   } catch (err) {
-    // A failed batch COMMIT is not a per-file problem — the transaction
-    // machinery itself broke (disk full, I/O error). Let it bubble to
-    // run()'s catch so the scan fails loudly instead of warning once per
-    // remaining file.
-    if (err.fatalScanError) { throw err; }
     errorCount++;
     console.error(`Warning: failed to process ${filepath}: ${err.message}`);
   }
@@ -1010,6 +979,25 @@ async function run() {
       console.log(`Scanning ${loadJson.directory}...`);
     }
 
+    // Scan-start snapshot for the stale sweep: every (id, filepath) this
+    // library had BEFORE the walk. Sweep candidates are the snapshot
+    // rows whose filepath the walk did not account for — the in-memory
+    // replacement for the old per-row scan_id marker. Taken before the
+    // walk so rows other writers insert mid-scan (ytdl downloads, which
+    // land with scan_id NULL) can never become candidates. (PRE-existing
+    // NULL-scan_id rows are a deliberate delta: the old `!=` predicate
+    // could never select them, so a ytdl row whose file was deleted
+    // leaked in the DB forever — they now converge out like ordinary
+    // rows once verify-absence proves the file gone.) Tens of bytes of
+    // RAM per track; the Rust scanner already holds a strictly larger
+    // per-row snapshot for its mtime fast-path. Subtree scans never
+    // sweep, so they skip the snapshot.
+    const preScanRows = subtreeMode
+      ? []
+      : db.prepare(
+          'SELECT id, filepath FROM tracks WHERE library_id = ? ORDER BY id'
+        ).all(loadJson.libraryId);
+
     // Single walk: collect supported files (with walk-time mtime) so we
     // don't stat the whole tree twice. files.length is the progress-bar
     // expected count.
@@ -1019,23 +1007,21 @@ async function run() {
       progressStmts.insert.run(loadJson.scanId, loadJson.libraryId, loadJson.vpath || '', files.length || null);
     } catch (_) {}
 
-    // No single transaction wraps the whole walk now: processFile batches
-    // the cheap unchanged-file scan_id bumps but commits and releases the
-    // write lock before parsing each changed file, so the lock is never held
-    // across a slow decode. Flush the trailing fast-path batch after the
-    // walk. (Mirrors the Rust scanner's extract-outside-the-transaction
-    // restructure.)
+    // No transaction wraps the walk: an unchanged file writes nothing at
+    // all (seen-ness is in-memory) and each changed file is written in
+    // its own tight transaction, so the writer lock is never held across
+    // a slow decode — and on a no-op rescan it is barely taken at all.
+    // (Mirrors the Rust scanner's writer restructure.)
     for (const f of files) {
       await processFile(f.filepath, f.mtime);
     }
-    flushBatch();
 
     // ── Post-walk data-loss guards ──────────────────────────────────
     // (a) The walk FOUND files but not one processed successfully —
     // systemic failure (permissions flip, disk fault, broken dependency),
-    // not 600 coincidentally-corrupt files. No row got its scan_id
-    // bumped, so the stale sweep would delete the entire library. Skip
-    // all cleanup and mark the scan failed.
+    // not 600 coincidentally-corrupt files. Nothing landed in the
+    // seen-set, so the stale sweep would treat the entire library as
+    // candidates. Skip all cleanup and mark the scan failed.
     if (!subtreeMode && files.length > 0 && totalProcessed === 0) {
       console.error(
         `Error: walk found ${files.length} files but every one failed to ` +
@@ -1068,11 +1054,12 @@ async function run() {
 
     // Re-check the schema version before the scan's only destructive
     // phase. If a migration ran mid-scan (a second server instance, or a
-    // boot racing this scanner after its parent died), what `scan_id != ?`
-    // selects may have changed under us — bail without sweeping rather
-    // than delete rows under stale assumptions. deleteStaleTracks also
-    // re-verifies before EVERY chunk (the sweep is many autocommit
-    // transactions with deliberate yields between them).
+    // boot racing this scanner after its parent died), the table contents
+    // our scan-start snapshot was read from may have changed under us —
+    // bail without sweeping rather than delete rows under stale
+    // assumptions. deleteStaleTracks also re-verifies before EVERY chunk
+    // (the sweep is many autocommit transactions with deliberate yields
+    // between them).
     const schemaVersionNow = db.prepare('PRAGMA user_version').get().user_version;
     if (schemaVersionNow !== schemaVersionAtOpen) {
       console.error(
@@ -1095,20 +1082,24 @@ async function run() {
 
     // Remove tracks that weren't seen in this scan (deleted files).
     // SKIPPED in subtree mode — tracks outside the subtree share the
-    // library_id but have an older scan_id, and wiping them would be a
-    // data-loss bug. Stale cleanup runs only when we've actually
-    // walked the whole library.
+    // library_id but were never walked (absent from the seen-set), and
+    // wiping them would be a data-loss bug. Stale cleanup runs only when
+    // we've actually walked the whole library.
+    // Candidates = snapshot rows the walk did not account for, already
+    // in id order (the snapshot SELECT orders by id) so chunk boundaries
+    // are deterministic. On a no-op rescan of a stable library this set
+    // is EMPTY and the sweep does no DB work at all.
     // CHUNKED stale-track sweep (see deleteStaleTracks) so the writer lock
     // is released — with a real 10-20ms yield — between batches instead of
-    // held for the whole cascade + FTS delete-trigger run. Runs in
-    // autocommit here (the fast-path batch was flushed above), so each
-    // chunk is its own transaction. libraryRoot/followSymlinks/
+    // held for the whole cascade + FTS delete-trigger run. Each chunk is
+    // its own autocommit transaction. libraryRoot/followSymlinks/
     // failedWalkPrefixes feed the verify-absence check: only rows whose
-    // file is provably gone get deleted; unstamped-but-alive rows are
-    // re-stamped '-kept'; unverifiable rows are left untouched.
+    // file is provably gone get deleted; unseen-but-alive rows are kept;
+    // unverifiable rows are left untouched.
     const deleted = subtreeMode
       ? { changes: 0 }
-      : { changes: deleteStaleTracks(db, loadJson.libraryId, loadJson.scanId, schemaVersionAtOpen,
+      : { changes: deleteStaleTracks(db,
+          preScanRows.filter((r) => !seenPaths.has(r.filepath)), schemaVersionAtOpen,
           { libraryRoot: loadJson.directory, followSymlinks: !!loadJson.followSymlinks,
             failedWalkPrefixes, supportedFiles: loadJson.supportedFiles }) };
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
@@ -1116,7 +1107,7 @@ async function run() {
     // Field shapes mirror the rust-parser's emitter:
     //   filesProcessed       New / modified rows actually written.
     //   filesUnchanged       Cache-hit fast-path skips (file existed in DB and
-    //                        mtime matched; only scan_id was bumped).
+    //                        mtime matched; no row was written).
     //   filesScanned         Total supported files visited (processed +
     //                        unchanged + per-file errors).
     //   staleEntriesRemoved  Tracks deleted because the file disappeared.

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -23,7 +23,7 @@
 //   V39 (torrent_client_vpath_access)      → V40
 //   V40 (managed_torrents.download_path)   → V41
 //   V41 (libraries.torrent_path_template)  → V42
-export const SCHEMA_VERSION = 46;
+export const SCHEMA_VERSION = 47;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -169,7 +169,6 @@ export const SCHEMA_V1 = `
   CREATE INDEX IF NOT EXISTS idx_tracks_album ON tracks(album_id);
   CREATE INDEX IF NOT EXISTS idx_tracks_hash ON tracks(file_hash);
   CREATE INDEX IF NOT EXISTS idx_tracks_filepath ON tracks(filepath, library_id);
-  CREATE INDEX IF NOT EXISTS idx_tracks_scan ON tracks(scan_id);
   CREATE INDEX IF NOT EXISTS idx_user_metadata_hash ON user_metadata(track_hash);
   CREATE INDEX IF NOT EXISTS idx_user_metadata_user ON user_metadata(user_id);
   CREATE INDEX IF NOT EXISTS idx_playlist_tracks_playlist ON playlist_tracks(playlist_id);
@@ -1166,13 +1165,15 @@ export const SCHEMA_V35 = `
 // their own labels without a migration.
 //
 // WHY A COLUMN AT ALL (vs. overloading `scan_id` as ytdl historically did):
-//   `scan_id` is the scanner's sweep marker — every scan generates a
-//   fresh UUID and the post-scan `DELETE FROM tracks WHERE scan_id != ?`
-//   evicts unswept rows. Any scan that touches the file (even just to
-//   bump the marker via `UPDATE tracks SET scan_id = ?` on the mtime
-//   fast path) silently overwrites the 'ytdl' label. So `scan_id` was
-//   never effective provenance. `source` is purpose-built and survives
-//   rescans.
+//   `scan_id` was the scanner's sweep marker at the time — every scan
+//   generated a fresh UUID, the post-scan `DELETE FROM tracks WHERE
+//   scan_id != ?` evicted unswept rows, and any scan that touched the
+//   file (even just the mtime fast path's marker bump) silently
+//   overwrote the 'ytdl' label. So `scan_id` was never effective
+//   provenance. `source` is purpose-built and survives rescans. (The
+//   sweep marker itself has since moved into scanner memory — the
+//   seen-set — and `scan_id` now only records the scan epoch that last
+//   REWROTE a row, which the boot-migration resume fast-path keys on.)
 //
 // WHY 'source' (not 'provider' / 'download_source'):
 //   - Short. Matches the verbiage of `play_events.source` (V7) and
@@ -1425,6 +1426,23 @@ export const SCHEMA_V46 = `
    WHERE typeof(modified) = 'real';
 `;
 
+// V47: drop idx_tracks_scan — pure write-amplification with no readers.
+// The only query that ever filtered tracks by scan_id was the stale
+// sweep's `scan_id != ?`, which SQLite cannot drive with an index (it
+// planned via idx_tracks_library instead) — and the sweep now derives
+// its candidates from the scanner's in-memory seen-set, so even that
+// non-consumer is gone. All scan_id EQUALITY lookups target the separate
+// scan_progress table. Meanwhile every tracks INSERT/UPSERT paid an
+// extra b-tree insert maintaining it, and the historical per-unchanged-
+// file scan_id bump paid a key delete+insert per row. Same dead-index
+// class V44 removed for idx_tracks_filepath. Index-only: no rescan.
+// (Removed from SCHEMA_V1 too; fresh DBs replay the whole migration
+// chain, so they still create it transiently at the V24 tracks rebuild
+// and drop it here — IF EXISTS covers every path.)
+export const SCHEMA_V47 = `
+  DROP INDEX IF EXISTS idx_tracks_scan;
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -1580,4 +1598,6 @@ export const MIGRATIONS = [
   // and caused permanent sidecar re-parse loops). Data-only, no rescan.
   // See SCHEMA_V46.
   { version: 46, sql: SCHEMA_V46 },
+  // See SCHEMA_V47. Index drop only — no rescan.
+  { version: 47, sql: SCHEMA_V47 },
 ];

--- a/test/scanner-parity.test.mjs
+++ b/test/scanner-parity.test.mjs
@@ -228,7 +228,7 @@ describe('scanner determinism + parity', () => {
 
   // Real libraries get incremental rescans after edits — some files
   // touched, most unchanged. The parallel writer routes Unchanged
-  // (scan_id UPDATE only) and Extracted (full commit_track) messages
+  // (seen-set insert only) and Extracted (full commit_track) messages
   // interleaved on the same Connection. This exercises that mix
   // explicitly: bumping mtime on a few files forces them onto the
   // Extracted path while the rest take the fast-path. With unchanged

--- a/test/scanner-schema-guard.test.mjs
+++ b/test/scanner-schema-guard.test.mjs
@@ -93,10 +93,16 @@ async function waitFor(predicate, ms) {
 }
 
 describe('stale sweep verify-absence (deleteStaleTracks)', () => {
-  // The sweep must only delete rows whose file is PROVABLY gone — an
-  // unstamped scan_id alone is not proof (swallowed per-file errors leave
-  // live tracks unstamped). Rows with a living file get re-stamped.
-  test('keeps and re-stamps unstamped rows whose file still exists; deletes only truly-gone files', async () => {
+  // Candidates as the scanner derives them: the scan-start snapshot minus
+  // the seen-set. These tests pass every row (an empty seen-set —
+  // simulating a scan that failed to account for any of them).
+  const allCandidates = (db) => db.prepare(
+    'SELECT id, filepath FROM tracks WHERE library_id = 1 ORDER BY id').all();
+
+  // The sweep must only delete rows whose file is PROVABLY gone — a row
+  // missing from the seen-set alone is not proof (swallowed per-file
+  // errors leave live tracks unseen). Rows with a living file are kept.
+  test('keeps unseen rows whose file still exists; deletes only truly-gone files', async () => {
     const { deleteStaleTracks } = await import('../src/db/orphan-cleanup.js');
     const tmp = makeTmp('verify-absence');
     const lib = path.join(tmp, 'music');
@@ -107,10 +113,10 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
     db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
     const ins = db.prepare(
       'INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)');
-    ins.run('alive.mp3', 'ancient'); // unstamped but file exists — a swallowed error victim
-    ins.run('gone.mp3', 'ancient');  // unstamped and file gone — genuinely stale
+    ins.run('alive.mp3', 'ancient'); // unseen but file exists — a swallowed error victim
+    ins.run('gone.mp3', 'ancient');  // unseen and file gone — genuinely stale
 
-    const deleted = deleteStaleTracks(db, 1, 'current-scan', SCHEMA_VERSION,
+    const deleted = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false });
     assert.strictEqual(deleted, 1, 'only the file that is really gone gets deleted');
     // Spread into plain objects: node:sqlite rows have a null prototype,
@@ -118,16 +124,16 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
     const rows = db.prepare('SELECT filepath, scan_id FROM tracks ORDER BY filepath')
       .all().map(r => ({ ...r }));
     db.close();
-    // The '-kept' sentinel: out of THIS sweep's way, but != any real scan
-    // id, so the next scan re-examines it and a resumable boot-rescan
-    // epoch doesn't mistake it for already-re-parsed.
-    assert.deepStrictEqual(rows, [{ filepath: 'alive.mp3', scan_id: 'current-scan-kept' }],
-      'the living file survives, re-stamped with the kept sentinel');
+    // Kept rows are untouched — no marker write. The candidate list lives
+    // in the scanner's memory and dies with the scan; the next scan just
+    // re-derives it.
+    assert.deepStrictEqual(rows, [{ filepath: 'alive.mp3', scan_id: 'ancient' }],
+      'the living file survives with its row untouched');
 
     // A second sweep re-examines the kept row (still a candidate) but
     // keeps it again and deletes nothing.
     const check = new DatabaseSync(dbPath);
-    const again = deleteStaleTracks(check, 1, 'current-scan', SCHEMA_VERSION,
+    const again = deleteStaleTracks(check, allCandidates(check), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false });
     check.close();
     assert.strictEqual(again, 0);
@@ -149,14 +155,14 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
     ins.run('broken/two.mp3', 'ancient');
     ins.run('ok/gone.mp3', 'ancient'); // dir exists, file doesn't — genuinely stale
 
-    const deleted = deleteStaleTracks(db, 1, 'scan-x', SCHEMA_VERSION,
+    const deleted = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false, failedWalkPrefixes: ['broken'] });
     assert.strictEqual(deleted, 1, 'only the verifiable-and-gone row is deleted');
     const rows = db.prepare('SELECT filepath, scan_id FROM tracks ORDER BY filepath')
       .all().map(r => ({ ...r }));
     db.close();
     assert.deepStrictEqual(rows, [
-      // Shielded rows keep their ORIGINAL stamp — untouched, not re-stamped.
+      // Shielded rows are untouched.
       { filepath: 'broken/one.mp3', scan_id: 'ancient' },
       { filepath: 'broken/two.mp3', scan_id: 'ancient' },
     ]);
@@ -174,7 +180,7 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
       .run('TRACK.mp3', 'ancient'); // stale row under the OLD casing
     // A per-file stat would hit case-insensitively on Windows and keep
     // resurrecting this row forever; the listing compares exact names.
-    const deleted = deleteStaleTracks(db, 1, 'scan-y', SCHEMA_VERSION,
+    const deleted = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false });
     const n = db.prepare('SELECT COUNT(*) AS n FROM tracks').get().n;
     db.close();
@@ -200,18 +206,18 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
       .run('linked.mp3', 'ancient');
     // followSymlinks=false: the walk would not index this entry, so the
     // sweep must agree it is "absent" and delete the row...
-    const deletedNoFollow = deleteStaleTracks(db, 1, 's1', SCHEMA_VERSION,
+    const deletedNoFollow = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false });
     assert.strictEqual(deletedNoFollow, 1);
-    // ...while followSymlinks=true treats it as present (re-stamp).
+    // ...while followSymlinks=true treats it as present (kept untouched).
     db.prepare('INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)')
       .run('linked.mp3', 'ancient');
-    const deletedFollow = deleteStaleTracks(db, 1, 's2', SCHEMA_VERSION,
+    const deletedFollow = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: true });
     assert.strictEqual(deletedFollow, 0);
     const row = db.prepare('SELECT scan_id FROM tracks WHERE filepath = ?').get('linked.mp3');
     db.close();
-    assert.strictEqual(row.scan_id, 's2-kept');
+    assert.strictEqual(row.scan_id, 'ancient');
   });
 
   test('V46 repairs REAL-poisoned mtime columns exactly, leaves healthy rows alone', () => {

--- a/test/ytdl-provenance.test.mjs
+++ b/test/ytdl-provenance.test.mjs
@@ -395,8 +395,8 @@ describe('V36 ytdl provenance — end-to-end', () => {
     assert.equal(querySource(dbPath, 'flac-roundtrip.flac'), 'ytdl',
       'first scan should populate source from the embedded tag');
 
-    // Bump mtime so the scanner takes the re-extract branch (vs. fast-
-    // path scan_id-only UPDATE). Future timestamp so it can't tie.
+    // Bump mtime so the scanner takes the re-extract branch (vs. the
+    // no-write fast path). Future timestamp so it can't tie.
     const future = new Date(Date.now() + 120_000);
     await fsp.utimes(file, future, future);
 


### PR DESCRIPTION
## What this fixes

A no-op rescan of a stable library rewrote **every tracks row**: the mtime fast-path issued `UPDATE tracks SET scan_id = ? WHERE id = ?` per unchanged file (plus `idx_tracks_scan` maintenance) through the single WAL writer, solely so the stale sweep's `scan_id != ?` predicate could find what was left. With the default 24h scan interval, a stable 100k-track library paid 100k row rewrites a day to discover nothing changed. This was the highest-severity remaining finding from the June scanner audit.

## What changed

**Seen-ness now lives in scanner memory for the lifetime of the scan.**

- **rust**: a `seen_ids` HashSet in `run_scan`. The Unchanged arm does no DB work at all; successful `commit_track`s mark the prior row id too. The parallel writer's per-batch `BEGIN IMMEDIATE` became **lazy** — a batch that drains only unchanged results never takes the writer lock, and the progress update runs as its own autocommit statement in that case (on a no-op rescan that's the writer's *only* lock acquisition, once per `scanCommitInterval` files). The serial path was restructured the same way; `write_extract_result` folded into it.
- **JS**: a `seenPaths` Set of library-relative paths. Path-keyed (not id-keyed) because the JS fast-path reads rows live while sweep candidates come from the scan-start snapshot — a ytdl `INSERT OR REPLACE` mid-scan changes the rowid, and filepath is the UNIQUE identity the walk actually visits. The entire fast-path write-batch machinery (`ensureBatch`/`flushBatch`/`COMMIT_BUDGET_MS`/`fatalScanError`) is **deleted** — it existed only to make the useless writes cheap.
- **Sweep**: candidates are now `(scan-start snapshot of id+filepath) − (seen)`, passed explicitly to `chunked_delete_stale_tracks` / `deleteStaleTracks`. All of #629's verify-absence machinery is unchanged — parent-directory listings, fail-closed error handling, walk-error shields, extension filter, per-chunk schema guard + root re-check, inter-chunk yields. Only candidate *discovery* moved in-memory. The `'-kept'` restamp is gone (nothing queries by scan_id anymore, so survivors are simply left untouched), and the doomed DELETE is **row-value-guarded** (`(id, filepath) IN (VALUES …)`) so a row whose path were ever rewritten mid-scan can't be deleted off a stale absence verdict.
- **Schema V47** drops `idx_tracks_scan`: its only consumer was the non-indexable `!=` predicate (SQLite planned via `idx_tracks_library`), so it was pure write-amplification on every insert and bump — the same dead-index class V44 removed for `idx_tracks_filepath`. Index drop only, no rescan.

UPSERTs still write `scan_id`: the boot-migration **resume fast-path** (`scan_id == current epoch id`) is unaffected, covered by the existing resume parity test.

## Measured evidence (800-file library, V47 DB, same machine)

No-op rescan, old code (master prebuilt / master scanner.mjs) vs this branch:

| Metric | rust old | rust new | JS old | JS new |
|---|---|---|---|---|
| tracks rows rewritten | **800** | **0** | **800** | **0** |
| WAL bytes dirtied | 2,113,592 | 181,312 (**−91%**) | 1,231,912 | 486,192 (**−61%**) |
| concurrent-write worst-case during scan | 46–49ms | 21–30ms | 72.9ms | 15.8ms |

Row-rewrite proof: after a new-code no-op scan the `scan_id` histogram is byte-identical to before the scan — not one row touched. The residual WAL bytes are the periodic progress-row updates plus the probe's own writes (which inflate both sides equally). At the audit's 500k-track reference point the old behavior extrapolates to roughly a gigabyte of WAL churn per daily no-op rescan; the new cost is flat.

## Verification

- **1188/1188 test suite** (0 skipped), including scanner parity (serial≡parallel snapshots, determinism), resume-epoch, and the rewritten sweep unit tests; eslint at exactly the master baseline (136/136).
- **Four-lens adversarial review** (data-loss, rust txn state machine, JS+parity, migration/rollout): no critical or medium findings; all confirmed low findings fixed in this PR (row-value DELETE guard, path-keyed JS seen tracking, comment truthfulness).
- **Fault-injection smoke, all PASS**: mass deletion (70 rows swept exactly, survivors untouched); icacls-denied directory shielded while a real deletion in the same sweep proceeds, converges after ACL restore; mixed-change scan (50 mtime bumps → exactly 50 re-parsed, zero spurious "missed" warnings — proves re-committed rows are marked seen); pre-existing ytdl NULL rows (live file claimed, deleted file reaped); **mid-sweep root vanish** at 4000-candidate scale (rename-away during the chunked sweep → "aborting stale-track cleanup" after a partial chunk, every real row intact, full convergence after restore); serial-path (scanThreads=1) no-op with byte-identical scan_id histogram.

## Behavior deltas (deliberate)

1. **Pre-existing ytdl rows with deleted files are now reaped.** `scan_id` NULL never matched the old `!=` predicate, so a ytdl download whose file was later deleted leaked in the DB forever. It now converges out once verify-absence proves the file gone. Mid-scan inserts remain protected (they're not in the scan-start snapshot). Expect a one-time cleanup of any such leaked rows on the first scan after upgrade.
2. **No more `'-kept'` restamps.** Survivor rows (alive on disk but missed by a scan) are left completely untouched and re-examined next scan; the warning remains.

## Transition window

Until CI rebuilds the prebuilt binaries, the old rust binary runs against the new server's V47 DB — verified safe: the schema guard passes (47==47), the dropped index is invisible to DML, and its old bump+`!=` sweep is still self-consistent. Its `'-kept'` stamps are inert to the new sweep. The reverse skew (new binary, old server) also runs correctly — the guard compares payload-vs-DB versions, not a compiled-in constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
