### PR TITLE
fix(api): validate download params with Joi (400 on missing field)

### DIFF
--- a/src/api/download.js
+++ b/src/api/download.js
@@ -7,6 +7,8 @@ import * as shared from '../api/shared.js';
 import * as m3u from '../util/m3u.js';
 import * as config from '../state/config.js';
 import { parseSizeToBytes } from '../util/parse-size.js';
+import { joiValidate } from '../util/validation.js';
+import Joi from 'joi';
 import WebError from '../util/web-error.js';
 
 // Configured cap on a bulk download's total uncompressed size, in bytes.
@@ -75,7 +77,7 @@ export function setup(mstream) {
   });
 
   async function downloadM3U(req, res) {
-    if (!req.body.path) { throw new WebError('Validation Error', 403); }
+    joiValidate(Joi.object({ path: Joi.string().required() }), req.body);
     const pathInfo = vpath.getVPathInfo(req.body.path, req.user);
     const playlistParentDir = path.dirname(pathInfo.fullPath);
     const songs = await m3u.readPlaylistSongs(pathInfo.fullPath);
@@ -114,7 +116,7 @@ export function setup(mstream) {
   });
 
   async function downloadDir(req, res) {
-    if (!req.body.directory) { throw new WebError('Validation Error', 403); }
+    joiValidate(Joi.object({ directory: Joi.string().required() }), req.body);
 
     const pathInfo = vpath.getVPathInfo(req.body.directory, req.user);
     if (!(await fs.stat(pathInfo.fullPath)).isDirectory()) { throw new WebError('Not A Directory', 400); }

--- a/src/api/shared.js
+++ b/src/api/shared.js
@@ -44,7 +44,7 @@ export function setupBeforeSecurity(mstream) {
       return res.redirect(301, req.path.slice(0, (matchEnd[0].length) * -1) + queryString[0]);
     }
 
-    if (!req.params.playlistId) { throw new WebError('Validation Error', 403); }
+    if (!req.params.playlistId) { throw new WebError('Validation Error', 400); }
     let sharePage = await fs.readFile(path.join(config.program.webAppDirectory, 'shared/index.html'), 'utf-8');
     sharePage = sharePage.replace(
       '<script></script>',
@@ -54,7 +54,7 @@ export function setupBeforeSecurity(mstream) {
   });
 
   mstream.get('/api/v1/shared/:playlistId', (req, res) => {
-    if (!req.params.playlistId) { throw new WebError('Validation Error', 403); }
+    if (!req.params.playlistId) { throw new WebError('Validation Error', 400); }
     res.json(lookupShared(req.params.playlistId));
   });
 }

--- a/test/download-routes.test.mjs
+++ b/test/download-routes.test.mjs
@@ -57,14 +57,17 @@ describe('download routes return a status on pre-stream errors (no hung connecti
     signal: AbortSignal.timeout(8000),
   });
 
-  test('m3u with no path → 4xx, not a hung connection', async () => {
+  // Missing required field → 400 (validation). The AbortSignal in `post`
+  // still guards the original concern: a regression to the old dropped-promise
+  // bug would hang and time out rather than return a status.
+  test('m3u with no path → 400', async () => {
     const r = await post('/api/v1/download/m3u', {});
-    assert.ok(r.status >= 400 && r.status < 500, `expected a 4xx, got ${r.status}`);
+    assert.equal(r.status, 400);
   });
 
-  test('directory with no directory → 4xx, not a hung connection', async () => {
+  test('directory with no directory → 400', async () => {
     const r = await post('/api/v1/download/directory', {});
-    assert.ok(r.status >= 400 && r.status < 500, `expected a 4xx, got ${r.status}`);
+    assert.equal(r.status, 400);
   });
 
   test('directory pointing at a file → 400 Not A Directory', async () => {


### PR DESCRIPTION
## What

`/download/m3u` and `/download/directory` checked for their required field by hand — `if (!req.body.path) throw new WebError('Validation Error', 403)` — returning a **403 Forbidden** for what's really a malformed request.

Rather than just flip the code, convert these to **Joi**, matching how the rest of the API validates:

```js
joiValidate(Joi.object({ path: Joi.string().required() }), req.body);
```

So a missing field now returns **400** via the global Joi handler (#644) with a clear message (`"path" is required` instead of generic "Validation Error"), and unknown keys are rejected too.

[shared.js](src/api/shared.js)'s two `/shared/:playlistId` guards are flipped **403 → 400** for the same reason, but they're **unreachable** — Express won't match `/shared/:playlistId` without a non-empty segment, so there's no input for Joi to validate. They stay as defensive checks.

Completes the validation→400 theme from #644 for the last hand-rolled checks. (Suggested mid-review: convert to Joi rather than hand-flip the code.)

## Tests

Tightened the two [download-routes.test.mjs](test/download-routes.test.mjs) cases from a loose `4xx` check to assert **400** (the helper's `AbortSignal` still guards the #647 hang regression).

**Proven against master**: those two assertions fail there (403); with the fix they pass. Full suite green except the unrelated pre-existing `subsonic-phase3 › jukeboxControl` env failure. Zero new lint.