### PR TITLE
test: read child stdout on 'close', not 'exit', in spawn harnesses

### DIFF
--- a/test/helpers/scanner-runner.mjs
+++ b/test/helpers/scanner-runner.mjs
@@ -150,7 +150,10 @@ function runScanProcess(cmd, args) {
     p.stdout.on('data', d => { stdout += d.toString(); });
     p.stderr.on('data', d => { stderr += d.toString(); });
     p.on('error', err => finish(err));
-    p.on('exit', code => {
+    // 'close' (not 'exit') guarantees stdout is fully drained before we parse
+    // the scanComplete line — 'exit' can fire while the pipe is still buffered,
+    // which races to an empty buffer under CPU pressure.
+    p.on('close', code => {
       if (code !== 0) {
         return finish(new Error(`scanner exit ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
       }

--- a/test/integration/album-art-downloader.test.mjs
+++ b/test/integration/album-art-downloader.test.mjs
@@ -140,7 +140,9 @@ function runWorker(config) {
     p.stdout.on('data', d => { stdout += d.toString(); });
     p.stderr.on('data', d => { stderr += d.toString(); });
     const timer = setTimeout(() => { p.kill('SIGKILL'); }, 60_000);
-    p.on('exit', (code) => {
+    // 'close' (not 'exit') so the worker's stdout is fully drained before we
+    // parse its event lines — 'exit' can fire with the pipe still buffered.
+    p.on('close', (code) => {
       clearTimeout(timer);
       const events = stdout.split('\n').map(l => l.trim()).filter(l => l.startsWith('{'))
         .map(l => { try { return JSON.parse(l); } catch (_e) { return null; } }).filter(Boolean);
@@ -470,7 +472,7 @@ describe('downloader worker (mock services)', () => {
       });
       let out = '';
       p.stdout.on('data', d => { out += d.toString(); });
-      p.on('exit', code => resolve({ code, out }));
+      p.on('close', code => resolve({ code, out }));
       p.on('error', reject);
     });
     assert.equal(r.code, 0);

--- a/test/scanner/audio-hash-parity.test.mjs
+++ b/test/scanner/audio-hash-parity.test.mjs
@@ -89,7 +89,8 @@ function runRustHash(rustBin, filepath) {
     p.stdout.on('data', d => { stdout += d.toString(); });
     p.stderr.on('data', d => { stderr += d.toString(); });
     p.on('error', reject);
-    p.on('exit', code => {
+    // 'close' (not 'exit') so stdout is fully drained before we JSON.parse it.
+    p.on('close', code => {
       if (code !== 0) { return reject(new Error(`rust-parser --audio-hash exit ${code}: ${stderr}`)); }
       try { resolve(JSON.parse(stdout)); }
       catch (err) { reject(new Error(`bad rust JSON: ${stdout}: ${err.message}`)); }

--- a/test/scanner/waveform.test.mjs
+++ b/test/scanner/waveform.test.mjs
@@ -85,7 +85,8 @@ function runRustWaveform(rustBin, filepath) {
     p.stdout.on('data', d => { stdout += d.toString(); });
     p.stderr.on('data', d => { stderr += d.toString(); });
     p.on('error', reject);
-    p.on('exit', code => {
+    // 'close' (not 'exit') so stdout is fully drained before we JSON.parse it.
+    p.on('close', code => {
       if (code !== 0) { return reject(new Error(`rust-parser --waveform exit ${code}: ${stderr}`)); }
       try { resolve(JSON.parse(stdout)); }
       catch (err) { reject(new Error(`bad rust JSON: ${stdout}: ${err.message}`)); }


### PR DESCRIPTION
## What

Fixes the flaky empty-stdout failures (`Unexpected end of JSON input` / `no scanComplete`) that intermittently hit the scanner/audio-hash/waveform/album-art tests under CI load — and were originally **misdiagnosed as a broken prebuilt `darwin-arm64` rust-parser binary** (a spawned investigation later proved the committed binary is byte-identical to a from-source rebuild and runs all the cited inputs fine).

## Root cause

These harnesses accumulate a child process's stdout in `'data'` handlers and then parse it inside the **`'exit'`** handler. Node's `'exit'` fires when the child terminates but **before its stdout pipe is guaranteed drained** (the docs note stdio streams "might still be open"; `'close'` always fires after `'exit'`). Under CPU pressure the parse therefore ran against an empty/truncated buffer even though the child printed its output and exited 0.

Proof it wasn't the binary: both errors came from the **`code === 0`** branch — the Rust binary always prints before exiting 0 and exits non-zero on error, so exit-0 + empty-stdout means *output produced but not captured*. The earlier `--test-concurrency=8` ("2× cores") oversubscribed the low-core arm64-macOS / Windows runners (each test also spawns a multi-threaded rayon scanner), widening the race; Linux (more cores) never lost it.

## The change (drop-in)

`'close'` is emitted with the same `(code, signal)` args as `'exit'`, so this is literally renaming the event — handler bodies (including the `if (code !== 0) reject(...)` branch and the parse) are unchanged.

| File | Handler |
| --- | --- |
| `test/helpers/scanner-runner.mjs` | `runScanProcess` — parses the `scanComplete` line (shared parity harness, highest blast radius) |
| `test/scanner/audio-hash-parity.test.mjs` | `runRustHash` — `JSON.parse(stdout)` |
| `test/scanner/waveform.test.mjs` | `runRustWaveform` — `JSON.parse(stdout)` |
| `test/integration/album-art-downloader.test.mjs` | `runWorker` (parses event lines) + a latent capture handler |

The `runFfmpeg`/`ffmpeg()` helpers read **stderr only** (no stdout parse), so they're intentionally left on `'exit'`. Already-correct sites (`waveform-scan`, `lyrics-parity`, `scanner-schema-guard`) are untouched.

## Verification

- Full `test/scanner` under `--test-concurrency=8` (the original stressor): **107 pass / 0 fail**.
- `album-art-downloader`: **17 pass**.

A separate small PR will apply the same `'exit'`→`'close'` fix to one production site (`src/api/cli-audio/index.js` `probeBinary`). The production scanner pipeline (`src/db/task-queue.js`) is already safe — it flushes via `bufferLines()` on stream `'end'` and decides lifecycle in `'close'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)