### PR TITLE
feat(discovery): similarity API — similar tracks + similar artists

### DIFF
--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -1,0 +1,203 @@
+// Music-discovery similarity API — the first consumer of the embeddings the
+// discovery worker builds (discovery.db). Two endpoints, shaped for the
+// webapp player (results carry the standard {filepath, metadata} envelope so
+// they queue without translation):
+//
+//   POST /api/v1/discovery/similar          tracks similar to a seed track
+//   POST /api/v1/discovery/similar-artists  artists similar to a seed artist
+//
+// Semantics:
+//   - 403 while scanOptions.collectDiscoveryData is off (house convention
+//     for disabled features).
+//   - notAnalyzed:true + empty results when the seed exists but the worker
+//     hasn't embedded it yet — a transient state, not an error.
+//   - 404 for unknown seeds (or seeds outside the user's libraries).
+//   - One result per canonical audio hash (duplicate files share one
+//     vector), resolved to a file THIS user can access; users never see
+//     tracks outside their vpaths.
+//   - `metadata` is the live-library lite envelope (includes bpm /
+//     musical-key / file-tag genres); `genreTags` alongside it is the
+//     MODEL's style predictions — different sources, deliberately separate.
+//   - bpmRange filters on live tracks.bpm (fresher than the discovery
+//     snapshot, which exists for exports/network, not local queries).
+
+import Joi from 'joi';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as db from '../db/manager.js';
+import * as sim from '../db/discovery-similarity.js';
+import { joiValidate } from '../util/validation.js';
+import WebError from '../util/web-error.js';
+import { renderMetadataObj, toLiteMetadata, trackQuery, libraryFilter } from './db.js';
+import { getVPathInfo } from '../util/vpath.js';
+
+const d = () => db.getDB();
+
+// Feature gate + index. 403 when the feature is off; 403 (generic) when the
+// store is unavailable despite the flag (boot init failed) — same status so
+// probing can't distinguish configuration from failure.
+function requireIndex() {
+  if (config.program.scanOptions.collectDiscoveryData !== true) {
+    throw new WebError('Discovery is disabled', 403);
+  }
+  const index = sim.getIndex();
+  if (!index) { throw new WebError('Discovery is disabled', 403); }
+  return index;
+}
+
+// Resolve a canonical hash to a track row THIS user may see. Returns null
+// when every copy of that audio lives outside the user's libraries.
+function resolveVisible(uid, filter, canonHash) {
+  const params = uid ? [uid, canonHash, ...filter.params] : [canonHash, ...filter.params];
+  return d().prepare(`
+    ${trackQuery(uid)}
+    WHERE COALESCE(t.audio_hash, t.file_hash) = ? AND ${filter.clause}
+    LIMIT 1
+  `).get(...params);
+}
+
+function modelBlock(index) {
+  return { id: index.modelId, version: index.modelVersion };
+}
+
+export function setup(mstream) {
+
+  mstream.post('/api/v1/discovery/similar', (req, res) => {
+    const schema = Joi.object({
+      filePath: Joi.string().required(),
+      limit: Joi.number().integer().min(1).max(100).default(10),
+      excludeSameArtist: Joi.boolean().default(false),
+      excludeSameAlbum: Joi.boolean().default(false),
+      bpmRange: Joi.array().items(Joi.number().min(0).max(1000)).length(2).optional(),
+    });
+    const { value: body } = joiValidate(schema, req.body);
+
+    const index = requireIndex();
+
+    // Seed resolution: vpath check (throws on unknown/forbidden vpaths —
+    // surfaced as 404 so probing can't map another user's library names),
+    // then the track row inside that library.
+    let info;
+    try {
+      info = getVPathInfo(body.filePath, req.user);
+    } catch (err) {
+      winston.warn(`discovery/similar: rejected seed path '${body.filePath}' for '${req.user?.username}': ${err.message}`);
+      throw new WebError('Track not found', 404);
+    }
+    const lib = db.getLibraryByName(info.vpath);
+    if (!lib) { throw new WebError('Track not found', 404); }
+    const uid = req.user?.id;
+    const seedParams = uid ? [uid, info.relativePath, lib.id] : [info.relativePath, lib.id];
+    const seedRow = d().prepare(`
+      ${trackQuery(uid)}
+      WHERE t.filepath = ? AND t.library_id = ?
+      LIMIT 1
+    `).get(...seedParams);
+    if (!seedRow) { throw new WebError('Track not found', 404); }
+
+    const seedRendered = renderMetadataObj(seedRow);
+    const canonHash = seedRow.audio_hash || seedRow.file_hash;
+    const seedEntry = canonHash ? index.byHash.get(canonHash) : null;
+
+    const seed = {
+      filepath: seedRendered.filepath,
+      metadata: toLiteMetadata(seedRendered.metadata),
+      genreTags: seedEntry?.genreTags ?? null,
+    };
+
+    if (!seedEntry) {
+      return res.json({ seed, model: modelBlock(index), notAnalyzed: true, results: [] });
+    }
+
+    const filter = libraryFilter(req.user);
+    const ranked = sim.rankTracks(index, seedEntry.vec, canonHash);
+    const results = [];
+    for (const { entry, similarity } of ranked) {
+      if (results.length >= body.limit) { break; }
+      const row = resolveVisible(uid, filter, entry.hash);
+      if (!row) { continue; }   // no copy visible to this user
+      if (body.excludeSameArtist && row.artist_name && row.artist_name === seedRow.artist_name) { continue; }
+      if (body.excludeSameAlbum && row.album_name && row.album_name === seedRow.album_name
+        && row.artist_name === seedRow.artist_name) { continue; }
+      if (body.bpmRange && !(row.bpm >= body.bpmRange[0] && row.bpm <= body.bpmRange[1])) { continue; }
+
+      const rendered = renderMetadataObj(row);
+      results.push({
+        filepath: rendered.filepath,
+        similarity: Math.round(similarity * 10000) / 10000,
+        metadata: toLiteMetadata(rendered.metadata),
+        genreTags: entry.genreTags,
+      });
+    }
+
+    res.json({ seed, model: modelBlock(index), notAnalyzed: false, results });
+  });
+
+  mstream.post('/api/v1/discovery/similar-artists', (req, res) => {
+    const schema = Joi.object({
+      artist: Joi.string().required(),
+      limit: Joi.number().integer().min(1).max(100).default(10),
+    });
+    const { value: body } = joiValidate(schema, req.body);
+
+    const index = requireIndex();
+    const uid = req.user?.id;
+    const filter = libraryFilter(req.user);
+
+    // Live library facts about the seed artist — also the access check:
+    // an artist with no tracks visible to this user doesn't exist for them.
+    const seedStats = d().prepare(`
+      SELECT COUNT(*) AS n FROM tracks t
+      JOIN artists a ON a.id = t.artist_id
+      WHERE a.name = ? AND ${filter.clause}
+    `).get(body.artist, ...filter.params);
+    if (!seedStats || seedStats.n === 0) { throw new WebError('Artist not found', 404); }
+
+    const seedCentroid = index.artists.get(body.artist);
+    const seed = {
+      artist: body.artist,
+      trackCount: seedStats.n,
+      analyzedCount: seedCentroid?.analyzedCount ?? 0,
+      genreTags: seedCentroid?.topTags ?? null,
+    };
+
+    if (!seedCentroid) {
+      return res.json({ seed, model: modelBlock(index), notAnalyzed: true, results: [] });
+    }
+
+    const artistVisible = d().prepare(`
+      SELECT 1 FROM tracks t
+      JOIN artists a ON a.id = t.artist_id
+      WHERE a.name = ? AND ${filter.clause}
+      LIMIT 1
+    `);
+
+    const ranked = sim.rankArtists(index, body.artist);
+    const results = [];
+    for (const cand of ranked) {
+      if (results.length >= body.limit) { break; }
+      if (!artistVisible.get(cand.artist, ...filter.params)) { continue; }
+
+      // Entry points: the candidate's tracks closest to the SEED's sound —
+      // playable doorways that continue the vibe the user came from.
+      const entryPoints = [];
+      for (const { entry } of sim.rankArtistTracks(index, cand.artist, seedCentroid.vec)) {
+        if (entryPoints.length >= 2) { break; }
+        const row = resolveVisible(uid, filter, entry.hash);
+        if (!row) { continue; }
+        const rendered = renderMetadataObj(row);
+        entryPoints.push({ filepath: rendered.filepath, metadata: toLiteMetadata(rendered.metadata) });
+      }
+
+      results.push({
+        artist: cand.artist,
+        similarity: Math.round(cand.similarity * 10000) / 10000,
+        analyzedCount: cand.analyzedCount,
+        genreTags: cand.topTags,
+        entryPoints,
+      });
+    }
+
+    res.json({ seed, model: modelBlock(index), notAnalyzed: false, results });
+  });
+}

