### PR TITLE
build(bun): bundle the iroh native addon so remote access works in releases

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -128,6 +128,23 @@ jobs:
           grep -q "Scan complete" "$RUN/boot.log" || { echo "FAIL: scan did not complete"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; }
           echo "SMOKE OK: $BIN booted, served 200, and completed a scan"
 
+      - name: Smoke test iroh native binding
+        # Proves the standalone binary can dlopen the bundled @number0/iroh .node
+        # (bin/iroh/, staged by build-bun.mjs) via NAPI_RS_NATIVE_LIBRARY_PATH —
+        # remote access silently degrades if it can't, so assert it loudly. Only
+        # the native (non-cross) targets can run here, same as the boot smoke.
+        if: matrix.smoke
+        shell: bash
+        run: |
+          set -e
+          D=$(ls -d dist/stage/mStream-*-${{ matrix.key }})
+          if [ -d "$D/mStream.app" ]; then BIN="$D/mStream.app/Contents/MacOS/mStream"; elif [ -f "$D/mStream.exe" ]; then BIN="$D/mStream.exe"; else BIN="$D/mStream-${{ matrix.key }}"; fi
+          echo "iroh smoke binary: $BIN"
+          OUT=$("$BIN" --mstream-worker=iroh-selftest '{}' 2>&1) || { echo "$OUT"; echo "FAIL: iroh self-test exited non-zero"; exit 1; }
+          echo "$OUT"
+          echo "$OUT" | grep -q IROH_OK || { echo "FAIL: iroh native binding did not load in the standalone binary"; exit 1; }
+          echo "OK: iroh native binding loaded from the bundled .node"
+
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -9,7 +9,7 @@
 // Windows icon + metadata flags are only applied for a win-x64 build running ON
 // Windows — Bun can't set them when cross-compiling. Name/version/etc. come from
 // package.json so they never drift.
-import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, cpSync, chmodSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, cpSync, chmodSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -155,6 +155,15 @@ for (const [dir, file] of sidecars) {
   }
 }
 
+// Iroh remote-access tunnel: @number0/iroh ships as a NAPI-RS *native addon*
+// (prebuilt .node), not a spawned exe like the rust sidecars. A Bun standalone
+// binary can't resolve it from node_modules, so we stage the target's .node next
+// to the binary and point the loader at it at runtime via
+// NAPI_RS_NATIVE_LIBRARY_PATH (see src/state/iroh.js). Best-effort: a build that
+// can't obtain the .node still ships — remote access just stays unavailable,
+// exactly as on an unsupported platform.
+stageIroh(t, contentRoot);
+
 // App icon. Windows embeds it in the .exe at compile time (--windows-icon
 // above). macOS and Linux can't embed an icon in a bare binary, so we package
 // one the platform-native way: a .app bundle (macOS) or a .desktop + PNG (Linux).
