### PR TITLE
fix(discovery): live-run UX polish — zero-touch publish + 5 fixes

### DIFF
--- a/p2p-sidecar/src/main.rs
+++ b/p2p-sidecar/src/main.rs
@@ -389,7 +389,13 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
                     .download(hash, iroh_blobs::api::downloader::Shuffled::new(ids))
                     .await
                     .map_err(|e| anyhow!("swarm transfer failed (no reachable provider): {e}"))?;
-                let out_path = out_dir.join(format!("{hash}.db"));
+                    // Short filename on purpose: the full 64-hex hash + ".db" burned
+                // 67 chars of Windows' 260-char MAX_PATH budget, so a deep
+                // dbDirectory produced a file Node/SQLite could not open (Rust
+                // writes long paths fine via \\?\ — that asymmetry is the trap).
+                // 16 hex is plenty unique for a per-peer shelf; the full hash
+                // travels in the RPC response and the Node-side registry.
+                let out_path = out_dir.join(format!("{}.db", &hash.to_string()[..16]));
                 node.store.blobs().export(hash, out_path.clone()).await
                     .map_err(|e| anyhow!("export to file failed: {e}"))?;
                 let size = tokio::fs::metadata(&out_path).await?.len();
@@ -417,7 +423,9 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
             node.store.remote().fetch(conn, hash).await
                 .map_err(|e| anyhow!("transfer failed: {e}"))?;
 
