### PR TITLE
fix(download): return a status on pre-stream errors instead of crashing/hanging

### DIFF
--- a/src/api/download.js
+++ b/src/api/download.js
@@ -8,11 +8,14 @@ import * as m3u from '../util/m3u.js';
 import WebError from '../util/web-error.js';
 
 export function setup(mstream) {
-  mstream.post('/api/v1/download/m3u', (req, res) => {
-    // custom wrap download functions to avoid an error with the archiver module
-    downloadM3U(req, res).catch(err  => {
-      throw err;
-    })
+  // These handlers must be async and `await` the worker. In Express 5 a
+  // rejected promise returned from the handler is forwarded to the error
+  // middleware; the old `fn(req,res).catch(err => { throw err })` threw into
+  // a promise nobody awaited, so a pre-stream error (validation, bad vpath,
+  // not-a-directory) became an unhandled rejection and the client got a hung
+  // connection with no status instead of a 4xx/5xx.
+  mstream.post('/api/v1/download/m3u', async (req, res) => {
+    await downloadM3U(req, res);
   });
 
   async function downloadM3U(req, res) {
@@ -43,17 +46,15 @@ export function setup(mstream) {
     archive.finalize();
   }
 
-  mstream.post('/api/v1/download/directory',  (req, res) => {
-    downloadDir(req, res).catch(err => {
-      throw err;
-    })
+  mstream.post('/api/v1/download/directory', async (req, res) => {
+    await downloadDir(req, res);
   });
 
   async function downloadDir(req, res) {
     if (!req.body.directory) { throw new WebError('Validation Error', 403); }
 
     const pathInfo = vpath.getVPathInfo(req.body.directory, req.user);
-    if (!(await fs.stat(pathInfo.fullPath)).isDirectory()) { throw new Error('Not A Directory'); }
+    if (!(await fs.stat(pathInfo.fullPath)).isDirectory()) { throw new WebError('Not A Directory', 400); }
 
     const archive = archiver('zip');
     archive.on('error', (err) => {
@@ -69,19 +70,15 @@ export function setup(mstream) {
     archive.finalize();
   }
 
-  mstream.get('/api/v1/download/shared', (req, res) => {
+  mstream.get('/api/v1/download/shared', async (req, res) => {
     if (!req.sharedPlaylistId) { throw new WebError('Missing Playlist Id', 403); }
     const fileArray = shared.lookupPlaylist(req.sharedPlaylistId).playlist;
-    download(req, res, fileArray).catch(err => {
-      throw err;
-    });
+    await download(req, res, fileArray);
   });
 
-  mstream.post('/api/v1/download/zip', (req, res) => {
+  mstream.post('/api/v1/download/zip', async (req, res) => {
     const fileArray = JSON.parse(req.body.fileArray);
-    download(req, res, fileArray).catch(err => {
-      throw err;
-    });
+    await download(req, res, fileArray);
   });
 
   async function download(req, res, fileArray) {

--- a/test/download-routes.test.mjs
+++ b/test/download-routes.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * Download routes must return an HTTP status on a pre-stream error, not hang.
+ *
+ * The handlers used to be sync wrappers that did
+ * `worker(req,res).catch(err => { throw err })`. In Express 5 the throw lands
+ * in a promise nobody awaits → unhandled rejection → the error middleware is
+ * never reached → the client connection hangs with no status. Making the
+ * handlers async + `await` lets Express forward the rejection so a validation
+ * / bad-path error becomes a real 4xx.
+ *
+ * Each request uses a short AbortSignal timeout so a regression (the hang)
+ * fails fast and loud instead of stalling the whole test run.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { startServer } from './helpers/server.mjs';
+
+function findMp3(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) { const r = findMp3(full); if (r) { return r; } }
+    else if (e.name.endsWith('.mp3')) { return full; }
+  }
+  return null;
+}
+
+describe('download routes return a status on pre-stream errors (no hung connection)', () => {
+  let server, token, fileVpath, dirVpath;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: false,
+      users: [{ username: 'paul', password: 'p', admin: true, vpaths: ['testlib'] }],
+    });
+    const login = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'paul', password: 'p' }),
+    });
+    token = (await login.json()).token;
+
+    const file = findMp3(server.musicDir);
+    const relFile = path.relative(server.musicDir, file).split(path.sep).join('/');
+    fileVpath = `testlib/${relFile}`;
+    dirVpath = `testlib/${relFile.split('/').slice(0, -1).join('/')}`;
+  });
+
+  after(async () => { if (server) { await server.stop(); } });
+
+  const post = (p, body) => fetch(`${server.baseUrl}${p}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-access-token': token },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(8000),
+  });
+
+  test('m3u with no path → 4xx, not a hung connection', async () => {
+    const r = await post('/api/v1/download/m3u', {});
+    assert.ok(r.status >= 400 && r.status < 500, `expected a 4xx, got ${r.status}`);
+  });
+
+  test('directory with no directory → 4xx, not a hung connection', async () => {
+    const r = await post('/api/v1/download/directory', {});
+    assert.ok(r.status >= 400 && r.status < 500, `expected a 4xx, got ${r.status}`);
+  });
+
+  test('directory pointing at a file → 400 Not A Directory', async () => {
+    const r = await post('/api/v1/download/directory', { directory: fileVpath });
+    assert.equal(r.status, 400);
+  });
+
+  test('directory pointing at a real directory still streams a zip (200)', async () => {
+    const r = await post('/api/v1/download/directory', { directory: dirVpath });
+    assert.equal(r.status, 200);
+    assert.match(r.headers.get('content-disposition') || '', /attachment/);
+    await r.arrayBuffer(); // drain the stream so the connection closes cleanly
+  });
+});


### PR DESCRIPTION
## What

All four `/api/v1/download/*` routes were registered as **sync** handlers that called an async worker and re-threw its rejection inside a non-awaited `.catch`:

```js
mstream.post('/api/v1/download/m3u', (req, res) => {
  downloadM3U(req, res).catch(err => { throw err })   // throws into a dropped promise
});
```

In Express 5 only a promise **returned from the handler** is forwarded to the error middleware. This handler returns `undefined`, so the re-thrown error becomes an **unhandled promise rejection** that never reaches the error handler.

So any pre-stream failure — missing field, bad vpath, not-a-directory — produced no HTTP status. And it's worse than a hang: mStream installs **no** `process.on('unhandledRejection')` handler (the codebase even notes "Node 20+ exits on that by default"), so on the supported Node version a single request like `POST /api/v1/download/m3u` with an empty body **crashes the whole server process**. Auth-walled, but any authenticated user can trigger it — and in public mode it's unauthenticated.

## Fix

Make the four handlers `async` and `await` the worker, so Express forwards the rejection to the global error handler (which renders the right `WebError` status). Also gave the now-reachable `throw new Error('Not A Directory')` a real code — **400** (it was the bare-Error path this bug had been blocking).

Routes: `/download/m3u`, `/download/directory`, `/download/shared`, `/download/zip`.

## Verification

- New regression test (`test/download-routes.test.mjs`): pre-stream errors now return a 4xx, and a valid directory download still streams a **200** zip. Each request uses a short `AbortSignal` timeout so a regression fails fast instead of stalling the run.
- **Proven against master**: with `download.js` reverted, all 4 tests fail (`pass 0`) — the first bad request takes the server down and the rest can't connect; with the fix, 4/4 pass.
- Full CI suite (72 files) file-by-file: no new failures (the one unrelated `subsonic-phase3 › jukeboxControl` failure is pre-existing/environment-specific — reproduces on `master`).
- Zero new lint problems (parity-checked against `master`).

## Out of scope

The remaining `WebError('Validation Error', 403)` missing-param throws in this file (and `shared.js`) are the manual-validation-403→400 cleanup tracked separately; left untouched here to keep this PR to the crash fix.