### PR TITLE
perf(discovery): pure-JS mel front-end + analysis-window seek-decode (7x faster embedding)

### DIFF
--- a/src/db/audio-analysis-lib.js
+++ b/src/db/audio-analysis-lib.js
@@ -97,11 +97,19 @@ export function decodePcmF32(audioPath, ffmpegBin, opts = {}) {
   const sampleRate = opts.sampleRate || ANALYSIS_SAMPLE_RATE;
   const maxSeconds = opts.maxSeconds || DEFAULT_MAX_SECONDS;
   const timeoutMs = opts.timeoutMs || DEFAULT_DECODE_TIMEOUT_MS;
+  // Optional input seek: decode a window starting at seekSec instead of the
+  // whole file. `-ss` BEFORE `-i` = fast container-level seek — how the
+  // discovery embedder grabs its 10 s analysis windows without decoding
+  // whole tracks. Seek granularity is codec-dependent (a window may start a
+  // few hundred ms off the requested position), which is fine for analysis
+  // windows but would NOT be fine for gapless/precise extraction.
+  const seekSec = opts.seekSec;
 
   return new Promise((resolve, reject) => {
     const args = [
       '-hide_banner', '-loglevel', 'error',
       '-threads', '1',
+      ...(seekSec != null ? ['-ss', String(seekSec)] : []),
       '-t', String(maxSeconds),   // before -i: limit decoded output duration
       '-i', audioPath,
       '-vn', '-dn', '-sn',        // drop cover art / data / subtitle streams

--- a/src/db/discovery-backfill.mjs
+++ b/src/db/discovery-backfill.mjs
@@ -258,7 +258,12 @@ async function run() {
     try {
       const absPath = path.join(t.root, t.filepath);
       const { embedding, genreTags } =
-        await analyzeFile(embedder, absPath, cfg.ffmpegPath, { maxSeconds: cfg.maxAnalyzeSeconds });
+        await analyzeFile(embedder, absPath, cfg.ffmpegPath, {
+          maxSeconds: cfg.maxAnalyzeSeconds,
+          // Known duration → analyzeFile seek-decodes just the analysis
+          // windows instead of the whole file.
+          durationSec: t.duration,
+        });
 
       upsertDiscoveryTrack({
         audioHash: t.canon_hash,

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -220,11 +220,12 @@ export async function ensureModelFile({ filename, url, sha256 }, modelCacheDir) 
 //   genreTags: string[] | null      // model-derived style tags, when the
 // }> }                              // model has a classification head
 //
-// MTG's Discogs-EffNet through onnxruntime-node, fed by essentia.js's
-// TensorflowInputMusiCNN — the exact mel front-end the model was trained on
-// (already shipped in mStream for the BPM/key pass; note it is AGPL-3.0,
-// the same deliberate acceptance as analyzeBpm). One inference yields both
-// the 1280-d embedding and the 400-style activations (→ genre tags).
+// MTG's Discogs-EffNet through onnxruntime-node, fed by the pure-JS mel
+// front-end in effnet-mel.js — a parity-exact reimplementation of essentia's
+// TensorflowInputMusiCNN (the pipeline the model was trained on), ~20×
+// faster than the WASM-per-frame original and with no AGPL dependency in
+// this path. One inference yields both the 1280-d embedding and the
+// 400-style activations (→ genre tags).
 async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
   let ort;
   try {
@@ -240,10 +241,8 @@ async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
     e.dependencyMissing = true;
     throw e;
   }
-  // essentia.js loads via the audio-analysis lib's runtime-switched loader
-  // (the 0.1.3 package's index.js is broken — never require it directly).
-  const { getEssentia } = await import('./audio-analysis-lib.js');
-  const essentia = await getEssentia();
+  const { createMelExtractor } = await import('./effnet-mel.js');
+  const { melFrames } = createMelExtractor();
 
   const modelPath = await ensureModelFile(spec.weights, modelCacheDir);
   const labelsPath = await ensureModelFile(spec.labels, modelCacheDir);
@@ -251,30 +250,15 @@ async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
 
   const session = await ort.InferenceSession.create(modelPath);
 
-  // Frames (512 samples, hop 256) → 96 log-mel bands each, via one WASM call
-  // per frame. Every essentia vector is delete()'d — the emscripten heap
-  // grows per leaked vector.
-  function melFrames(signal) {
-    const rows = [];
-    const frameBuf = new Float32Array(spec.frameSize);
-    for (let start = 0; start + spec.frameSize <= signal.length; start += spec.hopSize) {
-      frameBuf.set(signal.subarray(start, start + spec.frameSize));
-      const vec = essentia.arrayToVector(frameBuf);
-      const res = essentia.TensorflowInputMusiCNN(vec);
-      rows.push(essentia.vectorToArray(res.bands));
-      res.bands.delete();
-      vec.delete();
-    }
-    return rows;
-  }
-
   return {
-    async analyzeSignal(signal) {
-      // Mel rows across all segments → non-overlapping 128-frame patches.
-      // A signal shorter than one patch is zero-padded (silence rows) so
-      // short-but-eligible tracks still embed instead of crashing.
+    // Core path: pre-cut segments (either sliced from one decoded signal by
+    // analyzeSignal below, or seek-decoded windows from analyzeFile).
+    async analyzeSegments(segs) {
+      // Mel rows per segment → non-overlapping 128-frame patches. A segment
+      // shorter than one patch is zero-padded (silence rows) so short-but-
+      // eligible tracks still embed instead of crashing.
       const patches = [];
-      for (const seg of segments(signal, spec)) {
+      for (const seg of segs) {
         const rows = melFrames(seg);
         if (!rows.length) { continue; }
         while (rows.length < spec.patchFrames) { rows.push(new Float32Array(spec.melBands)); }
@@ -315,6 +299,12 @@ async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
         embedding: l2normalize(meanPool(perPatchEmb)),
         genreTags: genreTags.length ? genreTags : null,
       };
+    },
+    // Whole-signal path (callers without a known duration): cut the fixed
+    // windows out of the decoded signal, then run the core path. Returns
+    // analyzeSegments' promise directly — no `async` needed.
+    analyzeSignal(signal) {
+      return this.analyzeSegments(segments(signal, spec));
     },
   };
 }
@@ -404,15 +394,44 @@ export async function createEmbedder(key, opts = {}) {
 
 /**
  * Decode + analyse one file: ffmpeg → mono f32 at the model's rate →
- * analyzeSignal. Decode reuses audio-analysis-lib's ffmpeg glue.
+ * analyze. Decode reuses audio-analysis-lib's ffmpeg glue.
+ *
+ * When the caller knows the track duration (the worker reads it from the
+ * library DB) and the embedder supports pre-cut segments, only the analysis
+ * WINDOWS are decoded (ffmpeg input-seek per window) instead of the whole
+ * file — for a typical 4-minute track that's 30 s of decode instead of
+ * 240 s. Without a duration (or for whole-signal embedders) it falls back
+ * to the original full decode, which is also the path for tracks short
+ * enough to fit inside one window.
  *
  * @returns {Promise<{embedding: Float32Array, genreTags: string[]|null}>}
  */
-export async function analyzeFile(embedder, audioPath, ffmpegBin, { maxSeconds = 600, timeoutMs } = {}) {
-  const signal = await decodePcmF32(audioPath, ffmpegBin, {
-    sampleRate: embedder.spec.sampleRate,
-    maxSeconds,
+export async function analyzeFile(embedder, audioPath, ffmpegBin, { maxSeconds = 600, timeoutMs, durationSec } = {}) {
+  const spec = embedder.spec;
+  const decodeOpts = {
+    sampleRate: spec.sampleRate,
     ...(timeoutMs ? { timeoutMs } : {}),
-  });
+  };
+
+  const seekable = typeof embedder.analyzeSegments === 'function'
+    && Number.isFinite(durationSec)
+    && Array.isArray(spec.segmentPositions)
+    && durationSec > spec.segmentSeconds * 2;   // short tracks: one decode is cheaper
+
+  if (seekable) {
+    const cappedDuration = Math.min(durationSec, maxSeconds);
+    const segs = [];
+    for (const p of spec.segmentPositions) {
+      const start = Math.max(0, Math.min(cappedDuration * p, cappedDuration - spec.segmentSeconds));
+      segs.push(await decodePcmF32(audioPath, ffmpegBin, {
+        ...decodeOpts,
+        seekSec: start,
+        maxSeconds: spec.segmentSeconds,
+      }));
+    }
+    return embedder.analyzeSegments(segs);
+  }
+
+  const signal = await decodePcmF32(audioPath, ffmpegBin, { ...decodeOpts, maxSeconds });
   return embedder.analyzeSignal(signal);
 }

--- a/src/db/effnet-mel.js
+++ b/src/db/effnet-mel.js
@@ -1,0 +1,142 @@
+// Pure-JS mel front-end for Discogs-EffNet — a drop-in replacement for
+// essentia.js's TensorflowInputMusiCNN, ~20× faster (no per-frame WASM
+// boundary crossings; typed-array FFT + sparse filterbank).
+//
+// ⚠ PARITY CONTRACT: EffNet was trained on essentia's exact mel pipeline, so
+// this implementation must match it bit-closely or embedding quality degrades
+// SILENTLY. The exact configuration was established empirically by grid-
+// searching the parameter space against the golden essentia output
+// (max abs diff 1.7e-5 on real music — float32 noise floor):
+//
+//   frame 512, hop 256, Hann window (NOT normalized), POWER spectrum,
+//   96 mel bands 0–8000 Hz on the SLANEY scale (linear < 1 kHz, log above),
+//   area-normalized triangles (essentia's 'unit_tri': × 2/(f_right−f_left)),
+//   compression log10(1 + 10000·x).
+//
+// test/db/effnet-mel-parity.test.mjs re-derives the golden output from
+// essentia.js on every run — any drift here (or an essentia upgrade that
+// changes the reference) fails loudly instead of degrading quietly.
+
+export const MEL_FRAME_SIZE = 512;
+export const MEL_HOP_SIZE = 256;
+export const MEL_BANDS = 96;
+export const MEL_SAMPLE_RATE = 16000;
+const SPEC_BINS = MEL_FRAME_SIZE / 2 + 1;
+const LOW_HZ = 0;
+const HIGH_HZ = 8000;
+
+// Slaney mel scale: linear below 1 kHz, logarithmic above.
+function hzToMel(f) {
+  return f < 1000 ? (f * 3) / 200 : 15 + 27 * (Math.log(f / 1000) / Math.log(6.4));
+}
+function melToHz(m) {
+  return m < 15 ? (m * 200) / 3 : 1000 * Math.pow(6.4, (m - 15) / 27);
+}
+
+/**
+ * Precomputed mel extractor. Create ONCE per worker run and reuse — the
+ * window, FFT twiddles/bit-reversal, and sparse filterbank are all built
+ * here; melFrames() then allocates only its output rows.
+ */
+export function createMelExtractor() {
+  const N = MEL_FRAME_SIZE;
+
+  // Hann window, essentia-style (unnormalized): 0.5 − 0.5·cos(2πi/(N−1)).
+  const window = new Float64Array(N);
+  for (let i = 0; i < N; i++) { window[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (N - 1)); }
+
+  // Iterative radix-2 FFT tables.
+  const rev = new Uint32Array(N);
+  for (let i = 0, j = 0; i < N; i++) {
+    rev[i] = j;
+    let bit = N >> 1;
+    for (; j & bit; bit >>= 1) { j ^= bit; }
+    j ^= bit;
+  }
+  const cosT = new Float64Array(N / 2);
+  const sinT = new Float64Array(N / 2);
+  for (let i = 0; i < N / 2; i++) {
+    cosT[i] = Math.cos((-2 * Math.PI * i) / N);
+    sinT[i] = Math.sin((-2 * Math.PI * i) / N);
+  }
+
+  // Sparse mel filterbank: 96 area-normalized triangles on the Slaney scale.
+  // Stored flat per band as [binIndex, weight, binIndex, weight, ...].
+  const loMel = hzToMel(LOW_HZ);
+  const hiMel = hzToMel(HIGH_HZ);
+  const centers = new Float64Array(MEL_BANDS + 2);
+  for (let i = 0; i < MEL_BANDS + 2; i++) {
+    centers[i] = melToHz(loMel + ((hiMel - loMel) * i) / (MEL_BANDS + 1));
+  }
+  const binHz = MEL_SAMPLE_RATE / N;
+  const filterbank = [];
+  for (let b = 0; b < MEL_BANDS; b++) {
+    const fl = centers[b];
+    const fc = centers[b + 1];
+    const fr = centers[b + 2];
+    const areaNorm = 2 / (fr - fl);   // 'unit_tri'
+    const flat = [];
+    for (let k = 0; k < SPEC_BINS; k++) {
+      const f = k * binHz;
+      if (f < fl || f > fr) { continue; }
+      const w = f <= fc
+        ? (fc === fl ? 1 : (f - fl) / (fc - fl))
+        : (fr === fc ? 1 : (fr - f) / (fr - fc));
+      if (w > 0) { flat.push(k, w * areaNorm); }
+    }
+    filterbank.push(Float64Array.from(flat));
+  }
+
+  // Reusable scratch buffers (single-threaded worker — no reentrancy).
+  const re = new Float64Array(N);
+  const im = new Float64Array(N);
+  const power = new Float64Array(SPEC_BINS);
+
+  /**
+   * Signal → mel rows: one Float32Array(96) per frame (hop 256), matching
+   * essentia's TensorflowInputMusiCNN output. Trailing partial frame dropped,
+   * like the previous implementation.
+   */
+  function melFrames(signal) {
+    const rows = [];
+    for (let start = 0; start + N <= signal.length; start += MEL_HOP_SIZE) {
+      // Window into the FFT buffers.
+      for (let i = 0; i < N; i++) {
+        re[rev[i]] = signal[start + i] * window[i];
+      }
+      im.fill(0);
+      // In-place FFT — but bit-reversal wrote re[] permuted, so im must be
+      // permuted identically; it's all zeros, so fill(0) suffices.
+      for (let len = 2; len <= N; len <<= 1) {
+        const half = len >> 1;
+        const step = N / len;
+        for (let i = 0; i < N; i += len) {
+          for (let j = 0; j < half; j++) {
+            const k = j * step;
+            const xr = re[i + j + half];
+            const xi = im[i + j + half];
+            const tre = xr * cosT[k] - xi * sinT[k];
+            const tim = xr * sinT[k] + xi * cosT[k];
+            re[i + j + half] = re[i + j] - tre;
+            im[i + j + half] = im[i + j] - tim;
+            re[i + j] += tre;
+            im[i + j] += tim;
+          }
+        }
+      }
+      // Power spectrum → sparse filterbank → log compression.
+      for (let k = 0; k < SPEC_BINS; k++) { power[k] = re[k] * re[k] + im[k] * im[k]; }
+      const row = new Float32Array(MEL_BANDS);
+      for (let b = 0; b < MEL_BANDS; b++) {
+        const fb = filterbank[b];
+        let acc = 0;
+        for (let i = 0; i < fb.length; i += 2) { acc += power[fb[i]] * fb[i + 1]; }
+        row[b] = Math.log10(1 + 10000 * acc);
+      }
+      rows.push(row);
+    }
+    return rows;
+  }
+
+  return { melFrames };
+}

--- a/test/db/effnet-mel-parity.test.mjs
+++ b/test/db/effnet-mel-parity.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * GOLDEN-PARITY test for the pure-JS EffNet mel front-end
+ * (src/db/effnet-mel.js) against essentia.js's TensorflowInputMusiCNN —
+ * the exact pipeline Discogs-EffNet was trained on.
+ *
+ * This is the contract that makes the JS reimplementation safe: a mismatch
+ * here (a drifted constant, a changed essentia reference, a subtly wrong
+ * filterbank) would otherwise degrade embedding quality SILENTLY — wrong
+ * mels still produce plausible-looking vectors. The golden output is
+ * re-derived from essentia.js on every run, on ffmpeg-synthesized audio
+ * spanning tonal, noisy, and frequency-sweeping content.
+ *
+ * Measured parity at authoring time: max abs diff 1.7e-5 (float32 noise
+ * floor). The assertion allows 1e-3 — three orders of magnitude of margin,
+ * still far below anything that could affect the model (mel values span
+ * ~0–4 after log compression).
+ *
+ * Also covers the seek-decode addition to decodePcmF32 (opts.seekSec),
+ * which the discovery worker uses to decode only its analysis windows.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { createMelExtractor, MEL_FRAME_SIZE, MEL_HOP_SIZE, MEL_BANDS, MEL_SAMPLE_RATE } from '../../src/db/effnet-mel.js';
+import { decodePcmF32, getEssentia } from '../../src/db/audio-analysis-lib.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FFMPEG = process.platform === 'win32'
+  ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
+  : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+
+let scratch;
+let essentia;
+const { melFrames } = createMelExtractor();
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(FFMPEG, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    p.stderr.on('data', (d) => { stderr += d.toString(); });
+    p.on('error', reject);
+    p.on('close', (code) => code === 0 ? resolve() : reject(new Error(`ffmpeg ${code}: ${stderr.slice(-300)}`)));
+  });
+}
+
+async function makeAudio(name, filter, duration = 5) {
+  const out = path.join(scratch, name);
+  await runFfmpeg([
+    '-nostdin', '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', `${filter}:duration=${duration}`,
+    '-ac', '1', '-ar', String(MEL_SAMPLE_RATE), '-c:a', 'flac', out,
+  ]);
+  return out;
+}
+
+// Golden reference: essentia's TensorflowInputMusiCNN, frame-by-frame.
+function goldenMel(signal) {
+  const rows = [];
+  const buf = new Float32Array(MEL_FRAME_SIZE);
+  for (let s = 0; s + MEL_FRAME_SIZE <= signal.length; s += MEL_HOP_SIZE) {
+    buf.set(signal.subarray(s, s + MEL_FRAME_SIZE));
+    const vec = essentia.arrayToVector(buf);
+    const res = essentia.TensorflowInputMusiCNN(vec);
+    rows.push(essentia.vectorToArray(res.bands));
+    res.bands.delete();
+    vec.delete();
+  }
+  return rows;
+}
+
+function maxAbsDiff(a, b) {
+  assert.equal(a.length, b.length, 'frame counts must match');
+  let max = 0;
+  for (let i = 0; i < a.length; i++) {
+    assert.equal(a[i].length, MEL_BANDS);
+    for (let j = 0; j < MEL_BANDS; j++) {
+      max = Math.max(max, Math.abs(a[i][j] - b[i][j]));
+    }
+  }
+  return max;
+}
+
+before(async () => {
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-mel-parity-'));
+  assert.ok(fs.existsSync(FFMPEG), `ffmpeg required at ${FFMPEG}`);
+  essentia = await getEssentia();
+});
+
+after(() => {
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('effnet-mel golden parity vs essentia TensorflowInputMusiCNN', () => {
+  const FIXTURES = [
+    ['tone.flac', 'sine=frequency=440'],
+    ['chord.flac', 'aevalsrc=0.3*(sin(2*PI*261.63*t)+sin(2*PI*329.63*t)+sin(2*PI*392*t)):s=16000'],
+    ['noise.flac', 'anoisesrc=colour=pink:seed=42'],
+    ['sweep.flac', 'sine=frequency=100:beep_factor=0'],
+  ];
+
+  for (const [name, filter] of FIXTURES) {
+    test(`parity on ${name}`, async () => {
+      const file = await makeAudio(name, filter);
+      const signal = await decodePcmF32(file, FFMPEG, { sampleRate: MEL_SAMPLE_RATE });
+      const ours = melFrames(signal);
+      const gold = goldenMel(signal);
+      assert.ok(ours.length > 100, `expected real frame count, got ${ours.length}`);
+      const diff = maxAbsDiff(ours, gold);
+      assert.ok(diff < 1e-3, `max abs diff ${diff} exceeds parity tolerance`);
+    });
+  }
+
+  test('deterministic across calls', async () => {
+    const file = await makeAudio('det.flac', 'anoisesrc=colour=white:seed=7', 2);
+    const signal = await decodePcmF32(file, FFMPEG, { sampleRate: MEL_SAMPLE_RATE });
+    const a = melFrames(signal);
+    const b = melFrames(signal);
+    assert.equal(maxAbsDiff(a, b), 0);
+  });
+
+  test('sub-frame signal yields no rows (matches previous behavior)', () => {
+    assert.deepEqual(melFrames(new Float32Array(MEL_FRAME_SIZE - 1)), []);
+  });
+});
+
+describe('decodePcmF32 seekSec (analysis-window decode)', () => {
+  test('decodes a window of the requested length from mid-file', async () => {
+    const file = await makeAudio('seek.flac', 'sine=frequency=440', 8);
+    const win = await decodePcmF32(file, FFMPEG, {
+      sampleRate: MEL_SAMPLE_RATE, seekSec: 3, maxSeconds: 2,
+    });
+    // ~2s at 16kHz; ffmpeg may trim a frame either side of the seek point.
+    assert.ok(Math.abs(win.length - 2 * MEL_SAMPLE_RATE) < MEL_SAMPLE_RATE * 0.1,
+      `expected ~${2 * MEL_SAMPLE_RATE} samples, got ${win.length}`);
+    // Content sanity: a mid-tone window is not silence (ffmpeg's sine
+    // filter synthesizes at ~1/8 amplitude → RMS ≈ 0.09).
+    const rms = Math.sqrt(win.reduce((s, x) => s + x * x, 0) / win.length);
+    assert.ok(rms > 0.05, `expected tonal content, rms=${rms}`);
+  });
+
+  test('seek past EOF fails cleanly (no audio decoded)', async () => {
+    const file = await makeAudio('seek2.flac', 'sine=frequency=440', 3);
+    await assert.rejects(
+      decodePcmF32(file, FFMPEG, { sampleRate: MEL_SAMPLE_RATE, seekSec: 60, maxSeconds: 2 }),
+      /no audio|exited/);
+  });
+});


### PR DESCRIPTION
## What

The mel-loop optimization deferred from #691: the EffNet embedding pass is now **~7× faster in situ** (measured: 18 real tracks in 11 s = ~0.6 s/track through the actual worker, vs ~4.3 s/track on master with the same library) — and the EffNet path **no longer touches AGPL essentia**.

## The two changes

**1. Pure-JS mel front-end** ([src/db/effnet-mel.js](src/db/effnet-mel.js)). Profiling showed the cost was never the DSP — it was ~1,900 JS↔WASM boundary crossings per track (one per frame through essentia's `TensorflowInputMusiCNN`). The JS reimplementation (typed-array radix-2 FFT + precomputed sparse filterbank) is ~20× faster on the mel stage alone.

The dangerous part of reimplementing a model's training-time frontend is getting it *almost* right — wrong mels still produce plausible vectors, so quality degrades silently. Two defenses:
- The exact configuration (Slaney scale, `unit_tri` area-normalized triangles, power spectrum, unnormalized Hann, 0–8000 Hz, `log10(1+10000x)`) was found by **grid-searching the parameter space against the golden essentia output** — the winner matches at max abs diff **1.7e-5** (float32 noise floor); the runner-up config is 38,000× worse, so there's no ambiguity.
- A **golden-parity test** ([test/db/effnet-mel-parity.test.mjs](test/db/effnet-mel-parity.test.mjs)) re-derives the reference from essentia.js on every run (tonal/chord/noise/sweep fixtures, tolerance 1e-3). Any drift fails loudly.

(`FrameGenerator` batching — the originally-planned step 1 — was benchmarked and **rejected**: slower than the current loop, and its start-from-negative-half-frame convention silently shifts every frame.)

**2. Analysis-window seek-decode.** `decodePcmF32` gains `opts.seekSec` (ffmpeg input-seek); `analyzeFile` now decodes only the three 10 s analysis windows when the caller knows the track duration (the worker passes `tracks.duration`) instead of decoding whole files. A 4-minute track decodes 30 s of audio instead of 240 s. Whole-file decode remains the fallback (unknown duration, short tracks, whole-signal embedders).

## Continuity with existing datasets

New-path embeddings vs the ones master built for the same files: **cosine 0.996–1.000** (FLAC seek is sample-exact → 1.0000; MP3 seek granularity accounts for the rest), **top genre tag identical 6/6**. Existing rows are *not* re-embedded — same `model_id`/`model_version` pin, and sub-0.005 cosine differences are far below anything that affects similarity ranking.

## Verification

- **Full live smoke re-run on this branch** (same 18-track real-music rig used to smoke master after #689): boot → scan → two worker passes (perRun=10, hitCap re-enqueue) → **18/18 embedded, 0 errors, all 24 downstream checks pass** — 1280-d unit-norm vectors, genre tags, license/attribution in meta + export manifest + snapshot, sha256 round-trip, **18/18 same-artist nearest-neighbor**.
- 59 discovery + audio-analysis tests green — including the essentia BPM worker suite, which shares `decodePcmF32` and is unaffected by the `seekSec` addition.
- 8 new parity/seek tests; zero new lint.

## Numbers

| | master | this PR |
|---|---|---|
| mel stage (30 s audio) | ~2,000 ms | ~90 ms |
| decode per 4-min track | whole file (1.5–6 s) | 3×10 s windows (~0.3 s) |
| worker, per track in situ | ~4.3 s | **~0.6 s** |
| 10k-library first pass | ~12 h | **~1.7 h** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
