### PR TITLE
feat(discovery): signed server descriptions in catalog announcements

### DIFF
--- a/p2p-sidecar/src/main.rs
+++ b/p2p-sidecar/src/main.rs
@@ -40,7 +40,8 @@
 //   → {"id":4,"cmd":"fetch","hash":"<64 hex>","provider":"<endpoint id>","outDir":"..."}
 //   → {"id":5,"cmd":"join","bootstrap":["<endpoint ticket | endpoint id>",...]}
 //   → {"id":6,"cmd":"announce","payload":{"hash":"...","size":1,"rowCount":1,
-//        "modelId":"...","modelVersion":"...","snapshotSeq":1,"name":"..."}}
+//        "modelId":"...","modelVersion":"...","snapshotSeq":1,"name":"...",
+//        "description":"..."}}   (description optional, ≤180 chars)
 //   → {"id":7,"cmd":"shutdown"}
 //   ← {"id":N,"ok":true,...} | {"id":N,"ok":false,"error":"..."}
 // Unsolicited events:
@@ -135,6 +136,13 @@ struct AnnouncePayload {
     snapshot_seq: u64,
     #[serde(default)]
     name: String,
+    // Operator-written blurb shown in peers' catalog UIs ("what's in this
+    // DB?"). Signed like `name` — free text a relaying peer could otherwise
+    // rewrite in transit. Empty is omitted from the wire AND the signing
+    // string, so description-less announcements stay byte- and
+    // signature-compatible with pre-description builds.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    description: String,
 }
 
 // Holds beacon wire form (kind:"holds"). Signed like announcements — the
@@ -765,17 +773,32 @@ fn validate_payload(mut p: AnnouncePayload) -> Result<AnnouncePayload> {
         if value.len() > cap { bail!("payload.{field} too long"); }
         if value.contains('|') { bail!("payload.{field} must not contain '|'"); }
     }
+    // Description is capped in CHARACTERS (180, abuse guard chosen for UI
+    // real estate) rather than bytes so multibyte scripts get the same
+    // budget. Worst case 720 UTF-8 bytes still fits MAX_ANNOUNCEMENT_BYTES.
+    if p.description.chars().count() > 180 { bail!("payload.description too long (max 180 chars)"); }
+    if p.description.contains('|') { bail!("payload.description must not contain '|'"); }
+    if p.description.chars().any(char::is_control) { bail!("payload.description must not contain control characters"); }
     Ok(p)
 }
 
 // Deterministic signing input. Pipe-separated is safe because '|' is
 // rejected in every free-text field above and the rest are hex/integers.
