### PR TITLE
feat(discovery): community seed nodes — bootstrap for strangers (PR-1)

### DIFF
--- a/seeds/discovery-seeds.json
+++ b/seeds/discovery-seeds.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "updated": "2026-07-04",
+  "_readme": "Community seed nodes for the mStream discovery network. Servers with discoveryP2p.useCommunitySeeds (default on) fetch this file at most daily and bootstrap the gossip catalog off these tickets, in addition to any operator-configured bootstrapPeers. Seeds relay the mesh but hold no music and no snapshots; announcements stay signed by their origins. Rotating a seed = editing this file on master. Entry shape: {\"name\": \"...\", \"endpointId\": \"<64 hex>\", \"ticket\": \"endpoint...\"} — endpointId lets operator blocklists apply to seeds. The seed binary lives in the mstream-discovery-seed repo.",
+  "seeds": []
+}

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -445,6 +445,7 @@ export function setup(mstream) {
       endpointId: discoveryP2p.getEndpointId(),
       ticket: discoveryP2p.getEndpointTicket(),
       knownPeers: discoveryCatalog.size(),
+      communitySeeds: config.program.discoveryP2p.useCommunitySeeds,
     });
   });
 

--- a/src/server.js
+++ b/src/server.js
@@ -494,9 +494,20 @@ export async function serveIt(configFile) {
         try {
           const p2p = await import('./state/discovery-p2p.js');
           const catalog = await import('./state/discovery-catalog.js');
+          const seeds = await import('./state/discovery-seeds.js');
           catalog.subscribe();
           await p2p.start();
-          await p2p.join(config.program.discoveryP2p.bootstrapPeers);
+          // Two-phase bootstrap. Phase one joins the topic IMMEDIATELY with
+          // what's known locally (baked seeds + cached list + the operator's
+          // bootstrapPeers) — the subscription must never wait on a network
+          // fetch, both for boot speed and so peers bootstrapping off OUR
+          // ticket find a live topic. Phase two refreshes the community list
+          // and merges any additions (join is idempotent via join_peers).
+          await p2p.join(await seeds.resolveBootstrap({ localOnly: true }));
+          seeds.startMeshHealthWatch();
+          seeds.resolveBootstrap().then((full) => p2p.join(full)).catch((err) => {
+            winston.warn(`[discovery-seeds] community list refresh failed: ${err.message}`);
+          });
           try {
             const r = await p2p.announceCurrentSnapshot();
             winston.info(`[discovery-p2p] catalog joined; announced snapshot ${r.hash.slice(0, 12)}…`);

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -308,6 +308,19 @@ const discoveryP2pOptions = Joi.object({
   // Endpoint ids whose announcements are ignored and whose snapshots are
   // never fetched — the v1 spam/abuse lever.
   blockedPeers: Joi.array().items(Joi.string().hex().length(64)).default([]),
+  // Community seed nodes: well-known always-on mesh members whose tickets
+  // ship with mStream (baked defaults + the remote list below), so a fresh
+  // server joins the PUBLIC discovery network with zero manual peer
+  // exchange — the Bitcoin DNS-seeds model. Default ON because discoveryP2p
+  // itself is the opt-in: enabling the feature means joining the network.
+  // Off = only your own bootstrapPeers are used (friend-to-friend mode).
+  useCommunitySeeds: Joi.boolean().default(true),
+  // Where the updatable seed list lives (rotating seeds = a commit to the
+  // mStream repo, no release needed). Fetched at most ~daily, cached at
+  // {dbDirectory}/discovery-p2p/seeds-cache.json, and every failure falls
+  // back cache → baked defaults — boot never depends on this URL.
+  seedListUrl: Joi.string().uri().default(
+    'https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/seeds/discovery-seeds.json'),
 });
 
 const dlnaOptions = Joi.object({

--- a/src/state/discovery-seeds.js
+++ b/src/state/discovery-seeds.js
@@ -1,0 +1,159 @@
+// Community seed nodes: how a fresh server finds the discovery network
+// without knowing anybody.
+//
+// A seed is a well-known, always-on gossip-mesh member (the standalone
+// mstream-discovery-seed binary — a separate repo; it relays but never
+// announces). Its endpoint ticket is public knowledge. New servers bootstrap
+// off the seeds, HyParView weaves them into the real mesh, and from then on
+// they know actual peers — seeds are training wheels, not hubs.
+//
+// The bootstrap set a server joins with is the union of three sources:
+//   1. DEFAULT_SEEDS      baked into each release (below)
+//   2. the remote list    seeds/discovery-seeds.json fetched from the repo —
+//                         rotating seeds is a commit, not a release. Cached
+//                         on disk (~daily refresh); fetch failure falls back
+//                         cache → baked. Boot never depends on the URL.
+//   3. config bootstrapPeers   the operator's own friends — always additive
+// minus config blockedPeers (seed entries carry their endpointId so the
+// blocklist applies to them; bare-id bootstrapPeers are filterable too,
+// opaque tickets pass through — documented limitation).
+//
+// Security posture (deliberate, documented): a malicious seed cannot forge
+// catalog entries (announcements are origin-signed) and cannot observe
+// queries (those never leave each machine). It COULD try to eclipse a
+// brand-new node — mitigations are multiple independent seeds, the user's
+// own bootstrapPeers bypassing seeds entirely, and HTTPS+GitHub as the
+// list's trust anchor. List signing is a planned upgrade, not a v1 feature.
+
+import fs from 'fs';
+import path from 'path';
+import winston from 'winston';
+import * as config from './config.js';
+import * as discoveryP2p from './discovery-p2p.js';
+
+// Baked-in seed entries, same shape as the remote list: {name, endpointId,
+// ticket}. Empty until the first community seeds are deployed (PR-2 fills
+// this alongside seeds/discovery-seeds.json).
+export const DEFAULT_SEEDS = [];
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10 * 1000;
+const MAX_SEEDS = 20;            // sanity cap on a fetched list
+const MAX_TICKET_LEN = 4096;
+// Mesh-health watch: if we're joined but have heard nobody for this long,
+// re-resolve (fresh remote fetch) and re-join — covers seed rotation that
+// happened after this release shipped.
+const HEALTH_INTERVAL_MS = 5 * 60 * 1000;
+
+function cachePath() {
+  return path.join(config.program.storage.dbDirectory, 'discovery-p2p', 'seeds-cache.json');
+}
+
+// Shape-check one seed entry from an untrusted source (the remote list is
+// HTTPS-from-GitHub, but validate anyway — a bad deploy shouldn't wedge boot).
+function validEntry(e) {
+  return e && typeof e === 'object'
+    && typeof e.ticket === 'string' && e.ticket.length >= 16 && e.ticket.length <= MAX_TICKET_LEN
+    && (e.endpointId === undefined || (typeof e.endpointId === 'string' && /^[0-9a-f]{64}$/.test(e.endpointId)));
+}
+
+function parseSeedList(raw) {
+  const doc = JSON.parse(raw);
+  if (!doc || doc.version !== 1 || !Array.isArray(doc.seeds)) {
+    throw new Error('unrecognized seed-list shape (want {version:1, seeds:[...]})');
+  }
+  return doc.seeds.filter(validEntry).slice(0, MAX_SEEDS);
+}
+
+// Merge seed entries + the operator's own bootstrapPeers into the final
+// bootstrap array (of tickets/ids), applying the blocklist where an id is
+// known. Pure — unit-testable without config or network.
+export function mergeSeedLists(baked, remote, userPeers, blockedPeers) {
+  const blocked = new Set(blockedPeers || []);
+  const out = [];
+  const seen = new Set();
+  for (const entry of [...(baked || []), ...(remote || [])]) {
+    if (!validEntry(entry)) { continue; }
+    if (entry.endpointId && blocked.has(entry.endpointId)) { continue; }
+    if (seen.has(entry.ticket)) { continue; }
+    seen.add(entry.ticket);
+    out.push(entry.ticket);
+  }
+  for (const peer of (userPeers || [])) {
+    if (typeof peer !== 'string' || seen.has(peer)) { continue; }
+    // A bare endpoint id is filterable; an opaque ticket passes through.
+    if (/^[0-9a-f]{64}$/.test(peer) && blocked.has(peer)) { continue; }
+    seen.add(peer);
+    out.push(peer);
+  }
+  return out;
+}
+
+// The remote list, disk-cached. Returns [] rather than throwing — every
+// failure path is a WARN plus a fallback, never a boot problem.
+// localOnly: cache-or-nothing, no network — the boot path's phase one.
+async function remoteSeeds({ forceRefresh = false, localOnly = false } = {}) {
+  if (!config.program.discoveryP2p.useCommunitySeeds) { return []; }
+
+  let cached = null;
+  try {
+    const stat = fs.statSync(cachePath());
+    cached = parseSeedList(fs.readFileSync(cachePath(), 'utf8'));
+    if (!forceRefresh && Date.now() - stat.mtimeMs < CACHE_TTL_MS) { return cached; }
+  } catch (_err) { /* no cache yet, or unreadable — fetch below */ }
+  if (localOnly) { return cached || []; }
+
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+    const res = await fetch(config.program.discoveryP2p.seedListUrl, { signal: ctrl.signal });
+    clearTimeout(timer);
+    if (!res.ok) { throw new Error(`HTTP ${res.status}`); }
+    const raw = await res.text();
+    const seeds = parseSeedList(raw);
+    fs.mkdirSync(path.dirname(cachePath()), { recursive: true });
+    fs.writeFileSync(cachePath(), raw);
+    return seeds;
+  } catch (err) {
+    winston.warn(`community seed list fetch failed (${err.message}) — using ${cached ? 'cached copy' : 'baked defaults only'}`);
+    return cached || [];
+  }
+}
+
+// The full bootstrap set for gossip join. With {localOnly:true} this is
+// network-free (baked + disk cache + config) — the boot path joins with
+// that IMMEDIATELY so the topic subscription never waits on a fetch, then
+// phase two re-resolves with the network and join_peers()-merges any
+// additions. Without localOnly it may block ≤10s on the list fetch.
+export async function resolveBootstrap(opts = {}) {
+  const remote = await remoteSeeds(opts);
+  return mergeSeedLists(
+    config.program.discoveryP2p.useCommunitySeeds ? DEFAULT_SEEDS : [],
+    remote,
+    config.program.discoveryP2p.bootstrapPeers,
+    config.program.discoveryP2p.blockedPeers,
+  );
+}
+
+// Watch the mesh after boot: joined-but-zero-neighbors for a full interval
+// means our bootstrap set is stale or the peers are gone — re-resolve with a
+// forced list refresh and join again (join_peers is idempotent, so this can
+// never hurt an already-healthy mesh). Idempotent across server reboot()s.
+let watchTimer = null;
+export function startMeshHealthWatch() {
+  if (watchTimer) { return; }
+  watchTimer = setInterval(async () => {
+    try {
+      if (!discoveryP2p.isRunning()) { return; }
+      const s = await discoveryP2p.status();
+      if (!s.joined || s.neighbors > 0) { return; }
+      const bootstrap = await resolveBootstrap({ forceRefresh: true });
+      if (bootstrap.length === 0) { return; } // nothing to join with — nothing to do
+      winston.info(`[discovery-seeds] no mesh neighbors — re-joining with ${bootstrap.length} bootstrap peer(s)`);
+      await discoveryP2p.join(bootstrap);
+    } catch (err) {
+      winston.warn(`[discovery-seeds] mesh health check failed: ${err.message}`);
+    }
+  }, HEALTH_INTERVAL_MS);
+  if (watchTimer.unref) { watchTimer.unref(); }
+}

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -163,6 +163,15 @@ export async function startServer(opts = {}) {
     // (MSTREAM_*_BASE).
     ...extraConfig,
     scanOptions: { autoAlbumArt: false, ...(extraConfig.scanOptions || {}) },
+    // Same guard idea for the discovery network's community-seed list:
+    // config.js defaults seedListUrl to the REAL GitHub raw URL, so any test
+    // enabling discoveryP2p would otherwise fetch the internet at every
+    // boot. Point it at a dead local port (fails fast, falls back to baked
+    // defaults = none) unless the test brings its own stub URL.
+    discoveryP2p: {
+      seedListUrl: 'http://127.0.0.1:9/discovery-seeds.json',
+      ...(extraConfig.discoveryP2p || {}),
+    },
   };
 
   const configPath = path.join(tmpDir, 'config.json');

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -41,6 +41,7 @@ import { spawn } from 'node:child_process';
 import { DatabaseSync } from 'node:sqlite';
 import { startServer } from '../helpers/server.mjs';
 import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
+import { mergeSeedLists } from '../../src/state/discovery-seeds.js';
 
 const SIDECAR_BIN = resolveSidecarBinary();
 
@@ -608,5 +609,155 @@ describe('discovery p2p — similarity search + novelty filter', () => {
       const entry = s.peerDbs.find((p) => p.endpointId === peer.endpointId);
       return entry && entry.rowCount === 2 ? entry : null;
     }, { timeoutMs: 30000, what: 'auto-fetch to refresh the stale snapshot' });
+  });
+});
+
+// ── Community seeds: merge logic (pure, no server) ──────────────────────────
+describe('discovery seeds — mergeSeedLists', () => {
+  const T = (n) => `endpointticket${'x'.repeat(16)}${n}`;
+  const ID_A = 'a'.repeat(64);
+
+  test('merges baked + remote + user peers, deduped, in order', () => {
+    const out = mergeSeedLists(
+      [{ name: 's1', ticket: T(1) }],
+      [{ name: 's2', ticket: T(2) }, { name: 'dup', ticket: T(1) }],
+      [T(3), T(2)],
+      [],
+    );
+    assert.deepEqual(out, [T(1), T(2), T(3)]);
+  });
+
+  test('blocklist removes seeds by endpointId and bare-id user peers', () => {
+    const out = mergeSeedLists(
+      [{ name: 'blocked-seed', endpointId: ID_A, ticket: T(1) }],
+      [{ name: 'ok', ticket: T(2) }],
+      [ID_A, T(3)],
+      [ID_A],
+    );
+    assert.deepEqual(out, [T(2), T(3)]);
+  });
+
+  test('malformed entries are dropped, never thrown on', () => {
+    const out = mergeSeedLists(
+      [null, {}, { ticket: 42 }, { ticket: 'short' }, { name: 'ok', ticket: T(1) }],
+      [{ ticket: T(2), endpointId: 'NOT-HEX' }],
+      [123, null],
+      [],
+    );
+    assert.deepEqual(out, [T(1)]);
+  });
+});
+
+// ── Community seeds: the full boot path against a stub list server ──────────
+// A local HTTP server plays the role of raw.githubusercontent.com; a raw
+// sidecar plays the community seed. The mStream server must fetch the list,
+// cache it, bootstrap off the listed ticket, and hear announcements through
+// the mesh — the complete PR-2 behavior with zero real infrastructure.
+(SIDECAR_BIN ? describe : describe.skip)('discovery seeds — boot joins via fetched seed list', () => {
+  let server;
+  let seedNode;      // raw sidecar acting as the community seed (relay only)
+  let peerNode;      // raw sidecar acting as another mStream server
+  let listServer;
+  let listUrl;
+  let listHits = 0;
+  let tmpDir;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-seeds-'));
+    seedNode = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'seed'));
+    await seedNode.ready;
+    // The seed joins with no bootstrap — it IS the first node.
+    await seedNode.rpc('join', { bootstrap: [] });
+
+    // Stub "GitHub raw" endpoint serving a v1 seed list with the seed's ticket.
+    const http = await import('node:http');
+    listServer = http.createServer((req, res) => {
+      listHits += 1;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        version: 1,
+        seeds: [{ name: 'test-seed', endpointId: seedNode.endpointId, ticket: seedNode.ticket }],
+      }));
+    });
+    await new Promise((r) => listServer.listen(0, '127.0.0.1', r));
+    listUrl = `http://127.0.0.1:${listServer.address().port}/discovery-seeds.json`;
+
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      extraConfig: {
+        discoveryP2p: { enabled: true, serverName: 'Seed Test Server', seedListUrl: listUrl },
+        scanOptions: { collectDiscoveryData: true },
+      },
+    });
+
+    peerNode = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'peer'));
+    await peerNode.ready;
+  });
+  after(async () => {
+    if (peerNode) { await peerNode.stop(); }
+    if (seedNode) { await seedNode.stop(); }
+    if (server) { await server.stop(); }
+    if (listServer) { listServer.close(); }
+    if (tmpDir) { fs.rmSync(tmpDir, { recursive: true, force: true }); }
+  });
+
+  test('server fetches the list, caches it, and meshes through the seed', async () => {
+    // The boot path must have pulled the stub list at least once and written
+    // the on-disk cache next to the catalog.
+    await pollUntil(() => listHits > 0, { what: 'seed list to be fetched' });
+    const cache = path.join(server.tmpDir, 'db', 'discovery-p2p', 'seeds-cache.json');
+    await pollUntil(() => fs.existsSync(cache), { what: 'seed list cache on disk' });
+    assert.equal(JSON.parse(fs.readFileSync(cache, 'utf8')).seeds[0].name, 'test-seed');
+
+    // A peer that knows ONLY the seed announces; the server (which also knows
+    // only the seed) must hear it through the mesh — the strangers-meeting
+    // scenario community seeds exist for.
+    await peerNode.rpc('join', { bootstrap: [seedNode.ticket] });
+    await peerNode.waitForEvent('neighbor', (e) => e.up === true);
+    await peerNode.rpc('announce', {
+      payload: { hash: 'c'.repeat(64), size: 4096, rowCount: 7,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Stranger' },
+    });
+
+    const entry = await pollUntil(async () => {
+      const c = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`)).json();
+      return c.peers.find((p) => p.from === peerNode.endpointId) || null;
+    }, { timeoutMs: 30000, what: "stranger's announcement via the seed mesh" });
+    assert.equal(entry.payload.name, 'Stranger');
+
+    // The status route surfaces the community-seeds mode for the admin UI.
+    const status = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+    assert.equal(status.communitySeeds, true);
+  });
+});
+
+// ── Community seeds: dead URL must not break boot or friend-to-friend ───────
+describe('discovery seeds — unreachable list degrades gracefully', () => {
+  let server;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      extraConfig: {
+        discoveryP2p: {
+          enabled: true,
+          // Nothing listens here — the fetch fails fast and falls back.
+          seedListUrl: 'http://127.0.0.1:9/discovery-seeds.json',
+        },
+        scanOptions: { collectDiscoveryData: true },
+      },
+    });
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('server boots, joins the topic, and the p2p surface works', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running ? s : null;
+    }, { timeoutMs: 30000, what: 'sidecar up despite dead seed URL' });
+    // With the binary present the sidecar must still be running and joined-
+    // or-joinable; without it the route still answers. Either way the dead
+    // URL must not have prevented the boot path from completing.
+    assert.equal(status.enabled, true);
   });
 });

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1985,6 +1985,7 @@ const dbView = Vue.component('db-view', {
                   <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
                     {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
                     — auto-fetch {{ discoveryP2p.autoFetch ? 'on' : 'off' }}
+                    — community seeds {{ discoveryP2p.status.communitySeeds ? 'on (public network)' : 'off (friends only)' }}
                   </p>
                   <table v-if="discoveryP2p.peers.length > 0">
                     <thead><tr><th>Server</th><th>Tracks</th><th>Online</th><th>Model</th><th>Downloaded</th><th></th></tr></thead>


### PR DESCRIPTION
## What

The mStream half of community seed nodes: a fresh server enabling `discoveryP2p` should join the **public discovery network with zero manual peer exchange** — today it hears silence until the operator swaps tickets with a friend. Seeds are well-known, always-on gossip-mesh members whose tickets ship with mStream (the Bitcoin DNS-seeds model); HyParView weaves newcomers from the seed into the real mesh, so seeds are training wheels, not hubs.

**This PR is inert until real seeds exist** — the baked list is empty and `seeds/discovery-seeds.json` ships with zero entries. No behavior change on merge.

## Pieces

- **`src/state/discovery-seeds.js`** — bootstrap = baked `DEFAULT_SEEDS` + the remote list (fetched from this repo's `seeds/discovery-seeds.json`; **rotating seeds is a commit, not a release**; disk-cached ~daily; every failure falls back cache → baked) + the operator's `bootstrapPeers`, minus `blockedPeers` (seed entries carry `endpointId` so the blocklist reaches them).
- **Two-phase join** — the topic subscription happens *immediately* with locally-known peers (zero network), then the community list refreshes and `join_peers()`-merges additions. Honest note: the first cut awaited the fetch before joining, and the **existing gossip tests caught the race** (peers bootstrapping off our ticket found a live endpoint but no topic subscription yet) — the failure forced this better design.
- **Mesh-health watch** — joined-but-alone for a full interval triggers a forced list refresh + re-join, covering seeds rotated out after a release shipped.
- **Config** — `useCommunitySeeds` (default **on**: the feature itself is the opt-in, and enabling it now means joining the public network — the admin card says so explicitly) and `seedListUrl` (fork/test override).
- **Test hygiene** — the server helper now defaults `seedListUrl` to a dead local port for every suite (the `autoAlbumArt`-guard pattern), so tests never fetch GitHub.

## Security posture

A malicious seed **cannot forge** catalog entries (origin-signed announcements) and **cannot observe** queries (local-only). The real residual risk is **eclipsing a brand-new node**; mitigations are multiple independent seeds, user `bootstrapPeers` bypassing seeds entirely, and HTTPS+GitHub as the list's trust anchor. Signing the list is a planned upgrade, deliberately not v1.

## Tests

Discovery suite 25/25; full suite **1553/1553**. New coverage: merge/dedupe/blocklist units; a full-stack proof (stub HTTP server plays GitHub, a raw sidecar plays the seed — the server fetches the list, caches it, and hears a *stranger's* announcement through the seed's mesh: the exact scenario seeds exist for); and a dead-URL suite proving boot never depends on the list endpoint.

## What comes next (not in this PR)

1. The seed binary — separate `mstream-discovery-seed` repo (tiny standalone Rust crate + release CI + Docker; keeps ops/packaging out of this repo).
2. Deploy 1–2 seeds, collect tickets.
3. PR-2: add the real tickets to `seeds/discovery-seeds.json` — the moment it merges, every updated server joins one network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)