### PR TITLE
fix(dlna): security + robustness audit fixes, gate per-user data

### DIFF
--- a/docs/dlna-todo.md
+++ b/docs/dlna-todo.md
@@ -51,8 +51,10 @@ sorted roughly by impact and/or ease of implementation.
 ## Smart containers
 
 - **Recently Played / Most Played / Favorites aggregate across all users**
-  since DLNA has no auth context. Consider a `dlna.defaultUser` setting that
-  scopes smart-container queries to one user's history.
+  since DLNA has no auth context. `dlna.shareUserData: false` now hides these
+  (and the all-users Playlists container) wholesale for multi-user servers; a
+  finer-grained `dlna.defaultUser` setting that scopes the queries to one
+  user's history is still worth adding.
 - **Smart-container query results lack caching.** Each Browse re-runs the
   aggregate join. Add a short-TTL (e.g. 30s) in-memory cache keyed on
   SystemUpdateID.

--- a/src/api/dlna.js
+++ b/src/api/dlna.js
@@ -461,9 +461,11 @@ function getLibraryArtists(libraryId) {
     SELECT COALESCE(t.artist_id, 0) AS id,
            COALESCE(a.name, 'Unknown Artist') AS name,
            COUNT(DISTINCT COALESCE(t.album_id, 0)) AS album_count,
-           (SELECT t2.album_art_file FROM tracks t2
-            WHERE t2.library_id = t.library_id AND t2.artist_id IS t.artist_id
-              AND t2.album_art_file IS NOT NULL LIMIT 1) AS album_art_file
+           -- MIN (not an arbitrary LIMIT-1 row) so the art shown in this list
+           -- matches the BrowseMetadata art from getArtistById(), which also
+           -- uses MIN. MIN ignores NULLs, so it's still "first non-null art".
+           (SELECT MIN(t2.album_art_file) FROM tracks t2
+            WHERE t2.library_id = t.library_id AND t2.artist_id IS t.artist_id) AS album_art_file
     FROM tracks t
     LEFT JOIN artists a ON t.artist_id = a.id
     WHERE t.library_id = ?
@@ -1072,6 +1074,19 @@ function handleBrowse(body, res) {
   const libraries = db.getAllLibraries();
   const libById = libraryIndex(libraries);
 
+  // Per-user surfaces (play history, ratings, playlists) are gated behind
+  // dlna.shareUserData because the DLNA control surface is unauthenticated.
+  const shareUserData = config.program.dlna.shareUserData !== false;
+  // Fixed virtual containers under "Music": Recently Added, Shuffle and By Year
+  // are always present (3); Recently Played, Most Played, Favorites and
+  // Playlists (4) are listed only when per-user data is shared.
+  const musicVirtualCount = shareUserData ? 7 : 3;
+  // Block direct browse to a gated container when sharing is off, so a client
+  // holding a cached object ID can't pull the data the listing hides.
+  if (!shareUserData && /^(recentplayed|mostplayed|favorites|playlists|playlist-\d+)$/.test(objectId)) {
+    return sendXml(res, soapError('701', 'No Such Object'), 500);
+  }
+
   // ── Root container — wraps everything in a single "Music" child ──────────
   // Matches the layout of MiniDLNA / Plex / Jellyfin: renderers expect a
   // top-level category folder, not libraries scattered at root.
@@ -1084,28 +1099,31 @@ function handleBrowse(body, res) {
   </container>`);
       return sendBrowseResponse(res, didl, 1, 1);
     }
-    const music = simpleContainer('music', '0', 'Music', libraries.length + 7);
+    const music = simpleContainer('music', '0', 'Music', libraries.length + musicVirtualCount);
     const slice = paginate([music], startIdx, reqCount);
     return sendBrowseResponse(res, didlWrapper(slice.join('')), slice.length, 1);
   }
 
   // ── Music container — libraries + virtual "Recently Added/Played/..." ────
   if (objectId === 'music') {
-    // N libraries + 7 fixed virtual containers (Recently Added, Recently
-    // Played, Most Played, Favorites, Shuffle, By Year, Playlists).
-    const musicTotal = libraries.length + 7;
+    // N libraries + the fixed virtual containers. Recently Added, Shuffle and
+    // By Year are always present; Recently Played, Most Played, Favorites and
+    // Playlists are per-user surfaces, listed only when dlna.shareUserData is on.
+    const musicTotal = libraries.length + musicVirtualCount;
     if (browseFlag === 'BrowseMetadata') {
       return sendBrowseResponse(res, didlWrapper(simpleContainer('music', '0', 'Music', musicTotal)), 1, 1);
     }
     const musicChildren = [
       ...libraries.map(lib => libraryContainer(lib, 'music', getLibraryTrackCount(lib.id))),
       recentContainer('music', getRecentCount()),
-      simpleContainer('recentplayed', 'music', 'Recently Played', getRecentPlayedCount()),
-      simpleContainer('mostplayed',   'music', 'Most Played',     getMostPlayedCount()),
-      simpleContainer('favorites',    'music', 'Favorites',       getFavoriteCount()),
+      ...(shareUserData ? [
+        simpleContainer('recentplayed', 'music', 'Recently Played', getRecentPlayedCount()),
+        simpleContainer('mostplayed',   'music', 'Most Played',     getMostPlayedCount()),
+        simpleContainer('favorites',    'music', 'Favorites',       getFavoriteCount()),
+      ] : []),
       simpleContainer('shuffle',      'music', 'Shuffle',         getShuffleCount()),
       simpleContainer('years',        'music', 'By Year',         getYears().length),
-      playlistsContainer('music', getAllPlaylists().length),
+      ...(shareUserData ? [playlistsContainer('music', getAllPlaylists().length)] : []),
     ];
     const slice = paginate(musicChildren, startIdx, reqCount);
     return sendBrowseResponse(res, didlWrapper(slice.join('')), slice.length, musicTotal);
@@ -2002,8 +2020,14 @@ function handleSubscribe(req, res, service) {
 }
 
 function handleUnsubscribe(req, res) {
+  // UPnP 1.0 §4.1.2: an UNSUBSCRIBE carries SID and neither NT nor CALLBACK,
+  // and the SID must reference a current subscription. Presence of NT/CALLBACK
+  // is a bad request (400); a missing or unknown SID is a precondition failure
+  // (412) — previously we 200'd unconditionally, which masked both.
+  if (req.headers['nt'] || req.headers['callback']) { return res.status(400).end(); }
   const sid = req.headers['sid'];
-  if (sid) { subscribers.delete(sid); }
+  if (!sid || !subscribers.has(sid)) { return res.status(412).end(); }
+  subscribers.delete(sid);
   res.status(200).end();
 }
 

--- a/src/dlna/dlna-server.js
+++ b/src/dlna/dlna-server.js
@@ -1,12 +1,11 @@
 import express from 'express';
 import http from 'node:http';
-import path from 'node:path';
 import winston from 'winston';
 import * as config from '../state/config.js';
-import * as db from '../db/manager.js';
 import * as dlnaApi from '../api/dlna.js';
 import { serveAlbumArtFile } from '../api/album-art.js';
 import { timeSeekMiddleware } from './time-seek.js';
+import { resolveLibraryMediaPath } from './media-path.js';
 
 let dlnaServer = null;
 
@@ -22,23 +21,18 @@ export function start() {
   // Serve media files directly from library roots — no auth, no static mount.
   // Reads library list from DB at request time so additions/removals are live.
   app.use('/media', (req, res) => {
-    const parts = req.path.split('/').filter(Boolean);
-    if (parts.length < 2) { return res.status(404).end(); }
-    let libname, fileParts;
-    try {
-      libname = decodeURIComponent(parts[0]);
-      fileParts = parts.slice(1).map(p => decodeURIComponent(p));
-    } catch (_) {
-      return res.status(400).end();
-    }
-    const lib = db.getAllLibraries().find(l => l.name === libname);
-    if (!lib) { return res.status(404).end(); }
-    const resolved = path.resolve(path.join(lib.root_path, ...fileParts));
-    const rootResolved = path.resolve(lib.root_path);
-    if (!resolved.startsWith(rootResolved + path.sep) && resolved !== rootResolved) {
-      return res.status(403).end();
-    }
-    res.sendFile(resolved, { dotfiles: 'allow' });
+    const r = resolveLibraryMediaPath(req.path);
+    if (!r.ok) { return res.status(r.status).end(); }
+    res.sendFile(r.resolved, { dotfiles: 'allow' }, (err) => {
+      // sendFile streams asynchronously, so a stale DB row (file deleted before
+      // the scan caught up) or a client abort surfaces here rather than above.
+      // Map a missing file to a clean 404 instead of letting it fall through to
+      // Express's default error handler (which would leak a stack trace). Once
+      // bytes are already flowing the headers are committed — nothing left to do.
+      if (!err || res.headersSent) { return; }
+      const status = ((err.status || err.statusCode) === 404 || err.code === 'ENOENT') ? 404 : 500;
+      res.status(status).end();
+    });
   });
 
   app.get('/album-art/:file', serveAlbumArtFile);

--- a/src/dlna/media-path.js
+++ b/src/dlna/media-path.js
@@ -1,0 +1,50 @@
+/**
+ * Shared resolver for DLNA `/media/<library>/<...path>` URLs.
+ *
+ * Both the separate-port media server (dlna-server.js) and the time-seek
+ * middleware (time-seek.js) turn a request path into an absolute on-disk file
+ * path. That logic is security-sensitive — it must keep the resolved path
+ * inside the library root so a crafted `..` segment can't escape — so it lives
+ * in one place rather than being copy-pasted (and drifting) between callers.
+ */
+
+import path from 'node:path';
+import * as db from '../db/manager.js';
+
+/**
+ * Resolve an Express `req.path` of the form `/<library>/<...file>` to an
+ * absolute on-disk path, enforcing that it stays within the library root.
+ *
+ * @param {string} reqPath  e.g. `/MyLibrary/Artist/Album/Song.mp3`
+ * @returns {{ok: true, lib: object, resolved: string, fileParts: string[], relPath: string}
+ *          | {ok: false, status: number}}
+ *   On success `resolved` is guaranteed to sit within `lib.root_path`, and
+ *   `relPath` is the library-relative, forward-slash path used as the DB key.
+ *   On failure `status` is the HTTP status the caller should return:
+ *     404 — path too short, or no library by that name
+ *     400 — malformed percent-encoding in the URL
+ *     403 — path-traversal attempt (resolved outside the library root)
+ */
+export function resolveLibraryMediaPath(reqPath) {
+  const parts = reqPath.split('/').filter(Boolean);
+  if (parts.length < 2) { return { ok: false, status: 404 }; }
+
+  let libname, fileParts;
+  try {
+    libname = decodeURIComponent(parts[0]);
+    fileParts = parts.slice(1).map(p => decodeURIComponent(p));
+  } catch (_) {
+    return { ok: false, status: 400 };
+  }
+
+  const lib = db.getAllLibraries().find(l => l.name === libname);
+  if (!lib) { return { ok: false, status: 404 }; }
+
+  const resolved = path.resolve(path.join(lib.root_path, ...fileParts));
+  const rootResolved = path.resolve(lib.root_path);
+  if (!resolved.startsWith(rootResolved + path.sep) && resolved !== rootResolved) {
+    return { ok: false, status: 403 };
+  }
+
+  return { ok: true, lib, resolved, fileParts, relPath: fileParts.join('/') };
+}

--- a/src/dlna/ssdp.js
+++ b/src/dlna/ssdp.js
@@ -220,9 +220,13 @@ function handleSearch(msgStr, rinfo) {
   const pairs = matches[st];
   if (!pairs) { return; }
 
-  // Honor MX: delay responses by a random 0..MX seconds, then stagger by 50ms each
+  // Honor MX: delay responses by a random 0..MX seconds, then stagger by 50ms each.
+  // Clamp to the UPnP-recommended ceiling of 5s. Without an upper bound a client
+  // (the UDP source address is trivially spoofable) could send `MX: 999999` and
+  // make us hold response buffers + pending timers for hours — a cheap memory DoS,
+  // and a large value also widens the SSDP reflection/amplification window.
   const mxMatch = msgStr.match(/^MX:\s*(\d+)/im);
-  const mx = Math.max(1, parseInt(mxMatch ? mxMatch[1] : '1', 10));
+  const mx = Math.min(5, Math.max(1, parseInt(mxMatch ? mxMatch[1] : '1', 10)));
   let delay = Math.floor(Math.random() * mx * 1000);
   for (const [respSt, respUsn] of pairs) {
     const msg = searchResponseMsg(respSt, respUsn);

--- a/src/dlna/time-seek.js
+++ b/src/dlna/time-seek.js
@@ -17,6 +17,7 @@ import { spawn } from 'node:child_process';
 import winston from 'winston';
 import * as db from '../db/manager.js';
 import { ffmpegBin, getResolvedSource } from '../util/ffmpeg-bootstrap.js';
+import { resolveLibraryMediaPath } from './media-path.js';
 
 // Parse an NPT time spec per UPnP AV: either decimal seconds (`123.456`) or
 // `H:MM:SS.sss` / `MM:SS.sss`. Returns null on malformed input.
@@ -57,25 +58,11 @@ export function timeSeekMiddleware(req, res, next) {
   const start = parseNptStart(header);
   if (start === null || start < 0) { return res.status(400).end(); }
 
-  // Resolve library + file path from the URL.
-  const parts = req.path.split('/').filter(Boolean);
-  if (parts.length < 2) { return res.status(404).end(); }
-  let libname, fileParts;
-  try {
-    libname = decodeURIComponent(parts[0]);
-    fileParts = parts.slice(1).map(p => decodeURIComponent(p));
-  } catch (_) {
-    return res.status(400).end();
-  }
-
-  const lib = db.getAllLibraries().find(l => l.name === libname);
-  if (!lib) { return res.status(404).end(); }
-
-  const resolved = path.resolve(path.join(lib.root_path, ...fileParts));
-  const rootResolved = path.resolve(lib.root_path);
-  if (!resolved.startsWith(rootResolved + path.sep) && resolved !== rootResolved) {
-    return res.status(403).end();
-  }
+  // Resolve library + file path from the URL (shared with the separate-port
+  // media server — see media-path.js for the traversal-safety rationale).
+  const resolvedPath = resolveLibraryMediaPath(req.path);
+  if (!resolvedPath.ok) { return res.status(resolvedPath.status).end(); }
+  const { lib, resolved, relPath } = resolvedPath;
 
   // Verify the file is actually there before promising a 200. Without this,
   // a stale DB row (file deleted but scan hasn't caught up) would produce a
@@ -83,7 +70,6 @@ export function timeSeekMiddleware(req, res, next) {
   if (!fs.existsSync(resolved)) { return res.status(404).end(); }
 
   // Look up duration so we can emit the TimeSeekRange response header.
-  const relPath = fileParts.join('/');
   const row = db.getDB().prepare(
     'SELECT duration FROM tracks WHERE library_id = ? AND filepath = ?'
   ).get(lib.id, relPath);

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -253,6 +253,12 @@ const dlnaOptions = Joi.object({
   uuid: Joi.string().optional(),
   port: Joi.number().integer().min(1).max(65535).default(3011),
   browse: Joi.string().valid('flat', 'dirs', 'artist', 'album', 'genre').default('dirs'),
+  // The DLNA control surface is unauthenticated, but the smart containers
+  // (Recently Played / Most Played / Favorites) and Playlists aggregate data
+  // across ALL user accounts. Default true preserves the single-user/family
+  // behaviour; set false on multi-user servers to hide those per-user surfaces
+  // so anyone on the network can't read everyone's history, ratings, and lists.
+  shareUserData: Joi.boolean().default(true),
 });
 
 const subsonicOptions = Joi.object({

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -65,6 +65,9 @@ async function waitForScanComplete(baseUrl, timeoutMs = 30_000) {
  * @param {Object} opts
  * @param {string} [opts.dlnaMode='same-port']     DLNA mode to configure
  * @param {string} [opts.browseMode='dirs']        `dlna.browse` default-view setting
+ * @param {boolean} [opts.dlnaShareUserData]       `dlna.shareUserData`; omit for the
+ *                                                 config default (true). Set false to
+ *                                                 hide the per-user DLNA containers.
  * @param {string} [opts.subsonicMode='same-port'] Subsonic API mode to configure
  * @param {number} [opts.subsonicPort]             Port for Subsonic separate-port mode
  * @param {boolean} [opts.waitForScan=true]        Block until the initial scan finishes
@@ -80,6 +83,7 @@ export async function startServer(opts = {}) {
   const {
     dlnaMode      = 'same-port',
     browseMode    = 'dirs',
+    dlnaShareUserData,
     subsonicMode  = 'same-port',
     subsonicPort,
     rustPlayerPort,
@@ -126,6 +130,7 @@ export async function startServer(opts = {}) {
       mode: dlnaMode,
       name: 'mStream Test',
       browse: browseMode,
+      ...(dlnaShareUserData != null ? { shareUserData: dlnaShareUserData } : {}),
     },
     subsonic: {
       mode: subsonicMode,

--- a/test/integration/dlna.test.mjs
+++ b/test/integration/dlna.test.mjs
@@ -817,3 +817,37 @@ describe('DLNA identity (name + uuid)', () => {
     }
   });
 });
+
+// ── Per-user data gating (dlna.shareUserData = false) ───────────────────────
+// Recently Played / Most Played / Favorites and Playlists aggregate data across
+// every account, but the DLNA control surface is unauthenticated — so they are
+// hidden when shareUserData is off. Library-content containers stay visible.
+
+describe('Per-user data gating (shareUserData=false)', () => {
+  let priv, privClient;
+
+  before(async () => {
+    priv = await startServer({ dlnaMode: 'same-port', dlnaShareUserData: false });
+    privClient = makeClient(priv.baseUrl);
+  });
+
+  after(async () => { if (priv) { await priv.stop(); } });
+
+  test('Music listing hides the per-user containers but keeps library views', async () => {
+    const didl = decodeResult((await privClient.browse('music')).text);
+    for (const id of ['recentplayed', 'mostplayed', 'favorites', 'playlists']) {
+      assert.doesNotMatch(didl, new RegExp(`id="${id}"`), `${id} should be hidden`);
+    }
+    for (const id of ['recent', 'shuffle', 'years']) {
+      assert.match(didl, new RegExp(`id="${id}"`), `${id} should remain visible`);
+    }
+  });
+
+  test('direct browse to a gated container returns 701 No Such Object', async () => {
+    for (const id of ['recentplayed', 'mostplayed', 'favorites', 'playlists']) {
+      const { status, text } = await privClient.browse(id);
+      assert.equal(status, 500, `${id} should error`);
+      assert.match(text, /<errorCode>701<\/errorCode>/, `${id} should be 701`);
+    }
+  });
+});


### PR DESCRIPTION
## What

An audit pass over the DLNA subsystem (`src/api/dlna.js`, `src/dlna/*`) — code originally written by an older-model agent — fixing security/robustness issues and adding an opt-out for cross-user data exposure.

### Security / robustness
- **SSDP `MX` clamped to the UPnP 5s ceiling** (`ssdp.js`). A spoofed `MX: 999999` (the UDP source address is trivially forged) could otherwise pin response buffers + pending timers for hours — a cheap memory DoS — and widen the SSDP reflection/amplification window.
- **New `dlna.shareUserData` config (default `true`, behaviour unchanged).** The DLNA control surface is unauthenticated, but the smart containers (Recently Played / Most Played / Favorites) and the Playlists container aggregate data across **all** user accounts — so on a multi-user server anyone on the LAN could read everyone's listening history, ratings, and playlists. Set `false` to hide those per-user surfaces from the Music listing; a direct browse to a cached `recentplayed`/`mostplayed`/`favorites`/`playlists`/`playlist-N` object ID then returns `701 No Such Object`. Library-content views (Recently Added, Shuffle, By Year, libraries, search) are unaffected.

### Minor / cleanup
- **`res.sendFile` error handling** (`dlna-server.js`) — a file deleted before the scan caught up now returns a clean 404 instead of leaking a stack trace via Express's default error handler.
- **Shared `resolveLibraryMediaPath()` helper** (new `src/dlna/media-path.js`) — the security-sensitive `/media` library-root traversal check was duplicated in `time-seek.js` and `dlna-server.js`; extracted to one place so the two copies can't drift.
- **Consistent artist art** — the artist list view used an arbitrary `LIMIT 1` row while BrowseMetadata used `MIN()`; both now use `MIN()`, so a container shows the same art when listed vs. opened.
- **GENA `UNSUBSCRIBE` spec compliance** (UPnP 1.0 §4.1.2) — `412` for a missing/unknown SID, `400` if `NT`/`CALLBACK` is present (was an unconditional `200`).

## Why

The DLNA code hadn't been audited since it was first written. The standouts were the unauthenticated cross-user data exposure and the SSDP MX amplification vector; the rest are correctness/robustness papercuts found along the way.

## Reviewer notes

- The `shareUserData` default is **`true`**, so existing installs see no behaviour change. It's deliberately an opt-out — multi-user operators can lock it down without surprising single-user/family setups on upgrade. Finer-grained `dlna.defaultUser` scoping is left as a follow-up in `docs/dlna-todo.md`.
- New tests: a `Per-user data gating (shareUserData=false)` integration suite (hidden containers + `701` on direct browse), plus a `dlnaShareUserData` knob on the test `startServer` helper.
- **Tested:** full DLNA integration suite **77/77 pass** on this branch; ESLint clean (no new findings — the lone `no-empty` is pre-existing on master).
- Rebased onto current `master`. Note the browse-perf refactor from #622 coexists cleanly — that's actually the "stop loading the whole library on every folder browse" finding from the same audit, implemented separately.
- Deliberately **not** in this PR (tracked in `docs/dlna-todo.md`): the remaining audit findings — per-request `getLocalIp()`/`os.networkInterfaces()` in DIDL building, the HEAD-vs-GET ffmpeg-availability mismatch, and the `protocolInfo` time-seek/`DLNA.ORG_PN` mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
