### PR TITLE
build: ship release bundles as .zip instead of tar.gz

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1,7 +1,7 @@
 name: Build Bun Server
 
 # Produces per-platform Bun standalone server bundles (binary + webapp/ + bin
-# sidecars, tar.gz). Runs on release tags, on manual dispatch, and on PRs that
+# sidecars, zip). Runs on release tags, on manual dispatch, and on PRs that
 # touch the build inputs (build-only — the release job is tag-gated). Each target
 # builds on an OS runner; exec bits for committed sidecars are set by the bundler
 # (scripts/build-bun.mjs), not relied on from the runner's checkout mode.
@@ -132,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mStream-${{ matrix.key }}
-          path: dist/mStream-*-${{ matrix.key }}.tar.gz
+          path: dist/mStream-*-${{ matrix.key }}.zip
           if-no-files-found: error
 
   release:
@@ -162,4 +162,4 @@ jobs:
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes --draft
           fi
-          gh release upload "$TAG" bundles/*.tar.gz --clobber --repo "$REPO"
+          gh release upload "$TAG" bundles/*.zip --clobber --repo "$REPO"

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 Pre-built, self-contained server bundles are attached to each
 [GitHub release](https://github.com/IrosTheBeggar/mStream/releases) as
-`mStream-<version>-<platform>.tar.gz` (win-x64, linux-x64, linux-arm64,
+`mStream-<version>-<platform>.zip` (win-x64, linux-x64, linux-arm64,
 linux-x64-musl, linux-arm64-musl, darwin-x64, darwin-arm64). They embed their own
 runtime — no Node.js install.
 
@@ -12,8 +12,8 @@ A bundle is a **folder**, not a single file: the server binary plus `webapp/`
 first run (under `save/`).
 
 ```shell
-# Linux / macOS
-tar -xzf mStream-<version>-linux-x64.tar.gz
+# Linux / macOS (Windows: just extract the .zip in Explorer)
+unzip mStream-<version>-linux-x64.zip
 cd mStream-<version>-linux-x64
 ./mStream-linux-x64
 # then open http://localhost:3000

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -4,7 +4,7 @@
 //   key: win-x64 (default on Windows) | linux-x64 | linux-arm64 | darwin-x64 | darwin-arm64
 //        (no --target = build for the host platform)
 //   --bundle: after building, stage webapp/ + the platform's bin/ sidecars next
-//             to the binary and produce a dist/<name>.tar.gz release archive.
+//             to the binary and produce a dist/<name>.zip release archive.
 //
 // Windows icon + metadata flags are only applied for a win-x64 build running ON
 // Windows — Bun can't set them when cross-compiling. Name/version/etc. come from
@@ -96,7 +96,7 @@ if (build.status !== 0) { process.exit(build.status ?? 1); }
 
 if (!doBundle) { process.exit(0); }
 
-// ── Bundle: stage binary + webapp/ + the platform's bin/ sidecars, then tar.gz.
+// ── Bundle: stage binary + webapp/ + the platform's bin/ sidecars, then zip.
 // A bare binary isn't runnable (the UI ships loose, sidecars are spawned), so a
 // release is a folder, not a single file — same shape Electron shipped.
 const isUnix = t.plat !== 'win32';
@@ -168,15 +168,27 @@ if (isMac) {
   writeFileSync(join(stageDir, 'mStream.desktop'), linuxDesktopEntry(t.out));
 }
 
-const archivePath = join(root, 'dist', `${bundleName}.tar.gz`);
+const archivePath = join(root, 'dist', `${bundleName}.zip`);
 rmSync(archivePath, { force: true });
-console.log(`Bundling -> dist/${bundleName}.tar.gz`);
-// tar ships on all CI runners and Windows 10+; it preserves the staged file
-// modes set above, so a glibc-mode-0644 sidecar still ships runnable.
-const tar = spawnSync('tar', ['-czf', archivePath, '-C', stageRoot, bundleName], { stdio: 'inherit' });
-if (tar.error) { console.error(tar.error.message); }
-if (tar.status !== 0) { console.error('tar failed'); process.exit(tar.status ?? 1); }
-console.log(`Done: dist/${bundleName}.tar.gz`);
+console.log(`Bundling -> dist/${bundleName}.zip`);
+// Ship a .zip (double-click-extractable on every OS) instead of tar.gz. The
+// catch: the staged unix binaries were chmod +x'd above, and that execute bit
+// must survive the archive. Branch on the BUILD HOST — each target builds on its
+// matching-OS CI runner, so the host's tooling matches the bundle's needs:
+//   - unix host (linux/macOS runners): Info-ZIP `zip` records Unix file modes,
+//     so `unzip` restores +x and the binaries stay runnable; -y keeps symlinks
+//     (the .app). `zip` is preinstalled on the ubuntu/macOS runners.
+//   - Windows host: bsdtar (`tar -a`, ships on Windows 10+) writes a standard
+//     .zip from the extension; a Windows .exe carries no mode bit to lose.
+let zip;
+if (process.platform === 'win32') {
+  zip = spawnSync('tar', ['-a', '-c', '-f', archivePath, '-C', stageRoot, bundleName], { stdio: 'inherit' });
+} else {
+  zip = spawnSync('zip', ['-r', '-y', '-q', archivePath, bundleName], { cwd: stageRoot, stdio: 'inherit' });
+}
+if (zip.error) { console.error(zip.error.message); }
+if (zip.status !== 0) { console.error('archive (zip) failed'); process.exit(zip.status ?? 1); }
+console.log(`Done: dist/${bundleName}.zip`);
 
 // macOS .app Info.plist — points CFBundleIconFile at the staged mStream.icns
 // and CFBundleExecutable at the inner binary.


### PR DESCRIPTION
## What
Release bundles are now packaged as **`.zip`** instead of `.tar.gz` (same folder layout: server binary + `webapp/` + `bin/` sidecars).

## Why
`.zip` extracts with a double-click on every OS (Windows Explorer, macOS Finder, Linux) — no extra tool needed.

## How (the one gotcha: the execute bit)
`tar` carried the staged `+x` bit for free; zip needs the right tool. `scripts/build-bun.mjs` branches on the build host — each target builds on its matching-OS runner:
- **unix runners** (ubuntu/macOS): Info-ZIP `zip -r -y` records Unix file modes, so `unzip` restores `+x` on the server + sidecar binaries; `-y` keeps the `.app` symlinks. (`zip` is preinstalled on those runners.)
- **Windows runner**: bsdtar (`tar -a`) writes a standard zip; a `.exe` has no mode bit to lose.

Also updates the artifact-upload + `gh release upload` globs, the header comments, and `docs/install.md` (`unzip …` + a Windows double-click note). The smoke test reads the staged *folder*, not the archive, so it's untouched.

## Verified
Built `win-x64` locally → a valid 261-entry zip with `mStream.exe` + `webapp/` + `bin/`. (The unix `zip` perms path runs on its own runners; CI's smoke tests the staged dir, so watch the first real linux/mac run to confirm `+x` survives.)

## Note for the existing 6.13.0 release
This applies to the next release automatically. To swap the **current** release's assets to `.zip`, re-run the *Build Bun Server* workflow on the `6.13.0` tag — the release job `gh release upload --clobber`s, so it adds the `.zip` files (the old `.tar.gz` assets remain until deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
