### PR TITLE
test: write a real ID3v2.3 TCMP frame for compilation fixtures

### DIFF
--- a/test/helpers/ffmpeg.mjs
+++ b/test/helpers/ffmpeg.mjs
@@ -10,6 +10,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { appendId3v23TextFrames } from './id3.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -61,14 +62,21 @@ let tmpSeq = 0;
  * MP3. We encode to a unique temp file and atomically rename into place — the
  * `.mp3` suffix is preserved so ffmpeg still infers the mp3 muxer.
  *
+ * `appendFrames` carries ID3v2.3 text frames ffmpeg's mp3 muxer can't write
+ * itself — notably TCMP (compilation), which ffmpeg routes into an unread TXXX
+ * frame. They're spliced into the temp file BEFORE the rename, so the atomic
+ * swap still publishes a complete, correctly-tagged MP3 in one step.
+ *
  * @param {object}   o
  * @param {string}   o.outPath          Final destination path.
  * @param {number}   o.freq             Sine frequency in Hz.
  * @param {number}   [o.duration=1]     Duration in seconds.
  * @param {string[]} [o.metaArgs=[]]    Flat array of ffmpeg `-metadata` args.
+ * @param {object}   [o.appendFrames]   ID3v2.3 frames to splice post-encode,
+ *                                       e.g. `{ TCMP: '1' }`. Null/empty = none.
  * @param {string}   [o.ffmpegPath]     ffmpeg binary (defaults to bundled).
  */
