### PR TITLE
feat(db): AcoustID identification worker (external-ID Phase 2)

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -329,6 +329,33 @@ export function setup(mstream) {
     res.json({});
   });
 
+  // Toggle the AcoustID identification pass (chromaprint fingerprint →
+  // MusicBrainz recording MBID for tracks whose tags carry none). Default
+  // OFF — it sends acoustic fingerprints to an external service. Flipping
+  // ON enqueues an immediate pass through the same guarded path as the
+  // scan-drain trigger (config, API key, rust-parser, eligibility).
+  mstream.post("/api/v1/admin/db/params/analyze-acoustid", async (req, res) => {
+    const schema = Joi.object({
+      analyzeAcoustid: Joi.boolean().required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editAnalyzeAcoustid(req.body.analyzeAcoustid);
+    if (req.body.analyzeAcoustid === true) { dbQueue.maybeEnqueueAcoustid(); }
+    res.json({});
+  });
+
+  // Tracks identified per AcoustID pass. Mirrors analyze-bpm-per-run.
+  mstream.post("/api/v1/admin/db/params/acoustid-per-run", async (req, res) => {
+    const schema = Joi.object({
+      acoustidPerRun: Joi.number().integer().min(1).max(10000).required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editAcoustidPerRun(req.body.acoustidPerRun);
+    res.json({});
+  });
+
   // Toggle collection of music-discovery data (embeddings + external IDs)
   // into the separate discovery.db. Flipping it ON creates/migrates the DB
   // immediately AND enqueues an embedding pass (through the SAME guarded

--- a/src/db/acoustid-backfill.mjs
+++ b/src/db/acoustid-backfill.mjs
@@ -181,12 +181,17 @@ const recordLookup = db.prepare(`
 `);
 
 // Fill NULLs only, across every copy sharing the canonical hash — a
-// tag-sourced id (and its 'tag' provenance) is never overwritten.
+// tag-sourced recording MBID is never overwritten (the WHERE excludes such
+// rows entirely). mbz_id_source flips to 'acoustid' unconditionally here:
+// the column answers "who identified this track", and inside this UPDATE we
+// ARE the identity provider — even when a lesser id (ISRC) was tag-read
+// earlier and had set provenance to 'tag'. Found in the live smoke: ISRC-
+// bearing Bandcamp files kept 'tag' while their MBID came from AcoustID.
 const fillIdentity = db.prepare(`
   UPDATE tracks
      SET mbz_recording_id = COALESCE(mbz_recording_id, ?),
          acoustid_id      = COALESCE(acoustid_id, ?),
-         mbz_id_source    = CASE WHEN mbz_id_source IS NULL THEN 'acoustid' ELSE mbz_id_source END
+         mbz_id_source    = 'acoustid'
    WHERE COALESCE(audio_hash, file_hash) = ?
      AND mbz_recording_id IS NULL
 `);

--- a/src/db/acoustid-backfill.mjs
+++ b/src/db/acoustid-backfill.mjs
@@ -1,0 +1,368 @@
+// mStream AcoustID identifier — child process forked by src/db/task-queue.js.
+//
+// External-ID Phase 2, step two: derive MusicBrainz recording MBIDs for
+// tracks whose tags don't carry one. Identity chain per track:
+//   rust-parser --fingerprint (chromaprint TEST2, first 120s)
+//     → POST api.acoustid.org/v2/lookup (rate-limited, app API key)
+//     → recording MBID + AcoustID cluster id
+//     → tracks.mbz_recording_id / acoustid_id (mbz_id_source='acoustid',
+//       fill-NULL only — tag-sourced ids are never overwritten), fanned out
+//       to every copy sharing the canonical hash
+//     → discovery.db identity upgrade (export_id anon:→mbid:, rowversion
+//       bump) so the network sees portable ids; the post-drain auto-publish
+//       re-announces the snapshot.
+//
+// Mirrors audio-analysis-backfill.mjs's operational contract: serial task
+// slot, maxPerRun + wall-clock budget, per-outcome cooldowns in
+// acoustid_lookups (V56), hitCap re-enqueue. Network-bound: every attempt
+// costs an API request, so the 3-req/s throttle (350ms) is the pacing guard.
+//
+// Cooldown design (matches the discovery worker): SUCCESS needs no ledger
+// row — a matched track has mbz_recording_id set and drops out of the
+// eligible set. acoustid_lookups records FAILURES only:
+//   'nomatch'     not in AcoustID (long cooldown — coverage grows slowly)
+//   'lowconf'     matched below the score floor / ambiguous (long)
+//   'undecodable' fingerprinter returned null (opus, corrupt) (long)
+//   'error'       transient (network, API hiccup) (short)
+//
+// CLI input — single argv entry, JSON-encoded (built in task-queue.js):
+//   { dbPath, discoveryDbPath?, rustParserPath, apiKey, apiUrl?, maxPerRun,
+//     expectedSchemaVersion, minDurationSec, maxDurationSec, minScore,
+//     nomatchCooldownSec, errorCooldownSec, runBudgetSec, throttleMs }
+//
+// stdout protocol — line-buffered single-line JSON events:
+//   { event: 'acoustidProgress', attempted, total }
+//   { event: 'acoustidComplete', attempted, matched, nomatch, lowconf, undecodable, errors, hitCap }
+//   { event: 'error', message }     ← always followed by exit 1
+//
+// Exit codes: 0 completed (per-track failures recorded, not fatal);
+// 1 fatal (bad input, DB open failure, rust-parser predates --fingerprint);
+// 3 library schema-version guard.
+
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import Joi from 'joi';
+import { DatabaseSync } from './sqlite-driver.js';
+import { initDiscoveryDb, updateDiscoveryIdentity } from './discovery-db.js';
+
+const run_ = promisify(execFile);
+const SCHEMA_GUARD_EXIT = 3;
+
+// ── Parse + validate CLI input ───────────────────────────────────────────────
+
+let loadJson;
+try {
+  loadJson = JSON.parse(process.argv[process.argv.length - 1]);
+} catch (_error) {
+  console.error('Warning: failed to parse JSON input');
+  process.exit(1);
+}
+
+const schema = Joi.object({
+  dbPath: Joi.string().required(),
+  // Optional: present when discovery collection has a DB — matched ids are
+  // propagated so export_id upgrades from anon: to mbid:.
+  discoveryDbPath: Joi.string().optional(),
+  // Resolved rust-parser binary (the main process owns binary resolution).
+  rustParserPath: Joi.string().required(),
+  apiKey: Joi.string().required(),
+  apiUrl: Joi.string().uri().default('https://api.acoustid.org/v2/lookup'),
+  maxPerRun: Joi.number().integer().min(1).default(200),
+  expectedSchemaVersion: Joi.number().integer().optional(),
+  // Fingerprint window: very short files fingerprint poorly; very long ones
+  // (DJ sets, audiobooks) aren't a single recording.
+  minDurationSec: Joi.number().min(0).default(10),
+  maxDurationSec: Joi.number().min(1).default(2 * 60 * 60),
+  // Accept only confident matches — the live spike scored real music at
+  // 98%+, so 0.9 leaves comfortable margin while rejecting fuzzy hits.
+  minScore: Joi.number().min(0).max(1).default(0.9),
+  // 'nomatch'/'lowconf'/'undecodable' share the long cooldown (AcoustID
+  // coverage grows slowly; the audio never changes); 'error' retries soon.
+  nomatchCooldownSec: Joi.number().integer().min(0).default(30 * 24 * 60 * 60),
+  errorCooldownSec: Joi.number().integer().min(0).default(24 * 60 * 60),
+  runBudgetSec: Joi.number().integer().min(1).default(300),
+  // AcoustID allows 3 req/s per application — 350ms spacing keeps us under.
+  throttleMs: Joi.number().integer().min(0).default(350),
+});
+
+const { error: validationError, value: cfg } = schema.validate(loadJson);
+if (validationError) {
+  console.error('Invalid JSON Input');
+  console.log(validationError);
+  process.exit(1);
+}
+
+// ── Open SQLite databases ────────────────────────────────────────────────────
+
+const db = new DatabaseSync(cfg.dbPath);
+db.exec('PRAGMA journal_mode = WAL');
+db.exec('PRAGMA foreign_keys = ON');
+db.exec('PRAGMA busy_timeout = 5000');
+
+function emit(event) { console.log(JSON.stringify(event)); }
+
+function checkSchemaGuard(context) {
+  if (cfg.expectedSchemaVersion == null) { return; }
+  const v = db.prepare('PRAGMA user_version').get().user_version;
+  if (v !== cfg.expectedSchemaVersion) {
+    emit({ event: 'error',
+      message: `schema-version guard: DB is V${v}, expected V${cfg.expectedSchemaVersion} (${context})` });
+    try { db.close(); } catch (_) { /* best-effort */ }
+    process.exit(SCHEMA_GUARD_EXIT);
+  }
+}
+checkSchemaGuard('at open');
+
+// Discovery DB is optional — identity propagation is best-effort and the
+// feature works without collection enabled.
+let discoveryOpen = false;
+if (cfg.discoveryDbPath) {
+  try {
+    initDiscoveryDb(cfg.discoveryDbPath);
+    discoveryOpen = true;
+  } catch (err) {
+    console.error(`Warning: discovery DB unavailable, skipping propagation: ${err?.message || err}`);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function pruneOrphans() {
+  try {
+    db.prepare(`
+      DELETE FROM acoustid_lookups
+       WHERE audio_hash NOT IN (
+         SELECT audio_hash FROM tracks WHERE audio_hash IS NOT NULL
+         UNION
+         SELECT file_hash  FROM tracks WHERE file_hash  IS NOT NULL
+       )
+    `).run();
+  } catch (_e) { /* best-effort housekeeping */ }
+}
+
+// Tracks needing identification: no recording MBID (from tags OR a previous
+// pass), inside the duration window, off cooldown. One representative row
+// per canonical hash; the match fans out to every copy.
+function selectEligibleTracks(nowSec) {
+  const longCutoff = nowSec - cfg.nomatchCooldownSec;
+  const errorCutoff = nowSec - cfg.errorCooldownSec;
+  return db.prepare(`
+    SELECT MIN(t.id) AS track_id,
+           COALESCE(t.audio_hash, t.file_hash) AS canon_hash,
+           t.filepath AS filepath,
+           t.duration AS duration,
+           lib.root_path AS root
+      FROM tracks t
+      JOIN libraries lib ON lib.id = t.library_id
+      LEFT JOIN acoustid_lookups la
+             ON la.audio_hash = COALESCE(t.audio_hash, t.file_hash)
+     WHERE t.mbz_recording_id IS NULL
+       AND t.duration IS NOT NULL
+       AND t.duration >= ? AND t.duration <= ?
+       AND COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
+       AND (
+            la.audio_hash IS NULL
+         OR la.last_attempt_at < (CASE WHEN la.outcome = 'error' THEN ? ELSE ? END)
+       )
+     GROUP BY COALESCE(t.audio_hash, t.file_hash)
+     ORDER BY track_id
+     LIMIT ?
+  `).all(cfg.minDurationSec, cfg.maxDurationSec, errorCutoff, longCutoff, cfg.maxPerRun);
+}
+
+const recordLookup = db.prepare(`
+  INSERT INTO acoustid_lookups (audio_hash, last_attempt_at, outcome, attempts)
+  VALUES (?, ?, ?, 1)
+  ON CONFLICT(audio_hash) DO UPDATE SET
+    last_attempt_at = excluded.last_attempt_at,
+    outcome         = excluded.outcome,
+    attempts        = acoustid_lookups.attempts + 1
+`);
+
+// Fill NULLs only, across every copy sharing the canonical hash — a
+// tag-sourced id (and its 'tag' provenance) is never overwritten.
+const fillIdentity = db.prepare(`
+  UPDATE tracks
+     SET mbz_recording_id = COALESCE(mbz_recording_id, ?),
+         acoustid_id      = COALESCE(acoustid_id, ?),
+         mbz_id_source    = CASE WHEN mbz_id_source IS NULL THEN 'acoustid' ELSE mbz_id_source END
+   WHERE COALESCE(audio_hash, file_hash) = ?
+     AND mbz_recording_id IS NULL
+`);
+
+// ── Fingerprint + lookup ─────────────────────────────────────────────────────
+
+async function fingerprintFile(absPath) {
+  const { stdout } = await run_(cfg.rustParserPath, ['--fingerprint', absPath],
+    { maxBuffer: 4 * 1024 * 1024 });
+  return JSON.parse(stdout.trim());
+}
+
+let lastRequestMs = 0;
+async function throttledLookup(fingerprint, durationSec) {
+  const wait = lastRequestMs + cfg.throttleMs - Date.now();
+  if (wait > 0) { await new Promise((r) => setTimeout(r, wait)); }
+  lastRequestMs = Date.now();
+
+  const body = new URLSearchParams({
+    client: cfg.apiKey,
+    format: 'json',
+    duration: String(Math.round(durationSec)),
+    // sources ranks a result's recordings by how many submissions back them
+    // — the disambiguator when one fingerprint maps to several recordings.
+    meta: 'recordings sources',
+    fingerprint,
+  });
+  const res = await fetch(cfg.apiUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) { throw new Error(`AcoustID HTTP ${res.status}`); }
+  return res.json();
+}
+
+const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+// Distill a lookup response into an outcome. Exported shape:
+//   { outcome: 'matched', recordingMbid, acoustidId } | { outcome: 'nomatch'|'lowconf' }
+function judge(json) {
+  if (!Array.isArray(json.results) || json.results.length === 0) {
+    return { outcome: 'nomatch' };
+  }
+  const best = [...json.results].sort((a, b) => (b.score || 0) - (a.score || 0))[0];
+  if ((best.score || 0) < cfg.minScore) { return { outcome: 'lowconf' }; }
+  const recordings = (best.recordings || []).filter((r) => MBID_RE.test(r.id || ''));
+  if (recordings.length === 0) { return { outcome: 'nomatch' }; }
+  // Most-backed recording wins (sources counts submissions per recording).
+  recordings.sort((a, b) => (b.sources || 0) - (a.sources || 0));
+  return { outcome: 'matched', recordingMbid: recordings[0].id, acoustidId: best.id || null };
+}
+
+function commitMatched(canonHash, recordingMbid, acoustidId) {
+  // The library write is the source of truth; discovery propagation is a
+  // separate best-effort step (its own DB, its own transaction semantics).
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    fillIdentity.run(recordingMbid, acoustidId, canonHash);
+    db.exec('COMMIT');
+  } catch (err) {
+    try { db.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
+    throw err;
+  }
+  if (discoveryOpen) {
+    try {
+      updateDiscoveryIdentity(canonHash, recordingMbid, acoustidId);
+    } catch (err) {
+      console.error(`Warning: discovery identity propagation failed: ${err?.message || err}`);
+    }
+  }
+}
+
+// ── Run ──────────────────────────────────────────────────────────────────────
+
+async function run() {
+  // Capability probe: an old rust-parser treats --fingerprint as a scan
+  // config path and errors/garbage — without this guard every track would be
+  // cooldown-poisoned as 'undecodable'. Fatal: task-queue logs it once.
+  try {
+    const probe = await fingerprintFile('__mstream_fingerprint_probe__');
+    if (!probe || !('fingerprint' in probe)) { throw new Error('bad probe output'); }
+  } catch (_e) {
+    emit({ event: 'error', message: 'rust-parser binary predates --fingerprint — update bin/rust-parser or rebuild' });
+    process.exit(1);
+  }
+
+  pruneOrphans();
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const tracks = selectEligibleTracks(nowSec);
+
+  if (tracks.length === 0) {
+    emit({ event: 'acoustidComplete', attempted: 0, matched: 0, nomatch: 0, lowconf: 0, undecodable: 0, errors: 0, hitCap: false });
+    return;
+  }
+
+  const startMs = Date.now();
+  let attempted = 0;
+  let matched = 0;
+  let nomatch = 0;
+  let lowconf = 0;
+  let undecodable = 0;
+  let errors = 0;
+  let consecutiveApiErrors = 0;
+  let persisted = 0;
+  let hitBudget = false;
+
+  for (let i = 0; i < tracks.length; i++) {
+    if (Date.now() - startMs > cfg.runBudgetSec * 1000) { hitBudget = true; break; }
+    // A dead API (bad key, outage) fails every request — stop burning the
+    // budget; everything unattempted stays eligible for the next pass.
+    if (consecutiveApiErrors >= 3) { hitBudget = true; break; }
+
+    const t = tracks[i];
+    attempted++;
+    const attemptSec = Math.floor(Date.now() / 1000);
+    let outcome; // null = matched (no ledger row); otherwise the failure kind
+
+    try {
+      const fp = await fingerprintFile(path.join(t.root, t.filepath));
+      if (!fp.fingerprint) {
+        outcome = 'undecodable';
+        undecodable++;
+      } else {
+        const json = await throttledLookup(fp.fingerprint, t.duration);
+        if (json.status !== 'ok') { throw new Error(`AcoustID status ${json.status}: ${json.error?.message || '?'}`); }
+        consecutiveApiErrors = 0;
+        const verdict = judge(json);
+        if (verdict.outcome === 'matched') {
+          checkSchemaGuard('before commit');
+          commitMatched(t.canon_hash, verdict.recordingMbid, verdict.acoustidId);
+          matched++;
+          persisted++;
+          outcome = null; // success — no ledger row
+        } else {
+          outcome = verdict.outcome;
+          if (outcome === 'nomatch') { nomatch++; } else { lowconf++; }
+        }
+      }
+    } catch (err) {
+      outcome = 'error';
+      errors++;
+      consecutiveApiErrors++;
+      console.error(`Warning: acoustid lookup failed for ${t.filepath}: ${err?.message || err}`);
+    }
+
+    if (outcome) {
+      try { recordLookup.run(t.canon_hash, attemptSec, outcome); persisted++; }
+      catch (_e) { /* best-effort */ }
+    }
+
+    if (attempted % 10 === 0 && i + 1 < tracks.length) {
+      emit({ event: 'acoustidProgress', attempted, total: tracks.length });
+    }
+  }
+
+  emit({
+    event: 'acoustidComplete',
+    attempted,
+    matched,
+    nomatch,
+    lowconf,
+    undecodable,
+    errors,
+    hitCap: (tracks.length === cfg.maxPerRun || hitBudget) && persisted > 0,
+  });
+}
+
+run()
+  .then(() => {
+    try { db.close(); } catch (_) { /* best-effort */ }
+    process.exit(0);
+  })
+  .catch((err) => {
+    emit({ event: 'error', message: err?.message || String(err) });
+    try { db.close(); } catch (_) { /* best-effort */ }
+    process.exit(1);
+  });

--- a/src/db/discovery-backfill.mjs
+++ b/src/db/discovery-backfill.mjs
@@ -176,6 +176,8 @@ function selectEligibleTracks(nowSec) {
            t.duration AS duration,
            t.bpm AS bpm,
            t.musical_key AS musical_key,
+           t.mbz_recording_id AS mbz_recording_id,
+           t.acoustid_id AS acoustid_id,
            a.name AS artist
       FROM lib.tracks t
       JOIN lib.libraries l ON l.id = t.library_id
@@ -277,10 +279,15 @@ async function run() {
         // the same inference. NULL for models without a classifier head.
         genreTags,
         // Tier-1 filter metadata the library already knows (tag- or
-        // essentia-sourced); the identity fields (recording_mbid/acoustid)
-        // are the fingerprint phase's job.
+        // essentia-sourced).
         bpm: t.bpm,
         musicalKey: t.musical_key,
+        // Identity carried from the library (tag-ingested or a previous
+        // AcoustID pass) so a row CREATED after identification is born with
+        // its mbid: export_id — the acoustid worker's targeted update only
+        // covers rows that already existed.
+        recordingMbid: t.mbz_recording_id,
+        acoustidId: t.acoustid_id,
       });
       // A previous failure for this hash is superseded by success.
       try { clearError.run(t.canon_hash); } catch (_e) { /* best-effort */ }

--- a/src/db/discovery-db.js
+++ b/src/db/discovery-db.js
@@ -302,3 +302,25 @@ export function upsertDiscoveryTrack(fields) {
       analyzed_at    = excluded.analyzed_at
   `).run(...params);
 }
+
+// Identity upgrade from the AcoustID pass: set the recording MBID (+ the
+// AcoustID cluster id) on an EXISTING row and recompute export_id
+// (anon: → mbid:) with a rowversion bump — deliberately NOT
+// upsertDiscoveryTrack, which replaces unsupplied fields with NULL and
+// would wipe the embedding. Fill-NULL only (a tag-sourced id that arrived
+// via the embedding pass wins); no-op when the hash has no row yet — the
+// embedding pass carries identity from the library when it creates rows,
+// so either ordering converges. Returns true when a row changed.
+export function updateDiscoveryIdentity(audioHash, recordingMbid, acoustidId) {
+  if (!audioHash || !recordingMbid) { return false; }
+  const changes = getDiscoveryDb().prepare(`
+    UPDATE discovery_tracks
+       SET recording_mbid = COALESCE(recording_mbid, ?),
+           acoustid_id    = COALESCE(acoustid_id, ?),
+           export_id      = ?,
+           updated_at     = ?
+     WHERE audio_hash = ? AND recording_mbid IS NULL
+  `).run(recordingMbid, acoustidId ?? null,
+    exportIdFor(recordingMbid, audioHash), nextUpdateSeq(), audioHash).changes;
+  return changes > 0;
+}

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -50,7 +50,10 @@
 // recording/release-track MBID, AcoustID, ISRC + provenance on tracks, and a
 // release-group MBID on albums (the scanners now also fill the long-existing
 // albums.mbz_album_id). See SCHEMA_V55.
-export const SCHEMA_VERSION = 55;
+// V56 adds acoustid_lookups — the per-track attempt cache for the AcoustID
+// fingerprint identification pass (cooldowns so unmatched / undecodable
+// files aren't re-fingerprinted and re-queried every batch). See SCHEMA_V56.
+export const SCHEMA_VERSION = 56;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2118,6 +2121,22 @@ export const SCHEMA_V55 = `
   ALTER TABLE albums ADD COLUMN mbz_release_group_id TEXT;
 `;
 
+// ── AcoustID lookup ledger — external-ID Phase 2 ───────────────────────────
+//
+// Failure cooldowns for the acoustid-backfill worker (mirror of V54's
+// audio_analysis_lookups): one row per canonical hash whose LAST attempt did
+// not produce a recording MBID. Success writes no row — a matched track has
+// tracks.mbz_recording_id set and drops out of the eligible set. Outcomes:
+// 'nomatch' / 'lowconf' / 'undecodable' (long cooldown), 'error' (short).
+export const SCHEMA_V56 = `
+  CREATE TABLE IF NOT EXISTS acoustid_lookups (
+    audio_hash      TEXT PRIMARY KEY,
+    last_attempt_at INTEGER NOT NULL,
+    outcome         TEXT NOT NULL,
+    attempts        INTEGER NOT NULL DEFAULT 1
+  );
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -2316,4 +2335,7 @@ export const MIGRATIONS = [
   // albums — read from embedded tags by both scanners. rescanRequired so an
   // upgrade repopulates them for already-scanned libraries. See SCHEMA_V55.
   { version: 55, sql: SCHEMA_V55, rescanRequired: true },
+  // V56 adds the acoustid_lookups failure-cooldown ledger for the AcoustID
+  // fingerprint pass. Pure new table — no rescan needed. See SCHEMA_V56.
+  { version: 56, sql: SCHEMA_V56 },
 ];

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -231,7 +231,8 @@ function tryMuslRetry(scanObj, reason) {
 // warning. Real errors stay error-level.
 function logWorkerStderr(prefix, line) {
   if (!line) { return; }
-  if (/^\(node:\d+\)/.test(line) || line.startsWith('(Use `node ')) {
+  if (/^\(node:\d+\)/.test(line) || line.startsWith('(Use `node ')
+      || line.startsWith('[winston]')) {
     winston.debug(`${prefix}: ${line}`);
   } else if (line.startsWith('Warning:')) {
     winston.warn(`${prefix}: ${line}`);

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -92,6 +92,7 @@ let lyricsEnqueuePending = false;
 // BPM/key analysis pass — set on a clean scan, consumed once the batch drains.
 let audioAnalysisEnqueuePending = false;
 let discoveryEnqueuePending = false;
+let acoustidEnqueuePending = false;
 // True between runAfterBoot noticing a `.rescan-pending` migration marker
 // and the resulting rescan draining the queue. The marker is only
 // unlinked once this flag is set AND the queue empties — if the process
@@ -284,6 +285,7 @@ function nextTask() {
     else if (candidate.task === 'lyrics')   { runLyricsTask(candidate); }
     else if (candidate.task === 'audioanalysis') { runAudioAnalysisTask(candidate); }
     else if (candidate.task === 'discovery') { runDiscoveryTask(candidate); }
+    else if (candidate.task === 'acoustid') { runAcoustidTask(candidate); }
   }
 }
 
@@ -291,7 +293,7 @@ function nextTask() {
 // queue makes a decision: they don't count against "drained" (the side
 // effects below are about the SCAN batch), they don't surface as `locked`
 // (isScanning), and they run strictly serial like everything else.
-const ENRICHMENT_KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery'];
+const ENRICHMENT_KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid'];
 
 // Drained-queue side effects shared by onScanClose + onBackupClose.
 // Centralised here because the DLNA bump and the migration-rescan marker
@@ -382,6 +384,14 @@ function checkQueueDrainedSideEffects() {
   if (discoveryEnqueuePending) {
     discoveryEnqueuePending = false;
     maybeEnqueueDiscovery();
+  }
+
+  // AcoustID identification (network-bound, cheap CPU): fingerprints
+  // un-identified tracks and fills MusicBrainz recording MBIDs.
+  // maybeEnqueueAcoustid re-checks config + key + binary + eligibility.
+  if (acoustidEnqueuePending) {
+    acoustidEnqueuePending = false;
+    maybeEnqueueAcoustid();
   }
 }
 
@@ -652,6 +662,8 @@ function onScanClose(forkedScan, scanObj, code) {
     audioAnalysisEnqueuePending = true;
     // Same for the discovery-embedding pass (new/changed files need vectors).
     discoveryEnqueuePending = true;
+    // And the AcoustID identification pass (new files may lack MBIDs).
+    acoustidEnqueuePending = true;
   }
 
   nextTask();
@@ -1460,6 +1472,169 @@ function runDiscoveryTask(taskObj) {
   };
   forked.on('error', (err) => {
     winston.error(`Discovery-embedding pass failed to start: ${err.message}`);
+    closeOnce(-1, null);
+  });
+  forked.on('close', (code, signal) => closeOnce(code, signal));
+}
+
+// ── AcoustID identification task ─────────────────────────────────────────────
+//
+// External-ID Phase 2: fingerprint un-identified tracks (rust-parser
+// --fingerprint) and resolve them against AcoustID into MusicBrainz
+// recording MBIDs (src/db/acoustid-backfill.mjs). Fills
+// tracks.mbz_recording_id / acoustid_id with mbz_id_source='acoustid' and
+// upgrades discovery.db export_ids from anon: to mbid:. Gated by
+// scanOptions.analyzeAcoustid (default OFF — it sends acoustic fingerprints
+// to an external service).
+
+const ACOUSTID_SCRIPT_PATH = path.join(__dirname, './acoustid-backfill.mjs');
+
+const ACOUSTID_MIN_DURATION_SEC = 10;
+const ACOUSTID_MAX_DURATION_SEC = 2 * 60 * 60;
+// Enqueue pre-check retry horizon: the worker applies real per-outcome
+// cooldowns; this only has to avoid pointless no-op forks, so it uses the
+// SHORTEST cooldown (error, 24h) as "could anything be retryable".
+const ACOUSTID_PRECHECK_RETRY_SEC = 24 * 60 * 60;
+
+// Enqueue unless the feature is off, there's no API key or rust-parser, or
+// nothing could possibly be eligible. Exported so the admin toggle routes
+// through the same gates as the scan-drain trigger.
+export function maybeEnqueueAcoustid() {
+  if (config.program.scanOptions.analyzeAcoustid !== true) { return; }
+  if (!config.program.scanOptions.acoustidApiKey) { return; }
+  if (!findRustParser()) {
+    winston.info('AcoustID pass skipped — no usable rust-parser binary');
+    return;
+  }
+
+  try {
+    const database = db.getDB();
+    if (!database) { return; }
+    const row = database.prepare(`
+      SELECT 1 FROM tracks t
+       WHERE t.mbz_recording_id IS NULL
+         AND COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
+         AND t.duration IS NOT NULL AND t.duration >= ? AND t.duration <= ?
+         AND NOT EXISTS (
+               SELECT 1 FROM acoustid_lookups la
+                WHERE la.audio_hash = COALESCE(t.audio_hash, t.file_hash)
+                  AND la.last_attempt_at >= ?
+             )
+       LIMIT 1
+    `).get(ACOUSTID_MIN_DURATION_SEC, ACOUSTID_MAX_DURATION_SEC,
+      Math.floor(Date.now() / 1000) - ACOUSTID_PRECHECK_RETRY_SEC);
+    if (!row) { return; }
+  } catch (err) {
+    winston.warn('AcoustID pre-check failed; skipping enqueue', { stack: err });
+    return;
+  }
+
+  addAcoustidTask();
+}
+
+function addAcoustidTask() {
+  if (activeTask?.kind === 'acoustid') { return; }
+  if (taskQueue.some((t) => t.task === 'acoustid')) { return; }
+  taskQueue.push({ task: 'acoustid', id: nanoid(8) });
+  nextTask();
+}
+
+function runAcoustidTask(taskObj) {
+  // Re-check gates at run time — config may have flipped while queued.
+  if (config.program.scanOptions.analyzeAcoustid !== true) { return; }
+  if (!config.program.scanOptions.acoustidApiKey) { return; }
+  if (!findRustParser()) {
+    winston.info('AcoustID pass skipped — no usable rust-parser binary');
+    return;
+  }
+
+  const jsonLoad = {
+    dbPath: path.join(config.program.storage.dbDirectory, 'mstream.db'),
+    rustParserPath: rustParserBin,
+    apiKey: config.program.scanOptions.acoustidApiKey,
+    apiUrl: config.program.scanOptions.acoustidApiUrl,
+    maxPerRun: config.program.scanOptions.acoustidPerRun || 200,
+    expectedSchemaVersion: SCHEMA_VERSION,
+  };
+  // Matched ids propagate into discovery.db (export_id anon:→mbid:) when
+  // collection has ever created one.
+  const ddbPath = discoveryDb.discoveryDbPath();
+  if (fs.existsSync(ddbPath)) { jsonLoad.discoveryDbPath = ddbPath; }
+
+  const forked = launchWorker('acoustid', ACOUSTID_SCRIPT_PATH, JSON.stringify(jsonLoad));
+  winston.info('AcoustID identification pass started');
+  if (Number.isInteger(forked.pid)) {
+    writeScannerPidfile(config.program.storage.dbDirectory, forked.pid,
+      process.execPath, 'js', workerReaperMarker('acoustid', ACOUSTID_SCRIPT_PATH));
+  }
+
+  const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
+  addToKillQueue(killFn);
+  const observers = { hitCap: false, matched: 0 };
+  activeTask = { kind: 'acoustid', taskObj, child: forked, killFn, observers };
+
+  bufferLines(forked.stdout, (line) => {
+    if (!line) { return; }
+    if (line[0] === '{') {
+      try {
+        const evt = JSON.parse(line);
+        if (evt.event === 'acoustidComplete') {
+          observers.hitCap = !!evt.hitCap;
+          observers.matched = evt.matched || 0;
+          if (evt.attempted > 0) {
+            winston.info(`AcoustID pass complete: ${evt.matched} identified, `
+              + `${evt.nomatch} unknown to AcoustID, ${evt.lowconf} low-confidence, `
+              + `${evt.undecodable} undecodable, ${evt.errors} error(s) (${evt.attempted} attempted)`);
+          }
+          return;
+        }
+        if (evt.event === 'acoustidProgress') {
+          winston.info(`AcoustID: ${evt.attempted}/${evt.total} tracks attempted`);
+          return;
+        }
+        if (evt.event === 'error') {
+          winston.error(`AcoustID pass: ${evt.message}`);
+          return;
+        }
+      } catch (_) { /* not a structured event — log as plain text */ }
+    }
+    winston.info(line);
+  });
+  bufferLines(forked.stderr, (line) => logWorkerStderr('AcoustID pass', line));
+
+  let closed = false;
+  const closeOnce = (code, signal) => {
+    if (closed) { return; }
+    closed = true;
+    if (signal) {
+      winston.info(`AcoustID pass terminated by ${signal}`);
+    } else if (code === 3) {
+      winston.warn('AcoustID pass aborted: library schema changed under it (another instance migrating?)');
+    } else if (code !== 0 && code !== null) {
+      winston.warn(`AcoustID pass exited with code ${code}`);
+    }
+    clearScannerPidfile(config.program.storage.dbDirectory);
+    if (activeTask?.child === forked) {
+      removeFromKillQueue(activeTask.killFn);
+      activeTask = null;
+    }
+    if (code === 0 && !signal && observers.hitCap) {
+      maybeEnqueueAcoustid();
+    }
+    // Identity upgrades bump discovery.db's row_seq — publish them to the
+    // network once the backlog drains (no-ops when p2p is off or nothing
+    // moved; same hook as the embedding pass).
+    if (code === 0 && !signal && observers.matched > 0
+        && !taskQueue.some((t) => t.task === 'acoustid')) {
+      import('../state/discovery-p2p.js')
+        .then((p2p) => p2p.maybeAutoPublishSnapshot())
+        .catch((err) => winston.warn(`discovery auto-publish after AcoustID pass failed: ${err.message}`));
+    }
+    nextTask();
+    checkQueueDrainedSideEffects();
+  };
+  forked.on('error', (err) => {
+    winston.error(`AcoustID pass failed to start: ${err.message}`);
     closeOnce(-1, null);
   });
   forked.on('close', (code, signal) => closeOnce(code, signal));

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -83,6 +83,24 @@ const scanOptions = Joi.object({
   // runBudget and re-enqueues while a backlog remains — this just bounds one
   // batch. Mirrors autoAlbumArtPerRun.
   analyzeBpmPerRun: Joi.number().integer().min(1).max(10000).default(200),
+  // AcoustID identification: fingerprint tracks with no MusicBrainz
+  // recording MBID (rust-parser --fingerprint, chromaprint) and resolve
+  // them via api.acoustid.org into tracks.mbz_recording_id / acoustid_id
+  // (mbz_id_source='acoustid'; tag-sourced ids are never overwritten).
+  // Default OFF: opt-in by design — it sends acoustic fingerprints of the
+  // library to an external service.
+  analyzeAcoustid: Joi.boolean().default(false),
+  // Tracks identified per pass. Network-bound (one rate-limited API request
+  // each, ~3/s); the worker also caps wall-clock at its runBudget and
+  // re-enqueues while a backlog remains.
+  acoustidPerRun: Joi.number().integer().min(1).max(10000).default(200),
+  // The AcoustID application key. Client app keys are not secrets (the
+  // Picard convention) — the mStream project key ships as the default;
+  // forks register their own at acoustid.org/new-application.
+  acoustidApiKey: Joi.string().allow('').default('BOJOtheMHU'),
+  // Lookup endpoint — overridable so tests can stub the service. Not an
+  // admin surface.
+  acoustidApiUrl: Joi.string().uri().default('https://api.acoustid.org/v2/lookup'),
   // Collect per-track music-discovery data (audio embeddings + external IDs
   // + filter metadata) into the SEPARATE discovery.db (src/db/discovery-db.js)
   // — deliberately isolated from mstream.db so the dataset stays a single

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -457,6 +457,27 @@ export async function editAnalyzeBpmPerRun(val) {
   config.program.scanOptions.analyzeBpmPerRun = val;
 }
 
+// Toggle the AcoustID identification pass (fingerprint → MusicBrainz
+// recording MBID for tag-less tracks). Same live-update pattern as
+// editAnalyzeBpm; the api route enqueues an immediate pass when this
+// flips on.
+export async function editAnalyzeAcoustid(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.analyzeAcoustid = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.analyzeAcoustid = val;
+}
+
+// Tracks identified per AcoustID pass — live like editAnalyzeBpmPerRun.
+export async function editAcoustidPerRun(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.acoustidPerRun = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.acoustidPerRun = val;
+}
+
 // Music-discovery data collection toggle (the separate discovery.db —
 // src/db/discovery-db.js). Same live-update pattern as editAnalyzeBpm:
 // persist to config.json, then mutate config.program in-memory so no reboot

--- a/test/integration/acoustid-backfill.test.mjs
+++ b/test/integration/acoustid-backfill.test.mjs
@@ -212,7 +212,10 @@ describe('acoustid-backfill worker', () => {
   test('match fans out over the canonical hash and upgrades the discovery export_id', async (t) => {
     if (!gate(t)) { return; }
     const fx = makeDb([
-      { file: 'a.flac', dur: 200, hash: 'shared' },
+      // source 'tag' with NO mbid = the ISRC-from-tags case found in the
+      // live smoke: provenance must flip to 'acoustid' when AcoustID
+      // provides the identity.
+      { file: 'a.flac', dur: 200, hash: 'shared', source: 'tag' },
       { file: 'b.flac', dur: 200, hash: 'shared' },   // byte-identical copy
     ]);
     await makeAudio(path.join(fx.musicDir, 'a.flac'));
@@ -238,7 +241,8 @@ describe('acoustid-backfill worker', () => {
     for (const row of rows) {
       assert.equal(row.mbz_recording_id, MBID, `${row.filepath} gets the most-backed recording`);
       assert.equal(row.acoustid_id, ACOUSTID);
-      assert.equal(row.mbz_id_source, 'acoustid');
+      assert.equal(row.mbz_id_source, 'acoustid',
+        'provenance names the identity provider, even over a tag-sourced ISRC');
     }
     assert.equal(readLedger(fx.libraryDbPath).length, 0, 'success writes no ledger row');
 

--- a/test/integration/acoustid-backfill.test.mjs
+++ b/test/integration/acoustid-backfill.test.mjs
@@ -1,0 +1,350 @@
+/**
+ * AcoustID identification worker tests (src/db/acoustid-backfill.mjs).
+ *
+ * The worker is spawned exactly as task-queue.js forks it, against a fixture
+ * library DB whose tracks point at small ffmpeg-synthesized audio files. The
+ * fingerprint step uses the REAL rust-parser --fingerprint (capability-gated
+ * on old prebuilts, per the protocol-PR CI rule); the AcoustID service is a
+ * local HTTP stub keyed on the request's `duration` field, so every network
+ * outcome is scripted. Covers:
+ *
+ *   - matched: recording MBID + AcoustID id fanned out to every track
+ *     sharing the canonical hash, mbz_id_source='acoustid', no ledger row,
+ *     and the discovery.db identity upgrade (export_id anon: → mbid:,
+ *     rowversion bump) without touching the embedding.
+ *   - tag-sourced ids are never candidates (mbz_recording_id NULL gate).
+ *   - nomatch / lowconf / undecodable ledger outcomes + cooldown gating.
+ *   - error outcome retries after cooldown (backdated ledger row — never
+ *     cooldown=0, which races the wall clock on fast CI).
+ *   - per-run cap + hitCap signalling.
+ *   - library schema guard: wrong user_version → exit 3, no writes.
+ *
+ * Fixture durations are the stub's switchboard: 200s→match, 201s→nomatch,
+ * 202s→lowconf, 203s→API error. The .opus fixture never reaches the stub.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { spawn, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+import { findRustParser, FFMPEG } from '../helpers/scanner-runner.mjs';
+import {
+  initDiscoveryDb, closeDiscoveryDb, upsertDiscoveryTrack,
+} from '../../src/db/discovery-db.js';
+
+const run_ = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(REPO_ROOT, 'src', 'db', 'acoustid-backfill.mjs');
+
+const MBID = 'e3e94892-d414-426f-bca8-002f78905f79';
+const ACOUSTID = '3faa22b4-d32b-4a17-b7f4-e88ec229091b';
+
+let scratch;
+let rustBin;
+let hasFingerprint = false;
+let stubServer;
+let stubUrl;
+let stubHits = [];
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(FFMPEG, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    p.stderr.on('data', (d) => { stderr += d.toString(); });
+    p.on('error', reject);
+    p.on('close', (code) => code === 0 ? resolve() : reject(new Error(`ffmpeg ${code}: ${stderr.slice(-300)}`)));
+  });
+}
+
+async function makeAudio(outPath, codecArgs = ['-c:a', 'flac']) {
+  await runFfmpeg([
+    '-nostdin', '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', 'sine=frequency=440:sample_rate=44100:duration=5',
+    '-ac', '1', ...codecArgs, outPath,
+  ]);
+}
+
+// Fixture library DB. Track spec: { file, dur, hash, mbid?, source? }.
+// The DB duration is the stub's switchboard — files themselves are 5s tones.
+function makeDb(tracks) {
+  const dir = fs.mkdtempSync(path.join(scratch, 'acoustid-'));
+  const libraryDbPath = path.join(dir, 'mstream.db');
+  const discoveryDbPath = path.join(dir, 'discovery.db');
+  const musicDir = path.join(dir, 'music');
+  fs.mkdirSync(musicDir, { recursive: true });
+
+  const db = new DatabaseSync(libraryDbPath);
+  try {
+    db.exec('PRAGMA journal_mode = WAL');
+    applyAllMigrations(db);
+    const libId = Number(db.prepare(
+      "INSERT INTO libraries (name, root_path, type) VALUES ('lib', ?, 'music')"
+    ).run(musicDir).lastInsertRowid);
+    let n = 0;
+    for (const t of tracks) {
+      n++;
+      db.prepare(`
+        INSERT INTO tracks (filepath, library_id, title, duration, audio_hash, mbz_recording_id, mbz_id_source)
+        VALUES (?, ?, ?, ?, ?, ?, ?)`)
+        .run(t.file, libId, `T${n}`, t.dur, t.hash, t.mbid ?? null, t.source ?? null);
+    }
+  } finally {
+    db.close();
+  }
+  return { dir, libraryDbPath, discoveryDbPath, musicDir };
+}
+
+function readTracks(libraryDbPath) {
+  const db = new DatabaseSync(libraryDbPath, { readOnly: true });
+  try {
+    return db.prepare(
+      'SELECT filepath, audio_hash, mbz_recording_id, acoustid_id, mbz_id_source FROM tracks ORDER BY id'
+    ).all();
+  } finally { db.close(); }
+}
+
+function readLedger(libraryDbPath) {
+  const db = new DatabaseSync(libraryDbPath, { readOnly: true });
+  try {
+    return db.prepare('SELECT audio_hash, outcome, attempts, last_attempt_at FROM acoustid_lookups ORDER BY audio_hash').all();
+  } finally { db.close(); }
+}
+
+// ── worker harness ───────────────────────────────────────────────────────────
+
+function runWorker(payload) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(process.execPath, [WORKER, JSON.stringify(payload)],
+      { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    p.stdout.on('data', (d) => { stdout += d.toString(); });
+    p.stderr.on('data', (d) => { stderr += d.toString(); });
+    const timer = setTimeout(() => { p.kill('SIGKILL'); }, 120_000);
+    p.on('close', (code) => {
+      clearTimeout(timer);
+      const events = stdout.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('{'))
+        .map((l) => { try { return JSON.parse(l); } catch (_e) { return null; } }).filter(Boolean);
+      const complete = events.find((e) => e.event === 'acoustidComplete') || null;
+      resolve({ code, events, complete, stdout, stderr });
+    });
+    p.on('error', reject);
+  });
+}
+
+function basePayload(fx, extra = {}) {
+  return {
+    dbPath: fx.libraryDbPath,
+    rustParserPath: rustBin,
+    apiKey: 'test-key',
+    apiUrl: stubUrl,
+    throttleMs: 0, // no politeness needed against our own loopback stub
+    ...extra,
+  };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+before(async () => {
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-acoustid-worker-'));
+  rustBin = findRustParser();
+  if (!rustBin || !fs.existsSync(FFMPEG)) { return; } // tests skip
+
+  // Capability probe — full-ci tests against master's prebuilt rust-parser,
+  // which predates --fingerprint until the post-merge binaries rebuild.
+  try {
+    const { stdout } = await run_(rustBin, ['--fingerprint', '__probe__']);
+    hasFingerprint = 'fingerprint' in JSON.parse(stdout.trim());
+  } catch (_e) { hasFingerprint = false; }
+
+  // AcoustID stub: outcome keyed on the request's duration field.
+  stubServer = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (d) => { body += d; });
+    req.on('end', () => {
+      const form = new URLSearchParams(body);
+      stubHits.push({ duration: form.get('duration'), client: form.get('client'), fp: form.get('fingerprint') });
+      const responses = {
+        200: { status: 'ok', results: [{ id: ACOUSTID, score: 0.98, recordings: [
+          { id: 'ffffffff-0000-4000-8000-00000000000f', sources: 1 },
+          { id: MBID, sources: 12 },
+        ] }] },
+        201: { status: 'ok', results: [] },
+        202: { status: 'ok', results: [{ id: ACOUSTID, score: 0.41, recordings: [{ id: MBID, sources: 3 }] }] },
+        203: { status: 'error', error: { message: 'stubbed failure' } },
+      };
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(responses[form.get('duration')] || { status: 'ok', results: [] }));
+    });
+  });
+  await new Promise((r) => stubServer.listen(0, '127.0.0.1', r));
+  stubUrl = `http://127.0.0.1:${stubServer.address().port}/v2/lookup`;
+});
+
+after(() => {
+  if (stubServer) { stubServer.close(); }
+  closeDiscoveryDb();
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+function gate(t) {
+  if (!rustBin)               { t.skip('no rust-parser binary'); return false; }
+  if (!fs.existsSync(FFMPEG)) { t.skip('no bundled ffmpeg'); return false; }
+  if (!hasFingerprint) {
+    t.skip('rust-parser binary predates --fingerprint (CI prebuilt until the post-merge rebuild)');
+    return false;
+  }
+  return true;
+}
+
+describe('acoustid-backfill worker', () => {
+  test('match fans out over the canonical hash and upgrades the discovery export_id', async (t) => {
+    if (!gate(t)) { return; }
+    const fx = makeDb([
+      { file: 'a.flac', dur: 200, hash: 'shared' },
+      { file: 'b.flac', dur: 200, hash: 'shared' },   // byte-identical copy
+    ]);
+    await makeAudio(path.join(fx.musicDir, 'a.flac'));
+    await makeAudio(path.join(fx.musicDir, 'b.flac'));
+
+    // Pre-seed a discovery row for the hash: anon export_id + an embedding
+    // the identity update must NOT touch.
+    closeDiscoveryDb();
+    initDiscoveryDb(fx.discoveryDbPath);
+    upsertDiscoveryTrack({
+      audioHash: 'shared', artist: 'A', title: 'T1', duration: 200,
+      modelId: 'test-fake', modelVersion: '1',
+      embedding: Buffer.from(new Float32Array([1, 0, 0]).buffer),
+    });
+    closeDiscoveryDb();
+
+    const r = await runWorker(basePayload(fx, { discoveryDbPath: fx.discoveryDbPath }));
+    assert.equal(r.code, 0, r.stderr);
+    assert.equal(r.complete.attempted, 1, 'one attempt per canonical hash');
+    assert.equal(r.complete.matched, 1);
+
+    const rows = readTracks(fx.libraryDbPath);
+    for (const row of rows) {
+      assert.equal(row.mbz_recording_id, MBID, `${row.filepath} gets the most-backed recording`);
+      assert.equal(row.acoustid_id, ACOUSTID);
+      assert.equal(row.mbz_id_source, 'acoustid');
+    }
+    assert.equal(readLedger(fx.libraryDbPath).length, 0, 'success writes no ledger row');
+
+    const ddb = new DatabaseSync(fx.discoveryDbPath, { readOnly: true });
+    const drow = ddb.prepare('SELECT export_id, recording_mbid, acoustid_id, embedding FROM discovery_tracks WHERE audio_hash = ?').get('shared');
+    ddb.close();
+    assert.equal(drow.export_id, `mbid:${MBID}`, 'anon: upgraded to mbid:');
+    assert.equal(drow.recording_mbid, MBID);
+    assert.equal(drow.acoustid_id, ACOUSTID);
+    assert.ok(drow.embedding && drow.embedding.length === 12, 'embedding untouched by the identity update');
+  });
+
+  test('tag-identified tracks are never candidates', async (t) => {
+    if (!gate(t)) { return; }
+    const fx = makeDb([
+      { file: 'tagged.flac', dur: 200, hash: 'tagged', mbid: MBID, source: 'tag' },
+      { file: 'x.flac', dur: 201, hash: 'x' },
+    ]);
+    await makeAudio(path.join(fx.musicDir, 'tagged.flac'));
+    await makeAudio(path.join(fx.musicDir, 'x.flac'));
+
+    const r = await runWorker(basePayload(fx));
+    assert.equal(r.complete.attempted, 1, 'only the un-identified track is attempted');
+    const rows = readTracks(fx.libraryDbPath);
+    assert.equal(rows[0].mbz_id_source, 'tag', 'tag provenance untouched');
+  });
+
+  test('nomatch and lowconf land in the ledger and cool down', async (t) => {
+    if (!gate(t)) { return; }
+    const fx = makeDb([
+      { file: 'nm.flac', dur: 201, hash: 'nm' },
+      { file: 'lc.flac', dur: 202, hash: 'lc' },
+    ]);
+    await makeAudio(path.join(fx.musicDir, 'nm.flac'));
+    await makeAudio(path.join(fx.musicDir, 'lc.flac'));
+
+    const r1 = await runWorker(basePayload(fx));
+    assert.equal(r1.complete.nomatch, 1);
+    assert.equal(r1.complete.lowconf, 1);
+    const ledger = readLedger(fx.libraryDbPath);
+    assert.deepEqual(ledger.map((l) => [l.audio_hash, l.outcome]),
+      [['lc', 'lowconf'], ['nm', 'nomatch']]);
+
+    const r2 = await runWorker(basePayload(fx));
+    assert.equal(r2.complete.attempted, 0, 'both on cooldown');
+  });
+
+  test('opus is recorded as undecodable without an API call', async (t) => {
+    if (!gate(t)) { return; }
+    const fx = makeDb([{ file: 'o.opus', dur: 204, hash: 'o' }]);
+    await makeAudio(path.join(fx.musicDir, 'o.opus'), ['-c:a', 'libopus']);
+
+    stubHits = [];
+    const r = await runWorker(basePayload(fx));
+    assert.equal(r.complete.undecodable, 1);
+    assert.equal(stubHits.length, 0, 'no lookup for an unfingerprintable file');
+    assert.equal(readLedger(fx.libraryDbPath)[0].outcome, 'undecodable');
+  });
+
+  test('API errors cool down briefly and retry after backdating', async (t) => {
+    if (!gate(t)) { return; }
+    const fx = makeDb([{ file: 'e.flac', dur: 203, hash: 'e' }]);
+    await makeAudio(path.join(fx.musicDir, 'e.flac'));
+
+    const r1 = await runWorker(basePayload(fx));
+    assert.equal(r1.complete.errors, 1);
+    assert.equal(readLedger(fx.libraryDbPath)[0].outcome, 'error');
+
+    // Still cooling: not retried.
+    const r2 = await runWorker(basePayload(fx));
+    assert.equal(r2.complete.attempted, 0);
+
+    // Age the row past the error cooldown, flip the track to a matchable
+    // duration — the retry should now identify it.
+    const db = new DatabaseSync(fx.libraryDbPath);
+    db.prepare('UPDATE acoustid_lookups SET last_attempt_at = last_attempt_at - 100000').run();
+    db.prepare('UPDATE tracks SET duration = 200').run();
+    db.close();
+    const r3 = await runWorker(basePayload(fx));
+    assert.equal(r3.complete.matched, 1);
+    assert.equal(readLedger(fx.libraryDbPath).length, 1, 'stale error row remains (superseded, off the eligible path)');
+  });
+
+  test('per-run cap sets hitCap so task-queue re-enqueues', async (t) => {
+    if (!gate(t)) { return; }
+    const fx = makeDb([
+      { file: 'h1.flac', dur: 200, hash: 'h1' },
+      { file: 'h2.flac', dur: 200, hash: 'h2' },
+    ]);
+    await makeAudio(path.join(fx.musicDir, 'h1.flac'));
+    await makeAudio(path.join(fx.musicDir, 'h2.flac'));
+
+    const r1 = await runWorker(basePayload(fx, { maxPerRun: 1 }));
+    assert.equal(r1.complete.attempted, 1);
+    assert.equal(r1.complete.hitCap, true);
+    const r2 = await runWorker(basePayload(fx, { maxPerRun: 1 }));
+    assert.equal(r2.complete.matched, 1, 'second pass drains the remainder');
+  });
+
+  test('library schema guard refuses a mismatched DB with exit 3', async (t) => {
+    if (!gate(t)) { return; }
+    const fx = makeDb([{ file: 'g.flac', dur: 200, hash: 'g' }]);
+    await makeAudio(path.join(fx.musicDir, 'g.flac'));
+
+    const r = await runWorker(basePayload(fx, { expectedSchemaVersion: 9999 }));
+    assert.equal(r.code, 3);
+    assert.equal(readTracks(fx.libraryDbPath)[0].mbz_recording_id, null, 'no writes');
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1939,6 +1939,18 @@ const dbView = Vue.component('db-view', {
                       </td>
                     </tr>
                     <tr>
+                      <td><b>Identify tracks via AcoustID (fingerprint &rarr; MusicBrainz ID, post-scan):</b> {{dbParams.analyzeAcoustid}}</td>
+                      <td>
+                        [<a v-on:click="toggleAnalyzeAcoustid()">{{ t('admin.settings.edit') }}</a>]
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><b>Tracks identified per AcoustID pass:</b> {{dbParams.acoustidPerRun}}</td>
+                      <td>
+                        [<a v-on:click="openModal('edit-acoustid-per-run-modal')">{{ t('admin.settings.edit') }}</a>]
+                      </td>
+                    </tr>
+                    <tr>
                       <td><b>Collect music-discovery data (separate discovery.db):</b> {{dbParams.collectDiscoveryData}}</td>
                       <td>
                         [<a v-on:click="toggleCollectDiscoveryData()">{{ t('admin.settings.edit') }}</a>]
@@ -2492,6 +2504,46 @@ const dbView = Vue.component('db-view', {
               data: { generateWaveforms: !this.dbParams.generateWaveforms }
             }).then(() => {
               Vue.set(ADMINDATA.dbParams, 'generateWaveforms', !this.dbParams.generateWaveforms);
+              iziToast.success({
+                title: t('admin.settings.updated'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            }).catch(() => {
+              iziToast.error({
+                title: t('admin.settings.failed'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            });
+          }, true],
+          [`<button>${t('admin.folders.goBack')}</button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+          }],
+        ]
+      });
+    },
+    toggleAnalyzeAcoustid: function() {
+      iziToast.question({
+        timeout: false,
+        close: false,
+        overlay: true,
+        displayMode: 'once',
+        id: 'question',
+        zindex: 99999,
+        layout: 2,
+        maxWidth: 600,
+        title: `<b>${this.dbParams.analyzeAcoustid === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')} AcoustID identification? (post-scan; sends acoustic fingerprints of un-identified tracks to api.acoustid.org and fills in MusicBrainz recording IDs)</b>`,
+        position: 'center',
+        buttons: [
+          [`<button><b>${this.dbParams.analyzeAcoustid === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')}</b></button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+            API.axios({
+              method: 'POST',
+              url: `${API.url()}/api/v1/admin/db/params/analyze-acoustid`,
+              data: { analyzeAcoustid: !this.dbParams.analyzeAcoustid }
+            }).then(() => {
+              Vue.set(ADMINDATA.dbParams, 'analyzeAcoustid', !this.dbParams.analyzeAcoustid);
               iziToast.success({
                 title: t('admin.settings.updated'),
                 position: 'topCenter',
@@ -7911,6 +7963,67 @@ const editAnalyzeBpmPerRunView = Vue.component('edit-analyze-bpm-per-run-modal',
         });
 
         Vue.set(ADMINDATA.dbParams, 'analyzeBpmPerRun', Number(this.editValue));
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+const editAcoustidPerRunView = Vue.component('edit-acoustid-per-run-modal', {
+  data() {
+    return {
+      params: ADMINDATA.dbParams,
+      submitPending: false,
+      editValue: ADMINDATA.dbParams.acoustidPerRun
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Tracks identified per AcoustID pass</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-acoustid-per-run" required type="number" min="1" max="10000">
+          <label for="edit-acoustid-per-run">Tracks per pass</label>
+          <span class="helper-text">Caps how many tracks one AcoustID pass fingerprints and looks up (rate-limited to ~3 requests/second) before yielding the task slot. The pass re-runs to drain any backlog.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/db/params/acoustid-per-run`,
+          data: { acoustidPerRun: Number(this.editValue) }
+        });
+
+        Vue.set(ADMINDATA.dbParams, 'acoustidPerRun', Number(this.editValue));
 
         M.Modal.getInstance(document.getElementById('admin-modal')).close();
 


### PR DESCRIPTION
## What

The 7th enrichment worker, completing the AcoustID identity chain built across #707/#709: tracks with no MusicBrainz recording MBID get fingerprinted (`rust-parser --fingerprint`) and resolved via api.acoustid.org into `mbz_recording_id` + `acoustid_id` with `mbz_id_source='acoustid'`.

**The network payoff**: matched identities propagate into discovery.db — `export_id` upgrades from `anon:<salted>` to `mbid:<recording>` with a rowversion bump, the embedding untouched — and the post-run auto-publish (#704) re-announces the snapshot. Cross-library matching and the "new artists only" filter become identity-grade as libraries get identified. The embedding worker now also carries identity when it *creates* rows, so either pass ordering converges on the same state.

## Shape

- **Worker** (`src/db/acoustid-backfill.mjs`) on the established enrichment contract: serial slot, `maxPerRun`/`runBudgetSec`, per-outcome cooldowns (`acoustid_lookups`, **V56** — success writes no ledger row), hitCap re-enqueue, schema guard, orphan sweep. Network-bound specifics: 350 ms throttle (3 req/s limit), **≥0.9 score acceptance** (live spike scored real music 98%+) with the most-submissions recording winning, early abort after 3 consecutive API failures, and a startup capability probe that hard-fails on a pre-`--fingerprint` binary instead of cooldown-poisoning the library.
- **Fill-NULL only, hash-fanned**: tag-sourced IDs are never overwritten; byte-identical copies all get the ID from one lookup.
- **Config**: `analyzeAcoustid` (default **OFF** — it sends acoustic fingerprints to an external service), `acoustidPerRun`, `acoustidApiKey` (project app key as default, Picard-convention; forks can register their own), `acoustidApiUrl` (test override). Admin toggle + per-run row/modal cloned from the analyze-bpm recipe; enabling enqueues an immediate pass.

## Tests

7 integration tests: real rust fingerprinting against a **scripted local AcoustID stub** (outcome keyed on the request's `duration` field) — match fanout + discovery `export_id` upgrade with embedding untouched, tag-provenance immunity, nomatch/lowconf/undecodable ledger outcomes + cooldown gating, error retry via backdated ledger rows (never `cooldown=0`), hitCap, schema-guard exit 3. Capability-gated, though CI's prebuilt already has `--fingerprint` post-#709, so everything runs for real. db suite 155/155 (V56 trips no assertions), full suite **1580/1580**.

With this merged, external-ID Phase 2 is complete. Phase 3 (MusicBrainz ws/2 enrichment + "fix bad tags" UI) remains future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)