### PR TITLE
chore(deps): remove unused federation/syncthing deps (undici, fast-xml-parser, http-proxy)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "music-metadata": "^11.13.0",
         "nanoid": "^5.1.16",
         "tree-kill": "^1.2.2",
-        "undici": "^7.28.0",
         "winston": "^3.19.0",
         "ws": "^8.21.0"
       },
@@ -3805,15 +3804,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/unpipe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,6 @@
         "command-exists": "^1.2.9",
         "cookie-parser": "^1.4.7",
         "express": "^5.0.1",
-        "fast-xml-parser": "^5.9.3",
-        "http-proxy": "^1.18.1",
         "jimp": "^1.6.0",
         "joi": "^18.2.3",
         "jsonwebtoken": "^9.0.3",
@@ -748,18 +746,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@number0/iroh": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@number0/iroh/-/iroh-1.0.0.tgz",
@@ -1107,18 +1093,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
       "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-      "license": "MIT"
-    },
-    "node_modules/anynum": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
-      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/archiver": {
@@ -1986,12 +1960,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -2094,45 +2062,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
-      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.2.0",
-        "fast-xml-builder": "^1.2.0",
-        "is-unsafe": "^1.0.1",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.4.1",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
@@ -2234,26 +2163,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2421,20 +2330,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2545,18 +2440,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-unsafe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
-      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -3171,21 +3054,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
-      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3369,12 +3237,6 @@
       "funding": {
         "url": "https://github.com/sponsors/yqnn"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -3647,21 +3509,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strnum": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
-      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "anynum": "^1.0.1"
       }
     },
     "node_modules/strtok3": {
@@ -3954,21 +3801,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xml-parse-from-string": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "music-metadata": "^11.13.0",
     "nanoid": "^5.1.16",
     "tree-kill": "^1.2.2",
-    "undici": "^7.28.0",
     "winston": "^3.19.0",
     "ws": "^8.21.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "command-exists": "^1.2.9",
     "cookie-parser": "^1.4.7",
     "express": "^5.0.1",
-    "fast-xml-parser": "^5.9.3",
-    "http-proxy": "^1.18.1",
     "jimp": "^1.6.0",
     "joi": "^18.2.3",
     "jsonwebtoken": "^9.0.3",

--- a/src/api/federation.js
+++ b/src/api/federation.js
@@ -2,7 +2,6 @@ import jwt from 'jsonwebtoken';
 import Joi from 'joi';
 import { URL } from 'url';
 import crypto from 'crypto';
-import httpProxy from 'http-proxy';
 import * as sync from '../state/syncthing.js';
 import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
@@ -75,39 +74,9 @@ export function setup(mstream) {
     });
   });
 
-  const apiProxy = httpProxy.createProxyServer();
-
-  apiProxy.on('proxyReq', (proxyReq, req, _res, _options) => {
-    proxyReq.path = proxyReq.path.replace('/api/v1/syncthing-proxy', '');
-
-    if (proxyReq.path.charAt(0) !== '/') {
-      proxyReq.path = '/' + proxyReq.path;
-    }
-
-    if (req.body) {
-      const bodyData = JSON.stringify(req.body);
-      // incase if content-type is application/x-www-form-urlencoded -> we need to change to application/json
-      proxyReq.setHeader('Content-Type','application/json');
-      proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-      // stream the content
-      proxyReq.write(bodyData);
-    }
-  });
-
-  apiProxy.on('error', (err, req, res) => {
-    res.writeHead(500, { 'Content-Type': 'text/plain' });
-    res.end('Something went wrong. And we are reporting a custom error message.');
-  });
-
-  mstream.all('/api/v1/syncthing-proxy/{*path}', (req, res) => {
-    // Add the auth token as a cookie so all contents of the iframe use it
-    if (req.token) { res.cookie('x-access-token', req.token); }
-    apiProxy.web(req, res, {target: 'http://' + sync.getUiAddress(), changeOrigin: true});
-  });
-
-  mstream.all('/api/v1/syncthing-proxy/', (req, res) => {
-    // Add the auth token as a cookie so all contents of the iframe use it
-    if (req.token) { res.cookie('x-access-token', req.token); }
-    apiProxy.web(req, res, {target: 'http://' + sync.getUiAddress(), changeOrigin: true});
-  });
+  // FEDERATION UNWIRED: the /api/v1/syncthing-proxy/* routes reverse-proxied to
+  // Syncthing's local Web GUI via http-proxy (createProxyServer + apiProxy.web
+  // to http://sync.getUiAddress()). http-proxy has been removed from the
+  // dependency tree, so these routes are not registered here. Re-add a proxy
+  // mechanism when federation/syncthing is revived (see src/server.js).
 }

