### PR TITLE
fix(auth): return 401 for invalid tokens instead of 500

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -95,7 +95,17 @@ export function setup(mstream) {
     if (!token) { throw new WebError('Authentication Error', 401); }
     req.token = token;
 
-    const decoded = jwt.verify(token, config.program.secret);
+    // jwt.verify throws on a token we can't trust (malformed, bad signature,
+    // expired). That's a 401, not an unhandled error that falls through to a
+    // generic 500. Log the cause — an invalid token at the auth wall is a
+    // probing signal.
+    let decoded;
+    try {
+      decoded = jwt.verify(token, config.program.secret);
+    } catch (err) {
+      winston.warn(`Rejected invalid token from ${req.ip} on ${req.path}: ${err.message}`);
+      throw new WebError('Authentication Error', 401);
+    }
 
     // Handle federation invite tokens
     if (decoded.invite && decoded.invite === true) {

--- a/src/api/shared.js
+++ b/src/api/shared.js
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import jwt from 'jsonwebtoken';
+import winston from 'winston';
 import path from 'path';
 import fs from 'fs/promises';
 import Joi from 'joi';
@@ -14,10 +15,16 @@ function lookupShared(playlistId) {
     'SELECT * FROM shared_playlists WHERE share_id = ?'
   ).get(playlistId);
 
-  if (!row) { throw new WebError('Playlist Not Found'); }
+  if (!row) { throw new WebError('Playlist Not Found', 404); }
 
-  // Verify the token is still valid
-  jwt.verify(row.token, config.program.secret);
+  // Verify the token is still valid. An expired or forged share token is a
+  // 401, not an unhandled error that falls through to a generic 500.
+  try {
+    jwt.verify(row.token, config.program.secret);
+  } catch (err) {
+    winston.warn(`Rejected invalid share token for playlist '${playlistId}': ${err.message}`);
+    throw new WebError('Share Link Expired', 401);
+  }
 
   return {
     token: row.token,

--- a/test/media-access-control.test.mjs
+++ b/test/media-access-control.test.mjs
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import jwt from 'jsonwebtoken';
 import { startServer } from './helpers/server.mjs';
 
 function findMp3(dir) {
@@ -72,6 +73,21 @@ describe('media route enforces vpath access control', () => {
 
   test('unauthenticated request is rejected by the auth wall', async () => {
     const r = await fetch(server.baseUrl + mediaPath);
+    assert.equal(r.status, 401);
+  });
+
+  test('a malformed token is rejected with 401, not 500', async () => {
+    // jwt.verify throws on a non-JWT string; the auth wall must surface that
+    // as 401, not let it fall through to a generic 500 Server Error.
+    const r = await fetch(server.baseUrl + mediaPath, { headers: { 'x-access-token': 'not-a-real-jwt' } });
+    assert.equal(r.status, 401);
+  });
+
+  test('a forged-signature token is rejected with 401', async () => {
+    // Well-formed JWT signed with the wrong secret — jwt.verify throws
+    // "invalid signature". A forgery attempt must not get a 500.
+    const forged = jwt.sign({ username: 'alice' }, 'definitely-not-the-server-secret');
+    const r = await fetch(server.baseUrl + mediaPath, { headers: { 'x-access-token': forged } });
     assert.equal(r.status, 401);
   });
 });


### PR DESCRIPTION
## What

The core auth wall verified the request token with **no** error handling:

```js
// src/api/auth.js — auth middleware
const decoded = jwt.verify(token, config.program.secret);
```

`jwt.verify` **throws** on a malformed, forged, or expired token (`JsonWebTokenError` / `TokenExpiredError`). That's neither a `WebError` nor a `Joi.ValidationError`, so the global handler fell through to a generic **500 "Server Error"**. So any client with a stale/expired token — and any token-forgery attempt — got a 500 instead of a 401 telling it to re-authenticate.

Fix: wrap the verify and throw `WebError('Authentication Error', 401)`, logging the cause (`ip` + `path` + message), since an invalid token at the auth wall is a probing signal (consistent with the existing `winston.warn` convention for rejected vpaths/logins).

The **same unguarded-verify bug** lived in the shared-playlist path (`src/api/shared.js` `lookupShared`): an expired/forged share token 500'd. Guarded it → **401**. Also gave the adjacent `throw new WebError('Playlist Not Found')` its missing status code (it defaulted to 500) → **404**.

Third in the per-issue error-code cleanup series (after #644, #645).

## Scope notes

- `/login` is **intentionally** left returning a uniform `401 "Login Failed"` (with the 800ms delay) for *all* failures — that's deliberate anti-enumeration, not a bug.
- The other `jwt.verify` call sites are already safe: `server.js` (×3, UI routes) and `remote.js` wrap it in try/catch (redirect / `cb(false, 401)`); `shared.js:77` verifies a token it just signed.

## Verification

- **Regression tests** added (`test/media-access-control.test.mjs`): a malformed token and a forged-signature token at the auth wall must both be 401. Confirmed they **fail on master** (→500) and pass with the fix.
- **Live smoke test** on a booted instance: no token / garbage / forged / expired token → 401; valid token → 200; unknown shared playlist id → 404.
- Full CI suite (71 files) file-by-file: no new failures (the one unrelated `subsonic-phase3 › jukeboxControl` failure is pre-existing/environment-specific — reproduces on `master`).
- Zero new lint problems (parity-checked against `master`).