### PR TITLE
ci: run tests on the `full-ci` label + fix iroh handshake rejection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,19 @@
 name: Test
 
 on:
-  # The heavy 9-job matrix runs only in the merge queue — i.e. once on the
-  # exact commit about to land on master, not on every PR push. Enable the
-  # merge queue on master and mark the "tests passed" check required (branch
-  # protection); merging a PR then enqueues it, which is what triggers this.
-  merge_group:
+  # The heavy 9-job matrix runs only when a PR is labelled `full-ci` — i.e. once
+  # you mark it ready to merge — not on every push. (Merge queue would be the
+  # native "before merge" trigger, but it's org-only and this repo is on a
+  # personal account.) Require the "tests passed" check in branch protection so
+  # a PR can't merge until it's been labelled `full-ci` and the run is green.
+  pull_request:
+    types: [labeled]
   # Manual escape hatch — run on demand from the Actions tab or
   # `gh workflow run test.yml --ref <branch>`.
   workflow_dispatch:
 
-# Each merge-queue entry gets its own ref, so this only de-dupes re-runs of the
-# same entry — it never cancels a different queued PR's check.
+# Re-labelling the same PR cancels its prior in-flight run (each PR has its own
+# ref); runs for different PRs never cancel each other.
 concurrency:
   group: test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,6 +21,8 @@ concurrency:
 jobs:
   test:
     name: test (${{ matrix.os }} · ${{ matrix.shard }}/3)
+    # Only on the `full-ci` label or a manual dispatch — never plain PR pushes.
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'full-ci'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -114,7 +118,9 @@ jobs:
   # all 9, which change whenever the OS or shard list does.
   tests-passed:
     name: tests passed
-    if: always()
+    # Mirror the gate so this check only exists when the matrix ran; always()
+    # makes it still report (and fail) if a shard failed.
+    if: always() && (github.event_name == 'workflow_dispatch' || github.event.label.name == 'full-ci')
     needs: [test]
     runs-on: ubuntu-latest
     steps:

--- a/src/state/iroh.js
+++ b/src/state/iroh.js
@@ -332,7 +332,22 @@ export async function connectTunnel(compositeTicket, { awaitOnline = true } = {}
   const authBi = await conn.openBi();
   await authBi.send.writeAll(Array.from(Buffer.from(secret, 'base64')));
   await authBi.send.finish();
-  const resp = Buffer.from(await authBi.recv.readToEnd(8)).toString('utf8');
+  // The server rejects a bad secret by *closing* the connection with reason
+  // "unauthorized" (see runAcceptLoop) rather than replying with a non-"OK"
+  // body. Depending on timing/platform that surfaces here either as an empty
+  // read (resp !== 'OK' below) or as a thrown ConnectionLost/ApplicationClosed
+  // error — so the read must be wrapped, otherwise the raw QUIC error escapes
+  // on some platforms (it did on Linux) instead of the clean rejection.
+  let resp;
+  try {
+    resp = Buffer.from(await authBi.recv.readToEnd(8)).toString('utf8');
+  } catch (err) {
+    try { await client.close(); } catch (_err) { /* noop */ }
+    if (/unauthorized/i.test(err?.message || '')) {
+      throw new Error('tunnel handshake rejected (bad connect secret)', { cause: err });
+    }
+    throw err;
+  }
   if (resp !== 'OK') {
     try { await client.close(); } catch (_err) { /* noop */ }
     throw new Error('tunnel handshake rejected (bad connect secret)');


### PR DESCRIPTION
## Why

The previous trigger (`merge_group`, from #659) can never fire: **GitHub's merge queue is organization-only** — it's unavailable for repositories owned by a personal account, which is why the "Require merge queue" option is absent in the UI and the REST API rejected the `merge_queue` ruleset rule. ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue))

## What

Run the 9-job matrix only when a PR is **labelled `full-ci`** (plus a manual `workflow_dispatch`), not on every commit:

```yaml
on:
  pull_request:
    types: [labeled]
  workflow_dispatch:
# jobs gated: if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'full-ci'
```

- Add the `full-ci` label when a PR is ready to merge → one full run. Re-add it (or dispatch) to re-run.
- Other label events are no-ops (jobs skip → ~no minutes).
- The `tests passed` aggregator still collapses the 9 legs into one stable required check.

This keeps the resource savings you were after (one run per PR near merge, not per commit) without the merge queue.

## To enforce (one-time, in the UI — required checks *are* available on your account)

Settings → Branches (or Rules) → protect `master` → **Require status checks to pass** → add **`tests passed`**. A PR then can't merge until it's been labelled `full-ci` and the run is green.

## Verified

Dispatched this branch via `workflow_dispatch` → all 9 jobs run (none skipped), confirming the gate is correct. (The label path can't be exercised until this is on master; it's the standard `github.event.label.name` check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)