### PR TITLE
fix(api): return 404 for album-art / SSL "not found" instead of 400/500

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -14,6 +14,7 @@ import * as db from '../db/manager.js';
 import * as logger from '../logger.js';
 import { joiValidate } from '../util/validation.js';
 import { isAdminAllowed } from '../util/admin-network.js';
+import WebError from '../util/web-error.js';
 import { bootRustPlayer, killRustPlayer, proxyToRust, getActiveBackend, getDetectedCliPlayers, refreshDetectedCliPlayers } from './server-playback.js';
 import { listImplementedMethods, methodStatusTable } from './subsonic/index.js';
 import * as lyricsLrclib from './lyrics-lrclib.js';
@@ -909,7 +910,10 @@ export function setup(mstream) {
   // });
 
   mstream.delete("/api/v1/admin/ssl", async (req, res) => {
-    if (!config.program.ssl.cert) { throw new Error('No Certs'); }
+    // DELETE on a cert that isn't configured — there's nothing to remove.
+    // `ssl` is optional config, so guard the access too (it was an unguarded
+    // `.ssl.cert` that TypeError'd → 500 when ssl was absent entirely).
+    if (!config.program.ssl?.cert) { throw new WebError('No Certs', 404); }
     await admin.removeSSL();
     res.json({});
   });

--- a/src/api/album-art.js
+++ b/src/api/album-art.js
@@ -17,6 +17,7 @@ import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
 import * as vpath from '../util/vpath.js';
 import { joiValidate, sanitizeFilename } from '../util/validation.js';
+import WebError from '../util/web-error.js';
 import { ffmpegBin } from '../util/ffmpeg-bootstrap.js';
 import { isDownloaded as ffmpegIsDownloaded } from './transcode.js';
 
@@ -261,7 +262,9 @@ export function setup(mstream) {
       await applyAlbumArt(req.body.filepath, imgBuf, req.body.writeToFolder, req.body.writeToFile, req.user);
       res.json({ ok: true });
     } catch (e) {
-      res.status(400).json({ error: e.message });
+      // Honour a WebError's status (e.g. 404 not-found from applyAlbumArt);
+      // everything else here is a bad-image / processing failure → 400.
+      res.status(e instanceof WebError ? e.status : 400).json({ error: e.message });
     }
   });
 
@@ -298,7 +301,9 @@ export function setup(mstream) {
       await applyAlbumArt(req.body.filepath, imgBuf, req.body.writeToFolder, req.body.writeToFile, req.user);
       res.json({ ok: true });
     } catch (e) {
-      res.status(400).json({ error: e.message });
+      // Honour a WebError's status (e.g. 404 not-found from applyAlbumArt);
+      // everything else here is a bad-image / processing failure → 400.
+      res.status(e instanceof WebError ? e.status : 400).json({ error: e.message });
     }
   });
 
@@ -327,12 +332,12 @@ export function setup(mstream) {
     // Find the track in DB
     const pathInfo = vpath.getVPathInfo(filepath, user);
     const lib = db.getLibraryByName(pathInfo.vpath);
-    if (!lib) throw new Error('Library not found');
+    if (!lib) throw new WebError('Library not found', 404);
 
     const track = d().prepare(
       'SELECT id, album_id FROM tracks WHERE filepath = ? AND library_id = ?'
     ).get(pathInfo.relativePath, lib.id);
-    if (!track) throw new Error('Track not found');
+    if (!track) throw new WebError('Track not found', 404);
 
     // Update track art
     d().prepare('UPDATE tracks SET album_art_file = ? WHERE id = ?').run(filename, track.id);

--- a/test/notfound-codes.test.mjs
+++ b/test/notfound-codes.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * "Not found" conditions should return 404, not a flattened 400 / a 500.
+ *
+ *  - album-art set/upload threw `Error('Track not found')` inside applyAlbumArt,
+ *    which the route's catch turned into 400. Now it's a WebError(404) and the
+ *    catch honours its status (other bad-image errors still 400).
+ *  - DELETE /admin/ssl with no cert configured threw a bare Error → 500 (and
+ *    TypeError'd outright when ssl was absent). Now a clean 404.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { startServer } from './helpers/server.mjs';
+
+// Valid PNG magic bytes + padding to clear the endpoint's >=100-byte check.
+// Jimp can't decode it, but saveImageToCache swallows that, so the request
+// still reaches the track lookup — the path under test.
+const fakePng = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.alloc(200),
+]).toString('base64');
+
+describe('not-found codes (album art + admin ssl)', () => {
+  let server, token;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: false,
+      users: [{ username: 'paul', password: 'p', admin: true, vpaths: ['testlib'] }],
+    });
+    const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'paul', password: 'p' }),
+    });
+    token = (await r.json()).token;
+  });
+
+  after(async () => { if (server) { await server.stop(); } });
+
+  const post = (path, body) => fetch(`${server.baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-access-token': token },
+    body: JSON.stringify(body),
+  });
+
+  test('album-art/upload for a non-existent track → 404 (not 400)', async () => {
+    const r = await post('/api/v1/album-art/upload', {
+      filepath: 'testlib/does/not/exist.mp3',
+      image: fakePng,
+    });
+    assert.equal(r.status, 404);
+  });
+
+  test('album-art/upload with a malformed (too-small) image still → 400', async () => {
+    const r = await post('/api/v1/album-art/upload', {
+      filepath: 'testlib/does/not/exist.mp3',
+      image: Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'), // 4 bytes
+    });
+    assert.equal(r.status, 400);
+  });
+
+  test('DELETE /admin/ssl with no cert configured → 404 (not 500)', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/ssl`, {
+      method: 'DELETE',
+      headers: { 'x-access-token': token },
+    });
+    assert.equal(r.status, 404);
+  });
+});


### PR DESCRIPTION
## What

Two "not found" conditions returned the wrong status:

**Album art** — `applyAlbumArt` threw `Error('Library not found')` / `Error('Track not found')`, but both routes ([set-from-url](src/api/album-art.js), upload) wrap it in `try/catch { res.status(400) }`, so a missing track came back as **400**. Now those throw `WebError(404)` and the catch honours the status:

```js
res.status(e instanceof WebError ? e.status : 400).json({ error: e.message });
```

So a genuine bad-image error (too small/large, wrong format) still returns **400**, while not-found is **404**. (album-art.js wasn't actually importing `WebError` — added; the integration test caught the resulting `ReferenceError`-as-500.)

**SSL** — `DELETE /api/v1/admin/ssl` with no cert configured threw a bare `Error('No Certs')` → **500**, and worse, `config.program.ssl.cert` TypeError'd → 500 when `ssl` was absent from config entirely. Now `config.program.ssl?.cert` guards both cases and returns a clean **404** (deleting a cert that isn't there).

These are the "caught-local code flattening" leftovers from the original audit (#645 era). Fifth in the per-issue error-code cleanup series.

## Tests

[notfound-codes.test.mjs](test/notfound-codes.test.mjs):
- album-art/upload for a non-existent track → **404** (not 400)
- album-art/upload with a malformed (too-small) image → **400** (bad input unchanged)
- `DELETE /admin/ssl` with no cert configured → **404** (not 500)

**Proven against master**: with the source reverted, the two not-found tests fail (400 / 500) while the bad-image control still passes; with the fix, all three pass. Full suite green except the unrelated pre-existing `subsonic-phase3 › jukeboxControl` env failure. Zero new lint.

## Note

I used **404** for "No Certs" (DELETE on a non-existent cert resource). 409 Conflict would also be defensible — easy to switch if you'd prefer that.