@@ -224,4 +233,63 @@ Icon=%INSTALL_DIR%/mStream.png
 Terminal=true
 Categories=AudioVideo;Audio;Network;
 `;
+}
+
+// NAPI-RS target triple for @number0/iroh's platform package / .node filename
+// (e.g. win32-x64-msvc, linux-arm64-musl, darwin-arm64).
+function napiTriple(target) {
+  if (target.plat === 'win32') { return `win32-${target.arch}-msvc`; }
+  if (target.plat === 'darwin') { return `darwin-${target.arch}`; }
+  return `linux-${target.arch}-${target.musl ? 'musl' : 'gnu'}`; // linux
+}
+
+// Stage @number0/iroh's prebuilt .node for `target` into <contentRoot>/bin/iroh/.
+// Native targets reuse the host-installed platform package (npm install picks
+// the host triple); cross targets fetch the matching package from npm via
+// `npm pack` (which ignores os/cpu, unlike `npm install`). Best-effort — warns
+// and returns on any miss so the bundle still ships without remote access.
+function stageIroh(target, dest) {
+  const triple = napiTriple(target);
+  const file = `iroh.${triple}.node`;
+  const destDir = join(dest, 'bin', 'iroh');
+
+  // 1) Host-matching prebuilt already installed by `npm ci` (native targets).
+  const installed = join(root, 'node_modules', `@number0/iroh-${triple}`, file);
+  if (existsSync(installed)) {
+    mkdirSync(destDir, { recursive: true });
+    cpSync(installed, join(destDir, file));
+    console.log(`  iroh: staged ${file} (node_modules)`);
+    return;
+  }
+
+  // 2) Cross target: fetch the platform package tarball and extract its .node.
+  let version;
+  try {
+    version = JSON.parse(readFileSync(join(root, 'node_modules', '@number0', 'iroh', 'package.json'), 'utf8')).version;
+  } catch {
+    console.warn('  iroh: @number0/iroh not installed — remote access unavailable in this bundle');
+    return;
+  }
+  const tmp = join(root, 'dist', '.iroh-fetch');
+  rmSync(tmp, { recursive: true, force: true });
+  mkdirSync(tmp, { recursive: true });
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const spec = `@number0/iroh-${triple}@${version}`;
+  const pack = spawnSync(npm, ['pack', spec, '--pack-destination', tmp], { cwd: root, stdio: 'inherit' });
+  if (pack.status !== 0) {
+    console.warn(`  iroh: 'npm pack ${spec}' failed — remote access unavailable in this bundle`);
+    return;
+  }
+  const tgz = readdirSync(tmp).find((f) => f.endsWith('.tgz'));
+  if (!tgz) { console.warn('  iroh: npm pack produced no tarball — remote access unavailable'); return; }
+  const untar = spawnSync('tar', ['-xzf', join(tmp, tgz), '-C', tmp], { stdio: 'inherit' });
+  // npm tarballs put files under package/.
+  const extracted = join(tmp, 'package', file);
+  if (untar.status !== 0 || !existsSync(extracted)) {
+    console.warn(`  iroh: could not extract ${file} from ${tgz} — remote access unavailable`);
+    return;
+  }
+  mkdirSync(destDir, { recursive: true });
+  cpSync(extracted, join(destDir, file));
+  console.log(`  iroh: staged ${file} (fetched ${tgz})`);
 }

--- a/src/state/iroh.js
+++ b/src/state/iroh.js
@@ -34,6 +34,9 @@
 import net from 'net';
 import crypto from 'crypto';
 import winston from 'winston';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { appRoot, isBunStandalone } from '../util/esm-helpers.js';
 
 // ALPN for the mStream tunnel — both ends must present identical bytes.
 // v1 wants ALPNs as Array<number>. Bump the version if framing changes.
@@ -48,8 +51,37 @@ const delay = (ms) => new Promise((r) => setTimeout(r, ms));
 // missing/unloadable binary only surfaces when the feature is actually used.
 let irohMod = null;
 async function loadIroh() {
-  if (!irohMod) { irohMod = await import('@number0/iroh'); }
+  if (!irohMod) {
+    // Under a Bun `--compile` standalone binary, @number0/iroh's NAPI-RS loader
+    // can't resolve its platform package from the virtual node_modules, so point
+    // it at the prebuilt .node shipped next to the executable (staged into
+    // bin/iroh/ by scripts/build-bun.mjs). The loader honours
+    // NAPI_RS_NATIVE_LIBRARY_PATH ahead of its built-in resolution. No-op under
+    // Node/Electron, where normal node_modules resolution applies.
+    if (isBunStandalone && !process.env.NAPI_RS_NATIVE_LIBRARY_PATH) {
+      try {
+        const dir = join(appRoot, 'bin', 'iroh');
+        const node = existsSync(dir) && readdirSync(dir).find((f) => f.endsWith('.node'));
+        if (node) { process.env.NAPI_RS_NATIVE_LIBRARY_PATH = join(dir, node); }
+      } catch { /* fall back to the loader's default resolution */ }
+    }
+    irohMod = await import('@number0/iroh');
+  }
   return irohMod;
+}
+
+// Smoke check for the `iroh-selftest` worker (build CI + local build
+// verification). Forces the native binding to load and confirms it's the real
+// addon: a failed dlopen makes loadIroh() throw, so reaching the export check
+// proves THIS binary loaded the shipped .node.
+export async function selfTest() {
+  const iroh = await loadIroh();
+  const exports = Object.keys(iroh).length;
+  if (exports === 0) { throw new Error('iroh module loaded but exposed no exports'); }
+  return {
+    exports,
+    nativePath: process.env.NAPI_RS_NATIVE_LIBRARY_PATH || '(default resolution)',
+  };
 }
 
 // Normalize a secret given as a Buffer/Uint8Array/Array or a base64 string.

--- a/src/util/iroh-selftest.js
+++ b/src/util/iroh-selftest.js
@@ -1,0 +1,18 @@
+// Self-dispatch worker that verifies the native @number0/iroh binding loads in
+// THIS process. Under a Bun standalone binary it exercises loading the shipped
+// bin/iroh/*.node via NAPI_RS_NATIVE_LIBRARY_PATH (see ../state/iroh.js); under
+// Node it loads from node_modules. Prints a single IROH_OK / IROH_FAIL line and
+// exits with the matching code — consumed by the build smoke test
+// (.github/workflows/build-bun.yml) and ad-hoc local verification:
+//
+//   ./mStream --mstream-worker=iroh-selftest '{}'
+import { selfTest } from '../state/iroh.js';
+
+try {
+  const r = await selfTest();
+  console.log(`IROH_OK exports=${r.exports} native=${r.nativePath}`);
+  process.exit(0);
+} catch (e) {
+  console.error(`IROH_FAIL ${e?.stack || e?.message || e}`);
+  process.exit(1);
+}

--- a/src/util/worker-process.js
+++ b/src/util/worker-process.js
@@ -49,6 +49,7 @@ export async function maybeRunWorker(argv = process.argv) {
     case 'backup':         await import('../backup/worker.mjs'); break;
     case 'image-compress': await import('../db/image-compress-script.js'); break;
     case 'ssl-test':       await import('./ssl-test.js'); break;
+    case 'iroh-selftest':  await import('./iroh-selftest.js'); break;
     default:
       console.error(`Unknown mStream worker role: ${role}`);
       process.exit(1);


### PR DESCRIPTION
## Problem

The Bun `--compile` release binaries ship **without** `@number0/iroh`, so a packaged server boots with **remote access silently unavailable** — no error, the lazy `import('@number0/iroh')` just fails and the boot site degrades.

Why: `@number0/iroh` is a **NAPI-RS native addon** (an `optionalDependency`), Bun `--compile` can't embed native `.node` files, and `build-bun.mjs` only staged the spawned Rust sidecars. Confirmed by inspecting the published `v6.15.1` `win-x64` zip — `mStream.exe` + the two Rust sidecars + `webapp/`, but **zero `.node` files**.

## Fix

Stage the target's prebuilt iroh `.node` next to the binary (exactly like the Rust sidecars) and point the NAPI-RS loader at it via **`NAPI_RS_NATIVE_LIBRARY_PATH`**, which it honours ahead of its `node_modules` resolution. No reliance on Bun embedding native addons.

- **`scripts/build-bun.mjs`** — stage `@number0/iroh-<triple>`'s `.node` into `bin/iroh/`. Native targets reuse the host-installed platform package; cross targets fetch the matching prebuilt via `npm pack` (ignores `os`/`cpu`, unlike `npm install`). Best-effort: a build that can't obtain it still ships (remote access just stays off — same graceful degradation as an unsupported platform).
- **`src/state/iroh.js`** — under a Bun standalone, set `NAPI_RS_NATIVE_LIBRARY_PATH` to the bundled `bin/iroh/*.node` before `import('@number0/iroh')`. No-op under Node/Electron. Adds `selfTest()`.
- **`src/util/iroh-selftest.js`** + **`worker-process.js`** — an `iroh-selftest` self-dispatch worker that loads the native binding and prints `IROH_OK` / `IROH_FAIL`.
- **`build-bun.yml`** — assert `IROH_OK` on the native smoke targets (the gap that let this ship unnoticed).

## Testing

Built `win-x64` locally and ran the self-test against the **compiled standalone binary**:

```
$ ./mStream.exe --mstream-worker=iroh-selftest '{}'
IROH_OK exports=26 native=...\bin\iroh\iroh.win32-x64-msvc.node
```

The 123 MB standalone binary `dlopen`s the bundled 17.5 MB `.node` and exposes the full native binding. Bun compiled cleanly (the loader's conditional requires of un-installed platform packages don't break it).

## Notes

- **Bundle size:** +~17 MB per platform (the iroh `.node`).
- **Cross-target runtime** (linux-arm64, darwin-x64, musl) is staged via `npm pack` but can't be smoke-run on the build runner — same limitation as the Rust sidecars; the native targets (win-x64, linux-x64, darwin-arm64) are validated by the new smoke step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)