### PR TITLE
feat(db): V53 — lyrics provenance + lyrics search column

### DIFF
--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -40,7 +40,10 @@
 // V52 repairs canonical-hash drift in the user-state tables: mis-keyed
 // rows re-keyed (with merge), '' hashes normalized to NULL, dead all-null
 // rows dropped, user_bookmarks gains its rekey index. See SCHEMA_V52.
-export const SCHEMA_VERSION = 52;
+// V53 adds tracks.lyrics_source (lyrics provenance, mirrors album_art_source)
+// and rebuilds fts_tracks with a denormalised `lyrics` column + recreated
+// tracks_*_fts triggers, so a song is findable by a lyric line. See SCHEMA_V53.
+export const SCHEMA_VERSION = 53;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -1944,6 +1947,83 @@ export const SCHEMA_V52 = `
   CREATE INDEX IF NOT EXISTS idx_user_bookmarks_hash ON user_bookmarks(track_hash);
 `;
 
+export const SCHEMA_V53 = `
+  -- ── Lyrics provenance + lyrics full-text search ──────────────────────
+  --
+  -- PART 1 (FTS-independent): tracks.lyrics_source records where a track's
+  -- lyrics came from. A future proactive lyrics backfill fills the lyrics_*
+  -- columns for lyric-less tracks; this provenance lets the scanner's UPSERT
+  -- keep a backfilled value instead of NULLing it on the next rescan — the
+  -- exact role album_art_source plays for art (V48). 'embedded'/'sidecar'
+  -- = scanner-owned (local to the file); a provider name (e.g. 'lrclib')
+  -- = backfill-owned. Backfilled here from the existing V19 lyrics columns,
+  -- computed from data already in the DB — so NOT rescanRequired. (NULL is
+  -- safe for the eventual guard too; this just makes intent explicit and
+  -- the column queryable from day one.)
+  ALTER TABLE tracks ADD COLUMN lyrics_source TEXT;
+  UPDATE tracks SET lyrics_source = CASE
+    WHEN lyrics_sidecar_mtime IS NOT NULL                              THEN 'sidecar'
+    WHEN lyrics_embedded IS NOT NULL OR lyrics_synced_lrc IS NOT NULL  THEN 'embedded'
+    ELSE NULL
+  END;
+
+  -- PART 2: add a denormalised \`lyrics\` column to fts_tracks so a song is
+  -- findable by a remembered line. FTS5 has no ALTER TABLE ADD COLUMN, so a
+  -- column add means drop + recreate + repopulate. The three tracks_*_fts
+  -- triggers carry the new value and must be recreated too (the artists_/
+  -- albums_ fan-out triggers touch only artist_name/album_name and are left
+  -- untouched; FTS5 has no external indexes to rebuild). Assumes FTS5 — same
+  -- as V31, which creates these tables unguarded; node:sqlite always bundles
+  -- it. The indexed value is COALESCE(lyrics_embedded, lyrics_synced_lrc):
+  -- plain wins, else the synced LRC text (its [mm:ss.xx] stamps are non-alnum
+  -- and tokenise away, leaving the words searchable). Mirrors the V31 backfill
+  -- join (LEFT JOIN keeps NULL-FK rows). See the trigger-survival note up top.
+  DROP TRIGGER tracks_ai_fts;
+  DROP TRIGGER tracks_au_fts;
+  DROP TRIGGER tracks_ad_fts;
+  DROP TABLE fts_tracks;
+
+  CREATE VIRTUAL TABLE fts_tracks USING fts5(
+    title, artist_name, album_name, filepath, lyrics,
+    tokenize = 'unicode61 remove_diacritics 1'
+  );
+
+  INSERT INTO fts_tracks(rowid, title, artist_name, album_name, filepath, lyrics)
+    SELECT t.id, t.title, a.name, al.name, t.filepath,
+           COALESCE(t.lyrics_embedded, t.lyrics_synced_lrc)
+    FROM tracks t
+    LEFT JOIN artists a  ON a.id  = t.artist_id
+    LEFT JOIN albums  al ON al.id = t.album_id;
+
+  CREATE TRIGGER tracks_ai_fts AFTER INSERT ON tracks BEGIN
+    INSERT INTO fts_tracks(rowid, title, artist_name, album_name, filepath, lyrics)
+    VALUES (
+      NEW.id,
+      NEW.title,
+      (SELECT name FROM artists WHERE id = NEW.artist_id),
+      (SELECT name FROM albums  WHERE id = NEW.album_id),
+      NEW.filepath,
+      COALESCE(NEW.lyrics_embedded, NEW.lyrics_synced_lrc)
+    );
+  END;
+
+  CREATE TRIGGER tracks_ad_fts AFTER DELETE ON tracks BEGIN
+    DELETE FROM fts_tracks WHERE rowid = OLD.id;
+  END;
+
+  -- lyrics_embedded / lyrics_synced_lrc join the UPDATE OF allowlist so a
+  -- lyrics write reindexes; without them the denormalised copy goes stale.
+  CREATE TRIGGER tracks_au_fts AFTER UPDATE OF title, artist_id, album_id, filepath, lyrics_embedded, lyrics_synced_lrc ON tracks BEGIN
+    UPDATE fts_tracks
+       SET title       = NEW.title,
+           artist_name = (SELECT name FROM artists WHERE id = NEW.artist_id),
+           album_name  = (SELECT name FROM albums  WHERE id = NEW.album_id),
+           filepath    = NEW.filepath,
+           lyrics      = COALESCE(NEW.lyrics_embedded, NEW.lyrics_synced_lrc)
+     WHERE rowid = NEW.id;
+  END;
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -2125,4 +2205,11 @@ export const MIGRATIONS = [
   // re-keyed with merge, '' hashes normalized, dead rows dropped) and
   // adds the bookmarks rekey index. No rescan: rows only. See SCHEMA_V52.
   { version: 52, sql: SCHEMA_V52 },
+  // V53 adds tracks.lyrics_source (lyrics provenance for the proactive
+  // lyrics backfill, mirroring album_art_source) and rebuilds fts_tracks
+  // with a denormalised `lyrics` column — plus the three recreated
+  // tracks_*_fts triggers — so a song is findable by a remembered line.
+  // lyrics_source is backfilled from the existing V19 lyrics columns and
+  // the FTS index repopulates in-migration; no rescan. See SCHEMA_V53.
+  { version: 53, sql: SCHEMA_V53 },
 ];

--- a/test/db-fts5-lyrics.test.mjs
+++ b/test/db-fts5-lyrics.test.mjs
@@ -1,0 +1,197 @@
+/**
+ * V53 lyrics tests: tracks.lyrics_source provenance + the lyrics column
+ * on fts_tracks.
+ *
+ * Three angles:
+ *   1. Schema shape after all migrations (column + recreated triggers).
+ *   2. Backfill correctness on an upgrade from v52 (lyrics_source derived
+ *      from the existing V19 lyrics columns; fts_tracks.lyrics repopulated
+ *      via COALESCE; the other FTS columns survive the table rebuild).
+ *   3. Steady-state triggers keep fts_tracks.lyrics in sync on
+ *      insert/update, with embedded-over-synced COALESCE precedence.
+ *
+ * Same strategy as db-fts5-backfill.test.mjs: stop the runner at the
+ * version before the one under test, seed deterministic fixture data,
+ * then apply the target migration in isolation and inspect the result.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+
+import { SCHEMA_VERSION, MIGRATIONS } from '../src/db/schema.js';
+import { applyAllMigrations } from './helpers/apply-migrations.mjs';
+
+function freshDbAllMigrations() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA recursive_triggers = ON');
+  applyAllMigrations(db);
+  return db;
+}
+
+function getV53() {
+  const v53 = MIGRATIONS.find(m => m.version === 53);
+  if (!v53) throw new Error('V53 migration not found');
+  return v53;
+}
+
+// Seed a library + artist + album on a db migrated up to v52, returning ids.
+function seedV52(db) {
+  const libId = Number(db.prepare('INSERT INTO libraries (name, root_path) VALUES (?, ?)').run('Music', '/music').lastInsertRowid);
+  const artistId = Number(db.prepare('INSERT INTO artists (name) VALUES (?)').run('John Lennon').lastInsertRowid);
+  const albumId = Number(db.prepare('INSERT INTO albums (name, artist_id, year) VALUES (?, ?, ?)').run('Imagine', artistId, 1971).lastInsertRowid);
+  return { libId, artistId, albumId };
+}
+
+describe('V53 schema shape', () => {
+  test('SCHEMA_VERSION is 53 and is the last migration', () => {
+    assert.equal(SCHEMA_VERSION, 53);
+    assert.equal(MIGRATIONS[MIGRATIONS.length - 1].version, 53);
+  });
+
+  test('tracks gains a lyrics_source column', () => {
+    const db = freshDbAllMigrations();
+    const cols = db.prepare('PRAGMA table_info(tracks)').all().map(c => c.name);
+    assert.ok(cols.includes('lyrics_source'), 'tracks.lyrics_source missing');
+    db.close();
+  });
+
+  test('fts_tracks gains a lyrics column (5 columns total)', () => {
+    const db = freshDbAllMigrations();
+    const cols = db.prepare('PRAGMA table_info(fts_tracks)').all().map(c => c.name);
+    assert.deepEqual(cols, ['title', 'artist_name', 'album_name', 'filepath', 'lyrics']);
+    db.close();
+  });
+
+  test('all nine FTS sync triggers still exist after the rebuild', () => {
+    const db = freshDbAllMigrations();
+    const triggers = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'trigger' AND name LIKE '%_fts' ORDER BY name"
+    ).all().map(r => r.name);
+    assert.deepEqual(triggers, [
+      'albums_ad_fts', 'albums_ai_fts', 'albums_au_fts',
+      'artists_ad_fts', 'artists_ai_fts', 'artists_au_fts',
+      'tracks_ad_fts', 'tracks_ai_fts', 'tracks_au_fts',
+    ]);
+    db.close();
+  });
+
+  test('tracks_au_fts watches the lyrics columns in its UPDATE OF allowlist', () => {
+    const db = freshDbAllMigrations();
+    const sql = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='trigger' AND name='tracks_au_fts'"
+    ).get().sql;
+    assert.match(sql, /UPDATE OF title, artist_id, album_id, filepath, lyrics_embedded, lyrics_synced_lrc/i);
+    db.close();
+  });
+});
+
+describe('V53 lyrics_source backfill (upgrade from v52)', () => {
+  function seedAndUpgrade() {
+    const db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    db.exec('PRAGMA recursive_triggers = ON');
+    applyAllMigrations(db, { upToVersion: 52 });
+    const { libId, artistId, albumId } = seedV52(db);
+
+    const ins = db.prepare(
+      `INSERT INTO tracks (filepath, library_id, title, artist_id, album_id,
+         lyrics_embedded, lyrics_synced_lrc, lyrics_sidecar_mtime)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    // A: plain embedded only.
+    const aId = Number(ins.run('a.flac', libId, 'Imagine', artistId, albumId,
+      'imagine all the people living life in peace', null, null).lastInsertRowid);
+    // B: synced-only tag (no sidecar mtime).
+    const bId = Number(ins.run('b.flac', libId, 'Mind Games', artistId, albumId,
+      null, '[00:12.00]love is the answer and you know that for sure', null).lastInsertRowid);
+    // C: sidecar (synced text + a sidecar mtime).
+    const cId = Number(ins.run('c.flac', libId, 'Jealous Guy', artistId, albumId,
+      null, '[00:05.00]i was dreaming of the past', 1700000000000).lastInsertRowid);
+    // D: no lyrics at all.
+    const dId = Number(ins.run('d.flac', libId, 'Instrumental', artistId, albumId,
+      null, null, null).lastInsertRowid);
+
+    const v53 = getV53();
+    db.exec('BEGIN'); db.exec(v53.sql); db.exec('PRAGMA user_version = 53'); db.exec('COMMIT');
+    return { db, aId, bId, cId, dId };
+  }
+
+  test('lyrics_source is derived: embedded / sidecar / NULL', () => {
+    const { db, aId, bId, cId, dId } = seedAndUpgrade();
+    const src = id => db.prepare('SELECT lyrics_source FROM tracks WHERE id = ?').get(id).lyrics_source;
+    assert.equal(src(aId), 'embedded', 'plain embedded → embedded');
+    assert.equal(src(bId), 'embedded', 'synced tag (no sidecar) → embedded');
+    assert.equal(src(cId), 'sidecar', 'sidecar mtime present → sidecar');
+    assert.equal(src(dId), null, 'no lyrics → NULL');
+    db.close();
+  });
+
+  test('fts_tracks.lyrics is repopulated via COALESCE(embedded, synced)', () => {
+    const { db, aId, bId, dId } = seedAndUpgrade();
+    const lyr = id => db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics;
+    assert.match(lyr(aId), /imagine all the people/);
+    assert.match(lyr(bId), /love is the answer/, 'synced text falls through COALESCE');
+    assert.equal(lyr(dId), null, 'lyric-less track has NULL lyrics in the index');
+    db.close();
+  });
+
+  test('lyrics are searchable after the upgrade, and existing columns survive the rebuild', () => {
+    const { db, aId } = seedAndUpgrade();
+    // A lyric word that appears in no title/artist/album.
+    const lyricHits = db.prepare("SELECT rowid FROM fts_tracks WHERE fts_tracks MATCH 'peace'").all();
+    assert.equal(lyricHits.length, 1);
+    assert.equal(lyricHits[0].rowid, aId);
+    // The rebuild preserved the denormalised artist_name (search still works).
+    const artistHits = db.prepare("SELECT COUNT(*) AS c FROM fts_tracks WHERE fts_tracks MATCH 'lennon'").get().c;
+    assert.equal(artistHits, 4, 'all four seeded tracks still searchable by artist');
+    db.close();
+  });
+});
+
+describe('V53 fts_tracks lyrics triggers (steady state)', () => {
+  function seedTrack(db, { embedded = null, synced = null } = {}) {
+    const libId = Number(db.prepare('INSERT INTO libraries (name, root_path) VALUES (?, ?)').run('Music', '/music').lastInsertRowid);
+    return Number(db.prepare(
+      `INSERT INTO tracks (filepath, library_id, title, lyrics_embedded, lyrics_synced_lrc)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('t.flac', libId, 'Track', embedded, synced).lastInsertRowid);
+  }
+
+  test('insert trigger indexes lyrics; track is matchable by a lyric word', () => {
+    const db = freshDbAllMigrations();
+    const id = seedTrack(db, { embedded: 'here comes the sunshine after the rain' });
+    assert.match(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics, /sunshine/);
+    const hits = db.prepare("SELECT rowid FROM fts_tracks WHERE fts_tracks MATCH 'sunshine'").all();
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].rowid, id);
+    db.close();
+  });
+
+  test('updating lyrics_embedded reindexes (old text no longer matches)', () => {
+    const db = freshDbAllMigrations();
+    const id = seedTrack(db, { embedded: 'first version of the words' });
+    db.prepare('UPDATE tracks SET lyrics_embedded = ? WHERE id = ?').run('totally different replacement text', id);
+    assert.equal(db.prepare("SELECT COUNT(*) AS c FROM fts_tracks WHERE fts_tracks MATCH 'first'").get().c, 0);
+    assert.equal(db.prepare("SELECT COUNT(*) AS c FROM fts_tracks WHERE fts_tracks MATCH 'replacement'").get().c, 1);
+    db.close();
+  });
+
+  test('COALESCE precedence: embedded wins; clearing it surfaces the synced text', () => {
+    const db = freshDbAllMigrations();
+    const id = seedTrack(db, { embedded: 'plainword here', synced: '[00:01.00]syncedword here' });
+    assert.match(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics, /plainword/);
+    db.prepare('UPDATE tracks SET lyrics_embedded = NULL WHERE id = ?').run(id);
+    assert.match(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics, /syncedword/);
+    db.close();
+  });
+
+  test('a non-allowlisted column update does not disturb the indexed lyrics', () => {
+    const db = freshDbAllMigrations();
+    const id = seedTrack(db, { embedded: 'stable lyric content' });
+    db.prepare('UPDATE tracks SET year = ? WHERE id = ?').run(1999, id);
+    assert.match(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics, /stable lyric content/);
+    db.close();
+  });
+});

--- a/test/db/db-v48-multi-art.test.mjs
+++ b/test/db/db-v48-multi-art.test.mjs
@@ -163,7 +163,7 @@ describe('V48 schema shape', () => {
     // V48 that smuggles in (or drops) a column surfaces here.
     const cols = (db, table) => db.prepare(`PRAGMA table_info(${table})`).all().map(c => c.name).sort();
     const before = freshDb({ upToVersion: 47 });
-    const after = freshDb();
+    const after = freshDb({ upToVersion: 48 });
     assert.deepEqual(
       cols(after, 'tracks').filter(c => !cols(before, 'tracks').includes(c)),
       ['album_art_pinned', 'album_art_source']

--- a/test/db/db-v52-hash-repair.test.mjs
+++ b/test/db/db-v52-hash-repair.test.mjs
@@ -84,7 +84,7 @@ describe('V52 schema shape', () => {
     const v52 = MIGRATIONS.find(m => m.version === 52);
     assert.ok(v52, 'missing v52');
     assert.ok(!v52.rescanRequired, 'V52 repairs rows only — no rescan');
-    assert.equal(SCHEMA_VERSION, 52);
+    assert.ok(SCHEMA_VERSION >= 52, `SCHEMA_VERSION = ${SCHEMA_VERSION}`);
   });
 });
 


### PR DESCRIPTION
## What & why

First PR toward making **lyrics a first-class, searchable feature**. This is the **schema foundation only** — migration **V53**:

1. **`tracks.lyrics_source`** — provenance for a track's lyrics. `'embedded'`/`'sidecar'` = scanner-owned (from the file's tags or a `.lrc`/`.txt` sidecar); a provider name (e.g. `'lrclib'`) = fetched by the upcoming backfill. Mirrors V48's `album_art_source`, and is what will let a later rescan **preserve** backfilled lyrics instead of NULLing them. Backfilled here from the existing V19 lyrics columns; no rescan.
2. **`fts_tracks.lyrics`** — a denormalised lyrics column on the FTS5 index so a song can be found by a remembered line. FTS5 has no `ALTER TABLE ADD COLUMN`, so the table is dropped, recreated with the new column, repopulated via `COALESCE(lyrics_embedded, lyrics_synced_lrc)` (mirroring the V31 backfill join), and its three `tracks_*_fts` triggers recreated — with `lyrics_embedded, lyrics_synced_lrc` added to the `tracks_au_fts` `UPDATE OF` allowlist so lyric edits reindex.

Nothing reads these yet — this PR is intentionally foundational and low-risk.

## Scope / deferred

Per the agreed plan, follow-up PRs add: the proactive multi-provider lyrics-backfill worker (LRCLib + opt-in NetEase/Kugou), the provider lib, the scanner clobber-guard (`lyrics_source` CASE in both the JS + Rust scanners), the new `lyrics` search category, config + admin, and removal of the reactive LRCLib path.

## Design notes

- **No `lyrics_pinned`** (unlike album art): there's no user lyrics-edit flow to honor it yet, and `lyrics_source` alone covers scanner↔backfill coordination. Trivial to add later.
- **Assumes FTS5**, exactly like V31 (whose `CREATE VIRTUAL TABLE` is itself unguarded). `node:sqlite` always bundles FTS5, and a SQL-level `IF NOT EXISTS` wouldn't suppress a missing-module error anyway.
- **Existing search is unaffected** — every `fts_tracks` consumer uses column-scoped MATCH (`{title}`/`{filepath}`) or is column-agnostic; none read columns positionally.

## Testing

- New `test/db-fts5-lyrics.test.mjs`: schema shape, upgrade-from-V52 backfill (`embedded`/`sidecar`/NULL), COALESCE repopulate, steady-state triggers (insert/update reindex, embedded-over-synced precedence, allowlist).
- De-brittled two head-of-chain assertions that hard-coded V52 as latest: `db-v52-hash-repair` → floor check (matching every other version test), and `db-v48-multi-art`'s column-delta pinned to `upToVersion: 48`.
- `node --test` across all `db-*`, `search-*`, `subsonic-search`, `scanner-schema-guard`, `hash-migration`, `waveform-scan`: **188 passing, 0 failing**. Changed files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)