### PR TITLE
chore(rust-parser): update symphonia 0.5.5 → 0.6.0

### DIFF
--- a/rust-parser/Cargo.lock
+++ b/rust-parser/Cargo.lock
@@ -9,22 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -140,15 +128,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "extended"
@@ -387,7 +366,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -448,12 +427,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "rusqlite"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -568,9 +553,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "symphonia"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
@@ -589,44 +574,44 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-flac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+checksum = "ee69ad01236a67260b82fd1ff9790dd75ead29f2f46af145e63b7e72273e0e03"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+checksum = "350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546"
 dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+checksum = "f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-adpcm"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+checksum = "4ebbdfd76d6cc5a601c6292a44357c5b7c82f2cd7cdc0f171421f5c5cff0ea1f"
 dependencies = [
  "log",
  "symphonia-core",
@@ -634,19 +619,20 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-alac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+checksum = "3a149cbfc7fb5c405d123a273227d31de17138419552112bf1aa7b73e65827b8"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-pcm"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+checksum = "50baee168f0e9dcf6ba7fc06e8b57eb62072a4490cc7cf13af77e72baae5d328"
 dependencies = [
  "log",
  "symphonia-core",
@@ -654,59 +640,70 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-vorbis"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+checksum = "45b07b4423cd8e0fc472575909a5554b12c2f58e3c190b38c24f042e732fd8de"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55"
 dependencies = [
  "log",
  "symphonia-core",
- "symphonia-utils-xiph",
+ "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-core"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
+ "bitflags",
  "bytemuck",
  "lazy_static",
  "log",
+ "num-complex",
  "rustfft",
+ "smallvec",
 ]
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+checksum = "2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e"
 dependencies = [
- "encoding_rs",
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+checksum = "b05a67e02b1e4fca1a261ba4fe06910a9357489ad8c36aafdd2960e9c6559433"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-riff"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+checksum = "17424452a777666d3eaf09a5c651029b15b6a333812fcc5b5474f2a3f0cff3f0"
 dependencies = [
  "extended",
  "log",
@@ -716,24 +713,15 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
 dependencies = [
- "encoding_rs",
  "lazy_static",
  "log",
+ "regex-lite",
+ "smallvec",
  "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]

--- a/rust-parser/Cargo.toml
+++ b/rust-parser/Cargo.toml
@@ -21,12 +21,12 @@ md-5 = "0.10"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 # Pure-Rust audio decoder used to build the 800-bar waveform cache in the
 # post-scan `--waveform-scan` pass. Codec features cover every extension in
-# supportedAudioFiles (src/state/config.js) EXCEPT .opus — symphonia 0.5 has
+# supportedAudioFiles (src/state/config.js) EXCEPT .opus — symphonia 0.6 still has
 # no pure-Rust Opus decoder yet and we deliberately avoid linking libopus /
 # a C library. Opus files get a `.failed` marker from the pass; their
 # waveforms are generated on first play by the on-demand
 # GET /api/v1/db/waveform endpoint (which falls back to ffmpeg).
-symphonia = { version = "0.5", default-features = false, features = [
+symphonia = { version = "0.6", default-features = false, features = [
     "mp3",
     "mp1",     # mp1/mp2/adpcm were previously linked in transitively by
     "mp2",     # stratum-dsp's features=["all"] — keep them explicit so

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -20,12 +20,12 @@ use rusqlite::{Connection, OptionalExtension};
 use serde::Deserialize;
 use walkdir::WalkDir;
 
-use symphonia::core::audio::SampleBuffer;
-use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::codecs::audio::AudioDecoderOptions;
+use symphonia::core::codecs::CodecParameters;
+use symphonia::core::formats::probe::Hint;
 use symphonia::core::formats::FormatOptions;
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
 
 // Number of bars in a waveform — matches NUM_BARS in src/db/waveform-lib.js.
 // Cache files are exactly this many bytes (one u8 per bar).
@@ -542,7 +542,7 @@ fn main() {
 
     // Hidden developer/test subcommand: `rust-parser --waveform <path>`
     // prints `{"bars":"<hex of 800 bytes>"}` on success or `{"bars":null}`
-    // when no waveform can be produced (e.g. .opus, where symphonia 0.5
+    // when no waveform can be produced (e.g. .opus, where symphonia 0.6
     // has no decoder). Used by test/waveform.test.mjs to exercise the
     // decoder across every supported format without standing up a full
     // scan's worth of DB scaffolding.
@@ -4325,7 +4325,7 @@ fn audio_ranges_for_ext<R: Read + Seek>(
 // ── Waveform generation (symphonia-powered) ───────────────────────────────
 //
 // Decodes the audio stream, downmixes to mono magnitudes, and emits NUM_BARS
-// peak values (u8, 0-255). .opus is skipped because symphonia 0.5 lacks an
+// peak values (u8, 0-255). .opus is skipped because symphonia 0.6 still lacks an
 // Opus decoder. On any decoder/IO error we fall back to None so the scanner
 // continues and the on-demand endpoint can try ffmpeg later.
 //
@@ -4350,9 +4350,9 @@ struct WaveformOutput {
 fn waveform_from_source(
     source: Box<dyn symphonia::core::io::MediaSource>, ext: &str,
 ) -> Option<WaveformOutput> {
-    // Symphonia doesn't ship an Opus decoder in 0.5. We want to keep the
-    // binary pure-Rust (no libopus), so skip .opus here and let the
-    // on-demand endpoint handle it via ffmpeg on first playback.
+    // Symphonia still doesn't ship a pure-Rust Opus decoder in 0.6 (only a
+    // libopus C adapter, which we deliberately avoid). Skip .opus here and
+    // let the on-demand endpoint handle it via ffmpeg on first playback.
     if ext == "opus" { return None; }
 
     let mss = MediaSourceStream::new(source, Default::default());
@@ -4360,50 +4360,52 @@ fn waveform_from_source(
     let mut hint = Hint::new();
     hint.with_extension(ext);
 
-    let probed = symphonia::default::get_probe()
-        .format(&hint, mss, &FormatOptions::default(), &MetadataOptions::default())
+    // symphonia 0.6: probe() returns the FormatReader directly (no Probed
+    // wrapper), and per-track codec params became an Option'd enum — the
+    // old CODEC_TYPE_NULL sentinel is now simply a non-Audio/None entry.
+    let mut format = symphonia::default::get_probe()
+        .probe(&hint, mss, FormatOptions::default(), MetadataOptions::default())
         .ok()?;
-    let mut format = probed.format;
 
-    let track = format.tracks().iter().find(|t| t.codec_params.codec != CODEC_TYPE_NULL)?;
-    let track_id = track.id;
-    let n_frames = track.codec_params.n_frames;   // None → buffered path
-    let channels = track.codec_params.channels.map(|c| c.count()).unwrap_or(2);
+    let (track_id, n_frames, audio_params) = format.tracks().iter().find_map(|t| {
+        match &t.codec_params {
+            Some(CodecParameters::Audio(p)) => Some((t.id, t.num_frames, p.clone())),
+            _ => None,
+        }
+    })?;
+    let channels = audio_params.channels.as_ref().map(|c| c.count()).unwrap_or(2);
 
     let mut decoder = symphonia::default::get_codecs()
-        .make(&track.codec_params, &DecoderOptions::default())
+        .make_audio_decoder(&audio_params, &AudioDecoderOptions::default())
         .ok()?;
 
     let mut peaks = [0f32; NUM_BARS];
     let mut buffered: Vec<f32> = Vec::new();
     let mut frame_idx: u64 = 0;
-    let mut sample_buf: Option<SampleBuffer<f32>> = None;
+    // 0.6 replaced SampleBuffer with copy-out methods on the decoded buffer;
+    // one Vec reused across packets keeps the no-per-packet-alloc behavior.
+    let mut interleaved: Vec<f32> = Vec::new();
     let mut truncated = false;
 
     'outer: loop {
         let packet = match format.next_packet() {
-            Ok(p) => p,
-            Err(_) => break,   // EOF or unrecoverable — whatever we have is what we get
+            Ok(Some(p)) => p,
+            Ok(None) => break,  // clean EOF (explicit in 0.6)
+            Err(_) => break,    // unrecoverable — whatever we have is what we get
         };
-        if packet.track_id() != track_id { continue; }
+        if packet.track_id != track_id { continue; }
 
         let decoded = match decoder.decode(&packet) {
             Ok(d) => d,
             Err(_) => continue,   // skip corrupt packet, keep going
         };
 
-        if sample_buf.is_none() {
-            let spec = *decoded.spec();
-            let capacity = decoded.capacity() as u64;
-            sample_buf = Some(SampleBuffer::<f32>::new(capacity, spec));
-        }
-        let buf = sample_buf.as_mut().unwrap();
-        buf.copy_interleaved_ref(decoded);
+        decoded.copy_to_vec_interleaved(&mut interleaved);
 
         // Downmix interleaved samples to mono via abs-sum/channels
         // (perceived loudness — unchanged from the original
         // implementation, so cached bars stay byte-stable).
-        for chunk in buf.samples().chunks(channels) {
+        for chunk in interleaved.chunks(channels) {
             let mut abs_sum = 0f32;
             for &s in chunk {
                 abs_sum += s.abs();


### PR DESCRIPTION
## What

Updates rust-parser to symphonia **0.6.0** (released 2026-05-15) — the API-restructuring release. The entire migration is confined to the one decode surface, `waveform_from_source`: `probe()` returns the `FormatReader` directly, per-track codec params became an `Option<CodecParameters>` enum (no more `CODEC_TYPE_NULL` sentinel), decoders are created via `make_audio_decoder`, `SampleBuffer` is replaced by `copy_to_vec_interleaved` on the decoded buffer, and EOF is an explicit `Ok(None)`.

## Findings (the "any issues?" report)

Measured A/B against the 0.5.5 prebuilt on real music (10 files, FLAC + MP3):

1. **FLAC waveforms: byte-identical.** ✅
2. **MP3 waveforms differ slightly** (mean bar delta 0.6–4.2 out of 255; occasional transient bar up to 152). Root cause: 0.6's MP3 path **trims LAME encoder delay/padding** (the new `Track.delay`/`padding` machinery), so decoded audio sits ~25 ms earlier — sub-bar at our 800-bar resolution, so only sharp attacks at bin boundaries move. Verified it is NOT a bar-index shift (shift-0 alignment is 10× better than ±1) and the new binary is fully deterministic across runs. This is *more accurate* time alignment, not a regression. Existing cached `.bin` waveforms are untouched — the pass skips files that already have one, so there's no visible churn on upgrade.
3. **Opus: still no pure-Rust decoder in 0.6** (only a `symphonia-adapter-libopus` C adapter, which we deliberately avoid). The `.opus` skip + ffmpeg on-demand fallback stays; comments updated to say 0.6.
4. **rust-server-audio NOT updated**: rodio — even at latest 0.22.2 — still pins symphonia `^0.5.5`, so bumping its direct symphonia dep would ship two symphonia stacks in one binary. It follows whenever rodio migrates to 0.6.
5. Audio hashing is untouched (hand-written range extractors + MD5, no symphonia involvement) — JS↔Rust audio-hash parity unaffected by design.

Bonus for the upcoming AcoustID work: 0.6's cleaner decoder API is what the planned `--fingerprint` subcommand will build on.

## Verification

- `cargo check` clean, zero warnings; release build OK.
- Scanner suite 108/108 (includes the behavioral waveform tests — tone-position, markers, idempotence).
- Full suite **1565/1565**.
- Source-only for `bin/` — the binaries bot rebuilds on merge, as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)