### PR TITLE
feat(discovery): gossip catalog — signed announcements over iroh-gossip (N2)

### DIFF
--- a/p2p-sidecar/Cargo.lock
+++ b/p2p-sidecar/Cargo.lock
@@ -862,6 +862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +924,19 @@ checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
 ]
 
 [[package]]
@@ -1702,6 +1721,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-gossip"
+version = "0.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1dc4b05f73e7a1b9e83b531eb63c3fd671b0af3aeb13b59c546dd7ca747515"
+dependencies = [
+ "blake3",
+ "bytes",
+ "data-encoding",
+ "derive_more",
+ "futures-concurrency",
+ "hex",
+ "indexmap",
+ "iroh",
+ "iroh-base",
+ "iroh-metrics",
+ "irpc",
+ "n0-error",
+ "n0-future",
+ "postcard",
+ "rand",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "iroh-io"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2119,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
+ "anyhow",
  "n0-error-macros",
  "spez",
 ]
@@ -2526,9 +2573,12 @@ dependencies = [
  "anyhow",
  "iroh",
  "iroh-blobs",
+ "iroh-gossip",
+ "iroh-tickets",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/p2p-sidecar/Cargo.toml
+++ b/p2p-sidecar/Cargo.toml
@@ -16,10 +16,13 @@ path = "src/main.rs"
 # together, deliberately, and re-run the integration tests when you do.
 iroh = "=1.0.1"
 iroh-blobs = "=0.103.0"
+iroh-gossip = "=0.101.0"
+iroh-tickets = "=1.0.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "fs", "sync", "time"] }
+tokio-stream = "0.1"
 
 [profile.release]
 strip = true

--- a/p2p-sidecar/src/main.rs
+++ b/p2p-sidecar/src/main.rs
@@ -2,10 +2,10 @@
 // music-discovery network.
 //
 // WHY A SIDECAR: mStream is Node, but the rich iroh stack (iroh-blobs
-// verified transfers now, iroh-gossip for the catalog in the next phase)
-// only exists in Rust — the @number0/iroh NAPI binding exposes just the
-// connection layer, and n0 has deprioritized FFI parity. n0's own guidance
-// is an application-specific Rust wrapper; this binary is that wrapper,
+// verified transfers, iroh-gossip for the catalog) only exists in Rust —
+// the @number0/iroh NAPI binding exposes just the connection layer, and n0
+// has deprioritized FFI parity. n0's own guidance is an
+// application-specific Rust wrapper; this binary is that wrapper,
 // delivered like rust-parser: per-platform prebuilt binaries in bin/,
 // rebuilt + committed by CI on push to master (source-only PRs).
 //
@@ -19,32 +19,73 @@
 // tunnel's (config.program.iroh.secretKey): the public discovery persona must
 // not be linkable to the private paired-access endpoint.
 //
-// N1 scope: endpoint + blobs only. `publish` seeds a file (the discovery
-// export snapshot) as a content-addressed blob and returns a ticket;
-// `fetch` pulls a blob from the ticket's origin, BLAKE3-verified, into a
-// local file. Peer exchange is manual (copy the ticket). The gossip catalog
-// topic arrives in the next phase.
+// N1 (blobs): `publish` seeds a file (the discovery export snapshot) as a
+// content-addressed blob and returns a ticket; `fetch` pulls a blob —
+// BLAKE3-verified — into a local file, from a ticket or from {hash, provider}.
+//
+// N2 (gossip catalog): `join` subscribes to the well-known catalog topic
+// (bootstrap = endpoint tickets or bare ids); `announce` broadcasts a
+// SIGNED snapshot announcement and keeps re-broadcasting it periodically
+// (gossip has no history/replay — late joiners only hear periodic
+// re-announcements). Incoming announcements are signature-verified and
+// rate-limited here, then forwarded to Node as unsolicited events; the
+// catalog itself lives on the Node side. Signing is mandatory because a
+// gossip Message's `delivered_from` is the last hop, NOT the author —
+// without app-level signatures any peer could impersonate any other.
 //
 // Protocol (one JSON object per line):
 //   → {"id":1,"cmd":"status"}
 //   → {"id":2,"cmd":"publish","path":"C:/.../discovery-export.db"}
 //   → {"id":3,"cmd":"fetch","ticket":"blob...","outDir":"C:/.../discovery-peers"}
-//   → {"id":4,"cmd":"shutdown"}
+//   → {"id":4,"cmd":"fetch","hash":"<64 hex>","provider":"<endpoint id>","outDir":"..."}
+//   → {"id":5,"cmd":"join","bootstrap":["<endpoint ticket | endpoint id>",...]}
+//   → {"id":6,"cmd":"announce","payload":{"hash":"...","size":1,"rowCount":1,
+//        "modelId":"...","modelVersion":"...","snapshotSeq":1,"name":"..."}}
+//   → {"id":7,"cmd":"shutdown"}
 //   ← {"id":N,"ok":true,...} | {"id":N,"ok":false,"error":"..."}
-// plus a single unsolicited {"event":"ready",...} line once the endpoint is up.
+// Unsolicited events:
+//   ← {"event":"ready","endpointId":"...","ticket":"..."}
+//   ← {"event":"announcement","from":"...","payload":{...}}
+//   ← {"event":"neighbor","up":true|false,"id":"..."}
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
-use iroh::{endpoint::presets, protocol::Router, Endpoint, SecretKey};
-use iroh_blobs::{store::fs::FsStore, ticket::BlobTicket, BlobsProtocol};
-use serde::Deserialize;
+use iroh::{
+    address_lookup::memory::MemoryLookup, endpoint::presets, protocol::Router, Endpoint,
+    EndpointId, PublicKey, SecretKey, Signature,
+};
+use iroh_blobs::{store::fs::FsStore, ticket::BlobTicket, BlobsProtocol, Hash};
+use iroh_gossip::{
+    api::{Event, GossipReceiver, GossipSender},
+    net::Gossip,
+    proto::TopicId,
+};
+use iroh_tickets::endpoint::EndpointTicket;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
+
+// The well-known catalog topic. Deriving it from a versioned string means a
+// future incompatible announcement format simply moves to .../v2 — old and
+// new nodes stop hearing each other instead of choking on each other.
+const CATALOG_TOPIC: &[u8] = b"mstream/discovery/catalog/v1";
+
+// Gossip delivers no history: re-broadcast the current announcement on an
+// interval so late joiners hear about us within one period.
+const ANNOUNCE_INTERVAL: Duration = Duration::from_secs(15);
+// Ignore announcements from the same origin arriving faster than this — a
+// well-behaved peer re-announces every ANNOUNCE_INTERVAL, so anything much
+// faster is a flood.
+const MIN_ANNOUNCE_GAP: Duration = Duration::from_secs(5);
+const MAX_ANNOUNCEMENT_BYTES: usize = 2048;
+const SIGNING_CONTEXT: &str = "mstream-discovery-announce-v1";
 
 #[derive(Deserialize, Debug)]
 struct Request {
@@ -52,14 +93,60 @@ struct Request {
     cmd: String,
     path: Option<String>,
     ticket: Option<String>,
+    hash: Option<String>,
+    provider: Option<String>,
     #[serde(rename = "outDir")]
     out_dir: Option<String>,
+    bootstrap: Option<Vec<String>>,
+    payload: Option<AnnouncePayload>,
+}
+
+// What a server says about its current snapshot. `snapshot_seq` is the
+// app-managed monotonic counter from discovery_meta.row_seq — receivers keep
+// the highest-seq announcement per origin, so a replayed older announcement
+// can never roll a catalog entry back (wall clocks are not monotonic; the
+// counter is).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct AnnouncePayload {
+    hash: String,
+    size: u64,
+    #[serde(rename = "rowCount")]
+    row_count: u64,
+    #[serde(rename = "modelId")]
+    model_id: String,
+    #[serde(rename = "modelVersion")]
+    model_version: String,
+    #[serde(rename = "snapshotSeq")]
+    snapshot_seq: u64,
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Announcement {
+    v: u32,
+    from: String,
+    payload: AnnouncePayload,
+    sig: String,
 }
 
 struct Node {
     endpoint: Endpoint,
     store: FsStore,
+    #[allow(dead_code)] // held for its Drop side (accept loop shutdown)
     router: Router,
+    gossip: Gossip,
+    memory_lookup: MemoryLookup,
+    secret_key: SecretKey,
+    // Some(sender) once `join` has run; join_peers() feeds later bootstrap adds.
+    topic_sender: Mutex<Option<GossipSender>>,
+    // The signed wire bytes the announcer loop re-broadcasts.
+    current_announcement: Mutex<Option<Vec<u8>>>,
+    // Live direct neighbors on the catalog topic (from NeighborUp/Down).
+    neighbor_count: AtomicI64,
+    // origin endpoint id -> last accepted announcement instant (flood guard).
+    last_accepted: Mutex<HashMap<String, Instant>>,
+    out_tx: mpsc::UnboundedSender<Value>,
 }
 
 fn main() -> Result<()> {
@@ -93,8 +180,13 @@ fn main() -> Result<()> {
 
 async fn run(data_dir: PathBuf) -> Result<()> {
     let key = load_or_create_identity(&data_dir)?;
+    // MemoryLookup lets `join`/`fetch` seed full addresses from tickets, so
+    // bootstrap works LAN-local (and in tests) without any external address
+    // lookup; the N0 preset still provides relay + DNS discovery on top.
+    let memory_lookup = MemoryLookup::new();
     let endpoint = Endpoint::builder(presets::N0)
-        .secret_key(key)
+        .secret_key(key.clone())
+        .address_lookup(memory_lookup.clone())
         .bind()
         .await
         .map_err(|e| anyhow!("endpoint bind failed: {e}"))?;
@@ -103,16 +195,16 @@ async fn run(data_dir: PathBuf) -> Result<()> {
         .await
         .map_err(|e| anyhow!("blob store load failed: {e}"))?;
     let blobs = BlobsProtocol::new(&store, None);
+    let gossip = Gossip::builder().spawn(endpoint.clone());
     let router = Router::builder(endpoint.clone())
         .accept(iroh_blobs::ALPN, blobs)
+        .accept(iroh_gossip::ALPN, gossip.clone())
         .spawn();
 
     // Bounded wait for a home relay so tickets carry relay info — mirrors the
     // awaitOnline race in src/state/iroh.js. Offline hosts proceed anyway
     // (tickets then hold direct addresses only, which still works on a LAN).
     let _ = tokio::time::timeout(Duration::from_secs(8), endpoint.online()).await;
-
-    let node = Arc::new(Node { endpoint, store, router });
 
     // Single writer task owns stdout; handlers post JSON values to it. Keeps
     // concurrent responses from interleaving mid-line.
@@ -127,9 +219,24 @@ async fn run(data_dir: PathBuf) -> Result<()> {
         }
     });
 
+    let node = Arc::new(Node {
+        endpoint,
+        store,
+        router,
+        gossip,
+        memory_lookup,
+        secret_key: key,
+        topic_sender: Mutex::new(None),
+        current_announcement: Mutex::new(None),
+        neighbor_count: AtomicI64::new(0),
+        last_accepted: Mutex::new(HashMap::new()),
+        out_tx: out_tx.clone(),
+    });
+
     out_tx.send(json!({
         "event": "ready",
         "endpointId": node.endpoint.id().to_string(),
+        "ticket": endpoint_ticket(&node),
     }))?;
 
     // Request loop: one line = one request; each runs as its own task so a
@@ -182,6 +289,9 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
             Ok(json!({
                 "endpointId": node.endpoint.id().to_string(),
                 "hasRelay": addr.relay_urls().next().is_some(),
+                "ticket": endpoint_ticket(&node),
+                "joined": node.topic_sender.lock().await.is_some(),
+                "neighbors": node.neighbor_count.load(Ordering::Relaxed).max(0),
             }))
         }
 
@@ -203,21 +313,32 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
         }
 
         "fetch" => {
-            let ticket = BlobTicket::from_str(&req.ticket.context("fetch needs `ticket`")?)
-                .map_err(|e| anyhow!("bad ticket: {e}"))?;
             let out_dir = PathBuf::from(req.out_dir.context("fetch needs `outDir`")?);
             tokio::fs::create_dir_all(&out_dir).await?;
 
-            // Dial with the ticket's FULL EndpointAddr (relay URL + direct
-            // addresses), not just the id — works on a LAN with no external
-            // address lookup, and across NATs via the relay.
-            let conn = node.endpoint.connect(ticket.addr().clone(), iroh_blobs::ALPN)
+            // Two addressing modes:
+            //  - ticket: carries the full EndpointAddr (relay + direct) — works
+            //    with zero prior knowledge of the peer.
+            //  - hash + provider id: the catalog flow. The provider address
+            //    comes from the MemoryLookup (if it bootstrapped us) or from
+            //    discovery — the same resolution `connect` always does.
+            let (hash, addr): (Hash, iroh::EndpointAddr) = if let Some(t) = &req.ticket {
+                let ticket = BlobTicket::from_str(t).map_err(|e| anyhow!("bad ticket: {e}"))?;
+                (ticket.hash(), ticket.addr().clone())
+            } else {
+                let hash = Hash::from_str(&req.hash.context("fetch needs `ticket` or `hash`+`provider`")?)
+                    .map_err(|e| anyhow!("bad hash: {e}"))?;
+                let provider = EndpointId::from_str(&req.provider.context("fetch by hash needs `provider`")?)
+                    .map_err(|e| anyhow!("bad provider id: {e}"))?;
+                (hash, provider.into())
+            };
+
+            let conn = node.endpoint.connect(addr, iroh_blobs::ALPN)
                 .await
-                .map_err(|e| anyhow!("cannot reach the ticket's origin: {e}"))?;
-            node.store.remote().fetch(conn, ticket.hash_and_format()).await
+                .map_err(|e| anyhow!("cannot reach the blob's origin: {e}"))?;
+            node.store.remote().fetch(conn, hash).await
                 .map_err(|e| anyhow!("transfer failed: {e}"))?;
 
-            let hash = ticket.hash();
             let out_path = out_dir.join(format!("{hash}.db"));
             node.store.blobs().export(hash, out_path.clone()).await
                 .map_err(|e| anyhow!("export to file failed: {e}"))?;
@@ -229,10 +350,197 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
             }))
         }
 