+// The description segment is appended ONLY when non-empty: pre-description
+// builds compute the string without it, so servers that leave the field
+// blank stay verifiable by old peers in both directions. (A described
+// announcement is dropped by old verifiers — acceptable while the network
+// is young; a wholesale format break would move CATALOG_TOPIC to /v2.)
 fn canonical_bytes(from: &str, p: &AnnouncePayload) -> Vec<u8> {
-    format!(
+    let mut s = format!(
         "{SIGNING_CONTEXT}|{from}|{}|{}|{}|{}|{}|{}|{}",
         p.hash, p.size, p.row_count, p.model_id, p.model_version, p.snapshot_seq, p.name
-    )
-    .into_bytes()
+    );
+    if !p.description.is_empty() {
+        s.push('|');
+        s.push_str(&p.description);
+    }
+    s.into_bytes()
 }
 
 fn endpoint_ticket(node: &Node) -> String {
@@ -822,8 +845,8 @@ fn load_or_create_identity(data_dir: &Path) -> Result<SecretKey> {
 mod tests {
     use super::*;
 
-    fn signed_announcement(sk: &SecretKey, from_override: Option<String>, mutate: impl FnOnce(&mut AnnouncePayload)) -> Vec<u8> {
-        let mut payload = AnnouncePayload {
+    fn test_payload() -> AnnouncePayload {
+        AnnouncePayload {
             hash: "ab".repeat(32),
             size: 1024,
             row_count: 10,
@@ -831,13 +854,24 @@ mod tests {
             model_version: "1".into(),
             snapshot_seq: 7,
             name: "Unit Test".into(),
-        };
+            description: String::new(),
+        }
+    }
+
+    // `prepare` shapes the payload BEFORE signing; `mutate` tampers AFTER.
+    fn signed_announcement_with(sk: &SecretKey, from_override: Option<String>, prepare: impl FnOnce(&mut AnnouncePayload), mutate: impl FnOnce(&mut AnnouncePayload)) -> Vec<u8> {
+        let mut payload = test_payload();
+        prepare(&mut payload);
         let from = from_override.unwrap_or_else(|| sk.public().to_string());
         let sig = sk.sign(&canonical_bytes(&from, &payload));
         mutate(&mut payload); // tampering happens AFTER signing
         serde_json::to_vec(&Announcement {
             v: 1, from, payload, sig: hex_encode(&sig.to_bytes()), n: 0,
         }).unwrap()
+    }
+
+    fn signed_announcement(sk: &SecretKey, from_override: Option<String>, mutate: impl FnOnce(&mut AnnouncePayload)) -> Vec<u8> {
+        signed_announcement_with(sk, from_override, |_| {}, mutate)
     }
 
     fn signed_holds(sk: &SecretKey, holds: Vec<String>, tamper: bool) -> Vec<u8> {
@@ -899,16 +933,64 @@ mod tests {
         // '|' is the signing-string separator; a name containing it could
         // shift field boundaries. validate_payload must refuse it outright.
         let sk = SecretKey::generate();
-        let mut payload = AnnouncePayload {
-            hash: "ab".repeat(32), size: 1, row_count: 1,
-            model_id: "m".into(), model_version: "1".into(), snapshot_seq: 1,
-            name: "evil|1000000".into(),
-        };
-        let from = sk.public().to_string();
-        let sig = sk.sign(&canonical_bytes(&from, &payload));
-        payload.name = "evil|1000000".into();
-        let wire = serde_json::to_vec(&Announcement { v: 1, from, payload, sig: hex_encode(&sig.to_bytes()), n: 0 }).unwrap();
+        let wire = signed_announcement_with(&sk, None, |p| { p.name = "evil|1000000".into(); }, |_| {});
         assert!(verify_wire(&wire).is_err());
+    }
+
+    #[test]
+    fn described_announcement_verifies_and_round_trips() {
+        let sk = SecretKey::generate();
+        let wire = signed_announcement_with(&sk, None, |p| { p.description = "36k tracks — mostly electronic & jazz".into(); }, |_| {});
+        match verify_wire(&wire).expect("must verify") {
+            Verified::Announce { payload, .. } => {
+                assert_eq!(payload.description, "36k tracks — mostly electronic & jazz");
+            }
+            other => panic!("wrong kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tampered_description_is_rejected() {
+        // The whole point of signing it: a relaying peer must not be able to
+        // rewrite the blurb (phishing/vandalism vector) in transit.
+        let sk = SecretKey::generate();
+        let wire = signed_announcement_with(&sk, None,
+            |p| { p.description = "honest description".into(); },
+            |p| { p.description = "download the full DB at evil.example".into(); });
+        assert!(verify_wire(&wire).is_err(), "tampered description must not verify");
+        // Adding a description to a signed description-less announcement is
+        // the same forgery from the other side.
+        let wire = signed_announcement(&sk, None, |p| { p.description = "injected".into(); });
+        assert!(verify_wire(&wire).is_err(), "injected description must not verify");
+    }
+
+    #[test]
+    fn legacy_wire_without_description_still_verifies() {
+        // A pre-description build signs and sends JSON with no `description`
+        // key at all. New verifiers must accept it unchanged (serde default
+        // "" + omitted canonical segment reproduce the legacy signing bytes).
+        let sk = SecretKey::generate();
+        let wire = signed_announcement(&sk, None, |_| {});
+        assert!(!String::from_utf8(wire.clone()).unwrap().contains("description"),
+            "empty description must be omitted from the wire");
+        assert!(verify_wire(&wire).is_ok(), "legacy-format announcement must verify");
+    }
+
+    #[test]
+    fn invalid_descriptions_are_rejected() {
+        let sk = SecretKey::generate();
+        // Over the 180-CHAR cap (multibyte chars count as one, so build with chars).
+        let long: String = std::iter::repeat('é').take(181).collect();
+        let wire = signed_announcement_with(&sk, None, |p| { p.description = long; }, |_| {});
+        assert!(verify_wire(&wire).is_err(), "181-char description must be rejected");
+        let exactly: String = std::iter::repeat('é').take(180).collect();
+        let wire = signed_announcement_with(&sk, None, |p| { p.description = exactly; }, |_| {});
+        assert!(verify_wire(&wire).is_ok(), "180-char description must be accepted");
+        // Separator and control characters.
+        let wire = signed_announcement_with(&sk, None, |p| { p.description = "a|b".into(); }, |_| {});
+        assert!(verify_wire(&wire).is_err(), "pipe in description must be rejected");
+        let wire = signed_announcement_with(&sk, None, |p| { p.description = "line\nbreak".into(); }, |_| {});
+        assert!(verify_wire(&wire).is_err(), "control chars in description must be rejected");
     }
 
     #[test]

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -489,6 +489,8 @@ export function setup(mstream) {
       neighbors,
       knownPeers: discoveryCatalog.size(),
       communitySeeds: config.program.discoveryP2p.useCommunitySeeds,
+      serverName: config.program.discoveryP2p.serverName,
+      serverDescription: config.program.discoveryP2p.serverDescription,
     });
   });
 
@@ -571,6 +573,34 @@ export function setup(mstream) {
       winston.warn(`discovery P2P announce failed for admin '${req.user?.username}': ${err.message}`);
       throw new WebError(`announce failed: ${err.message}`, 500);
     }
+  });
+
+  // The operator-written catalog blurb (discoveryP2p.serverDescription) —
+  // what users on other servers read to decide whether a DB is worth
+  // downloading. Live: saves to config, then re-announces the current
+  // snapshot (if one is published) so the network hears the edit now —
+  // receivers treat a text change under an unchanged snapshotSeq as news
+  // (see discovery-catalog.record). The 180-char/no-pipe/no-control rules
+  // mirror the config Joi and the sidecar's own payload validation.
+  mstream.post("/api/v1/admin/discovery/p2p/description", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      description: Joi.string().allow('').max(180).pattern(/^[^|\p{Cc}]*$/u).required(),
+    });
+    joiValidate(schema, req.body);
+    await admin.editDiscoveryServerDescription(req.body.description.trim());
+    // Best-effort broadcast: no snapshot yet / sidecar down just means
+    // peers hear the new text with the next regular announce instead.
+    let announced = false;
+    try {
+      if (discoveryExport.snapshotExists()) {
+        await discoveryP2p.announceCurrentSnapshot();
+        announced = true;
+      }
+    } catch (err) {
+      winston.warn(`discovery description re-announce failed for admin '${req.user?.username}': ${err.message}`);
+    }
+    res.json({ announced });
   });
 
   // Join the catalog topic at runtime with an extra bootstrap peer (an

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -315,6 +315,11 @@ const discoveryP2pOptions = Joi.object({
   // Display name carried in our signed catalog announcements. Pipe is
   // reserved as the announcement signing-string separator.
   serverName: Joi.string().max(64).pattern(/^[^|]*$/).default('mStream'),
+  // Operator-written blurb carried alongside the name so users browsing the
+  // catalog can tell which DB is worth downloading. 180-char abuse cap; no
+  // pipe (signing separator) or control chars — the sidecar enforces the
+  // same rules and would refuse to announce otherwise.
+  serverDescription: Joi.string().allow('').max(180).pattern(/^[^|\p{Cc}]*$/u).default(''),
   // Auto-fetch: keep a local shelf of the most useful catalog peers'
   // snapshots (online-first, then biggest — true popularity ranking needs
   // the N3 seeder tracking) and refresh a copy when its announced

--- a/src/state/discovery-catalog.js
+++ b/src/state/discovery-catalog.js
@@ -80,9 +80,13 @@ export function record(from, payload) {
     const oldSeq = existing.payload.snapshotSeq || 0;
     const newSeq = payload.snapshotSeq || 0;
     // Same-seq re-announcements are the steady-state heartbeat; only rewrite
-    // when something actually moved forward.
+    // when something actually moved forward. Name/description edits count as
+    // forward — they re-announce under an unchanged snapshotSeq (the library
+    // didn't move), and ignoring them would pin a peer's old blurb forever.
     if (newSeq < oldSeq) { return false; }
-    if (newSeq === oldSeq && existing.payload.hash === payload.hash) {
+    const sameText = existing.payload.name === payload.name
+      && (existing.payload.description || '') === (payload.description || '');
+    if (newSeq === oldSeq && existing.payload.hash === payload.hash && sameText) {
       existing.updatedAt = new Date().toISOString();
       return false;
     }

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -270,6 +270,7 @@ export async function announceCurrentSnapshot() {
     modelVersion: (manifest.model && manifest.model.version) || '',
     snapshotSeq,
     name: config.program.discoveryP2p.serverName,
+    description: config.program.discoveryP2p.serverDescription,
   };
   const result = await announce(payload);
 

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -515,6 +515,17 @@ export async function editDiscoveryModel(val) {
   config.program.scanOptions.discoveryModel = val;
 }
 
+// The blurb our signed catalog announcements carry (discoveryP2p
+// .serverDescription). Live: the api route re-announces after saving, so
+// peers hear the new text within one gossip hop instead of on next reboot.
+export async function editDiscoveryServerDescription(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.serverDescription = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.serverDescription = val;
+}
+
 export async function editAutoAlbumArt(val) {
   const loadConfig = await loadFile(config.configFile);
   if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -8,6 +8,7 @@
  *   POST /api/v1/admin/discovery/p2p/announce   publish + broadcast signed announcement
  *   POST /api/v1/admin/discovery/p2p/join       add a bootstrap peer at runtime
  *   POST /api/v1/admin/discovery/p2p/fetch      pull a snapshot by ticket or endpointId
+ *   POST /api/v1/admin/discovery/p2p/description  edit the announced blurb (live)
  *
  * Three layers of coverage:
  *
@@ -197,6 +198,7 @@ describe('discovery p2p — route gating (no sidecar needed)', () => {
       ['POST', 'fetch', { ticket: 'blobAAAAAAAAAAAAAAAAAAAA' }],
       ['POST', 'peer-dbs/fetch', { endpointId: 'a'.repeat(64) }],
       ['POST', 'peer-dbs/remove', { endpointId: 'a'.repeat(64) }],
+      ['POST', 'description', { description: 'nope' }],
       ['GET', 'catalog', undefined],
     ]) {
       const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/${route}`, {
@@ -263,6 +265,39 @@ describe('discovery p2p — enabled, validation contract', () => {
       body: JSON.stringify({ peer: 'x' }),
     });
     assert.equal(r.status, 400);
+  });
+
+  test('description validates: 180-char cap, no pipe, no control chars', async () => {
+    const post = (body) => fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/description`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    for (const body of [
+      {},                                      // missing key
+      { description: 42 },                     // not a string
+      { description: 'é'.repeat(181) },        // over the char cap
+      { description: 'come get it | free' },   // signing separator
+      { description: 'line\nbreak' },          // control character
+    ]) {
+      const r = await post(body);
+      assert.equal(r.status, 400, `${JSON.stringify(body)} should be 400`);
+    }
+    // Exactly 180 chars is the documented maximum.
+    assert.equal((await post({ description: 'é'.repeat(180) })).status, 200);
+  });
+
+  test('description saves live and reads back from status; no export → announced:false', async () => {
+    const text = 'Mostly jazz and electronic — 500 tracks, well tagged';
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/description`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: text }),
+    });
+    assert.equal(r.status, 200);
+    assert.equal((await r.json()).announced, false, 'nothing published yet — nothing to re-announce');
+
+    const status = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+    assert.equal(status.serverDescription, text);
+    assert.equal(typeof status.serverName, 'string', 'status also exposes the announce name for the admin UI');
   });
 });
 
@@ -964,5 +999,123 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
     });
     assert.equal(got.hash, heard.payload.hash);
     t.diagnostic(`zero-touch announce heard; snapshot ${got.size} bytes`);
+  });
+});
+
+// ── Catalog descriptions — the signed blurb next to each server's name ──────
+// Descriptions ride the signed announcement payload (appended to the signing
+// string only when non-empty, so blank-description announcements stay
+// compatible with pre-description binaries). Same capability-gate dance as
+// N3: CI runs master's prebuilt sidecar until this PR's binaries land.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — catalog descriptions', () => {
+  const SERVER_DESC = 'Mostly jazz — 500 well-tagged tracks';
+  let server;
+  let peer;
+  let peerDir;
+  let sidecarHasDescription = false;
+  const api = (p) => `${server.baseUrl}/api/v1/admin/discovery/p2p/${p}`;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      extraConfig: {
+        discoveryP2p: { enabled: true, serverName: 'Description Server', serverDescription: SERVER_DESC },
+        scanOptions: { collectDiscoveryData: true },
+      },
+    });
+    peerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-desc-'));
+    peer = new RawSidecar(SIDECAR_BIN, path.join(peerDir, 'sidecar'));
+    await peer.ready;
+    // Probe: a NEW sidecar rejects a pipe in the description; an OLD one
+    // doesn't know the field exists and silently drops it (serde ignores
+    // unknown payload keys) — acceptance means "no description support".
+    try {
+      await peer.rpc('announce', {
+        payload: { hash: 'a'.repeat(64), size: 1, rowCount: 1, modelId: 'm',
+          modelVersion: '1', snapshotSeq: 1, name: 'probe', description: 'x|y' },
+      });
+      sidecarHasDescription = false;
+    } catch (_err) {
+      sidecarHasDescription = true;
+    }
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    if (peerDir) { fs.rmSync(peerDir, { recursive: true, force: true }); }
+  });
+
+  test('descriptions travel signed, live-edit, and update the catalog on same-seq re-announce', async (t) => {
+    if (!sidecarHasDescription) {
+      return t.skip('prebuilt sidecar predates the description field — rebuilt binaries land after this PR merges');
+    }
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(api('status'))).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    assert.equal(status.serverDescription, SERVER_DESC, 'status exposes the configured blurb');
+
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    // Server → peer: the configured description arrives inside the
+    // signature-verified announcement.
+    assert.equal((await fetch(`${server.baseUrl}/api/v1/admin/db/discovery-export`, { method: 'POST' })).status, 200);
+    assert.equal((await fetch(api('announce'), { method: 'POST' })).status, 200);
+    const heard = await peer.waitForEvent('announcement',
+      (e) => e.from === status.endpointId, 30000);
+    assert.equal(heard.payload.description, SERVER_DESC);
+    assert.equal(heard.payload.name, 'Description Server');
+
+    // Live edit: POST /description re-announces; the peer hears the new
+    // text (immediately, or via the 15s re-broadcast loop if the flood
+    // guard swallows the instant one).
+    const edited = 'Now with vinyl rips and live sets';
+    const r = await fetch(api('description'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: edited }),
+    });
+    assert.equal(r.status, 200);
+    assert.equal((await r.json()).announced, true, 'a published snapshot means the edit broadcasts');
+    await peer.waitForEvent('announcement',
+      (e) => e.from === status.endpointId && e.payload.description === edited, 45000);
+
+    // Peer → server: a described announcement lands in the catalog…
+    const blobFile = path.join(peerDir, 'peer-snapshot.db');
+    fs.writeFileSync(blobFile, Buffer.from('peer discovery data ' + 'x'.repeat(4096)));
+    const pub = await peer.rpc('publish', { path: blobFile });
+    const payload = { hash: pub.hash, size: pub.size, rowCount: 9, modelId: 'test-model',
+      modelVersion: '1', snapshotSeq: 3, name: 'DescPeer', description: 'first blurb' };
+    await peer.rpc('announce', { payload });
+    const entry = await pollUntil(async () => {
+      const c = await (await fetch(api('catalog'))).json();
+      const e = c.peers.find((p) => p.from === peer.endpointId);
+      return e && e.payload.description === 'first blurb' ? e : null;
+    }, { timeoutMs: 30000, what: "peer's description in the catalog" });
+    assert.equal(entry.payload.name, 'DescPeer');
+
+    // …and an edited description under the SAME snapshotSeq + hash still
+    // updates the entry — text changes count as news, not heartbeat (the
+    // discovery-catalog change-detection this feature depends on).
+    await peer.rpc('announce', { payload: { ...payload, description: 'second blurb' } });
+    await pollUntil(async () => {
+      const c = await (await fetch(api('catalog'))).json();
+      const e = c.peers.find((p) => p.from === peer.endpointId);
+      return e && e.payload.description === 'second blurb' ? e : null;
+    }, { timeoutMs: 45000, what: 'same-seq description edit to reach the catalog' });
+  });
+
+  test('the sidecar refuses an oversized description at the announce RPC', async (t) => {
+    if (!sidecarHasDescription) {
+      return t.skip('prebuilt sidecar predates the description field');
+    }
+    await assert.rejects(
+      peer.rpc('announce', {
+        payload: { hash: 'b'.repeat(64), size: 1, rowCount: 1, modelId: 'm',
+          modelVersion: '1', snapshotSeq: 1, name: 'x', description: 'y'.repeat(181) },
+      }),
+      /description/i,
+      'a 181-char description must be rejected before it is ever signed',
+    );
   });
 });

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1882,7 +1882,8 @@ const dbView = Vue.component('db-view', {
       sharedPlaylistsTS: ADMINDATA.sharedPlaylistUpdated,
       isPullingStats: false,
       isPullingShared: false,
-      discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false }
+      discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false },
+      p2pIdentity: P2PIDENTITY
     };
   },
   template: `
@@ -1990,6 +1991,11 @@ const dbView = Vue.component('db-view', {
                     The p2p-sidecar binary was not found for this platform — the network is unavailable.
                   </p>
                   <p><b>Endpoint:</b> <code style="word-break: break-all;">{{ discoveryP2p.status.endpointId || '(sidecar not running yet)' }}</code></p>
+                  <p><b>Announcing as:</b> {{ p2pIdentity.serverName }}
+                    <span v-if="p2pIdentity.serverDescription"> — {{ p2pIdentity.serverDescription }}</span>
+                    <span v-else style="color: #9e9e9e;"> — no description (other servers see only the name)</span>
+                    [<a v-on:click="openModal('edit-p2p-description-modal')">{{ t('admin.settings.edit') }}</a>]
+                  </p>
                   <p><b>Network:</b>
                     <span v-if="discoveryP2p.status.neighbors > 0" style="color: #2e7d32;">connected
                       — {{ discoveryP2p.status.neighbors }} mesh neighbor{{ discoveryP2p.status.neighbors === 1 ? '' : 's' }}</span>
@@ -2010,7 +2016,10 @@ const dbView = Vue.component('db-view', {
                     <thead><tr><th>Server</th><th>Tracks</th><th>Seeders</th><th>Online</th><th>Model</th><th>Downloaded</th><th></th></tr></thead>
                     <tbody>
                       <tr v-for="peer in discoveryP2p.peers" :key="peer.from">
-                        <td>{{ peer.payload.name || (peer.from.slice(0, 12) + '…') }}</td>
+                        <td>
+                          {{ peer.payload.name || (peer.from.slice(0, 12) + '…') }}
+                          <div v-if="peer.payload.description" style="color: #757575; font-size: 0.85em; max-width: 360px;">{{ peer.payload.description }}</div>
+                        </td>
                         <td>{{ peer.payload.rowCount }}</td>
                         <td>{{ peer.seeders }}</td>
                         <td>{{ peer.online ? 'online' : 'offline' }}</td>
@@ -2155,6 +2164,8 @@ const dbView = Vue.component('db-view', {
           method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/status`
         })).data;
         this.discoveryP2p.status = status;
+        P2PIDENTITY.serverName = status.serverName || '';
+        P2PIDENTITY.serverDescription = status.serverDescription || '';
         if (status.enabled === true) {
           const cat = (await API.axios({
             method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
@@ -8035,6 +8046,81 @@ const editAcoustidPerRunView = Vue.component('edit-acoustid-per-run-modal', {
       } catch(err) {
         iziToast.error({
           title: t('admin.modal.updateFailed'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+// The p2p announce identity, shared between the Discovery Network card
+// (loadDiscoveryP2p fills it from the status route) and the description
+// modal below. One object referenced from both components' data() so a
+// save in the modal re-renders the card without a refetch.
+const P2PIDENTITY = { serverName: '', serverDescription: '' };
+
+const editP2pDescriptionView = Vue.component('edit-p2p-description-modal', {
+  data() {
+    return {
+      submitPending: false,
+      editValue: P2PIDENTITY.serverDescription
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Server description</h4>
+        <div class="input-field">
+          <textarea v-model="editValue" id="edit-p2p-description" class="materialize-textarea" maxlength="180"></textarea>
+          <label for="edit-p2p-description">Description ({{ editValue.length }}/180 characters)</label>
+          <span class="helper-text">Shown next to your server's name to everyone browsing the discovery network — say what's in your library so they can tell whether your DB is worth downloading. Announced immediately; the '|' character isn't allowed.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+    M.textareaAutoResize(document.getElementById('edit-p2p-description'));
+  },
+  methods: {
+    updateParam: async function() {
+      const value = this.editValue.trim();
+      if (value.includes('|')) {
+        iziToast.warning({ title: `The '|' character is not allowed`, position: 'topCenter', timeout: 3500 });
+        return;
+      }
+      try {
+        this.submitPending = true;
+
+        const res = await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/description`,
+          data: { description: value }
+        });
+
+        P2PIDENTITY.serverDescription = value;
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: res.data.announced === true
+            ? 'Updated — announced to the network'
+            : 'Updated — will announce with the next snapshot',
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          message: err.response?.data?.error || '',
           position: 'topCenter',
           timeout: 3500
         });


### PR DESCRIPTION
## What

Operators can attach a description (≤180 chars) to their server's p2p catalog announcement, so users browsing the list of available DBs can tell which one is worth downloading before fetching it.

## How it works

- **Signed, not just carried.** The description rides the announcement payload and is covered by the ed25519 signature, same as `name` — a relaying peer can't rewrite someone's blurb in transit (phishing/vandalism vector otherwise). Tamper tests cover both directions (rewrite + injection).
- **Backward compatible by construction.** The canonical signing-string segment is appended **only when the description is non-empty**, and empty descriptions are omitted from the wire (serde `skip_serializing_if`). A server with no description produces byte-identical, signature-compatible announcements to pre-description builds. A *described* announcement fails signature recomputation on old binaries and is simply not recorded — the network's population today makes this the cheapest moment to add a signed field (verified live: rum.st's old sidecar keeps working, just doesn't show the labs' new blurbs).
- **Abuse cap:** 180 **characters** (not bytes — multibyte scripts get the same budget), no `|` (signing separator), no control chars. Enforced identically in the sidecar (`validate_payload`), config Joi, and the admin route.
- **Edits propagate without a library change.** `discovery-catalog.record()` now treats a name/description change under an unchanged `snapshotSeq` as news instead of heartbeat — without this, a blurb edit would pin until the next scan moved `row_seq`.
- **Live editing.** `POST /api/v1/admin/discovery/p2p/description` saves to config and re-announces immediately (best-effort; `announced:false` when nothing is published yet). New modal on the admin Discovery Network card; peer descriptions render under server names in the catalog table.

## Testing

- **Cargo (15):** round-trip, tampered/injected description rejected, legacy wire without the field verifies, 180-char boundary + pipe + control-char rejection.
- **Integration (31/31 with fresh binary):** route 403-gating + validation contract, and a full two-node loop — configured description travels signed → live edit re-announces → peer hears the new text → peer's description lands in the catalog → **same-seq re-announce updates the entry**. Capability-gated against master's prebuilt sidecar (probe + `t.skip`, N3 pattern), so CI stays green until the post-merge binary rebuild.
- **Full suite:** 1584/1584 pass.
- **Live smoke:** two labs on the real public mesh alongside rum.st (old binary). B's admin UI: edited the description through the modal → card updated reactively → Lab A's catalog picked up the new text in seconds at unchanged `snapshotSeq`. rum-st renders description-less next to a described peer, and its old sidecar kept verifying the labs' *empty-description* announcements (compat path confirmed in the wild).

⚠ Source-only PR: `bin/p2p-sidecar/*` rebuilds via CI on merge (`build-p2p-sidecar.yml`), same as every protocol PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)