### PR TITLE
fix(ci): restore exec bit on disk before committing prebuilt binaries

### DIFF
--- a/.github/workflows/build-p2p-sidecar.yml
+++ b/.github/workflows/build-p2p-sidecar.yml
@@ -150,9 +150,18 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Restore the exec bit ON DISK before staging. Artifact zips strip
+          # it, and files download-artifact CREATES (rather than overwrites —
+          # i.e. any binary name not already committed, like this workflow's
+          # very first run) land as 644. Staging the mode via update-index
+          # alone leaves the worktree at 644 vs a 755 index/HEAD — an
+          # unstaged mode change that makes `git pull --rebase` below refuse
+          # to run. That exact failure shipped zero p2p-sidecar binaries
+          # while every build leg was green.
+          chmod +x bin/p2p-sidecar/p2p-sidecar-*
           git add bin/p2p-sidecar/p2p-sidecar-*
-          # Artifact zip round-trips strip the exec bit; force 100755 so
-          # checkouts get +x (see build-rust-parser.yml for the history).
+          # Belt-and-braces: force 100755 in the index even if the chmod is
+          # ever lost (see build-rust-parser.yml for the EACCES history).
           git update-index --chmod=+x bin/p2p-sidecar/p2p-sidecar-*
           if git diff --cached --quiet; then
             echo "No binary changes to commit"

--- a/.github/workflows/build-rust-parser-musl.yml
+++ b/.github/workflows/build-rust-parser-musl.yml
@@ -124,9 +124,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # chmod BEFORE staging: a file download-artifact CREATES (vs
+          # overwrites) lands 644, and an index-only mode fix leaves an
+          # unstaged mode change that breaks `git pull --rebase` below.
+          # See build-rust-parser.yml for the full story.
+          chmod +x bin/rust-parser/rust-parser-*-musl*
           git add bin/rust-parser/rust-parser-*-musl*
-          # GH Actions artifact zip strips the exec bit; force 100755 in
-          # the index so user checkouts get `+x`. See build-rust-parser.yml.
+          # Belt-and-braces: force 100755 in the index so user checkouts
+          # get `+x` regardless.
           git update-index --chmod=+x bin/rust-parser/rust-parser-*-musl*
           if git diff --cached --quiet; then
             echo "No binary changes to commit"

--- a/.github/workflows/build-rust-parser.yml
+++ b/.github/workflows/build-rust-parser.yml
@@ -149,13 +149,19 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Restore the exec bit ON DISK before staging. Artifact zips strip
+          # it; for binaries that already exist in the repo the download
+          # merely overwrites content (checkout already gave them 755), but a
+          # file download-artifact CREATES (a new platform leg's first run)
+          # lands as 644 — and staging the mode via update-index alone then
+          # leaves an unstaged mode change that makes `git pull --rebase`
+          # refuse to run (this bit build-p2p-sidecar.yml's bootstrap).
+          chmod +x bin/rust-parser/rust-parser-*
           git add bin/rust-parser/rust-parser-*
-          # GH Actions artifact upload/download uses zip, which does not
-          # preserve the Unix exec bit. Force the index entries to 100755
-          # so users' checkouts get `+x` — without this, scanners spawn
-          # the binary and hit EACCES on every boot. Run AFTER `git add`
-          # but BEFORE the diff check so a pure-mode flip still skips
-          # the commit when content is unchanged.
+          # Belt-and-braces: force 100755 in the index regardless — without
+          # +x, scanners spawn the binary and hit EACCES on every boot. Run
+          # AFTER `git add` but BEFORE the diff check so a pure-mode flip
+          # still skips the commit when content is unchanged.
           git update-index --chmod=+x bin/rust-parser/rust-parser-*
           if git diff --cached --quiet; then
             echo "No binary changes to commit"

--- a/.github/workflows/build-rust-server-audio.yml
+++ b/.github/workflows/build-rust-server-audio.yml
@@ -114,10 +114,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # chmod BEFORE staging: a file download-artifact CREATES (vs
+          # overwrites) lands 644, and an index-only mode fix leaves an
+          # unstaged mode change that breaks `git pull --rebase` below.
+          # See build-rust-parser.yml for the full story.
+          chmod +x bin/rust-server-audio/rust-server-audio-*
           git add bin/rust-server-audio/rust-server-audio-*
-          # GH Actions artifact zip strips the exec bit; force 100755 in
-          # the index so user checkouts get `+x`. Without this, server-
-          # playback.js spawn hits EACCES on every boot in Docker.
+          # Belt-and-braces: force 100755 in the index so user checkouts get
+          # `+x` — without it, server-playback.js spawn hits EACCES on every
+          # boot in Docker.
           git update-index --chmod=+x bin/rust-server-audio/rust-server-audio-*
           if git diff --cached --quiet; then
             echo "No binary changes to commit"


### PR DESCRIPTION
## What

Fixes the `Build P2P Sidecar Binaries` workflow's `Commit binaries` job, which failed on both master runs (after #690 and #692) — **all six platform builds were green, but zero binaries ever landed in `bin/p2p-sidecar/`**, leaving the discovery-network feature inert for anyone without a local cargo build.

## Root cause

Artifact zips strip the Unix exec bit, and `download-artifact` **creates** files at 644 when they don't already exist in the checkout — exactly the situation for a workflow's first-ever commit (`bin/p2p-sidecar/` was empty on master). The existing `git update-index --chmod=+x` fixes the mode **in the index only**, so after `git commit` the worktree (644) disagrees with HEAD (755): six unstaged mode changes. `git pull --rebase` refuses to run on a dirty tree →

```
error: cannot pull with rebase: You have unstaged changes.
##[error]Process completed with exit code 128.
```

**Why rust-parser never hit this:** its binaries already exist in the repo, so checkout materializes them with 755 and the artifact download merely overwrites *content*, preserving the on-disk mode. The same latent bug would bite those workflows the day a new platform leg is added, so all four binary-committing workflows get the fix.

(The `digest-mismatch: error` line in the failed logs is a red herring — it's `download-artifact@v8` echoing its `digest-mismatch` **input**, whose value is `error`, meaning "error on mismatch". All downloads verified clean.)

## Fix

`chmod +x` the files **on disk** before `git add` — worktree and index then agree at 755, the tree is clean after commit, and `pull --rebase` proceeds. The `update-index --chmod=+x` stays as belt-and-braces. Applied to:

- `build-p2p-sidecar.yml` (the broken one)
- `build-rust-parser.yml`, `build-rust-parser-musl.yml`, `build-rust-server-audio.yml` (latent same bug for future new legs)

## After merge

Trigger the sidecar workflow once (`gh workflow run build-p2p-sidecar.yml` or the Actions UI — merging #694 will also trigger it via its `p2p-sidecar/**` changes) and confirm the bot commit `ci: update pre-built p2p-sidecar binaries` lands. That's the moment the discovery network actually turns on for prebuilt users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)