--- a/src/state/syncthing.js
+++ b/src/state/syncthing.js
@@ -4,14 +4,12 @@ import { nanoid } from 'nanoid';
 import winston from 'winston';
 import path from 'path';
 import { spawn } from 'child_process';
-import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import kill from 'tree-kill';
 import * as killQueue from './kill-list.js';
 import * as config from './config.js';
 import * as db from '../db/manager.js';
 import { appRoot } from '../util/esm-helpers.js';
 
-const parser = new XMLParser({ ignoreAttributes: false });
 const platform = os.platform();
 const osMap = {
   "win32": "syncthing.exe",
@@ -35,7 +33,6 @@ let spawnedProcess;
 let xmlObj; // Syncthing XML Config
 let myId; // Syncthing Device ID
 const cacheObj = {};
-let uiAddress;
 
 killQueue.addToKillQueue(
   () => {
@@ -55,8 +52,10 @@ export function getId() {
 }
 
 export function getUiAddress() {
-  if (typeof uiAddress !== 'string') { throw new Error('Syncthing UI Address Not Set'); }
-  return uiAddress;
+  // FEDERATION UNWIRED: uiAddress was populated by loadConfig, which was removed
+  // along with the fast-xml-parser dependency. It is never set while federation
+  // is parked, so this always throws (no live caller — see src/server.js).
+  throw new Error('Syncthing UI Address Not Set');
 }
 
 export function getPathId(path) {
@@ -145,29 +144,9 @@ function getSyncthingId() {
 }
 
 function loadConfig() {
-  xmlObj = parser.parse(fs.readFileSync(path.join(config.program.storage.syncConfigDirectory, 'config.xml'), 'utf8'));
-
-  // convert objects to arrays
-  if (typeof xmlObj.configuration.folder === 'object' && !(xmlObj.configuration.folder instanceof Array)) {
-    xmlObj.configuration.folder = [xmlObj.configuration.folder];
-  } else if (typeof xmlObj.configuration.folder !== 'object') {
-    xmlObj.configuration.folder = [];
-  }
-
-  // convert objects to arrays
-  if (typeof xmlObj.configuration.device === 'object' && !(xmlObj.configuration.device instanceof Array)) {
-    xmlObj.configuration.device = [xmlObj.configuration.device];
-  } else if (typeof xmlObj.configuration.device !== 'object') {
-    xmlObj.configuration.device = [];
-  }
-
-  // cache paths
-  xmlObj.configuration.folder.forEach(folderObj => {
-    cacheObj[folderObj['@_label']] = folderObj['@_id'];
-  });
-
-  // get UI address
-  uiAddress = xmlObj.configuration.gui.address;
+  // FEDERATION UNWIRED: parsed config.xml via fast-xml-parser, which has been
+  // removed from the dependency tree. Re-add an XML parser here (and the
+  // builder in saveIt) when federation/syncthing is revived (see src/server.js).
 }
 
 function removeFoldersFromConfig() {
@@ -241,12 +220,6 @@ function addFoldersToConfig() {
       }
     }
   );
-
-  const builder = new XMLBuilder({
-    format: true,
-    ignoreAttributes: false,
-  });
-  builder.build(xmlObj);
 }
 
 export function addDevice(deviceId, directories) {
@@ -373,14 +346,9 @@ export function addFederatedDirectory(directoryName, directoryId, path, deviceId
 // function removeFederatedDirectory(directory) {}
 
 function saveIt() {
-  const builder = new XMLBuilder({
-    format: true,
-    ignoreAttributes: false,
-  });
-  fs.writeFileSync(
-    path.join(config.program.storage.syncConfigDirectory, 'config.xml'),
-    builder.build(xmlObj),
-    'utf8');
+  // FEDERATION UNWIRED: serialised xmlObj back to config.xml via fast-xml-parser's
+  // XMLBuilder, which has been removed. Re-add an XML builder here (and the
+  // parser in loadConfig) when federation/syncthing is revived.
 }
 
 // Syncthing's local REST API serves HTTPS with a self-signed cert that Node's

--- a/src/state/syncthing.js
+++ b/src/state/syncthing.js
@@ -5,7 +5,6 @@ import winston from 'winston';
 import path from 'path';
 import { spawn } from 'child_process';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
-import { Agent } from 'undici';
 import kill from 'tree-kill';
 import * as killQueue from './kill-list.js';
 import * as config from './config.js';
@@ -384,16 +383,15 @@ function saveIt() {
     'utf8');
 }
 
-async function rebootSyncThing() {
-  try {
-    await fetch(`https://${xmlObj.configuration.gui.address}/rest/system/restart`, {
-      method: 'POST',
-      headers: { 'X-API-Key': xmlObj.configuration.gui.apikey },
-      dispatcher: new Agent({ connect: { rejectUnauthorized: false } })
-    });
-  } catch(err) {
-    winston.error('Syncthing Reboot Failed', { stack: err });
-  }
+// Syncthing's local REST API serves HTTPS with a self-signed cert that Node's
+// global fetch rejects; this reboot previously bypassed that with an undici
+// Agent dispatcher ({ connect: { rejectUnauthorized: false } }). `undici` was
+// the only thing in the dependency tree that used it, so the dependency was
+// removed and this call is stubbed while federation/syncthing is unwired (see
+// src/server.js). On revival, re-add a TLS-bypass mechanism (an undici Agent
+// dispatcher or a node:https request) for the POST to /rest/system/restart.
+function rebootSyncThing() {
+  winston.warn('Syncthing reboot skipped — federation is unwired (undici removed)');
 }
 
 function bootProgram() {


### PR DESCRIPTION
## What

Removes three dependencies that were used **only** by the unwired federation/syncthing feature:

| Dependency | Sole usage |
|---|---|
| `undici` | `Agent` dispatcher to bypass Syncthing's self-signed cert on reboot (`src/state/syncthing.js`) |
| `fast-xml-parser` | `config.xml` parse/build (`src/state/syncthing.js`) |
| `http-proxy` | the `/api/v1/syncthing-proxy/*` reverse proxy (`src/api/federation.js`) |

Federation + syncthing are currently **unwired** — `src/server.js` has their imports and `setup()` calls commented out ("disabled while the feature is rebuilt"). Each package appears exactly once in the whole repo, both in these dead modules, so nothing live (server or tests) loads them.

## Changes

- **`package.json`** — drop `undici`, `fast-xml-parser`, `http-proxy`.
- **`src/state/syncthing.js`** — remove the `undici` + `fast-xml-parser` imports; stub `rebootSyncThing()`, `loadConfig()`, `saveIt()` with revival notes; drop a vestigial `XMLBuilder` call (its result was already discarded) and the now-orphaned `uiAddress` var (`loadConfig` was its only writer).
- **`src/api/federation.js`** — remove the `http-proxy` import and the proxy/route block, with a revival note.

The modules are left on disk (matching the maintainers' "keep for revival" approach); every stub documents exactly what to restore.

## Impact

Removes **13 packages** from the lockfile — the three direct deps plus their transitives (`strnum`, `fast-xml-builder`, `@nodable/entities`, `anynum`, `follow-redirects`, `eventemitter3`, `requires-port`, …).

## Notes / safety

- **Global `fetch` is unaffected** — it uses Node's internal vendored undici, not the npm `undici` package.
- Nothing live imports `syncthing.js` / `federation.js`, so this is behaviorally inert.

## Verification

- No real code refs to any of the three remain in `src/` (only prose in revival comments).
- ESLint clean on the changed files.
- Full test suite → **1406/1406 pass**.
- `npm audit` → **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)