### PR TITLE
fix(wrapped): weekly period window started on next Monday on Sundays

### DIFF
--- a/src/api/wrapped.js
+++ b/src/api/wrapped.js
@@ -21,7 +21,11 @@ export function getPeriodRange(period, offset) {
   switch (period) {
     case 'weekly': {
       const weekStart = new Date(now);
-      weekStart.setDate(weekStart.getDate() - weekStart.getDay() + 1 + (offset * 7));
+      // Monday-based week, but getDay() is Sunday-based (0=Sun..6=Sat):
+      // Sunday must map to the Monday 6 days BACK, not tomorrow's Monday —
+      // the old `- getDay() + 1` put every Sunday into next week's window.
+      const daysSinceMonday = (weekStart.getDay() + 6) % 7;
+      weekStart.setDate(weekStart.getDate() - daysSinceMonday + (offset * 7));
       weekStart.setHours(0, 0, 0, 0);
       const weekEnd = new Date(weekStart);
       weekEnd.setDate(weekEnd.getDate() + 7);

--- a/test/unit/wrapped-period-range.test.mjs
+++ b/test/unit/wrapped-period-range.test.mjs
@@ -60,6 +60,35 @@ describe('getPeriodRange SQLite-format contract', () => {
     assert.ok('2026-07-01 23:59:59' < '2026-07-01T00:00:00.000Z');
   });
 
+  test('the current window contains now on every day of the week', (t) => {
+    // The "now inside the window" test above only exercises the weekday CI
+    // happens to run on. The weekly branch had a Sunday-only bug (getDay()
+    // is Sunday-based, the window is Monday-based: `- getDay() + 1` sent
+    // every Sunday into NEXT week's window), which surfaced as a full-ci
+    // failure on 2026-07-05 — so pin all seven weekdays with a mocked clock.
+    // 2026-07-06 is a Monday; noon dodges any DST/UTC-offset date shift.
+    for (let i = 0; i < 7; i++) {
+      const fakeNow = new Date(2026, 6, 6 + i, 12, 0, 0);
+      t.mock.timers.enable({ apis: ['Date'], now: fakeNow.getTime() });
+      const nowStamp = sqliteNow();
+      for (const period of PERIODS) {
+        const { start, end } = getPeriodRange(period, 0);
+        assert.ok(start <= nowStamp,
+          `${period} on ${fakeNow.toDateString()}: now (${nowStamp}) not before start (${start})`);
+        assert.ok(nowStamp < end,
+          `${period} on ${fakeNow.toDateString()}: now (${nowStamp}) inside end bound (${end})`);
+      }
+      // And the weekly window must always start on the SAME week's Monday.
+      const { start } = getPeriodRange('weekly', 0);
+      const weekStart = new Date(start.replace(' ', 'T') + 'Z');
+      assert.equal(weekStart.getDay(), 1,
+        `weekly window on ${fakeNow.toDateString()} starts on ${weekStart.toDateString()}, not a Monday`);
+      assert.ok(fakeNow.getTime() - weekStart.getTime() < 7 * 24 * 3600 * 1000,
+        `weekly window on ${fakeNow.toDateString()} starts more than a week before now`);
+      t.mock.timers.reset();
+    }
+  });
+
   test('consecutive windows tile exactly (no gap, no overlap)', () => {
     // The default branch (unrecognized period string) deliberately ignores
     // offset — it always answers "this month" — so only the real periods


### PR DESCRIPTION
## What

Fixes a Sunday-only off-by-one in `getPeriodRange`'s weekly branch (`src/api/wrapped.js`) that made `test/unit/wrapped-period-range.test.mjs` fail on untouched master every Sunday, and adds a deterministic all-weekdays regression test.

## Why

The weekly window computed Monday-of-week as `getDate() - getDay() + 1`. `getDay()` is Sunday-based (0=Sun), so on Sundays that evaluates to `date + 1`: the window started on **tomorrow's** Monday instead of the Monday six days back. Consequences:

- The period-range regression test failed on master every Sunday (observed 2026-07-05: now `2026-07-05 19:37` vs weekly start `2026-07-06 04:00`), blocking every `full-ci`-labeled PR that day — same failure mode as the 2026-07-01 first-of-month bug fixed in #688.
- Real weekly wrapped stats were wrong on Sundays: "This Week" was actually next week's (empty) window, and Sunday listens landed in "Last Week".

## How

- Standard days-since-Monday idiom: `(getDay() + 6) % 7`, subtracted from the current date.
- Checked the other period branches (monthly / quarterly / half-yearly / yearly / default) as well: they use `new Date(year, month, 1)` month arithmetic with no day-of-week math, so none share the pattern. The only other `getDay()` in `src/` is the weekday-histogram index, which is correct as-is.

## Test hardening

The existing "now falls inside every current window" test only exercises whatever weekday it runs on — which is why this sat undetected until a Sunday. Added a case that mocks the clock (`node:test` mock timers, `apis: ['Date']`) across all seven days of a known week and asserts:

- every period's current window contains "now", and
- the weekly window always starts on a Monday no more than a week back.

Verified the new test fails against the old math (on the mocked Sunday) and passes with the fix. Full unit suite: 264/264 pass. The two ESLint errors in `wrapped.js` are pre-existing on master (verified via `git show origin/master:... | eslint --stdin`), untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
