### PR TITLE
feat(rust-parser): --fingerprint subcommand (chromaprint → AcoustID)

### DIFF
--- a/rust-parser/Cargo.lock
+++ b/rust-parser/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,10 +433,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "rubato"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+]
 
 [[package]]
 name = "rusqlite"
@@ -450,11 +477,13 @@ dependencies = [
 name = "rust-parser"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "image",
  "lofty",
  "md-5",
  "rayon",
  "rusqlite",
+ "rusty-chromaprint",
  "serde",
  "serde_json",
  "symphonia",
@@ -473,6 +502,16 @@ dependencies = [
  "primal-check",
  "strength_reduce",
  "transpose",
+]
+
+[[package]]
+name = "rusty-chromaprint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e4234523e38d9c12201955f8216e1a60313e64c5077f4e1cf49b0db77bd7e8"
+dependencies = [
+ "rubato",
+ "rustfft",
 ]
 
 [[package]]

--- a/rust-parser/Cargo.toml
+++ b/rust-parser/Cargo.toml
@@ -58,6 +58,8 @@ symphonia = { version = "0.6", default-features = false, features = [
 # pipe results to the single writer thread that owns the SQLite
 # Connection (see run_scan in main.rs).
 rayon = "1"
+rusty-chromaprint = "0.3"
+base64 = "0.22"
 # (stratum-dsp BPM/key analysis left with scan-time decode; BPM
 # analysis returns as the separate essentia enrichment scanner.)
 

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -20,6 +20,9 @@ use rusqlite::{Connection, OptionalExtension};
 use serde::Deserialize;
 use walkdir::WalkDir;
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use rusty_chromaprint::{Configuration, FingerprintCompressor, Fingerprinter};
 use symphonia::core::codecs::audio::AudioDecoderOptions;
 use symphonia::core::codecs::CodecParameters;
 use symphonia::core::formats::probe::Hint;
@@ -572,6 +575,28 @@ fn main() {
             }
             None => {
                 println!("{{\"bars\":null}}");
+            }
+        }
+        return;
+    }
+
+    // Chromaprint fingerprint for the AcoustID identity chain:
+    // `rust-parser --fingerprint <file>` → single-line JSON. null fingerprint
+    // = undecodable/opus (per-file data, not a crash — exit stays 0); the
+    // acoustid-backfill worker records it as a skip. durationSec is
+    // best-effort from the container; the worker prefers the DB's scanned
+    // duration and falls back to this.
+    if args.len() == 3 && args[1] == "--fingerprint" {
+        let p = Path::new(&args[2]);
+        let ext = file_ext(p).to_lowercase();
+        match fingerprint_from_file(p, &ext) {
+            Some(o) => {
+                let dur = o.duration_sec.map(|d| d.to_string()).unwrap_or_else(|| "null".into());
+                println!("{{\"fingerprint\":\"{}\",\"durationSec\":{},\"fpSeconds\":{:.1}}}",
+                    o.fingerprint, dur, o.fp_seconds);
+            }
+            None => {
+                println!("{{\"fingerprint\":null}}");
             }
         }
         return;
@@ -4539,6 +4564,93 @@ fn waveform_from_source(
 fn waveform_from_symphonia(path: &Path, ext: &str) -> Option<WaveformOutput> {
     let file = fs::File::open(path).ok()?;
     waveform_from_source(Box::new(file), ext)
+}
+
+// ── Chromaprint fingerprint (--fingerprint) ─────────────────────────────────
+//
+// AcoustID identity chain, step one: decode → chromaprint TEST2 → compressed
+// base64 — the exact string api.acoustid.org/v2/lookup takes. Conventions
+// mirror the reference fpcalc (validated live against AcoustID at 98-99.8%
+// match scores in the Phase-2 spike): fingerprint only the FIRST 120s,
+// report the FULL duration; feed native-rate interleaved s16 (the crate
+// resamples internally); TEST2 is the only algorithm AcoustID indexes.
+
+struct FingerprintOutput {
+    fingerprint: String,        // base64 (url-safe, no pad) compressed fp
+    duration_sec: Option<u64>,  // full track length; None when the container doesn't say
+    fp_seconds: f64,            // seconds of audio actually fingerprinted
+}
+
+const FINGERPRINT_WINDOW_SEC: u64 = 120;
+
+fn fingerprint_from_file(path: &Path, ext: &str) -> Option<FingerprintOutput> {
+    // Same Opus posture as the waveform pass: no pure-Rust decoder in
+    // symphonia 0.6 (only a libopus C adapter, deliberately avoided).
+    // Callers treat null as skip-with-marker.
+    if ext == "opus" { return None; }
+
+    let file = fs::File::open(path).ok()?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    hint.with_extension(ext);
+
+    let mut format = symphonia::default::get_probe()
+        .probe(&hint, mss, FormatOptions::default(), MetadataOptions::default())
+        .ok()?;
+
+    let (track_id, num_frames, audio_params) = format.tracks().iter().find_map(|t| {
+        match &t.codec_params {
+            Some(CodecParameters::Audio(p)) => Some((t.id, t.num_frames, p.clone())),
+            _ => None,
+        }
+    })?;
+    // chromaprint needs the true input rate for its internal resampler —
+    // unlike the waveform pass there is no safe fallback here.
+    let sample_rate = audio_params.sample_rate?;
+    let channels = audio_params.channels.as_ref().map(|c| c.count()).unwrap_or(2) as u32;
+
+    let mut decoder = symphonia::default::get_codecs()
+        .make_audio_decoder(&audio_params, &AudioDecoderOptions::default())
+        .ok()?;
+
+    let config = Configuration::preset_test2();
+    let mut printer = Fingerprinter::new(&config);
+    printer.start(sample_rate, channels).ok()?;
+
+    let cap_samples = (FINGERPRINT_WINDOW_SEC * sample_rate as u64 * channels as u64) as usize;
+    let mut fed: usize = 0;
+    let mut interleaved: Vec<i16> = Vec::new();
+
+    loop {
+        let packet = match format.next_packet() {
+            Ok(Some(p)) => p,
+            _ => break, // clean EOF or unrecoverable — fingerprint what we have
+        };
+        if packet.track_id != track_id { continue; }
+        let decoded = match decoder.decode(&packet) {
+            Ok(d) => d,
+            Err(_) => continue, // skip corrupt packet, keep going
+        };
+        decoded.copy_to_vec_interleaved(&mut interleaved);
+        // Hard cap at exactly 120s of samples so the fingerprint is
+        // deterministic regardless of the container's packet sizing.
+        let take = interleaved.len().min(cap_samples - fed);
+        printer.consume(&interleaved[..take]);
+        fed += take;
+        if fed >= cap_samples { break; }
+    }
+
+    if fed == 0 { return None; }
+    printer.finish();
+    let raw = printer.fingerprint();
+    if raw.is_empty() { return None; }
+
+    let compressed = FingerprintCompressor::from(&config).compress(raw);
+    Some(FingerprintOutput {
+        fingerprint: URL_SAFE_NO_PAD.encode(&compressed),
+        duration_sec: num_frames.map(|n| n / sample_rate as u64),
+        fp_seconds: fed as f64 / (sample_rate as f64 * channels as f64),
+    })
 }
 
 // Hash a whole-file buffer. Direct slice access means no seeks, no

--- a/test/scanner/fingerprint.test.mjs
+++ b/test/scanner/fingerprint.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * rust-parser --fingerprint <file> — the AcoustID identity chain, step one.
+ *
+ * Contract (single-line JSON on stdout, exit 0 either way):
+ *   decodable  → {"fingerprint":"<base64 url-safe no-pad>","durationSec":N|null,"fpSeconds":F}
+ *   opus/undecodable → {"fingerprint":null}
+ *
+ * The fingerprint is a chromaprint TEST2 compressed fingerprint — the exact
+ * string api.acoustid.org/v2/lookup accepts (validated live in the Phase-2
+ * spike: real music matched AcoustID at 98–99.8% with correct recording
+ * MBIDs). These tests assert the CLI contract, format header, determinism
+ * and failure modes — not acoustic quality, which only the live service can
+ * judge.
+ *
+ * Capability-gated (the protocol-PR CI rule): full-ci runs against master's
+ * prebuilt rust-parser, which predates this subcommand until the post-merge
+ * binaries rebuild — probe in before(), skip with a reason on old binaries.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { findRustParser, FFMPEG } from '../helpers/scanner-runner.mjs';
+
+const run = promisify(execFile);
+
+let rustBin;
+let workDir;
+let hasFingerprint = false;
+
+// Real tones, not the silence the shared makeAudio fixture emits — chromaprint
+// over silence is degenerate and would undermine the differs-by-content test.
+async function makeTone(filepath, freqHz, seconds, codecArgs) {
+  await fsp.mkdir(path.dirname(filepath), { recursive: true });
+  await run(FFMPEG, [
+    '-nostdin', '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', `sine=frequency=${freqHz}:sample_rate=44100:duration=${seconds}`,
+    '-ac', '2', ...codecArgs,
+    filepath,
+  ]);
+}
+
+async function fingerprint(file) {
+  const { stdout } = await run(rustBin, ['--fingerprint', file]);
+  return JSON.parse(stdout.trim());
+}
+
+before(async () => {
+  rustBin = findRustParser();
+  if (!rustBin || !fs.existsSync(FFMPEG)) { return; } // tests skip
+
+  workDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-fp-'));
+  await makeTone(path.join(workDir, 'tone440.flac'), 440, 5, ['-c:a', 'flac']);
+  await makeTone(path.join(workDir, 'tone554.flac'), 554, 5, ['-c:a', 'flac']);
+  await makeTone(path.join(workDir, 'tone440.mp3'), 440, 5, ['-c:a', 'libmp3lame', '-b:a', '128k']);
+  await makeTone(path.join(workDir, 'tone440.opus'), 440, 5, ['-c:a', 'libopus']);
+  fs.writeFileSync(path.join(workDir, 'garbage.flac'), 'this is not audio at all\n'.repeat(64));
+
+  // Capability probe: an old binary treats "--fingerprint" as a scan-config
+  // path and errors out / prints something that isn't our JSON.
+  try {
+    const out = await fingerprint(path.join(workDir, 'tone440.flac'));
+    hasFingerprint = out !== null && typeof out === 'object' && 'fingerprint' in out;
+  } catch (_err) {
+    hasFingerprint = false;
+  }
+});
+
+after(async () => {
+  if (workDir) { await fsp.rm(workDir, { recursive: true, force: true }).catch(() => {}); }
+});
+
+// Every test needs the subcommand — one shared gate.
+function gate(t) {
+  if (!rustBin)               { t.skip('no rust-parser binary'); return false; }
+  if (!fs.existsSync(FFMPEG)) { t.skip('no bundled ffmpeg'); return false; }
+  if (!hasFingerprint) {
+    t.skip('rust-parser binary predates --fingerprint '
+      + '(CI prebuilt until the post-merge rebuild)');
+    return false;
+  }
+  return true;
+}
+
+describe('rust-parser --fingerprint', () => {
+  test('emits an AcoustID-ready fingerprint with duration', async (t) => {
+    if (!gate(t)) { return; }
+    const out = await fingerprint(path.join(workDir, 'tone440.flac'));
+
+    assert.match(out.fingerprint, /^[A-Za-z0-9_-]+$/,
+      'base64 url-safe, no padding — the exact lookup param format');
+    // The compressed-fingerprint header carries the algorithm id;
+    // AcoustID only indexes TEST2 (= 1).
+    const header = Buffer.from(out.fingerprint, 'base64url');
+    assert.equal(header[0], 1, 'chromaprint algorithm byte must be TEST2');
+
+    assert.equal(out.durationSec, 5, 'full duration from the container (integer seconds)');
+    assert.ok(out.fpSeconds > 4.9 && out.fpSeconds <= 5.1,
+      'whole (sub-120s) file fingerprinted');
+  });
+
+  test('is deterministic across runs', async (t) => {
+    if (!gate(t)) { return; }
+    const a = await fingerprint(path.join(workDir, 'tone440.flac'));
+    const b = await fingerprint(path.join(workDir, 'tone440.flac'));
+    assert.equal(a.fingerprint, b.fingerprint);
+    assert.equal(a.durationSec, b.durationSec);
+  });
+
+  test('different audio yields different fingerprints', async (t) => {
+    if (!gate(t)) { return; }
+    const a = await fingerprint(path.join(workDir, 'tone440.flac'));
+    const b = await fingerprint(path.join(workDir, 'tone554.flac'));
+    assert.notEqual(a.fingerprint, b.fingerprint);
+  });
+
+  test('mp3 input works (transform-codec path)', async (t) => {
+    if (!gate(t)) { return; }
+    const out = await fingerprint(path.join(workDir, 'tone440.mp3'));
+    assert.match(out.fingerprint, /^[A-Za-z0-9_-]+$/);
+    // MP3 containers pad; the duration is approximate but must be sane.
+    assert.ok(out.durationSec === null || (out.durationSec >= 4 && out.durationSec <= 6),
+      `mp3 durationSec sane, got ${out.durationSec}`);
+  });
+
+  test('opus is a clean null (no pure-Rust decoder — worker records a skip)', async (t) => {
+    if (!gate(t)) { return; }
+    const out = await fingerprint(path.join(workDir, 'tone440.opus'));
+    assert.equal(out.fingerprint, null);
+  });
+
+  test('garbage input is a clean null, not a crash', async (t) => {
+    if (!gate(t)) { return; }
+    const out = await fingerprint(path.join(workDir, 'garbage.flac'));
+    assert.equal(out.fingerprint, null);
+  });
+});


### PR DESCRIPTION
## What

External-ID **Phase 2, step one**: `rust-parser --fingerprint <file>` → single-line JSON with an AcoustID-ready chromaprint fingerprint (`base64` url-safe no-pad, the exact `/v2/lookup` param), full container duration, and the fingerprinted-window length. Opus/undecodable input → `{"fingerprint":null}` with exit 0 (per-file data, not a crash — the backfill worker records it as a skip).

## Fidelity to the reference

Mirrors fpcalc's conventions: fingerprint only the **first 120s** (hard sample cap — deterministic regardless of packet sizing), report the **full** duration, feed native-rate s16 (the crate resamples internally), TEST2 algorithm (the only one AcoustID indexes; the compressed header carries algorithm id 1, asserted in tests).

**Live validation** (spike + this subcommand): real library tracks matched AcoustID at **98.1–99.8%** with the correct recording MBIDs; the subcommand's own symphonia-decoded fingerprint re-verified at 98.2% on the same track/recording. A no-metadata file correctly no-matches. Matching AcoustID's index — which was built from reference fpcalc — is the parity criterion.

Deps: `rusty-chromaprint` 0.3 (MIT, ships the compressor) + `base64` 0.22. Pure Rust, no libchromaprint/libopus.

## Tests

`test/scanner/fingerprint.test.mjs` — 6 tests: format shape + TEST2 header byte, determinism, content-sensitivity, MP3 path, opus null, garbage null. **Capability-gated** per the protocol-PR CI rule (probe in `before()`; master's prebuilt skips with a reason until the post-merge binaries rebuild — verified fresh 6/6, hidden 6 skips). Scanner suite 116/116, full suite **1573/1573**. Source-only for `bin/`.

Next PR: `acoustid-backfill.mjs` — the enrichment worker that drives this per eligible track, does the rate-limited lookup, and fills `mbz_recording_id`/`acoustid_id` (upgrading discovery `export_id`s from `anon:` to `mbid:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)