+        "join" => {
+            let entries = req.bootstrap.unwrap_or_default();
+            let mut ids: Vec<EndpointId> = Vec::new();
+            for entry in &entries {
+                // Tickets seed the MemoryLookup so the peer is dialable with
+                // no external discovery; bare ids lean on the N0 preset.
+                if let Ok(ticket) = EndpointTicket::from_str(entry) {
+                    let addr = ticket.endpoint_addr().clone();
+                    let id = addr.id;
+                    node.memory_lookup.add_endpoint_info(addr);
+                    ids.push(id);
+                } else if let Ok(id) = EndpointId::from_str(entry) {
+                    ids.push(id);
+                } else {
+                    bail!("bootstrap entry is neither an endpoint ticket nor an endpoint id: {entry}");
+                }
+            }
+            ids.retain(|id| *id != node.endpoint.id());
+
+            let mut sender_slot = node.topic_sender.lock().await;
+            if let Some(sender) = sender_slot.as_ref() {
+                // Already subscribed: just feed the new peers into the mesh.
+                sender.join_peers(ids.clone()).await
+                    .map_err(|e| anyhow!("join_peers failed: {e}"))?;
+            } else {
+                let topic = TopicId::from_bytes(*Hash::new(CATALOG_TOPIC).as_bytes());
+                // subscribe() (NOT subscribe_and_join): returns immediately even
+                // with zero reachable peers — the first node in the network must
+                // not hang its RPC waiting for a mesh that doesn't exist yet.
+                let topic_handle = node.gossip.subscribe(topic, ids.clone()).await
+                    .map_err(|e| anyhow!("gossip subscribe failed: {e}"))?;
+                let (sender, receiver) = topic_handle.split();
+                *sender_slot = Some(sender.clone());
+                tokio::spawn(receive_loop(node.clone(), receiver));
+                tokio::spawn(announce_loop(node.clone(), sender));
+            }
+            Ok(json!({ "joined": true, "bootstrapPeers": ids.len() }))
+        }
+
+        "announce" => {
+            let payload = req.payload.context("announce needs `payload`")?;
+            let payload = validate_payload(payload)?;
+            let canonical = canonical_bytes(&node.endpoint.id().to_string(), &payload);
+            let sig = node.secret_key.sign(&canonical);
+            let wire = serde_json::to_vec(&Announcement {
+                v: 1,
+                from: node.endpoint.id().to_string(),
+                payload,
+                sig: hex_encode(&sig.to_bytes()),
+            })?;
+            if wire.len() > MAX_ANNOUNCEMENT_BYTES {
+                bail!("announcement too large ({} bytes)", wire.len());
+            }
+            *node.current_announcement.lock().await = Some(wire.clone());
+            // Broadcast immediately if we're on the topic; the announce loop
+            // handles the periodic re-sends either way.
+            let broadcast_now = node.topic_sender.lock().await.clone();
+            if let Some(sender) = broadcast_now {
+                sender.broadcast(wire.into()).await
+                    .map_err(|e| anyhow!("broadcast failed: {e}"))?;
+                Ok(json!({ "announced": true, "broadcast": true }))
+            } else {
+                Ok(json!({ "announced": true, "broadcast": false, "note": "not joined yet — will broadcast after join" }))
+            }
+        }
+
         "shutdown" => Ok(json!({})),
 
         other => Err(anyhow!("unknown command: {other}")),
     }
