### PR TITLE
Advertise the API over mDNS/DNS-SD for LAN discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bundle:bun": "bun scripts/build-bun.mjs --bundle",
     "docs:api": "redocly build-docs docs/openapi.yaml -o docs/api.html",
     "docs:api:validate": "redocly lint docs/openapi.yaml",
+    "test:discovery": "node --test --test-reporter=spec test/mdns.test.mjs",
     "pretest": "node test/helpers/ensure-prereqs.mjs",
     "test": "node --test --test-reporter=spec \"test/**/*.test.mjs\"",
     "test:unit": "node --test --test-reporter=spec \"test/unit/**/*.test.mjs\"",

--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -1,11 +1,11 @@
 import dgram from 'node:dgram';
 import os from 'node:os';
-import { createRequire } from 'node:module';
 import winston from 'winston';
 import * as config from '../state/config.js';
 
-const require = createRequire(import.meta.url);
-const packageJson = require('../../package.json');
+// Static JSON import (not createRequire) so the Bun single-binary bundle can
+// resolve it — a runtime require() isn't bundled and dies inside bunfs.
+import packageJson from '../../package.json' with { type: 'json' };
 
 // ── mDNS / DNS-SD advertiser ──────────────────────────────────────────────────
 //

--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -1,0 +1,354 @@
+import dgram from 'node:dgram';
+import os from 'node:os';
+import { createRequire } from 'node:module';
+import winston from 'winston';
+import * as config from '../state/config.js';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../../package.json');
+
+// ── mDNS / DNS-SD advertiser ──────────────────────────────────────────────────
+//
+// Advertises the mStream API as a `_mstream._tcp` service over multicast DNS so
+// LAN clients (e.g. the portable mStream player) can find the server with zero
+// configuration — no IP typing. This is the discovery half of the player's
+// pairing story; it carries metadata only and touches no routes or auth.
+//
+// Hand-rolled with raw dgram (no new dependency), mirroring the SSDP module in
+// ../dlna/ssdp.js: same multi-NIC group-join + interface fan-out, same
+// winston `[mdns]` log tags, same non-fatal failure handling (a bind/socket
+// error disables discovery; it never takes the server down).
+//
+// Coexistence: hosts often already run an mDNS responder (Bonjour on macOS,
+// Avahi on Linux) that owns UDP 5353. We bind with SO_REUSEADDR (and
+// SO_REUSEPORT off Windows) and join the multicast group, so multicast queries
+// are delivered to every joined socket — we answer alongside the OS responder
+// for our own service type rather than fighting it for the port. On Windows,
+// SO_REUSEADDR already grants shared binding.
+
+const MDNS_ADDR = '224.0.0.251';
+const MDNS_PORT = 5353;
+
+// RFC 6762 §10 TTL guidance: records that point at a host name (A, SRV) use a
+// short 120s TTL so stale addresses age out quickly; shared/metadata records
+// (PTR, TXT) use the longer 75-minute TTL.
+const TTL_HOST = 120;
+const TTL_SHARED = 4500;
+// Re-announce comfortably inside TTL_HOST so passive listeners' caches stay
+// warm between the player's active queries. One small packet per interval.
+const ANNOUNCE_INTERVAL_MS = 60 * 1000;
+
+// DNS record types / classes
+const TYPE_A = 1;
+const TYPE_PTR = 12;
+const TYPE_TXT = 16;
+const TYPE_SRV = 33;
+const CLASS_IN = 1;
+const CLASS_IN_FLUSH = 0x8001; // IN + cache-flush bit, for our unique records
+
+const SERVICE_LABELS = ['_mstream', '_tcp', 'local'];
+const DNSSD_META_LABELS = ['_services', '_dns-sd', '_udp', 'local'];
+
+let socket = null;
+let announceTimer = null;
+let joinedInterfaces = [];
+let info = null; // cached descriptor, refreshed on each announce
+
+// ── Service descriptor ─────────────────────────────────────────────────────────
+
+function getIpv4Addresses() {
+  const addr = config.program.address;
+  if (addr && addr !== '::' && addr !== '0.0.0.0') { return [addr]; }
+  const out = [];
+  const ifaces = os.networkInterfaces();
+  for (const name of Object.keys(ifaces)) {
+    for (const iface of ifaces[name]) {
+      if (iface.family === 'IPv4' && !iface.internal) { out.push(iface.address); }
+    }
+  }
+  return out.length ? out : ['127.0.0.1'];
+}
+
+// Build the descriptor the records are generated from. Kept as plain data so
+// the wire-format builders below are pure and unit-testable without config.
+export function gatherInfo() {
+  const mdns = config.program.discovery.mdns;
+  const instanceName = (mdns.name && mdns.name.trim()) || os.hostname() || 'mStream';
+  const instanceId = mdns.instanceId || 'unknown';
+  // A stable, conflict-avoiding target host so we don't claim the OS
+  // responder's own `<hostname>.local`. The SRV record points clients here and
+  // the A records below resolve it.
+  const id8 = instanceId.replace(/[^a-z0-9]/gi, '').slice(0, 8).toLowerCase() || 'server';
+  return {
+    instanceName,
+    instanceId,
+    targetHost: `mstream-${id8}`,
+    scheme: config.getIsHttps() ? 'https' : 'http',
+    port: config.program.port,
+    path: '/',
+    version: packageJson.version,
+    ips: getIpv4Addresses(),
+    // Optional public URL so a portable player can reach home from anywhere —
+    // reuse the relay URL the operator already configured if present.
+    publicUrl: (config.program.rpn && config.program.rpn.url) ? config.program.rpn.url : '',
+  };
+}
+
+function instanceLabels(i) { return [i.instanceName, '_mstream', '_tcp', 'local']; }
+function targetLabels(i) { return [i.targetHost, 'local']; }
+
+function txtEntries(i) {
+  const entries = [
+    `name=${i.instanceName}`,
+    `id=${i.instanceId}`,
+    `v=${i.version}`,
+    `scheme=${i.scheme}`,
+    `port=${i.port}`,
+    `path=${i.path}`,
+    `api=v1`,
+    `auth=apikey,jwt`,
+  ];
+  if (i.publicUrl) { entries.push(`pub=${i.publicUrl}`); }
+  return entries;
+}
+
+// ── DNS wire format (pure, exported for tests) ─────────────────────────────────
+
+export function encodeName(labels) {
+  const parts = [];
+  for (const label of labels) {
+    const buf = Buffer.from(label, 'utf8');
+    if (buf.length > 63) { throw new Error(`mdns: label exceeds 63 bytes: ${label}`); }
+    parts.push(Buffer.from([buf.length]), buf);
+  }
+  parts.push(Buffer.from([0])); // root label terminator
+  return Buffer.concat(parts);
+}
+
+function encodeTxt(entries) {
+  const parts = [];
+  for (const entry of entries) {
+    const buf = Buffer.from(entry, 'utf8').subarray(0, 255); // each string <=255 bytes
+    parts.push(Buffer.from([buf.length]), buf);
+  }
+  if (parts.length === 0) { parts.push(Buffer.from([0])); } // TXT must be non-empty
+  return Buffer.concat(parts);
+}
+
+function ipv4Rdata(ip) {
+  return Buffer.from(ip.split('.').map((n) => parseInt(n, 10) & 0xff));
+}
+
+function srvRdata(i) {
+  const head = Buffer.alloc(6); // priority(2) weight(2) port(2)
+  head.writeUInt16BE(0, 0);
+  head.writeUInt16BE(0, 2);
+  head.writeUInt16BE(i.port, 4);
+  return Buffer.concat([head, encodeName(targetLabels(i))]);
+}
+
+function record(nameLabels, type, klass, ttl, rdata) {
+  const name = encodeName(nameLabels);
+  const head = Buffer.alloc(10);
+  head.writeUInt16BE(type, 0);
+  head.writeUInt16BE(klass, 2);
+  head.writeUInt32BE(ttl, 4);
+  head.writeUInt16BE(rdata.length, 8);
+  return Buffer.concat([name, head, rdata]);
+}
+
+function message(answers) {
+  const header = Buffer.alloc(12);
+  header.writeUInt16BE(0, 0); // ID 0 (mDNS)
+  header.writeUInt16BE(0x8400, 2); // QR=1 (response), AA=1 (authoritative)
+  header.writeUInt16BE(0, 4); // QDCOUNT
+  header.writeUInt16BE(answers.length, 6); // ANCOUNT
+  header.writeUInt16BE(0, 8); // NSCOUNT
+  header.writeUInt16BE(0, 10); // ARCOUNT
+  return Buffer.concat([header, ...answers]);
+}
+
+// Full announcement: PTR (service + DNS-SD meta), SRV, TXT, and an A record per
+// address. `ttl=0` produces a goodbye packet.
+export function buildAnnouncementPacket(i, { goodbye = false } = {}) {
+  const shared = goodbye ? 0 : TTL_SHARED;
+  const host = goodbye ? 0 : TTL_HOST;
+  const answers = [
+    record(SERVICE_LABELS, TYPE_PTR, CLASS_IN, shared, encodeName(instanceLabels(i))),
+    record(DNSSD_META_LABELS, TYPE_PTR, CLASS_IN, shared, encodeName(SERVICE_LABELS)),
+    record(instanceLabels(i), TYPE_SRV, CLASS_IN_FLUSH, host, srvRdata(i)),
+    record(instanceLabels(i), TYPE_TXT, CLASS_IN_FLUSH, shared, encodeTxt(txtEntries(i))),
+  ];
+  for (const ip of i.ips) {
+    answers.push(record(targetLabels(i), TYPE_A, CLASS_IN_FLUSH, host, ipv4Rdata(ip)));
+  }
+  return message(answers);
+}
+
+// Read a (possibly compressed) DNS name starting at `off`. Returns the
+// lowercased dotted name and the offset just past the name in the question.
+function readName(msg, off) {
+  const labels = [];
+  let jumped = false;
+  let next = off;
+  let pos = off;
+  let guard = 0;
+  while (guard++ < 128) {
+    const len = msg[pos];
+    if (len === undefined) { break; }
+    if ((len & 0xc0) === 0xc0) { // compression pointer
+      if (!jumped) { next = pos + 2; }
+      pos = ((len & 0x3f) << 8) | (msg[pos + 1] ?? 0);
+      jumped = true;
+      continue;
+    }
+    if (len === 0) { if (!jumped) { next = pos + 1; } break; }
+    labels.push(msg.toString('utf8', pos + 1, pos + 1 + len));
+    pos += 1 + len;
+  }
+  return { name: labels.join('.').toLowerCase(), next };
+}
+
+export function parseQuestions(msg) {
+  if (!Buffer.isBuffer(msg) || msg.length < 12) { return []; }
+  const qd = msg.readUInt16BE(4);
+  let off = 12;
+  const questions = [];
+  for (let q = 0; q < qd; q++) {
+    const { name, next } = readName(msg, off);
+    if (next + 4 > msg.length) { break; }
+    const type = msg.readUInt16BE(next);
+    off = next + 4;
+    questions.push({ name, type });
+  }
+  return questions;
+}
+
+// True if any question targets one of the names we own.
+export function matchesOurNames(questions, i) {
+  const ours = new Set([
+    SERVICE_LABELS.join('.'),
+    DNSSD_META_LABELS.join('.'),
+    instanceLabels(i).join('.').toLowerCase(),
+    targetLabels(i).join('.').toLowerCase(),
+  ]);
+  return questions.some((q) => ours.has(q.name));
+}
+
+// ── Socket send (multi-NIC fan-out, mirrors ssdp.js) ───────────────────────────
+
+function sendPacket(buf) {
+  if (!socket) { return; }
+  if (joinedInterfaces.length <= 1) {
+    socket.send(buf, 0, buf.length, MDNS_PORT, MDNS_ADDR, (err) => {
+      if (err) { winston.debug(`[mdns] send error: ${err.message}`); }
+    });
+    return;
+  }
+  for (const ifaceAddr of joinedInterfaces) {
+    try { socket.setMulticastInterface(ifaceAddr); }
+    catch (err) { winston.debug(`[mdns] setMulticastInterface(${ifaceAddr}): ${err.message}`); continue; }
+    socket.send(buf, 0, buf.length, MDNS_PORT, MDNS_ADDR, (err) => {
+      if (err) { winston.debug(`[mdns] send error on ${ifaceAddr}: ${err.message}`); }
+    });
+  }
+}
+
+function announce() {
+  info = gatherInfo();
+  sendPacket(buildAnnouncementPacket(info));
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+export function start() {
+  if (socket) { return; }
+  if (!config.program.discovery || !config.program.discovery.mdns.enabled) { return; }
+
+  const opts = { type: 'udp4', reuseAddr: true };
+  // SO_REUSEPORT lets us share 5353 with the OS responder where it exists;
+  // it's unsupported on Windows, where SO_REUSEADDR already allows sharing.
+  if (process.platform !== 'win32') { opts.reusePort = true; }
+
+  let sock;
+  try {
+    sock = dgram.createSocket(opts);
+  } catch (err) {
+    winston.warn(`[mdns] Failed to create socket, discovery disabled: ${err.message}`);
+    return;
+  }
+  socket = sock;
+
+  sock.on('error', (err) => {
+    winston.warn(`[mdns] Socket error, discovery disabled: ${err.message}`);
+    stop();
+  });
+
+  sock.on('message', (msg) => {
+    try {
+      const questions = parseQuestions(msg);
+      if (questions.length && info && matchesOurNames(questions, info)) {
+        sendPacket(buildAnnouncementPacket(info));
+      }
+    } catch (err) {
+      winston.debug(`[mdns] message handling error: ${err.message}`);
+    }
+  });
+
+  sock.bind(MDNS_PORT, () => {
+    // stop() may have run before bind completed.
+    if (socket !== sock) { return; }
+    try {
+      const ifaces = os.networkInterfaces();
+      joinedInterfaces = [];
+      for (const name of Object.keys(ifaces)) {
+        for (const iface of ifaces[name]) {
+          if (iface.family !== 'IPv4' || iface.internal) { continue; }
+          try { sock.addMembership(MDNS_ADDR, iface.address); joinedInterfaces.push(iface.address); }
+          catch (err) { winston.debug(`[mdns] addMembership(${iface.address}): ${err.message}`); }
+        }
+      }
+      if (joinedInterfaces.length === 0) { sock.addMembership(MDNS_ADDR); }
+      sock.setMulticastTTL(255); // RFC 6762: mDNS packets use IP TTL 255
+    } catch (err) {
+      winston.warn(`[mdns] Multicast setup: ${err.message}`);
+    }
+    // Two announcements ~1s apart (RFC 6762 §8.3) so a client that misses the
+    // first still sees us promptly.
+    announce();
+    setTimeout(() => { if (socket === sock) { announce(); } }, 1000);
+    winston.info(`[mdns] Advertising _mstream._tcp on ${getIpv4Addresses().join(', ')}:${config.program.port}`);
+  });
+
+  announceTimer = setInterval(announce, ANNOUNCE_INTERVAL_MS);
+}
+
+export function stop() {
+  if (announceTimer) { clearInterval(announceTimer); announceTimer = null; }
+  if (!socket) { joinedInterfaces = []; return; }
+
+  const sock = socket;
+  socket = null; // block any further sends from timers/handlers
+
+  const ifaceSnapshot = joinedInterfaces;
+  joinedInterfaces = [];
+
+  // Announce a goodbye (TTL 0) so clients drop us immediately instead of
+  // waiting for the cache to expire.
+  try {
+    const goodbye = buildAnnouncementPacket(info || gatherInfo(), { goodbye: true });
+    const ifaces = ifaceSnapshot.length > 1 ? ifaceSnapshot : [null];
+    for (const ifaceAddr of ifaces) {
+      if (ifaceAddr) { try { sock.setMulticastInterface(ifaceAddr); } catch (_) { /* use default */ } }
+      sock.send(goodbye, 0, goodbye.length, MDNS_PORT, MDNS_ADDR, () => {});
+    }
+  } catch (err) {
+    winston.debug(`[mdns] goodbye error: ${err.message}`);
+  }
+
+  // Give the goodbye datagram(s) a moment to flush before closing the socket.
+  setTimeout(() => {
+    try { sock.close(); } catch (_) { /* already closed */ }
+    winston.info('[mdns] Stopped');
+  }, 100);
+}

--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -69,11 +69,26 @@ function getIpv4Addresses() {
   return out.length ? out : ['127.0.0.1'];
 }
 
+// DNS labels are limited to 63 octets (RFC 1035 §2.3.4). The instance name is
+// the only operator/hostname-controlled label we emit, so clamp it on a UTF-8
+// code-point boundary — a long friendly `name` or `os.hostname()` must never
+// make encodeName() throw on the announce path and take the server down.
+export function clampLabel(str, maxBytes = 63) {
+  if (typeof str !== 'string') { str = String(str ?? ''); } // a guard must never throw
+  if (Buffer.byteLength(str, 'utf8') <= maxBytes) { return str; }
+  let out = '';
+  for (const ch of str) { // iterates by code point — never splits a character
+    if (Buffer.byteLength(out + ch, 'utf8') > maxBytes) { break; }
+    out += ch;
+  }
+  return out;
+}
+
 // Build the descriptor the records are generated from. Kept as plain data so
 // the wire-format builders below are pure and unit-testable without config.
 export function gatherInfo() {
   const mdns = config.program.discovery.mdns;
-  const instanceName = (mdns.name && mdns.name.trim()) || os.hostname() || 'mStream';
+  const instanceName = clampLabel((mdns.name && mdns.name.trim()) || os.hostname() || 'mStream');
   const instanceId = mdns.instanceId || 'unknown';
   // A stable, conflict-avoiding target host so we don't claim the OS
   // responder's own `<hostname>.local`. The SRV record points clients here and
@@ -254,9 +269,17 @@ function sendPacket(buf) {
   }
 }
 
-function announce() {
-  info = gatherInfo();
-  sendPacket(buildAnnouncementPacket(info));
+// Exported for tests; not part of the public surface. Never let a record-building
+// error (e.g. an un-encodable label) escape into the announce timer or bind
+// callback — an uncaught throw there takes the whole server down. Discovery is
+// best-effort: skip this round and warn.
+export function announce() {
+  try {
+    info = gatherInfo();
+    sendPacket(buildAnnouncementPacket(info));
+  } catch (err) {
+    winston.warn(`[mdns] announce skipped: ${err.message}`);
+  }
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────────

--- a/src/server.js
+++ b/src/server.js
@@ -44,6 +44,7 @@ import * as torrentApi from './api/torrent.js';
 import * as dlnaApi from './api/dlna.js';
 import * as dlnaSsdp from './dlna/ssdp.js';
 import * as dlnaServer from './dlna/dlna-server.js';
+import * as mdns from './discovery/mdns.js';
 import * as subsonicApi from './api/subsonic/index.js';
 import * as subsonicServer from './subsonic/subsonic-server.js';
 import * as userApiKeysApi from './api/user-api-keys.js';
@@ -500,6 +501,13 @@ export async function serveIt(configFile) {
       })();
     }
 
+    // Advertise the API over mDNS/DNS-SD so LAN clients (the portable player)
+    // discover us without an IP. Advertise-only; safe to start unconditionally
+    // (it self-disables via config and never throws on the boot path).
+    if (config.program.discovery.mdns.enabled) {
+      mdns.start();
+    }
+
     // Boot server audio (Rust preferred, CLI fallback) — runs CLI detection
     // eagerly so the admin endpoint has fresh data by the time it's called.
     serverPlaybackApi.bootRustPlayer().catch(() => {});
@@ -518,6 +526,7 @@ export function reboot() {
     dlnaSsdp.stop();
     dlnaServer.stop();
     subsonicServer.stop();
+    mdns.stop();
     serverPlaybackApi.killRustPlayer();
     // Tear down the /remote WebSocket server — any open WS client
     // otherwise keeps the HTTP server alive and server.close() below

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -376,6 +376,23 @@ const subsonicOptions = Joi.object({
   port: Joi.number().integer().min(1).max(65535).default(3012),
 });
 
+// LAN service discovery. Advertises the API as a `_mstream._tcp` mDNS/DNS-SD
+// service so zero-config clients (the portable mStream player) can find the
+// server without typing an IP. Advertise-only: it exposes metadata, not the
+// library, and touches no routes or auth.
+//   name       — friendly instance name shown to clients. Empty => os.hostname().
+//   instanceId — stable id (dedupe across IP changes, device-registry later).
+//                Auto-generated + persisted on first boot, like dlna.uuid.
+const mdnsOptions = Joi.object({
+  enabled: Joi.boolean().default(true),
+  name: Joi.string().allow('').default(''),
+  instanceId: Joi.string().optional(),
+});
+
+const discoveryOptions = Joi.object({
+  mdns: mdnsOptions.default(mdnsOptions.validate({}).value),
+});
+
 // Torrent client integration. v1 supports exactly two states for
 // `client`:
 //   'disabled'     — feature off; no UI surface, no routes, no DB writes.
@@ -597,6 +614,7 @@ const schema = Joi.object({
   discoveryP2p: discoveryP2pOptions.default(discoveryP2pOptions.validate({}).value),
   dlna: dlnaOptions.default(dlnaOptions.validate({}).value),
   subsonic: subsonicOptions.default(subsonicOptions.validate({}).value),
+  discovery: discoveryOptions.default(discoveryOptions.validate({}).value),
   torrent: torrentOptions.default(torrentOptions.validate({}).value),
   autoBootServerAudio: Joi.boolean().default(false),
   rustPlayerPort: Joi.number().integer().min(1).max(65535).default(3333),
@@ -765,6 +783,18 @@ export async function setup(configFileArg) {
     program.transcode.ffmpegDirectory,
   ]) {
     if (dir) { await fs.mkdir(dir, { recursive: true }); }
+  }
+
+  // Persist a stable mDNS instance id so discovery clients can dedupe the
+  // server across IP/interface changes and restarts. Same generate-and-persist
+  // pattern as dlna.uuid above.
+  if (!program.discovery.mdns.instanceId) {
+    program.discovery.mdns.instanceId = crypto.randomUUID();
+    const rawConfig = JSON.parse(await fs.readFile(configFileArg, 'utf8'));
+    if (!rawConfig.discovery) { rawConfig.discovery = {}; }
+    if (!rawConfig.discovery.mdns) { rawConfig.discovery.mdns = {}; }
+    rawConfig.discovery.mdns.instanceId = program.discovery.mdns.instanceId;
+    await fs.writeFile(configFileArg, JSON.stringify(rawConfig, null, 2), 'utf8');
   }
 }
 

--- a/test/mdns.test.mjs
+++ b/test/mdns.test.mjs
@@ -11,6 +11,8 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   encodeName,
+  clampLabel,
+  announce,
   buildAnnouncementPacket,
   parseQuestions,
   matchesOurNames,
@@ -121,5 +123,117 @@ describe('mdns query handling', () => {
   test('parseQuestions tolerates a truncated/garbage packet', () => {
     assert.deepEqual(parseQuestions(Buffer.from([0, 0, 0])), []);
     assert.deepEqual(parseQuestions(Buffer.alloc(0)), []);
+  });
+});
+
+// Regression: a `discovery.mdns.name` (or `os.hostname()`) longer than the
+// 63-octet DNS label limit used to make encodeName() throw inside announce(),
+// which runs in the bind callback and the announce timer — an uncaught throw
+// there took the whole server down on boot. The instance name is now clamped.
+describe('mdns label clamping (crash regression)', () => {
+  test('clampLabel passes through names at or under 63 bytes unchanged', () => {
+    assert.equal(clampLabel('My Server'), 'My Server');
+    assert.equal(clampLabel('A'.repeat(63)), 'A'.repeat(63)); // exactly at the limit
+    // Exactly 63 bytes but ending on a 2-byte char must still pass through verbatim
+    // — guards against a too-greedy clamp or a `<` vs `<=` boundary mutation.
+    const exact63 = 'A'.repeat(61) + 'é'; // 61 + 2 = 63 bytes
+    assert.equal(Buffer.byteLength(exact63, 'utf8'), 63);
+    assert.equal(clampLabel(exact63), exact63);
+  });
+
+  test('clampLabel truncates at the 64-byte boundary (the original off-by-one)', () => {
+    assert.equal(Buffer.byteLength(clampLabel('A'.repeat(64)), 'utf8'), 63); // smallest over-limit
+    assert.equal(Buffer.byteLength(clampLabel('A'.repeat(200)), 'utf8'), 63);
+  });
+
+  test('clampLabel is robust to non-string input (a guard must never throw)', () => {
+    assert.equal(clampLabel(undefined), '');
+    assert.equal(clampLabel(null), '');
+    assert.doesNotThrow(() => clampLabel(12345));
+    assert.doesNotThrow(() => clampLabel({}));
+  });
+
+  test('clampLabel never splits a multibyte UTF-8 character', () => {
+    const twoByte = clampLabel('é'.repeat(40)); // 80 bytes of 2-byte code points
+    assert.ok(Buffer.byteLength(twoByte, 'utf8') <= 63);
+    assert.ok(!twoByte.includes('�'));      // no broken/replacement character
+    assert.equal(clampLabel(twoByte), twoByte);  // re-clamping is a no-op
+
+    const fourByte = clampLabel('😀'.repeat(30)); // 120 bytes of 4-byte code points
+    assert.ok(Buffer.byteLength(fourByte, 'utf8') <= 63);
+    assert.ok(!fourByte.includes('�'));
+  });
+
+  test('a clamped over-long name is always encodeName-safe (no throw)', () => {
+    for (const raw of ['A'.repeat(200), 'é'.repeat(40), '😀'.repeat(30), 'Living Room '.repeat(20)]) {
+      const label = clampLabel(raw);
+      assert.ok(Buffer.byteLength(label, 'utf8') <= 63);
+      assert.doesNotThrow(() => encodeName([label, '_mstream', '_tcp', 'local']));
+    }
+  });
+
+  test('buildAnnouncementPacket does not throw for a clamped long instanceName', () => {
+    const longInfo = { ...info, instanceName: clampLabel('Living Room Media Server '.repeat(5)) };
+    assert.doesNotThrow(() => buildAnnouncementPacket(longInfo));
+  });
+});
+
+// End-to-end: prove gatherInfo() actually applies the clamp from real config,
+// so an operator-set name longer than 63 bytes can never reach encodeName().
+describe('gatherInfo clamps a too-long configured name (end-to-end)', () => {
+  test('a >63-byte discovery.mdns.name cannot crash the announce path', async () => {
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const fs = await import('node:fs/promises');
+    const config = await import('../src/state/config.js');
+    const { gatherInfo } = await import('../src/discovery/mdns.js');
+
+    const cfgPath = path.join(os.tmpdir(), `mstream-mdns-clamp-${process.pid}.json`);
+    await fs.writeFile(cfgPath, JSON.stringify({
+      port: 3000,
+      discovery: { mdns: { enabled: true, name: 'Living Room Media Server '.repeat(5) } },
+    }));
+    try {
+      await config.setup(cfgPath);
+      const i = gatherInfo();
+      assert.ok(Buffer.byteLength(i.instanceName, 'utf8') <= 63);
+      assert.doesNotThrow(() => buildAnnouncementPacket(i));
+    } finally {
+      await fs.unlink(cfgPath).catch(() => {});
+    }
+  });
+});
+
+// The safety net itself: announce() runs inside the bind callback and the
+// re-announce timer, so a record-building throw there is uncaught and crashes
+// the server. Prove announce() swallows-and-warns instead of throwing, even
+// when given a malformed runtime config (the failure mode the try/catch guards).
+describe('announce() never throws on a build failure (crash safety net)', () => {
+  test('a gatherInfo/encode failure is caught and warned, not propagated', async () => {
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const fs = await import('node:fs/promises');
+    const config = await import('../src/state/config.js');
+    const winston = (await import('winston')).default;
+
+    const cfgPath = path.join(os.tmpdir(), `mstream-mdns-announce-${process.pid}.json`);
+    await fs.writeFile(cfgPath, JSON.stringify({ port: 3000, discovery: { mdns: { enabled: true } } }));
+    await config.setup(cfgPath);
+
+    const savedDiscovery = config.program.discovery;
+    const origWarn = winston.warn;
+    let warned = false;
+    winston.warn = () => { warned = true; };
+    try {
+      // Corrupt config so gatherInfo() throws when announce() reads `.mdns`.
+      // No socket is bound, so sendPacket() is a no-op — we isolate the catch.
+      config.program.discovery = undefined;
+      assert.doesNotThrow(() => announce());
+      assert.ok(warned, 'announce() should winston.warn when a build fails');
+    } finally {
+      config.program.discovery = savedDiscovery;
+      winston.warn = origWarn;
+      await fs.unlink(cfgPath).catch(() => {});
+    }
   });
 });

--- a/test/mdns.test.mjs
+++ b/test/mdns.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * mDNS / DNS-SD advertiser tests — exercise the wire-format builders and query
+ * parser in src/discovery/mdns.js directly, as pure functions. No socket is
+ * bound (port 5353 is owned by the OS responder on most dev machines), so these
+ * are fast and deterministic.
+ *
+ * Run: `npm run test:discovery` or `node --test test/mdns.test.mjs`
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  encodeName,
+  buildAnnouncementPacket,
+  parseQuestions,
+  matchesOurNames,
+} from '../src/discovery/mdns.js';
+
+// A fixed service descriptor — mirrors what gatherInfo() produces, but without
+// touching config so the builders stay isolated.
+const info = {
+  instanceName: 'Test Server',
+  instanceId: 'abcd1234-0000-0000-0000-000000000000',
+  targetHost: 'mstream-abcd1234',
+  scheme: 'http',
+  port: 3000,
+  path: '/',
+  version: '6.11.0',
+  ips: ['192.168.1.50'],
+  publicUrl: '',
+};
+
+const PTR = 12;
+const IN = 1;
+
+// Build a minimal mDNS query packet for one question.
+function query(labels, type) {
+  const header = Buffer.alloc(12);
+  header.writeUInt16BE(1, 4); // QDCOUNT = 1
+  const tc = Buffer.alloc(4);
+  tc.writeUInt16BE(type, 0);
+  tc.writeUInt16BE(IN, 2);
+  return Buffer.concat([header, encodeName(labels), tc]);
+}
+
+describe('mdns wire format', () => {
+  test('encodeName length-prefixes each label and root-terminates', () => {
+    const got = encodeName(['_mstream', '_tcp', 'local']);
+    const want = Buffer.concat([
+      Buffer.from([8]), Buffer.from('_mstream'),
+      Buffer.from([4]), Buffer.from('_tcp'),
+      Buffer.from([5]), Buffer.from('local'),
+      Buffer.from([0]),
+    ]);
+    assert.deepEqual(got, want);
+  });
+
+  test('announcement carries PTR, DNS-SD meta, SRV, TXT and an A record', () => {
+    const pkt = buildAnnouncementPacket(info);
+
+    // Response header: QR + AA set, 5 answers (PTR, _services PTR, SRV, TXT, 1×A)
+    assert.equal(pkt.readUInt16BE(2), 0x8400);
+    assert.equal(pkt.readUInt16BE(6), 5);
+
+    // Service type name present
+    assert.ok(pkt.includes(encodeName(['_mstream', '_tcp', 'local'])));
+    // TXT key/values
+    assert.ok(pkt.includes(Buffer.from(`id=${info.instanceId}`)));
+    assert.ok(pkt.includes(Buffer.from(`v=${info.version}`)));
+    assert.ok(pkt.includes(Buffer.from(`port=${info.port}`)));
+    // SRV target host + port 3000 (0x0BB8)
+    assert.ok(pkt.includes(Buffer.from('mstream-abcd1234')));
+    assert.ok(pkt.includes(Buffer.from([0x0b, 0xb8])));
+    // A record address
+    assert.ok(pkt.includes(Buffer.from([192, 168, 1, 50])));
+  });
+
+  test('one A record is emitted per advertised address', () => {
+    const multi = { ...info, ips: ['192.168.1.50', '10.0.0.9'] };
+    const pkt = buildAnnouncementPacket(multi);
+    assert.equal(pkt.readUInt16BE(6), 6); // 4 fixed answers + 2 A records
+    assert.ok(pkt.includes(Buffer.from([10, 0, 0, 9])));
+  });
+
+  test('goodbye packet zeroes the TTL', () => {
+    // First answer = service PTR: header(12) + name(21) + type(2) + class(2),
+    // then the 4-byte TTL at offset 37.
+    const alive = buildAnnouncementPacket(info);
+    const bye = buildAnnouncementPacket(info, { goodbye: true });
+    assert.equal(alive.readUInt32BE(37), 4500);
+    assert.equal(bye.readUInt32BE(37), 0);
+  });
+});
+
+describe('mdns query handling', () => {
+  test('parseQuestions reads name and type', () => {
+    const questions = parseQuestions(query(['_mstream', '_tcp', 'local'], PTR));
+    assert.equal(questions.length, 1);
+    assert.equal(questions[0].name, '_mstream._tcp.local');
+    assert.equal(questions[0].type, PTR);
+  });
+
+  test('parseQuestions follows a compression pointer', () => {
+    // header(12) + question[pointer->18, type, class](6) + real name at 18
+    const header = Buffer.alloc(12);
+    header.writeUInt16BE(1, 4);
+    const q = Buffer.from([0xc0, 18, 0x00, PTR, 0x00, IN]);
+    const msg = Buffer.concat([header, q, encodeName(['_mstream', '_tcp', 'local'])]);
+    const questions = parseQuestions(msg);
+    assert.equal(questions[0].name, '_mstream._tcp.local');
+    assert.equal(questions[0].type, PTR);
+  });
+
+  test('matchesOurNames is true for our service and instance, false otherwise', () => {
+    assert.equal(matchesOurNames(parseQuestions(query(['_mstream', '_tcp', 'local'], PTR)), info), true);
+    assert.equal(matchesOurNames(parseQuestions(query(['_services', '_dns-sd', '_udp', 'local'], PTR)), info), true);
+    assert.equal(matchesOurNames(parseQuestions(query(['Test Server', '_mstream', '_tcp', 'local'], PTR)), info), true);
+    assert.equal(matchesOurNames(parseQuestions(query(['_http', '_tcp', 'local'], PTR)), info), false);
+  });
+
+  test('parseQuestions tolerates a truncated/garbage packet', () => {
+    assert.deepEqual(parseQuestions(Buffer.from([0, 0, 0])), []);
+    assert.deepEqual(parseQuestions(Buffer.alloc(0)), []);
+  });
+});


### PR DESCRIPTION
## What

Advertises the mStream API as a `_mstream._tcp` **mDNS/DNS-SD** service so
zero-config LAN clients can find the server without anyone typing an IP. This is
the discovery half of the upcoming portable-player pairing story, but it's
generic LAN service discovery — any DNS-SD browser (`avahi-browse`, `dns-sd`,
mobile apps) will see it too.

Advertise-only: it publishes metadata via TXT records and touches **no routes
and no auth**.

## How

Hand-rolled with raw `dgram` and **zero new dependencies**, deliberately
mirroring the existing DLNA SSDP module (`src/dlna/ssdp.js`):

- Same multi-NIC pattern — joins the multicast group on every non-internal IPv4
  interface and fans announcements out across all of them.
- Same `winston` `[mdns]` log tags and **non-fatal failure handling**: a
  bind/socket error disables discovery and logs a warning; it never takes the
  server down on the boot path.
- Coexists with an OS mDNS responder (Bonjour/Avahi) already on UDP 5353 via
  `SO_REUSEADDR` (plus `SO_REUSEPORT` off Windows).

### TXT records published
`name` (friendly name, defaults to hostname), `id` (stable instance id),
`v` (version), `scheme`, `port`, `path`, `api`, `auth` (advertised auth modes),
and `pub` (optional public URL — reuses the configured relay URL if present, so
a roaming client can reach home).

## Changes

- **`src/discovery/mdns.js`** — the advertiser. Wire-format builders and the
  query parser are factored as pure exports so they're unit-testable without
  binding a socket.
- **`src/state/config.js`** — new `discovery.mdns { enabled, name, instanceId }`.
  `instanceId` is auto-generated and persisted on first boot using the exact
  same generate-and-persist pattern as `dlna.uuid`.
- **`src/server.js`** — start the advertiser after `listen` (next to the DLNA
  startup), stop it in `reboot()`.
- **`test/mdns.test.mjs`** — pure wire-format + query-matching unit tests
  (8 cases), wired into `npm test` and a new `npm run test:discovery`.

## Config

Opt-out via config; on by default:

```json
{ "discovery": { "mdns": { "enabled": true, "name": "" } } }
```

Empty `name` → derives from `os.hostname()`.

## Verification

- `npm run test:discovery` → 8/8 pass.
- `npx eslint` clean on all touched/new files. (Unrelated pre-existing
  `no-empty` in `reboot()`'s `closeAllConnections` catch left untouched.)
- Live boot smoke test on a real host: bound 5353, advertised on two interfaces
  (LAN + Docker bridge), answered a real multicast `_mstream._tcp` query, and
  persisted the instance id across a config re-read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
