### PR TITLE
feat(discovery): ed25519-sign the community seed list

### DIFF
--- a/scripts/sign-discovery-seeds.mjs
+++ b/scripts/sign-discovery-seeds.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Sign seeds/discovery-seeds.json with the maintainer's offline seed-list
+// key. Rotating a seed is now: edit the file → run this → commit.
+//
+//   node scripts/sign-discovery-seeds.mjs --key C:/path/to/key.pem
+//   MSTREAM_SEEDS_SIGNING_KEY=C:/path/to/key.pem node scripts/sign-discovery-seeds.mjs
+//
+// The seq counter auto-bumps on every signing (that's the rollback
+// protection — clients reject a fetched list older than their cached one).
+// --keep-seq re-signs without bumping, for the rare "re-sign identical
+// content" case. The script self-verifies against the PUBLIC key baked into
+// src/state/discovery-seeds-verify.js, so signing with the wrong key file
+// fails here instead of silently breaking every client's fetch.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { signSeedList, verifySeedList } from '../src/state/discovery-seeds-verify.js';
+
+const listPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'seeds', 'discovery-seeds.json');
+
+let keyPath = process.env.MSTREAM_SEEDS_SIGNING_KEY || null;
+let keepSeq = false;
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--key') { keyPath = args[++i]; }
+  else if (args[i] === '--keep-seq') { keepSeq = true; }
+  else { console.error(`unknown option: ${args[i]}`); process.exit(1); }
+}
+if (!keyPath) {
+  console.error('no signing key: pass --key <pem-file> or set MSTREAM_SEEDS_SIGNING_KEY');
+  process.exit(1);
+}
+
+const privateKeyPem = fs.readFileSync(keyPath, 'utf8');
+const doc = JSON.parse(fs.readFileSync(listPath, 'utf8'));
+
+if (!keepSeq) { doc.seq = (Number.isInteger(doc.seq) ? doc.seq : 0) + 1; }
+doc.updated = new Date().toISOString().slice(0, 10);
+
+const signed = signSeedList(doc, privateKeyPem);
+
+// Self-check against the baked public key BEFORE writing anything. If the
+// env test-override is set it would verify against the wrong root — refuse.
+if (process.env.MSTREAM_TEST_SEEDS_PUBKEY) {
+  console.error('refusing to sign with MSTREAM_TEST_SEEDS_PUBKEY set (would self-verify against the test key)');
+  process.exit(1);
+}
+verifySeedList(signed);
+
+// Stable field order so diffs stay reviewable.
+const out = {
+  version: signed.version,
+  updated: signed.updated,
+  _readme: signed._readme,
+  seq: signed.seq,
+  seeds: signed.seeds,
+  signature: signed.signature,
+};
+fs.writeFileSync(listPath, JSON.stringify(out, null, 2) + '\n');
+console.log(`signed ${path.relative(process.cwd(), listPath)}: seq ${signed.seq}, ${signed.seeds.length} seed(s)`);
+console.log('self-verified against the baked public key — commit the file.');

--- a/seeds/discovery-seeds.json
+++ b/seeds/discovery-seeds.json
@@ -1,7 +1,8 @@
 {
   "version": 1,
-  "updated": "2026-07-04",
-  "_readme": "Community seed nodes for the mStream discovery network. Servers with discoveryP2p.useCommunitySeeds (default on) fetch this file at most daily and bootstrap the gossip catalog off these tickets, in addition to any operator-configured bootstrapPeers. Seeds relay the mesh but hold no music and no snapshots; announcements stay signed by their origins. Rotating a seed = editing this file on master. Entry shape: {\"name\": \"...\", \"endpointId\": \"<64 hex>\", \"ticket\": \"endpoint...\"} \u2014 endpointId lets operator blocklists apply to seeds. The seed binary lives in the mstream-discovery-seed repo.",
+  "updated": "2026-07-05",
+  "_readme": "Community seed nodes for the mStream discovery network. Servers with discoveryP2p.useCommunitySeeds (default on) fetch this file at most daily and bootstrap the gossip catalog off these tickets, in addition to any operator-configured bootstrapPeers. Seeds relay the mesh but hold no music and no snapshots; announcements stay signed by their origins. Rotating a seed = editing this file, running scripts/sign-discovery-seeds.mjs (maintainer signing key required; clients reject unsigned or replayed lists by ed25519 signature + monotonic seq), and committing. Entry shape: {\"name\": \"...\", \"endpointId\": \"<64 hex>\", \"ticket\": \"endpoint...\"} — endpointId lets operator blocklists apply to seeds. The seed binary lives in the mstream-discovery-seed repo.",
+  "seq": 1,
   "seeds": [
     {
       "name": "seed-au-1",
@@ -13,5 +14,6 @@
       "endpointId": "d7d3f4501a5a70e17ea93106f303b77714d5625e9849aa4ebaff6d0c5d4b2260",
       "ticket": "endpointadl5h5cqdjnhbyl6veyqn4ydw53rjvlcl2metksoxl7w2dc5jmrgaayaenuhi5dqom5c6l3fovrtcljrfzzgk3dbpexg4mbonfzg62bonruw42zof4aqbhpvij2yz5icaeakyeiaakgpkaq"
     }
-  ]
+  ],
+  "signature": "sw4tXeuvfrMIvG7KveoH43OXs5CUyIAfpFGR+SvXbaqbykOQ+kyd7ESES3xvTmTKETjuOEpg7OkfW31MQVIgBQ=="
 }

