### PR TITLE
fix(api): return 404/400 instead of 500 for client errors

### DIFF
--- a/src/api/db.js
+++ b/src/api/db.js
@@ -4,6 +4,7 @@ import * as vpath from '../util/vpath.js';
 import * as dbQueue from '../db/task-queue.js';
 import * as db from '../db/manager.js';
 import { joiValidate, dualId } from '../util/validation.js';
+import WebError from '../util/web-error.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -534,15 +535,15 @@ export function setup(mstream) {
 
     const pathInfo = vpath.getVPathInfo(req.body.filepath);
     const lib = db.getLibraryByName(pathInfo.vpath);
-    if (!lib) { throw new Error('Library not found'); }
+    if (!lib) { throw new WebError('Library not found', 404); }
 
     const track = d().prepare(
       'SELECT file_hash, audio_hash FROM tracks WHERE filepath = ? AND library_id = ?'
     ).get(pathInfo.relativePath, lib.id);
-    if (!track) { throw new Error('File Not Found'); }
+    if (!track) { throw new WebError('File Not Found', 404); }
     // Hashless row (failed parse): track_hash is NOT NULL — binding
     // null would surface as a 500 constraint throw.
-    if (!track.audio_hash && !track.file_hash) { throw new Error('File Not Found'); }
+    if (!track.audio_hash && !track.file_hash) { throw new WebError('File Not Found', 404); }
 
     d().prepare(`
       INSERT INTO user_metadata (user_id, track_hash, rating)

--- a/src/api/playlist.js
+++ b/src/api/playlist.js
@@ -3,6 +3,7 @@ import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
 import * as transcode from './transcode.js';
 import { joiValidate, resolveId } from '../util/validation.js';
+import WebError from '../util/web-error.js';
 
 export function setup(mstream) {
   const d = () => db.getDB();
@@ -106,7 +107,7 @@ export function setup(mstream) {
     `).get(trackId);
 
     if (!track || track.user_id !== req.user.id) {
-      throw new Error('Access denied or track not found');
+      throw new WebError('Access denied or track not found', 404);
     }
 
     d().prepare('DELETE FROM playlist_tracks WHERE id = ?').run(trackId);

--- a/src/api/remote.js
+++ b/src/api/remote.js
@@ -9,6 +9,7 @@ import winston from 'winston';
 import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
 import { joiValidate } from '../util/validation.js';
+import WebError from '../util/web-error.js';
 
 // list of currently connected clients (users)
 const clients = {};
