### PR TITLE
ci: drop the macOS from-source rust-parser workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,17 +91,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # The committed darwin rust-parser binary crashes on some inputs (e.g.
-      # m4a) on the arm64 runner; build a fresh one from source (cargo is
-      # preinstalled). findRustParser prefers rust-parser/target/release, so the
-      # scanner-parity tests use it. Linux/Windows keep the committed binaries.
-      - name: Build rust-parser (macOS)
-        if: runner.os == 'macOS'
-        run: cargo build --release --manifest-path rust-parser/Cargo.toml
-
       # Build the fixture library once (normally npm's `pretest`), then run this
-      # shard. On Linux/Windows the committed rust-parser binary drives the
-      # scanner-parity tests; if it were absent they'd skip / use the JS scanner.
+      # shard. The committed rust-parser binary drives the scanner-parity tests
+      # on every OS — including macOS/arm64: the prebuilt binaries are now
+      # self-tested at build time (see build-rust-parser.yml), so the old
+      # macOS-only from-source rebuild is gone. If the binary were absent the
+      # parity tests would skip / fall back to the JS scanner.
       - name: Build fixtures
         run: npm run pretest
 


### PR DESCRIPTION
Targets the **#659** branch (`claude/ci-test-workflow`), not master — merge this into #659 (or cherry-pick) to remove the macOS-only from-source rebuild of rust-parser.

## Why this is safe now

The macOS `Build rust-parser` step was a workaround for the committed `bin/rust-parser/rust-parser-darwin-arm64` once producing no output on some inputs on the arm64 runner. That **no longer reproduces** on the current `macos-latest` (macOS 15.7.7):

- The two affected tests pass against the **committed** binary, nothing skipped: `audio-hash-parity` (all formats incl. m4a) + `scanner-multi-art` → **25/25**.
- A clean from-source rebuild is **byte-identical** to the committed binary.
- The binary is `minos 11.0`, links only libSystem — no deployment-target/dylib gating.

The original failure was tied to a since-superseded runner-image snapshot, not the committed bytes.

## What changes

- Remove the `Build rust-parser (macOS)` from-source step. macOS now exercises the **committed** binary like Linux/Windows (so a future regression fails loudly instead of being masked).
- Update the adjacent `Build fixtures` comment.

## Pairs with

[#660](https://github.com/IrosTheBeggar/mStream/pull/660) adds a build-time self-test to `build-rust-parser.yml`, so the prebuilt binaries are verified to actually run before they're committed — making this from-source rebuild redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)