### PR TITLE
feat(scanner): route artist-typed embedded pictures to artist_art

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -2440,12 +2440,19 @@ fn extract_track(
     } else {
         let folder_imgs = list_folder_images(filepath, config, dir_art_cache, known_ref_hashes);
         let emb_front = embedded_pics.iter().position(|p| p.pic_type() == PictureType::CoverFront);
-        let emb_def_idx = emb_front.or(if embedded_pics.is_empty() { None } else { Some(0) });
-        let has_folder = !folder_imgs.is_empty();
-        let has_embedded = !embedded_pics.is_empty();
+        // Never elect an artist-typed picture (APIC 7/8/10/19 → 'artist') as
+        // the album/track default — those are routed to artist_art. Prefer the
+        // front cover, else the first NON-artist embedded picture; likewise
+        // skip an 'artist'-typed folder image (e.g. artist.jpg). Mirrors the JS
+        // scanner's embDef/folDef election.
+        let emb_def_idx = emb_front.or_else(|| embedded_pics.iter()
+            .position(|p| normalize_pic_type(p.pic_type()) != Some("artist")));
+        let folder_def_idx = folder_imgs.iter().position(|f| f.ptype != Some("artist"));
+        let has_emb_default = emb_def_idx.is_some();
+        let has_folder_default = folder_def_idx.is_some();
         let prefer_folder = config.album_art_priority == "folder";
-        let default_is_folder = if prefer_folder { has_folder } else { !has_embedded && has_folder };
-        let default_is_embedded = if prefer_folder { !has_folder && has_embedded } else { has_embedded };
+        let default_is_folder = if prefer_folder { has_folder_default } else { !has_emb_default && has_folder_default };
+        let default_is_embedded = if prefer_folder { !has_folder_default && has_emb_default } else { has_emb_default };
 
         // Every embedded picture → cached art (thumbnails only for the default).
         for (i, pic) in embedded_pics.iter().enumerate() {
@@ -2462,9 +2469,11 @@ fn extract_track(
         }
 
         // Folder images → references, except the elected default (cached copy).
+        // The default is the first NON-artist folder image (folder_def_idx),
+        // not blindly index 0 — an 'artist'-typed folder image is gallery-only.
         for (i, fi) in folder_imgs.iter().enumerate() {
             let mut cached_default = false;
-            if default_is_folder && i == 0 {
+            if default_is_folder && Some(i) == folder_def_idx {
                 if let Ok(data) = fs::read(&fi.path) {
                     // Lowercase the extension so a `Folder.JPG` cover gets the
                     // same content-addressed cache filename from both scanners
@@ -2766,6 +2775,11 @@ fn commit_track(
               WHERE id = ? AND content_hash IS NULL")?;
         let mut ins_ta = conn.prepare_cached("INSERT OR IGNORE INTO track_art (track_id, art_id, source, picture_type, position) VALUES (?, ?, ?, ?, ?)")?;
         let mut ins_aa = conn.prepare_cached("INSERT OR IGNORE INTO album_art (album_id, art_id, source, picture_type, position) VALUES (?, ?, ?, ?, ?)")?;
+        // Artist-typed pictures are routed here (not track_art/album_art) and,
+        // when cached, seed the artist's default image (fill-NULL only —
+        // mirrors the JS scanner's insertArtistArt/setArtistImage).
+        let mut ins_aart = conn.prepare_cached("INSERT OR IGNORE INTO artist_art (artist_id, art_id, source, picture_type, position) VALUES (?, ?, ?, ?, ?)")?;
+        let mut set_artist_img = conn.prepare_cached("UPDATE artists SET image_file = ?, image_source = ? WHERE id = ? AND image_file IS NULL")?;
         for (i, a) in et.art_list.iter().enumerate() {
             let art_id: Option<i64> = if a.kind == "cached" {
                 let cf = a.cache_file.as_deref().unwrap_or("");
@@ -2779,6 +2793,18 @@ fn commit_track(
             if let Some(art_id) = art_id {
                 if let Some(hash) = a.content_hash.as_deref() {
                     heal.execute(rusqlite::params![hash, a.byte_size, art_id])?;
+                }
+                // Artist-typed picture → artist_art (about the artist, not the
+                // track/album). Needs a resolved artist; an artist-less track's
+                // artist picture has no home and is dropped (it isn't album art).
+                if a.picture_type == Some("artist") {
+                    if let Some(artist_fk) = primary_track_artist_id {
+                        ins_aart.execute(rusqlite::params![artist_fk, art_id, a.source, a.picture_type, i as i64])?;
+                        if a.kind == "cached" {
+                            set_artist_img.execute(rusqlite::params![a.cache_file, a.source, artist_fk])?;
+                        }
+                    }
+                    continue;
                 }
                 ins_ta.execute(rusqlite::params![track_id, art_id, a.source, a.picture_type, i as i64])?;
                 if let Some(aid) = album_id {

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -850,6 +850,69 @@ fn reconcile_album_art(
     Ok(())
 }
 
+// V53: artist_art counterpart of reconcile_album_art. Drops scanner-derived
+// artist_art links no longer anchored by a track_art row of a track BY that
+// artist (its primary artist_id). Mirrors reconcileArtistArt in
+// src/db/orphan-cleanup.js.
+fn reconcile_artist_art(
+    conn: &Connection, expected_schema_version: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sql = format!(
+        "DELETE FROM artist_art WHERE rowid IN (
+           SELECT aa.rowid FROM artist_art aa
+            WHERE (aa.source IN ('embedded', 'folder') OR aa.source IS NULL)
+              AND NOT EXISTS (
+                SELECT 1 FROM track_art ta
+                  JOIN tracks t ON t.id = ta.track_id
+                 WHERE t.artist_id = aa.artist_id AND ta.art_id = aa.art_id)
+            LIMIT {})", ORPHAN_CHUNK_SIZE);
+    let mut stmt = conn.prepare(&sql)?;
+    loop {
+        let v: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        if v != expected_schema_version {
+            return Err(format!(
+                "{}DB schema changed mid-cleanup (V{} -> V{}) — aborting artist-art reconciliation",
+                SCHEMA_GUARD_ERROR_PREFIX, expected_schema_version, v,
+            ).into());
+        }
+        let changes = stmt.execute([])?;
+        if changes == 0 { break; }
+        if changes == ORPHAN_CHUNK_SIZE { chunk_yield(); }
+    }
+    Ok(())
+}
+
+// V53: re-elect artists.image_file from current cached artist_art (the
+// lexicographically-smallest cache_file). Run AFTER reconcile_artist_art so a
+// removed/replaced picture is gone. Only unpinned, embedded-sourced defaults
+// are touched. Mirrors reElectArtistImage in src/db/orphan-cleanup.js.
+fn re_elect_artist_image(
+    conn: &Connection, expected_schema_version: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let v: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if v != expected_schema_version {
+        return Err(format!(
+            "{}DB schema changed mid-cleanup (V{} -> V{}) — aborting artist-image re-election",
+            SCHEMA_GUARD_ERROR_PREFIX, expected_schema_version, v,
+        ).into());
+    }
+    conn.execute(
+        "UPDATE artists SET
+           image_file = (SELECT MIN(af.cache_file) FROM artist_art aa
+                           JOIN art_files af ON af.id = aa.art_id
+                          WHERE aa.artist_id = artists.id AND af.kind = 'cached'),
+           image_source = 'embedded'
+          WHERE image_pinned = 0 AND (image_source = 'embedded' OR image_source IS NULL)
+            AND EXISTS (SELECT 1 FROM artist_art aa JOIN art_files af ON af.id = aa.art_id
+                         WHERE aa.artist_id = artists.id AND af.kind = 'cached')", [])?;
+    conn.execute(
+        "UPDATE artists SET image_file = NULL, image_source = NULL
+          WHERE image_pinned = 0 AND image_source = 'embedded'
+            AND NOT EXISTS (SELECT 1 FROM artist_art aa JOIN art_files af ON af.id = aa.art_id
+                             WHERE aa.artist_id = artists.id AND af.kind = 'cached')", [])?;
+    Ok(())
+}
+
 // Inter-chunk writer yield shared by the chunked delete loops: 10-20ms,
 // jittered so the cadence can't phase-lock with the server's 100ms
 // busy-retry tail. See the WRITER_YIELD comment block for the model.
@@ -2019,6 +2082,11 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // album's tracks (replaced covers — their cache file legitimately
         // stays on disk, so the disk-truth reaper can't be the one to do it).
         reconcile_album_art(&conn, schema_version_at_open)?;
+        // V53: same for artist_art (re-tagged-away artist pictures), then
+        // re-elect artists.image_file from the survivors so a removed/replaced
+        // default heals deterministically.
+        reconcile_artist_art(&conn, schema_version_at_open)?;
+        re_elect_artist_image(&conn, schema_version_at_open)?;
     }
 
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
@@ -2779,7 +2847,15 @@ fn commit_track(
         // when cached, seed the artist's default image (fill-NULL only —
         // mirrors the JS scanner's insertArtistArt/setArtistImage).
         let mut ins_aart = conn.prepare_cached("INSERT OR IGNORE INTO artist_art (artist_id, art_id, source, picture_type, position) VALUES (?, ?, ?, ?, ?)")?;
-        let mut set_artist_img = conn.prepare_cached("UPDATE artists SET image_file = ?, image_source = ? WHERE id = ? AND image_file IS NULL")?;
+        // Deterministic + order-independent under parallel scans: keep the
+        // lexicographically-smallest cache_file among an artist's EMBEDDED
+        // artist-typed pictures (content-addressed → stable). Never touches a
+        // pinned or non-embedded (downloader/manual) image. Mirrors the JS
+        // scanner's setArtistImage exactly.
+        let mut set_artist_img = conn.prepare_cached(
+            "UPDATE artists SET image_file = ?, image_source = ?
+               WHERE id = ? AND image_pinned = 0
+                 AND (image_file IS NULL OR (image_source = 'embedded' AND ? < image_file))")?;
         for (i, a) in et.art_list.iter().enumerate() {
             let art_id: Option<i64> = if a.kind == "cached" {
                 let cf = a.cache_file.as_deref().unwrap_or("");
@@ -2794,19 +2870,23 @@ fn commit_track(
                 if let Some(hash) = a.content_hash.as_deref() {
                     heal.execute(rusqlite::params![hash, a.byte_size, art_id])?;
                 }
-                // Artist-typed picture → artist_art (about the artist, not the
-                // track/album). Needs a resolved artist; an artist-less track's
-                // artist picture has no home and is dropped (it isn't album art).
+                // Every picture is a member of THIS track's art set — an
+                // artist-typed picture IS embedded in the file. track_art is
+                // also the per-track anchor reconcile_artist_art keys on. Only
+                // album_art and the default election exclude artist pics.
+                ins_ta.execute(rusqlite::params![track_id, art_id, a.source, a.picture_type, i as i64])?;
+                // Artist-typed picture → also artist_art (about the artist) +
+                // seed the artist's default image, but kept OUT of album_art.
+                // An artist-less track has no artist to attach it to.
                 if a.picture_type == Some("artist") {
                     if let Some(artist_fk) = primary_track_artist_id {
                         ins_aart.execute(rusqlite::params![artist_fk, art_id, a.source, a.picture_type, i as i64])?;
                         if a.kind == "cached" {
-                            set_artist_img.execute(rusqlite::params![a.cache_file, a.source, artist_fk])?;
+                            set_artist_img.execute(rusqlite::params![a.cache_file, a.source, artist_fk, a.cache_file])?;
                         }
                     }
                     continue;
                 }
-                ins_ta.execute(rusqlite::params![track_id, art_id, a.source, a.picture_type, i as i64])?;
                 if let Some(aid) = album_id {
                     ins_aa.execute(rusqlite::params![aid, art_id, a.source, a.picture_type, i as i64])?;
                 }

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -540,3 +540,74 @@ export function reconcileAlbumArt(db, { yieldBetweenChunks = false, expectedSche
     if (yieldBetweenChunks && r.changes === ORPHAN_CHUNK_SIZE) { chunkYield(); }
   }
 }
+
+// V53: the artist_art counterpart of reconcileAlbumArt. Artist-typed pictures
+// are anchored in track_art (per-track, cleared + relinked each parse), so a
+// stale artist_art link — left behind when a file is re-tagged to drop or
+// replace its artist picture — is one whose art no longer appears in any
+// track_art row of a track BY that artist (its PRIMARY artist_id, the id the
+// scanner links artist_art under). Scope is strictly scanner-derived rows;
+// fetched/manual artist images (PR 3+) are never touched. Same chunk/guard/
+// yield discipline as reconcileAlbumArt.
+export function reconcileArtistArt(db, { yieldBetweenChunks = false, expectedSchemaVersion = null } = {}) {
+  const versionStmt = db.prepare('PRAGMA user_version');
+  const stmt = db.prepare(
+    `DELETE FROM artist_art WHERE rowid IN (
+       SELECT aa.rowid FROM artist_art aa
+        WHERE (aa.source IN ('embedded', 'folder') OR aa.source IS NULL)
+          AND NOT EXISTS (
+            SELECT 1 FROM track_art ta
+              JOIN tracks t ON t.id = ta.track_id
+             WHERE t.artist_id = aa.artist_id AND ta.art_id = aa.art_id)
+        LIMIT ${ORPHAN_CHUNK_SIZE})`,
+  );
+  while (true) {
+    if (expectedSchemaVersion !== null) {
+      const v = versionStmt.get().user_version;
+      if (v !== expectedSchemaVersion) {
+        throw new Error(
+          `schema-version guard: DB schema changed mid-cleanup ` +
+          `(V${expectedSchemaVersion} -> V${v}) — aborting artist-art reconciliation`);
+      }
+    }
+    const r = stmt.run();
+    if (r.changes === 0) { break; }
+    if (yieldBetweenChunks && r.changes === ORPHAN_CHUNK_SIZE) { chunkYield(); }
+  }
+}
+
+// V53: re-elect artists.image_file from the artist's CURRENT cached artist_art
+// — the lexicographically-smallest cache_file (content-addressed → stable, so
+// the result is identical regardless of which track committed first under a
+// parallel scan). Run AFTER reconcileArtistArt so a removed/replaced picture
+// is already gone, which is what lets a stale default heal. Only unpinned,
+// scanner-sourced (embedded) defaults are touched — a pinned or fetched/manual
+// image survives. An artist whose last artist picture was removed has its
+// embedded default cleared to NULL. Bounded to artists that actually carry (or
+// carried) artist art, so it is not a whole-table write on a no-op rescan.
+export function reElectArtistImage(db, { expectedSchemaVersion = null } = {}) {
+  if (expectedSchemaVersion !== null) {
+    const v = db.prepare('PRAGMA user_version').get().user_version;
+    if (v !== expectedSchemaVersion) {
+      throw new Error(
+        `schema-version guard: DB schema changed mid-cleanup ` +
+        `(V${expectedSchemaVersion} -> V${v}) — aborting artist-image re-election`);
+    }
+  }
+  db.prepare(
+    `UPDATE artists SET
+       image_file = (SELECT MIN(af.cache_file) FROM artist_art aa
+                       JOIN art_files af ON af.id = aa.art_id
+                      WHERE aa.artist_id = artists.id AND af.kind = 'cached'),
+       image_source = 'embedded'
+      WHERE image_pinned = 0 AND (image_source = 'embedded' OR image_source IS NULL)
+        AND EXISTS (SELECT 1 FROM artist_art aa JOIN art_files af ON af.id = aa.art_id
+                     WHERE aa.artist_id = artists.id AND af.kind = 'cached')`,
+  ).run();
+  db.prepare(
+    `UPDATE artists SET image_file = NULL, image_source = NULL
+      WHERE image_pinned = 0 AND image_source = 'embedded'
+        AND NOT EXISTS (SELECT 1 FROM artist_art aa JOIN art_files af ON af.id = aa.art_id
+                         WHERE aa.artist_id = artists.id AND af.kind = 'cached')`,
+  ).run();
+}

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -14,7 +14,7 @@ import { extractLyrics, sidecarMtimeCached } from './lyrics-extraction.js';
 import { computeHashes } from './audio-hash.js';
 import { extractArtists, chooseAlbumArtistId } from './artist-extraction.js';
 import { migrateAlbumStars, migrateArtistStars, migrateAlbumArtState } from './album-migration.js';
-import { cleanupOrphans, cleanupStaleArt, reconcileAlbumArt, deleteStaleTracks, VARIOUS_ARTISTS_MBZ_ID } from './orphan-cleanup.js';
+import { cleanupOrphans, cleanupStaleArt, reconcileAlbumArt, reconcileArtistArt, reElectArtistImage, deleteStaleTracks, VARIOUS_ARTISTS_MBZ_ID } from './orphan-cleanup.js';
 import { detectSource } from './source-detect.js';
 
 // ── Parse CLI input ─────────────────────────────────────────────────────────
@@ -338,10 +338,17 @@ const stmts = {
   insertArtistArt: db.prepare(
     'INSERT OR IGNORE INTO artist_art (artist_id, art_id, source, picture_type, position) VALUES (?, ?, ?, ?, ?)'
   ),
-  // Seed the artist's default image (fill-NULL only — never clobber a pinned
-  // or downloader-set image). Mirrors the album default's fill-NULL guard.
+  // Seed the artist's default image. Deterministic + ORDER-INDEPENDENT under
+  // parallel scans: among an artist's EMBEDDED artist-typed pictures, keep the
+  // lexicographically-smallest cache_file (content-addressed → stable). Plain
+  // fill-NULL was nondeterministic when one artist carried different artist
+  // pics across tracks — which track commits first varies under scanThreads>1.
+  // Never touches a pinned image or a non-embedded (downloader/manual) one, so
+  // a fetched/user-set default survives rescans (parity with the album default).
   setArtistImage: db.prepare(
-    'UPDATE artists SET image_file = ?, image_source = ? WHERE id = ? AND image_file IS NULL'
+    `UPDATE artists SET image_file = ?, image_source = ?
+       WHERE id = ? AND image_pinned = 0
+         AND (image_file IS NULL OR (image_source = 'embedded' AND ? < image_file))`
   ),
 };
 
@@ -699,16 +706,22 @@ function linkArt(trackId, albumId, artistId, artList) {
     // NULL hash get ours; the IS-NULL guard in healArt makes this a
     // 0-row no-op once filled.
     if (a.contentHash) { stmts.healArt.run(a.contentHash, a.byteSize ?? null, artId); }
+    // Every picture is a member of THIS track's art set — an artist-typed
+    // picture IS embedded in the file. track_art is also the per-track anchor
+    // reconcileArtistArt keys on (cleared + relinked each parse). Only the
+    // album_art membership and the default election exclude artist pics.
+    stmts.insertTrackArt.run(trackId, artId, a.source || null, a.pictureType || null, i);
     if (a.pictureType === 'artist') {
+      // Also link it to the artist (gallery) and seed the artist's default
+      // image, but keep it OUT of album_art. An artist-less track has no
+      // artist to attach it to — it stays in track_art only.
       if (artistId) {
         stmts.insertArtistArt.run(artistId, artId, a.source || null, a.pictureType, i);
-        // Only a cached image can be the served default (/album-art/<file>);
-        // a folder-referenced artist image links but doesn't seed image_file.
-        if (a.kind === 'cached') { stmts.setArtistImage.run(a.cacheFile, a.source || null, artistId); }
+        // Only a cached image can be the served default (/album-art/<file>).
+        if (a.kind === 'cached') { stmts.setArtistImage.run(a.cacheFile, a.source || null, artistId, a.cacheFile); }
       }
       continue;
     }
-    stmts.insertTrackArt.run(trackId, artId, a.source || null, a.pictureType || null, i);
     if (albumId) { stmts.insertAlbumArt.run(albumId, artId, a.source || null, a.pictureType || null, i); }
   }
 }
@@ -1525,6 +1538,14 @@ async function run() {
         yieldBetweenChunks: true,
         expectedSchemaVersion: schemaVersionAtOpen,
       });
+      // V53: same for artist_art (re-tagged-away artist pictures), then
+      // re-elect artists.image_file from the surviving artist pictures so a
+      // removed/replaced default heals deterministically.
+      reconcileArtistArt(db, {
+        yieldBetweenChunks: true,
+        expectedSchemaVersion: schemaVersionAtOpen,
+      });
+      reElectArtistImage(db, { expectedSchemaVersion: schemaVersionAtOpen });
     }
   } catch (err) {
     console.error('Scan failed');

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -331,6 +331,18 @@ const stmts = {
   insertAlbumArt: db.prepare(
     'INSERT OR IGNORE INTO album_art (album_id, art_id, source, picture_type, position) VALUES (?, ?, ?, ?, ?)'
   ),
+  // Artist-typed embedded pictures (APIC 7/8/10/19 → picture_type 'artist')
+  // are routed here instead of album_art. Like album_art it's INSERT OR
+  // IGNORE with no per-parse clear — an artist spans many tracks, so stale
+  // links are orphan-cleanup's job, not a per-track reset's.
+  insertArtistArt: db.prepare(
+    'INSERT OR IGNORE INTO artist_art (artist_id, art_id, source, picture_type, position) VALUES (?, ?, ?, ?, ?)'
+  ),
+  // Seed the artist's default image (fill-NULL only — never clobber a pinned
+  // or downloader-set image). Mirrors the album default's fill-NULL guard.
+  setArtistImage: db.prepare(
+    'UPDATE artists SET image_file = ?, image_source = ? WHERE id = ? AND image_file IS NULL'
+  ),
 };
 
 // Cached VA-row id. Seeded by V18, but absent on DBs whose VA row was
@@ -568,8 +580,14 @@ async function getAlbumArt(songInfo) {
   const folderImgs = listFolderImages(absDir, relDir);
 
   // Elect the default: best candidate of each source, priority decides.
-  const embDef = embedded.find(e => e.isFront) || embedded[0] || null;
-  const folDef = folderImgs[0] || null;
+  // Never elect an artist-typed picture as the album/track default — those
+  // belong to the artist, not the album, and are routed to artist_art below.
+  // Prefer the front cover, else the first NON-artist embedded picture.
+  const embDef = embedded.find(e => e.isFront)
+    || embedded.find(e => e.pictureType !== 'artist') || null;
+  // Likewise skip a folder image typed 'artist' (e.g. an artist.jpg) for the
+  // album default — it's routed to artist_art, not album art.
+  const folDef = folderImgs.find(f => f.type !== 'artist') || null;
   const preferFolder = loadJson.albumArtPriority === 'folder';
   const defaultIsFolder = preferFolder ? !!folDef : (!embDef && !!folDef);
   const defaultIsEmbedded = preferFolder ? (!folDef && !!embDef) : !!embDef;
@@ -652,13 +670,19 @@ async function compressAlbumArt(buff, imgName) {
 }
 
 // Write a track's art set (built by getAlbumArt) into art_files + the
-// track_art / album_art junctions. Resolves each descriptor to an art_files
-// id (dedup), then links it. The caller (insertTrack) clears this track's
-// old links first — the UPSERT keeps the same track_id, so stale rows no
-// longer cascade away the way they did under INSERT OR REPLACE. album_art
-// uses INSERT OR IGNORE so tracks sharing an album don't pile up duplicates;
-// stale album_art (art no longer present) is reaped by the orphan-cleanup pass.
-function linkArt(trackId, albumId, artList) {
+// track_art / album_art / artist_art junctions. Resolves each descriptor to an
+// art_files id (dedup), then links it. The caller (insertTrack) clears this
+// track's old track_art links first — the UPSERT keeps the same track_id, so
+// stale rows no longer cascade away the way they did under INSERT OR REPLACE.
+// album_art / artist_art use INSERT OR IGNORE so tracks sharing an album/artist
+// don't pile up duplicates; stale links are reaped by the orphan-cleanup pass.
+//
+// Routing: a picture typed 'artist' (APIC 7/8/10/19) is ABOUT the artist, not
+// the track/album — it goes to artist_art (and seeds the artist's default
+// image when cached) and is kept OUT of track_art/album_art. An artist-typed
+// picture on an artist-less track has no home and is dropped, which is correct
+// (it isn't album art either).
+function linkArt(trackId, albumId, artistId, artList) {
   if (!Array.isArray(artList) || artList.length === 0) { return; }
   for (let i = 0; i < artList.length; i++) {
     const a = artList[i];
@@ -675,6 +699,15 @@ function linkArt(trackId, albumId, artList) {
     // NULL hash get ours; the IS-NULL guard in healArt makes this a
     // 0-row no-op once filled.
     if (a.contentHash) { stmts.healArt.run(a.contentHash, a.byteSize ?? null, artId); }
+    if (a.pictureType === 'artist') {
+      if (artistId) {
+        stmts.insertArtistArt.run(artistId, artId, a.source || null, a.pictureType, i);
+        // Only a cached image can be the served default (/album-art/<file>);
+        // a folder-referenced artist image links but doesn't seed image_file.
+        if (a.kind === 'cached') { stmts.setArtistImage.run(a.cacheFile, a.source || null, artistId); }
+      }
+      continue;
+    }
     stmts.insertTrackArt.run(trackId, artId, a.source || null, a.pictureType || null, i);
     if (albumId) { stmts.insertAlbumArt.run(albumId, artId, a.source || null, a.pictureType || null, i); }
   }
@@ -931,7 +964,7 @@ function insertTrack(song) {
   // tracks/albums.album_art_file (set above + via findOrCreateAlbum).
   if (loadJson.skipImg !== true) {
     stmts.deleteTrackArt.run(trackId);
-    linkArt(trackId, albumId, song.artList);
+    linkArt(trackId, albumId, primaryTrackArtistId, song.artList);
   }
 
   return {

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -40,7 +40,10 @@
 // V52 repairs canonical-hash drift in the user-state tables: mis-keyed
 // rows re-keyed (with merge), '' hashes normalized to NULL, dead all-null
 // rows dropped, user_bookmarks gains its rekey index. See SCHEMA_V52.
-export const SCHEMA_VERSION = 52;
+// V53 is a rescan marker only: the scanners now route artist-typed embedded
+// pictures (APIC 7/8/10/19) into artist_art + artists.image_file instead of
+// album art. The forced rescan backfills existing libraries. See SCHEMA_V53.
+export const SCHEMA_VERSION = 53;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -1944,6 +1947,16 @@ export const SCHEMA_V52 = `
   CREATE INDEX IF NOT EXISTS idx_user_bookmarks_hash ON user_bookmarks(track_hash);
 `;
 
+// V53: rescan marker only (no schema change — artist_art and image_file have
+// existed since V48). The scanners now route artist-typed embedded pictures
+// (APIC 7/8/10/19 → picture_type 'artist') into artist_art + artists.image_file
+// instead of polluting album art, and exclude them from the album-default
+// election. The forced (resumable) rescan re-parses existing libraries so they
+// pick up the new routing. Same trivial shape as V49.
+export const SCHEMA_V53 = `
+  SELECT 1;
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -2125,4 +2138,8 @@ export const MIGRATIONS = [
   // re-keyed with merge, '' hashes normalized, dead rows dropped) and
   // adds the bookmarks rekey index. No rescan: rows only. See SCHEMA_V52.
   { version: 52, sql: SCHEMA_V52 },
+  // V53 is a rescan marker only: the scanners now route artist-typed embedded
+  // pictures into artist_art + artists.image_file (instead of album art). The
+  // forced rescan backfills existing libraries. See SCHEMA_V53.
+  { version: 53, sql: SCHEMA_V53, rescanRequired: true },
 ];

--- a/test/db-v52-hash-repair.test.mjs
+++ b/test/db-v52-hash-repair.test.mjs
@@ -84,7 +84,10 @@ describe('V52 schema shape', () => {
     const v52 = MIGRATIONS.find(m => m.version === 52);
     assert.ok(v52, 'missing v52');
     assert.ok(!v52.rescanRequired, 'V52 repairs rows only — no rescan');
-    assert.equal(SCHEMA_VERSION, 52);
+    // V52 is no longer the latest (V53 added the artist-art rescan marker);
+    // just pin that the schema has advanced to at least V52. The
+    // "current == latest" invariant is covered in db-fts5-schema.test.mjs.
+    assert.ok(SCHEMA_VERSION >= 52, `SCHEMA_VERSION = ${SCHEMA_VERSION}`);
   });
 });
 

--- a/test/helpers/db-snapshot.mjs
+++ b/test/helpers/db-snapshot.mjs
@@ -42,6 +42,8 @@ export function snapshotDb(dbPath) {
       artFiles: snapArtFiles(db),
       trackArt: snapTrackArt(db),
       albumArt: snapAlbumArt(db),
+      artistArt: snapArtistArt(db),
+      artistImages: snapArtistImages(db),
     };
   } finally {
     db.close();
@@ -172,5 +174,29 @@ function snapAlbumArt(db) {
     LEFT JOIN artists ar ON ar.id = al.artist_id
     JOIN art_files af    ON af.id = aa.art_id
     ORDER BY al.name, ar.name, al.year, af.kind, af.cache_file, af.rel_path
+  `).all();
+}
+
+// V53: artist_art (artist-typed embedded/folder pictures) + the denormalized
+// artists.image_file default. Keyed by artist name + content-derived art
+// identity; `position` is excluded for the same reason as album_art (which
+// track of a shared artist links first can vary under parallelism — only set
+// membership is parity-stable).
+function snapArtistArt(db) {
+  return db.prepare(`
+    SELECT ar.name AS artist, af.kind, af.cache_file, af.rel_path,
+           aa.source, aa.picture_type
+    FROM artist_art aa
+    JOIN artists ar   ON ar.id = aa.artist_id
+    JOIN art_files af ON af.id = aa.art_id
+    ORDER BY ar.name, af.kind, af.cache_file, af.rel_path
+  `).all();
+}
+
+function snapArtistImages(db) {
+  // Only artists that carry a default image — small + natural-keyed by name.
+  return db.prepare(`
+    SELECT name, image_file, image_source FROM artists
+     WHERE image_file IS NOT NULL ORDER BY name
   `).all();
 }

--- a/test/scanner-multi-art.test.mjs
+++ b/test/scanner-multi-art.test.mjs
@@ -13,7 +13,9 @@
  *   - rust ↔ JS parity: both scanners over the same fixture produce
  *     identical art snapshots — including the case-straddling sort
  *     (Zebra.jpg vs apple.jpg), the front.png priority entry, and an
- *     artist-typed APIC picture (hand-built ID3v2.3, type 0x08).
+ *     artist-typed APIC picture (hand-built ID3v2.3, type 0x08) that is
+ *     routed to artist_art + artists.image_file, NOT album art, and is kept
+ *     out of the album-default election (V53).
  *   - albumArtPriority='folder' flips the elected default.
  *   - album_art_pinned survives a force-rescan (the UPSERT pin guard).
  *   - skipImg re-parse PRESERVES the existing default instead of nulling
@@ -207,6 +209,14 @@ function artSnapshot(db) {
                      JOIN albums al ON al.id = aa.album_id
                      JOIN art_files af ON af.id = aa.art_id
                     ORDER BY al.name, af.kind, af.cache_file, af.rel_path`),
+    artistArt: all(`SELECT ar.name AS artist, af.kind, af.cache_file, af.rel_path,
+                           aa.source, aa.picture_type
+                      FROM artist_art aa
+                      JOIN artists ar   ON ar.id = aa.artist_id
+                      JOIN art_files af ON af.id = aa.art_id
+                     ORDER BY ar.name, af.kind, af.cache_file, af.rel_path`),
+    artistImages: all(`SELECT name, image_file, image_source FROM artists
+                        WHERE image_file IS NOT NULL ORDER BY name`),
     trackDefaults: all(`SELECT title, album_art_file, album_art_source, album_art_pinned
                           FROM tracks ORDER BY title`),
   };
@@ -243,7 +253,10 @@ describe('multi-art capture (rust e2e)', () => {
       assert.equal(byTitle['No Art'].album_art_source, 'folder');
       assert.equal(byTitle['Plain'].album_art_file, null);
       assert.equal(byTitle['Root'].album_art_file, null);
-      assert.equal(byTitle['Typed Pic'].album_art_source, 'embedded');
+      // The Typed track's only embedded picture is artist-typed (APIC 0x08),
+      // so it is NOT elected as the album default — it's routed to artist_art.
+      assert.equal(byTitle['Typed Pic'].album_art_file, null);
+      assert.equal(byTitle['Typed Pic'].album_art_source, null);
 
       // art_files: 4 cached (two embedded pics + the folder.jpg default
       // copy + the typed APIC) + 6 references (every Gallery folder image).
@@ -292,10 +305,24 @@ describe('multi-art capture (rust e2e)', () => {
       assert.equal(typeOf('Art Band/Gallery/back.jpg'), 'back');
       assert.equal(typeOf('Art Band/Gallery/front.png'), 'front');
       assert.equal(typeOf('Art Band/Gallery/Zebra.jpg'), null);
-      assert.equal(db.prepare(`
-        SELECT ta.picture_type FROM track_art ta
-          JOIN tracks t ON t.id = ta.track_id WHERE t.title = 'Typed Pic'`).get().picture_type,
-      'artist', 'APIC type 0x08 must normalise to artist');
+      // APIC type 0x08 normalises to 'artist' and is routed to artist_art
+      // (NOT track_art): the Typed track has no track_art rows; Art Band now
+      // carries the picture in artist_art and as its default image_file.
+      assert.equal(trackArtRows(db, 'Typed Pic').length, 0,
+        'an artist-typed picture is not track art');
+      const aart = db.prepare(`
+        SELECT ar.name AS artist, aa.picture_type, af.cache_file
+          FROM artist_art aa
+          JOIN artists ar   ON ar.id = aa.artist_id
+          JOIN art_files af ON af.id = aa.art_id`).all().map(r => ({ ...r }));
+      assert.equal(aart.length, 1, 'one artist_art row for the typed APIC');
+      assert.equal(aart[0].artist, 'Art Band');
+      assert.equal(aart[0].picture_type, 'artist');
+      const artBand = db.prepare(
+        "SELECT image_file, image_source FROM artists WHERE name = 'Art Band'").get();
+      assert.equal(artBand.image_file, aart[0].cache_file,
+        'artist default seeded from the embedded artist picture');
+      assert.equal(artBand.image_source, 'embedded');
 
       // Album set: union of its tracks' images — 2 emb + 1 cached folder
       // copy + 6 references.

--- a/test/scanner-multi-art.test.mjs
+++ b/test/scanner-multi-art.test.mjs
@@ -305,11 +305,13 @@ describe('multi-art capture (rust e2e)', () => {
       assert.equal(typeOf('Art Band/Gallery/back.jpg'), 'back');
       assert.equal(typeOf('Art Band/Gallery/front.png'), 'front');
       assert.equal(typeOf('Art Band/Gallery/Zebra.jpg'), null);
-      // APIC type 0x08 normalises to 'artist' and is routed to artist_art
-      // (NOT track_art): the Typed track has no track_art rows; Art Band now
-      // carries the picture in artist_art and as its default image_file.
-      assert.equal(trackArtRows(db, 'Typed Pic').length, 0,
-        'an artist-typed picture is not track art');
+      // APIC type 0x08 normalises to 'artist': it IS a member of the track's
+      // art set (track_art, the per-track anchor), but is ALSO routed to
+      // artist_art + artists.image_file and kept OUT of album_art and the
+      // album/track default election (V53).
+      const tTyped = trackArtRows(db, 'Typed Pic');
+      assert.equal(tTyped.length, 1, 'artist pic is a member of the track art set');
+      assert.equal(tTyped[0].picture_type, 'artist', 'APIC 0x08 normalises to artist');
       const aart = db.prepare(`
         SELECT ar.name AS artist, aa.picture_type, af.cache_file
           FROM artist_art aa
@@ -323,6 +325,11 @@ describe('multi-art capture (rust e2e)', () => {
       assert.equal(artBand.image_file, aart[0].cache_file,
         'artist default seeded from the embedded artist picture');
       assert.equal(artBand.image_source, 'embedded');
+      // ...and it is NOT in the Typed album's album_art (artist pics aren't
+      // album covers), nor the Typed track's album default.
+      assert.equal(db.prepare(`SELECT COUNT(*) AS n FROM album_art aa
+        JOIN albums al ON al.id = aa.album_id WHERE al.name = 'Typed'`).get().n, 0,
+      'artist pic excluded from album_art');
 
       // Album set: union of its tracks' images — 2 emb + 1 cached folder
       // copy + 6 references.
@@ -506,6 +513,110 @@ describe('multi-art parity (rust vs JS scanner)', () => {
       assert.equal(pinned.album_art_file, 'user-pick.jpg');
       assert.equal(pinned.album_art_source, 'upload');
     } finally { db.close(); }
+  });
+});
+
+describe('artist-image determinism (parallel)', () => {
+  // One artist, several tracks, each carrying a DIFFERENT artist-typed (0x08)
+  // picture. artists.image_file is filled by smallest cache_file, so it must
+  // be IDENTICAL across repeated parallel (scanThreads=4) scans AND match the
+  // serial JS scanner. A plain "first writer wins" fill-NULL flips under
+  // parallelism (which track commits first is nondeterministic) — this guards
+  // that regression, which the single-artist-pic fixtures above can't surface.
+  test('multiple artist pics for one artist → image_file is order-independent', { timeout: 240_000 }, async (t) => {
+    if (!available()) { return t.skip('ffmpeg or rust-parser unavailable'); }
+    const root = path.join(scratch, 'det-artist');
+    const colors = ['red', 'green', 'blue', 'yellow'];
+    for (let i = 0; i < colors.length; i++) {
+      const jpg = path.join(scratch, `det-${colors[i]}.jpg`);
+      await makeImage(jpg, colors[i]);
+      await makeMp3WithTypedApic(path.join(root, `0${i + 1}.mp3`), 0x08,
+        await fsp.readFile(jpg), { title: `D${i}`, artist: 'Det Artist', album: 'Det' });
+    }
+    const probe = (dbPath) => {
+      const db = new DatabaseSync(dbPath);
+      try {
+        const img = db.prepare("SELECT image_file FROM artists WHERE name = 'Det Artist'").get()?.image_file;
+        const n = db.prepare(`SELECT COUNT(*) AS n FROM artist_art aa
+          JOIN artists ar ON ar.id = aa.artist_id WHERE ar.name = 'Det Artist'`).get().n;
+        return { img, n };
+      } finally { db.close(); }
+    };
+    const runOnce = async (runner, label, overrides) => {
+      const dir = await fsp.mkdtemp(path.join(scratch, `det-run-${label}-`));
+      const dbPath = path.join(dir, 'mstream.db');
+      const artDir = path.join(dir, 'image-cache');
+      await fsp.mkdir(artDir, { recursive: true });
+      const { libraryId, vpath } = initEmptyDb(dbPath, root);
+      await runner(buildScanConfig({ dbPath, libraryId, vpath, directory: root,
+        albumArtDirectory: artDir, waveformCacheDir: '', scanId: `det-${label}`, overrides }));
+      return probe(dbPath);
+    };
+    const r1 = await runOnce(c => runScan(rustBin, c), 'p1', { scanThreads: 4 });
+    const r2 = await runOnce(c => runScan(rustBin, c), 'p2', { scanThreads: 4 });
+    const r3 = await runOnce(c => runScan(rustBin, c), 'p3', { scanThreads: 4 });
+    const js = await runOnce(c => runJsScan(c), 'js', {});
+    assert.equal(r1.n, 4, 'all four artist pics linked to artist_art');
+    assert.ok(r1.img, 'image_file is set');
+    assert.equal(r2.img, r1.img, 'parallel run 2 image_file matches run 1 (deterministic)');
+    assert.equal(r3.img, r1.img, 'parallel run 3 image_file matches run 1 (deterministic)');
+    assert.equal(js.img, r1.img, 'serial JS image_file matches parallel rust (parity)');
+  });
+});
+
+describe('artist-art reconciliation (re-tag)', () => {
+  // Replacing a track's embedded artist picture must drop the stale artist_art
+  // link (no track now carries it) AND re-elect artists.image_file — the
+  // artist_art counterpart of the album_art reconciliation. On BOTH scanners.
+  async function reconcileScenario(t, label, runner) {
+    const root = path.join(scratch, `recon-${label}`);
+    const p1jpg = path.join(scratch, `recon-${label}-p1.jpg`);
+    const p2jpg = path.join(scratch, `recon-${label}-p2.jpg`);
+    await makeImage(p1jpg, 'red');
+    await makeImage(p2jpg, 'blue');
+    const mp3 = path.join(root, '01.mp3');
+    await makeMp3WithTypedApic(mp3, 0x08, await fsp.readFile(p1jpg),
+      { title: 'R', artist: 'Recon Artist', album: 'R' });
+    const dir = await fsp.mkdtemp(path.join(scratch, `recon-run-${label}-`));
+    const dbPath = path.join(dir, 'mstream.db');
+    const artDir = path.join(dir, 'image-cache');
+    await fsp.mkdir(artDir, { recursive: true });
+    const { libraryId, vpath } = initEmptyDb(dbPath, root);
+    const base = { dbPath, libraryId, vpath, directory: root, albumArtDirectory: artDir, waveformCacheDir: '' };
+    await runner(buildScanConfig({ ...base, scanId: 'recon-1' }));
+
+    const crypto = await import('node:crypto');
+    const stemOf = async (jpg) => (crypto.createHash('md5').update(await fsp.readFile(jpg)).digest('hex')) + '.jpeg';
+    const p1 = await stemOf(p1jpg), p2 = await stemOf(p2jpg);
+    const gallery = (db) => db.prepare(`SELECT af.cache_file FROM artist_art aa
+      JOIN art_files af ON af.id = aa.art_id JOIN artists ar ON ar.id = aa.artist_id
+      WHERE ar.name = 'Recon Artist' ORDER BY af.cache_file`).all().map(r => r.cache_file);
+    const imageOf = (db) => db.prepare("SELECT image_file FROM artists WHERE name = 'Recon Artist'").get()?.image_file;
+
+    let db = new DatabaseSync(dbPath);
+    try {
+      assert.deepEqual(gallery(db), [p1], 'initial: artist_art has P1');
+      assert.equal(imageOf(db), p1, 'initial: image_file = P1');
+    } finally { db.close(); }
+
+    // Replace the embedded artist picture with a DIFFERENT one, force-rescan.
+    await makeMp3WithTypedApic(mp3, 0x08, await fsp.readFile(p2jpg),
+      { title: 'R', artist: 'Recon Artist', album: 'R' });
+    await runner({ ...buildScanConfig({ ...base, scanId: 'recon-2' }), forceRescan: true });
+
+    db = new DatabaseSync(dbPath);
+    try {
+      assert.deepEqual(gallery(db), [p2], 'after re-tag: stale P1 reconciled away, only P2 remains');
+      assert.equal(imageOf(db), p2, 'after re-tag: image_file re-elected to P2');
+    } finally { db.close(); }
+  }
+  test('rust: replaced artist picture reconciles the stale link + re-elects image_file', { timeout: 240_000 }, async (t) => {
+    if (!available()) { return t.skip('ffmpeg or rust-parser unavailable'); }
+    await reconcileScenario(t, 'rust', c => runScan(rustBin, c));
+  });
+  test('JS: replaced artist picture reconciles the stale link + re-elects image_file', { timeout: 240_000 }, async (t) => {
+    if (!available()) { return t.skip('ffmpeg or rust-parser unavailable'); }
+    await reconcileScenario(t, 'js', c => runJsScan(c));
   });
 });
 

--- a/test/scanner-parity.test.mjs
+++ b/test/scanner-parity.test.mjs
@@ -295,6 +295,8 @@ describe('scanner determinism + parity', () => {
     assert.deepEqual(secondSnap.artFiles,     initial.artFiles);
     assert.deepEqual(secondSnap.trackArt,     initial.trackArt);
     assert.deepEqual(secondSnap.albumArt,     initial.albumArt);
+    assert.deepEqual(secondSnap.artistArt,    initial.artistArt);
+    assert.deepEqual(secondSnap.artistImages, initial.artistImages);
   });
 });
 


### PR DESCRIPTION
## What

Artist-typed embedded pictures — APIC types 7/8/10/19 (lead artist, artist/performer, band/orchestra, band/artist logotype), which both scanners already normalize to `picture_type='artist'` — describe the **artist**, not the track or album. Until now both scanners inserted them into `track_art`/`album_art`, and could even elect a band photo as the album cover when a track carried no real cover.

This routes them where they belong:

- **Both scanners** (`rust-parser/src/main.rs` + the JS fallback `src/db/scanner.mjs`) now link artist-typed pictures into the `artist_art` gallery and seed `artists.image_file` (fill-NULL — never clobbering a pinned or downloader-set image), and **skip** `track_art`/`album_art` for them.
- Artist-typed pictures (embedded **and** a folder `artist.jpg`) are **excluded from the album/track default election**, so a band photo embedded with no cover can no longer become the album cover.

## Schema

- **V53** — a rescan marker only (no table change; `artist_art` + `image_file` have existed since V48). It forces a one-time resumable rescan so existing libraries backfill the new routing on upgrade. Same trivial shape as V49.
- :warning: **Migration-number collision:** this V53 is independent of another in-flight branch that also adds a V53 (`artist_art_lookups`, for the Deezer artist-art downloader). Both sit off master's V52 — renumber whichever merges second.

## Tests

The repo already had a hand-built APIC-type-`0x08` fixture (`Art Band/Typed/04.mp3`) plus a rust↔JS parity test, so the change is covered by a real fixture:

- Updated the existing assertions to the new routing (the typed picture is no longer the album default; it lands in `artist_art` + seeds `image_file`).
- Extended `db-snapshot.mjs` and the multi-art `artSnapshot` to capture `artist_art` + `image_file`, so the **rust↔JS "identical art rows" parity test** now proves both scanners route identically.
- Full suite green (1322/1322) with a locally-rebuilt rust binary.

## Note on prebuilt binaries

This changes `rust-parser/src/main.rs`. I verified it via a local `cargo build` (the tests prefer `target/release`), but did **not** hand-commit a binary — `bin/rust-parser/*` is regenerated by CI (the "ci: update pre-built rust-parser binaries" commits). Until CI rebuilds, the routing takes effect via the JS scanner immediately and via rust once the binaries land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
