### PR TITLE
feat(admin): editable peer-snapshot storage cap + catalog search

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -491,6 +491,7 @@ export function setup(mstream) {
       communitySeeds: config.program.discoveryP2p.useCommunitySeeds,
       serverName: config.program.discoveryP2p.serverName,
       serverDescription: config.program.discoveryP2p.serverDescription,
+      maxPeerDbStorageMb: config.program.discoveryP2p.maxPeerDbStorageMb,
     });
   });
 
@@ -621,6 +622,21 @@ export function setup(mstream) {
       throw new WebError(`failed to start the discovery network: ${err.message}`, 500);
     }
     res.json({ enabled: true, collectForced });
+  });
+
+  // Disk cap for fetched peer snapshots. Live: the fetch paths read the
+  // config fresh per download, so no restart and no stack bounce. Bounds
+  // mirror the config Joi (discoveryP2pOptions.maxPeerDbStorageMb).
+  // Lowering below current usage blocks new fetches but evicts nothing —
+  // removal stays an explicit operator action.
+  mstream.post("/api/v1/admin/discovery/p2p/max-storage", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      maxPeerDbStorageMb: Joi.number().integer().min(10).max(100000).required(),
+    });
+    joiValidate(schema, req.body);
+    await admin.editMaxPeerDbStorageMb(req.body.maxPeerDbStorageMb);
+    res.json({});
   });
 
   // The display name peers see next to the description. Same save +

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -536,6 +536,19 @@ export async function editDiscoveryServerName(val) {
   config.program.discoveryP2p.serverName = val;
 }
 
+// Cap (MB) on how much disk fetched peer snapshots may use. Live: the
+// auto-fetch reconciler and the manual fetch route both read it fresh per
+// fetch, so a change applies to the very next download. Lowering it below
+// current usage blocks new fetches but evicts nothing — the operator
+// removes snapshots explicitly from the Discovery page.
+export async function editMaxPeerDbStorageMb(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.maxPeerDbStorageMb = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.maxPeerDbStorageMb = val;
+}
+
 // The p2p master switch. Persisting the flag is all this does — the api
 // route owns starting/stopping the runtime stack (and rolls this back if
 // the stack fails to come up), so the config file never claims a state the

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -1196,6 +1196,27 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
     assert.equal((await (await fetch(api('status'))).json()).serverName, 'Runtime Lab');
   });
 
