### PR TITLE
feat(discovery): separate discovery.db + admin export snapshot (P0)

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -11,6 +11,8 @@ import * as dbQueue from '../db/task-queue.js';
 import * as imageCompress from '../db/image-compress-manager.js';
 import * as transcode from './transcode.js';
 import * as db from '../db/manager.js';
+import * as discoveryDb from '../db/discovery-db.js';
+import * as discoveryExport from '../db/discovery-export.js';
 import * as logger from '../logger.js';
 import { joiValidate } from '../util/validation.js';
 import { isAdminAllowed } from '../util/admin-network.js';
@@ -321,6 +323,68 @@ export function setup(mstream) {
 
     await admin.editAnalyzeBpmPerRun(req.body.analyzeBpmPerRun);
     res.json({});
+  });
+
+  // Toggle collection of music-discovery data (embeddings + external IDs)
+  // into the separate discovery.db. Flipping it ON creates/migrates the DB
+  // immediately so the export surface below always has a valid store to
+  // work from; the post-scan embedding worker (next phase) will read this
+  // flag like analyzeBpm. Flipping OFF stops future collection but
+  // deliberately keeps the data — deleting {dbDirectory}/discovery.db is
+  // the operator's explicit purge.
+  mstream.post("/api/v1/admin/db/params/collect-discovery-data", async (req, res) => {
+    const schema = Joi.object({
+      collectDiscoveryData: Joi.boolean().required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editCollectDiscoveryData(req.body.collectDiscoveryData);
+    if (req.body.collectDiscoveryData === true) { discoveryDb.initDiscoveryDb(); }
+    res.json({});
+  });
+
+  // Build a fresh export snapshot of discovery.db — a cleaned copy holding
+  // only the share-safe columns (no local hashes, no cooldown ledger, no
+  // export salt) plus a manifest with sha256/row count. Returns the
+  // manifest. 404 until discovery collection has been enabled at least
+  // once; 409 while a build is already running (SQLite would reject the
+  // second ATTACH anyway — this just gives it a clean status code).
+  let discoveryExportInFlight = false;
+  mstream.post("/api/v1/admin/db/discovery-export", async (req, res) => {
+    if (!discoveryDb.openDiscoveryDbIfExists()) {
+      throw new WebError('discovery data collection has never been enabled', 404);
+    }
+    if (discoveryExportInFlight) {
+      throw new WebError('a discovery export is already in progress', 409);
+    }
+    discoveryExportInFlight = true;
+    try {
+      res.json(await discoveryExport.exportDiscoverySnapshot());
+    } finally {
+      discoveryExportInFlight = false;
+    }
+  });
+
+  // Manifest of the current snapshot — lets a caller check size / row count
+  // / model compatibility (and later, a peer decide whether to re-pull)
+  // without downloading the file.
+  mstream.get("/api/v1/admin/db/discovery-export/manifest", (req, res) => {
+    const manifest = discoveryExport.readManifest();
+    if (!manifest) { throw new WebError('no discovery export has been built yet', 404); }
+    res.json(manifest);
+  });
+
+  // The snapshot itself. res.download → sendFile supports HTTP Range, so
+  // large snapshots are resumable (which also makes this endpoint reusable
+  // over the iroh pairing tunnel as-is). dotfiles:'allow' because sendFile's
+  // default refuses any path CONTAINING a dot-segment — and dbDirectory
+  // commonly lives under one on Linux installs (~/.config/mstream,
+  // ~/.mstream), which would turn every download into a baffling 404.
+  mstream.get("/api/v1/admin/db/discovery-export/download", (req, res) => {
+    if (!discoveryExport.snapshotExists()) {
+      throw new WebError('no discovery export has been built yet', 404);
+    }
+    res.download(discoveryExport.snapshotPath(), 'discovery-export.db', { dotfiles: 'allow' });
   });
 
   mstream.post("/api/v1/admin/db/params/auto-album-art", async (req, res) => {

--- a/src/db/discovery-db.js
+++ b/src/db/discovery-db.js
@@ -1,0 +1,304 @@
+// The separate music-discovery database (discovery.db).
+//
+// Holds the per-track dataset behind the planned cross-server discovery
+// network: audio embeddings (similarity), external IDs (identity), and
+// coarse filter metadata (BPM / key / tags). It is DELIBERATELY a second
+// SQLite file next to mstream.db rather than more tables inside it:
+//
+//   * the whole point of the dataset is to be shared — a standalone file is
+//     the exportable unit (see discovery-export.js);
+//   * it quarantines opt-in, privacy-sensitive data (a music library is
+//     surprisingly identifying) behind one file the operator can delete
+//     wholesale without touching their library DB or its backups;
+//   * its schema evolves on its own version line, independent of
+//     mstream.db's migration chain.
+//
+// Nothing here runs unless `scanOptions.collectDiscoveryData` is enabled
+// (config default OFF): server boot initializes the DB only when the flag is
+// on, and the admin toggle initializes it the moment the flag flips on. The
+// post-scan embedding worker that will actually populate discovery_tracks is
+// the next phase — it writes through upsertDiscoveryTrack() below, following
+// the audio-analysis-backfill worker contract.
+//
+// Cross-referencing: rows are keyed by the same canonical audio_hash as
+// mstream.db's tracks table — that hash is the ONLY coupling between the two
+// databases, and it never leaves this machine (exports replace it with the
+// salted/derived export_id).
+
+import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
+import { DatabaseSync } from './sqlite-driver.js';
+import winston from 'winston';
+import * as config from '../state/config.js';
+
+// Independent version line — this is NOT mstream.db's SCHEMA_VERSION.
+export const DISCOVERY_SCHEMA_VERSION = 1;
+
+// Contract constants for the embedding column. Declared here (and copied
+// into discovery_meta + every export snapshot) so a consumer never has to
+// guess how to read the BLOBs. The model id / version / dimension are NOT
+// constants: the embedding worker records them in discovery_meta when it
+// writes its first vector, because vectors from different models (or model
+// versions) live in incompatible spaces and must never be mixed.
+export const EMBEDDING_DTYPE = 'float32le';
+export const EMBEDDING_NORMALIZATION = 'l2';
+
+let db = null;
+
+const SCHEMA_V1 = `
+  -- Self-description + small internal state. Every export snapshot copies
+  -- the embedding_* keys so the file explains its own vector format.
+  -- Internal keys (never exported): row_seq (the monotonic rowversion
+  -- counter behind updated_at) and export_salt (secret salt for anonymous
+  -- export ids — exporting it would let anyone brute-force local audio
+  -- hashes back out of a snapshot).
+  CREATE TABLE IF NOT EXISTS discovery_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS discovery_tracks (
+    -- INTERNAL columns (never exported) ------------------------------------
+    -- Canonical audio hash — joins to mstream.db tracks.audio_hash and
+    -- dedupes multiple files carrying identical audio.
+    audio_hash   TEXT PRIMARY KEY,
+    -- Library-file mtime at analysis time, so rescans can skip unchanged
+    -- files without re-deriving anything.
+    source_mtime INTEGER,
+    -- App-managed monotonic rowversion (discovery_meta.row_seq), NOT wall
+    -- clock — wall clock can step backwards, which breaks "everything since
+    -- cursor X" incremental export. Bumped on every insert/update.
+    updated_at   INTEGER NOT NULL,
+
+    -- EXPORTED columns ------------------------------------------------------
+    -- Stable share-safe identity: 'mbid:<recording-mbid>' when known, else
+    -- 'anon:<salted-hash>'. NOT unique — two different rips of the same
+    -- recording legitimately share an MBID.
+    export_id      TEXT NOT NULL,
+    recording_mbid TEXT,
+    acoustid_id    TEXT,
+    artist   TEXT,
+    title    TEXT,
+    duration REAL,
+    -- Embedding provenance, pinned per row so a model upgrade can migrate
+    -- gradually without ever mixing vector spaces silently.
+    model_id      TEXT,
+    model_version TEXT,
+    embedding     BLOB,
+    -- Tier-1 filter metadata (never the similarity metric — that is what
+    -- the embedding is for).
+    bpm          INTEGER,
+    musical_key  TEXT,
+    danceability REAL,
+    genre_tags   TEXT,   -- JSON array
+    mood_tags    TEXT,   -- JSON array
+    analyzed_at  INTEGER  -- wall-clock ms, informational only
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_discovery_tracks_export_id  ON discovery_tracks(export_id);
+  CREATE INDEX IF NOT EXISTS idx_discovery_tracks_updated_at ON discovery_tracks(updated_at);
+
+  -- Negative cache for the embedding worker (same shape as
+  -- audio_analysis_lookups in mstream.db): per-hash attempt ledger with
+  -- per-outcome cooldowns so undecodable files aren't retried every pass.
+  -- Internal only — never exported.
+  CREATE TABLE IF NOT EXISTS discovery_lookups (
+    audio_hash      TEXT PRIMARY KEY,
+    last_attempt_at INTEGER NOT NULL,
+    outcome         TEXT NOT NULL,
+    attempts        INTEGER NOT NULL DEFAULT 1
+  );
+`;
+
+const MIGRATIONS = [
+  { version: 1, sql: SCHEMA_V1 },
+];
+
+export function discoveryDbPath() {
+  return path.join(config.program.storage.dbDirectory, 'discovery.db');
+}
+
+export function isDiscoveryDbOpen() {
+  return db !== null;
+}
+
+export function getDiscoveryDb() {
+  if (!db) { throw new Error('discovery DB is not initialized'); }
+  return db;
+}
+
+// Idempotent open + migrate. Mirrors manager.js initDB(): WAL for
+// concurrent reader/writer friendliness, busy_timeout so a future forked
+// worker holding a write lock doesn't turn admin reads into instant
+// SQLITE_BUSY errors.
+//
+// `dbPath` is optional — the server passes nothing (config-derived path);
+// an explicit path is for callers with no config state (the future forked
+// embedding worker, which receives paths via its JSON payload, and tests).
+export function initDiscoveryDb(dbPath) {
+  if (db) { return db; }
+
+  db = new DatabaseSync(dbPath || discoveryDbPath());
+  try {
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA busy_timeout = 5000');
+    runMigrations();
+    seedMeta();
+  } catch (err) {
+    // Don't leave a half-initialized handle behind — callers treat
+    // isDiscoveryDbOpen() as "ready to use".
+    closeDiscoveryDb();
+    throw err;
+  }
+  return db;
+}
+
+// For admin surfaces (export/manifest/download) that may run while
+// collection is off: reuse the open handle, else open a DB that already
+// exists on disk, else null — deliberately does NOT create a fresh file,
+// so hitting an export endpoint never silently enables the feature.
+export function openDiscoveryDbIfExists() {
+  if (db) { return db; }
+  if (fs.existsSync(discoveryDbPath())) { return initDiscoveryDb(); }
+  return null;
+}
+
+export function closeDiscoveryDb() {
+  if (!db) { return; }
+  try { db.close(); } catch (err) {
+    winston.warn(`discovery DB close failed: ${err.message}`);
+  }
+  db = null;
+}
+
+function runMigrations() {
+  const currentVersion = db.prepare('PRAGMA user_version').get().user_version;
+
+  if (currentVersion >= DISCOVERY_SCHEMA_VERSION) {
+    winston.info(`Discovery database schema is up to date (v${currentVersion})`);
+    return;
+  }
+
+  winston.info(`Discovery database schema v${currentVersion} → v${DISCOVERY_SCHEMA_VERSION}`);
+
+  for (const migration of MIGRATIONS) {
+    if (migration.version > currentVersion) {
+      winston.info(`Applying discovery migration v${migration.version}...`);
+      // Same all-or-nothing wrapping as manager.js: a multi-statement
+      // migration either fully applies or fully rolls back.
+      db.exec('BEGIN');
+      try {
+        db.exec(migration.sql);
+        db.exec(`PRAGMA user_version = ${migration.version}`);
+        db.exec('COMMIT');
+      } catch (err) {
+        db.exec('ROLLBACK');
+        throw err;
+      }
+    }
+  }
+}
+
+// First-boot metadata. INSERT OR IGNORE keeps every key stable across
+// restarts — in particular export_salt must never rotate, or previously
+// exported anon: ids would stop matching future exports.
+function seedMeta() {
+  const seed = db.prepare('INSERT OR IGNORE INTO discovery_meta (key, value) VALUES (?, ?)');
+  seed.run('created_at', new Date().toISOString());
+  seed.run('row_seq', '0');
+  seed.run('export_salt', crypto.randomBytes(32).toString('hex'));
+  seed.run('embedding_dtype', EMBEDDING_DTYPE);
+  seed.run('embedding_normalization', EMBEDDING_NORMALIZATION);
+}
+
+export function getMeta(key) {
+  const row = getDiscoveryDb().prepare('SELECT value FROM discovery_meta WHERE key = ?').get(key);
+  return row ? row.value : null;
+}
+
+export function setMeta(key, value) {
+  getDiscoveryDb().prepare(
+    'INSERT INTO discovery_meta (key, value) VALUES (?, ?) ' +
+    'ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+  ).run(key, String(value));
+}
+
+// Monotonic rowversion for updated_at / incremental export cursors.
+function nextUpdateSeq() {
+  const row = getDiscoveryDb().prepare(
+    "UPDATE discovery_meta SET value = CAST(value AS INTEGER) + 1 " +
+    "WHERE key = 'row_seq' RETURNING CAST(value AS INTEGER) AS seq"
+  ).get();
+  return row.seq;
+}
+
+// Share-safe identity for one row. Prefer the MusicBrainz recording MBID
+// (the canonical cross-library key); tracks that haven't been identified
+// yet get an opaque salted id instead, so the export never carries the raw
+// local audio hash. The salt is per-install and secret — see seedMeta().
+export function exportIdFor(recordingMbid, audioHash) {
+  if (recordingMbid) { return `mbid:${String(recordingMbid).toLowerCase()}`; }
+  const salt = getMeta('export_salt');
+  const digest = crypto.createHash('sha256').update(salt + audioHash).digest('hex');
+  return `anon:${digest.slice(0, 32)}`;
+}
+
+// Single write path for discovery rows — the embedding worker (next phase)
+// and tests both go through here so the export_id / updated_at invariants
+// hold no matter who writes. Fields not supplied are stored as NULL;
+// re-upserting the same audio_hash replaces the row's values and bumps
+// updated_at (so incremental consumers see it as changed).
+export function upsertDiscoveryTrack(fields) {
+  if (!fields || !fields.audioHash) { throw new Error('upsertDiscoveryTrack requires audioHash'); }
+
+  // Positional params only — the Bun sqlite adapter (sqlite-driver.js under
+  // `bun --compile`) does not support named parameters.
+  const params = [
+    fields.audioHash,
+    fields.sourceMtime ?? null,
+    nextUpdateSeq(),
+    exportIdFor(fields.recordingMbid ?? null, fields.audioHash),
+    fields.recordingMbid ?? null,
+    fields.acoustidId ?? null,
+    fields.artist ?? null,
+    fields.title ?? null,
+    fields.duration ?? null,
+    fields.modelId ?? null,
+    fields.modelVersion ?? null,
+    fields.embedding ?? null,
+    fields.bpm ?? null,
+    fields.musicalKey ?? null,
+    fields.danceability ?? null,
+    fields.genreTags ? JSON.stringify(fields.genreTags) : null,
+    fields.moodTags ? JSON.stringify(fields.moodTags) : null,
+    Date.now(),
+  ];
+
+  getDiscoveryDb().prepare(`
+    INSERT INTO discovery_tracks (
+      audio_hash, source_mtime, updated_at, export_id, recording_mbid,
+      acoustid_id, artist, title, duration, model_id, model_version,
+      embedding, bpm, musical_key, danceability, genre_tags, mood_tags,
+      analyzed_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(audio_hash) DO UPDATE SET
+      source_mtime   = excluded.source_mtime,
+      updated_at     = excluded.updated_at,
+      export_id      = excluded.export_id,
+      recording_mbid = excluded.recording_mbid,
+      acoustid_id    = excluded.acoustid_id,
+      artist         = excluded.artist,
+      title          = excluded.title,
+      duration       = excluded.duration,
+      model_id       = excluded.model_id,
+      model_version  = excluded.model_version,
+      embedding      = excluded.embedding,
+      bpm            = excluded.bpm,
+      musical_key    = excluded.musical_key,
+      danceability   = excluded.danceability,
+      genre_tags     = excluded.genre_tags,
+      mood_tags      = excluded.mood_tags,
+      analyzed_at    = excluded.analyzed_at
+  `).run(...params);
+}

--- a/src/db/discovery-export.js
+++ b/src/db/discovery-export.js
@@ -1,0 +1,266 @@
+// Export-snapshot builder for the music-discovery dataset (discovery.db).
+//
+// Produces a cleaned, self-contained SQLite file that is safe to hand to
+// someone else: ONLY the share-safe columns travel. The internal columns
+// (raw audio_hash, source_mtime, updated_at) and internal tables
+// (discovery_lookups, the row_seq counter, the secret export_salt) never
+// leave the machine — a music library is identifying, so the snapshot is
+// built by explicit allowlist, not by copying-and-deleting.
+//
+// Mechanics note: `VACUUM INTO` cannot filter (it copies a whole schema
+// verbatim), so the snapshot is built the explicit way — ATTACH a fresh
+// file, CREATE the export tables, INSERT…SELECT the allowlisted columns.
+// A freshly built file is already compact; no vacuum needed.
+//
+// The snapshot is self-describing: its `meta` table carries the embedding
+// format contract (model id/version, dim, dtype, endianness, normalization)
+// copied from discovery_meta, so a consumer can (a) know how to read the
+// BLOBs and (b) refuse to mix vectors from an incompatible model version.
+// A manifest.json (row count, sha256, sizes) is written next to it so a
+// consumer can check compatibility before pulling the file.
+//
+// P0 scope: admin/local export only — one current snapshot at a stable
+// path, rebuilt (overwritten) on each request. Network-peer / public
+// distribution is a later phase; the incremental-cursor groundwork
+// (updated_at) already exists in the live DB for when that lands.
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { pipeline } from 'stream/promises';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import {
+  getDiscoveryDb, getMeta,
+  DISCOVERY_SCHEMA_VERSION, EMBEDDING_DTYPE, EMBEDDING_NORMALIZATION,
+} from './discovery-db.js';
+
+export const SNAPSHOT_FORMAT = 'mstream-discovery-snapshot';
+export const SNAPSHOT_FORMAT_VERSION = 1;
+
+export function exportDir() {
+  return path.join(config.program.storage.dbDirectory, 'discovery-export');
+}
+
+export function snapshotPath() {
+  return path.join(exportDir(), 'discovery-export.db');
+}
+
+export function manifestPath() {
+  return path.join(exportDir(), 'manifest.json');
+}
+
+export function snapshotExists() {
+  return fs.existsSync(snapshotPath());
+}
+
+// Current manifest, or null when no export has been built yet. A corrupt
+// manifest is treated as absent (and logged) rather than crashing the
+// admin endpoint — the fix is simply re-running the export.
+export function readManifest() {
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath(), 'utf8'));
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      winston.warn(`discovery export manifest unreadable (${err.message}) — treating as absent`);
+    }
+    return null;
+  }
+}
+
+async function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  await pipeline(fs.createReadStream(filePath), hash);
+  return hash.digest('hex');
+}
+
+// Build (or rebuild) the current snapshot + manifest + README.
+// Returns the manifest object. Caller is responsible for serializing
+// concurrent invocations (the admin route holds a simple in-flight flag).
+// `opts.outDir` overrides the config-derived output directory (tests /
+// config-less callers); the admin routes pass nothing.
+export async function exportDiscoverySnapshot(opts = {}) {
+  const db = getDiscoveryDb();
+
+  const outDir = opts.outDir || exportDir();
+  fs.mkdirSync(outDir, { recursive: true });
+  const finalPath = path.join(outDir, 'discovery-export.db');
+  const tmpPath = `${finalPath}.building`;
+  fs.rmSync(tmpPath, { force: true });
+
+  // SQLite string literal: escape embedded single quotes by doubling.
+  const attachTarget = tmpPath.replace(/'/g, "''");
+  db.exec(`ATTACH DATABASE '${attachTarget}' AS snap`);
+
+  let rowCount;
+  try {
+    // One transaction around the whole build: the main connection spans both
+    // schemas, so the snapshot is a consistent point-in-time view even if a
+    // writer (the future embedding worker) is running concurrently.
+    db.exec('BEGIN');
+    try {
+      db.exec(`
+        PRAGMA snap.user_version = ${SNAPSHOT_FORMAT_VERSION};
+
+        CREATE TABLE snap.meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+
+        CREATE TABLE snap.tracks (
+          -- Share-safe identity: 'mbid:<recording-mbid>' when known, else an
+          -- opaque salted id. NOT unique across rows — two rips of the same
+          -- recording legitimately share an MBID.
+          export_id      TEXT NOT NULL,
+          recording_mbid TEXT,
+          acoustid_id    TEXT,
+          artist   TEXT,
+          title    TEXT,
+          duration REAL,
+          model_id      TEXT,
+          model_version TEXT,
+          embedding     BLOB,
+          bpm          INTEGER,
+          musical_key  TEXT,
+          danceability REAL,
+          genre_tags   TEXT,
+          mood_tags    TEXT
+        );
+
+        CREATE INDEX snap.idx_tracks_export_id ON tracks(export_id);
+      `);
+
+      // Explicit column allowlist — audio_hash / source_mtime / updated_at
+      // deliberately absent. Deterministic ordering so identical data
+      // produces an identically ordered (diffable) snapshot; the trailing
+      // audio_hash tiebreaker only fixes row order, the value itself is
+      // not exported.
+      db.exec(`
+        INSERT INTO snap.tracks (
+          export_id, recording_mbid, acoustid_id, artist, title, duration,
+          model_id, model_version, embedding, bpm, musical_key, danceability,
+          genre_tags, mood_tags
+        )
+        SELECT
+          export_id, recording_mbid, acoustid_id, artist, title, duration,
+          model_id, model_version, embedding, bpm, musical_key, danceability,
+          genre_tags, mood_tags
+        FROM discovery_tracks
+        ORDER BY export_id, audio_hash
+      `);
+
+      // Meta travels by allowlist too — row_seq and (especially) the secret
+      // export_salt must never ship.
+      db.exec(`
+        INSERT INTO snap.meta (key, value)
+        SELECT key, value FROM discovery_meta
+        WHERE key IN (
+          'embedding_model_id', 'embedding_model_version', 'embedding_dim',
+          'embedding_dtype', 'embedding_normalization'
+        )
+      `);
+
+      rowCount = db.prepare('SELECT COUNT(*) AS n FROM snap.tracks').get().n;
+
+      const putMeta = db.prepare('INSERT OR REPLACE INTO snap.meta (key, value) VALUES (?, ?)');
+      putMeta.run('format', SNAPSHOT_FORMAT);
+      putMeta.run('format_version', String(SNAPSHOT_FORMAT_VERSION));
+      putMeta.run('source_schema_version', String(DISCOVERY_SCHEMA_VERSION));
+      putMeta.run('generated_at', new Date().toISOString());
+      putMeta.run('row_count', String(rowCount));
+      putMeta.run('generator', 'mStream');
+
+      db.exec('COMMIT');
+    } catch (err) {
+      db.exec('ROLLBACK');
+      throw err;
+    }
+  } catch (err) {
+    // Failed build: detach + drop the partial file, keep any previous
+    // snapshot/manifest intact.
+    try { db.exec('DETACH DATABASE snap'); } catch (_detachErr) { /* attach itself failed */ }
+    fs.rmSync(tmpPath, { force: true });
+    throw err;
+  }
+  db.exec('DETACH DATABASE snap');
+
+  // Swap into place. Windows rename() won't overwrite, so drop the old
+  // snapshot first — the manifest (written after) is the source of truth,
+  // and a crash in this window just means "re-run the export".
+  fs.rmSync(finalPath, { force: true });
+  fs.renameSync(tmpPath, finalPath);
+
+  const manifest = {
+    format: SNAPSHOT_FORMAT,
+    formatVersion: SNAPSHOT_FORMAT_VERSION,
+    sourceSchemaVersion: DISCOVERY_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    file: path.basename(finalPath),
+    sizeBytes: fs.statSync(finalPath).size,
+    sha256: await sha256File(finalPath),
+    rowCount,
+    model: {
+      id: getMeta('embedding_model_id'),
+      version: getMeta('embedding_model_version'),
+      dim: getMeta('embedding_dim') ? Number(getMeta('embedding_dim')) : null,
+      dtype: EMBEDDING_DTYPE,
+      normalization: EMBEDDING_NORMALIZATION,
+    },
+    // No license is asserted for the exported data — distributing a snapshot
+    // beyond personal backup is the operator's decision (and jurisdiction).
+    license: null,
+    notes: {
+      exportId: 'export_id is "mbid:<musicbrainz-recording-id>" when known, '
+        + 'else "anon:<opaque-salted-id>". It is NOT unique across rows: '
+        + 'different encodings of the same recording share an MBID.',
+      embedding: `Track embeddings are raw ${EMBEDDING_DTYPE} arrays `
+        + `(little-endian), ${EMBEDDING_NORMALIZATION}-normalized; dim/model in meta. `
+        + 'NULL until the analysis pass has processed the track.',
+    },
+  };
+
+  fs.writeFileSync(path.join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  fs.writeFileSync(path.join(outDir, 'README.md'), readmeText());
+
+  winston.info(`discovery export built: ${rowCount} tracks, ${manifest.sizeBytes} bytes`);
+  return manifest;
+}
+
+function readmeText() {
+  return `# mStream discovery-data snapshot
+
+A self-contained SQLite database exported from an mStream server's
+music-discovery dataset (\`${SNAPSHOT_FORMAT}\`, format version
+${SNAPSHOT_FORMAT_VERSION}). Verify integrity against \`manifest.json\`
+(sha256, row count) before use.
+
+## Tables
+
+- \`tracks\` — one row per analysed audio file.
+  - \`export_id\`: \`mbid:<musicbrainz-recording-id>\` when the recording was
+    identified, else \`anon:<opaque-id>\`. **Not unique** — different
+    encodings of the same recording share an MBID.
+  - \`embedding\`: raw little-endian float32 array, L2-normalized (cosine
+    similarity = dot product). Dimension and model are declared in \`meta\`.
+    NULL for tracks the analysis pass hasn't reached.
+  - \`bpm\`, \`musical_key\`, \`danceability\`, \`genre_tags\`, \`mood_tags\`:
+    coarse filter metadata (tags are JSON arrays).
+- \`meta\` — key/value self-description: embedding model id/version/dim/
+  dtype/normalization, format, generation time, row count.
+
+Embeddings from different \`model_id\`/\`model_version\` values live in
+incompatible vector spaces — never compare them.
+
+## Reading it
+
+\`\`\`python
+import sqlite3, numpy as np
+db = sqlite3.connect('discovery-export.db')
+meta = dict(db.execute('SELECT key, value FROM meta'))
+for export_id, blob in db.execute('SELECT export_id, embedding FROM tracks WHERE embedding IS NOT NULL'):
+    vec = np.frombuffer(blob, dtype='<f4')
+\`\`\`
+
+No file paths, local identifiers, or listening history are included.
+`;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,7 @@ import * as config from './state/config.js';
 import * as logger from './logger.js';
 import * as transcode from './api/transcode.js';
 import * as dbManager from './db/manager.js';
+import * as discoveryDb from './db/discovery-db.js';
 import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // Federation + syncthing are disabled while the feature is rebuilt
 // around the new local-backup story. The source files in
@@ -133,6 +134,19 @@ export async function serveIt(configFile) {
 
   // Setup DB
   dbManager.initDB();
+
+  // The separate music-discovery DB opens at boot only when collection is
+  // enabled (the admin toggle initializes it on demand otherwise). Failure
+  // here is deliberately non-fatal, unlike initDB(): discovery data is an
+  // optional side dataset, and a corrupt discovery.db shouldn't stop the
+  // music server from booting.
+  if (config.program.scanOptions?.collectDiscoveryData === true) {
+    try {
+      discoveryDb.initDiscoveryDb();
+    } catch (err) {
+      winston.error(`discovery DB failed to initialize — discovery data collection disabled this boot: ${err.message}`);
+    }
+  }
 
   // remove trailing slashes, needed for relative URLs on the webapp
   mstream.get('{*path}', (req, res, next) => {

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -77,6 +77,15 @@ const scanOptions = Joi.object({
   // runBudget and re-enqueues while a backlog remains — this just bounds one
   // batch. Mirrors autoAlbumArtPerRun.
   analyzeBpmPerRun: Joi.number().integer().min(1).max(10000).default(200),
+  // Collect per-track music-discovery data (audio embeddings + external IDs
+  // + filter metadata) into the SEPARATE discovery.db (src/db/discovery-db.js)
+  // — deliberately isolated from mstream.db so the dataset stays a single
+  // shareable/deletable file (see discovery-export.js). This flag currently
+  // gates DB creation + the admin export surface; the post-scan embedding
+  // worker that populates it lands next and reads this flag like analyzeBpm.
+  // Default OFF: opt-in by design (a music library is identifying), and the
+  // upcoming analysis pass is CPU-heavy.
+  collectDiscoveryData: Joi.boolean().default(false),
   autoAlbumArt: Joi.boolean().default(true),
   // What the post-scan album-art downloader targets. 'missing' (default):
   // only albums with no cover at all — the fill-in-the-blanks pass.

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -457,6 +457,20 @@ export async function editAnalyzeBpmPerRun(val) {
   config.program.scanOptions.analyzeBpmPerRun = val;
 }
 
+// Music-discovery data collection toggle (the separate discovery.db —
+// src/db/discovery-db.js). Same live-update pattern as editAnalyzeBpm:
+// persist to config.json, then mutate config.program in-memory so no reboot
+// is needed. The api route initializes the discovery DB when this flips on;
+// flipping it off stops future collection but keeps the existing data
+// (deleting {dbDirectory}/discovery.db is the operator's explicit purge).
+export async function editCollectDiscoveryData(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.collectDiscoveryData = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.collectDiscoveryData = val;
+}
+
 export async function editAutoAlbumArt(val) {
   const loadConfig = await loadFile(config.configFile);
   if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }

--- a/test/db/discovery-db.test.mjs
+++ b/test/db/discovery-db.test.mjs
@@ -1,0 +1,273 @@
+/**
+ * discovery.db — the separate music-discovery dataset (src/db/discovery-db.js)
+ * and its export-snapshot builder (src/db/discovery-export.js).
+ *
+ * Asserts:
+ *   1. Bootstrap: schema v1 tables, WAL, meta seeding (monotonic row_seq
+ *      counter, secret export_salt, embedding format contract keys).
+ *   2. Idempotent re-open: export_salt / created_at survive a close+reopen
+ *      (a rotating salt would silently break anon export-id stability).
+ *   3. exportIdFor: mbid-preferred, salted-anon fallback, deterministic.
+ *   4. upsertDiscoveryTrack: insert + replace semantics, monotonic
+ *      updated_at bumps, embedding BLOB round-trip.
+ *   5. Export snapshot: explicit column/meta allowlist (no audio_hash, no
+ *      source_mtime, no updated_at, no discovery_lookups, no export_salt,
+ *      no row_seq), deterministic ordering, manifest sha256/row-count
+ *      integrity, rebuild-overwrite.
+ *
+ * These run in-process against a temp directory — no server, no config
+ * (both modules take explicit paths for exactly this use, mirroring how the
+ * future forked embedding worker will receive paths via its JSON payload).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  initDiscoveryDb, closeDiscoveryDb, isDiscoveryDbOpen, getDiscoveryDb,
+  upsertDiscoveryTrack, exportIdFor, getMeta, setMeta,
+  DISCOVERY_SCHEMA_VERSION, EMBEDDING_DTYPE, EMBEDDING_NORMALIZATION,
+} from '../../src/db/discovery-db.js';
+import {
+  exportDiscoverySnapshot, SNAPSHOT_FORMAT, SNAPSHOT_FORMAT_VERSION,
+} from '../../src/db/discovery-export.js';
+
+let tmpDir;
+let dbPath;
+let outDir;
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-discovery-test-'));
+  dbPath = path.join(tmpDir, 'discovery.db');
+  outDir = path.join(tmpDir, 'export');
+});
+
+after(() => {
+  closeDiscoveryDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function embeddingBlob(floats) {
+  return Buffer.from(new Float32Array(floats).buffer);
+}
+
+function blobToFloats(blob) {
+  const u8 = Uint8Array.from(blob);
+  return Array.from(new Float32Array(u8.buffer, 0, u8.byteLength / 4));
+}
+
+describe('discovery-db bootstrap', () => {
+  test('initDiscoveryDb creates the schema at the current version', () => {
+    assert.equal(isDiscoveryDbOpen(), false);
+    initDiscoveryDb(dbPath);
+    assert.equal(isDiscoveryDbOpen(), true);
+    assert.ok(fs.existsSync(dbPath), 'discovery.db file created');
+
+    const db = getDiscoveryDb();
+    assert.equal(db.prepare('PRAGMA user_version').get().user_version,
+      DISCOVERY_SCHEMA_VERSION);
+
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).all().map(r => r.name);
+    assert.deepEqual(tables, ['discovery_lookups', 'discovery_meta', 'discovery_tracks']);
+  });
+
+  test('meta is seeded: counter, secret salt, embedding format contract', () => {
+    assert.equal(getMeta('row_seq'), '0');
+    assert.match(getMeta('export_salt'), /^[0-9a-f]{64}$/);
+    assert.ok(getMeta('created_at'));
+    assert.equal(getMeta('embedding_dtype'), EMBEDDING_DTYPE);
+    assert.equal(getMeta('embedding_normalization'), EMBEDDING_NORMALIZATION);
+    // The model pin is written by the embedding worker, not at bootstrap —
+    // an empty store must not claim a model it never ran.
+    assert.equal(getMeta('embedding_model_id'), null);
+  });
+
+  test('re-open is idempotent — salt and created_at survive', () => {
+    const salt = getMeta('export_salt');
+    const created = getMeta('created_at');
+    closeDiscoveryDb();
+    assert.equal(isDiscoveryDbOpen(), false);
+    initDiscoveryDb(dbPath);
+    assert.equal(getMeta('export_salt'), salt, 'export_salt must never rotate');
+    assert.equal(getMeta('created_at'), created);
+  });
+});
+
+describe('exportIdFor', () => {
+  test('prefers the MusicBrainz recording MBID, lowercased', () => {
+    assert.equal(
+      exportIdFor('B1A9C0E9-D987-4042-AE91-78D6A3267D69', 'hash-a'),
+      'mbid:b1a9c0e9-d987-4042-ae91-78d6a3267d69');
+  });
+
+  test('falls back to a deterministic salted anon id', () => {
+    const a1 = exportIdFor(null, 'hash-a');
+    const a2 = exportIdFor(null, 'hash-a');
+    const b  = exportIdFor(null, 'hash-b');
+    assert.match(a1, /^anon:[0-9a-f]{32}$/);
+    assert.equal(a1, a2, 'deterministic for the same hash');
+    assert.notEqual(a1, b);
+    // Salted — the raw hash must not be recoverable by hashing it unsalted.
+    assert.notEqual(a1.slice(5), sha256('hash-a').slice(0, 32));
+  });
+});
+
+describe('upsertDiscoveryTrack', () => {
+  test('insert populates export_id and a monotonic updated_at', () => {
+    upsertDiscoveryTrack({
+      audioHash: 'hash-1',
+      artist: 'Artist A', title: 'Song 1', duration: 123.4,
+      embedding: embeddingBlob([0.5, -0.25, 0.125]),
+      modelId: 'test-model', modelVersion: '1',
+      bpm: 120, musicalKey: 'C major', danceability: 0.7,
+      genreTags: ['rock'], moodTags: ['happy'],
+      sourceMtime: 111,
+    });
+    const row = getDiscoveryDb()
+      .prepare('SELECT * FROM discovery_tracks WHERE audio_hash = ?').get('hash-1');
+    assert.equal(row.updated_at, 1);
+    assert.match(row.export_id, /^anon:/);
+    assert.equal(row.artist, 'Artist A');
+    assert.deepEqual(JSON.parse(row.genre_tags), ['rock']);
+    assert.deepEqual(blobToFloats(row.embedding), [0.5, -0.25, 0.125]);
+    assert.ok(row.analyzed_at > 0);
+  });
+
+  test('re-upsert replaces values and bumps updated_at; MBID flips export_id', () => {
+    upsertDiscoveryTrack({
+      audioHash: 'hash-1',
+      recordingMbid: 'ABC-123',
+      artist: 'Artist A', title: 'Song 1 (fixed tags)',
+    });
+    const rows = getDiscoveryDb()
+      .prepare('SELECT * FROM discovery_tracks WHERE audio_hash = ?').all('hash-1');
+    assert.equal(rows.length, 1, 'upsert must not duplicate the row');
+    assert.equal(rows[0].updated_at, 2, 'rowversion bumps on every write');
+    assert.equal(rows[0].export_id, 'mbid:abc-123');
+    assert.equal(rows[0].title, 'Song 1 (fixed tags)');
+    assert.equal(getMeta('row_seq'), '2');
+  });
+
+  test('audioHash is required', () => {
+    assert.throws(() => upsertDiscoveryTrack({ artist: 'X' }), /audioHash/);
+  });
+});
+
+describe('export snapshot', () => {
+  before(() => {
+    // Rows whose insert order differs from export_id order, to prove the
+    // deterministic ORDER BY. hash-1 (mbid:abc-123) already exists.
+    upsertDiscoveryTrack({ audioHash: 'hash-2', artist: 'Zed', title: 'Last' });
+    upsertDiscoveryTrack({
+      audioHash: 'hash-3', recordingMbid: '000-first',
+      artist: 'Aardvark', title: 'First',
+      embedding: embeddingBlob([1, 0, 0, 0]),
+    });
+    // Negative-cache noise that must never travel.
+    getDiscoveryDb().prepare(
+      'INSERT INTO discovery_lookups (audio_hash, last_attempt_at, outcome) VALUES (?, ?, ?)'
+    ).run('hash-err', Date.now(), 'error');
+  });
+
+  test('builds a cleaned snapshot + integrity manifest', async () => {
+    const manifest = await exportDiscoverySnapshot({ outDir });
+
+    assert.equal(manifest.format, SNAPSHOT_FORMAT);
+    assert.equal(manifest.formatVersion, SNAPSHOT_FORMAT_VERSION);
+    assert.equal(manifest.sourceSchemaVersion, DISCOVERY_SCHEMA_VERSION);
+    assert.equal(manifest.rowCount, 3);
+    assert.equal(manifest.model.dtype, EMBEDDING_DTYPE);
+    assert.equal(manifest.model.normalization, EMBEDDING_NORMALIZATION);
+    assert.equal(manifest.model.id, null, 'no model pinned yet');
+
+    const snapshotFile = path.join(outDir, 'discovery-export.db');
+    const bytes = fs.readFileSync(snapshotFile);
+    assert.equal(bytes.length, manifest.sizeBytes);
+    assert.equal(sha256(bytes), manifest.sha256);
+    assert.ok(fs.existsSync(path.join(outDir, 'manifest.json')));
+    assert.ok(fs.existsSync(path.join(outDir, 'README.md')));
+    assert.ok(!fs.existsSync(`${snapshotFile}.building`), 'temp build file cleaned up');
+  });
+
+  test('snapshot carries ONLY the share-safe surface', () => {
+    const snap = new DatabaseSync(path.join(outDir, 'discovery-export.db'), { readOnly: true });
+    try {
+      assert.equal(snap.prepare('PRAGMA user_version').get().user_version,
+        SNAPSHOT_FORMAT_VERSION);
+
+      const tables = snap.prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+      ).all().map(r => r.name);
+      assert.deepEqual(tables, ['meta', 'tracks'], 'no internal tables travel');
+
+      const cols = snap.prepare('PRAGMA table_info(tracks)').all().map(c => c.name);
+      assert.deepEqual(cols, [
+        'export_id', 'recording_mbid', 'acoustid_id', 'artist', 'title',
+        'duration', 'model_id', 'model_version', 'embedding', 'bpm',
+        'musical_key', 'danceability', 'genre_tags', 'mood_tags',
+      ], 'internal columns (audio_hash / source_mtime / updated_at) must not travel');
+
+      const metaKeys = snap.prepare('SELECT key FROM meta ORDER BY key').all().map(r => r.key);
+      assert.ok(!metaKeys.includes('export_salt'), 'the salt is a secret');
+      assert.ok(!metaKeys.includes('row_seq'));
+      assert.ok(metaKeys.includes('embedding_dtype'));
+      assert.ok(metaKeys.includes('format'));
+      assert.ok(metaKeys.includes('row_count'));
+
+      // Deterministic ordering by export_id (mbid:… sorts before anon:…
+      // is NOT assumed — just assert sorted order).
+      const ids = snap.prepare('SELECT export_id FROM tracks').all().map(r => r.export_id);
+      assert.deepEqual(ids, [...ids].sort(), 'rows ordered by export_id');
+      assert.equal(ids.length, 3);
+      assert.ok(ids.includes('mbid:abc-123'));
+      assert.ok(ids.includes('mbid:000-first'));
+
+      // Embedding BLOB round-trips through the snapshot bit-exactly.
+      const emb = snap.prepare(
+        "SELECT embedding FROM tracks WHERE export_id = 'mbid:000-first'").get().embedding;
+      assert.deepEqual(blobToFloats(emb), [1, 0, 0, 0]);
+    } finally {
+      snap.close();
+    }
+  });
+
+  test('rebuild overwrites the previous snapshot', async () => {
+    const first = JSON.parse(fs.readFileSync(path.join(outDir, 'manifest.json'), 'utf8'));
+    upsertDiscoveryTrack({ audioHash: 'hash-4', artist: 'New', title: 'Row' });
+    const manifest = await exportDiscoverySnapshot({ outDir });
+    assert.equal(manifest.rowCount, 4);
+    assert.notEqual(manifest.sha256, first.sha256);
+    const bytes = fs.readFileSync(path.join(outDir, 'discovery-export.db'));
+    assert.equal(sha256(bytes), manifest.sha256);
+  });
+
+  test('model pin in discovery_meta lands in the manifest', async () => {
+    setMeta('embedding_model_id', 'laion-clap');
+    setMeta('embedding_model_version', '2026-test');
+    setMeta('embedding_dim', '512');
+    const manifest = await exportDiscoverySnapshot({ outDir });
+    assert.deepEqual(manifest.model, {
+      id: 'laion-clap', version: '2026-test', dim: 512,
+      dtype: EMBEDDING_DTYPE, normalization: EMBEDDING_NORMALIZATION,
+    });
+    const snap = new DatabaseSync(path.join(outDir, 'discovery-export.db'), { readOnly: true });
+    try {
+      const model = snap.prepare(
+        "SELECT value FROM meta WHERE key = 'embedding_model_id'").get();
+      assert.equal(model.value, 'laion-clap');
+    } finally {
+      snap.close();
+    }
+  });
+});

--- a/test/integration/discovery-export.test.mjs
+++ b/test/integration/discovery-export.test.mjs
@@ -1,0 +1,201 @@
+/**
+ * Integration tests for the music-discovery data admin surface:
+ *
+ *   POST /api/v1/admin/db/params/collect-discovery-data   opt-in toggle;
+ *                                                         ON creates discovery.db
+ *   POST /api/v1/admin/db/discovery-export                build snapshot, returns manifest
+ *   GET  /api/v1/admin/db/discovery-export/manifest       current manifest
+ *   GET  /api/v1/admin/db/discovery-export/download       the snapshot file (Range-capable)
+ *
+ * Two servers: one booted with the feature at its default (OFF) to prove the
+ * opt-in flow and the 404s, one booted with collectDiscoveryData already ON
+ * to prove boot-time initialization and a real data round-trip (rows seeded
+ * directly into discovery.db, then pulled back out through the export
+ * endpoints and verified byte-for-byte).
+ *
+ * Both run in public mode (no users) — admin endpoints are unauthenticated
+ * there, and the auth gate for /api/v1/admin/* has its own suite
+ * (admin-access.test.mjs).
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { DatabaseSync } from 'node:sqlite';
+import { startServer } from '../helpers/server.mjs';
+
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+describe('discovery export — feature off by default, opt-in via admin', () => {
+  let server;
+  const discoveryDbFile = () => path.join(server.tmpDir, 'db', 'discovery.db');
+
+  before(async () => {
+    server = await startServer({ dlnaMode: 'disabled', waitForScan: false });
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('collectDiscoveryData defaults to false and no discovery.db exists', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/db/params`);
+    assert.equal(r.status, 200);
+    assert.equal((await r.json()).collectDiscoveryData, false);
+    assert.ok(!fs.existsSync(discoveryDbFile()), 'no discovery.db before opt-in');
+  });
+
+  test('export surface 404s before the feature was ever enabled', async () => {
+    const build = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export`, { method: 'POST' });
+    assert.equal(build.status, 404);
+    const manifest = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export/manifest`);
+    assert.equal(manifest.status, 404);
+    const download = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export/download`);
+    assert.equal(download.status, 404);
+  });
+
+  test('toggle validation: non-boolean is a 400', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/db/params/collect-discovery-data`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ collectDiscoveryData: 'yes please' }),
+    });
+    assert.equal(r.status, 400);
+  });
+
+  test('enabling creates discovery.db and persists to config.json', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/db/params/collect-discovery-data`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ collectDiscoveryData: true }),
+    });
+    assert.equal(r.status, 200);
+
+    assert.ok(fs.existsSync(discoveryDbFile()), 'discovery.db created on enable');
+
+    const params = await (await fetch(`${server.baseUrl}/api/v1/admin/db/params`)).json();
+    assert.equal(params.collectDiscoveryData, true);
+
+    const savedConfig = JSON.parse(
+      fs.readFileSync(path.join(server.tmpDir, 'config.json'), 'utf8'));
+    assert.equal(savedConfig.scanOptions.collectDiscoveryData, true,
+      'setting persisted for the next boot');
+  });
+
+  test('empty store exports a valid zero-row snapshot', async () => {
+    const build = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export`, { method: 'POST' });
+    assert.equal(build.status, 200);
+    const manifest = await build.json();
+    assert.equal(manifest.format, 'mstream-discovery-snapshot');
+    assert.equal(manifest.rowCount, 0);
+    assert.match(manifest.sha256, /^[0-9a-f]{64}$/);
+
+    const served = await (await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export/manifest`)).json();
+    assert.deepEqual(served, manifest, 'GET manifest returns what the build reported');
+
+    const download = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export/download`);
+    assert.equal(download.status, 200);
+    assert.match(download.headers.get('content-disposition') || '', /attachment/);
+    const bytes = Buffer.from(await download.arrayBuffer());
+    assert.equal(bytes.length, manifest.sizeBytes);
+    assert.equal(sha256(bytes), manifest.sha256);
+  });
+
+  test('disabling keeps the data on disk (purge is a manual, explicit act)', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/db/params/collect-discovery-data`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ collectDiscoveryData: false }),
+    });
+    assert.equal(r.status, 200);
+    const params = await (await fetch(`${server.baseUrl}/api/v1/admin/db/params`)).json();
+    assert.equal(params.collectDiscoveryData, false);
+    assert.ok(fs.existsSync(discoveryDbFile()), 'existing data survives disable');
+  });
+});
+
+describe('discovery export — enabled at boot, real data round-trip', () => {
+  let server;
+  let snapshotBytes;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: false,
+      extraConfig: { scanOptions: { collectDiscoveryData: true } },
+    });
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('boot with the flag on initializes discovery.db', () => {
+    assert.ok(fs.existsSync(path.join(server.tmpDir, 'db', 'discovery.db')));
+  });
+
+  test('seeded rows travel through export → download, cleaned and ordered', async () => {
+    // Seed through a second connection, the same way any external writer
+    // would; insert order deliberately differs from export_id order.
+    const embedding = Buffer.from(new Float32Array([0.25, -1, 0.5]).buffer);
+    const db = new DatabaseSync(path.join(server.tmpDir, 'db', 'discovery.db'));
+    try {
+      const ins = db.prepare(`
+        INSERT INTO discovery_tracks
+          (audio_hash, source_mtime, updated_at, export_id, artist, title, embedding)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+      ins.run('local-hash-b', 42, 1, 'mbid:zzz-sorts-last', 'B Artist', 'B Song', null);
+      ins.run('local-hash-a', 43, 2, 'anon:aaa-sorts-first', 'A Artist', 'A Song', embedding);
+      db.prepare(
+        'INSERT INTO discovery_lookups (audio_hash, last_attempt_at, outcome) VALUES (?, ?, ?)'
+      ).run('local-hash-c', Date.now(), 'error');
+    } finally {
+      db.close();
+    }
+
+    const build = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export`, { method: 'POST' });
+    assert.equal(build.status, 200);
+    const manifest = await build.json();
+    assert.equal(manifest.rowCount, 2);
+
+    const download = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export/download`);
+    assert.equal(download.status, 200);
+    snapshotBytes = Buffer.from(await download.arrayBuffer());
+    assert.equal(sha256(snapshotBytes), manifest.sha256);
+
+    // Crack the snapshot open and verify the share-safe contract.
+    const snapFile = path.join(server.tmpDir, 'downloaded-snapshot.db');
+    fs.writeFileSync(snapFile, snapshotBytes);
+    const snap = new DatabaseSync(snapFile, { readOnly: true });
+    try {
+      const tables = snap.prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+      ).all().map(r => r.name);
+      assert.deepEqual(tables, ['meta', 'tracks'], 'no internal tables in the snapshot');
+
+      const cols = snap.prepare('PRAGMA table_info(tracks)').all().map(c => c.name);
+      assert.ok(!cols.includes('audio_hash'), 'raw local hash must not travel');
+      assert.ok(!cols.includes('source_mtime'));
+      assert.ok(!cols.includes('updated_at'));
+
+      const rows = snap.prepare('SELECT export_id, artist, embedding FROM tracks').all();
+      assert.deepEqual(rows.map(r => r.export_id),
+        ['anon:aaa-sorts-first', 'mbid:zzz-sorts-last'],
+        'deterministic export_id ordering regardless of insert order');
+      const embOut = Uint8Array.from(rows[0].embedding);
+      assert.deepEqual(Array.from(new Float32Array(embOut.buffer, 0, 3)), [0.25, -1, 0.5]);
+
+      const metaKeys = snap.prepare('SELECT key FROM meta').all().map(r => r.key);
+      assert.ok(!metaKeys.includes('export_salt'), 'salt is a secret');
+    } finally {
+      snap.close();
+    }
+  });
+
+  test('download supports HTTP Range (resumable pulls)', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export/download`, {
+      headers: { Range: 'bytes=0-99' },
+    });
+    assert.equal(r.status, 206);
+    const part = Buffer.from(await r.arrayBuffer());
+    assert.equal(part.length, 100);
+    assert.deepEqual(part, snapshotBytes.subarray(0, 100),
+      'partial content matches the full snapshot bytes');
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1937,6 +1937,13 @@ const dbView = Vue.component('db-view', {
                         [<a v-on:click="openModal('edit-analyze-bpm-per-run-modal')">{{ t('admin.settings.edit') }}</a>]
                       </td>
                     </tr>
+                    <tr>
+                      <td><b>Collect music-discovery data (separate discovery.db):</b> {{dbParams.collectDiscoveryData}}</td>
+                      <td>
+                        [<a v-on:click="toggleCollectDiscoveryData()">{{ t('admin.settings.edit') }}</a>]
+                        [<a v-on:click="exportDiscoveryData()">Export</a>]
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -2422,6 +2429,70 @@ const dbView = Vue.component('db-view', {
             instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
           }],
         ]
+      });
+    },
+    toggleCollectDiscoveryData: function() {
+      iziToast.question({
+        timeout: 20000,
+        close: false,
+        overlayClose: true,
+        overlay: true,
+        displayMode: 'once',
+        id: 'question',
+        zindex: 99999,
+        layout: 2,
+        maxWidth: 600,
+        title: `<b>${this.dbParams.collectDiscoveryData === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')} music-discovery data collection? (stores per-track audio fingerprint IDs + embeddings in a separate discovery.db you can export; disabling keeps existing data)</b>`,
+        position: 'center',
+        buttons: [
+          [`<button><b>${this.dbParams.collectDiscoveryData === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')}</b></button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+            API.axios({
+              method: 'POST',
+              url: `${API.url()}/api/v1/admin/db/params/collect-discovery-data`,
+              data: { collectDiscoveryData: !this.dbParams.collectDiscoveryData }
+            }).then(() => {
+              Vue.set(ADMINDATA.dbParams, 'collectDiscoveryData', !this.dbParams.collectDiscoveryData);
+              iziToast.success({
+                title: t('admin.settings.updated'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            }).catch(() => {
+              iziToast.error({
+                title: t('admin.settings.failed'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            });
+          }, true],
+          [`<button>${t('admin.folders.goBack')}</button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+          }],
+        ]
+      });
+    },
+    exportDiscoveryData: function() {
+      // Build a fresh snapshot, then pull it down. The endpoint 404s until
+      // collection has been enabled at least once.
+      API.axios({
+        method: 'POST',
+        url: `${API.url()}/api/v1/admin/db/discovery-export`
+      }).then((response) => {
+        iziToast.success({
+          title: `Discovery export ready: ${response.data.rowCount} tracks`,
+          position: 'topCenter',
+          timeout: 3500
+        });
+        window.location.href = `${API.url()}/api/v1/admin/db/discovery-export/download?token=${API.token()}`;
+      }).catch((err) => {
+        iziToast.error({
+          title: (err && err.response && err.response.status === 404)
+            ? 'Enable music-discovery data collection first'
+            : t('admin.settings.failed'),
+          position: 'topCenter',
+          timeout: 3500
+        });
       });
     },
     toggleSkipImg: function() {


### PR DESCRIPTION
## What

P0 of the music-discovery dataset ([discovery-network plan](https://github.com/IrosTheBeggar/mStream)): a **second SQLite file, `discovery.db`**, deliberately isolated from `mstream.db`, plus an **admin export surface** that produces a cleaned, self-contained, shareable snapshot. No scanner/worker yet — this is the store + export scaffolding the CLAP embedding worker (next phase) will write into.

## Why a separate DB

- The whole point of the dataset is to be shared later — a standalone file is the exportable unit.
- Quarantines opt-in, privacy-sensitive data behind one file the operator can delete wholesale.
- Its schema evolves on its own version line, independent of mstream.db''s migration chain.
- Only coupling to mstream.db is the canonical `audio_hash` — and that never leaves the machine.

## Pieces

- **`src/db/discovery-db.js`** — open/migrate (WAL, busy_timeout, own SCHEMA_VERSION=1). Tables: `discovery_tracks` (internal: audio_hash PK / source_mtime / monotonic `updated_at` rowversion; exported: `export_id`, MBIDs, artist/title/duration, model pin, embedding BLOB, tier-1 filter cols), `discovery_lookups` (worker negative-cache, never exported), `discovery_meta` (self-description + row_seq counter + secret export salt). `upsertDiscoveryTrack()` is the single write path the future worker and tests share.
- **`src/db/discovery-export.js`** — snapshot builder: ATTACH fresh file + `INSERT…SELECT` **explicit allowlist** (`VACUUM INTO` can''t filter), one consistent transaction, deterministic ordering, self-describing `meta` (embedding model/dim/dtype/endianness/normalization), `manifest.json` (sha256, row count, sizes) + README. `export_id` is `mbid:<recording-mbid>` when known, else a **salted** opaque id — the raw local hash and the salt never travel.
- **Admin API** — `POST /db/params/collect-discovery-data` (toggle; ON creates the DB, OFF keeps data), `POST /db/discovery-export` (build, returns manifest; 404 before first enable, 409 concurrent), `GET …/manifest`, `GET …/download` (Range-capable → resumable; works through the iroh pairing tunnel as-is).
- **Config** — `scanOptions.collectDiscoveryData`, default **OFF** (opt-in by design). Boot initializes the DB only when enabled — non-fatally, unlike initDB().
- **Admin UI** — Database-panel row: live toggle (confirm dialog) + Export link (builds then downloads).

## Bug found during browser verification

`res.download`''s default `dotfiles:''ignore''` 404s any file whose **path contains a dot-segment** — e.g. a dbDirectory under `~/.config/mstream`. Fixed with `dotfiles:''allow''` on the download route (verified in a live server whose dbDirectory sits under a dot-directory).

## Testing

- 12 in-process tests (`test/db/discovery-db.test.mjs`): schema bootstrap, meta seeding, salt stability across reopen, export-id semantics, upsert/rowversion, snapshot allowlist + sha256 integrity + rebuild.
- 9 integration tests (`test/integration/discovery-export.test.mjs`): opt-in flow, 404s before enable, config persistence, empty + seeded round-trip (byte-for-byte sha256), ordering, Range/206.
- Full suite: **1451/1452** — the 1 failure (`public-mode-privacy` wrapped play-start) **reproduces on clean master**, unrelated to this change.
- Zero new lint issues (flagged ones pre-exist on master).
- Live-verified in the browser: toggle → discovery.db created + config.json persisted → export → download (attachment, valid SQLite bytes, Range 206).

## Explicitly deferred (per plan)

Embedding worker (CLAP, P1), AcoustID identity fill (P2), network-peer/public distribution (per-server keys, aggregation), incremental export (the `updated_at` cursor groundwork is in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)