--- a/src/db/discovery-similarity.js
+++ b/src/db/discovery-similarity.js
@@ -1,0 +1,170 @@
+// In-memory similarity index over discovery.db's embeddings — the read side
+// of the discovery dataset. Powers /api/v1/discovery/similar and
+// /similar-artists (src/api/discovery.js).
+//
+// Design: brute-force cosine over an in-memory Float32Array matrix. At
+// self-hosted scale (10k tracks × 1280-d ≈ 50 MB, ~13M multiply-adds per
+// query ≈ 15-30 ms) an ANN index would be pure complexity; vectors are
+// L2-normalized at write time, so cosine = dot product.
+//
+// Cache invalidation rides the dataset's own monotonic rowversion:
+// discovery_meta.row_seq bumps on EVERY discovery_tracks write (that's what
+// updated_at is derived from), so one cheap meta read per request tells us
+// whether the matrix is stale. The active model is part of the cache key —
+// only rows pinned to the CURRENTLY configured model are comparable (rows
+// from an in-progress model migration are excluded until re-embedded).
+//
+// The peer-dataset import (the p2p thread) is expected to plug in here
+// later: peer snapshots become additional entry sources feeding the same
+// ranking scan.
+
+import winston from 'winston';
+import * as discoveryDb from './discovery-db.js';
+import * as config from '../state/config.js';
+
+let cache = null;
+
+// Test/ops hook: drop the cached matrix (e.g. after swapping discovery.db
+// files out from under the process).
+export function invalidate() { cache = null; }
+
+// Blob → aligned Float32Array. node:sqlite hands back Uint8Arrays whose
+// byteOffset isn't guaranteed 4-byte aligned; copy into a fresh buffer.
+function blobToVec(blob) {
+  const u8 = blob instanceof Uint8Array ? blob : new Uint8Array(blob);
+  const buf = new ArrayBuffer(u8.byteLength);
+  new Uint8Array(buf).set(u8);
+  return new Float32Array(buf);
+}
+
+function dot(a, b) {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) { s += a[i] * b[i]; }
+  return s;
+}
+
+function l2normalize(v) {
+  let ss = 0;
+  for (let i = 0; i < v.length; i++) { ss += v[i] * v[i]; }
+  const n = Math.sqrt(ss) || 1;
+  for (let i = 0; i < v.length; i++) { v[i] /= n; }
+  return v;
+}
+
+/**
+ * The current similarity index, rebuilt when the dataset or the configured
+ * model changed. Returns null when discovery has no store to read (feature
+ * never enabled / DB missing).
+ *
+ * Shape: {
+ *   modelId, modelVersion, dim,
+ *   entries: [{ hash, artist, vec, genreTags }],
+ *   byHash:  Map<hash, entry>,
+ *   artists: Map<artistName, { vec, analyzedCount, topTags }>,
+ * }
+ */
+export function getIndex() {
+  const ddb = discoveryDb.openDiscoveryDbIfExists();
+  if (!ddb) { return null; }
+
+  const modelId = config.program.scanOptions.discoveryModel;
+  const seq = discoveryDb.getMeta('row_seq') || '0';
+  if (cache && cache.seq === seq && cache.modelId === modelId) { return cache; }
+
+  const started = Date.now();
+  const rows = ddb.prepare(`
+    SELECT audio_hash, artist, embedding, genre_tags
+      FROM discovery_tracks
+     WHERE embedding IS NOT NULL AND model_id = ?
+  `).all(modelId);
+
+  const entries = [];
+  const byHash = new Map();
+  let dim = null;
+  for (const r of rows) {
+    const vec = blobToVec(r.embedding);
+    if (dim === null) { dim = vec.length; }
+    if (vec.length !== dim || dim === 0) { continue; }   // defensive: never mix dims
+    let genreTags = null;
+    if (r.genre_tags) {
+      try { genreTags = JSON.parse(r.genre_tags); } catch (_e) { /* stays null */ }
+    }
+    const entry = { hash: r.audio_hash, artist: r.artist || null, vec, genreTags };
+    entries.push(entry);
+    byHash.set(entry.hash, entry);
+  }
+
+  // Artist centroids: mean of the artist's track vectors, re-normalized.
+  // topTags = the artist's most frequent model tags (the "why similar"
+  // line for the artists endpoint). Untagged/unknown-artist rows are not
+  // part of the artist space.
+  const artists = new Map();
+  const grouped = new Map();
+  for (const e of entries) {
+    if (!e.artist) { continue; }
+    if (!grouped.has(e.artist)) { grouped.set(e.artist, []); }
+    grouped.get(e.artist).push(e);
+  }
+  for (const [name, list] of grouped) {
+    const centroid = new Float32Array(dim);
+    const tagCounts = new Map();
+    for (const e of list) {
+      for (let i = 0; i < dim; i++) { centroid[i] += e.vec[i]; }
+      for (const t of e.genreTags || []) { tagCounts.set(t, (tagCounts.get(t) || 0) + 1); }
+    }
+    for (let i = 0; i < dim; i++) { centroid[i] /= list.length; }
+    l2normalize(centroid);
+    const topTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map(([t]) => t);
+    artists.set(name, { vec: centroid, analyzedCount: list.length, topTags: topTags.length ? topTags : null });
+  }
+
+  const modelVersion = discoveryDb.getMeta('embedding_model_version') || null;
+  cache = { seq, modelId, modelVersion, dim, entries, byHash, artists };
+  winston.info(`discovery similarity index built: ${entries.length} tracks, ${artists.size} artists, ${dim}-d (${Date.now() - started} ms)`);
+  return cache;
+}
+
+/**
+ * All entries ranked by similarity to `seedVec`, descending, excluding
+ * `excludeHash`. The caller walks the ranking and applies its own
+ * access/exclusion filters until it has enough results.
+ */
+export function rankTracks(index, seedVec, excludeHash) {
+  const out = [];
+  for (const e of index.entries) {
+    if (e.hash === excludeHash) { continue; }
+    out.push({ entry: e, similarity: dot(seedVec, e.vec) });
+  }
+  out.sort((a, b) => b.similarity - a.similarity);
+  return out;
+}
+
+/**
+ * All artists ranked by centroid similarity to `seedArtist`'s centroid.
+ */
+export function rankArtists(index, seedArtist) {
+  const seed = index.artists.get(seedArtist);
+  if (!seed) { return null; }
+  const out = [];
+  for (const [name, a] of index.artists) {
+    if (name === seedArtist) { continue; }
+    out.push({ artist: name, analyzedCount: a.analyzedCount, topTags: a.topTags, similarity: dot(seed.vec, a.vec) });
+  }
+  out.sort((a, b) => b.similarity - a.similarity);
+  return out;
+}
+
+/**
+ * An artist's own tracks ranked by similarity to `seedVec` — the "entry
+ * points" into a similar artist: where to start listening, in the context
+ * of the sound the user came from.
+ */
+export function rankArtistTracks(index, artistName, seedVec) {
+  const out = [];
+  for (const e of index.entries) {
+    if (e.artist !== artistName) { continue; }
+    out.push({ entry: e, similarity: dot(seedVec, e.vec) });
+  }
+  out.sort((a, b) => b.similarity - a.similarity);
+  return out;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,7 @@ import http from 'http';
 import https from 'https';
 
 import * as dbApi from './api/db.js';
+import * as discoveryApi from './api/discovery.js';
 import * as searchApi from './api/search.js';
 import * as randomApi from './api/random.js';
 import * as playlistApi from './api/playlist.js';
@@ -305,6 +306,7 @@ export async function serveIt(configFile) {
   adminApi.setup(mstream);
   irohApi.setup(mstream);
   dbApi.setup(mstream);
+  discoveryApi.setup(mstream);
   searchApi.setup(mstream);
   randomApi.setup(mstream);
   playlistApi.setup(mstream);

--- a/test/integration/discovery-similarity.test.mjs
+++ b/test/integration/discovery-similarity.test.mjs
@@ -1,0 +1,349 @@
+/**
+ * Similarity API tests — POST /api/v1/discovery/similar and
+ * /api/v1/discovery/similar-artists (src/api/discovery.js +
+ * src/db/discovery-similarity.js).
+ *
+ * Strategy: boot a real server (discovery ON, model 'test-fake') over the
+ * scanned fixture library plus a second restricted library, then seed
+ * discovery.db with HANDCRAFTED unit vectors keyed to real scanned tracks —
+ * so every cosine in the ranking is known in advance and assertions are
+ * exact, no ML involved. Covers:
+ *
+ *   - 403 when the feature is off (separate default-config server).
+ *   - ranking order + similarity values match the handcrafted vectors.
+ *   - result shape: {filepath, similarity, metadata(lite incl. bpm), genreTags}.
+ *   - notAnalyzed for scanned-but-unembedded seeds (track AND artist).
+ *   - 404 for unknown seed paths/artists (and other users' vpaths).
+ *   - library access: users only see results (and entry points) from their
+ *     own vpaths; hashes whose only copy is elsewhere are skipped.
+ *   - excludeSameArtist + bpmRange (filters on LIVE tracks.bpm).
+ *   - artist centroids, entryPoints ordering, topTags aggregation.
+ *   - index invalidation via the row_seq rowversion.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { startServer } from '../helpers/server.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FFMPEG = process.platform === 'win32'
+  ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
+  : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+
+const ADMIN = { username: 'admin', password: 'pw-admin' };
+const BOB = { username: 'bob', password: 'pw-bob' };   // testlib only
+
+// ── handcrafted vector space (4-d, unit vectors) ────────────────────────────
+const vec = (...xs) => {
+  const v = new Float32Array(xs);
+  const n = Math.sqrt(v.reduce((s, x) => s + x * x, 0)) || 1;
+  return v.map((x) => x / n);
+};
+const dot = (a, b) => { let s = 0; for (let i = 0; i < a.length; i++) s += a[i] * b[i]; return s; };
+const blob = (v) => Buffer.from(v.buffer, v.byteOffset, v.byteLength);
+
+// Seeded tracks (fixture titles → vectors). Cosines vs SEED are exact.
+const V = {
+  seed: vec(1, 0, 0, 0),           // Icarus — Be Somebody
+  near: vec(0.95, 0.312, 0, 0),    // Icarus — Rise          cos ≈ 0.9500
+  mid: vec(0.8, 0.6, 0, 0),        // Vosto — Highway        cos = 0.8
+  far: vec(0.5, 0.866, 0, 0),      // Vosto — Neon           cos ≈ 0.5
+  lib2: vec(0.9, 0.436, 0, 0),     // Zed — Lib2 Song        cos ≈ 0.9 (admin-only library)
+};
+
+let offServer;   // discovery disabled
+let server;      // discovery enabled, seeded
+const tokens = {};
+let lib2Dir;
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(FFMPEG, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    p.stderr.on('data', (d) => { stderr += d.toString(); });
+    p.on('error', reject);
+    p.on('close', (code) => code === 0 ? resolve() : reject(new Error(`ffmpeg ${code}: ${stderr.slice(-200)}`)));
+  });
+}
+
+async function api(route, body, user = 'admin') {
+  const headers = { 'Content-Type': 'application/json' };
+  if (tokens[user]) { headers['x-access-token'] = tokens[user]; }
+  const r = await fetch(`${server.baseUrl}${route}`, {
+    method: 'POST', headers, body: JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+
+function openDiscovery() {
+  return new DatabaseSync(path.join(server.tmpDir, 'db', 'discovery.db'));
+}
+
+before(async () => {
+  // Second library visible only to admin.
+  lib2Dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-sim-lib2-'));
+  await runFfmpeg([
+    '-nostdin', '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', 'sine=frequency=550:duration=2',
+    '-metadata', 'artist=Zed', '-metadata', 'title=Lib2 Song', '-metadata', 'album=Zed Album',
+    '-ac', '1', path.join(lib2Dir, 'zed.mp3'),
+  ]);
+  // A second lib2 artist that never gets a discovery row — the
+  // "artist exists but nothing embedded yet" case.
+  await runFfmpeg([
+    '-nostdin', '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', 'sine=frequency=660:duration=2',
+    '-metadata', 'artist=Wex', '-metadata', 'title=Wex Song', '-metadata', 'album=Wex Album',
+    '-ac', '1', path.join(lib2Dir, 'wex.mp3'),
+  ]);
+
+  [offServer, server] = await Promise.all([
+    startServer({ dlnaMode: 'disabled', waitForScan: false }),
+    startServer({
+      dlnaMode: 'disabled',
+      extraConfig: { scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' } },
+      extraFolders: { lib2: lib2Dir },
+      users: [
+        { ...ADMIN, admin: true, vpaths: ['testlib', 'lib2'] },
+        { ...BOB, admin: false, vpaths: ['testlib'] },
+      ],
+    }),
+  ]);
+
+  for (const u of [ADMIN, BOB]) {
+    const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(u),
+    });
+    tokens[u.username] = (await r.json()).token;
+  }
+
+  // Seed discovery.db with handcrafted vectors keyed to REAL scanned tracks.
+  const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+  const trackByTitle = (title) => mdb.prepare(`
+    SELECT COALESCE(t.audio_hash, t.file_hash) AS hash, a.name AS artist, t.duration
+    FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id WHERE t.title = ?
+  `).get(title);
+  const rowsToSeed = [
+    ['Be Somebody', V.seed, null],
+    ['Rise', V.near, ['Test---StyleA', 'Test---StyleB']],
+    ['Highway', V.mid, ['Test---StyleC']],
+    ['Neon', V.far, ['Test---StyleC']],
+    ['Lib2 Song', V.lib2, null],
+  ];
+  const ddb = openDiscovery();
+  try {
+    const ins = ddb.prepare(`
+      INSERT INTO discovery_tracks
+        (audio_hash, updated_at, export_id, artist, title, duration, model_id, model_version, embedding, genre_tags)
+      VALUES (?, ?, ?, ?, ?, ?, 'test-fake', '1', ?, ?)
+    `);
+    let seq = 0;
+    for (const [title, v, tags] of rowsToSeed) {
+      const t = trackByTitle(title);
+      assert.ok(t?.hash, `fixture track '${title}' must exist with a hash`);
+      ins.run(t.hash, ++seq, `anon:${title.replace(/\s/g, '')}`, t.artist, title, t.duration ?? 120,
+        blob(v), tags ? JSON.stringify(tags) : null);
+    }
+    ddb.prepare("UPDATE discovery_meta SET value = ? WHERE key = 'row_seq'").run(String(seq));
+    ddb.prepare("INSERT OR REPLACE INTO discovery_meta (key, value) VALUES ('embedding_model_version', '1')").run();
+  } finally {
+    ddb.close();
+    mdb.close();
+  }
+});
+
+after(async () => {
+  await Promise.all([offServer?.stop(), server?.stop()]);
+  fs.rmSync(lib2Dir, { recursive: true, force: true });
+});
+
+// ── feature gating ───────────────────────────────────────────────────────────
+
+describe('similarity API gating', () => {
+  test('403 on both endpoints while discovery is disabled', async () => {
+    for (const [route, body] of [
+      ['/api/v1/discovery/similar', { filePath: 'testlib/x.mp3' }],
+      ['/api/v1/discovery/similar-artists', { artist: 'Icarus' }],
+    ]) {
+      const r = await fetch(`${offServer.baseUrl}${route}`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+      });
+      assert.equal(r.status, 403, route);
+    }
+  });
+
+  test('validation: missing seed → 400', async () => {
+    assert.equal((await api('/api/v1/discovery/similar', {})).status, 400);
+    assert.equal((await api('/api/v1/discovery/similar-artists', {})).status, 400);
+  });
+});
+
+// ── /discovery/similar ───────────────────────────────────────────────────────
+
+describe('POST /api/v1/discovery/similar', () => {
+  const seedPath = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
+
+  test('ranks by the handcrafted cosines, excludes the seed itself', async () => {
+    const { status, body } = await api('/api/v1/discovery/similar', { filePath: seedPath });
+    assert.equal(status, 200);
+    assert.equal(body.notAnalyzed, false);
+    assert.equal(body.model.id, 'test-fake');
+    assert.equal(body.seed.filepath, seedPath);
+    assert.ok(body.seed.metadata.title === 'Be Somebody');
+
+    const titles = body.results.map((r) => r.metadata.title);
+    assert.deepEqual(titles, ['Rise', 'Lib2 Song', 'Highway', 'Neon'],
+      'descending cosine order: 0.95, 0.9, 0.8, 0.5');
+    // Exact similarity values from the constructed vectors.
+    for (const [i, expected] of [dot(V.seed, V.near), dot(V.seed, V.lib2), dot(V.seed, V.mid), dot(V.seed, V.far)].entries()) {
+      assert.ok(Math.abs(body.results[i].similarity - expected) < 1e-3,
+        `result ${i}: ${body.results[i].similarity} ≈ ${expected}`);
+    }
+  });
+
+  test('result shape: lite metadata (with bpm key), model tags top-level', async () => {
+    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, limit: 1 });
+    const r = body.results[0];
+    assert.equal(r.metadata.title, 'Rise');
+    assert.ok('bpm' in r.metadata, 'lite metadata carries live bpm');
+    assert.ok('album-art' in r.metadata, 'lite metadata carries album-art');
+    assert.ok(!('hash' in r.metadata), 'identity fields are detail-view only (LITE subset)');
+    assert.ok(!('bpm' in r), 'no top-level bpm (lives in metadata)');
+    assert.deepEqual(r.genreTags, ['Test---StyleA', 'Test---StyleB'], 'model tags surface top-level');
+    assert.ok(r.filepath.startsWith('testlib/'), 'playable vpath-prefixed filepath');
+  });
+
+  test('limit caps results', async () => {
+    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, limit: 2 });
+    assert.equal(body.results.length, 2);
+  });
+
+  test('library access: bob never sees lib2 results', async () => {
+    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath }, 'bob');
+    const titles = body.results.map((r) => r.metadata.title);
+    assert.deepEqual(titles, ['Rise', 'Highway', 'Neon'], 'Lib2 Song skipped for bob');
+  });
+
+  test('excludeSameArtist drops the Icarus results', async () => {
+    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, excludeSameArtist: true });
+    const artists = body.results.map((r) => r.metadata.artist);
+    assert.ok(!artists.includes('Icarus'), `got ${artists}`);
+    assert.ok(artists.includes('Vosto'));
+  });
+
+  test('bpmRange filters on LIVE tracks.bpm; null bpm excluded', async () => {
+    // Give 'Rise' a live bpm inside the range and 'Highway' one outside.
+    const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'));
+    try {
+      mdb.prepare("UPDATE tracks SET bpm = 120 WHERE title = 'Rise'").run();
+      mdb.prepare("UPDATE tracks SET bpm = 60 WHERE title = 'Highway'").run();
+    } finally { mdb.close(); }
+
+    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, bpmRange: [100, 140] });
+    const titles = body.results.map((r) => r.metadata.title);
+    assert.ok(titles.includes('Rise'), 'in-range bpm kept');
+    assert.ok(!titles.includes('Highway'), 'out-of-range bpm dropped');
+    assert.ok(!titles.includes('Neon'), 'NULL bpm dropped when filter present');
+    assert.equal(body.results.find((r) => r.metadata.title === 'Rise').metadata.bpm, 120,
+      'metadata carries the live bpm the filter ran against');
+  });
+
+  test('scanned but not embedded → notAnalyzed, empty results', async () => {
+    const { status, body } = await api('/api/v1/discovery/similar',
+      { filePath: 'testlib/Icarus/Be Somebody/03 - Orbit.mp3' });
+    assert.equal(status, 200);
+    assert.equal(body.notAnalyzed, true);
+    assert.deepEqual(body.results, []);
+    assert.equal(body.seed.metadata.title, 'Orbit');
+  });
+
+  test('unknown path → 404; other users\' vpaths → 404', async () => {
+    assert.equal((await api('/api/v1/discovery/similar', { filePath: 'testlib/nope/missing.mp3' })).status, 404);
+    assert.equal((await api('/api/v1/discovery/similar', { filePath: 'lib2/zed.mp3' }, 'bob')).status, 404,
+      'bob probing lib2 gets 404, not 403 (no vpath-name oracle)');
+  });
+});
+
+// ── /discovery/similar-artists ───────────────────────────────────────────────
+
+describe('POST /api/v1/discovery/similar-artists', () => {
+  test('ranks artists by centroid similarity with tags and entry points', async () => {
+    const { status, body } = await api('/api/v1/discovery/similar-artists', { artist: 'Icarus' });
+    assert.equal(status, 200);
+    assert.equal(body.notAnalyzed, false);
+    assert.equal(body.seed.artist, 'Icarus');
+    assert.equal(body.seed.analyzedCount, 2, 'two Icarus tracks seeded');
+    assert.ok(body.seed.trackCount >= 5, 'live library count (all Icarus fixtures)');
+
+    const names = body.results.map((r) => r.artist);
+    assert.deepEqual(names, ['Zed', 'Vosto'],
+      'Zed centroid (single 0.9-ish vector) beats Vosto centroid (mean of 0.8/0.5 vectors)');
+
+    const vosto = body.results.find((r) => r.artist === 'Vosto');
+    assert.equal(vosto.analyzedCount, 2);
+    assert.deepEqual(vosto.genreTags, ['Test---StyleC'], 'most frequent model tags for the artist');
+
+    // Entry points: Vosto tracks ordered by closeness to the ICARUS centroid
+    // (Highway cos 0.8 > Neon cos 0.5 vs the near-seed centroid).
+    const entryTitles = vosto.entryPoints.map((e) => e.metadata.title);
+    assert.deepEqual(entryTitles, ['Highway', 'Neon']);
+    assert.ok(vosto.entryPoints[0].filepath.startsWith('testlib/'));
+  });
+
+  test('library access: bob does not see Zed (lib2-only artist)', async () => {
+    const { body } = await api('/api/v1/discovery/similar-artists', { artist: 'Icarus' }, 'bob');
+    assert.deepEqual(body.results.map((r) => r.artist), ['Vosto']);
+  });
+
+  test('artist with tracks but no embeddings → notAnalyzed', async () => {
+    // 'Wex' exists in lib2 but was never given a discovery row.
+    const { status, body } = await api('/api/v1/discovery/similar-artists', { artist: 'Wex' });
+    assert.equal(status, 200);
+    assert.equal(body.notAnalyzed, true);
+    assert.equal(body.seed.analyzedCount, 0);
+    assert.equal(body.seed.trackCount, 1);
+    assert.deepEqual(body.results, []);
+  });
+
+  test('unknown artist → 404', async () => {
+    assert.equal((await api('/api/v1/discovery/similar-artists', { artist: 'No Such Band' })).status, 404);
+  });
+});
+
+// ── index invalidation ───────────────────────────────────────────────────────
+
+describe('similarity index invalidation', () => {
+  test('a new row + row_seq bump is visible on the next request', async () => {
+    const seedPath = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
+    // Embed 'Orbit' (previously notAnalyzed) very close to the seed.
+    const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+    let orbit;
+    try {
+      orbit = mdb.prepare(`
+        SELECT COALESCE(t.audio_hash, t.file_hash) AS hash, a.name AS artist
+        FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id WHERE t.title = 'Orbit'
+      `).get();
+    } finally { mdb.close(); }
+
+    const ddb = openDiscovery();
+    try {
+      ddb.prepare(`
+        INSERT INTO discovery_tracks
+          (audio_hash, updated_at, export_id, artist, title, duration, model_id, model_version, embedding)
+        VALUES (?, 99, 'anon:orbit', ?, 'Orbit', 120, 'test-fake', '1', ?)
+      `).run(orbit.hash, orbit.artist, blob(vec(0.99, 0.141, 0, 0)));
+      ddb.prepare("UPDATE discovery_meta SET value = '99' WHERE key = 'row_seq'").run();
+    } finally { ddb.close(); }
+
+    const { body } = await api('/api/v1/discovery/similar', { filePath: seedPath, limit: 1 });
+    assert.equal(body.results[0].metadata.title, 'Orbit',
+      'freshly embedded track (cos 0.99) tops the ranking — index rebuilt');
+  });
+});


### PR DESCRIPTION
## What

The first **consumer** of the discovery embeddings — the feature all the infrastructure was for. Two authenticated endpoints, response shapes reviewed in-session:

### `POST /api/v1/discovery/similar`

Tracks similar to a seed track. Body: `filePath` (required), `limit` (≤100, default 10), `excludeSameArtist`, `excludeSameAlbum`, `bpmRange` ([min,max], filters on **live** `tracks.bpm`). Results carry the standard `{filepath, metadata}` envelope (lite projection — same shape as search results, queues in the player without translation), raw cosine `similarity`, and the **model's** `genreTags` top-level — deliberately separate from `metadata.genres` (file tags): different sources, and the distinction feeds the upcoming model-genres work.

### `POST /api/v1/discovery/similar-artists`

Artist-centroid ranking (mean of the artist's vectors, re-normalized). Each result carries aggregated model tags (the "why similar" line) and **`entryPoints`** — the candidate artist's tracks *closest to the seed artist's sound*, so "similar artist" is one click from playing the right introduction rather than a dead-end name. On the real library this picks exactly the right doorways: Vosto → Icarus surfaces "Killers" (the known crossover track), not the K-pop-styled one.

## The index (`src/db/discovery-similarity.js`)

In-memory brute-force cosine — no ANN complexity at self-hosted scale (~50 MB / 10k tracks, ms-scale scans). Invalidation rides the dataset's own **monotonic rowversion** (`discovery_meta.row_seq`, bumped by every worker write, readable cross-process) plus the active-model key: only rows pinned to the configured model are comparable, so an in-progress model migration never mixes vector spaces. The peer-snapshot import (p2p thread) can feed this same scan later.

## Semantics

403 while discovery is off · `notAnalyzed: true` + empty results for seeds the worker hasn't reached (transient state, not an error) · 404 for unknown/inaccessible seeds (no vpath-name oracle for probing) · one result per canonical audio hash, resolved to a file the requesting user can access · results **and entry points** never leave the user's vpaths.

## Testing

- **15 integration tests** over a real two-library, two-user server with **handcrafted unit vectors** keyed to scanned fixture tracks — every expected cosine is exact, no ML in the loop: gating, ranking order + values, response shape (lite metadata incl. `bpm`; no identity fields; no top-level bpm), notAnalyzed on both endpoints, 404s, per-user access on results and entry points, excludeSameArtist, bpmRange (incl. NULL-bpm exclusion), centroid ranking, entry-point ordering, tag aggregation, and rowversion-driven index invalidation.
- Discovery regression suites green (32 tests); zero new lint.
- **Live smoke on the real 18-track EffNet library**: `/similar` 54 ms including the first-request index build, `/similar-artists` 11 ms; rankings match the known neighbor structure (seed "Trails of Freedom" → "Cities of Corruption Pt 2" at 0.883, all-synthwave tags along for the ride).

## Not in this PR

Webapp UI (now-playing "similar tracks" panel — natural follow-up), text→audio queries (needs CLAP's text encoder), peer-dataset queries, Auto-DJ integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