+  test('max-storage saves live, persists, validates, and the catalog reports the new cap', async () => {
+    const r = await post('max-storage', { maxPeerDbStorageMb: 1234 });
+    assert.equal(r.status, 200);
+
+    // Status + catalog both reflect it immediately (the fetch paths read
+    // config live, so this is also the enforcement value from now on).
+    const status = await (await fetch(api('status'))).json();
+    assert.equal(status.maxPeerDbStorageMb, 1234);
+    const cat = await (await fetch(api('catalog'))).json();
+    assert.equal(cat.storage.capBytes, 1234 * 1024 * 1024);
+    // And it survives a reboot: persisted to the config file.
+    assert.equal(readConfig().discoveryP2p.maxPeerDbStorageMb, 1234);
+
+    for (const bad of [9, 100001, 12.5, 'many', null]) {
+      const rej = await post('max-storage', { maxPeerDbStorageMb: bad });
+      assert.equal(rej.status, 400, `${JSON.stringify(bad)} should be 400`);
+    }
+    assert.equal((await (await fetch(api('status'))).json()).maxPeerDbStorageMb, 1234,
+      'rejections must not clobber the saved cap');
+  });
+
   test('disable: stack stops, gates close, collection deliberately stays on', async () => {
     const r = await post('enabled', { enabled: false });
     assert.equal(r.status, 200);

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -718,6 +718,11 @@ I18N.onChange(() => { I18NSTATE.version += 1; });
 // the tail of this file is still in the const temporal dead zone.
 const P2PIDENTITY = { serverName: '', serverDescription: '' };
 
+// Same shared-object pattern (and the same must-be-hoisted TDZ rule) for
+// the editable p2p settings: the Discovery card fills it from the status
+// route, the max-storage modal edits it.
+const P2PSETTINGS = { maxPeerDbStorageMb: 500 };
+
 const foldersView = Vue.component('folders-view', {
   data() {
     return {
@@ -6920,7 +6925,8 @@ const discoveryView = Vue.component('discovery-view', {
     return {
       discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false },
       p2pIdentity: P2PIDENTITY,
-      p2pToggling: false
+      p2pToggling: false,
+      peerFilter: ''
     };
   },
   template: `
@@ -6980,13 +6986,20 @@ const discoveryView = Vue.component('discovery-view', {
                   </p>
                   <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
                     {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
+                    [<a v-on:click="openModal('edit-p2p-max-storage-modal')">{{ t('admin.settings.edit') }}</a>]
                     — auto-fetch {{ discoveryP2p.autoFetch ? 'on' : 'off' }}
                     — community seeds {{ discoveryP2p.status.communitySeeds ? 'on (public network)' : 'off (friends only)' }}
                   </p>
-                  <table v-if="discoveryP2p.peers.length > 0">
+                  <div v-if="discoveryP2p.peers.length > 5" class="input-field" style="max-width: 360px; margin: 4px 0 0 0;">
+                    <input v-model="peerFilter" id="p2p-peer-filter" type="text" placeholder="Search servers — name or description">
+                  </div>
+                  <p v-if="peerFilter && discoveryP2p.peers.length > 0" style="color: #757575; font-size: 0.85em; margin: 2px 0;">
+                    {{ filteredPeers.length }} of {{ discoveryP2p.peers.length }} servers
+                  </p>
+                  <table v-if="filteredPeers.length > 0">
                     <thead><tr><th>Server</th><th>Tracks</th><th>Seeders</th><th>Online</th><th>Model</th><th>Downloaded</th><th></th></tr></thead>
                     <tbody>
-                      <tr v-for="peer in discoveryP2p.peers" :key="peer.from">
+                      <tr v-for="peer in filteredPeers" :key="peer.from">
                         <td>
                           {{ peer.payload.name || (peer.from.slice(0, 12) + '…') }}
                           <div v-if="peer.payload.description" style="color: #757575; font-size: 0.85em; max-width: 360px;">{{ peer.payload.description }}</div>
@@ -7003,6 +7016,8 @@ const discoveryView = Vue.component('discovery-view', {
                       </tr>
                     </tbody>
                   </table>
+                  <p v-else-if="discoveryP2p.peers.length > 0">No servers match
+                    &ldquo;{{ peerFilter }}&rdquo; — [<a v-on:click="peerFilter = ''">clear</a>]</p>
                   <p v-else>No peers heard yet — add a friend's ticket to <code>discoveryP2p.bootstrapPeers</code>
                   (or POST it to the join endpoint) and give gossip a minute.</p>
                   <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]
@@ -7023,6 +7038,17 @@ const discoveryView = Vue.component('discovery-view', {
       const s = this.discoveryP2p.status;
       return !!(s && s.enabled === true
         && (!s.running || !s.joined || (s.neighbors || 0) === 0));
+    },
+    // Case-insensitive substring match over what the operator can see
+    // (name, description) plus the endpoint id for exactness. Preserves
+    // the server-side seeders/online/size ordering.
+    filteredPeers: function() {
+      const q = this.peerFilter.trim().toLowerCase();
+      if (!q) { return this.discoveryP2p.peers; }
+      return this.discoveryP2p.peers.filter((p) =>
+        (p.payload.name || '').toLowerCase().includes(q)
+        || (p.payload.description || '').toLowerCase().includes(q)
+        || p.from.toLowerCase().includes(q));
     },
   },
   created: async function () {
@@ -7148,6 +7174,7 @@ const discoveryView = Vue.component('discovery-view', {
         this.discoveryP2p.status = status;
         P2PIDENTITY.serverName = status.serverName || '';
         P2PIDENTITY.serverDescription = status.serverDescription || '';
+        if (status.maxPeerDbStorageMb) { P2PSETTINGS.maxPeerDbStorageMb = status.maxPeerDbStorageMb; }
         if (status.enabled === true) {
           const cat = (await API.axios({
             method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
@@ -8236,6 +8263,67 @@ const editAcoustidPerRunView = Vue.component('edit-acoustid-per-run-modal', {
 // server-side, so a no-op field shouldn't cost a broadcast). Opened from
 // the Discovery page's identity line AND auto-opened right after enabling
 // the network, so a fresh server never sits in the catalog as 'mStream'.
+const editP2pMaxStorageView = Vue.component('edit-p2p-max-storage-modal', {
+  data() {
+    return {
+      submitPending: false,
+      editValue: P2PSETTINGS.maxPeerDbStorageMb
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Peer snapshot storage cap</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-p2p-max-storage" required type="number" min="10" max="100000">
+          <label for="edit-p2p-max-storage">Max storage (MB)</label>
+          <span class="helper-text">How much disk downloaded peer snapshots may use, total. Applies to the next download immediately — lowering it below current usage blocks new downloads but never deletes anything; remove snapshots from the server list to free space.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/max-storage`,
+          data: { maxPeerDbStorageMb: Number(this.editValue) }
+        });
+
+        P2PSETTINGS.maxPeerDbStorageMb = Number(this.editValue);
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          message: err.response?.data?.error || '',
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
 const editP2pIdentityView = Vue.component('edit-p2p-identity-modal', {
   data() {
     return {


### PR DESCRIPTION
> **Stacked on #712** (which stacks on #711) — merge order: #711 → #712 → this.

Two growth valves for the Discovery page, for when the network stops being three friends:

## Editable storage cap

`discoveryP2p.maxPeerDbStorageMb` is now editable live — [edit] on the "Peer snapshots" line opens a modal (bounds mirror the config Joi: 10–100,000 MB). The fetch paths already read the config per download, so a saved change binds the very next fetch: no restart, no stack bounce. Persisted to the config file; current value exposed via the status route. Lowering the cap below current usage blocks new downloads but **never deletes** — snapshot removal stays an explicit operator action (helper text says so).

## Catalog search

Once the catalog outgrows a glance (>5 servers) a search box appears above the peers table: case-insensitive filter over server name, description, and endpoint id, with an "N of M servers" count and a clearable no-match state. Client-side, preserves the server-side seeders/online/size ordering.

## Housekeeping

Fixes the `.gitignore` repair forward (the base branch's append had glued `model-cache/` onto `docs/api.html`, leaving both patterns broken).

## Verification

- Runtime suite +1 test: cap saves live (status + catalog `capBytes` reflect immediately), persists to the config file, and 400s (`9`, `100001`, `12.5`, strings, null) don't clobber the saved value. p2p suite green.
- Browser (Lab B): modal prefilled with current value → save 750 → status reflects → restored 500. Search box hidden at ≤5 peers, appears at 6+; name match ('jazz' → 1 row), description match ('sludge' → 1 row), count line, no-match + clear link all render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)