### PR TITLE
feat(discovery): Discogs-EffNet as default model, auto-downloaded from project mirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^4.2.0",
-        "@number0/iroh": "^1.0.0"
+        "@number0/iroh": "^1.0.0",
+        "onnxruntime-node": "^1.24.3"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   },
   "optionalDependencies": {
     "@number0/iroh": "^1.0.0",
-    "@huggingface/transformers": "^4.2.0"
+    "@huggingface/transformers": "^4.2.0",
+    "onnxruntime-node": "^1.24.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/db/discovery-backfill.mjs
+++ b/src/db/discovery-backfill.mjs
@@ -49,7 +49,7 @@ import winston from 'winston';
 import {
   initDiscoveryDb, setMeta, upsertDiscoveryTrack,
 } from './discovery-db.js';
-import { createEmbedder, embedFile, EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL } from './discovery-features-lib.js';
+import { createEmbedder, analyzeFile, EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL } from './discovery-features-lib.js';
 
 const SCHEMA_GUARD_EXIT = 3;
 
@@ -231,9 +231,13 @@ async function run() {
   // Pin the active model in discovery_meta — the export manifest reads it,
   // and the (future) network layer declares it. Per-row pins still allow a
   // mixed-model dataset mid-migration; meta names the model being written.
+  // The license travels too: NC-SA models make the DATASET NC-SA (the
+  // manifest must say so), permissive models keep it unencumbered.
   setMeta('embedding_model_id', cfg.model);
   setMeta('embedding_model_version', embedder.spec.version);
   setMeta('embedding_dim', String(embedder.spec.dim));
+  setMeta('embedding_model_license', embedder.spec.license || '');
+  setMeta('embedding_model_attribution', embedder.spec.attribution || '');
 
   const startMs = Date.now();
   let attempted = 0;
@@ -253,7 +257,8 @@ async function run() {
 
     try {
       const absPath = path.join(t.root, t.filepath);
-      const vec = await embedFile(embedder, absPath, cfg.ffmpegPath, { maxSeconds: cfg.maxAnalyzeSeconds });
+      const { embedding, genreTags } =
+        await analyzeFile(embedder, absPath, cfg.ffmpegPath, { maxSeconds: cfg.maxAnalyzeSeconds });
 
       upsertDiscoveryTrack({
         audioHash: t.canon_hash,
@@ -262,7 +267,10 @@ async function run() {
         duration: t.duration,
         modelId: cfg.model,
         modelVersion: embedder.spec.version,
-        embedding: Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength),
+        embedding: Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength),
+        // Model-derived style tags (EffNet's activations head) — free with
+        // the same inference. NULL for models without a classifier head.
+        genreTags,
         // Tier-1 filter metadata the library already knows (tag- or
         // essentia-sourced); the identity fields (recording_mbid/acoustid)
         // are the fingerprint phase's job.

--- a/src/db/discovery-export.js
+++ b/src/db/discovery-export.js
@@ -156,7 +156,8 @@ export async function exportDiscoverySnapshot(opts = {}) {
         SELECT key, value FROM discovery_meta
         WHERE key IN (
           'embedding_model_id', 'embedding_model_version', 'embedding_dim',
-          'embedding_dtype', 'embedding_normalization'
+          'embedding_dtype', 'embedding_normalization',
+          'embedding_model_license', 'embedding_model_attribution'
         )
       `);
 
@@ -206,9 +207,12 @@ export async function exportDiscoverySnapshot(opts = {}) {
       dtype: EMBEDDING_DTYPE,
       normalization: EMBEDDING_NORMALIZATION,
     },
-    // No license is asserted for the exported data — distributing a snapshot
-    // beyond personal backup is the operator's decision (and jurisdiction).
-    license: null,
+    // Inherited from the embedding model that produced the vectors. NC-SA
+    // models (Discogs-EffNet) make the derived dataset NC-SA — declared
+    // here AND in the snapshot's own meta table so no consumer is
+    // surprised. Empty → no license asserted.
+    license: getMeta('embedding_model_license') || null,
+    attribution: getMeta('embedding_model_attribution') || null,
     notes: {
       exportId: 'export_id is "mbid:<musicbrainz-recording-id>" when known, '
         + 'else "anon:<opaque-salted-id>". It is NOT unique across rows: '
@@ -250,6 +254,14 @@ ${SNAPSHOT_FORMAT_VERSION}). Verify integrity against \`manifest.json\`
 
 Embeddings from different \`model_id\`/\`model_version\` values live in
 incompatible vector spaces — never compare them.
+
+## License
+
+The dataset inherits the license of the embedding model that produced it —
+declared in \`manifest.json\` (\`license\`, \`attribution\`) and this file's
+\`meta\` table. Datasets built with Discogs-EffNet are **CC BY-NC-SA 4.0**
+(non-commercial, share-alike; model by the Music Technology Group,
+Universitat Pompeu Fabra).
 
 ## Reading it
 

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -228,15 +228,13 @@ export async function ensureModelFile({ filename, url, sha256 }, modelCacheDir) 
 async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
   let ort;
   try {
-    // Specifier built by concatenation so Bun's `--compile` bundler doesn't
-    // try to statically resolve the package (same trick as sqlite-driver.js's
-    // 'node:' + 'sqlite'). onnxruntime-node's loader references per-platform
-    // .node binaries that don't exist on every platform (darwin-x64 has none
-    // upstream) — a static import makes the Bun bundle FAIL TO BUILD there.
-    // Node resolves the computed specifier normally; a Bun standalone binary
-    // hits the catch below at runtime and the discovery pass reports the
-    // model runtime as unavailable.
-    ort = (await import('onnxruntime' + '-node')).default;
+    // NOTE for Bun `--compile`: onnxruntime-node's loader requires a
+    // per-(platform,arch) .node binary that upstream doesn't ship for every
+    // target, so bundling it breaks cross-builds. It is marked `--external`
+    // in scripts/build-bun.mjs — concatenation tricks don't help because
+    // Bun's bundler constant-folds them. In a standalone binary this import
+    // fails at runtime and lands in the catch below.
+    ort = (await import('onnxruntime-node')).default;
   } catch (err) {
     const e = new Error(`onnxruntime-node is not installed — the '${spec.weights.filename}' embedding model cannot run (${err.message})`);
     e.dependencyMissing = true;

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -16,19 +16,28 @@
 // EffNet / MERT) if the commercial angle is dropped — this registry is what
 // makes that a config change instead of a rewrite.
 //
-// The default engine is LAION-CLAP (music_and_speech), Apache-2.0, via
-// @huggingface/transformers (transformers.js) on its bundled onnxruntime-node
-// backend — validated in the 2026-07-01 spike (Node 24, ~2.5-3.6 s/track
-// inference, sane cosine structure on real music). transformers.js is an
-// OPTIONAL dependency: a failed native install must never break the music
-// server, so it is imported lazily and only when a CLAP-kind model is
-// actually requested; the worker surfaces a clean error if it's missing.
+// The default engine is MTG's Discogs-EffNet — the strongest music-specific
+// embedding model available, adopted after the project dropped all
+// commercial aspects of the discovery feature (its weights are
+// CC BY-NC-SA 4.0: non-commercial, share-alike — the license rides along in
+// discovery_meta and every export manifest). Its weights are mirrored as a
+// GitHub release asset under project control and downloaded on first use
+// with sha256 verification — the lesson from Xenova/larger_clap_music
+// silently vanishing off HF. Bonus: the same inference emits 400 Discogs
+// style activations, which become free genre tags per track.
 //
-// ⚠ Weights availability: Xenova/larger_clap_music vanished from HF between
-// planning and the spike. Whatever model gets pinned into a shared network
-// must eventually be mirrored under project control (the registry's hfRepo
-// is a download source, not an identity — model_id/version is the identity).
+// LAION-CLAP (music_and_speech, Apache-2.0) stays selectable for operators
+// who want a permissively-licensed dataset or (future) text→audio queries.
+//
+// All heavy runtimes are OPTIONAL dependencies imported lazily per model
+// kind — a failed native install must never break the music server; the
+// worker surfaces a clean error instead.
 
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
 import { decodePcmF32 } from './audio-analysis-lib.js';
 
 // ── Registry ─────────────────────────────────────────────────────────────────
@@ -46,7 +55,48 @@ import { decodePcmF32 } from './audio-analysis-lib.js';
 //                fixed windows fed to the model; their mean is the track
 //                vector (validated in the spike: 3×10 s ≈ full-track quality
 //                at a fraction of the cost).
+const MODELS_RELEASE_BASE =
+  'https://github.com/IrosTheBeggar/mStream/releases/download/discovery-models-1';
+
 export const EMBEDDING_MODELS = {
+  // MTG-UPF's Discogs-EffNet (trained on 4M Discogs releases / 400 styles).
+  // DEFAULT. Weights are the project-mirrored copy of the official ONNX
+  // export from essentia.upf.edu — small (18 MB), sha256-pinned, fetched on
+  // first use into storage.modelCacheDirectory. The 'labels' file carries
+  // the 400 style names so the activations head can fill genre_tags.
+  'effnet-discogs': {
+    kind: 'effnet-discogs',
+    version: '1',
+    dim: 1280,
+    sampleRate: 16000,
+    segmentSeconds: 10,
+    segmentPositions: [0.25, 0.5, 0.75],
+    // NON-COMMERCIAL license, accepted deliberately: the discovery feature
+    // is free and must never be gated by / bundled into a paid offering.
+    // ShareAlike: exported datasets built from these embeddings inherit
+    // NC-SA terms (declared in the export manifest).
+    license: 'CC-BY-NC-SA-4.0',
+    attribution: 'Discogs-EffNet by Music Technology Group, Universitat Pompeu Fabra (essentia.upf.edu/models)',
+    weights: {
+      filename: 'discogs-effnet-bsdynamic-1.onnx',
+      url: `${MODELS_RELEASE_BASE}/discogs-effnet-bsdynamic-1.onnx`,
+      sha256: 'a280825b334797cf677939db8cd5762c0392aedd0ca6415dbc1cd083f045e43c',
+    },
+    labels: {
+      filename: 'discogs-effnet-bsdynamic-1.json',
+      url: `${MODELS_RELEASE_BASE}/discogs-effnet-bsdynamic-1.json`,
+      sha256: 'a2e85b2e7372d5f8e0f35bdd6aeae1139f101087d183d0b2fb60b0ea0f01a0ff',
+    },
+    // essentia's TensorflowInputMusiCNN front-end contract (the model was
+    // trained on exactly this mel pipeline — do not change independently).
+    frameSize: 512,
+    hopSize: 256,
+    melBands: 96,
+    patchFrames: 128,
+    // Style activations >= this probability become genre_tags (top-K).
+    tagThreshold: 0.1,
+    tagTopK: 5,
+  },
   'clap-music-and-speech': {
     kind: 'transformers-clap',
     hfRepo: 'Xenova/larger_clap_music_and_speech',   // base weights: laion/larger_clap_music_and_speech (Apache-2.0, verified 2026-07-01)
@@ -56,11 +106,13 @@ export const EMBEDDING_MODELS = {
     segmentSeconds: 10,
     segmentPositions: [0.25, 0.5, 0.75],
     dtype: 'fp32',
+    license: 'Apache-2.0',
+    attribution: 'LAION-CLAP (larger_clap_music_and_speech), ONNX conversion by Xenova',
   },
   // Deterministic, dependency-free pseudo-embedder. Exists for two reasons:
   // it lets the whole worker/task-queue/export pipeline be tested without a
-  // ~700 MB model download, and it exercises the model-swap path for real
-  // (tests flip between this and other pins). Not meaningful for similarity.
+  // model download, and it exercises the model-swap path for real (tests
+  // flip between this and other pins). Not meaningful for similarity.
   'test-fake': {
     kind: 'fake',
     version: '1',
@@ -68,10 +120,12 @@ export const EMBEDDING_MODELS = {
     sampleRate: 8000,
     segmentSeconds: 5,
     segmentPositions: [0.5],
+    license: 'GPL-3.0',   // it's just mStream code
+    attribution: 'mStream test fixture',
   },
 };
 
-export const DEFAULT_EMBEDDING_MODEL = 'clap-music-and-speech';
+export const DEFAULT_EMBEDDING_MODEL = 'effnet-discogs';
 
 export function getModelSpec(key) {
   const spec = EMBEDDING_MODELS[key];
@@ -114,7 +168,150 @@ function segments(signal, spec) {
   return out;
 }
 
+// ── Model-file acquisition ───────────────────────────────────────────────────
+
+function sha256OfFile(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+/**
+ * Ensure a pinned model file exists in `modelCacheDir`, downloading it (once)
+ * from the project-controlled mirror when absent. The sha256 pin is the
+ * integrity AND identity check: a cached file with the wrong hash is treated
+ * as corrupt and re-fetched; a downloaded file with the wrong hash is
+ * deleted and the pass fails cleanly (better no data than wrong-model data).
+ * Exported for tests.
+ */
+export async function ensureModelFile({ filename, url, sha256 }, modelCacheDir) {
+  if (!modelCacheDir) { throw new Error('modelCacheDir is required to download model files'); }
+  const dest = path.join(modelCacheDir, filename);
+
+  if (fs.existsSync(dest)) {
+    if (sha256OfFile(dest) === sha256) { return dest; }
+    // Corrupt / partial from a previous crash — refetch below.
+    fs.rmSync(dest, { force: true });
+  }
+
+  fs.mkdirSync(modelCacheDir, { recursive: true });
+  const tmp = `${dest}.downloading`;
+  fs.rmSync(tmp, { force: true });
+
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok || !res.body) {
+    throw new Error(`model download failed: HTTP ${res.status} for ${url}`);
+  }
+  await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(tmp));
+
+  const actual = sha256OfFile(tmp);
+  if (actual !== sha256) {
+    fs.rmSync(tmp, { force: true });
+    throw new Error(`model download checksum mismatch for ${filename}: expected ${sha256}, got ${actual}`);
+  }
+  fs.renameSync(tmp, dest);
+  return dest;
+}
+
 // ── Embedder factories ───────────────────────────────────────────────────────
+
+// Every factory returns { analyzeSignal(Float32Array) → Promise<{
+//   embedding: Float32Array (spec.dim, L2-normalized),
+//   genreTags: string[] | null      // model-derived style tags, when the
+// }> }                              // model has a classification head
+//
+// MTG's Discogs-EffNet through onnxruntime-node, fed by essentia.js's
+// TensorflowInputMusiCNN — the exact mel front-end the model was trained on
+// (already shipped in mStream for the BPM/key pass; note it is AGPL-3.0,
+// the same deliberate acceptance as analyzeBpm). One inference yields both
+// the 1280-d embedding and the 400-style activations (→ genre tags).
+async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
+  let ort;
+  try {
+    ort = (await import('onnxruntime-node')).default;
+  } catch (err) {
+    const e = new Error(`onnxruntime-node is not installed — the '${spec.weights.filename}' embedding model cannot run (${err.message})`);
+    e.dependencyMissing = true;
+    throw e;
+  }
+  // essentia.js loads via the audio-analysis lib's runtime-switched loader
+  // (the 0.1.3 package's index.js is broken — never require it directly).
+  const { getEssentia } = await import('./audio-analysis-lib.js');
+  const essentia = await getEssentia();
+
+  const modelPath = await ensureModelFile(spec.weights, modelCacheDir);
+  const labelsPath = await ensureModelFile(spec.labels, modelCacheDir);
+  const classes = JSON.parse(fs.readFileSync(labelsPath, 'utf8')).classes;
+
+  const session = await ort.InferenceSession.create(modelPath);
+
+  // Frames (512 samples, hop 256) → 96 log-mel bands each, via one WASM call
+  // per frame. Every essentia vector is delete()'d — the emscripten heap
+  // grows per leaked vector.
+  function melFrames(signal) {
+    const rows = [];
+    const frameBuf = new Float32Array(spec.frameSize);
+    for (let start = 0; start + spec.frameSize <= signal.length; start += spec.hopSize) {
+      frameBuf.set(signal.subarray(start, start + spec.frameSize));
+      const vec = essentia.arrayToVector(frameBuf);
+      const res = essentia.TensorflowInputMusiCNN(vec);
+      rows.push(essentia.vectorToArray(res.bands));
+      res.bands.delete();
+      vec.delete();
+    }
+    return rows;
+  }
+
+  return {
+    async analyzeSignal(signal) {
+      // Mel rows across all segments → non-overlapping 128-frame patches.
+      // A signal shorter than one patch is zero-padded (silence rows) so
+      // short-but-eligible tracks still embed instead of crashing.
+      const patches = [];
+      for (const seg of segments(signal, spec)) {
+        const rows = melFrames(seg);
+        if (!rows.length) { continue; }
+        while (rows.length < spec.patchFrames) { rows.push(new Float32Array(spec.melBands)); }
+        for (let start = 0; start + spec.patchFrames <= rows.length; start += spec.patchFrames) {
+          const patch = new Float32Array(spec.patchFrames * spec.melBands);
+          for (let f = 0; f < spec.patchFrames; f++) { patch.set(rows[start + f], f * spec.melBands); }
+          patches.push(patch);
+        }
+      }
+      if (!patches.length) { throw new Error('no audio content to analyse'); }
+
+      const batch = new Float32Array(patches.length * spec.patchFrames * spec.melBands);
+      patches.forEach((p, i) => batch.set(p, i * spec.patchFrames * spec.melBands));
+      const out = await session.run({
+        melspectrogram: new ort.Tensor('float32', batch, [patches.length, spec.patchFrames, spec.melBands]),
+      });
+
+      const embDim = out.embeddings.dims[1];
+      const perPatchEmb = [];
+      for (let i = 0; i < out.embeddings.dims[0]; i++) {
+        perPatchEmb.push(Float32Array.from(out.embeddings.data.subarray(i * embDim, (i + 1) * embDim)));
+      }
+
+      const actDim = out.activations.dims[1];
+      const perPatchAct = [];
+      for (let i = 0; i < out.activations.dims[0]; i++) {
+        perPatchAct.push(Float32Array.from(out.activations.data.subarray(i * actDim, (i + 1) * actDim)));
+      }
+      const styles = meanPool(perPatchAct);
+      const genreTags = Array.from(styles)
+        .map((p, i) => ({ p, name: classes[i] }))
+        .filter((s) => s.p >= spec.tagThreshold)
+        .sort((a, b) => b.p - a.p)
+        .slice(0, spec.tagTopK)
+        .map((s) => s.name);
+
+      return {
+        embedding: l2normalize(meanPool(perPatchEmb)),
+        genreTags: genreTags.length ? genreTags : null,
+      };
+    },
+  };
+}
 
 // LAION-CLAP through transformers.js. The processor computes the model's mel
 // patches from a raw Float32Array directly — no essentia, no wav wrapping.
@@ -139,14 +336,14 @@ async function createClapEmbedder(spec, { modelCacheDir } = {}) {
   const model = await ClapAudioModelWithProjection.from_pretrained(spec.hfRepo, { dtype: spec.dtype });
 
   return {
-    async embedSignal(signal) {
+    async analyzeSignal(signal) {
       const segEmbeds = [];
       for (const seg of segments(signal, spec)) {
         const inputs = await processor(seg);
         const { audio_embeds: audioEmbeds } = await model(inputs);
         segEmbeds.push(Float32Array.from(audioEmbeds.data));
       }
-      return l2normalize(meanPool(segEmbeds));
+      return { embedding: l2normalize(meanPool(segEmbeds)), genreTags: null };
     },
   };
 }
@@ -158,7 +355,7 @@ function createFakeEmbedder(spec) {
     // Not declared async (nothing to await) — callers `await` it anyway,
     // which is a no-op on a plain value, so the interface stays uniform
     // with the real embedders.
-    embedSignal(signal) {
+    analyzeSignal(signal) {
       const segEmbeds = segments(signal, spec).map((seg) => {
         const v = new Float32Array(spec.dim);
         const band = Math.max(1, Math.floor(seg.length / spec.dim));
@@ -171,7 +368,7 @@ function createFakeEmbedder(spec) {
         }
         return v;
       });
-      return l2normalize(meanPool(segEmbeds));
+      return { embedding: l2normalize(meanPool(segEmbeds)), genreTags: null };
     },
   };
 }
@@ -185,6 +382,7 @@ function createFakeEmbedder(spec) {
 export async function createEmbedder(key, opts = {}) {
   const spec = getModelSpec(key);
   switch (spec.kind) {
+    case 'effnet-discogs': return { spec, ...(await createEffnetEmbedder(spec, opts)) };
     case 'transformers-clap': return { spec, ...(await createClapEmbedder(spec, opts)) };
     case 'fake': return { spec, ...createFakeEmbedder(spec) };
     default: throw new Error(`no embedder factory for model kind '${spec.kind}'`);
@@ -192,18 +390,16 @@ export async function createEmbedder(key, opts = {}) {
 }
 
 /**
- * Decode + embed one file. Decode reuses audio-analysis-lib's ffmpeg glue
- * (pure child_process code — the AGPL essentia part of that module is only
- * ever loaded via its own getEssentia(), which this path never calls),
- * resampled to the model's expected rate.
+ * Decode + analyse one file: ffmpeg → mono f32 at the model's rate →
+ * analyzeSignal. Decode reuses audio-analysis-lib's ffmpeg glue.
  *
- * @returns {Promise<Float32Array>} L2-normalized, spec.dim long
+ * @returns {Promise<{embedding: Float32Array, genreTags: string[]|null}>}
  */
-export async function embedFile(embedder, audioPath, ffmpegBin, { maxSeconds = 600, timeoutMs } = {}) {
+export async function analyzeFile(embedder, audioPath, ffmpegBin, { maxSeconds = 600, timeoutMs } = {}) {
   const signal = await decodePcmF32(audioPath, ffmpegBin, {
     sampleRate: embedder.spec.sampleRate,
     maxSeconds,
     ...(timeoutMs ? { timeoutMs } : {}),
   });
-  return embedder.embedSignal(signal);
+  return embedder.analyzeSignal(signal);
 }

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -228,7 +228,15 @@ export async function ensureModelFile({ filename, url, sha256 }, modelCacheDir) 
 async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
   let ort;
   try {
-    ort = (await import('onnxruntime-node')).default;
+    // Specifier built by concatenation so Bun's `--compile` bundler doesn't
+    // try to statically resolve the package (same trick as sqlite-driver.js's
+    // 'node:' + 'sqlite'). onnxruntime-node's loader references per-platform
+    // .node binaries that don't exist on every platform (darwin-x64 has none
+    // upstream) — a static import makes the Bun bundle FAIL TO BUILD there.
+    // Node resolves the computed specifier normally; a Bun standalone binary
+    // hits the catch below at runtime and the discovery pass reports the
+    // model runtime as unavailable.
+    ort = (await import('onnxruntime' + '-node')).default;
   } catch (err) {
     const e = new Error(`onnxruntime-node is not installed — the '${spec.weights.filename}' embedding model cannot run (${err.message})`);
     e.dependencyMissing = true;

--- a/test/db/discovery-model-files.test.mjs
+++ b/test/db/discovery-model-files.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * Model registry contract + pinned model-file acquisition
+ * (src/db/discovery-features-lib.js).
+ *
+ * ensureModelFile is exercised against a local HTTP server — no network:
+ *   - downloads to modelCacheDir and verifies the sha256 pin;
+ *   - a checksum mismatch deletes the download and throws (no partial file
+ *     left behind — better no model than the wrong model);
+ *   - a valid cached copy short-circuits (no second request);
+ *   - a corrupt cached copy (crashed previous run) is re-fetched.
+ *
+ * The registry contract pins what every model entry must declare — dim,
+ * version, license, attribution — because exports and the (future) network
+ * protocol read them.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import crypto from 'node:crypto';
+
+import {
+  EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL, ensureModelFile,
+} from '../../src/db/discovery-features-lib.js';
+
+let scratch;
+let server;
+let baseUrl;
+let hits;
+const BLOB = Buffer.from('pretend-onnx-weights-'.repeat(64));
+const BLOB_SHA = crypto.createHash('sha256').update(BLOB).digest('hex');
+
+before(async () => {
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-modelfile-'));
+  hits = 0;
+  server = http.createServer((req, res) => {
+    hits++;
+    if (req.url === '/model.bin') {
+      res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+      res.end(BLOB);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('model registry contract', () => {
+  test('default model is effnet-discogs and exists', () => {
+    assert.equal(DEFAULT_EMBEDDING_MODEL, 'effnet-discogs');
+    assert.ok(EMBEDDING_MODELS[DEFAULT_EMBEDDING_MODEL]);
+  });
+
+  test('every entry declares the fields exports/protocol depend on', () => {
+    for (const [key, spec] of Object.entries(EMBEDDING_MODELS)) {
+      assert.ok(Number.isInteger(spec.dim) && spec.dim > 0, `${key}.dim`);
+      assert.ok(spec.version, `${key}.version`);
+      assert.ok(Number.isInteger(spec.sampleRate), `${key}.sampleRate`);
+      assert.ok(typeof spec.license === 'string' && spec.license.length, `${key}.license`);
+      assert.ok(typeof spec.attribution === 'string' && spec.attribution.length, `${key}.attribution`);
+    }
+  });
+
+  test('effnet weights are pinned to the project mirror with sha256', () => {
+    const { weights, labels } = EMBEDDING_MODELS['effnet-discogs'];
+    for (const dl of [weights, labels]) {
+      assert.match(dl.url, /^https:\/\/github\.com\/IrosTheBeggar\/mStream\/releases\/download\//,
+        'weights come from the project-controlled release mirror');
+      assert.match(dl.sha256, /^[0-9a-f]{64}$/);
+      assert.ok(dl.filename);
+    }
+    assert.equal(EMBEDDING_MODELS['effnet-discogs'].license, 'CC-BY-NC-SA-4.0');
+  });
+});
+
+describe('ensureModelFile', () => {
+  test('downloads, verifies the pin, and lands the file', async () => {
+    const dir = path.join(scratch, 'dl-ok');
+    const dest = await ensureModelFile(
+      { filename: 'model.bin', url: `${baseUrl}/model.bin`, sha256: BLOB_SHA }, dir);
+    assert.equal(dest, path.join(dir, 'model.bin'));
+    assert.ok(Buffer.from(fs.readFileSync(dest)).equals(BLOB));
+    assert.ok(!fs.existsSync(`${dest}.downloading`), 'temp file cleaned up');
+  });
+
+  test('checksum mismatch throws and leaves nothing behind', async () => {
+    const dir = path.join(scratch, 'dl-bad');
+    await assert.rejects(
+      ensureModelFile({ filename: 'model.bin', url: `${baseUrl}/model.bin`, sha256: 'f'.repeat(64) }, dir),
+      /checksum mismatch/);
+    assert.ok(!fs.existsSync(path.join(dir, 'model.bin')));
+    assert.ok(!fs.existsSync(path.join(dir, 'model.bin.downloading')));
+  });
+
+  test('valid cached copy short-circuits without a request', async () => {
+    const dir = path.join(scratch, 'dl-cache');
+    const spec = { filename: 'model.bin', url: `${baseUrl}/model.bin`, sha256: BLOB_SHA };
+    await ensureModelFile(spec, dir);
+    const before = hits;
+    await ensureModelFile(spec, dir);
+    assert.equal(hits, before, 'no re-download of a valid cached file');
+  });
+
+  test('corrupt cached copy is re-fetched', async () => {
+    const dir = path.join(scratch, 'dl-corrupt');
+    const spec = { filename: 'model.bin', url: `${baseUrl}/model.bin`, sha256: BLOB_SHA };
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'model.bin'), 'garbage from a crashed run');
+    const dest = await ensureModelFile(spec, dir);
+    assert.ok(Buffer.from(fs.readFileSync(dest)).equals(BLOB), 'replaced with the verified copy');
+  });
+
+  test('missing URL → clean error', async () => {
+    await assert.rejects(
+      ensureModelFile({ filename: 'nope.bin', url: `${baseUrl}/nope.bin`, sha256: BLOB_SHA },
+        path.join(scratch, 'dl-404')),
+      /HTTP 404/);
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1945,7 +1945,10 @@ const dbView = Vue.component('db-view', {
                       </td>
                     </tr>
                     <tr>
-                      <td><b>Discovery embedding model:</b> {{dbParams.discoveryModel}}</td>
+                      <td>
+                        <b>Discovery embedding model:</b> {{dbParams.discoveryModel}}
+                        <span v-if="dbParams.discoveryModel === 'effnet-discogs'"> — Discogs-EffNet by MTG-UPF (CC BY-NC-SA 4.0, non-commercial)</span>
+                      </td>
                       <td></td>
                     </tr>
                     <tr>


### PR DESCRIPTION
## What

**Stacked on #689** (the P1 worker — merge that first). With the commercial aspect of the discovery feature dropped, this PR makes **MTG's Discogs-EffNet the default embedding model**, auto-downloaded from a **project-controlled mirror**, and adds the free genre-tags bonus its classifier head provides.

## The mirror

The official 18 MB ONNX export + its labels/metadata json are rehosted as assets on the [`discovery-models-1` release](https://github.com/IrosTheBeggar/mStream/releases/tag/discovery-models-1) (deliberately **not** marked "latest" — the Electron auto-updater and website keep pointing at v6.15.2). Redistributed unmodified from essentia.upf.edu with attribution, as CC BY-NC-SA permits. This kills the third-party-hosting availability risk (the planned CLAP checkpoint literally vanished off HF mid-project).

`ensureModelFile()` fetches them on first use into `storage.modelCacheDirectory` with a **pinned sha256**: corrupt cached copies are re-fetched, bad downloads are deleted and fail the pass cleanly. Measured first-run cost on the real release URL: **under 2 seconds** (vs the ~700 MB HF download CLAP needed).

## The engine

`effnet-discogs` factory: essentia.js `TensorflowInputMusiCNN` mel front-end (the exact pipeline the model was trained on — already shipped for the BPM/key pass) → 128-frame patches (zero-padded for short signals) → `onnxruntime-node` (now a declared optionalDependency) → **1280-d** L2-normalized embedding. `DEFAULT_EMBEDDING_MODEL` flips to it; CLAP stays selectable; existing rows pinned to other models re-embed automatically via the #689 swap mechanism.

**Free genre tags:** the same inference emits 400 Discogs style activations — top-5 ≥ 0.1 land in `discovery_tracks.genre_tags` at zero extra compute (pulled forward from the P3 plan). On real music this is strikingly good: a synthwave album came back `Synthwave / Chillwave / Vaporwave / Synth-pop`, track by track.

## License plumbing (the point of going non-commercial)

Every registry entry declares `license` + `attribution` → the worker writes them to `discovery_meta` → **export manifests, snapshot meta, and the snapshot README now declare the dataset's inherited license** (EffNet datasets are CC BY-NC-SA 4.0 — ShareAlike applies to derived data; nobody downstream gets surprised). The admin UI shows the attribution next to the model name. The discovery feature is free and must never be gated by a paid offering.

## Testing

- +8 tests (`test/db/discovery-model-files.test.mjs`): registry contract (default, per-model license/attribution/dim, mirror-URL + sha256 pins) and `ensureModelFile` against a local HTTP stub (verify, checksum-mismatch cleanup, cache short-circuit, corrupt-cache refetch, 404).
- The 11 worker tests from #689 pass on the renamed `analyzeSignal` interface; P0 export suites pass with the license fields.
- Live e2e smoke of the **production code path**: real mirror download + verify, 1280-d unit-norm embedding, correct style tags on real music (`analyzeFile` ≈ 5.4 s/track; the mel loop is the known optimization target, inference itself is ~0.4 s).

## Deferred

Mel-loop batching optimization (correctness first; ~5 s/track is acceptable for the budgeted background pass); CLAP text-query surface; AcoustID identity fill (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
