### PR TITLE
fix(album-art): return 404 (not 500) for a missing cover file

### DIFF
--- a/src/api/album-art.js
+++ b/src/api/album-art.js
@@ -115,17 +115,33 @@ const SEND_FILE_OPTS = { dotfiles: 'allow' };
 export function serveAlbumArtFile(req, res) {
   const filename = sanitizeFilename(req.params.file);
   const dir = config.program.storage.albumArtDirectory;
+  // sendFile() with no error callback forwards a missing file to Express's
+  // error handler as a 500; handle it so a not-found cover is a clean 404
+  // instead. The error from `send` is an http-errors object (err.status===404
+  // for ENOENT/ENAMETOOLONG/ENOTDIR). Bail if the response already started
+  // (client aborted mid-stream → headers/data flushed); log genuine 5xx causes.
+  const send = (p) => res.sendFile(p, SEND_FILE_OPTS, (err) => {
+    if (!err || res.headersSent) return;
+    const notFound =
+      err.status === 404 || err.statusCode === 404 || err.code === 'ENOENT';
+    if (!notFound) {
+      winston.warn(`[album-art] failed to serve ${p}: ${err.message}`);
+    }
+    res.status(notFound ? 404 : 500).end();
+  });
   const compress = req.query.compress;
   if (compress !== undefined) {
     if (typeof compress !== 'string' || !/^[a-zA-Z0-9]{1,8}$/.test(compress)) {
       return res.status(400).end();
     }
     const compressedPath = path.resolve(path.join(dir, `z${compress}-${filename}`));
+    // existsSync stays as the fall-through trigger: a missing compressed variant
+    // serves the original rather than 404-ing.
     if (fs.existsSync(compressedPath)) {
-      return res.sendFile(compressedPath, SEND_FILE_OPTS);
+      return send(compressedPath);
     }
   }
-  res.sendFile(path.resolve(path.join(dir, filename)), SEND_FILE_OPTS);
+  send(path.resolve(path.join(dir, filename)));
 }
 
 // ── Art save helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
`serveAlbumArtFile` (`src/api/album-art.js`) calls `res.sendFile()` with **no error callback**, so a request for an album-art file that isn't on disk is forwarded to Express's error handler and returns **HTTP 500** instead of a 404. On the standalone DLNA app (`src/dlna/dlna-server.js`), which has no central error handler, it also leaks a stack trace.

## Fix
Pass an error callback to `sendFile` (via a small local `send` helper used at both send sites) that:
- maps a missing file (`send`'s http-errors object: `status`/`statusCode === 404`, also `ENOENT`) → **404**;
- maps any other *pre-headers* error → 500, with a `winston.warn` so genuine disk/permission failures are still logged;
- guards `res.headersSent` so a client abort **mid-stream** isn't double-handled (`Cannot set headers after they are sent`).

The `existsSync` pre-check on the compressed variant is kept, so a missing **compressed** file still falls back to the original rather than 404-ing.

## Why it's safe for all callers
- `src/server.js` GET `/album-art/:file` — real Express res; strict improvement (404 instead of a logged 500).
- Subsonic `getCoverArt` (`src/api/subsonic/handlers.js`) — only synthesizes `req.params`/`req.query`; `res` is the real Express response, so the callback works. A bare HTTP 404 matches the adjacent `res.status(404).end()` for a missing DB row and is the correct shape for a binary cover-art endpoint (real Subsonic servers return a binary 404, not a `<subsonic-response>` envelope).
- DLNA standalone app — real res; biggest improvement (no more stack-trace 500).

Matches the repo's existing missing-file convention (`res.status(404).end()`).

## Notes
- Verified against the installed Express 5.2.1 / `send` 1.2.1 semantics (callback receives an http-errors 404 for ENOENT; with a callback present `send` neither forwards to `next()` nor double-responds).
- The file has two **pre-existing** `no-empty` lint errors (empty `catch (_e) {}` in `saveImageToCache` and the art-search endpoint) unrelated to this change — left untouched to keep the diff focused.

Found while debugging an unrelated album-art display issue in the Flutter client.