--- a/src/state/discovery-seeds-verify.js
+++ b/src/state/discovery-seeds-verify.js
@@ -1,0 +1,81 @@
+// Seed-list signing: the remote seeds/discovery-seeds.json is the one
+// remotely-fetched input that shapes who a fresh server trusts, so it is
+// ed25519-signed by an offline key that never touches the repo or CI. This
+// closes the gap the v1 posture documented: a hijacked GitHub account, a
+// tampering mirror (operators may point seedListUrl elsewhere), or a TLS
+// middlebox can no longer swap the seed set — they'd have to steal the
+// signing key itself. The baked DEFAULT_SEEDS need no signature: they ship
+// inside the reviewed, released code.
+//
+// Scheme (matches the sidecar's gossip-signing conventions):
+//   - canonical pipe-separated string over seq + every entry's fields —
+//     both signer and verifier BUILD it from the structured document, so
+//     there is no canonical-JSON problem; '|' and ',' are rejected in
+//     fields so no two documents can canonicalize identically;
+//   - `seq` is a monotonic counter bumped on every signing. The fetcher
+//     rejects a fetched list older than its cached one, so a replayed old
+//     (validly signed) list can't resurrect a rotated-out seed;
+//   - signature is embedded in the document (single fetch, no sidecar-file
+//     skew) and old clients ignore the extra fields (version stays 1).
+//
+// This module is deliberately pure (node:crypto only — no config, no
+// winston) so scripts/sign-discovery-seeds.mjs and the tests can share the
+// exact canonicalization with the runtime verifier.
+
+import crypto from 'crypto';
+
+// The mStream project seed-list public key (SPKI, base64). The private half
+// lives offline with the maintainer — NOT in this repo, NOT in CI secrets.
+export const SEEDS_PUBLIC_KEY_B64 = 'MCowBQYDK2VwAyEApefSH8q8tqaFQ065BfI6I8ewwbq7HwvGFyUBAnxZY5k=';
+
+function publicKey() {
+  // Test override: hermetic suites sign their stub lists with a throwaway
+  // key and point the spawned server here. Anyone who can set a server's
+  // environment already owns the process, so this adds no attack surface.
+  const b64 = process.env.MSTREAM_TEST_SEEDS_PUBKEY || SEEDS_PUBLIC_KEY_B64;
+  return crypto.createPublicKey({ key: Buffer.from(b64, 'base64'), format: 'der', type: 'spki' });
+}
+
+// The exact bytes that get signed. Field order inside an entry and entry
+// order in the list are both significant (they're part of the statement
+// "this is the seed list").
+export function canonicalSeedListString(doc) {
+  if (!Number.isInteger(doc.seq) || doc.seq < 0) {
+    throw new Error('seed list needs a non-negative integer `seq`');
+  }
+  if (!Array.isArray(doc.seeds)) { throw new Error('seed list needs a `seeds` array'); }
+  const parts = ['mstream-discovery-seeds-v1', `seq:${doc.seq}`];
+  for (const s of doc.seeds) {
+    const fields = [s.name || '', s.endpointId || '', s.ticket || ''];
+    for (const f of fields) {
+      if (typeof f !== 'string' || f.includes('|') || f.includes(',')) {
+        throw new Error("seed entry fields must be strings without '|' or ','");
+      }
+    }
+    parts.push(fields.join(','));
+  }
+  return parts.join('|');
+}
+
+// Throws with a specific reason when the document is unsigned, malformed,
+// or fails verification; returns quietly when it's genuine.
+export function verifySeedList(doc) {
+  if (!doc || typeof doc !== 'object') { throw new Error('not an object'); }
+  if (doc.version !== 1) { throw new Error(`unsupported version ${doc.version}`); }
+  if (typeof doc.signature !== 'string' || doc.signature.length === 0) {
+    throw new Error('missing signature');
+  }
+  const canonical = canonicalSeedListString(doc);
+  const ok = crypto.verify(null, Buffer.from(canonical, 'utf8'),
+    publicKey(), Buffer.from(doc.signature, 'base64'));
+  if (!ok) { throw new Error('signature verification failed'); }
+}
+
+// Returns a NEW document with the signature over the given doc's canonical
+// form. Used by scripts/sign-discovery-seeds.mjs and the test suites.
+export function signSeedList(doc, privateKeyPem) {
+  const key = crypto.createPrivateKey(privateKeyPem);
+  const canonical = canonicalSeedListString(doc);
+  const signature = crypto.sign(null, Buffer.from(canonical, 'utf8'), key).toString('base64');
+  return { ...doc, signature };
+}

