### PR TITLE
fix(api): return 400 (not 403) for request validation errors

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -406,9 +406,11 @@ export async function serveIt(configFile) {
   mstream.use((error, req, res, _next) => {
     winston.error(`Server error on route ${req.originalUrl}`, { stack: error });
 
-    // Check for validation error
+    // Schema validation failures are malformed-request errors: the client
+    // sent a body/params we can't accept. That's 400 Bad Request, not 403
+    // Forbidden (which means "authenticated but not permitted").
     if (error instanceof Joi.ValidationError) {
-      return res.status(403).json({ error: error.message });
+      return res.status(400).json({ error: error.message });
     }
 
     if (error instanceof WebError) {

--- a/test/admin-access.test.mjs
+++ b/test/admin-access.test.mjs
@@ -423,12 +423,12 @@ describe('whitelist /0 range is rejected by validation', () => {
     if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   });
 
-  test("POST admin-access with whitelist ['0.0.0.0/0'] → 403 and mode unchanged", async () => {
+  test("POST admin-access with whitelist ['0.0.0.0/0'] → 400 and mode unchanged", async () => {
     const r = await postAdminAccess(server.baseUrl, {
       mode: 'whitelist',
       whitelist: ['0.0.0.0/0'],
     });
-    assert.equal(r.status, 403, 'a /0 allow-all range must fail Joi validation');
+    assert.equal(r.status, 400, 'a /0 allow-all range must fail Joi validation');
     const body = await r.json();
     assert.ok(body.error, 'a validation error message is returned');
 

--- a/test/admin-scan-params.test.mjs
+++ b/test/admin-scan-params.test.mjs
@@ -115,19 +115,19 @@ describe('POST /api/v1/admin/db/params/analyze-bpm', () => {
 
   test('rejects non-boolean payload', async () => {
     // joiValidate throws on bad input; mStream's global error handler
-    // surfaces all thrown route errors as 403. Same status used by
+    // maps Joi.ValidationError to 400 Bad Request. Same status used by
     // every other admin-API validation failure in the codebase — see
     // any of the sibling /db/params/* routes for the pattern.
     for (const bad of [{ analyzeBpm: 'yes' }, { analyzeBpm: 1 }, { analyzeBpm: null }]) {
       const r = await adminPost('/api/v1/admin/db/params/analyze-bpm', bad);
-      assert.equal(r.status, 403,
+      assert.equal(r.status, 400,
         `expected validation rejection for ${JSON.stringify(bad)}, got ${r.status}`);
     }
   });
 
   test('rejects missing analyzeBpm field', async () => {
     const r = await adminPost('/api/v1/admin/db/params/analyze-bpm', {});
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
   test('rejects non-admin users with 405', async () => {
@@ -140,7 +140,7 @@ describe('POST /api/v1/admin/db/params/analyze-bpm', () => {
 // ── POST /db/params/auto-album-art-* (the downloader's config family) ──────
 //
 // Same four-part pattern as analyze-bpm above: GET defaults, happy-path
-// flip + reflect, Joi boundary rejections (403), non-admin 405. All
+// flip + reflect, Joi boundary rejections (400), non-admin 405. All
 // side-effect-free against the fixtures: the helper boots with
 // autoAlbumArt:false, so no flip here can enqueue a download pass.
 
@@ -161,7 +161,7 @@ describe('downloader config params', () => {
 
     for (const bad of [{ autoAlbumArtMode: 'sometimes' }, { autoAlbumArtMode: true }, {}]) {
       const r = await adminPost('/api/v1/admin/db/params/auto-album-art-mode', bad);
-      assert.equal(r.status, 403, `expected rejection for ${JSON.stringify(bad)}`);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/auto-album-art-mode',
       { autoAlbumArtMode: 'all' }, userJwt)).status, 405);
@@ -177,7 +177,7 @@ describe('downloader config params', () => {
 
     for (const bad of [{ autoAlbumArtWriteToFolder: 'yes' }, { autoAlbumArtWriteToFolder: 1 }, {}]) {
       const r = await adminPost('/api/v1/admin/db/params/auto-album-art-write-to-folder', bad);
-      assert.equal(r.status, 403, `expected rejection for ${JSON.stringify(bad)}`);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/auto-album-art-write-to-folder',
       { autoAlbumArtWriteToFolder: true }, userJwt)).status, 405);
@@ -193,7 +193,7 @@ describe('downloader config params', () => {
     for (const bad of [{ autoAlbumArtPerRun: 0 }, { autoAlbumArtPerRun: 10001 },
       { autoAlbumArtPerRun: 'abc' }, { autoAlbumArtPerRun: 2.5 }, {}]) {
       const r = await adminPost('/api/v1/admin/db/params/auto-album-art-per-run', bad);
-      assert.equal(r.status, 403, `expected rejection for ${JSON.stringify(bad)}`);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/auto-album-art-per-run',
       { autoAlbumArtPerRun: 50 }, userJwt)).status, 405);
@@ -278,7 +278,7 @@ describe('POST /api/v1/admin/config/trust-proxy', () => {
   test('rejects non-boolean payload', async () => {
     for (const bad of [{ trustProxy: 'yes' }, { trustProxy: 1 }, {}]) {
       const r = await adminPost('/api/v1/admin/config/trust-proxy', bad);
-      assert.equal(r.status, 403,
+      assert.equal(r.status, 400,
         `expected validation rejection for ${JSON.stringify(bad)}, got ${r.status}`);
     }
   });

--- a/test/dlna.test.mjs
+++ b/test/dlna.test.mjs
@@ -794,10 +794,10 @@ describe('DLNA identity (name + uuid)', () => {
     const xml = await (await client.httpGet('/dlna/device.xml')).text();
     assert.match(xml, /<friendlyName>Padded Name<\/friendlyName>/);
 
-    // Empty / whitespace-only is rejected (joiValidate throws → 403).
+    // Empty / whitespace-only is rejected (joiValidate throws → 400).
     for (const bad of [{ name: '' }, { name: '   ' }, {}]) {
       const r = await client.apiPost('/api/v1/admin/dlna/name', bad);
-      assert.equal(r.status, 403, `expected rejection for ${JSON.stringify(bad)}, got ${r.status}`);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}, got ${r.status}`);
     }
   });
 
@@ -813,7 +813,7 @@ describe('DLNA identity (name + uuid)', () => {
   test('rejects a malformed uuid', async () => {
     for (const bad of [{ uuid: 'not-a-uuid' }, { uuid: 'uuid:1234' }, { uuid: '' }, {}]) {
       const r = await client.apiPost('/api/v1/admin/dlna/uuid', bad);
-      assert.equal(r.status, 403, `expected rejection for ${JSON.stringify(bad)}, got ${r.status}`);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}, got ${r.status}`);
     }
   });
 });

--- a/test/random-route.test.mjs
+++ b/test/random-route.test.mjs
@@ -596,22 +596,22 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
 
   // ── Joi validation ────────────────────────────────────────────────
 
-  test('bpmRanges item missing min → 403', async () => {
+  test('bpmRanges item missing min → 400', async () => {
     const r = await randomReq(server.baseUrl, { bpmRanges: [{ max: 130 }] });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('minRating > 10 → 403', async () => {
+  test('minRating > 10 → 400', async () => {
     const r = await randomReq(server.baseUrl, { minRating: 11 });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('minRating < 0 → 403', async () => {
+  test('minRating < 0 → 400', async () => {
     // 0 is accepted (alpha UI's "Disabled" rating option sends 0 by
     // default — see webapp/assets/js/mstream.player.js:71). Negative
     // values still rejected as semantically meaningless.
     const r = await randomReq(server.baseUrl, { minRating: -1 });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
   test('minRating = 0 is accepted (legacy alpha-UI compat)', async () => {
@@ -619,27 +619,27 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
     // any minRating because the body branch `if (req.body.minRating && ...)`
     // skipped the filter when 0 (falsy). PR #586 must preserve that
     // — every default autoDJ() call from the current webapp sends
-    // `minRating: 0` and would otherwise hit 403.
+    // `minRating: 0` and would otherwise hit 400.
     const r = await randomReq(server.baseUrl, { minRating: 0 });
     // Status can be 200 (pick found) or 400 (scope empty) — what we
     // assert here is that Joi did NOT reject the payload.
-    assert.notEqual(r.status, 403, 'minRating=0 must not be Joi-rejected');
+    assert.notEqual(r.status, 400, 'minRating=0 must not be Joi-rejected');
   });
 
-  test('unknown body key → 403 (Joi default rejects unknown keys)', async () => {
+  test('unknown body key → 400 (Joi default rejects unknown keys)', async () => {
     const r = await randomReq(server.baseUrl, { totallyMadeUp: 'whatever' });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
   // ── Joi: array caps + bpmRange ordering (audit follow-up) ─────────
 
-  test('bpmRanges item with min > max → 403', async () => {
+  test('bpmRanges item with min > max → 400', async () => {
     // Backwards range is the most common typo and would silently match
-    // nothing — the custom Joi validator on bpmRangeItem now 403s it.
+    // nothing — the custom Joi validator on bpmRangeItem now rejects it (400).
     const r = await randomReq(server.baseUrl, {
       bpmRanges: [{ min: 200, max: 50 }],
     });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
   test('bpmRanges item with min === max → 200 (degenerate but valid)', async () => {
@@ -650,39 +650,39 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
     });
     // Not rejected at the Joi layer. May return 400 if no t.bpm=128
     // exists in the fixture (it doesn't — t1=124, t2=125, t3=128).
-    assert.notEqual(r.status, 403);
+    assert.notEqual(r.status, 400);
   });
 
-  test('artists array exceeds max=100 → 403', async () => {
+  test('artists array exceeds max=100 → 400', async () => {
     const longArtists = Array.from({ length: 101 }, (_, i) => `Artist${i}`);
     const r = await randomReq(server.baseUrl, { artists: longArtists });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('ignoreArtists array exceeds max=100 → 403', async () => {
+  test('ignoreArtists array exceeds max=100 → 400', async () => {
     const longArtists = Array.from({ length: 101 }, (_, i) => `Artist${i}`);
     const r = await randomReq(server.baseUrl, { ignoreArtists: longArtists });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('ignoreList array exceeds max=500 → 403', async () => {
+  test('ignoreList array exceeds max=500 → 400', async () => {
     const longList = Array.from({ length: 501 }, (_, i) => i);
     const r = await randomReq(server.baseUrl, { ignoreList: longList });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('musicalKeys array exceeds max=24 → 403', async () => {
+  test('musicalKeys array exceeds max=24 → 400', async () => {
     const tooMany = Array.from({ length: 25 }, (_, i) => `${(i % 12) + 1}A`);
     const r = await randomReq(server.baseUrl, { musicalKeys: tooMany });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('bpmRanges array exceeds max=16 → 403', async () => {
+  test('bpmRanges array exceeds max=16 → 400', async () => {
     const tooManyRanges = Array.from({ length: 17 }, (_, i) => ({
       min: 60 + i, max: 70 + i,
     }));
     const r = await randomReq(server.baseUrl, { bpmRanges: tooManyRanges });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
   // ── Step 1: tight BPM + key ───────────────────────────────────────
@@ -1114,27 +1114,27 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
 
   // ── V35 plan — genre filter validation ────────────────────────────
 
-  test('genres array exceeds max=200 → 403', async () => {
+  test('genres array exceeds max=200 → 400', async () => {
     const tooMany = Array.from({ length: 201 }, (_, i) => `Genre${i}`);
     const r = await randomReq(server.baseUrl, { genres: tooMany });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('genres array with empty-string item → 403 (Joi min(1))', async () => {
+  test('genres array with empty-string item → 400 (Joi min(1))', async () => {
     const r = await randomReq(server.baseUrl, { genres: ['Jazz', ''] });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('genres array with non-string element → 403', async () => {
+  test('genres array with non-string element → 400', async () => {
     const r = await randomReq(server.baseUrl, { genres: ['Jazz', 42] });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('invalid genreMode → 403', async () => {
+  test('invalid genreMode → 400', async () => {
     // Joi `.valid('whitelist', 'blacklist')` rejects anything else.
     for (const invalid of ['allow', 'deny', 'block', 42, null]) {
       const r = await randomReq(server.baseUrl, { genres: ['Jazz'], genreMode: invalid });
-      assert.equal(r.status, 403, `expected 403 for genreMode=${JSON.stringify(invalid)}, got ${r.status}`);
+      assert.equal(r.status, 400, `expected 400 for genreMode=${JSON.stringify(invalid)}, got ${r.status}`);
     }
   });
 

--- a/test/random-similar-artists.test.mjs
+++ b/test/random-similar-artists.test.mjs
@@ -376,14 +376,14 @@ describe('POST /api/v1/db/random-songs — similar-artists waterfall (PR D)', ()
 
   // ── Joi validation ────────────────────────────────────────────────
 
-  test('artists must be array of strings — number entry → 403', async () => {
+  test('artists must be array of strings — number entry → 400', async () => {
     const r = await randomReq(server.baseUrl, { artists: [42] });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
-  test('ignoreArtists must be array of strings — object entry → 403', async () => {
+  test('ignoreArtists must be array of strings — object entry → 400', async () => {
     const r = await randomReq(server.baseUrl, { ignoreArtists: [{ name: 'Foo' }] });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
   test('empty artists array is treated as "no filter" — picks from all 5 rows', async () => {

--- a/test/search-route.test.mjs
+++ b/test/search-route.test.mjs
@@ -194,25 +194,23 @@ describe('/api/v1/db/search algorithm dispatch', () => {
     assert.ok(r.body.artists.some(a => a.name === 'Pink Floyd'));
   });
 
-  test('algorithm=foo (unknown value) → 403 from Joi error middleware', async () => {
+  test('algorithm=foo (unknown value) → 400 from Joi error middleware', async () => {
     const r = await searchReq(server.baseUrl, { search: 'pink', algorithm: 'foo' });
-    // mStream's error middleware maps Joi.ValidationError to 403, not
-    // 400 — the existing convention in src/server.js since long before
-    // PR3. Locking that in here means a future shift to 400 is a
-    // visible test diff rather than a silent client compatibility break.
-    assert.equal(r.status, 403);
+    // mStream's error middleware maps Joi.ValidationError to 400 Bad
+    // Request (src/server.js): a malformed `algorithm` value is a bad
+    // request, not an authorization failure.
+    assert.equal(r.status, 400);
   });
 
-  test('algorithm="" (empty string) → 403 from Joi error middleware', async () => {
+  test('algorithm="" (empty string) → 400 from Joi error middleware', async () => {
     const r = await searchReq(server.baseUrl, { search: 'pink', algorithm: '' });
-    // mStream's error middleware maps Joi.ValidationError to 403, not
-    // 400 — the existing convention in src/server.js since long before
-    // PR3. Locking that in here means a future shift to 400 is a
-    // visible test diff rather than a silent client compatibility break.
-    assert.equal(r.status, 403);
+    // mStream's error middleware maps Joi.ValidationError to 400 Bad
+    // Request (src/server.js): a malformed `algorithm` value is a bad
+    // request, not an authorization failure.
+    assert.equal(r.status, 400);
   });
 
-  test('algorithm=null (explicit null) → 403 from Joi error middleware', async () => {
+  test('algorithm=null (explicit null) → 400 from Joi error middleware', async () => {
     // PR3 audit follow-up. Joi.string().valid(...) rejects an explicit
     // null payload — `.optional().default('combo')` only fills in for
     // the MISSING case, not for the EXPLICITLY-NULL case. Pinned here
@@ -220,7 +218,7 @@ describe('/api/v1/db/search algorithm dispatch', () => {
     // accidentally route a null through to the dispatch as `undefined`
     // and silently land on the combo default) is a loud diff.
     const r = await searchReq(server.baseUrl, { search: 'pink', algorithm: null });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 
   // ── Default-is-combo + combo vs fts5 divergence on parse failure ──

--- a/test/subsonic-lyrics-lrclib.test.mjs
+++ b/test/subsonic-lyrics-lrclib.test.mjs
@@ -558,13 +558,13 @@ describe('LRCLib cache: drain-on-disable (round-2 fix)', () => {
 });
 
 describe('LRCLib cache: admin validation (round-2 fix)', () => {
-  test('malformed purge body → 403 with a Joi error, no side effect', async () => {
+  test('malformed purge body → 400 with a Joi error, no side effect', async () => {
     const r = await fetch(`${server.baseUrl}/api/v1/admin/subsonic/lyrics-cache/purge`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-access-token': await adminToken() },
       body: JSON.stringify({ mode: 'not-a-valid-mode' }),
     });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
     const body = await r.json();
     assert.match(body.error, /mode.*must be one of/);
   });
@@ -575,7 +575,7 @@ describe('LRCLib cache: admin validation (round-2 fix)', () => {
       headers: { 'Content-Type': 'application/json', 'x-access-token': await adminToken() },
       body: JSON.stringify({ enabled: 'yes' }),   // string, not bool
     });
-    assert.equal(r.status, 403);
+    assert.equal(r.status, 400);
   });
 });
 


### PR DESCRIPTION
## What

The global Express error handler in `src/server.js` mapped `Joi.ValidationError` to **403 Forbidden**. That's the wrong status — a schema-validation failure means the client sent a body/params we can't accept, which is **400 Bad Request**. 403 means "authenticated but not permitted", which validation failures are not.

Because validation runs through the single global handler, *every* endpoint using `joiValidate` was returning 403 on malformed input (search, random/auto-DJ, admin db-params, DLNA name/uuid, lyrics-cache purge, admin-access whitelist, …).

```diff
-    // Check for validation error
     if (error instanceof Joi.ValidationError) {
-      return res.status(403).json({ error: error.message });
+      return res.status(400).json({ error: error.message });
     }
```

## Scope

This is the **first in a series of per-issue error-code cleanup PRs** (kept small so review + smoke testing stay manageable). It only touches the Joi→HTTP mapping. Manual/bare-`Error` status codes that currently collapse to 500 (e.g. "File Not Found", "Library not found") are deliberately **out of scope** and will follow as separate PRs.

## Tests

Updated the tests that pinned the old 403 behaviour to assert 400:
`search-route`, `random-route`, `random-similar-artists`, `admin-scan-params`, `dlna`, `subsonic-lyrics-lrclib`, `admin-access`.

Genuine 403s are **untouched** — they don't flow through the Joi branch:
- admin-access IP-based block (`adminAccess` whitelist/localhost mode)
- feature-disabled gates (`WebError(..., 403)`)
- DLNA TimeSeek path (its own handler, already 400-correct)

Subsonic endpoints are unaffected (they use the spec-mandated 200 + envelope error code, not the HTTP-status handler).

Full CI suite runs clean on this branch (the one unrelated `subsonic-phase3 › jukeboxControl` failure is a pre-existing, environment-specific failure — it reproduces identically on `master` because a server-audio backend is present on the dev machine).