### PR TITLE
fix(admin): repair broken POST /admin/users/lastfm endpoint

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -18,6 +18,7 @@ import WebError from '../util/web-error.js';
 import { bootRustPlayer, killRustPlayer, proxyToRust, getActiveBackend, getDetectedCliPlayers, refreshDetectedCliPlayers } from './server-playback.js';
 import { listImplementedMethods, methodStatusTable } from './subsonic/index.js';
 import * as lyricsLrclib from './lyrics-lrclib.js';
+import { warmScrobbleUser } from './scrobbler.js';
 import { listTokenAuthAttempts, clearTokenAuthAttempts, generateApiKey } from './subsonic/auth.js';
 import * as nowPlaying from './subsonic/now-playing.js';
 // Torrent admin endpoints live in their own module — see
@@ -536,12 +537,18 @@ export function setup(mstream) {
   mstream.post("/api/v1/admin/users/lastfm", async (req, res) => {
     const schema = Joi.object({
       username: Joi.string().required(),
-      lasftfmUser: Joi.string().required(),
-      lasftfmPassword: Joi.string().required()
+      lastfmUser: Joi.string().required(),
+      lastfmPassword: Joi.string().required()
     });
     joiValidate(schema, req.body);
 
-    await admin.setUserLastFM(req.body.username, req.body.password);
+    await admin.setUserLastFM(req.body.username, req.body.lastfmUser, req.body.lastfmPassword);
+    // Register the new creds with the in-process Scribble session map so the
+    // user can scrobble without a server restart — the same warm /lastfm/connect
+    // does. Without it the first post-set scrobble throws: Scribble.Scrobble
+    // dereferences users[lastfmUser].sessionKey, and that entry only exists for
+    // creds present when scrobbler.setup() pre-loaded the DB at boot.
+    warmScrobbleUser(req.body.lastfmUser, req.body.lastfmPassword);
     res.json({});
   });
 

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -259,6 +259,23 @@ export async function setSubsonicPassword(username, plaintext) {
   db.invalidateCache();
 }
 
+// Set a user's stored Last.fm credentials — the V1 lastfm_user/lastfm_password
+// columns that live directly on the users row. Same lookup-then-UPDATE shape as
+// editUserPassword, and the same storage write the self-service /lastfm/connect
+// endpoint (velvet-stubs.js) uses. Registering the creds with the in-process
+// Scribble session map (warmScrobbleUser) is the route handler's job — that
+// singleton lives in the api layer, so util/ stays out of it.
+export async function setUserLastFM(username, lastfmUser, lastfmPassword) {
+  const user = db.getUserByUsername(username);
+  if (!user) { throw new Error(`'${username}' does not exist`); }
+
+  db.getDB().prepare(
+    'UPDATE users SET lastfm_user = ?, lastfm_password = ? WHERE id = ?'
+  ).run(lastfmUser, lastfmPassword, user.id);
+
+  db.invalidateCache();
+}
+
 // ── Config file settings (server-level, stay in JSON) ───────────────────────
 
 export async function editUI(ui) {

--- a/test/integration/admin-users-lastfm.test.mjs
+++ b/test/integration/admin-users-lastfm.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Integration tests for POST /api/v1/admin/users/lastfm — the admin endpoint
+ * that stores a target user's Last.fm credentials (the V1
+ * lastfm_user/lastfm_password columns on the users row).
+ *
+ * This route was previously dead on arrival on two counts:
+ *   1. it called admin.setUserLastFM(), which didn't exist / wasn't exported
+ *      from src/util/admin.js → TypeError on every request;
+ *   2. its Joi schema required `lasftfmUser`/`lasftfmPassword` (typo'd) while
+ *      the handler read req.body.username/req.body.password — so the required
+ *      fields were never used and the read fields were never validated.
+ *
+ * The fix settles the request shape as { username, lastfmUser, lastfmPassword }
+ * (matching /lastfm/connect's lastfmUser/lastfmPassword naming and the
+ * username-targeting of the sibling /admin/users/* routes). These tests pin
+ * that shape: the happy path persists + reflects via /lastfm/status, and the
+ * old typo'd field names are now rejected.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startServer } from '../helpers/server.mjs';
+
+const ADMIN = { username: 'admin', password: 'pw-admin' };
+const USER  = { username: 'bob',   password: 'pw-bob'   };
+
+let server;
+let adminJwt;
+let userJwt;
+
+before(async () => {
+  server = await startServer({
+    dlnaMode: 'disabled',
+    users: [
+      { ...ADMIN, admin: true },
+      { ...USER,  admin: false },
+    ],
+  });
+  for (const [u, setJwt] of [[ADMIN, v => adminJwt = v], [USER, v => userJwt = v]]) {
+    const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(u),
+    });
+    setJwt((await r.json()).token);
+  }
+});
+
+after(async () => {
+  if (server) { await server.stop(); }
+});
+
+function post(path, body, jwt = adminJwt) {
+  return fetch(`${server.baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-access-token': jwt },
+    body: JSON.stringify(body),
+  });
+}
+
+// /lastfm/status echoes the requesting user's stored lastfm_user as
+// `linkedUser` — a clean end-to-end read-back of what the admin endpoint wrote.
+async function linkedUser(jwt) {
+  const r = await fetch(`${server.baseUrl}/api/v1/lastfm/status`, {
+    headers: { 'x-access-token': jwt },
+  });
+  assert.equal(r.status, 200);
+  return (await r.json()).linkedUser;
+}
+
+describe('POST /api/v1/admin/users/lastfm', () => {
+  test('stores the target user\'s creds; reflected via that user\'s /lastfm/status', async () => {
+    // Precondition: bob has no linked Last.fm account yet.
+    assert.equal(await linkedUser(userJwt), null);
+
+    const r = await post('/api/v1/admin/users/lastfm', {
+      username: 'bob', lastfmUser: 'bob-fm', lastfmPassword: 'hunter2',
+    });
+    assert.equal(r.status, 200);
+    assert.deepEqual(await r.json(), {}, 'happy-path response is the empty object {}');
+
+    // The write targeted bob by username, persisted lastfm_user, and the
+    // helper's db.invalidateCache() means bob's next authenticated request
+    // re-reads the fresh row — so /lastfm/status surfaces the linked account.
+    assert.equal(await linkedUser(userJwt), 'bob-fm');
+
+    // ...and only bob's row: the admin who made the call is unaffected
+    // (proves we keyed off req.body.username, not the caller's identity).
+    assert.equal(await linkedUser(adminJwt), null);
+  });
+
+  test('rejects the legacy typo\'d field names (lasftfmUser/lasftfmPassword) with 400', async () => {
+    // This is the exact mismatch the fix corrected — the old schema required
+    // these misspelled keys. They must now fail validation (unknown keys +
+    // the real required fields absent).
+    const r = await post('/api/v1/admin/users/lastfm', {
+      username: 'bob', lasftfmUser: 'x', lasftfmPassword: 'y',
+    });
+    assert.equal(r.status, 400);
+  });
+
+  test('rejects missing / malformed payloads with 400', async () => {
+    const bad = [
+      {},                                                       // nothing
+      { username: 'bob' },                                      // creds missing
+      { username: 'bob', lastfmUser: 'x' },                     // password missing
+      { username: 'bob', lastfmPassword: 'y' },                 // user missing
+      { lastfmUser: 'x', lastfmPassword: 'y' },                 // username missing
+      { username: 'bob', password: 'y' },                       // the old handler's read shape
+      { username: 'bob', lastfmUser: 'x', lastfmPassword: 'y', extra: 1 }, // unknown key
+    ];
+    for (const body of bad) {
+      const r = await post('/api/v1/admin/users/lastfm', body);
+      assert.equal(r.status, 400, `expected 400 for ${JSON.stringify(body)}, got ${r.status}`);
+    }
+  });
+
+  test('rejects non-admin callers with 405 (outer admin guard)', async () => {
+    const r = await post('/api/v1/admin/users/lastfm', {
+      username: 'bob', lastfmUser: 'bob-fm', lastfmPassword: 'hunter2',
+    }, userJwt);
+    assert.equal(r.status, 405);
+  });
+
+  test('unknown target user surfaces the helper\'s thrown error (500)', async () => {
+    // setUserLastFM throws a bare Error for a non-existent user — same shape as
+    // every sibling user-management helper (editUserPassword, deleteUser, …),
+    // which the global handler maps to 500. Pinned here so the not-found guard
+    // can't silently regress into a no-op or a wrong-row write.
+    const r = await post('/api/v1/admin/users/lastfm', {
+      username: 'ghost', lastfmUser: 'x', lastfmPassword: 'y',
+    });
+    assert.equal(r.status, 500);
+  });
+});


### PR DESCRIPTION
## What

Fixes `POST /api/v1/admin/users/lastfm`, which threw on **every** request due to two independent bugs:

1. **Missing function.** The handler called `admin.setUserLastFM(...)`, but that function was never implemented or exported from `src/util/admin.js` — a guaranteed `TypeError: admin.setUserLastFM is not a function`. (Surfaced as a `bun build` bundler warning: *"Import 'setUserLastFM' will always be undefined because there is no matching export in src/util/admin.js"*.)
2. **Schema/field mismatch.** The Joi schema required `lasftfmUser` / `lasftfmPassword` (both misspelled — `lasftfm` → `lastfm`) while the handler read `req.body.username` / `req.body.password`. So the validated fields were never used, and `password` (the field actually read) wasn't in the schema at all.

## Changes

- **`src/util/admin.js`** — implement & export `setUserLastFM(username, lastfmUser, lastfmPassword)`. Mirrors the existing `editUserPassword` / `setSubsonicPassword` helpers: look up the user (throw if absent), `UPDATE users SET lastfm_user = ?, lastfm_password = ?`, then `db.invalidateCache()`. Writes to the same V1 `lastfm_user` / `lastfm_password` columns that the self-service `/lastfm/connect` endpoint uses.
- **`src/api/admin.js`** — correct the schema field names to `lastfmUser` / `lastfmPassword`, pass the right fields to `setUserLastFM`, and `warmScrobbleUser(...)` after the write.
- **`test/integration/admin-users-lastfm.test.mjs`** — new integration test.

## Settled request shape

```json
{ "username": "<mstream user>", "lastfmUser": "<last.fm user>", "lastfmPassword": "<last.fm password>" }
```

Chosen to match `/lastfm/connect`'s `lastfmUser` / `lastfmPassword` naming and the `username`-targeting of the sibling `/admin/users/*` routes. The default-UI admin modal that would call this is currently an empty "Coming Soon" stub, so no existing client contract was broken.

## Why the `warmScrobbleUser` call matters

It isn't cosmetic. `Scribble.Scrobble()` dereferences `users[lastfmUser].sessionKey` with **no guard** (`src/state/lastfm.js`), and that map entry only exists for credentials pre-loaded at boot. Without warming, the first scrobble by a freshly-credentialed user would throw until a server restart — which is exactly why `/lastfm/connect` already warms after its write.

## Test coverage

The new test (mirrors the sibling admin integration tests) covers:
- **Happy path** — admin sets a user's creds → read-back via that user's `GET /api/v1/lastfm/status` returns `linkedUser`, proving persistence, cache invalidation, and that the write keyed off `username` (not the caller's identity).
- **Legacy typo'd fields** (`lasftfmUser` / `lasftfmPassword`) now rejected with `400`.
- **Malformed payloads** (missing fields, the old `{ username, password }` shape, unknown keys) → `400`.
- **Non-admin** caller → `405`.
- **Unknown target user** → `500` (the bare-`Error` mapping, consistent with every sibling user-management helper).

## Verification

- `npx eslint src/api/admin.js src/util/admin.js test/integration/admin-users-lastfm.test.mjs` → **0 errors** (only the pre-existing `require-await` style warning shared by every sibling helper).
- New test → **5/5 pass** (the full server boots, confirming the new `admin.js → scrobbler.js` import is cycle-free).
- Sibling suites `admin-scan-params` + `admin-access` → **31/31 pass**, no regression from the shared `admin.js` edit.

## Reviewer notes

- `setUserLastFM` is kept `async` (no `await` inside) purely for a uniform await-able surface, matching `deleteUser` / `editUserVPaths` / `editUserAccess` / `setSubsonicPassword`.
- Warming lives in the route handler (api layer) rather than inside the util helper, so `src/util/admin.js` doesn't reach up into the api-layer Scribble singleton — same split as `/lastfm/connect`.
- Follow-up (not in this PR): the default-UI admin "Add last.fm account" modal (`webapp/admin/index.js`) is still a "Coming Soon" stub with an empty `setLastFM()`, so this now-working endpoint has no UI caller yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)