### PR TITLE
fix(cli-audio): probe player availability on 'close', not 'exit'

### DIFF
--- a/src/api/cli-audio/index.js
+++ b/src/api/cli-audio/index.js
@@ -53,7 +53,12 @@ function probeBinary(binary, args) {
     // exit codes vary (mplayer -v returns non-zero because it wants a file).
     if (proc.stdout) { proc.stdout.on('data', mark); }
     if (proc.stderr) { proc.stderr.on('data', mark); }
-    proc.on('exit', () => { clearTimeout(timer); resolve(gotOutput); });
+    // 'close' (not 'exit') so the stdout/stderr 'data' handlers above have
+    // fired before we read gotOutput — on 'exit' a fast-printing player's
+    // banner can still be buffered, making it look like it produced nothing
+    // and be misdetected as unavailable. Exit codes are intentionally ignored
+    // here, so output-presence is the only signal.
+    proc.on('close', () => { clearTimeout(timer); resolve(gotOutput); });
     proc.on('error', () => { clearTimeout(timer); resolve(false); });
   });
 }


### PR DESCRIPTION
## What

The production counterpart to the test-harness fix (#675). `probeBinary()` in [src/api/cli-audio/index.js](src/api/cli-audio/index.js) auto-detects whether a CLI player (mpv / vlc / mplayer / mpd) is installed by spawning it and checking **whether it produced any stdout/stderr output** (`gotOutput`, set by the `'data'` handlers). Exit codes are intentionally ignored — e.g. `mplayer -v` exits non-zero — so output-presence is the *only* signal.

It read `gotOutput` in the **`'exit'`** handler, which can fire before the player's banner has been delivered to the `'data'` callbacks (Node's `'exit'` doesn't guarantee the stdio pipes are drained; `'close'` always fires after). A fast-printing player could therefore resolve `gotOutput=false` and be **misdetected as unavailable**.

## The change

Read on `'close'` instead of `'exit'` — one line, handler body unchanged:

```js
proc.on('close', () => { clearTimeout(timer); resolve(gotOutput); });
```

`'close'` guarantees the `'data'`/`mark` callbacks have run first.

## Notes

- Low stakes (player auto-detect can misfire under load), but it's the one production site of the `'exit'`-races-undrained-stdout class found alongside the test-harness flakes.
- The production scanner pipeline (`src/db/task-queue.js`) is already safe — it flushes child output via `bufferLines()` on stream `'end'` and decides lifecycle in `'close'` handlers.
- Not browser-observable; verified by lint + syntax check. Exercising it live needs the real CLI players (the Docker `test:cli-audio` harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)