### PR TITLE
fix(cli-audio): map playback errors to real codes instead of blanket 400

### DIFF
--- a/src/api/cli-audio/base.js
+++ b/src/api/cli-audio/base.js
@@ -8,6 +8,8 @@
  * for `proxyToRust()` in server-playback.js.
  */
 
+import WebError from '../../util/web-error.js';
+
 const LOOP_MODES = ['none', 'one', 'all'];
 
 export class BaseCliAdapter {
@@ -87,13 +89,13 @@ export class BaseCliAdapter {
 
   async next() {
     const idx = this._pickNextIndex();
-    if (idx === null) { throw new Error('Already at end of queue'); }
+    if (idx === null) { throw new WebError('Already at end of queue', 409); }
     this.queueIndex = idx;
     await this._loadCurrent();
   }
 
   async previous() {
-    if (this.queue.length === 0) { throw new Error('Queue is empty'); }
+    if (this.queue.length === 0) { throw new WebError('Queue is empty', 409); }
     if (this.queueIndex === 0) {
       if (this.loopMode === 'all') {
         this.queueIndex = this.queue.length - 1;
@@ -127,7 +129,7 @@ export class BaseCliAdapter {
 
   async queuePlayIndex(index) {
     if (index < 0 || index >= this.queue.length) {
-      throw new Error('Index out of range');
+      throw new WebError('Index out of range', 400);
     }
     this.queueIndex = index;
     await this._loadCurrent();
@@ -135,7 +137,7 @@ export class BaseCliAdapter {
 
   async queueRemove(index) {
     if (index < 0 || index >= this.queue.length) {
-      throw new Error('Index out of range');
+      throw new WebError('Index out of range', 400);
     }
     this.queue.splice(index, 1);
     if (this.queue.length === 0) {
@@ -221,7 +223,11 @@ export class BaseCliAdapter {
       const data = await this._dispatch(method, rustPath, body || {});
       return { status: 200, data: data ?? { ok: true } };
     } catch (e) {
-      return { status: 400, data: { error: e.message } };
+      // Known conditions carry their HTTP status via WebError (503 player
+      // unavailable, 409 queue-state, 404 unknown route, 400 bad input).
+      // Anything else is an unexpected internal failure → 500, not a blanket
+      // 400 that hides real bugs as "client error".
+      return { status: e instanceof WebError ? e.status : 500, data: { error: e.message } };
     }
   }
 
@@ -229,7 +235,7 @@ export class BaseCliAdapter {
     const key = `${method} ${rustPath}`;
     switch (key) {
       case 'POST /play':
-        if (!body.file) { throw new Error('Missing file'); }
+        if (!body.file) { throw new WebError('Missing file', 400); }
         await this.play(body.file);
         return { ok: true };
       case 'POST /pause':
@@ -260,11 +266,11 @@ export class BaseCliAdapter {
         await this.cycleLoop();
         return { ok: true };
       case 'POST /queue/add':
-        if (!body.file) { throw new Error('Missing file'); }
+        if (!body.file) { throw new WebError('Missing file', 400); }
         await this.queueAdd(body.file);
         return { ok: true };
       case 'POST /queue/add-many':
-        if (!Array.isArray(body.files)) { throw new Error('Missing files'); }
+        if (!Array.isArray(body.files)) { throw new WebError('Missing files', 400); }
         await this.queueAddMany(body.files);
         return { ok: true };
       case 'POST /queue/play-index':
@@ -281,7 +287,7 @@ export class BaseCliAdapter {
       case 'GET /queue':
         return this.getQueue();
       default:
-        throw new Error(`Unsupported route: ${key}`);
+        throw new WebError(`Unsupported route: ${key}`, 404);
     }
   }
 }

--- a/src/api/cli-audio/mplayer.js
+++ b/src/api/cli-audio/mplayer.js
@@ -8,6 +8,7 @@
  */
 
 import child_process from 'child_process';
+import WebError from '../../util/web-error.js';
 import winston from 'winston';
 import { BaseCliAdapter } from './base.js';
 
@@ -71,7 +72,7 @@ export class MplayerAdapter extends BaseCliAdapter {
 
   _send(cmd) {
     if (!this._proc || !this._proc.stdin.writable) {
-      throw new Error('mplayer not running');
+      throw new WebError('mplayer not running', 503);
     }
     this._proc.stdin.write(cmd + '\n');
   }

--- a/test/cli-audio-error-codes.test.mjs
+++ b/test/cli-audio-error-codes.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * cli-audio's handleRequest used to collapse EVERY failure to a blanket 400.
+ * It now maps known conditions to real codes via WebError (409 queue-state,
+ * 404 unknown route, 400 bad input) and treats anything unexpected as 500.
+ *
+ * BaseCliAdapter owns handleRequest + _dispatch + the queue logic, so a stub
+ * subclass (no-op player hooks) exercises all of it without a real CLI player.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { BaseCliAdapter } from '../src/api/cli-audio/base.js';
+
+class StubAdapter extends BaseCliAdapter {
+  async _loadFile() {}
+  async _pause() {}
+  async _resume() {}
+  async _stop() {}
+  async _seek() {}
+  async _setVolume() {}
+}
+
+test('happy path returns 200', async () => {
+  const a = new StubAdapter('stub');
+  assert.equal((await a.handleRequest('POST', '/pause', {})).status, 200);
+});
+
+test('missing required body → 400', async () => {
+  const a = new StubAdapter('stub');
+  assert.equal((await a.handleRequest('POST', '/play', {})).status, 400);
+  assert.equal((await a.handleRequest('POST', '/queue/add', {})).status, 400);
+  assert.equal((await a.handleRequest('POST', '/queue/add-many', {})).status, 400);
+});
+
+test('out-of-range queue index → 400', async () => {
+  const a = new StubAdapter('stub');
+  assert.equal((await a.handleRequest('POST', '/queue/play-index', { index: 5 })).status, 400);
+  assert.equal((await a.handleRequest('POST', '/queue/remove', { index: 5 })).status, 400);
+});
+
+test('queue-state conflicts → 409', async () => {
+  const a = new StubAdapter('stub');
+  // empty queue: nothing to advance to / nothing to step back from
+  assert.equal((await a.handleRequest('POST', '/next', {})).status, 409);
+  assert.equal((await a.handleRequest('POST', '/previous', {})).status, 409);
+});
+
+test('unknown route → 404', async () => {
+  const a = new StubAdapter('stub');
+  assert.equal((await a.handleRequest('GET', '/does-not-exist', {})).status, 404);
+  assert.equal((await a.handleRequest('POST', '/play/extra', {})).status, 404);
+});
+
+test('an unexpected (non-WebError) failure → 500, not 400', async () => {
+  class Boom extends StubAdapter {
+    async _loadFile() { throw new Error('kaboom'); }
+  }
+  const a = new Boom('boom');
+  const r = await a.handleRequest('POST', '/play', { file: '/x.mp3' });
+  assert.equal(r.status, 500);
+  assert.equal(r.data.error, 'kaboom');
+});


### PR DESCRIPTION
## What

The CLI server-playback fallback (`src/api/cli-audio/`) is a drop-in for the Rust audio binary. Its `handleRequest` caught **every** failure and returned `{ status: 400 }`:

```js
} catch (e) {
  return { status: 400, data: { error: e.message } };
}
```

`server-playback.js` passes that `status` straight through to the client, so "player not running", "queue is empty", "index out of range" and "unknown route" were **all 400 Bad Request** — and a genuine internal bug looked like a client error too.

## Fix

Carry the intended HTTP status on the thrown error (`WebError`) and have `handleRequest` read it, defaulting an **unexpected** (non-`WebError`) failure to **500**:

| Code | Condition | Was |
|------|-----------|-----|
| **503** | mplayer not running | 400 |
| **409** | queue-state: empty / already at end | 400 |
| **404** | unknown route | 400 |
| **400** | missing file(s) / out-of-range index | 400 (genuine bad input — unchanged) |
| **500** | unexpected internal error | 400 |

`server-playback.js`'s own catch still maps a hard proxy failure (no adapter running at all → `proxyToCli` rejects) to 503, so that path is unaffected.

This is the CLI-audio item from the error-code cleanup series (after #644–#649, #651).

## Tests

[cli-audio-error-codes.test.mjs](test/cli-audio-error-codes.test.mjs) drives `BaseCliAdapter.handleRequest` through a stub subclass (no real CLI player needed) across each mapping — 400 / 409 / 404 / 500 / 200.

**Proven against master**: with the source reverted, the 409 / 404 / 500 assertions fail (everything is 400 there); the genuinely-400 cases still pass. With the fix, all six pass. Full suite green except the unrelated pre-existing `subsonic-phase3 › jukeboxControl` env failure. Zero new lint.