### PR TITLE
feat(discovery): auto-fetch + cross-library similarity search (N4a)

### DIFF
--- a/p2p-sidecar/src/main.rs
+++ b/p2p-sidecar/src/main.rs
@@ -122,12 +122,22 @@ struct AnnouncePayload {
     name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct Announcement {
     v: u32,
     from: String,
     payload: AnnouncePayload,
     sig: String,
+    // Heartbeat counter, bumped on every re-broadcast and deliberately NOT
+    // part of the signature. Gossip (Plumtree) deduplicates by message
+    // content, so byte-identical re-broadcasts are silently dropped — late
+    // joiners would never hear us and receivers' last-heard timestamps (the
+    // "online" indicator) would never refresh. The counter makes each
+    // heartbeat unique bytes. Replaying with a fresh counter buys an
+    // attacker nothing: the payload is still signed, snapshotSeq still
+    // can't roll back, and the per-origin rate limit caps processing.
+    #[serde(default)]
+    n: u64,
 }
 
 struct Node {
@@ -140,12 +150,15 @@ struct Node {
     secret_key: SecretKey,
     // Some(sender) once `join` has run; join_peers() feeds later bootstrap adds.
     topic_sender: Mutex<Option<GossipSender>>,
-    // The signed wire bytes the announcer loop re-broadcasts.
-    current_announcement: Mutex<Option<Vec<u8>>>,
+    // The signed announcement the announcer loop re-broadcasts (with a fresh
+    // heartbeat counter per send — see Announcement::n).
+    current_announcement: Mutex<Option<Announcement>>,
+    heartbeat: std::sync::atomic::AtomicU64,
     // Live direct neighbors on the catalog topic (from NeighborUp/Down).
     neighbor_count: AtomicI64,
-    // origin endpoint id -> last accepted announcement instant (flood guard).
-    last_accepted: Mutex<HashMap<String, Instant>>,
+    // origin endpoint id -> (last accepted instant, its snapshotSeq). Flood
+    // guard state: same-seq heartbeats coalesce, higher seqs pass (news).
+    last_accepted: Mutex<HashMap<String, (Instant, u64)>>,
     out_tx: mpsc::UnboundedSender<Value>,
 }
 
@@ -228,6 +241,7 @@ async fn run(data_dir: PathBuf) -> Result<()> {
         secret_key: key,
         topic_sender: Mutex::new(None),
         current_announcement: Mutex::new(None),
+        heartbeat: std::sync::atomic::AtomicU64::new(0),
         neighbor_count: AtomicI64::new(0),
         last_accepted: Mutex::new(HashMap::new()),
         out_tx: out_tx.clone(),
@@ -394,16 +408,15 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
             let payload = validate_payload(payload)?;
             let canonical = canonical_bytes(&node.endpoint.id().to_string(), &payload);
             let sig = node.secret_key.sign(&canonical);
-            let wire = serde_json::to_vec(&Announcement {
+            let ann = Announcement {
                 v: 1,
                 from: node.endpoint.id().to_string(),
                 payload,
                 sig: hex_encode(&sig.to_bytes()),
-            })?;
-            if wire.len() > MAX_ANNOUNCEMENT_BYTES {
-                bail!("announcement too large ({} bytes)", wire.len());
-            }
-            *node.current_announcement.lock().await = Some(wire.clone());
+                n: 0,
+            };
+            let wire = announcement_wire(&node, &ann)?;
+            *node.current_announcement.lock().await = Some(ann);
             // Broadcast immediately if we're on the topic; the announce loop
             // handles the periodic re-sends either way.
             let broadcast_now = node.topic_sender.lock().await.clone();
@@ -422,15 +435,32 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
     }
 }
 
+// Serialize an announcement with a fresh heartbeat counter so every send is
+// unique bytes (gossip dedups identical content — see Announcement::n).
+fn announcement_wire(node: &Node, ann: &Announcement) -> Result<Vec<u8>> {
+    let mut out = ann.clone();
+    out.n = node.heartbeat.fetch_add(1, Ordering::Relaxed);
+    let wire = serde_json::to_vec(&out)?;
+    if wire.len() > MAX_ANNOUNCEMENT_BYTES {
+        bail!("announcement too large ({} bytes)", wire.len());
+    }
+    Ok(wire)
+}
+
 // Periodically re-broadcast the current announcement. Errors are logged, not
 // fatal — a transient mesh hiccup shouldn't kill the announcer.
 async fn announce_loop(node: Arc<Node>, sender: GossipSender) {
     loop {
         tokio::time::sleep(ANNOUNCE_INTERVAL).await;
-        let wire = node.current_announcement.lock().await.clone();
-        if let Some(wire) = wire {
-            if let Err(e) = sender.broadcast(wire.into()).await {
-                eprintln!("[p2p-sidecar] periodic announce failed: {e}");
+        let ann = node.current_announcement.lock().await.clone();
+        if let Some(ann) = ann {
+            match announcement_wire(&node, &ann) {
+                Ok(wire) => {
+                    if let Err(e) = sender.broadcast(wire.into()).await {
+                        eprintln!("[p2p-sidecar] periodic announce failed: {e}");
+                    }
+                }
+                Err(e) => eprintln!("[p2p-sidecar] periodic announce serialization failed: {e}"),
             }
         }
     }
@@ -482,14 +512,19 @@ async fn process_announcement(node: &Node, content: &[u8]) -> Result<()> {
         .verify(&canonical_bytes(&ann.from, &payload), &Signature::from_bytes(&sig_bytes))
         .map_err(|_| anyhow!("signature verification failed"))?;
 
-    // Flood guard: at most one accepted announcement per origin per gap.
+    // Flood guard: same-or-older-seq announcements from one origin coalesce
+    // to at most one per gap (they're heartbeats), but a HIGHER snapshotSeq
+    // is genuine news and passes immediately — a seq bump right after a
+    // heartbeat must not wait out the gap. Only the key holder can sign a
+    // higher seq, so this can't be exploited by third parties.
     {
         let mut last = node.last_accepted.lock().await;
         let now = Instant::now();
-        if let Some(prev) = last.get(&ann.from) {
-            if now.duration_since(*prev) < MIN_ANNOUNCE_GAP { return Ok(()); } // silently coalesce
+        if let Some((prev, prev_seq)) = last.get(&ann.from) {
+            let is_news = payload.snapshot_seq > *prev_seq;
+            if !is_news && now.duration_since(*prev) < MIN_ANNOUNCE_GAP { return Ok(()); } // coalesce
         }
-        last.insert(ann.from.clone(), now);
+        last.insert(ann.from.clone(), (now, payload.snapshot_seq));
     }
 
     let _ = node.out_tx.send(json!({

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -16,6 +16,7 @@ import * as discoveryExport from '../db/discovery-export.js';
 import { EMBEDDING_MODELS } from '../db/discovery-features-lib.js';
 import * as discoveryP2p from '../state/discovery-p2p.js';
 import * as discoveryCatalog from '../state/discovery-catalog.js';
+import * as discoveryPeerDbs from '../state/discovery-peer-dbs.js';
 import * as logger from '../logger.js';
 import { joiValidate } from '../util/validation.js';
 import { isAdminAllowed } from '../util/admin-network.js';
@@ -448,10 +449,64 @@ export function setup(mstream) {
   });
 
   // The catalog: every peer we've heard a signed announcement from (newest
-  // per peer), populated by gossip while the sidecar is joined.
+  // per peer), enriched with what the shelf knows (fetched? current?) and
+  // sorted most-useful-first: online-now (heard within ~90s — announcers
+  // re-broadcast every ~15s), then by library size. True popularity
+  // (seeder counts) arrives with the N3 provider tracking.
   mstream.get("/api/v1/admin/discovery/p2p/catalog", (req, res) => {
     requireP2pEnabled();
-    res.json({ peers: discoveryCatalog.list() });
+    const now = Date.now();
+    const localModel = discoveryDb.openDiscoveryDbIfExists()
+      ? discoveryDb.getMeta('embedding_model_id') : null;
+    const peers = discoveryCatalog.list().map((entry) => {
+      const held = discoveryPeerDbs.get(entry.from);
+      return {
+        ...entry,
+        online: now - Date.parse(entry.updatedAt) < 90 * 1000,
+        fetched: held ? {
+          snapshotSeq: held.snapshotSeq,
+          stale: (entry.payload.snapshotSeq || 0) > (held.snapshotSeq || 0),
+          sizeBytes: held.sizeBytes,
+          fetchedAt: held.fetchedAt,
+        } : null,
+        // null = unknown (no local model established yet), not "incompatible"
+        compatible: localModel ? entry.payload.modelId === localModel : null,
+      };
+    }).sort((a, b) => (b.online - a.online)
+      || ((b.payload.rowCount || 0) - (a.payload.rowCount || 0)));
+    res.json({
+      peers,
+      localModelId: localModel,
+      autoFetch: config.program.discoveryP2p.autoFetch,
+      storage: {
+        usedBytes: discoveryPeerDbs.totalBytes(),
+        capBytes: config.program.discoveryP2p.maxPeerDbStorageMb * 1024 * 1024,
+      },
+    });
+  });
+
+  // Manual shelf management: fetch a specific catalog peer's snapshot now
+  // (still subject to the blocklist + storage cap), or drop one.
+  mstream.post("/api/v1/admin/discovery/p2p/peer-dbs/fetch", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({ endpointId: Joi.string().hex().length(64).required() });
+    joiValidate(schema, req.body);
+    try {
+      res.json(await discoveryPeerDbs.fetchPeer(req.body.endpointId));
+    } catch (err) {
+      winston.warn(`discovery peer-db fetch failed for admin '${req.user?.username}' (peer ${req.body.endpointId.slice(0, 12)}…): ${err.message}`);
+      throw new WebError(`fetch failed: ${err.message}`, 500);
+    }
+  });
+
+  mstream.post("/api/v1/admin/discovery/p2p/peer-dbs/remove", (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({ endpointId: Joi.string().hex().length(64).required() });
+    joiValidate(schema, req.body);
+    if (!discoveryPeerDbs.removePeerDb(req.body.endpointId)) {
+      throw new WebError('no fetched snapshot for that peer', 404);
+    }
+    res.json({});
   });
 
   // Publish the current export snapshot and broadcast its signed

--- a/src/api/discovery-p2p.js
+++ b/src/api/discovery-p2p.js
@@ -1,0 +1,179 @@
+// The P2P side of the discovery API: find music you DON'T have, on servers
+// in the discovery network, that sounds like music you DO have.
+//
+// Namespace contract (deliberate split, mirrored by the admin surface):
+//   /api/v1/discovery/local/*   similarity within YOUR library
+//                               (src/api/discovery.js — in-memory index)
+//   /api/v1/discovery/p2p/*     similarity across FETCHED PEER snapshots
+//                               (this file — the auto-fetch shelf)
+//
+// Everything here queries LOCAL copies of peer snapshots (fetched by
+// discovery-peer-dbs.js) — no query ever leaves this machine, so what a
+// user searches for is private; peers only ever observe snapshot fetches.
+// Responses are metadata-only (artist/title/similarity/which-peer): the
+// network shares knowledge about music, never the music itself.
+//
+// Similarity = cosine over the per-track embeddings. The vectors are
+// L2-normalized at write time (declared in the snapshot meta), so cosine is
+// a plain dot product. Vectors only compare within ONE model space — the
+// search filters peer rows to the query track's model_id, so a network mid
+// model-migration degrades to fewer results, never to garbage rankings.
+//
+// The novelty filter (the point of the feature) is a chain, because no
+// single identity signal covers every library:
+//   1. recording MBID match        exact, when both sides are tagged
+//   2. normalized artist+title     the pragmatic fallback
+//   3. near-duplicate embedding    cosine ≥ NEAR_DUP vs the QUERY track
+//                                  catches untagged re-encodes of it
+// plus opt-in `newArtistsOnly`, which drops every artist the local library
+// already knows — the "introduce me to someone new" mode.
+
+import Joi from 'joi';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as db from '../db/manager.js';
+import * as discoveryDb from '../db/discovery-db.js';
+import * as peerDbs from '../state/discovery-peer-dbs.js';
+import { resolveSeedTrack } from './discovery.js';
+import { joiValidate } from '../util/validation.js';
+import WebError from '../util/web-error.js';
+
+const NEAR_DUP = 0.99;
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+function requireP2p() {
+  if (!config.program.discoveryP2p.enabled) {
+    throw new WebError('discovery P2P is disabled (config: discoveryP2p.enabled)', 403);
+  }
+}
+
+// "The Beatles" / "beatles" / "The  Beatles!" all collide — good enough for
+// an exclusion filter (false positives here just hide a result, never rank
+// a wrong one).
+function norm(s) {
+  return String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// The local library's identity sets for the novelty filter. Built per
+// request — two indexed scans over a 10k-track library are a few ms, and a
+// live cache would need scanner invalidation hooks for marginal gain.
+function localIdentitySets() {
+  const sets = { mbids: new Set(), artistTitles: new Set(), artists: new Set() };
+  const rows = db.getDB().prepare(`
+    SELECT a.name AS artist, t.title AS title
+    FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id
+  `).all();
+  for (const r of rows) {
+    const artist = norm(r.artist);
+    if (artist) { sets.artists.add(artist); }
+    sets.artistTitles.add(`${artist} ${norm(r.title)}`);
+  }
+  // MBIDs live in discovery.db (populated by tagging/analysis passes).
+  if (discoveryDb.openDiscoveryDbIfExists()) {
+    const mbids = discoveryDb.getDiscoveryDb().prepare(
+      'SELECT recording_mbid FROM discovery_tracks WHERE recording_mbid IS NOT NULL'
+    ).all();
+    for (const r of mbids) { sets.mbids.add(r.recording_mbid); }
+  }
+  return sets;
+}
+
+export function setup(mstream) {
+  // Similar-but-not-owned tracks across the fetched peer shelf.
+  //   filePath        the local seed track ("<vpath>/<relpath>")
+  //   limit           max results (default 25, cap 100)
+  //   newArtistsOnly  also drop artists the local library already has
+  mstream.post('/api/v1/discovery/p2p/similar', (req, res) => {
+    requireP2p();
+    const schema = Joi.object({
+      filePath: Joi.string().required(),
+      limit: Joi.number().integer().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+      newArtistsOnly: Joi.boolean().default(false),
+    });
+    const { value: { filePath, limit, newArtistsOnly } } = joiValidate(schema, req.body);
+
+    // Same resolution + uniform-404 + probe logging as the local routes.
+    const seedRow = resolveSeedTrack(req, filePath, 'discovery/p2p/similar');
+    const canonHash = seedRow.audio_hash || seedRow.file_hash;
+
+    if (!discoveryDb.openDiscoveryDbIfExists()) {
+      throw new WebError('discovery data collection has never been enabled — no embeddings to search with', 404);
+    }
+    const seed = discoveryDb.getDiscoveryDb().prepare(`
+      SELECT embedding, model_id, artist, title FROM discovery_tracks WHERE audio_hash = ?
+    `).get(canonHash);
+    if (!seed || !seed.embedding) {
+      throw new WebError('track has no embedding yet — the analysis pass has not processed it', 404);
+    }
+
+    const dim = seed.embedding.byteLength / 4;
+    const q = new Float32Array(seed.embedding.buffer.slice(
+      seed.embedding.byteOffset, seed.embedding.byteOffset + dim * 4));
+
+    const exclude = localIdentitySets();
+    const results = [];
+    let searchedPeers = 0;
+    let searchedTracks = 0;
+
+    for (const peer of peerDbs.list()) {
+      let space;
+      try {
+        space = peerDbs.readEmbeddings(peer.endpointId, seed.model_id);
+      } catch (err) {
+        winston.warn(`discovery p2p similar: peer DB ${peer.endpointId.slice(0, 12)}… unreadable: ${err.message}`);
+        continue;
+      }
+      if (!space || space.dim !== dim) { continue; } // no rows in this model space
+      searchedPeers += 1;
+      searchedTracks += space.count;
+
+      for (let i = 0; i < space.count; i++) {
+        // L2-normalized vectors: cosine == dot product.
+        let dot = 0;
+        const off = i * dim;
+        for (let k = 0; k < dim; k++) { dot += q[k] * space.matrix[off + k]; }
+
+        if (dot >= NEAR_DUP) { continue; } // same recording, different encode
+        const artist = norm(space.artists[i]);
+        if (space.mbids[i] && exclude.mbids.has(space.mbids[i])) { continue; }
+        if (exclude.artistTitles.has(`${artist} ${norm(space.titles[i])}`)) { continue; }
+        if (newArtistsOnly && artist && exclude.artists.has(artist)) { continue; }
+
+        results.push({
+          artist: space.artists[i],
+          title: space.titles[i],
+          duration: space.durations[i],
+          similarity: dot,
+          recordingMbid: space.mbids[i],
+          exportId: space.ids[i],
+          peer: { endpointId: space.endpointId, name: space.peerName },
+        });
+      }
+    }
+
+    results.sort((a, b) => b.similarity - a.similarity);
+    res.json({
+      query: { filePath, modelId: seed.model_id, newArtistsOnly },
+      searched: { peers: searchedPeers, tracks: searchedTracks },
+      results: results.slice(0, limit),
+    });
+  });
+
+  // The fetched shelf — what the p2p similar route is currently searching
+  // over. Read-only and metadata-only, so it sits with the user-facing
+  // routes (the player UI needs it to explain result provenance).
+  mstream.get('/api/v1/discovery/p2p/peer-dbs', (req, res) => {
+    requireP2p();
+    res.json({
+      peerDbs: peerDbs.list().map((e) => ({
+        endpointId: e.endpointId,
+        name: e.name,
+        rowCount: e.rowCount,
+        modelId: e.modelId,
+        sizeBytes: e.sizeBytes,
+        fetchedAt: e.fetchedAt,
+      })),
+    });
+  });
+}

--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -3,8 +3,8 @@
 // webapp player (results carry the standard {filepath, metadata} envelope so
 // they queue without translation):
 //
-//   POST /api/v1/discovery/local/similar          tracks similar to a seed track
-//   POST /api/v1/discovery/local/similar-artists  artists similar to a seed artist
+//   POST /api/v1/discovery/local/similar/tracks   tracks similar to a seed track
+//   POST /api/v1/discovery/local/similar/artists  artists similar to a seed artist
 //
 // Semantics:
 //   - 403 while scanOptions.collectDiscoveryData is off (house convention
@@ -89,7 +89,7 @@ function modelBlock(index) {
 
 export function setup(mstream) {
 
-  mstream.post('/api/v1/discovery/local/similar', (req, res) => {
+  mstream.post('/api/v1/discovery/local/similar/tracks', (req, res) => {
     const schema = Joi.object({
       filePath: Joi.string().required(),
       limit: Joi.number().integer().min(1).max(100).default(10),
@@ -101,7 +101,7 @@ export function setup(mstream) {
 
     const index = requireIndex();
 
-    const seedRow = resolveSeedTrack(req, body.filePath, 'discovery/similar');
+    const seedRow = resolveSeedTrack(req, body.filePath, 'discovery/local/similar/tracks');
     const uid = req.user?.id;
 
     const seedRendered = renderMetadataObj(seedRow);
@@ -142,7 +142,7 @@ export function setup(mstream) {
     res.json({ seed, model: modelBlock(index), notAnalyzed: false, results });
   });
 
-  mstream.post('/api/v1/discovery/local/similar-artists', (req, res) => {
+  mstream.post('/api/v1/discovery/local/similar/artists', (req, res) => {
     const schema = Joi.object({
       artist: Joi.string().required(),
       limit: Joi.number().integer().min(1).max(100).default(10),

--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -3,8 +3,8 @@
 // webapp player (results carry the standard {filepath, metadata} envelope so
 // they queue without translation):
 //
-//   POST /api/v1/discovery/similar          tracks similar to a seed track
-//   POST /api/v1/discovery/similar-artists  artists similar to a seed artist
+//   POST /api/v1/discovery/local/similar          tracks similar to a seed track
+//   POST /api/v1/discovery/local/similar-artists  artists similar to a seed artist
 //
 // Semantics:
 //   - 403 while scanOptions.collectDiscoveryData is off (house convention
@@ -89,7 +89,7 @@ function modelBlock(index) {
 
 export function setup(mstream) {
 
-  mstream.post('/api/v1/discovery/similar', (req, res) => {
+  mstream.post('/api/v1/discovery/local/similar', (req, res) => {
     const schema = Joi.object({
       filePath: Joi.string().required(),
       limit: Joi.number().integer().min(1).max(100).default(10),
@@ -142,7 +142,7 @@ export function setup(mstream) {
     res.json({ seed, model: modelBlock(index), notAnalyzed: false, results });
   });
 
-  mstream.post('/api/v1/discovery/similar-artists', (req, res) => {
+  mstream.post('/api/v1/discovery/local/similar-artists', (req, res) => {
     const schema = Joi.object({
       artist: Joi.string().required(),
       limit: Joi.number().integer().min(1).max(100).default(10),

--- a/src/db/discovery-similarity.js
+++ b/src/db/discovery-similarity.js
@@ -1,5 +1,5 @@
 // In-memory similarity index over discovery.db's embeddings — the read side
-// of the discovery dataset. Powers /api/v1/discovery/local/similar and
+// of the discovery dataset. Powers /api/v1/discovery/local/similar/tracks and
 // /similar-artists (src/api/discovery.js).
 //
 // Design: brute-force cosine over an in-memory Float32Array matrix. At

--- a/src/db/discovery-similarity.js
+++ b/src/db/discovery-similarity.js
@@ -1,5 +1,5 @@
 // In-memory similarity index over discovery.db's embeddings — the read side
-// of the discovery dataset. Powers /api/v1/discovery/similar and
+// of the discovery dataset. Powers /api/v1/discovery/local/similar and
 // /similar-artists (src/api/discovery.js).
 //
 // Design: brute-force cosine over an in-memory Float32Array matrix. At

--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,7 @@ import * as fileExplorerApi from './api/file-explorer.js';
 import * as downloadApi from './api/download.js';
 import * as adminApi from './api/admin.js';
 import * as irohApi from './api/iroh.js';
+import * as discoveryP2pApi from './api/discovery-p2p.js';
 import * as remoteApi from './api/remote.js';
 import * as sharedApi from './api/shared.js';
 import * as scrobblerApi from './api/scrobbler.js';
@@ -305,8 +306,9 @@ export async function serveIt(configFile) {
 
   adminApi.setup(mstream);
   irohApi.setup(mstream);
-  dbApi.setup(mstream);
   discoveryApi.setup(mstream);
+  discoveryP2pApi.setup(mstream);
+  dbApi.setup(mstream);
   searchApi.setup(mstream);
   randomApi.setup(mstream);
   playlistApi.setup(mstream);
@@ -501,6 +503,12 @@ export async function serveIt(configFile) {
           } catch (_err) {
             winston.info('[discovery-p2p] catalog joined; nothing to announce yet (no export snapshot)');
           }
+          // Auto-fetch: keep a local shelf of the best catalog peers'
+          // snapshots so the /api/v1/discovery/similar surface has data to
+          // search the moment users ask. Event-driven + periodic; all
+          // failures are per-peer logged, never fatal.
+          const peerDbs = await import('./state/discovery-peer-dbs.js');
+          peerDbs.startAutoFetch();
         } catch (err) {
           winston.error(`[discovery-p2p] catalog unavailable — feature disabled this boot: ${err.message}`);
         }

--- a/src/server.js
+++ b/src/server.js
@@ -504,7 +504,7 @@ export async function serveIt(configFile) {
             winston.info('[discovery-p2p] catalog joined; nothing to announce yet (no export snapshot)');
           }
           // Auto-fetch: keep a local shelf of the best catalog peers'
-          // snapshots so the /api/v1/discovery/similar surface has data to
+          // snapshots so the /api/v1/discovery/p2p/similar surface has data to
           // search the moment users ask. Event-driven + periodic; all
           // failures are per-peer logged, never fatal.
           const peerDbs = await import('./state/discovery-peer-dbs.js');

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -297,6 +297,17 @@ const discoveryP2pOptions = Joi.object({
   // Display name carried in our signed catalog announcements. Pipe is
   // reserved as the announcement signing-string separator.
   serverName: Joi.string().max(64).pattern(/^[^|]*$/).default('mStream'),
+  // Auto-fetch: keep a local shelf of the most useful catalog peers'
+  // snapshots (online-first, then biggest — true popularity ranking needs
+  // the N3 seeder tracking) and refresh a copy when its announced
+  // monotonic snapshotSeq moves ahead. On by default WITHIN the opt-in
+  // feature: downloading metadata-only snapshots is the product working.
+  autoFetch: Joi.boolean().default(true),
+  autoFetchCount: Joi.number().integer().min(0).max(50).default(3),
+  maxPeerDbStorageMb: Joi.number().integer().min(10).max(100000).default(500),
+  // Endpoint ids whose announcements are ignored and whose snapshots are
+  // never fetched — the v1 spam/abuse lever.
+  blockedPeers: Joi.array().items(Joi.string().hex().length(64)).default([]),
 });
 
 const dlnaOptions = Joi.object({

--- a/src/state/discovery-catalog.js
+++ b/src/state/discovery-catalog.js
@@ -71,6 +71,10 @@ function scheduleSave() {
 // (new peer, or newer snapshotSeq / different hash for a known one).
 export function record(from, payload) {
   ensureLoaded();
+  // The v1 abuse lever: blocked peers don't exist as far as the catalog is
+  // concerned (their snapshots are also never fetched — see
+  // discovery-peer-dbs.js).
+  if (config.program.discoveryP2p.blockedPeers.includes(from)) { return false; }
   const existing = catalog.get(from);
   if (existing) {
     const oldSeq = existing.payload.snapshotSeq || 0;

--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -1,0 +1,352 @@
+// Fetched peer snapshots: the local shelf of other servers' discovery DBs.
+//
+// The catalog (discovery-catalog.js) knows who EXISTS; this module knows
+// what we've actually DOWNLOADED — one snapshot file per peer under
+// {dbDirectory}/discovery-peers/, tracked in peer-dbs.json, opened read-only
+// for the similarity API (src/api/discovery.js).
+//
+// Auto-fetch turns the catalog into a working library shelf without admin
+// babysitting: on boot (and as announcements arrive) reconcile() downloads
+// the top-N most useful peers — online-now first, then biggest — and
+// re-fetches a peer whose announced snapshotSeq moved past our copy. The
+// monotonic seq (not wall clocks) is what makes "is our copy stale?" a safe
+// comparison. Guardrails: peer-count target, total-storage cap, and the
+// blockedPeers config list.
+//
+// Every snapshot is validated before it's accepted onto the shelf — a peer
+// hands us an arbitrary SQLite file, so we check the snapshot format marker
+// and schema shape before ever querying it, and open it with a fresh
+// read-only connection afterwards.
+
+import fs from 'fs';
+import path from 'path';
+import winston from 'winston';
+import { DatabaseSync } from '../db/sqlite-driver.js';
+import * as config from './config.js';
+import * as discoveryP2p from './discovery-p2p.js';
+import * as discoveryCatalog from './discovery-catalog.js';
+
+const REGISTRY_FILE = 'peer-dbs.json';
+const SNAPSHOT_FORMAT_VERSION = 1; // must match discovery-export.js
+// Debounce after a burst of announcements. The env override exists for the
+// integration tests (waiting 30 real seconds per assertion is unkind);
+// production installs should never set it.
+const RECONCILE_DEBOUNCE_MS =
+  Number(process.env.MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS) || 30 * 1000;
+const RECONCILE_INTERVAL_MS = 10 * 60 * 1000;
+// A peer is "online" when we heard a re-announcement recently. Announcers
+// re-broadcast every ~15s; 90s tolerates a few missed rounds.
+const ONLINE_WINDOW_MS = 90 * 1000;
+// Cache of parsed embedding matrices (they're a few MB each) — keep the
+// working set small so a Pi isn't holding every peer's vectors forever.
+const MATRIX_CACHE_MAX = 4;
+
+// endpointId -> { endpointId, hash, path, snapshotSeq, modelId, modelVersion,
+//                 rowCount, sizeBytes, name, fetchedAt }
+const registry = new Map();
+let loaded = false;
+
+// endpointId -> open read-only DatabaseSync (invalidated on hash change/remove)
+const connections = new Map();
+// endpointId -> { hash, modelId, ids, artists, titles, durations, mbids, matrix }
+const matrixCache = new Map();
+
+let reconcileTimer = null;
+let debounceTimer = null;
+let reconcileInFlight = false;
+let wired = false;
+
+export function peerDbDir() {
+  return path.join(config.program.storage.dbDirectory, 'discovery-peers');
+}
+
+function registryPath() {
+  return path.join(config.program.storage.dbDirectory, 'discovery-p2p', REGISTRY_FILE);
+}
+
+function ensureLoaded() {
+  if (loaded) { return; }
+  loaded = true;
+  try {
+    for (const e of JSON.parse(fs.readFileSync(registryPath(), 'utf8'))) {
+      // Drop registry entries whose file has vanished (manual cleanup etc.).
+      if (e && e.endpointId && e.path && fs.existsSync(e.path)) { registry.set(e.endpointId, e); }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      winston.warn(`discovery peer-db registry unreadable (${err.message}) — starting empty`);
+    }
+  }
+}
+
+function save() {
+  try {
+    fs.mkdirSync(path.dirname(registryPath()), { recursive: true });
+    fs.writeFileSync(registryPath(), JSON.stringify([...registry.values()], null, 2));
+  } catch (err) {
+    winston.warn(`discovery peer-db registry save failed: ${err.message}`);
+  }
+}
+
+export function list() {
+  ensureLoaded();
+  return [...registry.values()];
+}
+
+export function get(endpointId) {
+  ensureLoaded();
+  return registry.get(endpointId) || null;
+}
+
+export function totalBytes() {
+  ensureLoaded();
+  return [...registry.values()].reduce((sum, e) => sum + (e.sizeBytes || 0), 0);
+}
+
+function storageCapBytes() {
+  return config.program.discoveryP2p.maxPeerDbStorageMb * 1024 * 1024;
+}
+
+function isBlocked(endpointId) {
+  return config.program.discoveryP2p.blockedPeers.includes(endpointId);
+}
+
+// Validate + read identity facts from a freshly fetched snapshot. The file
+// comes from an untrusted peer: confirm it IS a discovery snapshot before
+// anything else queries it. Returns { modelId, modelVersion, rowCount }.
+function inspectSnapshot(filePath) {
+  const db = new DatabaseSync(filePath, { readOnly: true });
+  try {
+    const version = db.prepare('PRAGMA user_version').get();
+    const userVersion = Number(Object.values(version)[0]);
+    if (userVersion !== SNAPSHOT_FORMAT_VERSION) {
+      throw new Error(`not a discovery snapshot (user_version=${userVersion})`);
+    }
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('meta','tracks')"
+    ).all();
+    if (tables.length !== 2) { throw new Error('snapshot is missing the meta/tracks tables'); }
+    const meta = {};
+    for (const row of db.prepare('SELECT key, value FROM meta').all()) { meta[row.key] = row.value; }
+    const rowCount = db.prepare('SELECT COUNT(*) AS n FROM tracks').get().n;
+    return {
+      modelId: meta.embedding_model_id || null,
+      modelVersion: meta.embedding_model_version || null,
+      rowCount,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function dropConnection(endpointId) {
+  const conn = connections.get(endpointId);
+  if (conn) {
+    try { conn.close(); } catch (_err) { /* already closed */ }
+    connections.delete(endpointId);
+  }
+  matrixCache.delete(endpointId);
+}
+
+// Download one peer's current snapshot (per its catalog announcement) and
+// put it on the shelf. Manual (admin route) and automatic (reconcile) fetches
+// both come through here — blocklist and storage cap always apply.
+export async function fetchPeer(endpointId) {
+  ensureLoaded();
+  const entry = discoveryCatalog.get(endpointId);
+  if (!entry) { throw new Error('peer is not in the catalog (no announcement heard)'); }
+  if (isBlocked(endpointId)) { throw new Error('peer is blocked (config: discoveryP2p.blockedPeers)'); }
+
+  const existing = registry.get(endpointId);
+  const announcedSize = entry.payload.size || 0;
+  const projected = totalBytes() - (existing ? existing.sizeBytes : 0) + announcedSize;
+  if (projected > storageCapBytes()) {
+    throw new Error(`fetch would exceed the peer-DB storage cap `
+      + `(${Math.round(projected / 1048576)}MB > ${config.program.discoveryP2p.maxPeerDbStorageMb}MB)`);
+  }
+
+  const fetched = await discoveryP2p.fetch(
+    { hash: entry.payload.hash, provider: endpointId },
+    peerDbDir(),
+  );
+
+  let inspected;
+  try {
+    inspected = inspectSnapshot(fetched.path);
+  } catch (err) {
+    // Failed validation = not a snapshot we can use; don't leave it around.
+    try { fs.rmSync(fetched.path, { force: true }); } catch (_rmErr) { /* best effort */ }
+    throw new Error(`peer sent an invalid snapshot: ${err.message}`, { cause: err });
+  }
+
+  // Replace-on-update: a peer has ONE live snapshot; drop the old file.
+  if (existing && existing.path !== fetched.path) {
+    dropConnection(endpointId);
+    try { fs.rmSync(existing.path, { force: true }); } catch (_err) { /* best effort */ }
+  }
+
+  const record = {
+    endpointId,
+    hash: fetched.hash,
+    path: fetched.path,
+    snapshotSeq: entry.payload.snapshotSeq || 0,
+    modelId: inspected.modelId,
+    modelVersion: inspected.modelVersion,
+    rowCount: inspected.rowCount,
+    sizeBytes: fetched.size,
+    name: entry.payload.name || '',
+    fetchedAt: new Date().toISOString(),
+  };
+  registry.set(endpointId, record);
+  save();
+  winston.info(`[discovery-peer-dbs] fetched ${endpointId.slice(0, 12)}… `
+    + `(${record.rowCount} tracks, ${Math.round(record.sizeBytes / 1048576)}MB)`);
+  return record;
+}
+
+export function removePeerDb(endpointId) {
+  ensureLoaded();
+  const entry = registry.get(endpointId);
+  if (!entry) { return false; }
+  dropConnection(endpointId);
+  try { fs.rmSync(entry.path, { force: true }); } catch (_err) { /* best effort */ }
+  registry.delete(endpointId);
+  save();
+  return true;
+}
+
+function openPeerDb(entry) {
+  let conn = connections.get(entry.endpointId);
+  if (conn) { return conn; }
+  conn = new DatabaseSync(entry.path, { readOnly: true });
+  connections.set(entry.endpointId, conn);
+  return conn;
+}
+
+// Read a peer's embedding matrix for one model space. Returns null when the
+// peer has no rows in that space. Cached per (peer, snapshot hash) — the
+// snapshot file is immutable by construction (content-addressed), so hash
+// equality means the cache is valid.
+export function readEmbeddings(endpointId, modelId) {
+  ensureLoaded();
+  const entry = registry.get(endpointId);
+  if (!entry) { return null; }
+
+  const cached = matrixCache.get(endpointId);
+  if (cached && cached.hash === entry.hash && cached.modelId === modelId) { return cached; }
+
+  const rows = openPeerDb(entry).prepare(`
+    SELECT export_id, recording_mbid, artist, title, duration, embedding
+    FROM tracks
+    WHERE embedding IS NOT NULL AND model_id = ?
+  `).all(modelId);
+  if (rows.length === 0) { return null; }
+
+  const dim = rows[0].embedding.byteLength / 4;
+  const matrix = new Float32Array(rows.length * dim);
+  const ids = new Array(rows.length);
+  const mbids = new Array(rows.length);
+  const artists = new Array(rows.length);
+  const titles = new Array(rows.length);
+  const durations = new Array(rows.length);
+  let n = 0;
+  for (const row of rows) {
+    if (row.embedding.byteLength !== dim * 4) { continue; } // mixed-dim row: skip, don't crash
+    // BLOB arrives as a Buffer whose byteOffset may not be 4-aligned — copy
+    // through a fresh view instead of aliasing the pool.
+    matrix.set(new Float32Array(row.embedding.buffer.slice(
+      row.embedding.byteOffset, row.embedding.byteOffset + dim * 4)), n * dim);
+    ids[n] = row.export_id;
+    mbids[n] = row.recording_mbid;
+    artists[n] = row.artist;
+    titles[n] = row.title;
+    durations[n] = row.duration;
+    n += 1;
+  }
+
+  const result = {
+    hash: entry.hash, modelId, dim, count: n,
+    matrix: n === rows.length ? matrix : matrix.subarray(0, n * dim),
+    ids, mbids, artists, titles, durations,
+    peerName: entry.name, endpointId,
+  };
+  matrixCache.set(endpointId, result);
+  // Tiny LRU: evict the oldest insertions beyond the cap.
+  while (matrixCache.size > MATRIX_CACHE_MAX) {
+    matrixCache.delete(matrixCache.keys().next().value);
+  }
+  return result;
+}
+
+// ── Auto-fetch ───────────────────────────────────────────────────────────────
+
+// Sort candidates by usefulness: peers we can hear right now first, then by
+// library size. (True popularity — seeder counts — needs the N3 provider
+// tracking; this proxy is honest about what we can actually observe today.)
+function candidateOrder(a, b) {
+  const now = Date.now();
+  const aOnline = now - Date.parse(a.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+  const bOnline = now - Date.parse(b.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+  if (aOnline !== bOnline) { return bOnline - aOnline; }
+  return (b.payload.rowCount || 0) - (a.payload.rowCount || 0);
+}
+
+// One reconcile pass: refresh stale shelf entries, then top up to
+// autoFetchCount from the best-looking catalog peers. Serialized; failures
+// log and move on (an unreachable peer must not wedge the loop).
+export async function reconcile() {
+  if (!config.program.discoveryP2p.autoFetch || reconcileInFlight) { return; }
+  reconcileInFlight = true;
+  try {
+    ensureLoaded();
+    const targets = [];
+
+    // Stale refresh: the announced monotonic seq moved past our copy.
+    for (const held of registry.values()) {
+      const cat = discoveryCatalog.get(held.endpointId);
+      if (cat && (cat.payload.snapshotSeq || 0) > (held.snapshotSeq || 0)) {
+        targets.push(held.endpointId);
+      }
+    }
+
+    // Top-up: best candidates we don't hold yet.
+    const room = config.program.discoveryP2p.autoFetchCount - registry.size;
+    if (room > 0) {
+      const candidates = discoveryCatalog.list()
+        .filter((c) => !registry.has(c.from) && !isBlocked(c.from))
+        .sort(candidateOrder)
+        .slice(0, room);
+      targets.push(...candidates.map((c) => c.from));
+    }
+
+    for (const endpointId of targets) {
+      try {
+        await fetchPeer(endpointId);
+      } catch (err) {
+        winston.warn(`[discovery-peer-dbs] auto-fetch of ${endpointId.slice(0, 12)}… failed: ${err.message}`);
+      }
+    }
+  } finally {
+    reconcileInFlight = false;
+  }
+}
+
+// Wire auto-fetch into the world: run soon after boot (give the catalog a
+// moment to fill from gossip), re-run debounced as announcements arrive, and
+// sweep periodically as a catch-all. Idempotent across server reboot()s.
+export function startAutoFetch() {
+  if (wired) { return; }
+  wired = true;
+  discoveryP2p.events.on('announcement', () => {
+    if (debounceTimer) { return; }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      reconcile().catch((err) => winston.warn(`[discovery-peer-dbs] reconcile failed: ${err.message}`));
+    }, RECONCILE_DEBOUNCE_MS);
+    if (debounceTimer.unref) { debounceTimer.unref(); }
+  });
+  reconcileTimer = setInterval(() => {
+    reconcile().catch((err) => winston.warn(`[discovery-peer-dbs] reconcile failed: ${err.message}`));
+  }, RECONCILE_INTERVAL_MS);
+  if (reconcileTimer.unref) { reconcileTimer.unref(); }
+}

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -38,10 +38,55 @@ import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline';
 import { spawn } from 'node:child_process';
+import { DatabaseSync } from 'node:sqlite';
 import { startServer } from '../helpers/server.mjs';
 import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
 
 const SIDECAR_BIN = resolveSidecarBinary();
+
+// Serialize a unit vector as the little-endian float32 BLOB the schema stores.
+function embeddingBlob(vec) {
+  const f = new Float32Array(vec);
+  return Buffer.from(f.buffer, f.byteOffset, f.byteLength);
+}
+
+// Build a synthetic peer snapshot file with the exact P0 export format
+// (user_version marker, meta + tracks tables) — what fetchPeer() validates
+// and the similarity search reads. Lets the whole N4a query path be tested
+// without any network or sidecar.
+function makeSnapshotFile(filePath, { modelId = 'test-model', tracks = [] } = {}) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.rmSync(filePath, { force: true });
+  const db = new DatabaseSync(filePath);
+  db.exec(`
+    PRAGMA user_version = 1;
+    CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE tracks (
+      export_id TEXT NOT NULL, recording_mbid TEXT, acoustid_id TEXT,
+      artist TEXT, title TEXT, duration REAL,
+      model_id TEXT, model_version TEXT, embedding BLOB,
+      bpm INTEGER, musical_key TEXT, danceability REAL,
+      genre_tags TEXT, mood_tags TEXT
+    );
+  `);
+  const meta = db.prepare('INSERT INTO meta (key, value) VALUES (?, ?)');
+  meta.run('format', 'mstream-discovery-snapshot');
+  meta.run('format_version', '1');
+  meta.run('embedding_model_id', modelId);
+  meta.run('embedding_model_version', '1');
+  meta.run('row_count', String(tracks.length));
+  const ins = db.prepare(`
+    INSERT INTO tracks (export_id, recording_mbid, artist, title, duration, model_id, model_version, embedding)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const t of tracks) {
+    ins.run(t.exportId || `anon:${t.title}`, t.mbid || null, t.artist, t.title,
+      t.duration || 180, t.modelId || modelId, '1',
+      t.vec ? embeddingBlob(t.vec) : null);
+  }
+  db.close();
+  return filePath;
+}
 
 async function pollUntil(fn, { timeoutMs = 15000, everyMs = 250, what = 'condition' } = {}) {
   const deadline = Date.now() + timeoutMs;
@@ -125,12 +170,24 @@ describe('discovery p2p — route gating (no sidecar needed)', () => {
     assert.equal(typeof body.binaryFound, 'boolean');
   });
 
+  test('user-facing discovery routes are 403 while the feature is disabled', async () => {
+    const similar = await fetch(`${server.baseUrl}/api/v1/discovery/p2p/similar`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filePath: 'testlib/x.mp3' }),
+    });
+    assert.equal(similar.status, 403);
+    const shelf = await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`);
+    assert.equal(shelf.status, 403);
+  });
+
   test('all mutating + catalog routes are 403 while the feature is disabled', async () => {
     for (const [method, route, body] of [
       ['POST', 'publish', undefined],
       ['POST', 'announce', undefined],
       ['POST', 'join', { peer: 'endpointAAAAAAAAAAAAAAAA' }],
       ['POST', 'fetch', { ticket: 'blobAAAAAAAAAAAAAAAAAAAA' }],
+      ['POST', 'peer-dbs/fetch', { endpointId: 'a'.repeat(64) }],
+      ['POST', 'peer-dbs/remove', { endpointId: 'a'.repeat(64) }],
       ['GET', 'catalog', undefined],
     ]) {
       const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/${route}`, {
@@ -311,5 +368,233 @@ describe('discovery p2p — enabled, validation contract', () => {
     // And the catalog survives on disk for the next boot.
     const persisted = path.join(server.tmpDir, 'db', 'discovery-p2p', 'catalog.json');
     await pollUntil(() => fs.existsSync(persisted), { what: 'catalog.json to persist' });
+  });
+});
+
+// ── N4a: the similarity search over fetched peer snapshots ─────────────────
+// Entirely synthetic — no sidecar, no network. Peer snapshot files are built
+// with the exact P0 export format and placed on the shelf (registry +
+// discovery-peers/) by hand; the local seed embedding is inserted straight
+// into the server's discovery.db, following the discovery-export test's
+// precedent for direct seeding.
+describe('discovery p2p — similarity search + novelty filter', () => {
+  let server;
+  let trackA;      // local seed: has an embedding, artist known locally
+  let trackB;      // local track whose artist+title a peer duplicates
+  let trackC;      // local track with NO discovery row (404 case)
+  const MODEL = 'test-model';
+  const PEER_X = 'a'.repeat(64);
+  const PEER_Y = 'b'.repeat(64);
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: true,
+      extraConfig: {
+        discoveryP2p: { enabled: true, autoFetch: false },
+        scanOptions: { collectDiscoveryData: true },
+      },
+    });
+
+    // Three real scanned tracks with distinct non-null artists.
+    const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+    const rows = mdb.prepare(`
+      SELECT t.filepath, t.audio_hash, a.name AS artist, t.title AS title
+      FROM tracks t JOIN artists a ON a.id = t.artist_id
+      WHERE t.audio_hash IS NOT NULL AND t.title IS NOT NULL
+      ORDER BY t.filepath LIMIT 3
+    `).all();
+    mdb.close();
+    assert.ok(rows.length === 3, 'fixture library must yield 3 tagged tracks');
+    [trackA, trackB, trackC] = rows;
+
+    // Local embedding for track A (unit vector [1,0,0,0]) + an owned MBID.
+    const ddb = new DatabaseSync(path.join(server.tmpDir, 'db', 'discovery.db'));
+    ddb.prepare(`
+      INSERT INTO discovery_tracks
+        (audio_hash, source_mtime, updated_at, export_id, recording_mbid,
+         artist, title, model_id, model_version, embedding)
+      VALUES (?, 1, 1, ?, ?, ?, ?, ?, '1', ?)
+    `).run(trackA.audio_hash, 'anon:seed', 'mbid-owned', trackA.artist,
+      trackA.title, MODEL, embeddingBlob([1, 0, 0, 0]));
+    ddb.close();
+
+    // Peer X: the novelty-filter menagerie in the matching model space.
+    const peerDir = path.join(server.tmpDir, 'db', 'discovery-peers');
+    makeSnapshotFile(path.join(peerDir, 'x'.repeat(64) + '.db'), {
+      modelId: MODEL,
+      tracks: [
+        // near-duplicate of the query itself -> excluded (same recording)
+        { artist: 'Dup Artist', title: 'Same Recording', vec: [1, 0, 0, 0] },
+        // MBID the local library owns -> excluded
+        { artist: 'Mbid Artist', title: 'Owned Song', mbid: 'mbid-owned', vec: [0.7, 0.7141, 0, 0] },
+        // artist+title collides with local track B -> excluded
+        { artist: trackB.artist, title: trackB.title, vec: [0.8, 0.6, 0, 0] },
+        // known artist, new song -> kept (dropped by newArtistsOnly)
+        { artist: trackA.artist, title: 'Brand New Song', vec: [0.6, 0.8, 0, 0] },
+        // brand-new artist -> kept, ranks first
+        { artist: 'Totally New Artist', title: 'Fresh Cut', vec: [0.9, 0.43589, 0, 0] },
+        // another new artist, orthogonal -> kept, ranks last
+        { artist: 'Another New Artist', title: 'Distant Sound', vec: [0, 1, 0, 0] },
+        // no embedding -> never part of the search space
+        { artist: 'Null Artist', title: 'No Vector', vec: null },
+        // wrong model space -> never part of the search space
+        { artist: 'Wrong Model', title: 'Alien Vector', vec: [1, 0, 0, 0], modelId: 'other-model' },
+      ],
+    });
+    // Peer Y: nothing in the query's model space at all.
+    makeSnapshotFile(path.join(peerDir, 'y'.repeat(64) + '.db'), {
+      modelId: 'other-model',
+      tracks: [{ artist: 'Other Space', title: 'Unreachable', vec: [1, 0, 0, 0], modelId: 'other-model' }],
+    });
+
+    // Hand-write the shelf registry the peer-db module lazy-loads.
+    const p2pDir = path.join(server.tmpDir, 'db', 'discovery-p2p');
+    fs.mkdirSync(p2pDir, { recursive: true });
+    fs.writeFileSync(path.join(p2pDir, 'peer-dbs.json'), JSON.stringify([
+      { endpointId: PEER_X, hash: 'x'.repeat(64), path: path.join(peerDir, 'x'.repeat(64) + '.db'),
+        snapshotSeq: 1, modelId: MODEL, rowCount: 8, sizeBytes: 8192, name: 'Peer X', fetchedAt: new Date().toISOString() },
+      { endpointId: PEER_Y, hash: 'y'.repeat(64), path: path.join(peerDir, 'y'.repeat(64) + '.db'),
+        snapshotSeq: 1, modelId: 'other-model', rowCount: 1, sizeBytes: 4096, name: 'Peer Y', fetchedAt: new Date().toISOString() },
+    ]));
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  const similar = (body) => fetch(`${server.baseUrl}/api/v1/discovery/p2p/similar`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  test('filter chain: same-recording/mbid/artist+title excluded, rest ranked by cosine', async () => {
+    const r = await similar({ filePath: `testlib/${trackA.filepath}` });
+    assert.equal(r.status, 200);
+    const body = await r.json();
+
+    assert.equal(body.query.modelId, MODEL);
+    // Peer Y has zero rows in the model space -> only Peer X is searched.
+    assert.equal(body.searched.peers, 1);
+    assert.equal(body.searched.tracks, 6, 'null-embedding and wrong-model rows are outside the space');
+
+    const titles = body.results.map((x) => x.title);
+    assert.deepEqual(titles, ['Fresh Cut', 'Brand New Song', 'Distant Sound'],
+      'exclusions applied and ranking is cosine-descending');
+    assert.ok(Math.abs(body.results[0].similarity - 0.9) < 0.001);
+    assert.equal(body.results[0].peer.endpointId, PEER_X);
+    assert.equal(body.results[0].peer.name, 'Peer X');
+  });
+
+  test('newArtistsOnly also drops artists the local library knows', async () => {
+    const r = await similar({ filePath: `testlib/${trackA.filepath}`, newArtistsOnly: true });
+    const body = await r.json();
+    assert.deepEqual(body.results.map((x) => x.title), ['Fresh Cut', 'Distant Sound']);
+  });
+
+  test('limit caps the result list', async () => {
+    const r = await similar({ filePath: `testlib/${trackA.filepath}`, limit: 1 });
+    const body = await r.json();
+    assert.equal(body.results.length, 1);
+    assert.equal(body.results[0].title, 'Fresh Cut');
+  });
+
+  test('a track without an embedding is a clear 404, not an empty result', async () => {
+    const r = await similar({ filePath: `testlib/${trackC.filepath}` });
+    assert.equal(r.status, 404);
+  });
+
+  test('unknown filepath is 404; junk body is 400', async () => {
+    assert.equal((await similar({ filePath: 'testlib/does-not-exist.mp3' })).status, 404);
+    assert.equal((await similar({})).status, 400);
+    assert.equal((await similar({ filePath: `testlib/${trackA.filepath}`, limit: 0 })).status, 400);
+  });
+
+  test('the shelf route lists both fetched snapshots', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`);
+    assert.equal(r.status, 200);
+    const body = await r.json();
+    assert.equal(body.peerDbs.length, 2);
+    const x = body.peerDbs.find((p) => p.endpointId === PEER_X);
+    assert.equal(x.name, 'Peer X');
+  });
+
+  test('admin catalog reports shelf state + storage', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`);
+    assert.equal(r.status, 200);
+    const body = await r.json();
+    assert.ok(body.storage.usedBytes > 0);
+    assert.equal(body.autoFetch, false);
+  });
+});
+
+// ── N4a: auto-fetch — announcements turn into downloaded snapshots ─────────
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — auto-fetch loop', () => {
+  let server;
+  let peer;
+  let peerDir;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      env: { MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS: '750' },
+      extraConfig: {
+        discoveryP2p: { enabled: true, serverName: 'AutoFetch Server' },
+        scanOptions: { collectDiscoveryData: true },
+      },
+    });
+    peerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-af-'));
+    peer = new RawSidecar(SIDECAR_BIN, path.join(peerDir, 'sidecar'));
+    await peer.ready;
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    if (peerDir) { fs.rmSync(peerDir, { recursive: true, force: true }); }
+  });
+
+  test('an announced snapshot is fetched automatically and refreshed on seq bump', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    // Publish + announce a REAL snapshot-format file (auto-fetch validates it).
+    const v1 = makeSnapshotFile(path.join(peerDir, 'snap-v1.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Net Artist', title: 'Net Song', vec: [1, 0, 0, 0] }],
+    });
+    const pub1 = await peer.rpc('publish', { path: v1 });
+    await peer.rpc('announce', {
+      payload: { hash: pub1.hash, size: pub1.size, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 5, name: 'AutoPeer' },
+    });
+
+    // Debounced reconcile (750ms in this test) should pull it down unprompted.
+    const shelf1 = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+      return s.peerDbs.find((p) => p.endpointId === peer.endpointId) || null;
+    }, { timeoutMs: 30000, what: 'auto-fetch to download the announced snapshot' });
+    assert.equal(shelf1.rowCount, 1);
+    assert.equal(shelf1.modelId, 'test-model');
+
+    // Bump: new snapshot content + higher monotonic seq -> auto-refresh.
+    const v2 = makeSnapshotFile(path.join(peerDir, 'snap-v2.db'), {
+      modelId: 'test-model',
+      tracks: [
+        { artist: 'Net Artist', title: 'Net Song', vec: [1, 0, 0, 0] },
+        { artist: 'Second Artist', title: 'Second Song', vec: [0, 1, 0, 0] },
+      ],
+    });
+    const pub2 = await peer.rpc('publish', { path: v2 });
+    await peer.rpc('announce', {
+      payload: { hash: pub2.hash, size: pub2.size, rowCount: 2,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 6, name: 'AutoPeer' },
+    });
+
+    await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+      const entry = s.peerDbs.find((p) => p.endpointId === peer.endpointId);
+      return entry && entry.rowCount === 2 ? entry : null;
+    }, { timeoutMs: 30000, what: 'auto-fetch to refresh the stale snapshot' });
   });
 });

--- a/test/integration/discovery-similarity.test.mjs
+++ b/test/integration/discovery-similarity.test.mjs
@@ -1,6 +1,6 @@
 /**
- * Similarity API tests — POST /api/v1/discovery/local/similar and
- * /api/v1/discovery/local/similar-artists (src/api/discovery.js +
+ * Similarity API tests — POST /api/v1/discovery/local/similar/tracks and
+ * /api/v1/discovery/local/similar/artists (src/api/discovery.js +
  * src/db/discovery-similarity.js).
  *
  * Strategy: boot a real server (discovery ON, model 'test-fake') over the
@@ -169,8 +169,8 @@ after(async () => {
 describe('similarity API gating', () => {
   test('403 on both endpoints while discovery is disabled', async () => {
     for (const [route, body] of [
-      ['/api/v1/discovery/local/similar', { filePath: 'testlib/x.mp3' }],
-      ['/api/v1/discovery/local/similar-artists', { artist: 'Icarus' }],
+      ['/api/v1/discovery/local/similar/tracks', { filePath: 'testlib/x.mp3' }],
+      ['/api/v1/discovery/local/similar/artists', { artist: 'Icarus' }],
     ]) {
       const r = await fetch(`${offServer.baseUrl}${route}`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
@@ -180,18 +180,18 @@ describe('similarity API gating', () => {
   });
 
   test('validation: missing seed → 400', async () => {
-    assert.equal((await api('/api/v1/discovery/local/similar', {})).status, 400);
-    assert.equal((await api('/api/v1/discovery/local/similar-artists', {})).status, 400);
+    assert.equal((await api('/api/v1/discovery/local/similar/tracks', {})).status, 400);
+    assert.equal((await api('/api/v1/discovery/local/similar/artists', {})).status, 400);
   });
 });
 
 // ── /discovery/similar ───────────────────────────────────────────────────────
 
-describe('POST /api/v1/discovery/local/similar', () => {
+describe('POST /api/v1/discovery/local/similar/tracks', () => {
   const seedPath = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
 
   test('ranks by the handcrafted cosines, excludes the seed itself', async () => {
-    const { status, body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath });
+    const { status, body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, false);
     assert.equal(body.model.id, 'test-fake');
@@ -209,7 +209,7 @@ describe('POST /api/v1/discovery/local/similar', () => {
   });
 
   test('result shape: lite metadata (with bpm key), model tags top-level', async () => {
-    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, limit: 1 });
+    const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath, limit: 1 });
     const r = body.results[0];
     assert.equal(r.metadata.title, 'Rise');
     assert.ok('bpm' in r.metadata, 'lite metadata carries live bpm');
@@ -221,18 +221,18 @@ describe('POST /api/v1/discovery/local/similar', () => {
   });
 
   test('limit caps results', async () => {
-    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, limit: 2 });
+    const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath, limit: 2 });
     assert.equal(body.results.length, 2);
   });
 
   test('library access: bob never sees lib2 results', async () => {
-    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath }, 'bob');
+    const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath }, 'bob');
     const titles = body.results.map((r) => r.metadata.title);
     assert.deepEqual(titles, ['Rise', 'Highway', 'Neon'], 'Lib2 Song skipped for bob');
   });
 
   test('excludeSameArtist drops the Icarus results', async () => {
-    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, excludeSameArtist: true });
+    const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath, excludeSameArtist: true });
     const artists = body.results.map((r) => r.metadata.artist);
     assert.ok(!artists.includes('Icarus'), `got ${artists}`);
     assert.ok(artists.includes('Vosto'));
@@ -246,7 +246,7 @@ describe('POST /api/v1/discovery/local/similar', () => {
       mdb.prepare("UPDATE tracks SET bpm = 60 WHERE title = 'Highway'").run();
     } finally { mdb.close(); }
 
-    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, bpmRange: [100, 140] });
+    const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath, bpmRange: [100, 140] });
     const titles = body.results.map((r) => r.metadata.title);
     assert.ok(titles.includes('Rise'), 'in-range bpm kept');
     assert.ok(!titles.includes('Highway'), 'out-of-range bpm dropped');
@@ -256,7 +256,7 @@ describe('POST /api/v1/discovery/local/similar', () => {
   });
 
   test('scanned but not embedded → notAnalyzed, empty results', async () => {
-    const { status, body } = await api('/api/v1/discovery/local/similar',
+    const { status, body } = await api('/api/v1/discovery/local/similar/tracks',
       { filePath: 'testlib/Icarus/Be Somebody/03 - Orbit.mp3' });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, true);
@@ -265,17 +265,17 @@ describe('POST /api/v1/discovery/local/similar', () => {
   });
 
   test('unknown path → 404; other users\' vpaths → 404', async () => {
-    assert.equal((await api('/api/v1/discovery/local/similar', { filePath: 'testlib/nope/missing.mp3' })).status, 404);
-    assert.equal((await api('/api/v1/discovery/local/similar', { filePath: 'lib2/zed.mp3' }, 'bob')).status, 404,
+    assert.equal((await api('/api/v1/discovery/local/similar/tracks', { filePath: 'testlib/nope/missing.mp3' })).status, 404);
+    assert.equal((await api('/api/v1/discovery/local/similar/tracks', { filePath: 'lib2/zed.mp3' }, 'bob')).status, 404,
       'bob probing lib2 gets 404, not 403 (no vpath-name oracle)');
   });
 });
 
 // ── /discovery/similar-artists ───────────────────────────────────────────────
 
-describe('POST /api/v1/discovery/local/similar-artists', () => {
+describe('POST /api/v1/discovery/local/similar/artists', () => {
   test('ranks artists by centroid similarity with tags and entry points', async () => {
-    const { status, body } = await api('/api/v1/discovery/local/similar-artists', { artist: 'Icarus' });
+    const { status, body } = await api('/api/v1/discovery/local/similar/artists', { artist: 'Icarus' });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, false);
     assert.equal(body.seed.artist, 'Icarus');
@@ -298,13 +298,13 @@ describe('POST /api/v1/discovery/local/similar-artists', () => {
   });
 
   test('library access: bob does not see Zed (lib2-only artist)', async () => {
-    const { body } = await api('/api/v1/discovery/local/similar-artists', { artist: 'Icarus' }, 'bob');
+    const { body } = await api('/api/v1/discovery/local/similar/artists', { artist: 'Icarus' }, 'bob');
     assert.deepEqual(body.results.map((r) => r.artist), ['Vosto']);
   });
 
   test('artist with tracks but no embeddings → notAnalyzed', async () => {
     // 'Wex' exists in lib2 but was never given a discovery row.
-    const { status, body } = await api('/api/v1/discovery/local/similar-artists', { artist: 'Wex' });
+    const { status, body } = await api('/api/v1/discovery/local/similar/artists', { artist: 'Wex' });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, true);
     assert.equal(body.seed.analyzedCount, 0);
@@ -313,7 +313,7 @@ describe('POST /api/v1/discovery/local/similar-artists', () => {
   });
 
   test('unknown artist → 404', async () => {
-    assert.equal((await api('/api/v1/discovery/local/similar-artists', { artist: 'No Such Band' })).status, 404);
+    assert.equal((await api('/api/v1/discovery/local/similar/artists', { artist: 'No Such Band' })).status, 404);
   });
 });
 
@@ -342,7 +342,7 @@ describe('similarity index invalidation', () => {
       ddb.prepare("UPDATE discovery_meta SET value = '99' WHERE key = 'row_seq'").run();
     } finally { ddb.close(); }
 
-    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, limit: 1 });
+    const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath, limit: 1 });
     assert.equal(body.results[0].metadata.title, 'Orbit',
       'freshly embedded track (cos 0.99) tops the ranking — index rebuilt');
   });

--- a/test/integration/discovery-similarity.test.mjs
+++ b/test/integration/discovery-similarity.test.mjs
@@ -1,6 +1,6 @@
 /**
- * Similarity API tests — POST /api/v1/discovery/similar and
- * /api/v1/discovery/similar-artists (src/api/discovery.js +
+ * Similarity API tests — POST /api/v1/discovery/local/similar and
+ * /api/v1/discovery/local/similar-artists (src/api/discovery.js +
  * src/db/discovery-similarity.js).
  *
  * Strategy: boot a real server (discovery ON, model 'test-fake') over the
@@ -169,8 +169,8 @@ after(async () => {
 describe('similarity API gating', () => {
   test('403 on both endpoints while discovery is disabled', async () => {
     for (const [route, body] of [
-      ['/api/v1/discovery/similar', { filePath: 'testlib/x.mp3' }],
-      ['/api/v1/discovery/similar-artists', { artist: 'Icarus' }],
+      ['/api/v1/discovery/local/similar', { filePath: 'testlib/x.mp3' }],
+      ['/api/v1/discovery/local/similar-artists', { artist: 'Icarus' }],
     ]) {
       const r = await fetch(`${offServer.baseUrl}${route}`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
@@ -180,18 +180,18 @@ describe('similarity API gating', () => {
   });
 
   test('validation: missing seed → 400', async () => {
-    assert.equal((await api('/api/v1/discovery/similar', {})).status, 400);
-    assert.equal((await api('/api/v1/discovery/similar-artists', {})).status, 400);
+    assert.equal((await api('/api/v1/discovery/local/similar', {})).status, 400);
+    assert.equal((await api('/api/v1/discovery/local/similar-artists', {})).status, 400);
   });
 });
 
 // ── /discovery/similar ───────────────────────────────────────────────────────
 
-describe('POST /api/v1/discovery/similar', () => {
+describe('POST /api/v1/discovery/local/similar', () => {
   const seedPath = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
 
   test('ranks by the handcrafted cosines, excludes the seed itself', async () => {
-    const { status, body } = await api('/api/v1/discovery/similar', { filePath: seedPath });
+    const { status, body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, false);
     assert.equal(body.model.id, 'test-fake');
@@ -209,7 +209,7 @@ describe('POST /api/v1/discovery/similar', () => {
   });
 
   test('result shape: lite metadata (with bpm key), model tags top-level', async () => {
-    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, limit: 1 });
+    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, limit: 1 });
     const r = body.results[0];
     assert.equal(r.metadata.title, 'Rise');
     assert.ok('bpm' in r.metadata, 'lite metadata carries live bpm');
@@ -221,18 +221,18 @@ describe('POST /api/v1/discovery/similar', () => {
   });
 
   test('limit caps results', async () => {
-    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, limit: 2 });
+    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, limit: 2 });
     assert.equal(body.results.length, 2);
   });
 
   test('library access: bob never sees lib2 results', async () => {
-    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath }, 'bob');
+    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath }, 'bob');
     const titles = body.results.map((r) => r.metadata.title);
     assert.deepEqual(titles, ['Rise', 'Highway', 'Neon'], 'Lib2 Song skipped for bob');
   });
 
   test('excludeSameArtist drops the Icarus results', async () => {
-    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, excludeSameArtist: true });
+    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, excludeSameArtist: true });
     const artists = body.results.map((r) => r.metadata.artist);
     assert.ok(!artists.includes('Icarus'), `got ${artists}`);
     assert.ok(artists.includes('Vosto'));
@@ -246,7 +246,7 @@ describe('POST /api/v1/discovery/similar', () => {
       mdb.prepare("UPDATE tracks SET bpm = 60 WHERE title = 'Highway'").run();
     } finally { mdb.close(); }
 
-    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, bpmRange: [100, 140] });
+    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, bpmRange: [100, 140] });
     const titles = body.results.map((r) => r.metadata.title);
     assert.ok(titles.includes('Rise'), 'in-range bpm kept');
     assert.ok(!titles.includes('Highway'), 'out-of-range bpm dropped');
@@ -256,7 +256,7 @@ describe('POST /api/v1/discovery/similar', () => {
   });
 
   test('scanned but not embedded → notAnalyzed, empty results', async () => {
-    const { status, body } = await api('/api/v1/discovery/similar',
+    const { status, body } = await api('/api/v1/discovery/local/similar',
       { filePath: 'testlib/Icarus/Be Somebody/03 - Orbit.mp3' });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, true);
@@ -265,17 +265,17 @@ describe('POST /api/v1/discovery/similar', () => {
   });
 
   test('unknown path → 404; other users\' vpaths → 404', async () => {
-    assert.equal((await api('/api/v1/discovery/similar', { filePath: 'testlib/nope/missing.mp3' })).status, 404);
-    assert.equal((await api('/api/v1/discovery/similar', { filePath: 'lib2/zed.mp3' }, 'bob')).status, 404,
+    assert.equal((await api('/api/v1/discovery/local/similar', { filePath: 'testlib/nope/missing.mp3' })).status, 404);
+    assert.equal((await api('/api/v1/discovery/local/similar', { filePath: 'lib2/zed.mp3' }, 'bob')).status, 404,
       'bob probing lib2 gets 404, not 403 (no vpath-name oracle)');
   });
 });
 
 // ── /discovery/similar-artists ───────────────────────────────────────────────
 
-describe('POST /api/v1/discovery/similar-artists', () => {
+describe('POST /api/v1/discovery/local/similar-artists', () => {
   test('ranks artists by centroid similarity with tags and entry points', async () => {
-    const { status, body } = await api('/api/v1/discovery/similar-artists', { artist: 'Icarus' });
+    const { status, body } = await api('/api/v1/discovery/local/similar-artists', { artist: 'Icarus' });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, false);
     assert.equal(body.seed.artist, 'Icarus');
@@ -298,13 +298,13 @@ describe('POST /api/v1/discovery/similar-artists', () => {
   });
 
   test('library access: bob does not see Zed (lib2-only artist)', async () => {
-    const { body } = await api('/api/v1/discovery/similar-artists', { artist: 'Icarus' }, 'bob');
+    const { body } = await api('/api/v1/discovery/local/similar-artists', { artist: 'Icarus' }, 'bob');
     assert.deepEqual(body.results.map((r) => r.artist), ['Vosto']);
   });
 
   test('artist with tracks but no embeddings → notAnalyzed', async () => {
     // 'Wex' exists in lib2 but was never given a discovery row.
-    const { status, body } = await api('/api/v1/discovery/similar-artists', { artist: 'Wex' });
+    const { status, body } = await api('/api/v1/discovery/local/similar-artists', { artist: 'Wex' });
     assert.equal(status, 200);
     assert.equal(body.notAnalyzed, true);
     assert.equal(body.seed.analyzedCount, 0);
@@ -313,7 +313,7 @@ describe('POST /api/v1/discovery/similar-artists', () => {
   });
 
   test('unknown artist → 404', async () => {
-    assert.equal((await api('/api/v1/discovery/similar-artists', { artist: 'No Such Band' })).status, 404);
+    assert.equal((await api('/api/v1/discovery/local/similar-artists', { artist: 'No Such Band' })).status, 404);
   });
 });
 
@@ -342,7 +342,7 @@ describe('similarity index invalidation', () => {
       ddb.prepare("UPDATE discovery_meta SET value = '99' WHERE key = 'row_seq'").run();
     } finally { ddb.close(); }
 
-    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, limit: 1 });
+    const { body } = await api('/api/v1/discovery/local/similar', { filePath: seedPath, limit: 1 });
     assert.equal(body.results[0].metadata.title, 'Orbit',
       'freshly embedded track (cos 0.99) tops the ranking — index rebuilt');
   });

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1881,7 +1881,8 @@ const dbView = Vue.component('db-view', {
       sharedPlaylists: ADMINDATA.sharedPlaylists,
       sharedPlaylistsTS: ADMINDATA.sharedPlaylistUpdated,
       isPullingStats: false,
-      isPullingShared: false
+      isPullingShared: false,
+      discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false }
     };
   },
   template: `
@@ -1959,6 +1960,52 @@ const dbView = Vue.component('db-view', {
                     </tr>
                   </tbody>
                 </table>
+              </div>
+            </div>
+          </div>
+          <div class="col s12">
+            <div class="card">
+              <div class="card-content">
+                <span class="card-title">Discovery Network (P2P)</span>
+                <div v-if="!discoveryP2p.loaded"><p>Loading…</p></div>
+                <div v-else-if="!discoveryP2p.status || discoveryP2p.status.enabled !== true">
+                  <p>Disabled. Set <code>discoveryP2p.enabled: true</code> in the config file and restart
+                  to join the discovery network — your server will share its (metadata-only) discovery
+                  snapshot and automatically download snapshots from other servers.</p>
+                </div>
+                <div v-else>
+                  <p v-if="!discoveryP2p.status.binaryFound" style="color: #b71c1c;">
+                    The p2p-sidecar binary was not found for this platform — the network is unavailable.
+                  </p>
+                  <p><b>Endpoint:</b> <code style="word-break: break-all;">{{ discoveryP2p.status.endpointId || '(sidecar not running yet)' }}</code></p>
+                  <p v-if="discoveryP2p.status.ticket"><b>Your ticket</b> — a friend pastes this into their
+                  <code>discoveryP2p.bootstrapPeers</code> to befriend this server:<br>
+                    <textarea readonly rows="2" style="width:100%; font-size: 0.8em;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>
+                  </p>
+                  <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
+                    {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
+                    — auto-fetch {{ discoveryP2p.autoFetch ? 'on' : 'off' }}
+                  </p>
+                  <table v-if="discoveryP2p.peers.length > 0">
+                    <thead><tr><th>Server</th><th>Tracks</th><th>Online</th><th>Model</th><th>Downloaded</th><th></th></tr></thead>
+                    <tbody>
+                      <tr v-for="peer in discoveryP2p.peers" :key="peer.from">
+                        <td>{{ peer.payload.name || (peer.from.slice(0, 12) + '…') }}</td>
+                        <td>{{ peer.payload.rowCount }}</td>
+                        <td>{{ peer.online ? 'online' : 'offline' }}</td>
+                        <td>{{ peer.compatible === null ? 'unknown' : (peer.compatible ? 'compatible' : 'incompatible') }}</td>
+                        <td>{{ peer.fetched ? (peer.fetched.stale ? 'update available' : 'yes') : 'no' }}</td>
+                        <td>
+                          [<a v-on:click="discoveryFetchPeer(peer.from)">{{ peer.fetched ? 'Update' : 'Download' }}</a>]
+                          <span v-if="peer.fetched">[<a v-on:click="discoveryRemovePeer(peer.from)">Remove</a>]</span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <p v-else>No peers heard yet — add a friend's ticket to <code>discoveryP2p.bootstrapPeers</code>
+                  (or POST it to the join endpoint) and give gossip a minute.</p>
+                  <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]</p>
+                </div>
               </div>
             </div>
           </div>
@@ -2077,7 +2124,65 @@ const dbView = Vue.component('db-view', {
         </div>
       </div>
     </div>`,
+  created: async function () {
+    this.loadDiscoveryP2p();
+  },
   methods: {
+    loadDiscoveryP2p: async function() {
+      try {
+        const status = (await API.axios({
+          method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/status`
+        })).data;
+        this.discoveryP2p.status = status;
+        if (status.enabled === true) {
+          const cat = (await API.axios({
+            method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
+          })).data;
+          this.discoveryP2p.peers = cat.peers;
+          this.discoveryP2p.storage = cat.storage;
+          this.discoveryP2p.autoFetch = cat.autoFetch;
+        }
+      } catch (err) {
+        iziToast.error({ title: 'Failed to load discovery network status', position: 'topCenter', timeout: 3000 });
+      }
+      this.discoveryP2p.loaded = true;
+    },
+    discoveryFetchPeer: async function(endpointId) {
+      try {
+        iziToast.info({ title: 'Downloading peer snapshot…', position: 'topCenter', timeout: 2500 });
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-dbs/fetch`,
+          data: { endpointId }
+        });
+        iziToast.success({ title: 'Peer snapshot downloaded', position: 'topCenter', timeout: 3000 });
+      } catch (err) {
+        iziToast.error({
+          title: 'Download failed',
+          message: err.response?.data?.error || '',
+          position: 'topCenter', timeout: 4000
+        });
+      }
+      this.loadDiscoveryP2p();
+    },
+    discoveryRemovePeer: async function(endpointId) {
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-dbs/remove`,
+          data: { endpointId }
+        });
+      } catch (err) {
+        iziToast.error({ title: 'Remove failed', position: 'topCenter', timeout: 3000 });
+      }
+      this.loadDiscoveryP2p();
+    },
+    discoveryBytes: function(n) {
+      if (typeof n !== 'number' || !isFinite(n)) { return '?'; }
+      if (n >= 1073741824) { return (n / 1073741824).toFixed(1) + ' GB'; }
+      if (n >= 1048576) { return (n / 1048576).toFixed(1) + ' MB'; }
+      return Math.ceil(n / 1024) + ' KB';
+    },
     pullStats: async function() {
       try {
         this.isPullingStats = true;

--- a/webapp/alpha/api.js
+++ b/webapp/alpha/api.js
@@ -98,11 +98,11 @@ const MSTREAMAPI = (() => {
   }
 
   mstreamModule.discoverySimilar = (filePath, limit) => {
-    return discoveryReq('api/v1/discovery/local/similar', { filePath, limit: limit || 5 });
+    return discoveryReq('api/v1/discovery/local/similar/tracks', { filePath, limit: limit || 5 });
   };
 
   mstreamModule.discoverySimilarArtists = (artist, limit) => {
-    return discoveryReq('api/v1/discovery/local/similar-artists', { artist, limit: limit || 3 });
+    return discoveryReq('api/v1/discovery/local/similar/artists', { artist, limit: limit || 3 });
   };
 
   // POST /api/v1/db/genres → { genres: [{ name, track_count }] }.

--- a/webapp/alpha/api.js
+++ b/webapp/alpha/api.js
@@ -98,11 +98,11 @@ const MSTREAMAPI = (() => {
   }
 
   mstreamModule.discoverySimilar = (filePath, limit) => {
-    return discoveryReq('api/v1/discovery/similar', { filePath, limit: limit || 5 });
+    return discoveryReq('api/v1/discovery/local/similar', { filePath, limit: limit || 5 });
   };
 
   mstreamModule.discoverySimilarArtists = (artist, limit) => {
-    return discoveryReq('api/v1/discovery/similar-artists', { artist, limit: limit || 3 });
+    return discoveryReq('api/v1/discovery/local/similar-artists', { artist, limit: limit || 3 });
   };
 
   // POST /api/v1/db/genres → { genres: [{ name, track_count }] }.


### PR DESCRIPTION
## What

N4a of the discovery network (follows #690/#692): **the payoff layer**. Servers now automatically download the most useful peers' snapshot DBs, and a user-facing API answers the question this whole effort exists for:

> *"What's on the network that sounds like this track — that I don't already have?"*

`POST /api/v1/discovery/similar {filepath, newArtistsOnly?}` → ranked, metadata-only results with peer attribution. With `newArtistsOnly`, every artist the local library already knows is dropped — the introduce-me-to-someone-new mode.

A privacy property worth calling out: **queries never leave the machine.** Similarity runs against local copies of peer snapshots, so peers only ever observe that you fetched their DB once — never what you search for.

## Pieces

**Peer-DB shelf** (`src/state/discovery-peer-dbs.js`) — the local collection of fetched snapshots:
- Auto-fetch reconcile loop (announcement-debounced + periodic): pulls the top-N catalog peers — **online-now first, then library size**. That's an honest proxy; real popularity ranking (seeder counts) needs N3's provider tracking and slots into the same sort later.
- Refresh-on-staleness: a peer's announced monotonic `snapshotSeq` moving past our copy triggers a re-fetch — the P0 counter doing exactly what it was designed for.
- Guardrails: `autoFetchCount` (default 3), `maxPeerDbStorageMb` (default 500), and `blockedPeers` (config) which also hides a peer from the catalog entirely — the v1 abuse lever.
- Every snapshot is **format-validated before first query** (it's an untrusted peer's SQLite file) and opened read-only.

**Similarity search** (`src/api/discovery.js`):
- Cosine = plain dot product (vectors are L2-normalized at write time), brute-force over every model-compatible peer DB — 50k peer tracks ≈ milliseconds.
- **Novelty filter chain** (no single identity signal covers every library): owned recording-MBID → normalized artist+title → near-duplicate embedding (≥0.99 vs the query catches untagged re-encodes). `newArtistsOnly` adds the artist-level drop.
- **Per-row `model_id` gating**: only vectors in the query track's model space are compared, so a network mid model-migration degrades to fewer results, never to garbage rankings.

**Admin surface**: catalog route now carries online/fetched/stale/compatible flags + most-useful-first sort + storage usage; manual fetch/remove routes; and a **Discovery Network card** in the admin UI — endpoint id, the shareable bootstrap ticket, a peer table with download/update/remove, and a storage gauge. Verified live in a browser: renders with real data, zero console errors.

## A real protocol bug the new tests caught

Gossip (Plumtree) **deduplicates identical message bytes** — so the sidecar's byte-identical 15-second re-announcements were being silently dropped after the first delivery. Consequences: late joiners would never hear existing peers, and last-heard timestamps (the "online" indicator) would never refresh. Announcements now carry an **unsigned heartbeat counter** so every re-broadcast is unique bytes. Replaying one buys an attacker nothing: the payload is still signed, `snapshotSeq` still can't roll back, and the per-origin rate limit caps processing. Relatedly, a **higher** `snapshotSeq` now bypasses the same-origin flood-guard gap — a seq bump right after a heartbeat is news, not a flood.

## Tests

18/18 in the discovery suite. The similarity engine is tested **fully synthetically** — hand-built snapshot files + directly-seeded embeddings, exact cosine assertions, no sidecar/network needed, so it runs everywhere including CI. The auto-fetch loop runs live against a raw peer sidecar (download-on-announce + refresh-on-seq-bump; needs a sidecar binary, auto-skips otherwise). Full suite: **1474/1474**.

## Reviewer notes

- `MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS` is a test-only env knob (waiting 30 real seconds per assertion is unkind); production never sets it.
- Meaningful results need embeddings — #689 (the embedding worker) populates them; this PR works against whatever model the registry pins (per-row gating), so the EffNet default flip composes cleanly.
- Deliberate scope cuts: player-UI discovery panel is N4b; seeder-count ranking + multi-source swarming are N3; runtime blocklist editing (vs config-file) can ride along with N4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)