--- a/src/state/discovery-seeds.js
+++ b/src/state/discovery-seeds.js
@@ -18,18 +18,23 @@
 // blocklist applies to them; bare-id bootstrapPeers are filterable too,
 // opaque tickets pass through — documented limitation).
 //
-// Security posture (deliberate, documented): a malicious seed cannot forge
-// catalog entries (announcements are origin-signed) and cannot observe
-// queries (those never leave each machine). It COULD try to eclipse a
-// brand-new node — mitigations are multiple independent seeds, the user's
-// own bootstrapPeers bypassing seeds entirely, and HTTPS+GitHub as the
-// list's trust anchor. List signing is a planned upgrade, not a v1 feature.
+// Security posture: a malicious seed cannot forge catalog entries
+// (announcements are origin-signed) and cannot observe queries (those never
+// leave each machine). It COULD try to eclipse a brand-new node —
+// mitigations are multiple independent seeds, the user's own bootstrapPeers
+// bypassing seeds entirely, and the remote list being ed25519-SIGNED by an
+// offline maintainer key (discovery-seeds-verify.js): an unsigned/tampered
+// list — hijacked repo, tampering mirror, TLS middlebox — is treated as a
+// failed fetch, and a replayed OLD signed list is rejected by its `seq`
+// against the cached copy. Fallback order stays cache → baked; boot never
+// depends on the URL.
 
 import fs from 'fs';
 import path from 'path';
 import winston from 'winston';
 import * as config from './config.js';
 import * as discoveryP2p from './discovery-p2p.js';
+import { verifySeedList } from './discovery-seeds-verify.js';
 
 // Baked-in seed entries, same shape as the remote list: {name, endpointId,
 // ticket}. These are the zero-network fallback (first boot, offline hosts,
@@ -74,12 +79,17 @@ function validEntry(e) {
     && (e.endpointId === undefined || (typeof e.endpointId === 'string' && /^[0-9a-f]{64}$/.test(e.endpointId)));
 }
 
+// Parse + AUTHENTICATE a seed list (remote fetch or disk cache — one code
+// path, so a tampered cache file is caught too). Throws on anything less
+// than a well-formed, correctly signed document; callers treat that as a
+// failed fetch. Returns { seq, seeds }.
 function parseSeedList(raw) {
   const doc = JSON.parse(raw);
   if (!doc || doc.version !== 1 || !Array.isArray(doc.seeds)) {
     throw new Error('unrecognized seed-list shape (want {version:1, seeds:[...]})');
   }
-  return doc.seeds.filter(validEntry).slice(0, MAX_SEEDS);
+  verifySeedList(doc);
+  return { seq: doc.seq, seeds: doc.seeds.filter(validEntry).slice(0, MAX_SEEDS) };
 }
 
 // Merge seed entries + the operator's own bootstrapPeers into the final
