### PR TITLE
test: opt-in scripts + docs for the manual harnesses

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "test:torrent": "node --test --test-reporter=spec \"test/torrent/**/*.test.mjs\"",
     "test:subsonic": "node --test --test-reporter=spec \"test/subsonic/**/*.test.mjs\"",
     "test:integration": "node --test --test-reporter=spec \"test/integration/**/*.test.mjs\"",
-    "test:dlna": "node --test --test-reporter=spec \"test/**/dlna.test.mjs\""
+    "test:dlna": "node --test --test-reporter=spec \"test/**/dlna.test.mjs\"",
+    "test:cli-audio": "docker build -f test/cli-audio/Dockerfile -t mstream-cli-audio-smoke . && docker run --rm mstream-cli-audio-smoke",
+    "test:smoke:docker": "node test/smoke/docker/run-docker-stack-smoke.mjs",
+    "test:smoke:windows": "node test/smoke/windows-native-daemons.mjs"
   },
   "repository": {
     "type": "git",

--- a/test/README.md
+++ b/test/README.md
@@ -25,8 +25,8 @@ Non-test support code lives alongside but is **not** picked up by the runner
 | ------------- | ----------------------------------------------------------------------- |
 | `helpers/`    | Shared harness: server spawner, fixtures, scanner runner, DB snapshot…   |
 | `fixtures/`   | Generated media library (built lazily by ffmpeg, gitignored).            |
-| `smoke/`      | Manual Docker / live-daemon smoke harnesses — run by hand, see their README. |
-| `cli-audio/`  | Manual Docker harness for the mpv/vlc/mplayer/mpd adapters.              |
+| `smoke/`      | Manual live-daemon smoke harnesses (`test:smoke:*`) — see [smoke/README.md](smoke/README.md). |
+| `cli-audio/`  | Manual Docker harness for the mpv/vlc/mplayer/mpd adapters (`test:cli-audio`).           |
 
 ## Running
 
@@ -46,3 +46,18 @@ node --test --watch "test/unit/**/*.test.mjs"
   git worktree won't have it; copy `bin/ffmpeg/` from your main checkout.
 - **rust-parser** (optional) at `bin/rust-parser/` or `rust-parser/target/release/`.
   Scanner-parity tests skip cleanly when it's absent and fall back to the JS scanner.
+
+## Manual harnesses (opt-in)
+
+These exercise real external systems, so they're **not** part of `npm test` —
+run them deliberately:
+
+```bash
+npm run test:cli-audio      # mpv/vlc/mplayer/mpd adapter routing, inside Docker
+npm run test:smoke:docker   # mStream + torrent daemons, all in Docker
+npm run test:smoke:windows  # native-Windows Transmission / qBittorrent
+```
+
+`test:cli-audio` is self-contained (it builds its own image). The two
+`test:smoke:*` harnesses need their daemons brought up first — see
+[smoke/README.md](smoke/README.md).

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -1,0 +1,26 @@
+# Smoke harnesses
+
+Manual, opt-in checks against **live external systems** — Docker'd or
+natively-installed torrent daemons. They are deliberately **not** part of
+`npm test`: they don't match `*.test.mjs`, they need infrastructure the
+unit/integration suite doesn't, and they talk to real daemons over the
+network. Run them by hand when working on the torrent path-handling code.
+
+| Harness | Script | Needs |
+| --- | --- | --- |
+| All-Docker torrent stack (`docker/`) | `npm run test:smoke:docker` | the compose stack up — see [docker/README.md](docker/README.md) |
+| Native-Windows daemons (`windows-native-daemons.mjs`) | `npm run test:smoke:windows` | Transmission / qBittorrent installed on Windows, plus env config |
+
+Each script just runs the harness; bringing the daemons up (and tearing them
+down) is the operator's job. The setup, credentials and env knobs are
+documented at:
+
+- **All-Docker:** [docker/README.md](docker/README.md) — `compose.smoke.yaml` up/down, daemon creds.
+- **Native-Windows:** the header comment of
+  [windows-native-daemons.mjs](windows-native-daemons.mjs) — ports, download
+  dirs, and the `MSTREAM_SECRET` / per-daemon env vars (set a daemon's config
+  to `null` to skip it).
+
+The CLI-audio adapter routing harness is a sibling but self-contained (it runs
+mpv/vlc/mplayer/mpd inside Docker, no external daemons): `npm run test:cli-audio`
+— see [../cli-audio/](../cli-audio/).


### PR DESCRIPTION
## What

Phase 3, item 2 of the test-suite cleanup. The smoke and cli-audio harnesses were runnable only by remembering their bare `node test/…mjs` / `docker` invocations. This makes them **discoverable and consistently named**, while keeping them firmly **out of `npm test`** (they need Docker / live daemons / audio binaries, and aren't `*.test.mjs`).

New opt-in scripts:

| Script | Harness | Needs |
| --- | --- | --- |
| `test:cli-audio` | mpv/vlc/mplayer/mpd adapter routing | Docker (builds its own self-contained image) |
| `test:smoke:docker` | all-Docker mStream + torrent-daemon stack | the `compose.smoke.yaml` stack up |
| `test:smoke:windows` | native-Windows Transmission / qBittorrent | those daemons installed + env config |

Docs:
- New [test/smoke/README.md](test/smoke/README.md) indexing both smoke harnesses, their scripts, and where the setup/credentials live.
- [test/README.md](test/README.md) gains a "Manual harnesses (opt-in)" section and links the scripts from the support-code table.

**No harness code changed** — this is purely discoverability + docs.

## Verification

- `package.json` valid; the three scripts resolve to existing targets (`Dockerfile`, both smoke `.mjs`).
- Default suite unaffected: still **78** files, and `*.test.mjs` globbing picks up **nothing** under `test/smoke/` or `test/cli-audio/`.
- The harnesses themselves need infra this environment lacks, so they weren't executed here: the **Docker daemon isn't running** (the CLI is, and `npm run test:cli-audio` invoked `docker build … && docker run …` correctly before failing to connect), and there are no live torrent daemons. The harness scripts are unchanged from their last working state.

Independent of the other test PRs — targets `master` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)