### PR TITLE
test: pre-build fixtures once and fail fast on missing prereqs (re-land)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build-rust": "cd rust-parser && cargo build --release",
     "docs:api": "redocly build-docs docs/openapi.yaml -o docs/api.html",
     "docs:api:validate": "redocly lint docs/openapi.yaml",
+    "pretest": "node test/helpers/ensure-prereqs.mjs",
     "test": "node --test --test-reporter=spec \"test/**/*.test.mjs\"",
     "test:unit": "node --test --test-reporter=spec \"test/unit/**/*.test.mjs\"",
     "test:db": "node --test --test-reporter=spec \"test/db/**/*.test.mjs\"",

--- a/test/README.md
+++ b/test/README.md
@@ -39,6 +39,10 @@ node --test "test/db/**/*.test.mjs"   # ad-hoc glob
 node --test --watch "test/unit/**/*.test.mjs"
 ```
 
+`npm test` first runs a `pretest` check ([helpers/ensure-prereqs.mjs](helpers/ensure-prereqs.mjs))
+that pre-builds the fixture library once and fails fast with a clear message when
+a prerequisite is missing — rather than a cryptic error deep into the run.
+
 `unit/` and `db/` need nothing but Node. The `scanner/`, `subsonic/` and
 `integration/` folders boot a server and/or generate fixtures, so they need:
 

--- a/test/helpers/ensure-prereqs.mjs
+++ b/test/helpers/ensure-prereqs.mjs
@@ -1,0 +1,43 @@
+/**
+ * `pretest` guard — runs once before `npm test`.
+ *
+ *   1. Builds the shared fixture library serially, up front. The runner then
+ *      executes test files concurrently; without this each cold-checkout run
+ *      would have many processes racing to encode the same fixtures. (The
+ *      generator is also race-safe on its own — see fixtures.mjs — but doing
+ *      it once here avoids the redundant work and surfaces problems early.)
+ *   2. Fails fast with an actionable message when ffmpeg is missing, instead
+ *      of a cryptic spawn error deep into the suite.
+ *   3. Soft-warns when the optional rust-parser binary is absent — scanner
+ *      parity tests fall back to the JS scanner / skip, so it isn't fatal.
+ */
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ensureFixtures, FIXTURE_SUMMARY } from './fixtures.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+try {
+  const dir = await ensureFixtures();
+  console.log(`✓ fixtures ready — ${FIXTURE_SUMMARY.trackCount} tracks at ${dir}`);
+} catch (err) {
+  console.error(`✗ ${err.message}`);
+  process.exit(1);
+}
+
+const ext  = process.platform === 'win32' ? '.exe' : '';
+const libc = process.platform === 'linux' ? '-musl' : '';
+const rustParser = [
+  path.join(REPO_ROOT, 'rust-parser', 'target', 'release', `rust-parser${ext}`),
+  path.join(REPO_ROOT, 'bin', 'rust-parser',
+    `rust-parser-${process.platform}-${process.arch}${libc}${ext}`),
+].find(p => existsSync(p));
+
+if (rustParser) {
+  console.log(`✓ rust-parser — ${rustParser}`);
+} else {
+  console.log('• rust-parser binary not found — scanner tests use the JS fallback (some may skip).');
+}

--- a/test/helpers/fixtures.mjs
+++ b/test/helpers/fixtures.mjs
@@ -9,6 +9,7 @@
  */
 
 import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -35,6 +36,28 @@ const FIXTURES = [
 const BUNDLED_FFMPEG =
   process.platform === 'win32' ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
                                : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+
+// Fixtures are encoded with mStream's bundled ffmpeg, which is gitignored.
+// A fresh git worktree won't have it, so fail with an actionable message the
+// first time we actually need to encode (rather than a cryptic spawn error
+// deep into a run). Checked once — if every fixture is already cached the
+// suite runs fine without ffmpeg present.
+let ffmpegChecked = false;
+function assertFfmpegAvailable() {
+  if (ffmpegChecked) { return; }
+  if (!existsSync(BUNDLED_FFMPEG)) {
+    throw new Error(
+      `ffmpeg not found at ${BUNDLED_FFMPEG}. Test fixtures are generated with ` +
+      `mStream's bundled ffmpeg (gitignored). In a fresh git worktree, copy ` +
+      `bin/ffmpeg/ from your main checkout before running the suite — see test/README.md.`,
+    );
+  }
+  ffmpegChecked = true;
+}
+
+// Monotonic counter for temp-file names so two encodes in one process never
+// collide on the same temp path (see encode() for why we rename).
+let tmpSeq = 0;
 
 function relPathFor(f) {
   const trackNum = String(f.track).padStart(2, '0');
@@ -82,15 +105,31 @@ async function encode(outPath, f, fixtureIndex) {
   // content correctly share one audio_hash, but we want distinct content
   // here so per-track state stays per-track.
   const freq = 220 + fixtureIndex * 40;  // 220, 260, 300, … Hz
-  await runFfmpeg([
-    '-nostdin', '-y', '-loglevel', 'error',
-    '-f', 'lavfi', '-i', `sine=frequency=${freq}:sample_rate=44100:duration=1`,
-    '-ac', '2',
-    '-c:a', 'libmp3lame', '-b:a', '64k',
-    ...metaArgs,
-    '-id3v2_version', '3',
-    outPath,
-  ]);
+  // Encode to a unique temp file, then atomically rename into place. Test
+  // files run in concurrent child processes, so on a cold checkout several
+  // may try to materialise the same fixture at once; writing ffmpeg's output
+  // straight to outPath would let a scanner read a half-written MP3. Rename is
+  // atomic within the directory, so readers only ever see a complete file. The
+  // `.mp3` suffix is preserved so ffmpeg still infers the mp3 muxer.
+  const tmp = path.join(
+    path.dirname(outPath),
+    `.tmp-${process.pid}-${tmpSeq++}-${path.basename(outPath)}`,
+  );
+  try {
+    await runFfmpeg([
+      '-nostdin', '-y', '-loglevel', 'error',
+      '-f', 'lavfi', '-i', `sine=frequency=${freq}:sample_rate=44100:duration=1`,
+      '-ac', '2',
+      '-c:a', 'libmp3lame', '-b:a', '64k',
+      ...metaArgs,
+      '-id3v2_version', '3',
+      tmp,
+    ]);
+    await fs.rename(tmp, outPath);
+  } catch (err) {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
 }
 
 // Summary of what the test suite will see. Derived from FIXTURES so assertions
@@ -117,6 +156,7 @@ export async function ensureFixtures() {
     const f = FIXTURES[i];
     const full = path.join(MUSIC_DIR, relPathFor(f));
     try { await fs.access(full); continue; } catch { /* need to generate */ }
+    assertFfmpegAvailable();
     await fs.mkdir(path.dirname(full), { recursive: true });
     await encode(full, f, i);
   }


### PR DESCRIPTION
## What

Re-lands the Phase 3 fixture-hardening work that **never reached master**. [#655](https://github.com/IrosTheBeggar/mStream/pull/655) shows as merged, but it was merged into its stacked base branch (`claude/test-folder-taxonomy`) *after* that branch had already merged to master via #654 — so its commit stranded on the orphaned branch. The taxonomy (#654) landed; this hardening did not. This PR cherry-picks the same commit straight onto master.

Identical to the #655 diff — 4 files, +97/−9:

**1. Race-safe fixture generation.** `ensureFixtures()` ([fixtures.mjs](test/helpers/fixtures.mjs)) encoded straight to the final path; with the runner executing files concurrently, a cold checkout could have two processes racing to write the same fixture and a scanner reading a half-written MP3. Now each encode goes to a unique temp file and is **atomically renamed** into place.

**2. Fail fast on missing ffmpeg.** A fresh worktree has no bundled `bin/ffmpeg` — previously a cryptic spawn error deep into the run. Now checked up front with an actionable message ("copy `bin/ffmpeg/` from your main checkout"), only when a fixture actually needs generating.

**3. `pretest` hook.** New [helpers/ensure-prereqs.mjs](test/helpers/ensure-prereqs.mjs) builds the fixture library once, serially, before `npm test` fans out, and soft-warns when the optional rust-parser binary is absent.

## Verification

Cherry-pick applied with no conflicts (its parent — the reorg commit — is already on master). Re-confirmed on top of master: `npm run pretest` builds 9 fixtures + reports rust-parser; `eslint` on both changed files is clean. The underlying change was previously validated in #655 (fail-fast exit 1, 3 concurrent generators leave 9 complete files + 0 temp leftovers, `dlna` scans the renamed fixtures — 75 pass).

> Targets `master` directly (not stacked) to avoid the merge-order trap that stranded #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)