@@ -108,11 +109,11 @@ export function setupAfterAuth(mstream, server) {
     joiValidate(schema, req.body);
 
     if (!(req.body.code in clients)) {
-      throw new Error('Code Not Found');
+      throw new WebError('Code Not Found', 404);
     }
 
     if (allowedCommands.indexOf(req.body.command) === -1) {
-      throw new Error('Command Not Recognized');
+      throw new WebError('Command Not Recognized', 400);
     }
 
     // Push commands to client
@@ -135,7 +136,7 @@ export function setupAfterAuth(mstream, server) {
     joiValidate(schema, req.body);
 
     if (!(req.body.code in clients)) {
-      throw new Error('Code Not Found');
+      throw new WebError('Code Not Found', 404);
     }
 
     playlistCache[req.body.code] = req.body.playlist;
@@ -161,7 +162,7 @@ export function setupAfterAuth(mstream, server) {
     joiValidate(schema, req.body);
 
     if (!(req.body.code in clients)) {
-      throw new Error('Code Not Found');
+      throw new WebError('Code Not Found', 404);
     }
 
     nowPlayingCache[req.body.code] = req.body.nowPlaying;
@@ -203,7 +204,7 @@ export function setupBeforeAuth(mstream) {
   mstream.get('/remote/:remoteId', async (req, res) => {
     const clientCode = req.params.remoteId;
     if (!(clientCode in clients) || !(clientCode in codeTokenMap)) {
-      throw new Error('Token Not Found');
+      throw new WebError('Token Not Found', 404);
     }
 
     let sharePage = await fs.readFile(path.join(config.program.webAppDirectory, 'remote/index.html'), 'utf-8');

--- a/src/api/ytdl.js
+++ b/src/api/ytdl.js
@@ -29,7 +29,7 @@ const youtubeUrlSchema = Joi.string().uri({ scheme: ['http', 'https'] }).require
 function sanitizeYoutubeUrl(url) {
   const parsed = new URL(url);
   const v = parsed.searchParams.get('v');
-  if (!v) { throw new Error('Invalid YouTube URL - missing video ID'); }
+  if (!v) { throw new WebError('Invalid YouTube URL - missing video ID', 400); }
   parsed.search = '';
   parsed.searchParams.set('v', v);
   return parsed.toString();
@@ -94,7 +94,7 @@ export function setup(mstream) {
 
     // verify path exists
     const pathInfo = vpath.getVPathInfo(value.directory, req.user);
-    if (!(await fs.stat(pathInfo.fullPath)).isDirectory()) { throw new Error('Not A Directory'); }
+    if (!(await fs.stat(pathInfo.fullPath)).isDirectory()) { throw new WebError('Not A Directory', 400); }
 
     value.url = sanitizeYoutubeUrl(value.url);
 

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -1,4 +1,5 @@
 import Joi from 'joi';
+import WebError from './web-error.js';
 
 export const joiValidate = (joiSchema, validateThis, throwErr) => {
   const { error, value } = joiSchema.validate(validateThis);
@@ -20,10 +21,10 @@ export function resolveId(body) {
   const hasId = body.id != null;
 
   if (hasLoki && hasId) {
-    throw new Error('Request must use either `id` or `lokiid`, not both');
+    throw new WebError('Request must use either `id` or `lokiid`, not both', 400);
   }
   if (!hasLoki && !hasId) {
-    throw new Error('Missing required field: `id`');
+    throw new WebError('Missing required field: `id`', 400);
   }
 
   return Number(hasLoki ? body.lokiid : body.id);


### PR DESCRIPTION
## What

Several route handlers signalled **client** errors with a bare `throw new Error(...)`. The global error handler only special-cases `WebError` and `Joi.ValidationError`; everything else falls through to `res.status(500).json({ error: 'Server Error' })`. So genuine not-found / bad-input conditions surfaced as a generic **500** — the real cause hidden from the client, and the response indistinguishable from a server crash.

This converts the ones that actually propagate to the global handler to `throw new WebError(msg, code)`:

| Code | Sites |
|------|-------|
| **404** not found | `db.js` rate-song (unknown library / track / hashless row), `playlist.js` remove-song (missing or other-user's track), `remote.js` jukebox push/update + `GET /remote/:id` (unknown code/token) |
| **400** bad request | `validation.js` `resolveId` (missing id, or `id`+`lokiid` both), `remote.js` jukebox push (unrecognised command), `ytdl.js` (missing video id; target not a directory) |

Second in the per-issue error-code cleanup series (follows #644, validation 403→400).

## Out of scope (deliberate, separate issues)

- `album-art.js` / `transcode.js` — their "not found" throws are **caught locally** and already return 4xx (400/404), so they're a different "local catch flattens the code" problem, not a 500.
- `download.js` — its error paths are entangled with the non-awaited `.catch(err => { throw err })` unhandled-rejection bug; fixing the code there needs that bug fixed first.
- `admin.js` "No Certs" / `backup.js` validation throws — belong to their own cleanups (backup has a separate pending audit).

## Verification

- Live smoke test against a booted instance confirmed each path: rate-song unknown file → 404, remove-song missing/ambiguous id → 400, remove-song unknown id → 404, jukebox unknown code → 404, `/remote/<unknown>` → 404, and valid requests still 200.
- Full CI suite (71 files) run file-by-file: no new failures. The one unrelated `subsonic-phase3 › jukeboxControl` failure is pre-existing and environment-specific (reproduces identically on `master` — a server-audio backend is present on the dev machine).
- Zero new lint problems (parity-checked each changed file against `master`).