-export async function encodeTone({ outPath, freq, duration = 1, metaArgs = [], ffmpegPath = BUNDLED_FFMPEG }) {
+export async function encodeTone({ outPath, freq, duration = 1, metaArgs = [], appendFrames = null, ffmpegPath = BUNDLED_FFMPEG }) {
   const tmp = path.join(
     path.dirname(outPath),
     `.tmp-${process.pid}-${tmpSeq++}-${path.basename(outPath)}`,
@@ -83,6 +91,9 @@ export async function encodeTone({ outPath, freq, duration = 1, metaArgs = [], f
       '-id3v2_version', '3',
       tmp,
     ]);
+    if (appendFrames && Object.keys(appendFrames).length) {
+      await appendId3v23TextFrames(tmp, appendFrames);
+    }
     await fs.rename(tmp, outPath);
   } catch (err) {
     await fs.rm(tmp, { force: true }).catch(() => {});

--- a/test/helpers/fixtures.mjs
+++ b/test/helpers/fixtures.mjs
@@ -39,7 +39,7 @@ function relPathFor(f) {
 }
 
 async function encode(outPath, f, fixtureIndex) {
-  const meta = ['title', 'artist', 'album', 'date', 'track', 'disc', 'genre', 'album_artist', 'compilation'];
+  const meta = ['title', 'artist', 'album', 'date', 'track', 'disc', 'genre', 'album_artist'];
   const metaArgs = [];
   const pairs = {
     title:  f.title,
@@ -49,9 +49,10 @@ async function encode(outPath, f, fixtureIndex) {
     track:  String(f.track),
     disc:   String(f.disc),
     genre:  f.genre,
-    // V17: album_artist → ID3v2 TPE2; compilation → TCMP.
+    // V17: album_artist → ID3v2 TPE2. compilation is appended as a real
+    // TCMP frame after the encode — ffmpeg's mp3 muxer would write it
+    // into a TXXX frame neither scanner reads.
     album_artist: f.albumArtist || null,
-    compilation:  f.compilation ? '1' : null,
   };
   for (const key of meta) {
     if (pairs[key] != null) {
@@ -65,7 +66,10 @@ async function encode(outPath, f, fixtureIndex) {
   // content correctly share one audio_hash, but we want distinct content
   // here so per-track state stays per-track.
   const freq = 220 + fixtureIndex * 40;  // 220, 260, 300, … Hz
-  await encodeTone({ outPath, freq, metaArgs });
+  await encodeTone({
+    outPath, freq, metaArgs,
+    appendFrames: f.compilation ? { TCMP: '1' } : null,
+  });
 }
 
 // Summary of what the test suite will see. Derived from FIXTURES so assertions

--- a/test/helpers/id3.mjs
+++ b/test/helpers/id3.mjs
@@ -1,0 +1,64 @@
+/**
+ * Minimal ID3v2.3 frame surgery for fixture generation.
+ *
+ * ffmpeg's mp3 muxer only writes frames from its own known-tag table, so
+ * iTunes-style frames like TCMP (compilation) are NOT expressible through
+ * `-metadata`: both `-metadata compilation=1` and `-metadata TCMP=1` land
+ * in TXXX frames that neither music-metadata's common.compilation nor
+ * lofty's FlagCompilation reads. Fixtures that need such frames let
+ * ffmpeg write the tags it CAN express, then append the rest here.
+ */
+
+import fs from 'node:fs/promises';
+
+// One ID3v2.3 text frame: latin1 body (encoding byte 0x00), plain
+// big-endian size — v2.3 frame sizes are NOT syncsafe.
+export function id3TextFrame(id, text) {
+  const body = Buffer.concat([Buffer.from([0x00]), Buffer.from(text, 'latin1')]);
+  const head = Buffer.alloc(10);
+  head.write(id, 0, 'latin1');
+  head.writeUInt32BE(body.length, 4);
+  return Buffer.concat([head, body]);
+}
+
+// Split a buffer into { frames, audio }: the concatenated frame data of
+// the leading ID3v2.3 tag (padding stripped) and everything after the
+// tag. Only handles what our ffmpeg invocations produce — v2.3, no
+// unsync/extended-header flags — and throws on anything else rather
+// than silently corrupting a fixture.
+function splitId3v23(buf) {
+  if (buf.length < 10 || buf.toString('latin1', 0, 3) !== 'ID3') {
+    return { frames: Buffer.alloc(0), audio: buf };
+  }
+  if (buf[3] !== 0x03) { throw new Error(`expected ID3v2.3, got v2.${buf[3]}`); }
+  if (buf[5] !== 0x00) { throw new Error(`unsupported ID3v2 flags 0x${buf[5].toString(16)}`); }
+  const tagSize = (buf[6] << 21) | (buf[7] << 14) | (buf[8] << 7) | buf[9];
+  const tagEnd = 10 + tagSize;
+  let pos = 10;
+  while (pos + 10 <= tagEnd && buf[pos] !== 0x00) {
+    pos += 10 + buf.readUInt32BE(pos + 4);
+  }
+  if (pos > tagEnd) { throw new Error('ID3v2.3 frame overruns tag boundary'); }
+  return { frames: buf.subarray(10, pos), audio: buf.subarray(tagEnd) };
+}
+
+/**
+ * Append text frames to the ID3v2.3 tag at the head of an MP3 (creating
+ * the tag if the file has none). `tags` maps frame id → value, e.g.
+ * `{ TCMP: '1' }`. Audio bytes are untouched, so audio_hash is stable.
+ */
+export async function appendId3v23TextFrames(filepath, tags) {
+  const { frames, audio } = splitId3v23(await fs.readFile(filepath));
+  const appended = Buffer.concat([
+    frames,
+    ...Object.entries(tags).map(([id, value]) => id3TextFrame(id, value)),
+  ]);
+  const header = Buffer.alloc(10);
+  header.write('ID3', 0, 'latin1');
+  header[3] = 0x03;
+  header[6] = (appended.length >> 21) & 0x7f;
+  header[7] = (appended.length >> 14) & 0x7f;
+  header[8] = (appended.length >> 7) & 0x7f;
+  header[9] = appended.length & 0x7f;
+  await fs.writeFile(filepath, Buffer.concat([header, appended, audio]));
+}

--- a/test/helpers/library-gen.mjs
+++ b/test/helpers/library-gen.mjs
@@ -71,7 +71,9 @@ import { encodeTone, BUNDLED_FFMPEG } from './ffmpeg.mjs';
  *                                        each as a separate track_genres
  *                                        row.
  * @param {string} [opts.albumArtist]     ID3 TPE2 (ALBUM_ARTIST).
- * @param {boolean} [opts.compilation]    ID3 TCMP (COMPILATION).
+ * @param {boolean} [opts.compilation]    ID3 TCMP (COMPILATION). Written as a
+ *                                        hand-built frame after the encode —
+ *                                        ffmpeg can't express TCMP.
  * @param {number} [opts.bpm]             ID3 TBPM. Integer.
  * @param {string} [opts.musicalKey]      ID3 TKEY. Free-form (e.g. "A minor", "8A", "Am").
  * @param {object} [opts.extraTags]       Arbitrary ID3 frames keyed by ffmpeg
@@ -132,8 +134,12 @@ export function mkSpec(opts) {
  * the shared ffmpeg helper, so this and fixtures.mjs stay in lock-step.
  */
 async function encodeSpec(spec, outPath, ffmpegPath) {
+  // `compilation` can't be written by ffmpeg's mp3 muxer (it lands in a
+  // TXXX frame neither scanner reads) — pull it out of the ffmpeg pass
+  // and splice a real TCMP frame in before the atomic rename.
+  const { compilation, ...ffmpegTags } = spec.tags || {};
   const metaArgs = [];
-  for (const [key, value] of Object.entries(spec.tags || {})) {
+  for (const [key, value] of Object.entries(ffmpegTags)) {
     metaArgs.push('-metadata', `${key}=${value}`);
   }
   await encodeTone({
@@ -141,6 +147,7 @@ async function encodeSpec(spec, outPath, ffmpegPath) {
     freq: spec.toneFreq,
     duration: spec.duration,
     metaArgs,
+    appendFrames: compilation != null ? { TCMP: String(compilation) } : null,
     ffmpegPath,
   });
 }

--- a/test/helpers/scanner-fixture.mjs
+++ b/test/helpers/scanner-fixture.mjs
@@ -23,6 +23,7 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { FFMPEG } from './scanner-runner.mjs';
+import { appendId3v23TextFrames } from './id3.mjs';
 
 // Exported so focused fixture builders (scanner-multi-art.test.mjs)
 // can reuse the same ffmpeg plumbing without re-rolling it.
@@ -93,6 +94,17 @@ const OGG   = ['-c:a', 'libvorbis', '-q:a', '2'];
 const M4A   = ['-c:a', 'aac', '-b:a', '64k', '-movflags', '+faststart'];
 const WAV   = ['-c:a', 'pcm_s16le'];
 
+// MP3 with a REAL ID3v2.3 TCMP (compilation) frame. ffmpeg writes the
+// rest of the tags, then TCMP is appended by hand — its mp3 muxer maps
+// `-metadata compilation=1` to a TXXX:compilation frame that NEITHER
+// music-metadata's common.compilation nor lofty's FlagCompilation
+// reads. (Vorbis is different: there ffmpeg writes a real COMPILATION
+// comment both scanners honour.) Exported for compilation-flag tests.
+export async function makeCompilationMp3(filepath, meta = {}) {
+  await makeAudio(filepath, MP3, meta);
+  await appendId3v23TextFrames(filepath, { TCMP: '1' });
+}
+
 export async function buildFixtureLibrary(rootDir) {
   await fs.mkdir(rootDir, { recursive: true });
 
@@ -154,23 +166,33 @@ export async function buildFixtureLibrary(rootDir) {
     await makeAudio(path.join(a2, `${i.toString().padStart(2, '0')}.mp3`), MP3, tags);
   }
 
-  // ── Album 3: "Various" compilation (8 tracks, different artists) ──
-  // COMPILATION=1 + no ALBUMARTIST → falls back to Various Artists.
+  // ── Album 3: "Various" compilation (10 tracks, different artists) ──
+  // Compilation flag + no ALBUMARTIST → falls back to Various Artists.
   // Tests the various_artists_id cache and the album-artist fallback.
+  // The flag is carried two ways so BOTH tag paths stay covered: tracks
+  // 1-8 are OGG (ffmpeg writes a real Vorbis COMPILATION comment),
+  // tracks 9-10 are MP3 with a hand-appended ID3v2.3 TCMP frame. All
+  // ten must converge on ONE Various-Artists-owned album row.
   const a3 = path.join(rootDir, 'Various Artists', 'Various');
   const compilationArtists = [
     'Aria', 'Boris', 'Cleo', 'Drake', 'Eve', 'Frank', 'Gina', 'Hugo',
+    'Iris', 'Jules',
   ];
   for (let i = 0; i < compilationArtists.length; i++) {
-    await makeAudio(path.join(a3, `${(i + 1).toString().padStart(2, '0')}.ogg`), OGG, {
+    const meta = {
       title:       `Comp Track ${i + 1}`,
       artist:      compilationArtists[i],
       album:       'Various',
-      compilation: '1',
       date:        '2023',
       track:       `${i + 1}/${compilationArtists.length}`,
       genre:       'Compilation',
-    });
+    };
+    const base = path.join(a3, `${(i + 1).toString().padStart(2, '0')}`);
+    if (i < 8) {
+      await makeAudio(`${base}.ogg`, OGG, { ...meta, compilation: '1' });
+    } else {
+      await makeCompilationMp3(`${base}.mp3`, meta);
+    }
   }
 
   // ── Album 4: "Acoustic" by Solo Artist again (3 tracks) ───────────
@@ -232,13 +254,16 @@ export async function buildFixtureLibrary(rootDir) {
 
   // Return summary the test can sanity-check against.
   return {
-    expectedAudioFiles: 5 + 6 + 8 + 3 + 5 + 4,
+    expectedAudioFiles: 5 + 6 + 10 + 3 + 5 + 4,
     expectedArtists: new Set([
       'Solo Artist', 'Foo', 'Bar', 'Format Test', 'Lyric Artist',
       ...compilationArtists,
       // Various Artists is seeded by the schema; not added by the scanner
       // but counted in the artists table.
     ]).size + 1, // +1 for Various Artists seed
+    // One row per album above — the compilation MUST collapse to a single
+    // Various-Artists-owned 'Various' row, not per-track-artist fragments.
     expectedAlbums: 6,
+    compilationTracks: compilationArtists.length,
   };
 }

--- a/test/scanner/scanner-parity.test.mjs
+++ b/test/scanner/scanner-parity.test.mjs
@@ -25,7 +25,7 @@ import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import {
-  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan,
+  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
   waveformFilenames,
 } from '../helpers/scanner-runner.mjs';
 import { snapshotDb } from '../helpers/db-snapshot.mjs';
@@ -79,8 +79,9 @@ async function freshScanEnv(label) {
 }
 
 // Run one full scan against a fresh env. Returns { snapshot, waveforms,
-// event } for assertion.
-async function scanAndSnapshot(label, overrides = {}) {
+// event } for assertion. Drives the rust binary unless a different
+// runner is supplied (the VA-collapse test pins both engines).
+async function scanAndSnapshot(label, overrides = {}, runner = cfg => runScan(rustBin, cfg)) {
   const env = await freshScanEnv(label);
   const cfg = buildScanConfig({
     dbPath: env.dbPath, libraryId: env.libraryId, vpath: env.vpath,
@@ -90,7 +91,7 @@ async function scanAndSnapshot(label, overrides = {}) {
     scanId: `scan-${label}-${Date.now()}`,
     overrides,
   });
-  const result = await runScan(rustBin, cfg);
+  const result = await runner(cfg);
   return {
     snapshot: snapshotDb(env.dbPath),
     waveforms: await waveformFilenames(env.wfSub),
@@ -126,6 +127,42 @@ describe('scanner determinism + parity', () => {
       'scanner should produce identical DB state across two runs of the same library');
     assert.deepEqual(b.waveforms, a.waveforms,
       'scanner should produce the same waveform .bin set across two runs');
+  });
+
+  // Determinism alone can't catch a fixture whose compilation flag is
+  // written in a form the scanner never reads — the album fragments into
+  // per-track-artist rows in BOTH runs and the snapshots still match. Pin
+  // the collapse itself, across both tag paths the fixture carries
+  // (Vorbis COMPILATION on the .ogg tracks, ID3v2.3 TCMP on the .mp3s).
+  test('compilation album collapses to one Various-Artists-owned row [rust+js]', async (t) => {
+    if (!rustBin)              { return t.skip('no rust-parser binary'); }
+    if (!fs.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+
+    const engines = { rust: undefined, js: runJsScan };
+    for (const [engine, runner] of Object.entries(engines)) {
+      const { snapshot } = await scanAndSnapshot(`va-collapse-${engine}`, {}, runner);
+
+      assert.equal(snapshot.artists.length, fixtureSummary.expectedArtists,
+        `[${engine}] artists table should hold ${fixtureSummary.expectedArtists} rows, got: ${snapshot.artists.join(', ')}`);
+      assert.ok(snapshot.artists.includes('Various Artists'), `[${engine}] VA row present`);
+      assert.equal(snapshot.albums.length, fixtureSummary.expectedAlbums,
+        `[${engine}] albums table should hold ${fixtureSummary.expectedAlbums} rows, got: ` +
+        snapshot.albums.map(a => `${a.name}/${a.artist_name}`).join(', '));
+
+      const various = snapshot.albums.filter(a => a.name === 'Various');
+      assert.equal(various.length, 1,
+        `[${engine}] compilation must collapse to ONE album row, not per-artist fragments`);
+      assert.equal(various[0].artist_name, 'Various Artists', `[${engine}] owned by VA`);
+      assert.equal(various[0].compilation, 1, `[${engine}] compilation flag stored`);
+
+      const compTracks = snapshot.tracks.filter(tr => tr.album_name === 'Various');
+      assert.equal(compTracks.length, fixtureSummary.compilationTracks,
+        `[${engine}] every compilation track lands on the album`);
+      const byFormat = {};
+      for (const tr of compTracks) { byFormat[tr.format] = (byFormat[tr.format] || 0) + 1; }
+      assert.deepEqual(byFormat, { mp3: 2, ogg: 8 },
+        `[${engine}] both the Vorbis COMPILATION and the ID3 TCMP tracks must land on the album`);
+    }
   });
 
   test('rescan of unchanged library is a fast-path no-op', async (t) => {


### PR DESCRIPTION
## Problem

The fixture helpers claimed to write the ID3 compilation flag (TCMP) but didn't. ffmpeg's mp3 muxer can't express the iTunes compilation flag — both `-metadata compilation=1` and `-metadata TCMP=1` land in `TXXX` frames that neither music-metadata's `common.compilation` nor lofty's `FlagCompilation` reads. So `test/helpers/fixtures.mjs` and `test/helpers/library-gen.mjs` passed `compilation=1` to ffmpeg and silently produced non-compilation files.

One correction to the original report: **only the MP3 paths were actually broken.** ffmpeg's **ogg** muxer *does* write a real Vorbis `COMPILATION` comment, and both the JS and rust scanners honour it — so `scanner-fixture.mjs`'s OGG compilation album was already collapsing to Various Artists correctly. The real gap there was that nothing *asserted* it: `expectedArtists`/`expectedAlbums` were computed but never checked, and the parity tests only deepEqual run-vs-run, which can't tell "collapsed" apart from "consistently fragmented". (Verified empirically by probing generated files and scanning probe libraries with each engine.)

## Changes

- **`test/helpers/id3.mjs`** (new) — shared ID3v2.3 frame surgery: `appendId3v23TextFrames()` appends hand-built text frames to an ffmpeg-written tag with audio bytes untouched (so `audio_hash` stays stable). Same recipe as `scanner-multi-art.test.mjs`'s typed-APIC fixture.
- **`test/helpers/ffmpeg.mjs`** — `encodeTone` gains an `appendFrames` option that splices ID3v2.3 frames (e.g. `{ TCMP: '1' }`) into the temp file **before** the atomic rename, so the race-safe publish still emits a complete, correctly-tagged MP3 in one step.
- **`fixtures.mjs` / `library-gen.mjs`** — route `compilation` through `encodeTone`'s `appendFrames` instead of the unread ffmpeg TXXX path. This also makes `scripts/gen-param-smoke-library.mjs`'s `compilation: true` real.
- **`scanner-fixture.mjs`** — compilation album grows to 10 tracks: 8 OGG (Vorbis `COMPILATION`) + 2 MP3 (real TCMP), so **both** tag paths flow through the parity snapshots. Exports `makeCompilationMp3` for compilation-flag tests.
- **`test/scanner/scanner-parity.test.mjs`** — new `[rust+js]` test pinning the collapse: exactly one Various-Artists-owned `Various` row (`compilation=1`) carrying all 10 tracks (`{mp3: 2, ogg: 8}`), plus the previously-unasserted `expectedArtists`/`expectedAlbums` counts. Determinism alone can't catch a fixture whose flag the scanner can't read — fragmented runs still snapshot identically.

## Verification

Rebased onto `master` (`71d46309`); integrated with master's new shared `test/helpers/ffmpeg.mjs` encoder.

- `npm test` — **1401 pass / 0 fail / 0 skipped**
- `npm run lint` — no net-new issues (the 2 problems eslint reports in the parity file exist identically on `master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)