### PR TITLE
test: extract a shared ffmpeg helper for the fixture generators

### DIFF
--- a/test/helpers/ffmpeg.mjs
+++ b/test/helpers/ffmpeg.mjs
@@ -1,0 +1,91 @@
+/**
+ * Shared ffmpeg plumbing for the two fixture generators (fixtures.mjs and
+ * library-gen.mjs). Keeps the bundled-binary path, the spawn wrapper, the
+ * "missing ffmpeg" check, and the race-safe tone encoder in one place so the
+ * two generators can't drift apart.
+ */
+
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// mStream's bundled ffmpeg. Gitignored, so a fresh worktree won't have it.
+export const BUNDLED_FFMPEG =
+  process.platform === 'win32' ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
+                               : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+
+// Fail with an actionable message rather than a cryptic spawn error deep into a
+// run. Cached per-path so repeated calls are free.
+const verified = new Set();
+export function assertFfmpegAvailable(ffmpegPath = BUNDLED_FFMPEG) {
+  if (verified.has(ffmpegPath)) { return; }
+  if (!existsSync(ffmpegPath)) {
+    throw new Error(
+      `ffmpeg not found at ${ffmpegPath}. Test fixtures are generated with ` +
+      `mStream's bundled ffmpeg (gitignored). In a fresh git worktree, copy ` +
+      `bin/ffmpeg/ from your main checkout before running the suite — see test/README.md.`,
+    );
+  }
+  verified.add(ffmpegPath);
+}
+
+// Resolves on exit 0; rejects on non-zero with the tail of stderr. Suppresses
+// stdout (we don't need the encode logs).
+export function runFfmpeg(ffmpegPath, args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(ffmpegPath, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    p.stderr.on('data', d => { stderr += d.toString(); });
+    p.on('error', reject);
+    p.on('exit', code => {
+      if (code === 0) { resolve(); }
+      else { reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-500)}`)); }
+    });
+  });
+}
+
+// Monotonic counter so two encodes in one process never collide on a temp path.
+let tmpSeq = 0;
+
+/**
+ * Encode a stereo sine-tone MP3 (ID3v2.3 tags) to `outPath`, race-safely.
+ *
+ * Test files run in concurrent child processes, so on a cold checkout several
+ * may try to materialise the same file at once; writing ffmpeg's output
+ * straight to outPath would let a reader (e.g. the scanner) see a half-written
+ * MP3. We encode to a unique temp file and atomically rename into place — the
+ * `.mp3` suffix is preserved so ffmpeg still infers the mp3 muxer.
+ *
+ * @param {object}   o
+ * @param {string}   o.outPath          Final destination path.
+ * @param {number}   o.freq             Sine frequency in Hz.
+ * @param {number}   [o.duration=1]     Duration in seconds.
+ * @param {string[]} [o.metaArgs=[]]    Flat array of ffmpeg `-metadata` args.
+ * @param {string}   [o.ffmpegPath]     ffmpeg binary (defaults to bundled).
+ */
+export async function encodeTone({ outPath, freq, duration = 1, metaArgs = [], ffmpegPath = BUNDLED_FFMPEG }) {
+  const tmp = path.join(
+    path.dirname(outPath),
+    `.tmp-${process.pid}-${tmpSeq++}-${path.basename(outPath)}`,
+  );
+  try {
+    await runFfmpeg(ffmpegPath, [
+      '-nostdin', '-y', '-loglevel', 'error',
+      '-f', 'lavfi', '-i', `sine=frequency=${freq}:sample_rate=44100:duration=${duration}`,
+      '-ac', '2',
+      '-c:a', 'libmp3lame', '-b:a', '64k',
+      ...metaArgs,
+      '-id3v2_version', '3',
+      tmp,
+    ]);
+    await fs.rename(tmp, outPath);
+  } catch (err) {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
+}

--- a/test/helpers/fixtures.mjs
+++ b/test/helpers/fixtures.mjs
@@ -9,10 +9,9 @@
  */
 
 import fs from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { assertFfmpegAvailable, encodeTone } from './ffmpeg.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -33,49 +32,10 @@ const FIXTURES = [
   { artist: 'Vosto',  album: 'Untitled EP',       year: null, genre: null,         disc: 1, track: 1, title: 'Sketch 1' },
 ];
 
-const BUNDLED_FFMPEG =
-  process.platform === 'win32' ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
-                               : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
-
-// Fixtures are encoded with mStream's bundled ffmpeg, which is gitignored.
-// A fresh git worktree won't have it, so fail with an actionable message the
-// first time we actually need to encode (rather than a cryptic spawn error
-// deep into a run). Checked once — if every fixture is already cached the
-// suite runs fine without ffmpeg present.
-let ffmpegChecked = false;
-function assertFfmpegAvailable() {
-  if (ffmpegChecked) { return; }
-  if (!existsSync(BUNDLED_FFMPEG)) {
-    throw new Error(
-      `ffmpeg not found at ${BUNDLED_FFMPEG}. Test fixtures are generated with ` +
-      `mStream's bundled ffmpeg (gitignored). In a fresh git worktree, copy ` +
-      `bin/ffmpeg/ from your main checkout before running the suite — see test/README.md.`,
-    );
-  }
-  ffmpegChecked = true;
-}
-
-// Monotonic counter for temp-file names so two encodes in one process never
-// collide on the same temp path (see encode() for why we rename).
-let tmpSeq = 0;
-
 function relPathFor(f) {
   const trackNum = String(f.track).padStart(2, '0');
   const safe = s => s.replace(/[/\\:*?"<>|]/g, '_');
   return path.join(safe(f.artist), safe(f.album), `${trackNum} - ${safe(f.title)}.mp3`);
-}
-
-function runFfmpeg(args) {
-  return new Promise((resolve, reject) => {
-    const p = spawn(BUNDLED_FFMPEG, args, { stdio: ['ignore', 'ignore', 'pipe'] });
-    let stderr = '';
-    p.stderr.on('data', d => { stderr += d.toString(); });
-    p.on('error', reject);
-    p.on('exit', code => {
-      if (code === 0) { resolve(); }
-      else { reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-500)}`)); }
-    });
-  });
 }
 
 async function encode(outPath, f, fixtureIndex) {
@@ -105,31 +65,7 @@ async function encode(outPath, f, fixtureIndex) {
   // content correctly share one audio_hash, but we want distinct content
   // here so per-track state stays per-track.
   const freq = 220 + fixtureIndex * 40;  // 220, 260, 300, … Hz
-  // Encode to a unique temp file, then atomically rename into place. Test
-  // files run in concurrent child processes, so on a cold checkout several
-  // may try to materialise the same fixture at once; writing ffmpeg's output
-  // straight to outPath would let a scanner read a half-written MP3. Rename is
-  // atomic within the directory, so readers only ever see a complete file. The
-  // `.mp3` suffix is preserved so ffmpeg still infers the mp3 muxer.
-  const tmp = path.join(
-    path.dirname(outPath),
-    `.tmp-${process.pid}-${tmpSeq++}-${path.basename(outPath)}`,
-  );
-  try {
-    await runFfmpeg([
-      '-nostdin', '-y', '-loglevel', 'error',
-      '-f', 'lavfi', '-i', `sine=frequency=${freq}:sample_rate=44100:duration=1`,
-      '-ac', '2',
-      '-c:a', 'libmp3lame', '-b:a', '64k',
-      ...metaArgs,
-      '-id3v2_version', '3',
-      tmp,
-    ]);
-    await fs.rename(tmp, outPath);
-  } catch (err) {
-    await fs.rm(tmp, { force: true }).catch(() => {});
-    throw err;
-  }
+  await encodeTone({ outPath, freq, metaArgs });
 }
 
 // Summary of what the test suite will see. Derived from FIXTURES so assertions

--- a/test/helpers/library-gen.mjs
+++ b/test/helpers/library-gen.mjs
@@ -35,15 +35,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
-
-const DEFAULT_FFMPEG =
-  process.platform === 'win32' ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
-                               : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+import { encodeTone, BUNDLED_FFMPEG } from './ffmpeg.mjs';
 
 /**
  * Convenience helper — builds a spec object with the common ID3 fields
@@ -128,23 +120,6 @@ export function mkSpec(opts) {
 }
 
 /**
- * Run ffmpeg with the given args. Resolves on exit 0; rejects on non-zero
- * with the tail of stderr. Suppresses stdout (we don't need the encode logs).
- */
-function runFfmpeg(ffmpegPath, args) {
-  return new Promise((resolve, reject) => {
-    const p = spawn(ffmpegPath, args, { stdio: ['ignore', 'ignore', 'pipe'] });
-    let stderr = '';
-    p.stderr.on('data', d => { stderr += d.toString(); });
-    p.on('error', reject);
-    p.on('exit', code => {
-      if (code === 0) { resolve(); }
-      else { reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-500)}`)); }
-    });
-  });
-}
-
-/**
  * Encode a single spec to disk.
  *
  * ID3v2 version 3 is hard-coded — matches what fixtures.mjs uses and what
@@ -152,21 +127,22 @@ function runFfmpeg(ffmpegPath, args) {
  * weaker compatibility across the long tail of consumer tools, so the
  * fixture path stays on v3 for parity with what real-world libraries
  * predominantly look like.
+ *
+ * The actual encode — and its race-safe temp-file + atomic rename — lives in
+ * the shared ffmpeg helper, so this and fixtures.mjs stay in lock-step.
  */
 async function encodeSpec(spec, outPath, ffmpegPath) {
   const metaArgs = [];
   for (const [key, value] of Object.entries(spec.tags || {})) {
     metaArgs.push('-metadata', `${key}=${value}`);
   }
-  await runFfmpeg(ffmpegPath, [
-    '-nostdin', '-y', '-loglevel', 'error',
-    '-f', 'lavfi', '-i', `sine=frequency=${spec.toneFreq}:sample_rate=44100:duration=${spec.duration}`,
-    '-ac', '2',
-    '-c:a', 'libmp3lame', '-b:a', '64k',
-    ...metaArgs,
-    '-id3v2_version', '3',
+  await encodeTone({
     outPath,
-  ]);
+    freq: spec.toneFreq,
+    duration: spec.duration,
+    metaArgs,
+    ffmpegPath,
+  });
 }
 
 /**
@@ -191,7 +167,7 @@ async function encodeSpec(spec, outPath, ffmpegPath) {
 export async function generateLibrary({
   outputDir,
   specs,
-  ffmpegPath = DEFAULT_FFMPEG,
+  ffmpegPath = BUNDLED_FFMPEG,
   skipExisting = true,
   cleanFirst = false,
 } = {}) {
@@ -225,4 +201,4 @@ export async function generateLibrary({
   return { outputDir, generated, skipped };
 }
 
-export const DEFAULT_FFMPEG_PATH = DEFAULT_FFMPEG;
+export const DEFAULT_FFMPEG_PATH = BUNDLED_FFMPEG;


### PR DESCRIPTION
## What

Phase 3, item 3 — the optional dedup. [fixtures.mjs](test/helpers/fixtures.mjs) and [library-gen.mjs](test/helpers/library-gen.mjs) each carried their own copy of three things: the bundled-ffmpeg path, the `spawn` wrapper, and the sine-tone encode args. This pulls them into one module, [test/helpers/ffmpeg.mjs](test/helpers/ffmpeg.mjs):

- `BUNDLED_FFMPEG` — the gitignored bundled-binary path, now in **one** place
- `assertFfmpegAvailable(path?)` — the fail-fast "missing ffmpeg" check
- `runFfmpeg(path, args)` — the spawn wrapper
- `encodeTone({ outPath, freq, duration, metaArgs, ffmpegPath })` — race-safe encode (temp file + atomic rename)

Both generators now delegate to it.

## Why it's more than tidiness

`library-gen.mjs` previously wrote ffmpeg's output **straight to the final path**. Routing it through `encodeTone` means it now inherits the **temp-file + atomic-rename** race-safety that `fixtures.mjs` got in #656 — so concurrent generators can't leave a half-written MP3. And the bundled path living in one spot is the natural home for the **env-overridable ffmpeg path** that Phase 1 (CI) will need.

Net: −116 lines of duplication for +91 shared (3 files, +105/−102).

## No behavior change

Identical ffmpeg args, and the public surface is untouched — `ensureFixtures` / `FIXTURE_SUMMARY` / `mkSpec` / `generateLibrary` / `DEFAULT_FFMPEG_PATH` all unchanged. `library-gen` keeps its own tailored upfront ffmpeg-missing message.

## Verification

| Check | Result |
| --- | --- |
| `eslint` on all 3 files | ✓ clean |
| Force fixtures regen → `npm run pretest` | ✓ 9 fixtures via the shared `encodeTone` |
| `dlna` (scans the rebuilt fixtures) | ✓ 75 pass |
| `library-gen` smoke: 2 concurrent `generateLibrary` runs | ✓ 3 valid files, **0 temp leftovers**, atomic |

> Scope is the two generators the plan named. `scanner-fixture.mjs` has its own multi-format (flac/ogg/m4a/wav + embedded art) encodes that don't fit the MP3-sine `encodeTone`, so it's intentionally left alone.

Independent of the other test PRs — targets `master` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)