### PR TITLE
build(deps): refresh in-range dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "jsonwebtoken": "^9.0.3",
         "m3u8-parser": "^7.2.0",
         "mime-types": "^3.0.2",
-        "music-metadata": "^11.11.1",
-        "nanoid": "^5.0.9",
+        "music-metadata": "^11.13.0",
+        "nanoid": "^5.1.16",
         "tree-kill": "^1.2.2",
         "undici": "^7.28.0",
         "winston": "^3.19.0",
@@ -33,9 +33,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@redocly/cli": "^2.34.0",
-        "eslint": "^10.0.0",
-        "globals": "^17.3.0"
+        "@redocly/cli": "^2.35.1",
+        "eslint": "^10.6.0",
+        "globals": "^17.7.0"
       },
       "engines": {
         "node": ">=22.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1067,9 +1067,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.34.0.tgz",
-      "integrity": "sha512-wlEy03fyf+xrEatHbSSLFGP7T8slYwyJHO6xooArvUOntiGRMPuTGivaSPhxx+f2bFhe69zDDzDy51+CsvJ/zw==",
+      "version": "2.35.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.35.1.tgz",
+      "integrity": "sha512-8XcUIR6bCI4KmVg6RJyzL3peZhld/tu7oO8WGVaHp43byhcds6ProHlfqEFa+dZA+qA+dUMebgRELVOe5AW4Lg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1990,19 +1990,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2579,9 +2582,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3199,9 +3202,9 @@
       "license": "MIT"
     },
     "node_modules/music-metadata": {
-      "version": "11.12.3",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.3.tgz",
-      "integrity": "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.13.0.tgz",
+      "integrity": "sha512-uXRaov9dfjSpQufXIU7sMxVZnh+FilCQv2mXn+K5EJ/decP3dTWrgvPYa5r6MtRbieNSCE708Da4J0u1UGfQIw==",
       "funding": [
         {
           "type": "github",
@@ -3216,11 +3219,11 @@
       "dependencies": {
         "@borewit/text-codec": "^0.2.2",
         "@tokenizer/token": "^0.3.0",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "file-type": "^21.3.1",
-        "media-typer": "^1.1.0",
-        "strtok3": "^10.3.4",
+        "file-type": "^21.3.4",
+        "media-typer": "^2.0.0",
+        "strtok3": "^10.3.5",
         "token-types": "^6.1.2",
         "uint8array-extras": "^1.5.0",
         "win-guid": "^0.2.1"
@@ -3229,10 +3232,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/music-metadata/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/music-metadata/node_modules/media-typer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-2.0.0.tgz",
+      "integrity": "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "jsonwebtoken": "^9.0.3",
     "m3u8-parser": "^7.2.0",
     "mime-types": "^3.0.2",
-    "music-metadata": "^11.11.1",
-    "nanoid": "^5.0.9",
+    "music-metadata": "^11.13.0",
+    "nanoid": "^5.1.16",
     "tree-kill": "^1.2.2",
     "undici": "^7.28.0",
     "winston": "^3.19.0",
@@ -73,8 +73,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@redocly/cli": "^2.34.0",
-    "eslint": "^10.0.0",
-    "globals": "^17.3.0"
+    "@redocly/cli": "^2.35.1",
+    "eslint": "^10.6.0",
+    "globals": "^17.7.0"
   }
 }


### PR DESCRIPTION
## What

Refreshes the dependency set to the latest versions allowed by the existing **major** ranges. Both `package.json` (declared semver floors) **and** `package-lock.json` (resolved versions) are updated.

| Package | Resolved (was → now) | Type |
|---|---|---|
| music-metadata | 11.12.3 → 11.13.0 | prod |
| nanoid | 5.1.9 → 5.1.16 | prod |
| eslint | 10.2.1 → 10.6.0 | dev |
| @redocly/cli | 2.34.0 → 2.35.1 | dev |
| globals | 17.5.0 → 17.7.0 | dev |

`package.json` floors bumped to match: `music-metadata ^11.11.1→^11.13.0`, `nanoid ^5.0.9→^5.1.16`, `eslint ^10.0.0→^10.6.0`, `@redocly/cli ^2.34.0→^2.35.1`, `globals ^17.3.0→^17.7.0`. Every bump stays within the existing major — no breaking jumps.

Transitive bumps pulled in alongside these: `@eslint/config-helpers`, `@eslint/plugin-kit`, and music-metadata's nested `content-type`/`media-typer`/`file-type`/`strtok3`.

## Why

Keeps both the manifest and the lockfile current with the latest non-major releases.

## Verification

- `npm audit` → **0 vulnerabilities**
- Full test suite → **1406/1406 pass**
- Runtime deps (music-metadata, nanoid) import smoke ✓
- eslint 10.6.0 loads the flat config ✓

## Deliberately excluded

The two available majors — **archiver 7→8** (handled separately in #681) and **undici 7→8** (raises the Node floor to ≥22.19.0) — are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)