+}
+
+// Periodically re-broadcast the current announcement. Errors are logged, not
+// fatal — a transient mesh hiccup shouldn't kill the announcer.
+async fn announce_loop(node: Arc<Node>, sender: GossipSender) {
+    loop {
+        tokio::time::sleep(ANNOUNCE_INTERVAL).await;
+        let wire = node.current_announcement.lock().await.clone();
+        if let Some(wire) = wire {
+            if let Err(e) = sender.broadcast(wire.into()).await {
+                eprintln!("[p2p-sidecar] periodic announce failed: {e}");
+            }
+        }
+    }
+}
+
+// Verify + rate-limit incoming gossip, forward good announcements to Node.
+async fn receive_loop(node: Arc<Node>, mut receiver: GossipReceiver) {
+    use tokio_stream::StreamExt;
+    while let Some(event) = receiver.next().await {
+        match event {
+            Ok(Event::Received(msg)) => {
+                if let Err(reason) = process_announcement(&node, &msg.content).await {
+                    eprintln!("[p2p-sidecar] dropped announcement from {}: {reason}", msg.delivered_from);
+                }
+            }
+            Ok(Event::NeighborUp(id)) => {
+                node.neighbor_count.fetch_add(1, Ordering::Relaxed);
+                let _ = node.out_tx.send(json!({"event":"neighbor","up":true,"id":id.to_string()}));
+            }
+            Ok(Event::NeighborDown(id)) => {
+                node.neighbor_count.fetch_sub(1, Ordering::Relaxed);
+                let _ = node.out_tx.send(json!({"event":"neighbor","up":false,"id":id.to_string()}));
+            }
+            Ok(Event::Lagged) => eprintln!("[p2p-sidecar] gossip receiver lagged — some announcements were missed"),
+            Err(e) => {
+                eprintln!("[p2p-sidecar] gossip stream error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+async fn process_announcement(node: &Node, content: &[u8]) -> Result<()> {
+    if content.len() > MAX_ANNOUNCEMENT_BYTES {
+        bail!("oversized ({} bytes)", content.len());
+    }
+    let ann: Announcement = serde_json::from_slice(content).map_err(|e| anyhow!("unparseable: {e}"))?;
+    if ann.v != 1 { bail!("unknown version {}", ann.v); }
+    if ann.from == node.endpoint.id().to_string() { return Ok(()); } // our own echo
+    let payload = validate_payload(ann.payload)?;
+
+    // The signature is the ONLY thing tying the announcement to `from` —
+    // delivered_from is just the last gossip hop.
+    let author = PublicKey::from_str(&ann.from).map_err(|e| anyhow!("bad author id: {e}"))?;
+    let sig_bytes: [u8; 64] = hex_decode(&ann.sig)?
+        .try_into()
+        .map_err(|_| anyhow!("bad signature length"))?;
+    author
+        .verify(&canonical_bytes(&ann.from, &payload), &Signature::from_bytes(&sig_bytes))
+        .map_err(|_| anyhow!("signature verification failed"))?;
+
+    // Flood guard: at most one accepted announcement per origin per gap.
+    {
+        let mut last = node.last_accepted.lock().await;
+        let now = Instant::now();
+        if let Some(prev) = last.get(&ann.from) {
+            if now.duration_since(*prev) < MIN_ANNOUNCE_GAP { return Ok(()); } // silently coalesce
+        }
+        last.insert(ann.from.clone(), now);
+    }
+
+    let _ = node.out_tx.send(json!({
+        "event": "announcement",
+        "from": ann.from,
+        "payload": payload,
+    }));
+    Ok(())
+}
+
+// Field sanity: hashes are 64 hex chars; strings are capped and must not
+// contain the signing-string separator.
+fn validate_payload(mut p: AnnouncePayload) -> Result<AnnouncePayload> {
+    if p.hash.len() != 64 || !p.hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+        bail!("payload.hash must be 64 hex chars");
+    }
+    for (field, value, cap) in [
+        ("modelId", &mut p.model_id, 128),
+        ("modelVersion", &mut p.model_version, 128),
+        ("name", &mut p.name, 64),
+    ] {
+        if value.len() > cap { bail!("payload.{field} too long"); }
+        if value.contains('|') { bail!("payload.{field} must not contain '|'"); }
+    }
+    Ok(p)
+}
+
+// Deterministic signing input. Pipe-separated is safe because '|' is
+// rejected in every free-text field above and the rest are hex/integers.
+fn canonical_bytes(from: &str, p: &AnnouncePayload) -> Vec<u8> {
+    format!(
+        "{SIGNING_CONTEXT}|{from}|{}|{}|{}|{}|{}|{}|{}",
+        p.hash, p.size, p.row_count, p.model_id, p.model_version, p.snapshot_seq, p.name
+    )
+    .into_bytes()
+}
+
+fn endpoint_ticket(node: &Node) -> String {
+    EndpointTicket::new(node.endpoint.addr()).to_string()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn hex_decode(s: &str) -> Result<Vec<u8>> {
+    if s.len() % 2 != 0 { bail!("odd-length hex"); }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| anyhow!("bad hex: {e}")))
+        .collect()
 }
 
 // Load the persistent identity key, creating it on first run. Best-effort

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -14,6 +14,7 @@ import * as db from '../db/manager.js';
 import * as discoveryDb from '../db/discovery-db.js';
 import * as discoveryExport from '../db/discovery-export.js';
 import * as discoveryP2p from '../state/discovery-p2p.js';
+import * as discoveryCatalog from '../state/discovery-catalog.js';
 import * as logger from '../logger.js';
 import { joiValidate } from '../util/validation.js';
 import { isAdminAllowed } from '../util/admin-network.js';
@@ -399,14 +400,59 @@ export function setup(mstream) {
   };
 
   // Sidecar status. Deliberately side-effect free: reports the sidecar as
-  // stopped rather than starting it (publish/fetch are the lazy-starters).
+  // stopped rather than starting it (publish/fetch/join are the lazy-starters).
+  // `ticket` is what another operator pastes into their bootstrapPeers config
+  // (or POSTs to /join) to befriend this server.
   mstream.get("/api/v1/admin/discovery/p2p/status", (req, res) => {
     res.json({
       enabled: config.program.discoveryP2p.enabled,
       binaryFound: discoveryP2p.resolveSidecarBinary() !== null,
       running: discoveryP2p.isRunning(),
       endpointId: discoveryP2p.getEndpointId(),
+      ticket: discoveryP2p.getEndpointTicket(),
+      knownPeers: discoveryCatalog.size(),
     });
+  });
+
+  // The catalog: every peer we've heard a signed announcement from (newest
+  // per peer), populated by gossip while the sidecar is joined.
+  mstream.get("/api/v1/admin/discovery/p2p/catalog", (req, res) => {
+    requireP2pEnabled();
+    res.json({ peers: discoveryCatalog.list() });
+  });
+
+  // Publish the current export snapshot and broadcast its signed
+  // announcement to the catalog topic. 404 until an export exists.
+  mstream.post("/api/v1/admin/discovery/p2p/announce", async (req, res) => {
+    requireP2pEnabled();
+    if (!discoveryExport.snapshotExists()) {
+      throw new WebError('no discovery export has been built yet — build one first (POST /api/v1/admin/db/discovery-export)', 404);
+    }
+    try {
+      res.json(await discoveryP2p.announceCurrentSnapshot());
+    } catch (err) {
+      winston.warn(`discovery P2P announce failed for admin '${req.user?.username}': ${err.message}`);
+      throw new WebError(`announce failed: ${err.message}`, 500);
+    }
+  });
+
+  // Join the catalog topic at runtime with an extra bootstrap peer (an
+  // endpoint ticket or bare endpoint id — e.g. pasted from a friend's
+  // status route). Non-persistent: add it to config discoveryP2p.bootstrapPeers
+  // to survive restarts.
+  mstream.post("/api/v1/admin/discovery/p2p/join", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      peer: Joi.string().min(16).max(4096).required(),
+    });
+    joiValidate(schema, req.body);
+    try {
+      discoveryCatalog.subscribe();
+      res.json(await discoveryP2p.join([req.body.peer]));
+    } catch (err) {
+      winston.warn(`discovery P2P join failed for admin '${req.user?.username}' (peer ${req.body.peer.slice(0, 32)}…): ${err.message}`);
+      throw new WebError(`join failed: ${err.message}`, 500);
+    }
   });
 
   // Seed the current export snapshot as a content-addressed blob. Returns