@@ -116,9 +126,16 @@ async function remoteSeeds({ forceRefresh = false, localOnly = false } = {}) {
   try {
     const stat = fs.statSync(cachePath());
     cached = parseSeedList(fs.readFileSync(cachePath(), 'utf8'));
-    if (!forceRefresh && Date.now() - stat.mtimeMs < CACHE_TTL_MS) { return cached; }
-  } catch (_err) { /* no cache yet, or unreadable — fetch below */ }
-  if (localOnly) { return cached || []; }
+    if (!forceRefresh && Date.now() - stat.mtimeMs < CACHE_TTL_MS) { return cached.seeds; }
+  } catch (err) {
+    // No cache is normal (first boot). A cache that EXISTS but won't verify
+    // is worth a note — expected once right after upgrading from the
+    // pre-signing release, alarming any other time.
+    if (err.code !== 'ENOENT') {
+      winston.warn(`cached community seed list rejected (${err.message}) — ignoring it`);
+    }
+  }
+  if (localOnly) { return cached ? cached.seeds : []; }
 
   try {
     const ctrl = new AbortController();
@@ -127,13 +144,21 @@ async function remoteSeeds({ forceRefresh = false, localOnly = false } = {}) {
     clearTimeout(timer);
     if (!res.ok) { throw new Error(`HTTP ${res.status}`); }
     const raw = await res.text();
-    const seeds = parseSeedList(raw);
+    const fetched = parseSeedList(raw);
+    // Rollback protection: a validly signed but OLDER list never replaces a
+    // newer one we've already verified — replaying a stale list can't
+    // resurrect a rotated-out seed.
+    if (cached && fetched.seq < cached.seq) {
+      winston.warn(`fetched community seed list is older than the cached one `
+        + `(seq ${fetched.seq} < ${cached.seq}) — keeping the cached copy`);
+      return cached.seeds;
+    }
     fs.mkdirSync(path.dirname(cachePath()), { recursive: true });
     fs.writeFileSync(cachePath(), raw);
-    return seeds;
+    return fetched.seeds;
   } catch (err) {
     winston.warn(`community seed list fetch failed (${err.message}) — using ${cached ? 'cached copy' : 'baked defaults only'}`);
-    return cached || [];
+    return cached ? cached.seeds : [];
   }
 }
 

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -39,9 +39,11 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { spawn } from 'node:child_process';
 import { DatabaseSync } from 'node:sqlite';
+import crypto from 'node:crypto';
 import { startServer } from '../helpers/server.mjs';
 import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
 import { mergeSeedLists } from '../../src/state/discovery-seeds.js';
+import { signSeedList } from '../../src/state/discovery-seeds-verify.js';
 
 const SIDECAR_BIN = resolveSidecarBinary();
 
