### PR TITLE
fix(wrapped): stop dropping first-of-period plays from stats windows

### DIFF
--- a/src/api/wrapped.js
+++ b/src/api/wrapped.js
@@ -13,7 +13,8 @@ function genEventId() {
   return crypto.randomBytes(12).toString('hex');
 }
 
-function getPeriodRange(period, offset) {
+// Exported for the regression test (wrapped-period-range.test.mjs).
+export function getPeriodRange(period, offset) {
   const now = new Date();
   let start, end, label;
 
@@ -68,7 +69,17 @@ function getPeriodRange(period, offset) {
     }
   }
 
-  return { start: start.toISOString(), end: end.toISOString(), label };
+  // The bounds are compared as TEXT against play_events.started_at, which
+  // SQLite writes as 'YYYY-MM-DD HH:MM:SS' (datetime('now') — UTC, space
+  // separator, no milliseconds). They MUST use that exact format: TEXT
+  // comparison is lexicographic, and toISOString()'s 'T' separator sorts
+  // AFTER ' ', so any event whose date equals the window's start date
+  // compared as before-the-window — silently dropping every play made on
+  // the first day of the period (and, mirrored at the exclusive end bound,
+  // leaking end-date plays into the previous period). Surfaced 2026-07-01,
+  // when "This Month" lost all of that day's plays.
+  const toSqliteUtc = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+  return { start: toSqliteUtc(start), end: toSqliteUtc(end), label };
 }
 
 // Parse "vpath/rel/path.mp3" with access validation

--- a/test/unit/wrapped-period-range.test.mjs
+++ b/test/unit/wrapped-period-range.test.mjs
@@ -1,0 +1,74 @@
+/**
+ * Regression test for the wrapped stats period windows (src/api/wrapped.js).
+ *
+ * play_events.started_at is written by SQLite as 'YYYY-MM-DD HH:MM:SS'
+ * (datetime('now') — UTC, space separator). The window bounds from
+ * getPeriodRange() are compared against it as TEXT, i.e. lexicographically.
+ * They used to be toISOString() output ('YYYY-MM-DDTHH:MM:SS.sssZ'), whose
+ * 'T' separator sorts AFTER ' ' — so whenever an event's DATE equalled the
+ * window's start date, the event compared as before-the-window and was
+ * dropped. In practice: every play made on the first day of a month
+ * vanished from "This Month" (first surfaced 2026-07-01, when CI and the
+ * public-mode-privacy suite failed on exactly this).
+ *
+ * These tests pin the two properties that prevent the bug class:
+ *   1. Bounds use the exact SQLite datetime format (space, no ms, no zone).
+ *   2. A datetime('now')-style timestamp taken right now falls inside the
+ *      current window of every period — true on EVERY calendar day,
+ *      including period-boundary days, which is where the old code failed.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getPeriodRange } from '../../src/api/wrapped.js';
+
+const SQLITE_DATETIME = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+const PERIODS = ['weekly', 'monthly', 'quarterly', 'half-yearly', 'yearly', 'anything-else-defaults'];
+
+// What SQLite's datetime('now') produces, built the same way (UTC).
+function sqliteNow() {
+  return new Date().toISOString().slice(0, 19).replace('T', ' ');
+}
+
+describe('getPeriodRange SQLite-format contract', () => {
+  test('bounds are SQLite datetime strings, start < end', () => {
+    for (const period of PERIODS) {
+      for (const offset of [0, -1, -3]) {
+        const { start, end } = getPeriodRange(period, offset);
+        assert.match(start, SQLITE_DATETIME, `${period} offset ${offset} start`);
+        assert.match(end, SQLITE_DATETIME, `${period} offset ${offset} end`);
+        assert.ok(start < end, `${period} offset ${offset}: start sorts before end`);
+      }
+    }
+  });
+
+  test("an event stamped datetime('now') falls inside every current window", () => {
+    // The exact property that broke: on a period's first day, the old
+    // ISO-format bounds excluded same-day events by string comparison.
+    const nowStamp = sqliteNow();
+    for (const period of PERIODS) {
+      const { start, end } = getPeriodRange(period, 0);
+      assert.ok(start <= nowStamp, `${period}: now (${nowStamp}) not before start (${start})`);
+      assert.ok(nowStamp < end, `${period}: now (${nowStamp}) inside end bound (${end})`);
+    }
+  });
+
+  test('documents the lexicographic trap the format avoids', () => {
+    // A same-date SQLite timestamp sorts BEFORE any ISO 'T' string —
+    // this is why mixing the two formats in one comparison is never safe.
+    assert.ok('2026-07-01 23:59:59' < '2026-07-01T00:00:00.000Z');
+  });
+
+  test('consecutive windows tile exactly (no gap, no overlap)', () => {
+    // The default branch (unrecognized period string) deliberately ignores
+    // offset — it always answers "this month" — so only the real periods
+    // are expected to tile.
+    for (const period of ['weekly', 'monthly', 'quarterly', 'half-yearly', 'yearly']) {
+      const prev = getPeriodRange(period, -1);
+      const cur = getPeriodRange(period, 0);
+      assert.equal(prev.end, cur.start,
+        `${period}: previous window's end must equal current window's start`);
+    }
+  });
+});


### PR DESCRIPTION
## The bug

Since 2026-07-01 (today), the test matrix fails on **master** and every PR: `public-mode-privacy.test.mjs › Wrapped /play-start persists an event under the sentinel`. It is not flake and not the PRs' fault — it is a real date-dependent bug in the wrapped stats feature.

`play_events.started_at` is written by SQLite as `'2026-07-01 23:28:19'` (`datetime('now')` — UTC, **space** separator). But `getPeriodRange()` built the stats window bounds with `.toISOString()` → `'2026-07-01T00:00:00.000Z'` (**T** separator). SQLite compares TEXT lexicographically, and `'T'` (0x54) sorts after `' '` (0x20) — so whenever an event's **date equals the window's start date**, the event compares as *before* the window and is silently dropped.

Consequences for real users, not just the test:
- Every play made on the **first day of a month** vanishes from "This Month" (same for the first day of a week/quarter/half/year in those views).
- Mirrored at the exclusive `end` bound: boundary-date plays leak into the *previous* period.

All of June the suite passed because mid-month day numbers decide the string comparison before the separator character is reached. July 1st is the first period-boundary day since the feature landed — CI and local runs fail everywhere today, and will pass again tomorrow on their own (until Aug 1).

## The fix

Format both window bounds exactly the way SQLite writes timestamps — `'YYYY-MM-DD HH:MM:SS'` UTC (`toISOString().slice(0, 19).replace('T', ' ')`). Same instants, comparable format. One-line change at the single source (`getPeriodRange`), which feeds every query in wrapped.js.

## Tests

New `test/unit/wrapped-period-range.test.mjs` pins:
- bounds match the SQLite datetime format, `start < end`;
- **an event stamped `datetime('now')` falls inside every current window** — the property that only bites on boundary days (deterministic year-round: it fails on the old code every 1st of the month, today included);
- the lexicographic trap itself, as documentation;
- consecutive windows tile exactly (no gap/overlap) for all five real periods.

Verified today (the exact repro day): the previously failing `public-mode-privacy` suite now passes fully (15/15 across both files). No new lint (the two flagged errors in wrapped.js pre-exist on master at shifted line numbers).

## Note

This unblocks [#687](https://github.com/IrosTheBeggar/mStream/pull/687) (and any other PR opened today) — once this merges, update/rerun their checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