@@ -427,22 +473,41 @@ export function setup(mstream) {
     }
   });
 
-  // Pull a peer's snapshot by ticket into {dbDirectory}/discovery-peers/.
-  // Returns { hash, size, path }. The transfer is BLAKE3-verified by the
-  // protocol, so a completed fetch is an intact file.
+  // Pull a peer's snapshot into {dbDirectory}/discovery-peers/. Returns
+  // { hash, size, path }; the transfer is BLAKE3-verified by the protocol,
+  // so a completed fetch is an intact file. Addressing is EITHER a blob
+  // ticket (manual hand-off, works with zero prior contact) OR the
+  // endpointId of a catalog peer (the gossip flow — hash + provider come
+  // from their latest signed announcement).
   mstream.post("/api/v1/admin/discovery/p2p/fetch", async (req, res) => {
     requireP2pEnabled();
     const schema = Joi.object({
       // BlobTickets are base32 strings; a generous cap guards the sidecar
       // from junk without rejecting legitimate multi-address tickets.
-      ticket: Joi.string().min(16).max(4096).required(),
-    });
+      ticket: Joi.string().min(16).max(4096),
+      endpointId: Joi.string().hex().length(64),
+    }).xor('ticket', 'endpointId');
     joiValidate(schema, req.body);
+
+    let addressing;
+    let label;
+    if (req.body.ticket) {
+      addressing = { ticket: req.body.ticket };
+      label = `ticket ${req.body.ticket.slice(0, 32)}…`;
+    } else {
+      const entry = discoveryCatalog.get(req.body.endpointId);
+      if (!entry) {
+        throw new WebError('unknown peer — not in the catalog (no announcement heard from that endpointId)', 404);
+      }
+      addressing = { hash: entry.payload.hash, provider: entry.from };
+      label = `peer ${req.body.endpointId.slice(0, 12)}…`;
+    }
+
     const outDir = path.join(config.program.storage.dbDirectory, 'discovery-peers');
     try {
-      res.json(await discoveryP2p.fetch(req.body.ticket, outDir));
+      res.json(await discoveryP2p.fetch(addressing, outDir));
     } catch (err) {
-      winston.warn(`discovery P2P fetch failed for admin '${req.user?.username}' (ticket ${req.body.ticket.slice(0, 32)}…): ${err.message}`);
+      winston.warn(`discovery P2P fetch failed for admin '${req.user?.username}' (${label}): ${err.message}`);
       throw new WebError(`fetch failed: ${err.message}`, 500);
     }
   });

--- a/src/server.js
+++ b/src/server.js
@@ -479,6 +479,32 @@ export async function serveIt(configFile) {
       }
     }
 