@@ -669,21 +671,29 @@ describe('discovery seeds — mergeSeedLists', () => {
     // The seed joins with no bootstrap — it IS the first node.
     await seedNode.rpc('join', { bootstrap: [] });
 
-    // Stub "GitHub raw" endpoint serving a v1 seed list with the seed's ticket.
+    // Stub "GitHub raw" endpoint serving a v1 seed list with the seed's
+    // ticket. Lists are signature-checked now, so the stub signs with a
+    // throwaway key and the spawned server trusts it via the test-only
+    // pubkey override.
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const testPubB64 = publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+    const signedList = signSeedList({
+      version: 1,
+      seq: 1,
+      seeds: [{ name: 'test-seed', endpointId: seedNode.endpointId, ticket: seedNode.ticket }],
+    }, privateKey.export({ type: 'pkcs8', format: 'pem' }));
     const http = await import('node:http');
     listServer = http.createServer((req, res) => {
       listHits += 1;
       res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({
-        version: 1,
-        seeds: [{ name: 'test-seed', endpointId: seedNode.endpointId, ticket: seedNode.ticket }],
-      }));
+      res.end(JSON.stringify(signedList));
     });
     await new Promise((r) => listServer.listen(0, '127.0.0.1', r));
     listUrl = `http://127.0.0.1:${listServer.address().port}/discovery-seeds.json`;
 
     server = await startServer({
       dlnaMode: 'disabled', waitForScan: false,
+      env: { MSTREAM_TEST_SEEDS_PUBKEY: testPubB64 },
       extraConfig: {
         // useCommunitySeeds must be re-enabled explicitly: the test helper
         // forces it off so ordinary suites can never join the real network

--- a/test/unit/discovery-seeds-verify.test.mjs
+++ b/test/unit/discovery-seeds-verify.test.mjs
@@ -1,0 +1,115 @@
+// Seed-list signing: the canonicalization + ed25519 verify that guards the
+// community bootstrap path. Adversarial by design — every rejection here is
+// an attack the fetcher must treat as a failed fetch.
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import {
+  canonicalSeedListString,
+  signSeedList,
+  verifySeedList,
+  SEEDS_PUBLIC_KEY_B64,
+} from '../../src/state/discovery-seeds-verify.js';
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+const PUB_B64 = publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+const PRIV_PEM = privateKey.export({ type: 'pkcs8', format: 'pem' });
+
+const BASE_DOC = {
+  version: 1,
+  seq: 3,
+  seeds: [
+    { name: 'seed-one', endpointId: 'a'.repeat(64), ticket: 'endpoint' + 'x'.repeat(40) },
+    { name: 'seed-two', endpointId: 'b'.repeat(64), ticket: 'endpoint' + 'y'.repeat(40) },
+  ],
+};
+
+describe('discovery seeds — list signing', () => {
+  // Verify against OUR throwaway key for the whole suite; the baked
+  // production key is asserted on separately below.
+  before(() => { process.env.MSTREAM_TEST_SEEDS_PUBKEY = PUB_B64; });
+  after(() => { delete process.env.MSTREAM_TEST_SEEDS_PUBKEY; });
+
+  test('sign → verify roundtrip accepts a genuine list', () => {
+    const signed = signSeedList(BASE_DOC, PRIV_PEM);
+    assert.equal(typeof signed.signature, 'string');
+    verifySeedList(signed); // throws on failure
+  });
+
+  test('canonical string covers seq and every entry field, in order', () => {
+    const s = canonicalSeedListString(BASE_DOC);
+    assert.equal(s,
+      'mstream-discovery-seeds-v1|seq:3'
+      + `|seed-one,${'a'.repeat(64)},endpoint${'x'.repeat(40)}`
+      + `|seed-two,${'b'.repeat(64)},endpoint${'y'.repeat(40)}`);
+  });
+
+  test('any field tamper after signing is rejected', () => {
+    const signed = signSeedList(BASE_DOC, PRIV_PEM);
+    const tampers = [
+      (d) => { d.seeds[0].ticket = 'endpoint' + 'z'.repeat(40); },   // swapped dial target
+      (d) => { d.seeds[0].endpointId = 'c'.repeat(64); },            // swapped identity
+      (d) => { d.seq = d.seq + 1; },                                  // seq forged forward
+      (d) => { d.seeds.push({ name: 'evil', endpointId: 'd'.repeat(64), ticket: 'endpoint' + 'e'.repeat(40) }); },
+      (d) => { d.seeds.pop(); },                                      // entry removed
+      (d) => { [d.seeds[0], d.seeds[1]] = [d.seeds[1], d.seeds[0]]; }, // reordered
+    ];
+    for (const tamper of tampers) {
+      const doc = structuredClone(signed);
+      tamper(doc);
+      assert.throws(() => verifySeedList(doc), /signature verification failed/);
+    }
+  });
+
+  test('a stripped or garbage signature is rejected, never treated as unsigned-ok', () => {
+    const signed = signSeedList(BASE_DOC, PRIV_PEM);
+    const stripped = { ...signed };
+    delete stripped.signature;
+    assert.throws(() => verifySeedList(stripped), /missing signature/);
+    assert.throws(() => verifySeedList({ ...signed, signature: '' }), /missing signature/);
+    assert.throws(() => verifySeedList({ ...signed, signature: 'AAAA' }), /verification failed/);
+  });
+
+  test('a list signed by a different key is rejected', () => {
+    const other = crypto.generateKeyPairSync('ed25519');
+    const signed = signSeedList(BASE_DOC, other.privateKey.export({ type: 'pkcs8', format: 'pem' }));
+    assert.throws(() => verifySeedList(signed), /signature verification failed/);
+  });
+
+  test('separator characters in fields are refused at both sign and verify time', () => {
+    for (const bad of ['pipe|name', 'comma,name']) {
+      const doc = structuredClone(BASE_DOC);
+      doc.seeds[0].name = bad;
+      assert.throws(() => signSeedList(doc, PRIV_PEM), /without '\|' or ','/);
+      assert.throws(() => verifySeedList({ ...doc, signature: 'AAAA' }), /without '\|' or ','/);
+    }
+  });
+
+  test('missing or non-integer seq is refused', () => {
+    for (const seq of [undefined, -1, 1.5, '3']) {
+      const doc = { ...structuredClone(BASE_DOC), seq };
+      assert.throws(() => signSeedList(doc, PRIV_PEM), /integer `seq`/);
+    }
+  });
+});
+
+describe('discovery seeds — production trust root', () => {
+  test('the baked public key is a valid ed25519 SPKI key', () => {
+    const key = crypto.createPublicKey({
+      key: Buffer.from(SEEDS_PUBLIC_KEY_B64, 'base64'), format: 'der', type: 'spki',
+    });
+    assert.equal(key.asymmetricKeyType, 'ed25519');
+  });
+
+  test('the committed seeds/discovery-seeds.json verifies against the baked key', async () => {
+    const fs = await import('node:fs');
+    const url = new URL('../../seeds/discovery-seeds.json', import.meta.url);
+    const doc = JSON.parse(fs.readFileSync(url, 'utf8'));
+    // No env override in this suite — this is the real production check:
+    // a PR that edits the seed list without running the signing script
+    // fails here before it can break every client's fetch.
+    assert.equal(process.env.MSTREAM_TEST_SEEDS_PUBKEY, undefined);
+    verifySeedList(doc);
+    assert.ok(doc.seq >= 1);
+  });
+});


### PR DESCRIPTION
## What

The remote `seeds/discovery-seeds.json` is the one remotely-fetched input that shapes who a fresh server trusts. Now that the network is public (6.16), this closes the documented v1 gap: the list is **ed25519-signed by an offline maintainer key** that never touches the repo or CI.

## Design

- **Canonical pipe-separated string** over `seq` + every entry's `name,endpointId,ticket` — the same signing convention as the sidecar's gossip messages. Both signer and verifier build it from the structured document (no canonical-JSON problem); `|` and `,` are rejected in fields so no two documents canonicalize identically.
- **Signature embedded in the document** — single fetch, no sidecar-file skew; old 6.16 clients ignore the extra fields (`version` stays 1).
- **No unsigned acceptance path**: an unsigned/tampered list — hijacked repo, tampering mirror (operators may point `seedListUrl` elsewhere), TLS middlebox — is treated as a failed fetch (warn + fallback cache → baked; boot never blocked). Stripping the signature is not a downgrade.
- **Monotonic `seq` = rollback protection**: a replayed older-but-validly-signed list can't resurrect a rotated-out seed; the fetcher keeps its newer cached copy.
- The disk cache goes through the same verify path as the remote fetch, so a tampered cache file is caught too.
- Baked `DEFAULT_SEEDS` need no signature — they ship inside reviewed, released code.

**Rotation flow**: edit the file → `node scripts/sign-discovery-seeds.mjs --key <pem>` (auto-bumps seq, self-verifies against the *baked public key* so signing with the wrong key fails at the desk, not in the field) → commit.

## Rollout

The committed list is signed (seq 1). Until this merges, new-code clients reject the raw-GitHub list ("missing signature") and fall back to the **identical baked seeds** — zero downtime, observed live (below). After merge, the GitHub URL serves the signed list and fetches go clean.

## Verification

**Tests**: unit suite (9) — tamper matrix (ticket/id/seq/add/remove/reorder), wrong key, stripped signature, separator injection, plus a production check that the *committed* seed list verifies against the *baked* key (a PR editing seeds without re-signing fails CI). Integration stub-list suite signs with a throwaway key via the `MSTREAM_TEST_SEEDS_PUBKEY` test-only override. Discovery suite 27/27; full suite 1563/1564 — the one failure is the pre-existing Sunday weekly-window bug in `wrapped-period-range.test.mjs` (fails on untouched master today; flagged separately, #688's sibling).

**Live smoke, real servers on the real seed mesh** (all four pass):
1. *Upgrade path*: server with yesterday's unsigned cache + the real (still-unsigned) GitHub URL → both rejected with clean warns, mesh joined via baked seeds (`neighbors=2`).
2. *Signed fetch, production trust root*: server pointed at a stub serving the committed signed file, **no test overrides** → clean verified fetch, signed doc cached.
3. *Tampered list* (valid signature, one ticket char flipped) → `signature verification failed`, not cached, baked fallback still joins.
4. *Replay*: cache primed with a newer signed list (seq 2), stub serving the older seq 1 → `seq 1 < 2 — keeping the cached copy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)