### PR TITLE
fix(replaygain): apply real track gain in the web player + related fixes

### DIFF
--- a/src/api/db.js
+++ b/src/api/db.js
@@ -32,7 +32,7 @@ export function renderMetadataObj(row) {
       rating: row.rating || null,
       'play-count': row.play_count || null,
       'last-played': row.last_played || null,
-      'replaygain-track': row.replaygain_track_db || null,
+      'replaygain-track': row.replaygain_track_db ?? null,
       // V32 columns surfaced for client-side Auto-DJ. The webapp uses
       // these to display "128 BPM · A minor (8A)" pills and to drive
       // the BPM-continuity / harmonic-mixing toggles (build a request

--- a/src/api/ytdl.js
+++ b/src/api/ytdl.js
@@ -712,7 +712,7 @@ export function setup(mstream) {
         userMeta.title || metadata.title || null, artistId, albumId,
         metadata.track?.no || null, metadata.disk?.no || null,
         metadata.year || null, expectedExt, hash, audioHash || null,
-        aaFile, null,
+        aaFile, (metadata.replaygain_track_gain ? metadata.replaygain_track_gain.dB : null),
         Date.now(), null, 'ytdl'
       );
     }

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -429,7 +429,7 @@ const VUEPLAYERCORE = (() => {
         MSTREAMPLAYER.setReplayGainActive(localStorage.getItem("replayGain") == "true");
 
         const rgPregain = Number(localStorage.getItem("replayGainPreGainDb"));
-        MSTREAMPLAYER.setReplayGainPreGainDb(rgPregain === NaN ? 0 : rgPregain);
+        MSTREAMPLAYER.setReplayGainPreGainDb(Number.isNaN(rgPregain) ? 0 : rgPregain);
       }
     },
     computed: {

--- a/webapp/assets/js/mstream.player.js
+++ b/webapp/assets/js/mstream.player.js
@@ -31,7 +31,11 @@ const MSTREAMPLAYER = (() => {
     }
     mstreamModule.playerStats.volume = newVolume;
 
-    const rgainAdjustedVolume = newVolume / 100 * currentReplayGainAmp;
+    // ReplayGain (positive track gain on quiet masters) plus pre-gain can push
+    // the product above 1.0. HTMLMediaElement.volume throws a RangeError for
+    // values outside [0, 1], so clamp. With no peak metadata we can't do true
+    // clipping prevention; this caps boost at unity and prevents the throw.
+    const rgainAdjustedVolume = Math.min(1, Math.max(0, newVolume / 100 * currentReplayGainAmp));
     getCurrentPlayer().playerObject.volume = rgainAdjustedVolume;
     getOtherPlayer().playerObject.volume = rgainAdjustedVolume;
   }
@@ -851,7 +855,7 @@ const MSTREAMPLAYER = (() => {
     mstreamModule.playerStats.metadata.title = curSong.metadata && curSong.metadata.title ? curSong.metadata.title : "";
     mstreamModule.playerStats.metadata.year = curSong.metadata && curSong.metadata.year ? curSong.metadata.year : "";
     mstreamModule.playerStats.metadata['album-art'] = curSong.metadata && curSong.metadata['album-art'] ? curSong.metadata['album-art'] : "";
-    mstreamModule.playerStats.metadata['replaygain-track-db'] = curSong.metadata && curSong.metadata['replaygain-track-db'] ? curSong.metadata['replaygain-track-db'] : "";
+    mstreamModule.playerStats.metadata['replaygain-track'] = curSong.metadata && curSong.metadata['replaygain-track'] ? curSong.metadata['replaygain-track'] : "";
     // V32 columns — used by the now-playing pill display + Auto-DJ
     // BPM continuity / harmonic-mixing anchor management.
     mstreamModule.playerStats.metadata.bpm = curSong.metadata && Number.isFinite(curSong.metadata.bpm) ? curSong.metadata.bpm : null;
@@ -887,8 +891,15 @@ const MSTREAMPLAYER = (() => {
 
     if (mstreamModule.playerStats.replayGain) {
       if (song.metadata) {
-        const rgainDb = song.metadata['replaygain-track-db'];
-        if (rgainDb) {
+        // The server sends track gain under the 'replaygain-track' key
+        // (src/api/db.js renderMetadataObj) as a dB number or null. Read that
+        // exact key: a previous mismatch ('replaygain-track-db') made this
+        // always undefined, so every track silently fell through to the no-data
+        // -10 dB branch below instead of being normalized by its real gain.
+        const rgainDb = song.metadata['replaygain-track'];
+        // typeof check (not truthiness) so a genuine 0 dB gain counts as real
+        // data rather than being treated as "missing".
+        if (typeof rgainDb === 'number' && !isNaN(rgainDb)) {
           // Note: the music-metadata package has a similar calculation in its Utils class, and that's used to
           // calculate a returned 'ratio' value. However, the calculation used there is actually calculating the power
           // ratio and not the amplitude ratio as required. As power is amplitude squared, that results in a volume

--- a/webapp/assets/js/mstream.server-audio.js
+++ b/webapp/assets/js/mstream.server-audio.js
@@ -74,7 +74,7 @@ var MSTREAMPLAYER = (function () {
       title: '',
       year: '',
       'album-art': '',
-      'replaygain-track-db': '',
+      'replaygain-track': '',
       filepath: ''
     }
   };
@@ -281,7 +281,7 @@ var MSTREAMPLAYER = (function () {
     mstreamModule.playerStats.metadata.title = meta.title || '';
     mstreamModule.playerStats.metadata.year = meta.year || '';
     mstreamModule.playerStats.metadata['album-art'] = meta['album-art'] || '';
-    mstreamModule.playerStats.metadata['replaygain-track-db'] = meta['replaygain-track-db'] || '';
+    mstreamModule.playerStats.metadata['replaygain-track'] = meta['replaygain-track'] || '';
     mstreamModule.playerStats.metadata.filepath = curSong.rawFilePath || curSong.filepath || '';
   };
 


### PR DESCRIPTION
## Summary

Audited ReplayGain end-to-end and fixed the bugs found. The headline issue: **the web player's ReplayGain feature never actually applied per-track gain.**

The server emits the value under the key `replaygain-track` ([`renderMetadataObj`](src/api/db.js)), but the player read `replaygain-track-db` — a key **no code path ever produces**. So for every library track `rgainDb` was `undefined`, the player fell into the "no ReplayGain info" branch, and enabling ReplayGain hard-attenuated **everything by a flat −10 dB** (the opposite of normalization). The pre-gain stepper had no audible effect, since the only branch that uses it was never reached.

## How ReplayGain works in mStream (context)

Purely **metadata-scraped, track-gain only** — no loudness is ever computed:
- **Scanners** read the track-gain tag (`ItemKey::ReplayGainTrackGain` in the Rust parser; `replaygain_track_gain.dB` via `music-metadata` in the JS fallback) into a single `tracks.replaygain_track_db REAL` column.
- **APIs** pass it through: native `replaygain-track`, OpenSubsonic `replayGain: { trackGain }`.
- **Player** converts dB → linear amplitude (`10^((dB + preGain)/20)`) and scales the `<audio>` element's `.volume`.

## Bugs fixed

| Sev | Bug | Fix |
|-----|-----|-----|
| 🔴 High | Player read `replaygain-track-db`; server sends `replaygain-track` → real gain never applied; RG-on = flat −10 dB on all tracks | Read the correct key in `mstream.player.js` (+ `mstream.server-audio.js`) |
| 🟠 Med | `changeVolume` never clamped; positive gain + pre-gain can push `audio.volume > 1`, which throws a `RangeError` | Clamp gain-adjusted volume to `[0, 1]` |
| 🟡 Low | A genuine `0 dB` gain was treated as "missing" (truthiness check) and dropped to `null` by the API (`\|\| null`) | `typeof === 'number'` guard in player; `?? null` in API |
| 🟡 Low | `rgPregain === NaN` is always false (`NaN !== NaN`) | `Number.isNaN()` in `vp.js` |
| 🟡 Low | yt-dlp download path hardcoded `null` for `replaygain_track_db` despite re-parsed tags being in scope | Read `metadata.replaygain_track_gain.dB` like the other path |

## Out of scope (follow-ups, not bugs)

- **Album gain & peak values** — would need new schema columns; these are feature additions. Peak would also enable true clipping-prevention (this PR caps boost at unity instead).
- **Opus `R128_TRACK_GAIN`** — the Rust parser only reads the generic `ReplayGainTrackGain` ItemKey, so standard-tagged Opus files yield NULL. Fixing needs a Q7.8 fixed-point → dB reference-level (−23 vs −18 LUFS) conversion **and** a rebuild of the committed parser binaries.

## Testing

- Targeted server suites pass with no regressions: `random-route`, `subsonic-polish`, `ytdl-provenance` (**103/103**).
- Changed files add **no new lint problems** (the reported items are pre-existing tree-wide debt).
- ⚠️ The frontend apply-path still has **no automated coverage** — a pre-existing gap (the webapp has no JS test harness). Recommend a manual QA pass: enable ReplayGain on a library with RG-tagged tracks and confirm per-track levels even out rather than dropping a flat −10 dB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)