+    // Discovery-network gossip catalog (opt-in; default off). Start the
+    // p2p-sidecar, join the well-known catalog topic with the configured
+    // bootstrap peers, and re-announce our current export snapshot if one
+    // exists. Detached + non-fatal, mirroring the iroh tunnel above: a host
+    // with no sidecar binary just logs and leaves the feature off, and a
+    // slow relay handshake must not delay boot.
+    if (config.program.discoveryP2p.enabled) {
+      (async () => {
+        try {
+          const p2p = await import('./state/discovery-p2p.js');
+          const catalog = await import('./state/discovery-catalog.js');
+          catalog.subscribe();
+          await p2p.start();
+          await p2p.join(config.program.discoveryP2p.bootstrapPeers);
+          try {
+            const r = await p2p.announceCurrentSnapshot();
+            winston.info(`[discovery-p2p] catalog joined; announced snapshot ${r.hash.slice(0, 12)}…`);
+          } catch (_err) {
+            winston.info('[discovery-p2p] catalog joined; nothing to announce yet (no export snapshot)');
+          }
+        } catch (err) {
+          winston.error(`[discovery-p2p] catalog unavailable — feature disabled this boot: ${err.message}`);
+        }
+      })();
+    }
+
     // Boot server audio (Rust preferred, CLI fallback) — runs CLI detection
     // eagerly so the admin endpoint has fresh data by the time it's called.
     serverPlaybackApi.bootRustPlayer().catch(() => {});

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -272,6 +272,14 @@ const irohOptions = Joi.object({
 // (and useless anyway until collectDiscoveryData has built a dataset).
 const discoveryP2pOptions = Joi.object({
   enabled: Joi.boolean().default(false),
+  // Catalog-topic bootstrap: endpoint tickets (from a friend's status route —
+  // dialable with zero external discovery) and/or bare endpoint ids (resolved
+  // via n0 DNS). Empty = this server waits to BE bootstrapped (it still joins
+  // the topic so peers holding OUR ticket can find the mesh through us).
+  bootstrapPeers: Joi.array().items(Joi.string().min(16).max(4096)).default([]),
+  // Display name carried in our signed catalog announcements. Pipe is
+  // reserved as the announcement signing-string separator.
+  serverName: Joi.string().max(64).pattern(/^[^|]*$/).default('mStream'),
 });
 
 const dlnaOptions = Joi.object({

--- a/src/state/discovery-catalog.js
+++ b/src/state/discovery-catalog.js
@@ -1,0 +1,126 @@
+// The local view of the discovery-network catalog: every peer we've heard a
+// (signature-verified, sidecar-vetted) snapshot announcement from, newest
+// announcement per peer.
+//
+// Gossip gives us a stream of claims, not a database — this module turns
+// that stream into state. Rules:
+//   - keyed by origin endpoint id (one live snapshot per server);
+//   - latest-wins ordered by snapshotSeq, the announcer's app-managed
+//     monotonic counter (discovery_meta.row_seq). A replayed or out-of-order
+//     older announcement can never roll an entry back — this is exactly why
+//     the counter exists instead of wall-clock timestamps;
+//   - persisted to {dbDirectory}/discovery-p2p/catalog.json (debounced) so
+//     the catalog survives restarts — peers announce every ~15s while
+//     online, but a rebooted server shouldn't forget everyone who is
+//     currently offline.
+//
+// This is deliberately NOT a table in discovery.db: that file is the
+// exportable share-safe unit, and what other servers exist is internal
+// state that must never travel with it.
+
+import fs from 'fs';
+import path from 'path';
+import winston from 'winston';
+import * as config from './config.js';
+import { events } from './discovery-p2p.js';
+
+const SAVE_DEBOUNCE_MS = 2000;
+
+// endpointId -> { from, payload, firstSeenAt, updatedAt }
+const catalog = new Map();
+let loaded = false;
+let saveTimer = null;
+
+function catalogPath() {
+  return path.join(config.program.storage.dbDirectory, 'discovery-p2p', 'catalog.json');
+}
+
+// Lazy-load on first touch. A corrupt file logs + starts empty — the network
+// re-populates it within one announce interval per live peer.
+function ensureLoaded() {
+  if (loaded) { return; }
+  loaded = true;
+  try {
+    const entries = JSON.parse(fs.readFileSync(catalogPath(), 'utf8'));
+    for (const e of entries) {
+      if (e && typeof e.from === 'string' && e.payload) { catalog.set(e.from, e); }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      winston.warn(`discovery catalog unreadable (${err.message}) — starting empty`);
+    }
+  }
+}
+
+function scheduleSave() {
+  if (saveTimer) { return; }
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    try {
+      fs.mkdirSync(path.dirname(catalogPath()), { recursive: true });
+      fs.writeFileSync(catalogPath(), JSON.stringify([...catalog.values()], null, 2));
+    } catch (err) {
+      winston.warn(`discovery catalog save failed: ${err.message}`);
+    }
+  }, SAVE_DEBOUNCE_MS);
+  // Don't hold the process open just to flush a catalog write.
+  if (saveTimer.unref) { saveTimer.unref(); }
+}
+
+// Record one verified announcement. Returns true when it changed the catalog
+// (new peer, or newer snapshotSeq / different hash for a known one).
+export function record(from, payload) {
+  ensureLoaded();
+  const existing = catalog.get(from);
+  if (existing) {
+    const oldSeq = existing.payload.snapshotSeq || 0;
+    const newSeq = payload.snapshotSeq || 0;
+    // Same-seq re-announcements are the steady-state heartbeat; only rewrite
+    // when something actually moved forward.
+    if (newSeq < oldSeq) { return false; }
+    if (newSeq === oldSeq && existing.payload.hash === payload.hash) {
+      existing.updatedAt = new Date().toISOString();
+      return false;
+    }
+  }
+  catalog.set(from, {
+    from,
+    payload,
+    firstSeenAt: existing ? existing.firstSeenAt : new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+  scheduleSave();
+  winston.info(`[discovery-catalog] ${existing ? 'updated' : 'new'} peer ${from.slice(0, 12)}… `
+    + `(${payload.rowCount} tracks, model ${payload.modelId})`);
+  return true;
+}
+
+export function list() {
+  ensureLoaded();
+  return [...catalog.values()];
+}
+
+export function get(endpointId) {
+  ensureLoaded();
+  return catalog.get(endpointId) || null;
+}
+
+export function size() {
+  ensureLoaded();
+  return catalog.size;
+}
+
+// Wire the sidecar's event stream into the catalog. Idempotent; called once
+// from server boot (and by tests).
+let subscribed = false;
+export function subscribe() {
+  if (subscribed) { return; }
+  subscribed = true;
+  events.on('announcement', (msg) => {
+    try {
+      record(msg.from, msg.payload);
+    } catch (err) {
+      winston.warn(`discovery catalog failed to record announcement from ${msg.from}: ${err.message}`);
+    }
+  });
+}

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -24,10 +24,18 @@
 import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
+import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
 import winston from 'winston';
 import { appRoot } from '../util/esm-helpers.js';
 import * as config from './config.js';
+
+// Unsolicited sidecar events surface here:
+//   'announcement' → { from, payload }   a peer's signed catalog announcement
+//                                        (signature already verified in Rust)
+//   'neighbor'     → { up, id }          gossip mesh membership changes
+// The catalog module (discovery-catalog.js) is the main subscriber.
+export const events = new EventEmitter();
 
 const ext = process.platform === 'win32' ? '.exe' : '';
 // musl detection mirrors task-queue.js's rust-parser resolution.
@@ -41,8 +49,9 @@ const SHUTDOWN_GRACE_MS = 5000;
 
 let proc = null;          // live child process (null when stopped)
 let endpointId = null;    // from the sidecar's ready event
-let readyPromise = null;  // in-flight start() so concurrent callers share one spawn
+let endpointTicket = null; // full dialable address (relay + direct), from ready
 let nextId = 1;
+let readyPromise = null;  // in-flight start() so concurrent callers share one spawn
 const pending = new Map(); // id -> { resolve, reject, timer }
 
 // Prebuilt binary (CI-committed) or a local `npm run build-p2p-sidecar`
@@ -69,6 +78,10 @@ export function dataDir() {
 export function isRunning() { return proc !== null && endpointId !== null; }
 
 export function getEndpointId() { return endpointId; }
+
+// The sidecar's own endpoint ticket — what another operator pastes into
+// their bootstrapPeers to befriend this server.
+export function getEndpointTicket() { return endpointTicket; }
 
 // Start the sidecar (idempotent; concurrent callers await the same spawn).
 // Resolves once the sidecar's ready event arrives. Rejects with an
@@ -103,8 +116,14 @@ export function start() {
       if (msg.event === 'ready') {
         clearTimeout(readyTimer);
         endpointId = msg.endpointId;
+        endpointTicket = msg.ticket || null;
         winston.info(`[p2p-sidecar] ready — endpointId=${endpointId}`);
         resolve({ endpointId });
+        return;
+      }
+      if (msg.event) {
+        // Unsolicited event (announcement / neighbor) — hand off to listeners.
+        events.emit(msg.event, msg);
         return;
       }
       const waiter = pending.get(msg.id);
@@ -140,6 +159,7 @@ export function start() {
 function teardown(why) {
   proc = null;
   endpointId = null;
+  endpointTicket = null;
   for (const [, waiter] of pending) {
     clearTimeout(waiter.timer);
     waiter.reject(new Error(`p2p-sidecar ${why}`));
@@ -173,15 +193,64 @@ export async function publish(filePath) {
   return rpc('publish', { path: filePath });
 }
 
-// Fetch a blob by ticket into outDir. Returns { hash, size, path }.
-export async function fetch(ticket, outDir) {
+// Fetch a blob into outDir. Returns { hash, size, path }. Addressing is
+// either { ticket } (full self-contained address) or { hash, provider }
+// (the catalog flow — provider resolves via the sidecar's address book /
+// discovery).
+export async function fetch(addressing, outDir) {
   await start();
-  return rpc('fetch', { ticket, outDir }, FETCH_TIMEOUT_MS);
+  return rpc('fetch', { ...addressing, outDir }, FETCH_TIMEOUT_MS);
 }
 
 export async function status() {
   await start();
   return rpc('status');
+}
+
+// Join the well-known catalog topic. bootstrap = endpoint tickets (dialable
+// with zero external discovery) and/or bare endpoint ids (resolved via n0
+// discovery). Idempotent — later calls feed extra peers into the mesh.
+export async function join(bootstrap = []) {
+  await start();
+  return rpc('join', { bootstrap });
+}
+
+// Sign + broadcast our snapshot announcement; the sidecar re-broadcasts it
+// every ~15s (gossip has no history — late joiners rely on re-announces).
+export async function announce(payload) {
+  await start();
+  return rpc('announce', { payload });
+}
+
+// Publish the current export snapshot as a blob and broadcast its signed
+// announcement — the one code path shared by server boot and the admin
+// announce route. Throws when no export snapshot exists (callers turn that
+// into a 404 / boot no-op as appropriate). Dynamic imports keep this module
+// import-light for the paths that never announce.
+export async function announceCurrentSnapshot() {
+  const discoveryExport = await import('../db/discovery-export.js');
+  const manifest = discoveryExport.readManifest();
+  if (!manifest || !discoveryExport.snapshotExists()) {
+    throw new Error('no discovery export snapshot to announce');
+  }
+  // Re-adding the blob is idempotent and guarantees the announced hash
+  // matches the file on disk even if the export was rebuilt while the
+  // sidecar was down.
+  const pub = await publish(discoveryExport.snapshotPath());
+  const discoveryDb = await import('../db/discovery-db.js');
+  const snapshotSeq = discoveryDb.openDiscoveryDbIfExists()
+    ? Number(discoveryDb.getMeta('row_seq') || 0) : 0;
+  const payload = {
+    hash: pub.hash,
+    size: pub.size,
+    rowCount: manifest.rowCount || 0,
+    modelId: (manifest.model && manifest.model.id) || '',
+    modelVersion: (manifest.model && manifest.model.version) || '',
+    snapshotSeq,
+    name: config.program.discoveryP2p.serverName,
+  };
+  const result = await announce(payload);
+  return { ...pub, announced: true, broadcast: !!result.broadcast, payload };
 }
 
 // Graceful stop: ask politely, then close stdin (the sidecar's EOF exit

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -2,26 +2,33 @@
  * Integration tests for the discovery P2P layer (p2p-sidecar + its admin
  * surface):
  *
- *   GET  /api/v1/admin/discovery/p2p/status    always available, side-effect free
- *   POST /api/v1/admin/discovery/p2p/publish   seed the export snapshot as a blob
- *   POST /api/v1/admin/discovery/p2p/fetch     pull a peer's snapshot by ticket
+ *   GET  /api/v1/admin/discovery/p2p/status     always available, side-effect free
+ *   GET  /api/v1/admin/discovery/p2p/catalog    peers heard via gossip
+ *   POST /api/v1/admin/discovery/p2p/publish    seed the export snapshot as a blob
+ *   POST /api/v1/admin/discovery/p2p/announce   publish + broadcast signed announcement
+ *   POST /api/v1/admin/discovery/p2p/join       add a bootstrap peer at runtime
+ *   POST /api/v1/admin/discovery/p2p/fetch      pull a snapshot by ticket or endpointId
  *
- * Two layers of coverage:
+ * Three layers of coverage:
  *
  *  1. Route gating (always runs, no binary needed): the 403-until-enabled
- *     contract, Joi validation, publish's 404-until-export-built, and the
- *     side-effect-free status shape.
+ *     contract, Joi validation, publish/announce 404-until-export-built.
  *
- *  2. The real loop (runs only when a p2p-sidecar binary is present —
- *     prebuilt in bin/p2p-sidecar/ or a local cargo build): boot a server
- *     with the feature on, build a real export snapshot, publish it, then
- *     have a second, raw sidecar process (the "peer") fetch it by ticket and
- *     verify bytes — and the reverse direction, fetching a peer-published
- *     blob through the admin route. Transfers ride the tickets' direct
- *     addresses, so the loop works on loopback without external services.
+ *  2. The blob loop (needs a p2p-sidecar binary — prebuilt in
+ *     bin/p2p-sidecar/ or a local cargo build): publish → a raw peer
+ *     sidecar fetches by ticket → bytes identical, and the reverse through
+ *     the admin route.
  *
- * Both suites run in public mode (no users) — the admin auth gate has its
- * own suite (admin-access.test.mjs).
+ *  3. The gossip loop (same binary requirement): the server joins the
+ *     catalog topic at boot; a raw peer bootstraps off the server's
+ *     endpoint ticket; announcements flow BOTH ways (signed in Rust,
+ *     verified in Rust, recorded by the Node catalog); the peer fetches by
+ *     {hash, provider} with no ticket, and the server fetches by bare
+ *     endpointId straight from its catalog.
+ *
+ * Everything rides the tickets' direct addresses, so the whole suite works
+ * on loopback without external services. Public mode (no users) — the admin
+ * auth gate has its own suite (admin-access.test.mjs).
  */
 
 import { describe, before, after, test } from 'node:test';
@@ -36,6 +43,16 @@ import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
 
 const SIDECAR_BIN = resolveSidecarBinary();
 
+async function pollUntil(fn, { timeoutMs = 15000, everyMs = 250, what = 'condition' } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn();
+    if (value) { return value; }
+    if (Date.now() > deadline) { throw new Error(`timed out waiting for ${what}`); }
+    await new Promise((r) => setTimeout(r, everyMs));
+  }
+}
+
 // Minimal raw-protocol driver for a standalone "peer" sidecar — deliberately
 // independent of src/state/discovery-p2p.js (which manages the SERVER's
 // singleton instance) so the test exercises the wire protocol itself.
@@ -44,11 +61,21 @@ class RawSidecar {
     this.proc = spawn(bin, ['--data-dir', dataDir], { stdio: ['pipe', 'pipe', 'pipe'] });
     this.pending = new Map();
     this.nextId = 1;
+    this.events = [];   // every unsolicited event, in arrival order
+    this.endpointId = null;
+    this.ticket = null;
     this.ready = new Promise((resolve, reject) => {
       const t = setTimeout(() => reject(new Error('peer sidecar never became ready')), 30000);
       readline.createInterface({ input: this.proc.stdout }).on('line', (line) => {
         const msg = JSON.parse(line);
-        if (msg.event === 'ready') { clearTimeout(t); resolve(msg); return; }
+        if (msg.event === 'ready') {
+          clearTimeout(t);
+          this.endpointId = msg.endpointId;
+          this.ticket = msg.ticket;
+          resolve(msg);
+          return;
+        }
+        if (msg.event) { this.events.push(msg); return; }
         const w = this.pending.get(msg.id);
         if (w) { this.pending.delete(msg.id); msg.ok ? w.resolve(msg) : w.reject(new Error(msg.error)); }
       });
@@ -64,6 +91,12 @@ class RawSidecar {
         if (this.pending.delete(id)) { reject(new Error(`peer rpc timeout (${cmd})`)); }
       }, 60000).unref();
     });
+  }
+  waitForEvent(type, predicate = () => true, timeoutMs = 20000) {
+    return pollUntil(
+      () => this.events.find((e) => e.event === type && predicate(e)),
+      { timeoutMs, what: `sidecar event '${type}'` },
+    );
   }
   async stop() {
     try { this.proc.stdin.end(); } catch (_err) { /* noop */ }
@@ -92,18 +125,25 @@ describe('discovery p2p — route gating (no sidecar needed)', () => {
     assert.equal(typeof body.binaryFound, 'boolean');
   });
 
-  test('publish and fetch are 403 while the feature is disabled', async () => {
-    const pub = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/publish`, { method: 'POST' });
-    assert.equal(pub.status, 403);
-    const fetchR = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/fetch`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ticket: 'blobAAAAAAAAAAAAAAAAAAAA' }),
-    });
-    assert.equal(fetchR.status, 403);
+  test('all mutating + catalog routes are 403 while the feature is disabled', async () => {
+    for (const [method, route, body] of [
+      ['POST', 'publish', undefined],
+      ['POST', 'announce', undefined],
+      ['POST', 'join', { peer: 'endpointAAAAAAAAAAAAAAAA' }],
+      ['POST', 'fetch', { ticket: 'blobAAAAAAAAAAAAAAAAAAAA' }],
+      ['GET', 'catalog', undefined],
+    ]) {
+      const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/${route}`, {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : {},
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      assert.equal(r.status, 403, `${method} ${route} should be 403 when disabled`);
+    }
   });
 });
 
-describe('discovery p2p — enabled, pre-sidecar contract', () => {
+describe('discovery p2p — enabled, validation contract', () => {
   let server;
 
   before(async () => {
@@ -114,34 +154,59 @@ describe('discovery p2p — enabled, pre-sidecar contract', () => {
   });
   after(async () => { if (server) { await server.stop(); } });
 
-  test('publish is 404 until an export snapshot has been built', async () => {
-    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/publish`, { method: 'POST' });
-    assert.equal(r.status, 404);
+  test('publish and announce are 404 until an export snapshot has been built', async () => {
+    for (const route of ['publish', 'announce']) {
+      const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/${route}`, { method: 'POST' });
+      assert.equal(r.status, 404, `${route} should 404 before an export exists`);
+    }
   });
 
-  test('fetch validates the ticket body (400 on junk)', async () => {
-    for (const body of [{}, { ticket: 'short' }, { ticket: 42 }]) {
+  test('fetch validates addressing (400 on junk / both / neither)', async () => {
+    for (const body of [
+      {},
+      { ticket: 'short' },
+      { ticket: 42 },
+      { endpointId: 'not-hex' },
+      { ticket: 'blobAAAAAAAAAAAAAAAAAAAA', endpointId: 'a'.repeat(64) }, // xor
+    ]) {
       const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/fetch`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
-      assert.equal(r.status, 400);
+      assert.equal(r.status, 400, `body ${JSON.stringify(body)} should be 400`);
     }
+  });
+
+  test('fetch by endpointId 404s for a peer the catalog has never heard of', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/fetch`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpointId: 'a'.repeat(64) }),
+    });
+    assert.equal(r.status, 404);
+  });
+
+  test('join validates the peer body', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/join`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ peer: 'x' }),
+    });
+    assert.equal(r.status, 400);
   });
 });
 
-// The real loop — needs a sidecar binary. Skips cleanly (visible in the test
+// The real loops — need a sidecar binary. Skip cleanly (visible in the test
 // summary) on machines that have neither the prebuilt nor a local build.
-(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — real transfer loop', () => {
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — blob + gossip loops', () => {
   let server;
   let peer;
   let peerDir;
+  const api = (p) => `${server.baseUrl}/api/v1/admin/discovery/p2p/${p}`;
 
   before(async () => {
     server = await startServer({
       dlnaMode: 'disabled', waitForScan: false,
       extraConfig: {
-        discoveryP2p: { enabled: true },
+        discoveryP2p: { enabled: true, serverName: 'Gossip Test Server' },
         scanOptions: { collectDiscoveryData: true },
       },
     });
@@ -155,24 +220,27 @@ describe('discovery p2p — enabled, pre-sidecar contract', () => {
     if (peerDir) { fs.rmSync(peerDir, { recursive: true, force: true }); }
   });
 
-  test('publish the export snapshot, peer fetches it by ticket, bytes match', async () => {
-    // Build a real (empty-but-valid) export snapshot first.
+  test('boot wiring auto-starts the sidecar and joins the topic', async () => {
+    // discoveryP2p.enabled was on at boot, so the server should already be
+    // running its sidecar (or come up within the poll window).
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(api('status'))).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot + join' });
+    assert.match(status.endpointId, /^[0-9a-f]{64}$/);
+    assert.ok(status.ticket.length > 32, 'status must expose the bootstrap ticket');
+  });
+
+  test('blob loop: publish → peer fetches by ticket → bytes match', async () => {
     const build = await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export`, { method: 'POST' });
     assert.equal(build.status, 200);
 
-    const pub = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/publish`, { method: 'POST' });
+    const pub = await fetch(api('publish'), { method: 'POST' });
     assert.equal(pub.status, 200);
     const { hash, size, ticket } = await pub.json();
     assert.match(hash, /^[0-9a-f]{64}$/);
     assert.ok(size > 0);
-    assert.ok(ticket.length > 32);
 
-    // Status now shows a live sidecar with an endpoint identity.
-    const status = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
-    assert.equal(status.running, true);
-    assert.match(status.endpointId, /^[0-9a-f]{64}$/);
-
-    // The peer pulls the snapshot by ticket (loopback direct addresses).
     const outDir = path.join(peerDir, 'fetched');
     const got = await peer.rpc('fetch', { ticket, outDir });
     assert.equal(got.hash, hash);
@@ -183,19 +251,65 @@ describe('discovery p2p — enabled, pre-sidecar contract', () => {
       'fetched bytes must match the published snapshot exactly');
   });
 
-  test('server fetches a peer-published blob through the admin route', async () => {
+  test('gossip loop: announcements flow both ways; fetch works ticketless', async () => {
+    const serverStatus = await (await fetch(api('status'))).json();
+
+    // Peer bootstraps off the server's endpoint ticket (loopback direct
+    // addresses — no external discovery involved).
+    await peer.rpc('join', { bootstrap: [serverStatus.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    // Server → peer: re-announce now that the mesh is up (gossip has no
+    // history, so the peer wouldn't hear anything until the next periodic
+    // re-broadcast otherwise).
+    const ann = await (await fetch(api('announce'), { method: 'POST' })).json();
+    assert.equal(ann.announced, true);
+    assert.equal(ann.broadcast, true, 'server must already be joined (boot wiring)');
+
+    const heard = await peer.waitForEvent('announcement', (e) => e.from === serverStatus.endpointId);
+    assert.equal(heard.payload.hash, ann.hash);
+    assert.equal(heard.payload.name, 'Gossip Test Server');
+    assert.ok(Number.isInteger(heard.payload.snapshotSeq));
+
+    // Ticketless fetch: hash + provider from the announcement, address
+    // resolution via the peer's memory lookup (seeded by the join ticket).
+    const outDir = path.join(peerDir, 'fetched-gossip');
+    const got = await peer.rpc('fetch', {
+      hash: heard.payload.hash, provider: heard.from, outDir,
+    });
+    assert.equal(got.hash, heard.payload.hash);
+
+    // Peer → server: peer publishes + announces its own blob; the server's
+    // catalog should record it, then fetch by bare endpointId.
     const blobFile = path.join(peerDir, 'peer-snapshot.db');
     fs.writeFileSync(blobFile, Buffer.from('peer discovery data ' + 'x'.repeat(4096)));
-    const pub = await peer.rpc('publish', { path: blobFile });
-
-    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/fetch`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ticket: pub.ticket }),
+    const peerPub = await peer.rpc('publish', { path: blobFile });
+    await peer.rpc('announce', {
+      payload: {
+        hash: peerPub.hash, size: peerPub.size, rowCount: 42,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Peer',
+      },
     });
-    assert.equal(r.status, 200);
-    const got = await r.json();
-    assert.equal(got.hash, pub.hash);
-    assert.ok(got.path.includes('discovery-peers'));
-    assert.deepEqual(fs.readFileSync(got.path), fs.readFileSync(blobFile));
+
+    const catalogEntry = await pollUntil(async () => {
+      const c = await (await fetch(api('catalog'))).json();
+      return c.peers.find((p) => p.from === peer.endpointId) || null;
+    }, { what: "peer's announcement in the server catalog" });
+    assert.equal(catalogEntry.payload.hash, peerPub.hash);
+    assert.equal(catalogEntry.payload.rowCount, 42);
+    assert.equal(catalogEntry.payload.name, 'Peer');
+
+    const fetched = await fetch(api('fetch'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpointId: peer.endpointId }),
+    });
+    assert.equal(fetched.status, 200);
+    const gotPeer = await fetched.json();
+    assert.equal(gotPeer.hash, peerPub.hash);
+    assert.deepEqual(fs.readFileSync(gotPeer.path), fs.readFileSync(blobFile));
+
+    // And the catalog survives on disk for the next boot.
+    const persisted = path.join(server.tmpDir, 'db', 'discovery-p2p', 'catalog.json');
+    await pollUntil(() => fs.existsSync(persisted), { what: 'catalog.json to persist' });
   });
 });


### PR DESCRIPTION
## What

N2 of the decentralized discovery network (follows #690): servers now **find each other automatically**. Each server joins a well-known gossip topic, broadcasts a **signed announcement** of its current discovery snapshot, and builds a local catalog of every peer it hears. Fetching a peer's snapshot no longer needs a manually exchanged ticket — just their entry in your catalog.

The end-to-end flow this enables:

1. Operator A enables `discoveryP2p`, builds an export, hits **announce**.
2. Operator B pastes A's endpoint ticket (from A's status route) into `bootstrapPeers` — or POSTs it to **join** at runtime.
3. B's catalog fills with A's announcement (and everything else A's mesh knows); B fetches A's snapshot by bare `endpointId`. BLAKE3-verified, NAT-traversed, no DNS/certs.

## Why signatures are load-bearing

A gossip `Message`'s `delivered_from` is the **last hop, not the author** — announcements are multi-hop broadcast. Without app-level signatures, any peer could impersonate any other and poison every catalog on the topic. So the sidecar signs the canonical announcement string with its identity key and **verifies + rate-limits + size-caps every incoming announcement in Rust** before Node ever sees it. Catalog entries are latest-wins ordered by `snapshotSeq` — the announcer's monotonic `discovery_meta.row_seq` counter — so replaying an older (validly signed) announcement can never roll an entry back.

## Pieces

**Sidecar** (`p2p-sidecar/`, adds `iroh-gossip =0.101.0` + `iroh-tickets =1.0.0`, exact pins like N1):
- `join` — non-blocking subscribe (the network's first node must not hang waiting for a mesh that doesn't exist). Bootstrap = endpoint tickets (seeded into a `MemoryLookup`, so LAN/test joins need zero external discovery) and/or bare ids (n0 DNS). Idempotent: later calls feed `join_peers()`.
- `announce` — sign + broadcast + re-broadcast every 15 s (gossip has no history; late joiners rely on re-announces).
- `fetch` — now also `{hash, provider}`: the catalog flow, no ticket required.
- Unsolicited events to Node: verified announcements, neighbor up/down.

**Node:**
- `src/state/discovery-catalog.js` — the catalog: one newest entry per peer, persisted (debounced) to `{dbDirectory}/discovery-p2p/catalog.json`. Deliberately **not** a table in discovery.db: that file is the exportable share-safe unit, and who your peers are must never travel with it.
- `announceCurrentSnapshot()` — publish + `row_seq` + announce as one shared code path (server boot and the admin route both use it).
- Boot wiring (mirrors the iroh tunnel block: detached, non-fatal): when enabled — start sidecar, join with configured `bootstrapPeers`, re-announce the current snapshot.
- Config: `discoveryP2p.bootstrapPeers`, `discoveryP2p.serverName` (carried in announcements; `|` rejected — it's the signing-string separator).
- Admin API: `GET …/catalog`, `POST …/announce`, `POST …/join`, and `fetch` now takes `{ticket}` XOR `{endpointId}`; `status` exposes this server's **endpoint ticket** (the thing a friend pastes to befriend you) + known-peer count.

## Tests

9/9 in `test/integration/discovery-p2p.test.mjs`: gating/validation suites (always run) plus the full live loop when a sidecar binary is present — boot auto-join, **bidirectional** announcements between the server and a raw peer sidecar, ticketless fetch by hash+provider, server fetch by bare endpointId, catalog persistence to disk. Rides ticket direct addresses → runs entirely on loopback, no external services. Full suite locally: **1465/1465**.

## Reviewer notes

- CI will rebuild the sidecar binaries on merge (`build-p2p-sidecar.yml` triggers on `p2p-sidecar/**`); until that bot commit lands, only hosts with a local cargo build run the feature.
- Deliberate gaps for N3+: no adversarial test for forged signatures (needs a raw gossip client — the verify path is ~15 lines of Rust), multi-source swarming, seeder-count ranking, and the browse UI.
- The N1 fetch route's body contract changed from `{ticket}` (required) to `{ticket} XOR {endpointId}` — N1 was merged yesterday and unreleased, so no compat shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)