### PR TITLE
feat(discovery): sonic similarity constraint for the Auto-DJ picker (PR 1/2)

### DIFF
--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -35,14 +35,41 @@ const d = () => db.getDB();
 
 // Feature gate + index. 403 when the feature is off; 403 (generic) when the
 // store is unavailable despite the flag (boot init failed) — same status so
-// probing can't distinguish configuration from failure.
-function requireIndex() {
+// probing can't distinguish configuration from failure. Exported for other
+// routes that compose with the similarity index (the Auto-DJ picker's
+// sonic filter in random.js).
+export function requireIndex() {
   if (config.program.scanOptions.collectDiscoveryData !== true) {
     throw new WebError('Discovery is disabled', 403);
   }
   const index = sim.getIndex();
   if (!index) { throw new WebError('Discovery is disabled', 403); }
   return index;
+}
+
+// Resolve a client-supplied file path to the track row THIS user may see.
+// The vpath check throws on unknown/forbidden library names — surfaced as
+// a uniform 404 so probing can't map another user's library names. The
+// rejection is logged (rejected vpaths are a probing signal).
+export function resolveSeedTrack(req, filePath, routeTag) {
+  let info;
+  try {
+    info = getVPathInfo(filePath, req.user);
+  } catch (err) {
+    winston.warn(`${routeTag}: rejected seed path '${filePath}' for '${req.user?.username}': ${err.message}`);
+    throw new WebError('Track not found', 404);
+  }
+  const lib = db.getLibraryByName(info.vpath);
+  if (!lib) { throw new WebError('Track not found', 404); }
+  const uid = req.user?.id;
+  const seedParams = uid ? [uid, info.relativePath, lib.id] : [info.relativePath, lib.id];
+  const seedRow = d().prepare(`
+    ${trackQuery(uid)}
+    WHERE t.filepath = ? AND t.library_id = ?
+    LIMIT 1
+  `).get(...seedParams);
+  if (!seedRow) { throw new WebError('Track not found', 404); }
+  return seedRow;
 }
 
 // Resolve a canonical hash to a track row THIS user may see. Returns null
@@ -74,26 +101,8 @@ export function setup(mstream) {
 
     const index = requireIndex();
 
-    // Seed resolution: vpath check (throws on unknown/forbidden vpaths —
-    // surfaced as 404 so probing can't map another user's library names),
-    // then the track row inside that library.
-    let info;
-    try {
-      info = getVPathInfo(body.filePath, req.user);
-    } catch (err) {
-      winston.warn(`discovery/similar: rejected seed path '${body.filePath}' for '${req.user?.username}': ${err.message}`);
-      throw new WebError('Track not found', 404);
-    }
-    const lib = db.getLibraryByName(info.vpath);
-    if (!lib) { throw new WebError('Track not found', 404); }
+    const seedRow = resolveSeedTrack(req, body.filePath, 'discovery/similar');
     const uid = req.user?.id;
-    const seedParams = uid ? [uid, info.relativePath, lib.id] : [info.relativePath, lib.id];
-    const seedRow = d().prepare(`
-      ${trackQuery(uid)}
-      WHERE t.filepath = ? AND t.library_id = ?
-      LIMIT 1
-    `).get(...seedParams);
-    if (!seedRow) { throw new WebError('Track not found', 404); }
 
     const seedRendered = renderMetadataObj(seedRow);
     const canonHash = seedRow.audio_hash || seedRow.file_hash;

--- a/src/api/random.js
+++ b/src/api/random.js
@@ -19,7 +19,9 @@
 
 import Joi from 'joi';
 import * as db from '../db/manager.js';
+import * as sim from '../db/discovery-similarity.js';
 import { renderMetadataObj, libraryFilter, trackQuery, fetchGenresForTrack } from './db.js';
+import { requireIndex, resolveSeedTrack } from './discovery.js';
 import { joiValidate } from '../util/validation.js';
 import WebError from '../util/web-error.js';
 
@@ -348,6 +350,54 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts) {
   return d.prepare(sql).all(...baseParams, ...params);
 }
 
+// ── Sonic similarity pool (discovery embeddings) ────────────────────────────
+//
+// `similarTo` + `minSimilarity` constrain Auto-DJ picks to tracks whose
+// embedding cosine vs the seed is at least the threshold. Multiple seed
+// paths average into a session centroid (mean + L2, same math as the
+// artist centroids) — the client sends its recent DJ picks so the session
+// gravitates toward its own center instead of drifting song-by-song.
+//
+// The pool is a HARD base constraint, same contract as the genre filter:
+// the waterfall never relaxes it — BPM/key/artist steps relax WITHIN the
+// sonic pool, and even the final unrestricted step stays inside it. That's
+// the whole point of the user-facing promise ("only songs within X of the
+// vibe"); when nothing survives, the route fails loud rather than playing
+// something outside the range.
+//
+// Inherent consequence: tracks the discovery worker hasn't embedded yet
+// have no vector, so they can never be "within the range" — sonic mode
+// restricts the pool to analyzed tracks.
+//
+// Errors mirror the /api/v1/discovery routes: 403 feature-off/store-dead
+// (requireIndex), 404 unknown/forbidden seed path (resolveSeedTrack),
+// 400 with a distinct message for a seed that exists but has no embedding
+// yet (transient — the client can toast "pick a different seed").
+function buildSonicPool(req, body) {
+  const index = requireIndex();
+
+  const vecs = [];
+  const seedHashes = [];
+  for (const p of body.similarTo) {
+    const row = resolveSeedTrack(req, p, 'random-songs sonic');
+    const canonHash = row.audio_hash || row.file_hash;
+    const entry = canonHash ? index.byHash.get(canonHash) : null;
+    if (!entry) {
+      throw new WebError('Sonic seed track has not been analyzed yet', 400);
+    }
+    vecs.push(entry.vec);
+    seedHashes.push(canonHash);
+  }
+
+  const seedVec = sim.centroidOf(vecs);
+  const allowed = sim.hashesWithinThreshold(index, seedVec, body.minSimilarity);
+  // The seeds are the session's recent picks (rolling anchor) or the
+  // currently-playing song (locked anchor) — Auto-DJ must never answer
+  // "what's next" with "the song you just played".
+  for (const h of seedHashes) { allowed.delete(h); }
+  return { index, seedVec, allowed };
+}
+
 function pickRandomNonIgnored(rowCount, ignoreList) {
   // Trim ignoreList when it grows too large — pre-V32 behaviour.
   const trimmed = [...ignoreList];
@@ -370,6 +420,15 @@ function pickRandomNonIgnored(rowCount, ignoreList) {
 export function runRandomSongs(req, body) {
   const d = db.getDB();
   if (!d) { throw new WebError('Database not ready', 400); }
+
+  // Sonic pool first — it can 403/404/400 on its own and there's no point
+  // running SQL when the seed itself is bad.
+  const sonic = (Array.isArray(body.similarTo) && body.similarTo.length > 0)
+    ? buildSonicPool(req, body)
+    : null;
+  const sonicFilter = sonic
+    ? (rows) => rows.filter((r) => sonic.allowed.has(r.audio_hash || r.file_hash))
+    : (rows) => rows;
 
   const filter = libraryFilter(req.user, body.ignoreVPaths);
   const baseConditions = [filter.clause];
@@ -415,11 +474,13 @@ export function runRandomSongs(req, body) {
   // step-5b "drop cooldown" fallback if the user pruned themselves
   // into an empty pool.)
   if (!hasBpm && !hasBpmWide && !hasKey && !hasArtists && !hasIgnoreArtists) {
-    const rows = d.prepare(baseSql).all(...baseParams);
+    const rows = sonicFilter(d.prepare(baseSql).all(...baseParams));
     if (rows.length === 0) {
-      throw new WebError('No songs that match criteria', 400);
+      throw new WebError(sonic
+        ? 'No songs within the similarity range match criteria'
+        : 'No songs that match criteria', 400);
     }
-    return finalisePick(rows, body);
+    return finalisePick(rows, body, sonic);
   }
 
   // Helper: build the constraint object passed to runWaterfallQuery.
@@ -537,12 +598,18 @@ export function runRandomSongs(req, body) {
   let rows = [];
   for (const step of steps) {
     if (!step.gate()) { continue; }
-    rows = runWaterfallQuery(d, baseSql, baseParams, step.opts());
+    // The sonic pool intersects EVERY step's result before the emptiness
+    // check that drives relaxation — the waterfall relaxes BPM/key/artist
+    // constraints WITHIN the pool and never relaxes the pool itself
+    // (including the final unrestricted step).
+    rows = sonicFilter(runWaterfallQuery(d, baseSql, baseParams, step.opts()));
     if (rows.length > 0) { break; }
   }
 
   if (rows.length === 0) {
-    throw new WebError('No songs that match criteria', 400);
+    throw new WebError(sonic
+      ? 'No songs within the similarity range match criteria'
+      : 'No songs that match criteria', 400);
   }
 
   // Apply tier filter against the ORIGINAL request constraints so that
@@ -552,10 +619,10 @@ export function runRandomSongs(req, body) {
     musicalKeys: body.musicalKeys,
   });
 
-  return finalisePick(rows, body);
+  return finalisePick(rows, body, sonic);
 }
 
-function finalisePick(rows, body) {
+function finalisePick(rows, body, sonic) {
   const count = rows.length;
   const ignoreList = Array.isArray(body.ignoreList) ? body.ignoreList : [];
   const { idx, trimmedIgnore } = pickRandomNonIgnored(count, ignoreList);
@@ -570,10 +637,24 @@ function finalisePick(rows, body) {
   const { genres_concat } = fetchGenresForTrack(db.getDB(), picked.id);
   picked.genres_concat = genres_concat;
 
-  return {
+  const out = {
     songs: [renderMetadataObj(picked)],
     ignoreList: trimmedIgnore,
   };
+
+  // Sonic mode: report the pick's actual cosine vs the seed/centroid (UI
+  // display + slider tuning) and how many analyzed tracks are inside the
+  // range at all (before the other filters cut it down further).
+  if (sonic) {
+    const similarity = sim.similarityToHash(
+      sonic.index, sonic.seedVec, picked.audio_hash || picked.file_hash);
+    out.sonic = {
+      similarity: similarity === null ? null : Math.round(similarity * 10000) / 10000,
+      poolSize: sonic.allowed.size,
+    };
+  }
+
+  return out;
 }
 
 // ── Route setup ─────────────────────────────────────────────────────────────
@@ -671,7 +752,20 @@ export function setup(mstream) {
       // selects a small subset.
       genres: Joi.array().items(Joi.string().min(1).max(200)).max(200).optional(),
       genreMode: Joi.string().valid('whitelist', 'blacklist').default('whitelist'),
-    });
+      // Sonic similarity (discovery embeddings) — both-or-neither, enforced
+      // by the .and() below.
+      //   • similarTo:     1-8 file paths. One = plain seed; several average
+      //                    into a session centroid (the client sends its
+      //                    recent DJ picks as a rolling anchor — 8 is
+      //                    headroom over the expected 5-deep ring buffer).
+      //   • minSimilarity: raw cosine threshold 0..1. The pool is a hard
+      //                    base constraint — never relaxed by the waterfall.
+      //                    (EffNet reality: same-artist ≈ .6-.9, cross ≈
+      //                    .3-.7 — the client maps a perceptual slider onto
+      //                    this; the API takes the raw value.)
+      similarTo: Joi.array().items(Joi.string()).min(1).max(8).optional(),
+      minSimilarity: Joi.number().min(0).max(1).optional(),
+    }).and('similarTo', 'minSimilarity');
     const { value } = joiValidate(schema, req.body || {});
 
     res.json(runRandomSongs(req, value));

--- a/src/db/discovery-similarity.js
+++ b/src/db/discovery-similarity.js
@@ -125,6 +125,45 @@ export function getIndex() {
 }
 
 /**
+ * Mean of several (L2-normalized) vectors, re-normalized — the session
+ * centroid for multi-seed queries (Auto-DJ's rolling anchor). Same math as
+ * the artist centroids above. Returns null on empty input.
+ */
+export function centroidOf(vecs) {
+  if (!Array.isArray(vecs) || vecs.length === 0) { return null; }
+  const dim = vecs[0].length;
+  const c = new Float32Array(dim);
+  for (const v of vecs) {
+    for (let i = 0; i < dim; i++) { c[i] += v[i]; }
+  }
+  for (let i = 0; i < dim; i++) { c[i] /= vecs.length; }
+  return l2normalize(c);
+}
+
+/**
+ * The set of canonical hashes whose cosine vs `seedVec` is >= `minSimilarity`.
+ * The sonic pool for Auto-DJ: un-analyzed tracks have no entry and are
+ * therefore never in the pool — "within the similarity range" is only a
+ * promise the index can make about vectors it has.
+ */
+export function hashesWithinThreshold(index, seedVec, minSimilarity) {
+  const out = new Set();
+  for (const e of index.entries) {
+    if (dot(seedVec, e.vec) >= minSimilarity) { out.add(e.hash); }
+  }
+  return out;
+}
+
+/**
+ * Cosine of one indexed track vs `seedVec`, or null when the hash isn't in
+ * the index.
+ */
+export function similarityToHash(index, seedVec, hash) {
+  const e = index.byHash.get(hash);
+  return e ? dot(seedVec, e.vec) : null;
+}
+
+/**
  * All entries ranked by similarity to `seedVec`, descending, excluding
  * `excludeHash`. The caller walks the ranking and applies its own
  * access/exclusion filters until it has enough results.

--- a/test/integration/random-sonic.test.mjs
+++ b/test/integration/random-sonic.test.mjs
@@ -1,0 +1,337 @@
+/**
+ * Sonic-similarity Auto-DJ tests — POST /api/v1/db/random-songs with
+ * `similarTo` + `minSimilarity` (src/api/random.js's sonic pool over
+ * src/db/discovery-similarity.js).
+ *
+ * Strategy mirrors discovery-similarity.test.mjs: boot a real server
+ * (discovery ON, model 'test-fake') over the scanned fixture library plus a
+ * second admin-only library, then seed discovery.db with HANDCRAFTED unit
+ * vectors keyed to real scanned tracks — every cosine is known in advance,
+ * so pool membership is asserted exactly. Covers:
+ *
+ *   - 403 when discovery is off (sonic params on a default-config server).
+ *   - validation: both-or-neither params, bounds, array caps.
+ *   - the threshold pool: repeated picks only ever land inside it, the
+ *     seed itself is never picked, poolSize/similarity report exactly.
+ *   - hard-constraint semantics: the waterfall relaxes BPM inside the pool
+ *     (down to the unrestricted step) but NEVER picks outside it; genre
+ *     stays composed as a base filter.
+ *   - multi-seed centroid math (a pool reachable only via the centroid).
+ *   - distinct 400 for empty pools ("similarity range" message).
+ *   - access: restricted users never receive other-library picks; their
+ *     vpaths can't be used as seeds by others (404).
+ *   - 400 for scanned-but-unembedded seeds, 404 for unknown paths.
+ *   - plain random-songs (no sonic params) is unaffected.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { startServer } from '../helpers/server.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FFMPEG = process.platform === 'win32'
+  ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
+  : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+
+const ADMIN = { username: 'admin', password: 'pw-admin' };
+const BOB = { username: 'bob', password: 'pw-bob' };   // testlib only
+
+const ROUTE = '/api/v1/db/random-songs';
+const SEED_PATH = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
+const NEON_PATH = 'testlib/Vosto/Night Drive/02 - Neon.mp3';
+const UNSEEDED_PATH = 'testlib/Vosto/Night Drive/03 - Static.mp3';   // scanned, never embedded
+const LIB2_PATH = 'lib2/zed.mp3';
+
+// ── handcrafted vector space (4-d, unit vectors) ────────────────────────────
+const vec = (...xs) => {
+  const v = new Float32Array(xs);
+  const n = Math.sqrt(v.reduce((s, x) => s + x * x, 0)) || 1;
+  return v.map((x) => x / n);
+};
+const dot = (a, b) => { let s = 0; for (let i = 0; i < a.length; i++) s += a[i] * b[i]; return s; };
+const blob = (v) => Buffer.from(v.buffer, v.byteOffset, v.byteLength);
+
+// Cosines vs `seed` are exact: near ≈ 0.95, lib2 ≈ 0.9, mid = 0.8, far ≈ 0.5.
+const V = {
+  seed: vec(1, 0, 0, 0),           // Icarus — Be Somebody (genre Electronic)
+  near: vec(0.95, 0.312, 0, 0),    // Icarus — Rise        (genre Electronic)
+  mid: vec(0.8, 0.6, 0, 0),        // Vosto — Highway      (genre Ambient)
+  far: vec(0.5, 0.866, 0, 0),      // Vosto — Neon         (genre Ambient)
+  lib2: vec(0.9, 0.436, 0, 0),     // Zed — Lib2 Song      (admin-only library)
+};
+
+let offServer;   // discovery disabled
+let server;      // discovery enabled, seeded
+const tokens = {};
+let lib2Dir;
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(FFMPEG, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    p.stderr.on('data', (d) => { stderr += d.toString(); });
+    p.on('error', reject);
+    p.on('close', (code) => code === 0 ? resolve() : reject(new Error(`ffmpeg ${code}: ${stderr.slice(-200)}`)));
+  });
+}
+
+async function pick(body, user = 'admin') {
+  const headers = { 'Content-Type': 'application/json' };
+  if (tokens[user]) { headers['x-access-token'] = tokens[user]; }
+  const r = await fetch(`${server.baseUrl}${ROUTE}`, {
+    method: 'POST', headers, body: JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+
+// Repeated picks — the route returns ONE random song per call, so pool
+// membership is asserted over many draws.
+async function pickTitles(body, n, user = 'admin') {
+  const titles = new Set();
+  for (let i = 0; i < n; i++) {
+    const { status, body: res } = await pick(body, user);
+    assert.equal(status, 200, `pick ${i}: ${JSON.stringify(res)}`);
+    titles.add(res.songs[0].metadata.title);
+  }
+  return titles;
+}
+
+before(async () => {
+  lib2Dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-sonic-lib2-'));
+  await runFfmpeg([
+    '-nostdin', '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', 'sine=frequency=550:duration=2',
+    '-metadata', 'artist=Zed', '-metadata', 'title=Lib2 Song', '-metadata', 'album=Zed Album',
+    '-ac', '1', path.join(lib2Dir, 'zed.mp3'),
+  ]);
+
+  [offServer, server] = await Promise.all([
+    startServer({ dlnaMode: 'disabled', waitForScan: false }),
+    startServer({
+      dlnaMode: 'disabled',
+      extraConfig: { scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' } },
+      extraFolders: { lib2: lib2Dir },
+      users: [
+        { ...ADMIN, admin: true, vpaths: ['testlib', 'lib2'] },
+        { ...BOB, admin: false, vpaths: ['testlib'] },
+      ],
+    }),
+  ]);
+
+  for (const u of [ADMIN, BOB]) {
+    const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(u),
+    });
+    tokens[u.username] = (await r.json()).token;
+  }
+
+  // Seed discovery.db with handcrafted vectors keyed to REAL scanned tracks.
+  // Everything not listed here (Static, Orbit, Return, …) stays un-embedded.
+  const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+  const trackByTitle = (title) => mdb.prepare(`
+    SELECT COALESCE(t.audio_hash, t.file_hash) AS hash, a.name AS artist, t.duration
+    FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id WHERE t.title = ?
+  `).get(title);
+  const rowsToSeed = [
+    ['Be Somebody', V.seed],
+    ['Rise', V.near],
+    ['Highway', V.mid],
+    ['Neon', V.far],
+    ['Lib2 Song', V.lib2],
+  ];
+  const ddb = new DatabaseSync(path.join(server.tmpDir, 'db', 'discovery.db'));
+  try {
+    const ins = ddb.prepare(`
+      INSERT INTO discovery_tracks
+        (audio_hash, updated_at, export_id, artist, title, duration, model_id, model_version, embedding)
+      VALUES (?, ?, ?, ?, ?, ?, 'test-fake', '1', ?)
+    `);
+    let seq = 0;
+    for (const [title, v] of rowsToSeed) {
+      const t = trackByTitle(title);
+      assert.ok(t?.hash, `fixture track '${title}' must exist with a hash`);
+      ins.run(t.hash, ++seq, `anon:${title.replace(/\s/g, '')}`, t.artist, title, t.duration ?? 120, blob(v));
+    }
+    // Raw INSERTs don't bump the rowversion — only upsertDiscoveryTrack
+    // does. Without this the similarity index would cache an empty view.
+    ddb.prepare("UPDATE discovery_meta SET value = ? WHERE key = 'row_seq'").run(String(seq));
+    ddb.prepare("INSERT OR REPLACE INTO discovery_meta (key, value) VALUES ('embedding_model_version', '1')").run();
+  } finally {
+    ddb.close();
+    mdb.close();
+  }
+});
+
+after(async () => {
+  await Promise.all([offServer?.stop(), server?.stop()]);
+  fs.rmSync(lib2Dir, { recursive: true, force: true });
+});
+
+// ── gating + validation ──────────────────────────────────────────────────────
+
+describe('sonic random-songs gating', () => {
+  test('403 when discovery is disabled and sonic params are present', async () => {
+    const r = await fetch(`${offServer.baseUrl}${ROUTE}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ similarTo: ['x/y.mp3'], minSimilarity: 0.5 }),
+    });
+    assert.equal(r.status, 403);
+  });
+
+  test('plain random-songs (no sonic params) still works on the sonic server', async () => {
+    const { status, body } = await pick({});
+    assert.equal(status, 200);
+    assert.equal(body.songs.length, 1);
+    assert.ok(Array.isArray(body.ignoreList));
+    assert.ok(!('sonic' in body), 'no sonic block without sonic params');
+  });
+
+  test('validation: both-or-neither + bounds', async () => {
+    assert.equal((await pick({ similarTo: [SEED_PATH] })).status, 400, 'similarTo without minSimilarity');
+    assert.equal((await pick({ minSimilarity: 0.5 })).status, 400, 'minSimilarity without similarTo');
+    assert.equal((await pick({ similarTo: [], minSimilarity: 0.5 })).status, 400, 'empty similarTo');
+    assert.equal((await pick({ similarTo: [SEED_PATH], minSimilarity: 1.5 })).status, 400, 'minSimilarity > 1');
+    assert.equal((await pick({ similarTo: Array(9).fill(SEED_PATH), minSimilarity: 0.5 })).status, 400, '9 seeds > cap');
+  });
+});
+
+// ── the threshold pool ───────────────────────────────────────────────────────
+
+describe('sonic threshold pool', () => {
+  test('picks only land inside the pool; the seed itself is never picked', async () => {
+    // minSimilarity 0.85 → pool = {Rise 0.95, Lib2 Song 0.9}; the seed's own
+    // cos of 1.0 is in range but seeds are excluded by contract.
+    const body = { similarTo: [SEED_PATH], minSimilarity: 0.85 };
+    const titles = await pickTitles(body, 16);
+    assert.deepEqual([...titles].sort(), ['Lib2 Song', 'Rise']);
+
+    const { body: one } = await pick(body);
+    assert.equal(one.sonic.poolSize, 2, 'poolSize counts in-range tracks minus seeds');
+    const expected = { 'Rise': dot(V.seed, V.near), 'Lib2 Song': dot(V.seed, V.lib2) };
+    const got = one.sonic.similarity;
+    assert.ok(Math.abs(got - expected[one.songs[0].metadata.title]) < 1e-3,
+      `reported similarity ${got} matches the picked track's exact cosine`);
+  });
+
+  test('lower threshold widens the pool', async () => {
+    // 0.75 additionally admits Highway (cos 0.8); Neon (0.5) and every
+    // un-embedded track stay out.
+    const titles = await pickTitles({ similarTo: [SEED_PATH], minSimilarity: 0.75 }, 24);
+    assert.deepEqual([...titles].sort(), ['Highway', 'Lib2 Song', 'Rise']);
+  });
+
+  test('empty pool → 400 with the similarity-range message', async () => {
+    const { status, body } = await pick({ similarTo: [SEED_PATH], minSimilarity: 0.99 });
+    assert.equal(status, 400);
+    assert.match(body.error, /similarity range/i);
+  });
+});
+
+// ── hard constraint vs the waterfall ─────────────────────────────────────────
+
+describe('sonic pool is never relaxed', () => {
+  test('BPM waterfall falls through to unrestricted but stays inside the pool', async () => {
+    // Fixtures carry no BPM tags, so every BPM-constrained step returns
+    // nothing and the chain ends at the unrestricted step — which must
+    // still be sonic-filtered.
+    const body = {
+      similarTo: [SEED_PATH], minSimilarity: 0.85,
+      bpmRanges: [{ min: 900, max: 950 }],
+    };
+    const titles = await pickTitles(body, 12);
+    for (const t of titles) {
+      assert.ok(['Rise', 'Lib2 Song'].includes(t), `pick '${t}' escaped the sonic pool`);
+    }
+  });
+
+  test('genre filter composes as a base condition inside the pool', async () => {
+    // Pool at 0.85 = {Rise (Electronic), Lib2 Song (no genre)}. Whitelist
+    // Electronic → only Rise survives; whitelist Ambient → intersection
+    // empty → the sonic-flavoured 400.
+    const only = await pickTitles({
+      similarTo: [SEED_PATH], minSimilarity: 0.85,
+      genres: ['Electronic'], genreMode: 'whitelist',
+    }, 8);
+    assert.deepEqual([...only], ['Rise']);
+
+    const { status, body } = await pick({
+      similarTo: [SEED_PATH], minSimilarity: 0.85,
+      genres: ['Ambient'], genreMode: 'whitelist',
+    });
+    assert.equal(status, 400);
+    assert.match(body.error, /similarity range/i);
+  });
+});
+
+// ── multi-seed centroid ──────────────────────────────────────────────────────
+
+describe('multi-seed centroid', () => {
+  test('two seeds average into a centroid that reaches tracks neither seed reaches alone', async () => {
+    // centroid(seed, far) ≈ (0.866, 0.5, 0, 0). Cosines: Highway ≈ 0.993,
+    // Lib2 Song ≈ 0.997, Rise ≈ 0.979 — all above 0.97, while the
+    // single-seed pool at 0.97 is empty (max non-seed cos is 0.95).
+    const single = await pick({ similarTo: [SEED_PATH], minSimilarity: 0.97 });
+    assert.equal(single.status, 400, 'single seed at 0.97 has an empty pool');
+
+    const body = { similarTo: [SEED_PATH, NEON_PATH], minSimilarity: 0.97 };
+    const titles = await pickTitles(body, 24);
+    assert.deepEqual([...titles].sort(), ['Highway', 'Lib2 Song', 'Rise'],
+      'both seeds excluded, centroid-reachable tracks included');
+
+    const { body: one } = await pick(body);
+    assert.equal(one.sonic.poolSize, 3);
+  });
+});
+
+// ── access control ───────────────────────────────────────────────────────────
+
+describe('sonic access control', () => {
+  test('restricted user never receives picks from other libraries', async () => {
+    const titles = await pickTitles({ similarTo: [SEED_PATH], minSimilarity: 0.85 }, 16, 'bob');
+    assert.deepEqual([...titles], ['Rise'], 'Lib2 Song is in range but not in bob\'s libraries');
+  });
+
+  test("other users' vpaths are unusable as seeds (uniform 404)", async () => {
+    const { status } = await pick({ similarTo: [LIB2_PATH], minSimilarity: 0.5 }, 'bob');
+    assert.equal(status, 404);
+  });
+});
+
+// ── seed edge cases ──────────────────────────────────────────────────────────
+
+describe('sonic seed edge cases', () => {
+  test('scanned but un-embedded seed → 400 with a distinct message', async () => {
+    const { status, body } = await pick({ similarTo: [UNSEEDED_PATH], minSimilarity: 0.5 });
+    assert.equal(status, 400);
+    assert.match(body.error, /analyzed/i);
+  });
+
+  test('unknown seed path → 404', async () => {
+    const { status } = await pick({ similarTo: ['testlib/nope/missing.mp3'], minSimilarity: 0.5 });
+    assert.equal(status, 404);
+  });
+
+  test('response shape: songs envelope unchanged, ignoreList grows, sonic block present', async () => {
+    const first = await pick({ similarTo: [SEED_PATH], minSimilarity: 0.75 });
+    assert.equal(first.status, 200);
+    const song = first.body.songs[0];
+    assert.ok(song.filepath.startsWith('testlib/') || song.filepath.startsWith('lib2/'));
+    assert.ok(song.metadata && typeof song.metadata.title === 'string');
+    assert.equal(first.body.ignoreList.length, 1);
+
+    const second = await pick({
+      similarTo: [SEED_PATH], minSimilarity: 0.75,
+      ignoreList: first.body.ignoreList,
+    });
+    assert.equal(second.status, 200);
+    assert.equal(second.body.ignoreList.length, 2, 'server appends its pick to the returned ignoreList');
+    assert.ok(second.body.sonic.similarity >= 0.75 - 1e-6, 'pick is inside the requested range');
+  });
+});


### PR DESCRIPTION
# Auto-DJ sonic similarity — server API (PR 1 of 2)

Lets Auto-DJ promise "only songs that *sound* within X of the session" using the discovery embeddings. This PR is the server side; PR 2 wires the DJ panel (slider, seed picker, anchor mode).

## API

`POST /api/v1/db/random-songs` gains two fields (both-or-neither):

```json
{ "similarTo": ["lib/artist/track.mp3", "..."], "minSimilarity": 0.55 }
```

- **`similarTo`** — 1–8 file paths. One path is a plain seed; several average into a **session centroid** (mean + L2, same math as the artist centroids). The client's rolling anchor sends its recent DJ picks here, so the session gravitates toward its own center instead of drifting song-by-song. A locked anchor just always sends the original seed — the server doesn't care, which is what makes the anchor mode a pure client-side setting.
- **`minSimilarity`** — raw cosine 0–1. EffNet reality: same-artist ≈ 0.6–0.9, cross-artist ≈ 0.3–0.7; the UI maps a perceptual slider onto this.

Response adds `sonic: { similarity, poolSize }` (the pick's actual cosine + how many analyzed tracks are in range) next to the untouched `songs`/`ignoreList` envelope.

## Semantics

- **The pool is a hard constraint** — same contract as the genre filter. The BPM/key/similar-artist waterfall relaxes *within* the sonic pool and never escapes it, including the final unrestricted step. Nothing in range → 400 with a distinct "similarity range" message, never a pick outside the range.
- **Seeds are excluded from the pool** — they're the just-played songs; "what's next" must never answer "the song you just played".
- **Un-analyzed tracks are inherently out** — no vector, no similarity promise. Sonic mode restricts picks to analyzed tracks (partially-scanned libraries will feel this).
- **Errors mirror `/api/v1/discovery/*`**: 403 feature-off/store-dead, uniform 404 for unknown/forbidden seed paths (logged — rejected vpaths are a probing signal), 400 for a scanned-but-not-yet-embedded seed.

## Implementation notes

- The pool intersects candidate rows **in JS after each SQL step** (the route already materializes each step's rows), so there's no `IN (...thousands of hashes)` placeholder risk and zero SQL changes.
- Same `row_seq`-cached in-memory index as the `/discovery` routes — the added per-pick cost is one cosine pass (~ms at 10k tracks).
- `requireIndex` + a new shared `resolveSeedTrack` (extracted from `/discovery/similar`) are exported from `api/discovery.js`; `discovery-similarity.js` gains `centroidOf` / `hashesWithinThreshold` / `similarityToHash`.

## Tests

14 new integration tests (`test/integration/random-sonic.test.mjs`) over handcrafted exact-cosine vectors, same fixture pattern as the similarity API suite:

- threshold pool membership over repeated draws (+ exact `poolSize`/`similarity` values)
- BPM waterfall falling through to unrestricted **without escaping the pool**; genre filter composing inside it
- multi-seed centroid reaching tracks neither seed reaches alone (proves the centroid math end-to-end)
- access control (restricted users never see other-library picks; foreign vpaths 404 as seeds)
- un-embedded seed → 400, unknown path → 404, empty pool → the distinct 400
- plain (non-sonic) requests byte-identical to before

Neighboring suites re-run green: random-route + random-similar-artists + discovery-similarity, 108/108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