-            let out_path = out_dir.join(format!("{hash}.db"));
+            // Short filename on purpose — see the swarm branch above for the
+            // Windows MAX_PATH rationale.
+            let out_path = out_dir.join(format!("{}.db", &hash.to_string()[..16]));
             node.store.blobs().export(hash, out_path.clone()).await
                 .map_err(|e| anyhow!("export to file failed: {e}"))?;
             let size = tokio::fs::metadata(&out_path).await?.len();

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -437,13 +437,29 @@ export function setup(mstream) {
   // stopped rather than starting it (publish/fetch/join are the lazy-starters).
   // `ticket` is what another operator pastes into their bootstrapPeers config
   // (or POSTs to /join) to befriend this server.
-  mstream.get("/api/v1/admin/discovery/p2p/status", (req, res) => {
+  mstream.get("/api/v1/admin/discovery/p2p/status", async (req, res) => {
+    // Live mesh state from the sidecar — joined + neighbor count is the
+    // only way an operator can tell "am I actually connected to the
+    // network?" as opposed to "the process is running".
+    let joined = false;
+    let neighbors = 0;
+    if (discoveryP2p.isRunning()) {
+      try {
+        const s = await discoveryP2p.status();
+        joined = s.joined === true;
+        neighbors = Number(s.neighbors) || 0;
+      } catch (err) {
+        winston.warn(`discovery p2p sidecar status query failed: ${err.message}`);
+      }
+    }
     res.json({
       enabled: config.program.discoveryP2p.enabled,
       binaryFound: discoveryP2p.resolveSidecarBinary() !== null,
       running: discoveryP2p.isRunning(),
       endpointId: discoveryP2p.getEndpointId(),
       ticket: discoveryP2p.getEndpointTicket(),
+      joined,
+      neighbors,
       knownPeers: discoveryCatalog.size(),
       communitySeeds: config.program.discoveryP2p.useCommunitySeeds,
     });

--- a/src/db/discovery-export.js
+++ b/src/db/discovery-export.js
@@ -93,6 +93,7 @@ export async function exportDiscoverySnapshot(opts = {}) {
   db.exec(`ATTACH DATABASE '${attachTarget}' AS snap`);
 
   let rowCount;
+  let sourceRowSeq;
   try {
     // One transaction around the whole build: the main connection spans both
     // schemas, so the snapshot is a consistent point-in-time view even if a
@@ -162,6 +163,10 @@ export async function exportDiscoverySnapshot(opts = {}) {
       `);
 
       rowCount = db.prepare('SELECT COUNT(*) AS n FROM snap.tracks').get().n;
+      // Captured INSIDE the transaction so it can't overshoot the snapshot's
+      // actual content: auto-publish compares this against the live row_seq
+      // to decide whether the export is stale.
+      sourceRowSeq = Number(getMeta('row_seq') || 0);
 
       const putMeta = db.prepare('INSERT OR REPLACE INTO snap.meta (key, value) VALUES (?, ?)');
       putMeta.run('format', SNAPSHOT_FORMAT);
@@ -200,6 +205,10 @@ export async function exportDiscoverySnapshot(opts = {}) {
     sizeBytes: fs.statSync(finalPath).size,
     sha256: await sha256File(finalPath),
     rowCount,
+    // discovery_meta.row_seq at build time — the freshness watermark
+    // auto-publish (discovery-p2p.js) compares against. Not share-relevant
+    // (the manifest never travels with the snapshot blob).
+    sourceRowSeq,
     model: {
       id: getMeta('embedding_model_id'),
       version: getMeta('embedding_model_version'),

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -10,7 +10,7 @@ import { writeScannerPidfile, clearScannerPidfile } from './scan-pidfile.js';
 import { SCHEMA_VERSION } from './schema.js';
 import { getDirname, appRoot } from '../util/esm-helpers.js';
 import { launchWorker, workerReaperMarker } from '../util/worker-process.js';
-import { ffmpegBin } from '../util/ffmpeg-bootstrap.js';
+import { ffmpegBin, ensureFfmpeg } from '../util/ffmpeg-bootstrap.js';
 import * as dlnaApi from '../api/dlna.js';
 import * as discoveryDb from './discovery-db.js';
 
@@ -223,6 +223,22 @@ function tryMuslRetry(scanObj, reason) {
 // scattered across the file (scanner stdout, scanner stderr, backup
 // stdout, backup stderr) and any tweak to the buffering invariant had
 // to be made in all four places.
+// Forked-worker stderr → log level. Node runtime chatter (the
+// "(node:PID) ExperimentalWarning: …" banner and its "(Use `node
+// --trace-warnings …" follow-up) is not a worker failure — it was painting
+// red error lines over every fresh boot via the node:sqlite experimental
+// warning. Real errors stay error-level.
+function logWorkerStderr(prefix, line) {
+  if (!line) { return; }
+  if (/^\(node:\d+\)/.test(line) || line.startsWith('(Use `node ')) {
+    winston.debug(`${prefix}: ${line}`);
+  } else if (line.startsWith('Warning:')) {
+    winston.warn(`${prefix}: ${line}`);
+  } else {
+    winston.error(`${prefix} error: ${line}`);
+  }
+}
+
 function bufferLines(stream, onLine) {
   let buffer = '';
   stream.on('data', (chunk) => {
@@ -539,11 +555,7 @@ function attachScanHandlers(forkedScan, scanObj) {
   // (metadata parse failures fall back to null tags; the track still gets
   // indexed) and are logged at warn level so a library with malformed ID3
   // tags doesn't flood error-level log streams. Anything else is a real error.
-  bufferLines(forkedScan.stderr, (line) => {
-    if (!line) { return; }
-    if (line.startsWith('Warning:')) { winston.warn(`File scan: ${line}`); }
-    else { winston.error(`File scan error: ${line}`); }
-  });
+  bufferLines(forkedScan.stderr, (line) => logWorkerStderr('File scan', line));
 }
 
 function onScanClose(forkedScan, scanObj, code) {
@@ -738,11 +750,7 @@ function runWaveformTask(taskObj) {
     }
     winston.info(line);
   });
-  bufferLines(wfChild.stderr, (line) => {
-    if (!line) { return; }
-    if (line.startsWith('Warning:')) { winston.warn(`Waveform pass: ${line}`); }
-    else { winston.error(`Waveform pass error: ${line}`); }
-  });
+  bufferLines(wfChild.stderr, (line) => logWorkerStderr('Waveform pass', line));
 
   let closed = false;
   const closeOnce = (code, signal) => {
@@ -908,11 +916,7 @@ function runAlbumArtTask(taskObj) {
     }
     winston.info(line);
   });
-  bufferLines(forked.stderr, (line) => {
-    if (!line) { return; }
-    if (line.startsWith('Warning:')) { winston.warn(`Album-art download: ${line}`); }
-    else { winston.error(`Album-art download error: ${line}`); }
-  });
+  bufferLines(forked.stderr, (line) => logWorkerStderr('Album-art download', line));
 
   // Same close/error double-fire latch as the backup + waveform workers.
   let closed = false;
@@ -1061,11 +1065,7 @@ function runLyricsTask(taskObj) {
     }
     winston.info(line);
   });
-  bufferLines(forked.stderr, (line) => {
-    if (!line) { return; }
-    if (line.startsWith('Warning:')) { winston.warn(`Lyrics backfill: ${line}`); }
-    else { winston.error(`Lyrics backfill error: ${line}`); }
-  });
+  bufferLines(forked.stderr, (line) => logWorkerStderr('Lyrics backfill', line));
 
   // Same close/error double-fire latch as the album-art + waveform workers.
   let closed = false;
@@ -1129,16 +1129,32 @@ const AUDIO_ANALYSIS_SCRIPT_PATH = path.join(__dirname, './audio-analysis-backfi
 const ANALYSIS_MIN_DURATION_SEC = 30;
 const ANALYSIS_MAX_DURATION_SEC = 30 * 60;
 
+// First-boot race: a small scan can drain BEFORE ffmpeg-bootstrap has
+// resolved a binary (its download/probe takes seconds; six files scan in
+// two). The old behavior silently postponed the enrichment pass to the
+// NEXT scan — a day away at the default scanInterval. Instead, piggyback
+// on the (already in-flight, promise-cached) ensureFfmpeg() and re-run the
+// enqueue when it settles. Set-dedup so a burst of scan-drains registers
+// one retry per gate.
+const ffmpegRetryWaiters = new Set();
+function retryWhenFfmpegResolves(retryFn) {
+  if (ffmpegRetryWaiters.has(retryFn)) { return; }
+  ffmpegRetryWaiters.add(retryFn);
+  ensureFfmpeg().catch(() => null).then(() => {
+    ffmpegRetryWaiters.delete(retryFn);
+    if (ffmpegBin()) { retryFn(); }
+    else { winston.warn('Enrichment pass skipped — no working ffmpeg could be resolved'); }
+  });
+}
+
 // Enqueue unless the feature is off, ffmpeg isn't resolved, or nothing is
 // eligible. Exported so the admin analyze-bpm toggle routes through the same
 // gates as the scan-drain trigger.
 export function maybeEnqueueAudioAnalysis() {
   if (config.program.scanOptions.analyzeBpm !== true) { return; }
-  // No decoder, no analysis — bail quietly. ffmpeg-bootstrap resolves early in
-  // boot, so by the time a scan drains this is normally set; if not, the next
-  // scan-drain (or the admin toggle) retries.
   if (!ffmpegBin()) {
-    winston.info('Audio-analysis pass skipped — ffmpeg not resolved yet');
+    winston.info('Audio-analysis pass deferred — waiting for ffmpeg to resolve');
+    retryWhenFfmpegResolves(maybeEnqueueAudioAnalysis);
     return;
   }
 
@@ -1232,11 +1248,7 @@ function runAudioAnalysisTask(taskObj) {
     }
     winston.info(line);
   });
-  bufferLines(forked.stderr, (line) => {
-    if (!line) { return; }
-    if (line.startsWith('Warning:')) { winston.warn(`Audio-analysis: ${line}`); }
-    else { winston.error(`Audio-analysis error: ${line}`); }
-  });
+  bufferLines(forked.stderr, (line) => logWorkerStderr('Audio-analysis', line));
 
   let closed = false;
   const closeOnce = (code, signal) => {
@@ -1295,7 +1307,8 @@ const DISCOVERY_MAX_DURATION_SEC = 30 * 60;
 export function maybeEnqueueDiscovery() {
   if (config.program.scanOptions.collectDiscoveryData !== true) { return; }
   if (!ffmpegBin()) {
-    winston.info('Discovery-embedding pass skipped — ffmpeg not resolved yet');
+    winston.info('Discovery-embedding pass deferred — waiting for ffmpeg to resolve');
+    retryWhenFfmpegResolves(maybeEnqueueDiscovery);
     return;
   }
 
@@ -1408,11 +1421,7 @@ function runDiscoveryTask(taskObj) {
     }
     winston.info(line);
   });
-  bufferLines(forked.stderr, (line) => {
-    if (!line) { return; }
-    if (line.startsWith('Warning:')) { winston.warn(`Discovery-embedding: ${line}`); }
-    else { winston.error(`Discovery-embedding error: ${line}`); }
-  });
+  bufferLines(forked.stderr, (line) => logWorkerStderr('Discovery-embedding', line));
 
   let closed = false;
   const closeOnce = (code, signal) => {
@@ -1435,6 +1444,16 @@ function runDiscoveryTask(taskObj) {
     // embedding (drops out of the eligible set) or an error-cooldown row.
     if (code === 0 && !signal && observers.hitCap) {
       maybeEnqueueDiscovery();
+    }
+    // Backlog drained (no follow-up batch got queued — covers both the
+    // terminal pass and the backlog-size-divisible-by-cap edge where the
+    // re-enqueue pre-check finds nothing left): publish the results to the
+    // discovery network. No-ops unless p2p is enabled and the dataset
+    // actually advanced past the last announced snapshot.
+    if (code === 0 && !signal && !taskQueue.some((t) => t.task === 'discovery')) {
+      import('../state/discovery-p2p.js')
+        .then((p2p) => p2p.maybeAutoPublishSnapshot())
+        .catch((err) => winston.warn(`discovery auto-publish after embedding pass failed: ${err.message}`));
     }
     nextTask();
     checkQueueDrainedSideEffects();

--- a/src/server.js
+++ b/src/server.js
@@ -509,10 +509,15 @@ export async function serveIt(configFile) {
             winston.warn(`[discovery-seeds] community list refresh failed: ${err.message}`);
           });
           try {
-            const r = await p2p.announceCurrentSnapshot();
-            winston.info(`[discovery-p2p] catalog joined; announced snapshot ${r.hash.slice(0, 12)}…`);
-          } catch (_err) {
-            winston.info('[discovery-p2p] catalog joined; nothing to announce yet (no export snapshot)');
+            // Builds the export first when the collected dataset is ahead of
+            // (or has never had) a snapshot — a server whose embeddings
+            // finished while p2p was off still shows up on the network.
+            const r = await p2p.maybeAutoPublishSnapshot({ announceEvenIfFresh: true });
+            if (!r.published) {
+              winston.info('[discovery-p2p] catalog joined; nothing to announce yet (no discovery data)');
+            }
+          } catch (err) {
+            winston.warn(`[discovery-p2p] catalog joined; snapshot announce failed: ${err.message}`);
           }
           // Auto-fetch: keep a local shelf of the best catalog peers'
           // snapshots so the /api/v1/discovery/p2p/similar surface has data to

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -287,6 +287,45 @@ export async function announceCurrentSnapshot() {
   return { ...pub, announced: true, broadcast: !!result.broadcast, payload };
 }
 
+// Auto-publish: rebuild the export snapshot and announce it whenever the
+// collected dataset has advanced past what the network last saw. This is
+// what makes a fresh server APPEAR on the network with zero admin steps
+// (scan → embed → here → announced) — before it existed, a server stayed
+// invisible until an operator manually curl'd export + announce. Cheap to
+// call often: it compares discovery_meta.row_seq against the manifest's
+// sourceRowSeq watermark and no-ops when the published snapshot is
+// current. announceEvenIfFresh re-broadcasts an up-to-date snapshot (the
+// boot path — a restarted sidecar needs its announce payload back).
+let autoPublishInFlight = false;
+export async function maybeAutoPublishSnapshot({ announceEvenIfFresh = false } = {}) {
+  if (config.program.discoveryP2p.enabled !== true) { return { published: false }; }
+  if (autoPublishInFlight) { return { published: false }; }
+  autoPublishInFlight = true;
+  try {
+    const discoveryExport = await import('../db/discovery-export.js');
+    const discoveryDb = await import('../db/discovery-db.js');
+    if (!discoveryDb.openDiscoveryDbIfExists()) { return { published: false }; }
+    const rowSeq = Number(discoveryDb.getMeta('row_seq') || 0);
+    const manifest = discoveryExport.readManifest();
+    const stale = !manifest || !discoveryExport.snapshotExists()
+      || Number(manifest.sourceRowSeq || 0) < rowSeq;
+    if (stale) {
+      if (rowSeq === 0) { return { published: false }; } // nothing collected yet
+      const built = await discoveryExport.exportDiscoverySnapshot();
+      winston.info(`[discovery-p2p] dataset advanced (seq ${rowSeq}) — rebuilt export `
+        + `(${built.rowCount} tracks) for announcement`);
+    } else if (!announceEvenIfFresh) {
+      return { published: false };
+    }
+    const r = await announceCurrentSnapshot();
+    winston.info(`[discovery-p2p] announced snapshot ${r.hash.slice(0, 12)}… `
+      + `(${r.payload.rowCount} tracks, seq ${r.payload.snapshotSeq})`);
+    return { published: true, hash: r.hash, rebuilt: stale };
+  } finally {
+    autoPublishInFlight = false;
+  }
+}
+
 // Graceful stop: ask politely, then close stdin (the sidecar's EOF exit
 // path), then SIGKILL as the last resort.
 export async function stop() {

--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -215,8 +215,12 @@ export async function fetchPeer(endpointId) {
   };
   registry.set(endpointId, record);
   save();
+  const sizeLabel = record.sizeBytes >= 1048576
+    ? `${Math.round(record.sizeBytes / 1048576)}MB` : `${Math.round(record.sizeBytes / 1024)}KB`;
   winston.info(`[discovery-peer-dbs] fetched ${endpointId.slice(0, 12)}… `
-    + `(${record.rowCount} tracks, ${Math.round(record.sizeBytes / 1048576)}MB)`);
+    + `(${record.rowCount} tracks, ${sizeLabel})`);
+  // Any success (auto or manual admin fetch) resets the failure backoff.
+  clearFetchBackoff(endpointId);
   // We now hold (and therefore seed) this snapshot — tell the network.
   pushHolds();
   return record;
@@ -330,6 +334,33 @@ function candidateOrder(a, b) {
   return (b.payload.rowCount || 0) - (a.payload.rowCount || 0);
 }
 
+// Failure backoff: a peer whose fetch keeps failing (unreachable, invalid
+// snapshot, disk trouble) must not be retried on every 30s reconcile
+// forever — that's a warn-spam firehose and pointless network churn.
+// Exponential per-peer cooldown, reset by any success (including a manual
+// admin fetch, which deliberately bypasses the backoff). In-memory only:
+// a reboot retrying immediately is fine.
+const FETCH_BACKOFF_BASE_MS = 2 * 60 * 1000;
+const FETCH_BACKOFF_MAX_MS = 60 * 60 * 1000;
+const fetchFailures = new Map(); // endpointId -> { failures, nextTryMs }
+
+function recordFetchFailure(endpointId) {
+  const cur = fetchFailures.get(endpointId) || { failures: 0 };
+  const failures = cur.failures + 1;
+  const delay = Math.min(FETCH_BACKOFF_BASE_MS * 2 ** (failures - 1), FETCH_BACKOFF_MAX_MS);
+  fetchFailures.set(endpointId, { failures, nextTryMs: Date.now() + delay });
+  return delay;
+}
+
+export function clearFetchBackoff(endpointId) {
+  fetchFailures.delete(endpointId);
+}
+
+function inFetchBackoff(endpointId) {
+  const cur = fetchFailures.get(endpointId);
+  return cur !== undefined && Date.now() < cur.nextTryMs;
+}
+
 // One reconcile pass: refresh stale shelf entries, then top up to
 // autoFetchCount from the best-looking catalog peers. Serialized; failures
 // log and move on (an unreachable peer must not wedge the loop).
@@ -359,10 +390,13 @@ export async function reconcile() {
     }
 
     for (const endpointId of targets) {
+      if (inFetchBackoff(endpointId)) { continue; }
       try {
-        await fetchPeer(endpointId);
+        await fetchPeer(endpointId); // success clears the backoff internally
       } catch (err) {
-        winston.warn(`[discovery-peer-dbs] auto-fetch of ${endpointId.slice(0, 12)}… failed: ${err.message}`);
+        const delayMs = recordFetchFailure(endpointId);
+        winston.warn(`[discovery-peer-dbs] auto-fetch of ${endpointId.slice(0, 12)}… failed `
+          + `(retry in ~${Math.round(delayMs / 60000)}min): ${err.message}`);
       }
     }
   } finally {

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -864,3 +864,95 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
       'bytes fetched from a non-author holder must match the original exactly');
   });
 });
+
+// ── Zero-touch auto-publish ─────────────────────────────────────────────────
+// The live-run polish headline: a fresh server with collection + p2p enabled
+// must appear on the network — export built, snapshot announced — with ZERO
+// admin steps. This suite never POSTs discovery-export or announce; the
+// announcement must arrive purely from scan → embed → auto-publish.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — zero-touch auto-publish', () => {
+  let server;
+  let peer;
+  let peerDir;
+  let musicDir;
+
+  // Minimal PCM WAV writer (8kHz mono 16-bit sine) — the shared fixtures are
+  // all shorter than the worker's 30s eligibility floor, and generating
+  // audio in JS keeps this hermetic (no encoder needed; the worker's ffmpeg
+  // decode is already a prereq of the other discovery-worker suites).
+  function writeSineWav(filePath, seconds) {
+    const rate = 8000;
+    const n = rate * seconds;
+    const data = Buffer.alloc(n * 2);
+    for (let i = 0; i < n; i++) {
+      data.writeInt16LE(Math.round(Math.sin((2 * Math.PI * 440 * i) / rate) * 12000), i * 2);
+    }
+    const header = Buffer.alloc(44);
+    header.write('RIFF', 0); header.writeUInt32LE(36 + data.length, 4);
+    header.write('WAVE', 8); header.write('fmt ', 12);
+    header.writeUInt32LE(16, 16); header.writeUInt16LE(1, 20); header.writeUInt16LE(1, 22);
+    header.writeUInt32LE(rate, 24); header.writeUInt32LE(rate * 2, 28);
+    header.writeUInt16LE(2, 32); header.writeUInt16LE(16, 34);
+    header.write('data', 36); header.writeUInt32LE(data.length, 40);
+    fs.writeFileSync(filePath, Buffer.concat([header, data]));
+  }
+
+  before(async () => {
+    musicDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-zerotouch-lib-'));
+    writeSineWav(path.join(musicDir, 'long-tone.wav'), 35);
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: true,
+      extraFolders: { zerotouch: musicDir },
+      extraConfig: {
+        discoveryP2p: { enabled: true, serverName: 'Zero Touch' },
+        scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' },
+      },
+    });
+    peerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-zt-'));
+    peer = new RawSidecar(SIDECAR_BIN, path.join(peerDir, 'sidecar'));
+    await peer.ready;
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    for (const d of [peerDir, musicDir]) {
+      if (d) { fs.rmSync(d, { recursive: true, force: true }); }
+    }
+  });
+
+  test('scan → embed → export + announce, with no admin calls', async (t) => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'sidecar to boot' });
+
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    // The announcement arrives on its own: the embedding pass drains,
+    // auto-publish rebuilds the export and announces, and the sidecar's
+    // 15s re-broadcast loop covers the join-after-publish ordering.
+    const heard = await peer.waitForEvent('announcement',
+      (e) => e.from === status.endpointId && (e.payload.rowCount || 0) > 0, 90000);
+    assert.equal(heard.payload.name, 'Zero Touch');
+    assert.equal(heard.payload.rowCount, 1, 'exactly the one eligible (≥30s) track');
+    assert.ok(heard.payload.snapshotSeq > 0, 'announces the app-managed row_seq');
+
+    // The export the announcement points at exists and carries the
+    // freshness watermark auto-publish keys off.
+    const manifest = await (await fetch(
+      `${server.baseUrl}/api/v1/admin/db/discovery-export/manifest`)).json();
+    assert.equal(manifest.rowCount, 1);
+    assert.equal(Number(manifest.sourceRowSeq), heard.payload.snapshotSeq,
+      'manifest sourceRowSeq must match the announced snapshotSeq');
+
+    // And the payload is really fetchable — the network got a usable blob.
+    const got = await peer.rpc('fetch', {
+      hash: heard.payload.hash, provider: heard.from,
+      outDir: path.join(peerDir, 'fetched'),
+    });
+    assert.equal(got.hash, heard.payload.hash);
+    t.diagnostic(`zero-touch announce heard; snapshot ${got.size} bytes`);
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1978,6 +1978,13 @@ const dbView = Vue.component('db-view', {
                     The p2p-sidecar binary was not found for this platform — the network is unavailable.
                   </p>
                   <p><b>Endpoint:</b> <code style="word-break: break-all;">{{ discoveryP2p.status.endpointId || '(sidecar not running yet)' }}</code></p>
+                  <p><b>Network:</b>
+                    <span v-if="discoveryP2p.status.neighbors > 0" style="color: #2e7d32;">connected
+                      — {{ discoveryP2p.status.neighbors }} mesh neighbor{{ discoveryP2p.status.neighbors === 1 ? '' : 's' }}</span>
+                    <span v-else-if="discoveryP2p.status.joined" style="color: #e65100;">joined, waiting for
+                      neighbors — the mesh weaves in within a minute or two of another server coming online</span>
+                    <span v-else>not joined yet</span>
+                  </p>
                   <p v-if="discoveryP2p.status.ticket"><b>Your ticket</b> — a friend pastes this into their
                   <code>discoveryP2p.bootstrapPeers</code> to befriend this server:<br>
                     <textarea readonly rows="2" style="width:100%; font-size: 0.8em;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>

--- a/webapp/alpha/spa.css
+++ b/webapp/alpha/spa.css
@@ -1943,7 +1943,10 @@ select {
   flex-shrink: 0;
   border-top: 1px solid #2c313a;
   background: #15171c;
-  max-height: 45%;
+  /* 60% (was 45%): the "From the network" section shares this budget with
+     the local list; content-sized below the cap, so short panels are
+     unaffected. */
+  max-height: 60%;
   display: flex;
   flex-direction: column;
 }
@@ -1986,10 +1989,17 @@ select {
   flex-direction: column;
   min-height: 0;
   padding: 0 0 6px 0;
+  /* Backstop only: when the panel cap is smaller than the sections'
+     minimums (tiny viewports), scroll the whole body rather than paint
+     rows over the footer/player bar. Invisible when content fits. */
+  overflow-y: auto;
 }
 .discover-rows {
   overflow-y: auto;
-  min-height: 0;
+  /* Never let pinned siblings (artists strip, network section, footer)
+     crush the song list to nothing — always keep ~1.5 rows visible. */
+  min-height: 58px;
+  flex: 1 1 auto;
 }
 .discover-hint {
   padding: 6px 14px 10px 14px;
@@ -2107,10 +2117,14 @@ select {
    marked as leads (teal match bar + peer name where genre tags would be)
    since these tracks aren't in the library and can't be queued. */
 .discover-network {
+  /* Deterministically bounded: at most ~3 lead rows visible (the inner
+     list scrolls for the rest), so it can never starve the local song
+     list of panel height — local results are playable, these are leads. */
   flex-shrink: 0;
   border-top: 1px solid #21252d;
   margin-top: 4px;
 }
+.discover-network .discover-rows { min-height: 0; max-height: 116px; }
 .discover-network-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

First real two-server live run over the community seed mesh (AU + EU), driving the whole pipeline as a fresh user would. It surfaced six issues; this PR fixes all of them. Headline: **a fresh server now appears on the discovery network with zero admin steps** — scan → embed → export → announce is fully automatic.

## The six findings

1. **Zero-touch publish** (the big one). The export snapshot was only ever built/announced via manual admin routes, so a fresh server with `collectDiscoveryData` + `discoveryP2p` on stayed invisible forever. Now:
   - the export manifest records a `sourceRowSeq` watermark (captured inside the build transaction),
   - `maybeAutoPublishSnapshot()` compares it to the live `discovery_meta.row_seq` and rebuilds + announces only when the dataset actually advanced,
   - called when the embedding backlog drains (incl. the backlog-divisible-by-cap edge where no terminal pass runs) and at boot with `announceEvenIfFresh` (covers "embedded while p2p was off"). The admin routes still work and share the same idempotent path.

2. **ffmpeg first-boot race.** A small library scan-drains before ffmpeg-bootstrap resolves, and the enrichment passes were silently postponed to the *next* scan — a day away at default `scanInterval`. The enqueue gates now piggyback the promise-cached `ensureFfmpeg()` and retry once it settles (observed live: deferred at boot+0.4s, pass started at boot+3s).

3. **Windows MAX_PATH bug.** Fetched snapshots were written as `discovery-peers/<64-hex>.db`; past 260 chars total, Rust writes the file fine (std auto-uses `\?\` verbatim paths) but **Node/SQLite cannot open it** — fetch "succeeded", validation failed with `unable to open database file`, cleanup deleted the evidence, and reconcile retried every 30s forever. The sidecar now exports `<16-hex>.db` (full hash still in the RPC response + registry). Wire protocol unchanged — CI's prebuilt binaries stay compatible.

4. **Auto-fetch failure backoff.** Failed peers retried on every 30s reconcile with a warn each time. Now exponential per-peer backoff (2 min → 1 h cap), reset by any success; manual admin fetches bypass it.

5. **Admin visibility.** The p2p status route never surfaced mesh state — an operator couldn't tell "connected" from "process running". It now returns `joined` + `neighbors` from the sidecar and the admin card shows *"connected — N mesh neighbors"* (live: `neighbors: 3` = the second lab server + both community seeds).

6. **Scary red boot errors.** Every forked worker logged Node's `(node:PID) ExperimentalWarning: SQLite…` banner as `error:` lines on every boot. Shared `logWorkerStderr()` demotes Node runtime chatter to debug across all six workers.

Plus a real UI bug found in the panel: with 5 network rows, the pinned (`flex-shrink: 0`) "From the network" section consumed the height-capped Discover panel entirely and **crushed the local song list to 0 height** (the two lists painted into the same space). Flexbox subtlety: a scroll container's *automatic minimum* is 0, but its *intrinsic contribution* to the parent's min-content is still its full content height — so "let both lists share via flex" can never shrink the network block. Fixed with deterministic bounds: panel cap 45%→60%, local list flexes with a 58px floor, network section pinned at ≤3 visible rows with internal scroll, body-scroll backstop for tiny viewports. Verified desktop + mobile.

## Tests

- New integration test: **zero-touch auto-publish** — boots a fresh server (collection + p2p on, `test-fake` model), never touches the admin export/announce routes, and asserts a listening sidecar hears a signed announcement with `rowCount > 0`, the manifest watermark matches the announced seq, and the blob is fetchable. Generates its own 35s WAV (shared fixtures sit under the worker's 30s eligibility floor).
- Full suite **1555/1555**, discovery suite 27/27, sidecar cargo tests 7/7.
- Live-verified end to end: fresh wipe → boot → deferred ffmpeg → embed → auto-export → announce → mutual auto-fetch (16-hex filenames on disk) in under a minute, on the real seed mesh.

Source-only for `bin/` (sidecar binaries rebuild via the bot on merge, as usual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)