### PR TITLE
feat(admin): P2P discovery UI — nav reorg, Discovery page, one-click enable (re-land of #712)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,4 @@ save/waveform-cache-smoke/
 
 # Generated API docs (built from docs/openapi.yaml via `npm run docs:api`;
 # also built+deployed by .github/workflows/publish-api-docs.yml)
-docs/api.html
+docs/api.htmlmodel-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,6 @@ save/waveform-cache-smoke/
 
 # Generated API docs (built from docs/openapi.yaml via `npm run docs:api`;
 # also built+deployed by .github/workflows/publish-api-docs.yml)
-docs/api.htmlmodel-cache/
+docs/api.html
+model-cache/
+

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -575,6 +575,81 @@ export function setup(mstream) {
     }
   });
 
+  // The p2p master switch, runtime edition — what the config-file flag +
+  // reboot used to be. Enabling FORCES discovery data collection on (the
+  // network is useless without embeddings; the UI's confirm dialog says so)
+  // through the exact same steps as the collect-discovery-data route, then
+  // starts the same runtime stack boot runs. Disabling stops the stack but
+  // deliberately leaves collection on — local Discover/similar features
+  // don't depend on the network. NOT behind requireP2pEnabled, obviously.
+  mstream.post("/api/v1/admin/discovery/p2p/enabled", async (req, res) => {
+    const schema = Joi.object({ enabled: Joi.boolean().required() });
+    joiValidate(schema, req.body);
+    const stack = await import('../state/discovery-p2p-stack.js');
+
+    if (req.body.enabled === false) {
+      await admin.editDiscoveryP2pEnabled(false);
+      try {
+        await stack.stopDiscoveryP2pStack();
+      } catch (err) {
+        // Already persisted off; every route gate reads the flag live, so
+        // the feature IS off — a shutdown hiccup only merits a log line.
+        winston.warn(`discovery P2P stack stop failed for admin '${req.user?.username}': ${err.message}`);
+      }
+      return res.json({ enabled: false });
+    }
+
+    if (discoveryP2p.resolveSidecarBinary() === null) {
+      throw new WebError('the p2p-sidecar binary is missing for this platform — the network cannot be enabled', 503);
+    }
+    const collectForced = config.program.scanOptions.collectDiscoveryData !== true;
+    if (collectForced) {
+      await admin.editCollectDiscoveryData(true);
+      discoveryDb.initDiscoveryDb();
+      dbQueue.maybeEnqueueDiscovery();
+    }
+    await admin.editDiscoveryP2pEnabled(true);
+    try {
+      await stack.startDiscoveryP2pStack();
+    } catch (err) {
+      // Roll the flag back so the config file never claims a state the
+      // process didn't reach (collection stays on — it's independently
+      // useful and harmless). The operator gets the cause verbatim.
+      winston.warn(`discovery P2P stack start failed for admin '${req.user?.username}': ${err.message}`);
+      await admin.editDiscoveryP2pEnabled(false);
+      await stack.stopDiscoveryP2pStack().catch(() => {});
+      throw new WebError(`failed to start the discovery network: ${err.message}`, 500);
+    }
+    res.json({ enabled: true, collectForced });
+  });
+
+  // The display name peers see next to the description. Same save +
+  // re-announce contract as the description route below; the catalog treats
+  // a name edit under an unchanged snapshotSeq as news (discovery-catalog
+  // record), so the network picks it up within a gossip hop.
+  mstream.post("/api/v1/admin/discovery/p2p/name", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      // Mirrors the config Joi (serverName): 64 chars, no pipe (the
+      // announcement signing-string separator).
+      name: Joi.string().min(1).max(64).pattern(/^[^|\p{Cc}]*$/u).required(),
+    });
+    joiValidate(schema, req.body);
+    const name = req.body.name.trim();
+    if (!name) { throw new WebError('name must not be blank', 400); }
+    await admin.editDiscoveryServerName(name);
+    let announced = false;
+    try {
+      if (discoveryExport.snapshotExists()) {
+        await discoveryP2p.announceCurrentSnapshot();
+        announced = true;
+      }
+    } catch (err) {
+      winston.warn(`discovery name re-announce failed for admin '${req.user?.username}': ${err.message}`);
+    }
+    res.json({ announced });
+  });
+
   // The operator-written catalog blurb (discoveryP2p.serverDescription) —
   // what users on other servers read to decide whether a DB is worth
   // downloading. Live: saves to config, then re-announces the current

--- a/src/server.js
+++ b/src/server.js
@@ -483,48 +483,17 @@ export async function serveIt(configFile) {
       }
     }
 
-    // Discovery-network gossip catalog (opt-in; default off). Start the
-    // p2p-sidecar, join the well-known catalog topic with the configured
-    // bootstrap peers, and re-announce our current export snapshot if one
-    // exists. Detached + non-fatal, mirroring the iroh tunnel above: a host
-    // with no sidecar binary just logs and leaves the feature off, and a
-    // slow relay handshake must not delay boot.
+    // Discovery-network gossip catalog (opt-in; default off, and also
+    // toggleable at runtime through the admin Discovery page — both paths
+    // run the SAME stack in state/discovery-p2p-stack.js). Detached +
+    // non-fatal, mirroring the iroh tunnel above: a host with no sidecar
+    // binary just logs and leaves the feature off, and a slow relay
+    // handshake must not delay boot.
     if (config.program.discoveryP2p.enabled) {
       (async () => {
         try {
-          const p2p = await import('./state/discovery-p2p.js');
-          const catalog = await import('./state/discovery-catalog.js');
-          const seeds = await import('./state/discovery-seeds.js');
-          catalog.subscribe();
-          await p2p.start();
-          // Two-phase bootstrap. Phase one joins the topic IMMEDIATELY with
-          // what's known locally (baked seeds + cached list + the operator's
-          // bootstrapPeers) — the subscription must never wait on a network
-          // fetch, both for boot speed and so peers bootstrapping off OUR
-          // ticket find a live topic. Phase two refreshes the community list
-          // and merges any additions (join is idempotent via join_peers).
-          await p2p.join(await seeds.resolveBootstrap({ localOnly: true }));
-          seeds.startMeshHealthWatch();
-          seeds.resolveBootstrap().then((full) => p2p.join(full)).catch((err) => {
-            winston.warn(`[discovery-seeds] community list refresh failed: ${err.message}`);
-          });
-          try {
-            // Builds the export first when the collected dataset is ahead of
-            // (or has never had) a snapshot — a server whose embeddings
-            // finished while p2p was off still shows up on the network.
-            const r = await p2p.maybeAutoPublishSnapshot({ announceEvenIfFresh: true });
-            if (!r.published) {
-              winston.info('[discovery-p2p] catalog joined; nothing to announce yet (no discovery data)');
-            }
-          } catch (err) {
-            winston.warn(`[discovery-p2p] catalog joined; snapshot announce failed: ${err.message}`);
-          }
-          // Auto-fetch: keep a local shelf of the best catalog peers'
-          // snapshots so the /api/v1/discovery/p2p/similar surface has data to
-          // search the moment users ask. Event-driven + periodic; all
-          // failures are per-peer logged, never fatal.
-          const peerDbs = await import('./state/discovery-peer-dbs.js');
-          peerDbs.startAutoFetch();
+          const stack = await import('./state/discovery-p2p-stack.js');
+          await stack.startDiscoveryP2pStack();
         } catch (err) {
           winston.error(`[discovery-p2p] catalog unavailable — feature disabled this boot: ${err.message}`);
         }

--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -1,0 +1,73 @@
+// The discovery-p2p runtime stack — sidecar process, gossip-catalog
+// subscription, community-seed join, snapshot auto-publish, peer auto-fetch —
+// as ONE idempotent start/stop pair. Server boot and the admin
+// enable/disable route both call this, so toggling the feature at runtime
+// replays exactly what a reboot would do (the announceCurrentSnapshot
+// precedent: one code path, never two drifting copies).
+//
+// Errors THROW from here; callers pick the policy — boot logs and leaves the
+// feature off for the session, the admin route rolls the config flag back
+// and returns the cause. Dynamic imports keep the p2p modules out of memory
+// for the (default) servers that never enable the feature.
+
+import winston from 'winston';
+
+let running = false;
+let starting = null;
+
+export function isStackRunning() { return running; }
+
+export async function startDiscoveryP2pStack() {
+  if (running) { return; }
+  if (starting) { return starting; }
+  starting = (async () => {
+    const p2p = await import('./discovery-p2p.js');
+    const catalog = await import('./discovery-catalog.js');
+    const seeds = await import('./discovery-seeds.js');
+    catalog.subscribe();
+    await p2p.start();
+    // Two-phase bootstrap. Phase one joins the topic IMMEDIATELY with
+    // what's known locally (baked seeds + cached list + the operator's
+    // bootstrapPeers) — the subscription must never wait on a network
+    // fetch, both for start speed and so peers bootstrapping off OUR
+    // ticket find a live topic. Phase two refreshes the community list
+    // and merges any additions (join is idempotent via join_peers).
+    await p2p.join(await seeds.resolveBootstrap({ localOnly: true }));
+    seeds.startMeshHealthWatch();
+    seeds.resolveBootstrap().then((full) => p2p.join(full)).catch((err) => {
+      winston.warn(`[discovery-seeds] community list refresh failed: ${err.message}`);
+    });
+    try {
+      // Builds the export first when the collected dataset is ahead of
+      // (or has never had) a snapshot — a server whose embeddings
+      // finished while p2p was off still shows up on the network.
+      const r = await p2p.maybeAutoPublishSnapshot({ announceEvenIfFresh: true });
+      if (!r.published) {
+        winston.info('[discovery-p2p] catalog joined; nothing to announce yet (no discovery data)');
+      }
+    } catch (err) {
+      winston.warn(`[discovery-p2p] catalog joined; snapshot announce failed: ${err.message}`);
+    }
+    // Auto-fetch: keep a local shelf of the best catalog peers' snapshots
+    // so the /api/v1/discovery/p2p/similar surface has data to search the
+    // moment users ask. Event-driven + periodic; all failures are per-peer
+    // logged, never fatal.
+    const peerDbs = await import('./discovery-peer-dbs.js');
+    peerDbs.startAutoFetch();
+    running = true;
+  })();
+  try { await starting; } finally { starting = null; }
+}
+
+// Timers first so nothing re-touches the sidecar mid-shutdown, then the
+// process itself. Catalog + shelf files stay on disk — a re-enable (or the
+// next boot) picks up right where this left off.
+export async function stopDiscoveryP2pStack() {
+  const seeds = await import('./discovery-seeds.js');
+  const peerDbs = await import('./discovery-peer-dbs.js');
+  seeds.stopMeshHealthWatch();
+  peerDbs.stopAutoFetch();
+  const p2p = await import('./discovery-p2p.js');
+  await p2p.stop();
+  running = false;
+}

--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -407,19 +407,35 @@ export async function reconcile() {
 // Wire auto-fetch into the world: run soon after boot (give the catalog a
 // moment to fill from gossip), re-run debounced as announcements arrive, and
 // sweep periodically as a catch-all. Idempotent across server reboot()s.
+// Named (not inline) so stopAutoFetch can detach it — the runtime disable
+// path must leave no listener that would wake the reconciler back up.
+function onAnnouncement() {
+  if (debounceTimer) { return; }
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    reconcile().catch((err) => winston.warn(`[discovery-peer-dbs] reconcile failed: ${err.message}`));
+  }, RECONCILE_DEBOUNCE_MS);
+  if (debounceTimer.unref) { debounceTimer.unref(); }
+}
+
 export function startAutoFetch() {
   if (wired) { return; }
   wired = true;
-  discoveryP2p.events.on('announcement', () => {
-    if (debounceTimer) { return; }
-    debounceTimer = setTimeout(() => {
-      debounceTimer = null;
-      reconcile().catch((err) => winston.warn(`[discovery-peer-dbs] reconcile failed: ${err.message}`));
-    }, RECONCILE_DEBOUNCE_MS);
-    if (debounceTimer.unref) { debounceTimer.unref(); }
-  });
+  discoveryP2p.events.on('announcement', onAnnouncement);
   reconcileTimer = setInterval(() => {
     reconcile().catch((err) => winston.warn(`[discovery-peer-dbs] reconcile failed: ${err.message}`));
   }, RECONCILE_INTERVAL_MS);
   if (reconcileTimer.unref) { reconcileTimer.unref(); }
+}
+
+// The disable half: detach the listener and kill both timers so nothing
+// re-touches the sidecar after the stack shuts it down. Fetched snapshots
+// stay on the shelf — the similar-songs surface keeps working offline, and
+// a re-enable resumes refreshing them.
+export function stopAutoFetch() {
+  if (!wired) { return; }
+  wired = false;
+  discoveryP2p.events.removeListener('announcement', onAnnouncement);
+  if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+  if (reconcileTimer) { clearInterval(reconcileTimer); reconcileTimer = null; }
 }

--- a/src/state/discovery-seeds.js
+++ b/src/state/discovery-seeds.js
@@ -199,3 +199,9 @@ export function startMeshHealthWatch() {
   }, HEALTH_INTERVAL_MS);
   if (watchTimer.unref) { watchTimer.unref(); }
 }
+
+// The disable half — without it a runtime-disabled server would keep
+// probing the (stopped) sidecar every health interval and warn-spam.
+export function stopMeshHealthWatch() {
+  if (watchTimer) { clearInterval(watchTimer); watchTimer = null; }
+}

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -526,6 +526,28 @@ export async function editDiscoveryServerDescription(val) {
   config.program.discoveryP2p.serverDescription = val;
 }
 
+// The display name in our signed catalog announcements. Same live +
+// re-announce contract as the description above.
+export async function editDiscoveryServerName(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.serverName = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.serverName = val;
+}
+
+// The p2p master switch. Persisting the flag is all this does — the api
+// route owns starting/stopping the runtime stack (and rolls this back if
+// the stack fails to come up), so the config file never claims a state the
+// process didn't reach.
+export async function editDiscoveryP2pEnabled(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.enabled = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.enabled = val;
+}
+
 export async function editAutoAlbumArt(val) {
   const loadConfig = await loadFile(config.configFile);
   if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -1119,3 +1119,116 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
     );
   });
 });
+
+// ── Runtime enable/disable — the admin-UI onboarding path ───────────────────
+// A factory-defaults server (no discovery config at all) must be able to
+// join the network through ONE admin call and leave it the same way, no
+// reboot anywhere. The route runs the same stack boot does; the helper's
+// hermetic seed keys (dead list URL + useCommunitySeeds:false) apply to the
+// runtime path exactly like the boot path, so this can never touch the
+// real network.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — runtime enable/disable', () => {
+  let server;
+  const api = (p) => `${server.baseUrl}/api/v1/admin/discovery/p2p/${p}`;
+  const post = (route, body) => fetch(api(route), {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const readConfig = () => JSON.parse(fs.readFileSync(path.join(server.tmpDir, 'config.json'), 'utf8'));
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      // Factory defaults: NO discoveryP2p.enabled, NO collectDiscoveryData.
+      // test-fake model so a forced-on collection pass never downloads
+      // real weights if it runs during the test window.
+      extraConfig: { scanOptions: { discoveryModel: 'test-fake' } },
+    });
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('enable: one call forces collection on, persists both flags, and starts the stack', async () => {
+    // Precondition: everything off, catalog gated.
+    assert.equal((await fetch(api('catalog'))).status, 403);
+    const before = await (await fetch(`${server.baseUrl}/api/v1/ping`)).json();
+    assert.equal(before.discoveryP2p, false);
+    assert.equal(before.discovery, false);
+
+    const r = await post('enabled', { enabled: true });
+    assert.equal(r.status, 200);
+    const body = await r.json();
+    assert.equal(body.enabled, true);
+    assert.equal(body.collectForced, true, 'collection was off — enabling the network must force it on');
+
+    // Both flags persisted to the config FILE (not just in-memory) — a
+    // reboot must come back in the same state.
+    const conf = readConfig();
+    assert.equal(conf.discoveryP2p.enabled, true);
+    assert.equal(conf.scanOptions.collectDiscoveryData, true);
+    // The forced enable initializes the separate discovery DB immediately.
+    assert.ok(fs.existsSync(path.join(server.tmpDir, 'db', 'discovery.db')));
+
+    // The stack is actually up: sidecar running with a dialable ticket.
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(api('status'))).json();
+      return s.running && s.ticket ? s : null;
+    }, { timeoutMs: 30000, what: 'runtime-enabled sidecar to come up' });
+    assert.match(status.endpointId, /^[0-9a-f]{64}$/);
+
+    // Every live gate flipped without a reboot.
+    assert.equal((await fetch(api('catalog'))).status, 200);
+    const ping = await (await fetch(`${server.baseUrl}/api/v1/ping`)).json();
+    assert.equal(ping.discoveryP2p, true);
+    assert.equal(ping.discovery, true, 'forced collection must reveal the Discover panel too');
+  });
+
+  test('name edits save live and validate like the description', async () => {
+    const r = await post('name', { name: '  Runtime Lab  ' });
+    assert.equal(r.status, 200);
+    const status = await (await fetch(api('status'))).json();
+    assert.equal(status.serverName, 'Runtime Lab', 'saved trimmed');
+
+    for (const name of ['evil|pipe', '', 'x'.repeat(65), '   ']) {
+      const bad = await post('name', { name });
+      assert.equal(bad.status, 400, `${JSON.stringify(name)} should be 400`);
+    }
+    // Rejections must not have clobbered the saved name.
+    assert.equal((await (await fetch(api('status'))).json()).serverName, 'Runtime Lab');
+  });
+
+  test('disable: stack stops, gates close, collection deliberately stays on', async () => {
+    const r = await post('enabled', { enabled: false });
+    assert.equal(r.status, 200);
+
+    await pollUntil(async () => {
+      const s = await (await fetch(api('status'))).json();
+      return s.running === false ? s : null;
+    }, { timeoutMs: 15000, what: 'sidecar to stop' });
+
+    assert.equal((await fetch(api('catalog'))).status, 403);
+    const ping = await (await fetch(`${server.baseUrl}/api/v1/ping`)).json();
+    assert.equal(ping.discoveryP2p, false);
+
+    const conf = readConfig();
+    assert.equal(conf.discoveryP2p.enabled, false);
+    assert.equal(conf.scanOptions.collectDiscoveryData, true,
+      'leaving the network must not turn off local discovery features');
+    assert.equal(ping.discovery, true);
+  });
+
+  test('re-enable: the stack survives a full stop/start cycle', async () => {
+    const r = await post('enabled', { enabled: true });
+    assert.equal(r.status, 200);
+    assert.equal((await r.json()).collectForced, false, 'collection was already on this time');
+
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(api('status'))).json();
+      return s.running && s.ticket ? s : null;
+    }, { timeoutMs: 30000, what: 'sidecar to come back up' });
+    assert.match(status.endpointId, /^[0-9a-f]{64}$/);
+    assert.equal((await fetch(api('catalog'))).status, 200);
+
+    // Idempotence: enabling while enabled is a clean no-op.
+    assert.equal((await post('enabled', { enabled: true })).status, 200);
+  });
+});

--- a/webapp/admin/index.html
+++ b/webapp/admin/index.html
@@ -87,25 +87,32 @@
     <div class="side-nav-header">
       <span data-i18n="admin.nav.config">Config</span>
     </div>
-    <div class="side-nav-item waves-effect waves-purple select" onclick="changeView('folders-view', this)">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" height="28"><path fill="#FFA000" d="M38 12H22l-4-4H8c-2.2 0-4 1.8-4 4v24c0 2.2 1.8 4 4 4h31c1.7 0 3-1.3 3-3V16c0-2.2-1.8-4-4-4z"/><path fill="#FFCA28" d="M42.2 18H15.3c-1.9 0-3.6 1.4-3.9 3.3L8 40h31.7c1.9 0 3.6-1.4 3.9-3.3l2.5-14c.5-2.4-1.4-4.7-3.9-4.7z"/></svg>
-      <span data-i18n="admin.nav.directories">Directories</span>
-    </div>
     <div class="side-nav-item waves-effect waves-purple" onclick="changeView('users-view', this)">
       <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="200 200 800 800"><path fill="#FFF" d="M671.027 410.286c31.749 19.852 54.013 53.574 58.044 92.642 12.928 6.092 27.325 9.578 42.596 9.578 55.593 0 100.645-45.073 100.645-100.73 0-55.591-45.052-100.706-100.645-100.706-55.152.087-99.807 44.283-100.64 99.216m-65.998 206.146c55.611 0 100.749-45.093 100.749-100.705 0-55.568-45.138-100.665-100.749-100.665-55.569 0-100.662 45.097-100.662 100.665 0 55.612 45.092 100.705 100.662 100.705m42.706 6.883H562.3c-71.084 0-128.886 57.823-128.886 128.886v104.541l.218 1.623 7.232 2.255c67.816 21.213 126.781 28.225 175.295 28.225 94.746 0 149.683-26.955 153.076-28.728l6.707-3.375h.723V752.201c0-71.063-57.827-128.886-128.93-128.886M814.33 519.32h-84.754c-.965 33.965-15.406 64.487-38.305 86.465 63.217 18.8 109.431 77.392 109.431 146.613v32.211c83.705-3.089 131.951-26.823 135.152-28.442l6.707-3.42h.744V648.273c0-71.106-57.826-128.953-128.975-128.953m-385.958-6.814c19.655 0 37.997-5.742 53.556-15.537 4.907-32.188 22.172-60.344 46.827-79.498.108-1.882.283-3.726.283-5.611 0-55.631-45.094-100.704-100.666-100.704-55.633 0-100.751 45.073-100.751 100.704.001 55.573 45.118 100.646 100.751 100.646m90.433 93.279c-22.766-21.846-37.249-52.261-38.279-85.942-3.159-.216-6.248-.523-9.468-.523h-85.455c-71.083 0-128.929 57.847-128.929 128.953v104.474l.26 1.644 7.188 2.301c54.474 17.026 103.075 24.829 145.234 27.238v-31.532c-.001-69.221 46.233-127.77 109.449-146.613"/></svg>
       <span data-i18n="admin.nav.users">Users</span>
     </div>
-    <div class="side-nav-item waves-effect waves-purple" onclick="changeView('dlna-view', this)">
-      <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 0 1 0 8.49"/><path d="M7.76 7.76a6 6 0 0 0 0 8.49"/><path d="M20.49 3.51a12 12 0 0 1 0 16.97"/><path d="M3.51 3.51a12 12 0 0 0 0 16.97"/></svg>
-      <span>DLNA</span>
+    <div class="side-nav-item waves-effect waves-purple select" onclick="changeView('folders-view', this)">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" height="28"><path fill="#FFA000" d="M38 12H22l-4-4H8c-2.2 0-4 1.8-4 4v24c0 2.2 1.8 4 4 4h31c1.7 0 3-1.3 3-3V16c0-2.2-1.8-4-4-4z"/><path fill="#FFCA28" d="M42.2 18H15.3c-1.9 0-3.6 1.4-3.9 3.3L8 40h31.7c1.9 0 3.6-1.4 3.9-3.3l2.5-14c.5-2.4-1.4-4.7-3.9-4.7z"/></svg>
+      <span data-i18n="admin.nav.directories">Directories</span>
+    </div>
+    <div class="side-nav-item waves-effect waves-purple" onclick="changeView('iroh-view', this)">
+      <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+      <span>Quick Connect</span>
+    </div>
+    <div class="side-nav-item waves-effect waves-purple" onclick="changeView('discovery-view', this)">
+      <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 24" fill="none" stroke="#4dd0e1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+      <span data-i18n="admin.nav.discovery">Discovery</span>
+    </div>
+    <div class="side-nav-header">
+      <span data-i18n="admin.nav.features">Features</span>
     </div>
     <div class="side-nav-item waves-effect waves-purple" onclick="changeView('subsonic-view', this)">
       <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 18V6l16 6z"/><circle cx="4" cy="18" r="2"/></svg>
       <span>Subsonic API</span>
     </div>
-    <div class="side-nav-item waves-effect waves-purple" onclick="changeView('iroh-view', this)">
-      <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-      <span>Quick Connect</span>
+    <div class="side-nav-item waves-effect waves-purple" onclick="changeView('dlna-view', this)">
+      <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 0 1 0 8.49"/><path d="M7.76 7.76a6 6 0 0 0 0 8.49"/><path d="M20.49 3.51a12 12 0 0 1 0 16.97"/><path d="M3.51 3.51a12 12 0 0 0 0 16.97"/></svg>
+      <span>DLNA</span>
     </div>
     <div class="side-nav-item waves-effect waves-purple" onclick="changeView('torrent-view', this)">
       <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 24" fill="none" stroke="#7fabda" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/><line x1="12" y1="3" x2="12" y2="15"/><path d="M3 17v2a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2"/></svg>

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -710,6 +710,14 @@ I18N.onChange(() => { I18NSTATE.version += 1; });
   });
 })();
 
+// The p2p announce identity, shared between the Discovery page card
+// (loadDiscoveryP2p fills it from the status route) and the description
+// modal. One object referenced from both components' data() so a save in
+// the modal re-renders the card without a refetch. Declared BEFORE every
+// view component: a URL-hash deep-link mounts its view synchronously while
+// the tail of this file is still in the const temporal dead zone.
+const P2PIDENTITY = { serverName: '', serverDescription: '' };
+
 const foldersView = Vue.component('folders-view', {
   data() {
     return {
@@ -1881,9 +1889,7 @@ const dbView = Vue.component('db-view', {
       sharedPlaylists: ADMINDATA.sharedPlaylists,
       sharedPlaylistsTS: ADMINDATA.sharedPlaylistUpdated,
       isPullingStats: false,
-      isPullingShared: false,
-      discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false },
-      p2pIdentity: P2PIDENTITY
+      isPullingShared: false
     };
   },
   template: `
@@ -1973,69 +1979,6 @@ const dbView = Vue.component('db-view', {
                     </tr>
                   </tbody>
                 </table>
-              </div>
-            </div>
-          </div>
-          <div class="col s12">
-            <div class="card">
-              <div class="card-content">
-                <span class="card-title">Discovery Network (P2P)</span>
-                <div v-if="!discoveryP2p.loaded"><p>Loading…</p></div>
-                <div v-else-if="!discoveryP2p.status || discoveryP2p.status.enabled !== true">
-                  <p>Disabled. Set <code>discoveryP2p.enabled: true</code> in the config file and restart
-                  to join the discovery network — your server will share its (metadata-only) discovery
-                  snapshot and automatically download snapshots from other servers.</p>
-                </div>
-                <div v-else>
-                  <p v-if="!discoveryP2p.status.binaryFound" style="color: #b71c1c;">
-                    The p2p-sidecar binary was not found for this platform — the network is unavailable.
-                  </p>
-                  <p><b>Endpoint:</b> <code style="word-break: break-all;">{{ discoveryP2p.status.endpointId || '(sidecar not running yet)' }}</code></p>
-                  <p><b>Announcing as:</b> {{ p2pIdentity.serverName }}
-                    <span v-if="p2pIdentity.serverDescription"> — {{ p2pIdentity.serverDescription }}</span>
-                    <span v-else style="color: #9e9e9e;"> — no description (other servers see only the name)</span>
-                    [<a v-on:click="openModal('edit-p2p-description-modal')">{{ t('admin.settings.edit') }}</a>]
-                  </p>
-                  <p><b>Network:</b>
-                    <span v-if="discoveryP2p.status.neighbors > 0" style="color: #2e7d32;">connected
-                      — {{ discoveryP2p.status.neighbors }} mesh neighbor{{ discoveryP2p.status.neighbors === 1 ? '' : 's' }}</span>
-                    <span v-else-if="discoveryP2p.status.joined" style="color: #e65100;">joined, waiting for
-                      neighbors — the mesh weaves in within a minute or two of another server coming online</span>
-                    <span v-else>not joined yet</span>
-                  </p>
-                  <p v-if="discoveryP2p.status.ticket"><b>Your ticket</b> — a friend pastes this into their
-                  <code>discoveryP2p.bootstrapPeers</code> to befriend this server:<br>
-                    <textarea readonly rows="2" style="width:100%; font-size: 0.8em;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>
-                  </p>
-                  <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
-                    {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
-                    — auto-fetch {{ discoveryP2p.autoFetch ? 'on' : 'off' }}
-                    — community seeds {{ discoveryP2p.status.communitySeeds ? 'on (public network)' : 'off (friends only)' }}
-                  </p>
-                  <table v-if="discoveryP2p.peers.length > 0">
-                    <thead><tr><th>Server</th><th>Tracks</th><th>Seeders</th><th>Online</th><th>Model</th><th>Downloaded</th><th></th></tr></thead>
-                    <tbody>
-                      <tr v-for="peer in discoveryP2p.peers" :key="peer.from">
-                        <td>
-                          {{ peer.payload.name || (peer.from.slice(0, 12) + '…') }}
-                          <div v-if="peer.payload.description" style="color: #757575; font-size: 0.85em; max-width: 360px;">{{ peer.payload.description }}</div>
-                        </td>
-                        <td>{{ peer.payload.rowCount }}</td>
-                        <td>{{ peer.seeders }}</td>
-                        <td>{{ peer.online ? 'online' : 'offline' }}</td>
-                        <td>{{ peer.compatible === null ? 'unknown' : (peer.compatible ? 'compatible' : 'incompatible') }}</td>
-                        <td>{{ peer.fetched ? (peer.fetched.stale ? 'update available' : 'yes') : 'no' }}</td>
-                        <td>
-                          [<a v-on:click="discoveryFetchPeer(peer.from)">{{ peer.fetched ? 'Update' : 'Download' }}</a>]
-                          <span v-if="peer.fetched">[<a v-on:click="discoveryRemovePeer(peer.from)">Remove</a>]</span>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                  <p v-else>No peers heard yet — add a friend's ticket to <code>discoveryP2p.bootstrapPeers</code>
-                  (or POST it to the join endpoint) and give gossip a minute.</p>
-                  <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]</p>
-                </div>
               </div>
             </div>
           </div>
@@ -2154,67 +2097,7 @@ const dbView = Vue.component('db-view', {
         </div>
       </div>
     </div>`,
-  created: async function () {
-    this.loadDiscoveryP2p();
-  },
   methods: {
-    loadDiscoveryP2p: async function() {
-      try {
-        const status = (await API.axios({
-          method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/status`
-        })).data;
-        this.discoveryP2p.status = status;
-        P2PIDENTITY.serverName = status.serverName || '';
-        P2PIDENTITY.serverDescription = status.serverDescription || '';
-        if (status.enabled === true) {
-          const cat = (await API.axios({
-            method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
-          })).data;
-          this.discoveryP2p.peers = cat.peers;
-          this.discoveryP2p.storage = cat.storage;
-          this.discoveryP2p.autoFetch = cat.autoFetch;
-        }
-      } catch (err) {
-        iziToast.error({ title: 'Failed to load discovery network status', position: 'topCenter', timeout: 3000 });
-      }
-      this.discoveryP2p.loaded = true;
-    },
-    discoveryFetchPeer: async function(endpointId) {
-      try {
-        iziToast.info({ title: 'Downloading peer snapshot…', position: 'topCenter', timeout: 2500 });
-        await API.axios({
-          method: 'POST',
-          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-dbs/fetch`,
-          data: { endpointId }
-        });
-        iziToast.success({ title: 'Peer snapshot downloaded', position: 'topCenter', timeout: 3000 });
-      } catch (err) {
-        iziToast.error({
-          title: 'Download failed',
-          message: err.response?.data?.error || '',
-          position: 'topCenter', timeout: 4000
-        });
-      }
-      this.loadDiscoveryP2p();
-    },
-    discoveryRemovePeer: async function(endpointId) {
-      try {
-        await API.axios({
-          method: 'POST',
-          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-dbs/remove`,
-          data: { endpointId }
-        });
-      } catch (err) {
-        iziToast.error({ title: 'Remove failed', position: 'topCenter', timeout: 3000 });
-      }
-      this.loadDiscoveryP2p();
-    },
-    discoveryBytes: function(n) {
-      if (typeof n !== 'number' || !isFinite(n)) { return '?'; }
-      if (n >= 1073741824) { return (n / 1073741824).toFixed(1) + ' GB'; }
-      if (n >= 1048576) { return (n / 1048576).toFixed(1) + ' MB'; }
-      return Math.ceil(n / 1024) + ' KB';
-    },
     pullStats: async function() {
       try {
         this.isPullingStats = true;
@@ -7028,6 +6911,155 @@ const backupView = Vue.component('backup-view', {
   },
 });
 
+// The Discovery page (Config section of the nav): the p2p network card,
+// moved out of the Database page so the network has a home of its own —
+// the local-analysis settings (collect/model/per-run) stay with the scan
+// settings on the Database page, since they run whether or not p2p is on.
+const discoveryView = Vue.component('discovery-view', {
+  data() {
+    return {
+      discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false },
+      p2pIdentity: P2PIDENTITY
+    };
+  },
+  template: `
+    <div>
+      <div class="container">
+        <div class="row">
+          <div class="col s12">
+            <div class="card">
+              <div class="card-content">
+                <span class="card-title">Discovery Network (P2P)</span>
+                <div v-if="!discoveryP2p.loaded"><p>Loading…</p></div>
+                <div v-else-if="!discoveryP2p.status || discoveryP2p.status.enabled !== true">
+                  <p>Disabled. Set <code>discoveryP2p.enabled: true</code> in the config file and restart
+                  to join the discovery network — your server will share its (metadata-only) discovery
+                  snapshot and automatically download snapshots from other servers.</p>
+                </div>
+                <div v-else>
+                  <p v-if="!discoveryP2p.status.binaryFound" style="color: #b71c1c;">
+                    The p2p-sidecar binary was not found for this platform — the network is unavailable.
+                  </p>
+                  <p><b>Endpoint:</b> <code style="word-break: break-all;">{{ discoveryP2p.status.endpointId || '(sidecar not running yet)' }}</code></p>
+                  <p><b>Announcing as:</b> {{ p2pIdentity.serverName }}
+                    <span v-if="p2pIdentity.serverDescription"> — {{ p2pIdentity.serverDescription }}</span>
+                    <span v-else style="color: #9e9e9e;"> — no description (other servers see only the name)</span>
+                    [<a v-on:click="openModal('edit-p2p-description-modal')">{{ t('admin.settings.edit') }}</a>]
+                  </p>
+                  <p><b>Network:</b>
+                    <span v-if="discoveryP2p.status.neighbors > 0" style="color: #2e7d32;">connected
+                      — {{ discoveryP2p.status.neighbors }} mesh neighbor{{ discoveryP2p.status.neighbors === 1 ? '' : 's' }}</span>
+                    <span v-else-if="discoveryP2p.status.joined" style="color: #e65100;">joined, waiting for
+                      neighbors — the mesh weaves in within a minute or two of another server coming online</span>
+                    <span v-else>not joined yet</span>
+                  </p>
+                  <p v-if="discoveryP2p.status.ticket"><b>Your ticket</b> — a friend pastes this into their
+                  <code>discoveryP2p.bootstrapPeers</code> to befriend this server:<br>
+                    <textarea readonly rows="2" style="width:100%; font-size: 0.8em;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>
+                  </p>
+                  <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
+                    {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
+                    — auto-fetch {{ discoveryP2p.autoFetch ? 'on' : 'off' }}
+                    — community seeds {{ discoveryP2p.status.communitySeeds ? 'on (public network)' : 'off (friends only)' }}
+                  </p>
+                  <table v-if="discoveryP2p.peers.length > 0">
+                    <thead><tr><th>Server</th><th>Tracks</th><th>Seeders</th><th>Online</th><th>Model</th><th>Downloaded</th><th></th></tr></thead>
+                    <tbody>
+                      <tr v-for="peer in discoveryP2p.peers" :key="peer.from">
+                        <td>
+                          {{ peer.payload.name || (peer.from.slice(0, 12) + '…') }}
+                          <div v-if="peer.payload.description" style="color: #757575; font-size: 0.85em; max-width: 360px;">{{ peer.payload.description }}</div>
+                        </td>
+                        <td>{{ peer.payload.rowCount }}</td>
+                        <td>{{ peer.seeders }}</td>
+                        <td>{{ peer.online ? 'online' : 'offline' }}</td>
+                        <td>{{ peer.compatible === null ? 'unknown' : (peer.compatible ? 'compatible' : 'incompatible') }}</td>
+                        <td>{{ peer.fetched ? (peer.fetched.stale ? 'update available' : 'yes') : 'no' }}</td>
+                        <td>
+                          [<a v-on:click="discoveryFetchPeer(peer.from)">{{ peer.fetched ? 'Update' : 'Download' }}</a>]
+                          <span v-if="peer.fetched">[<a v-on:click="discoveryRemovePeer(peer.from)">Remove</a>]</span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <p v-else>No peers heard yet — add a friend's ticket to <code>discoveryP2p.bootstrapPeers</code>
+                  (or POST it to the join endpoint) and give gossip a minute.</p>
+                  <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>`,
+  created: async function () {
+    this.loadDiscoveryP2p();
+  },
+  methods: {
+    openModal: function(modalView) {
+      modVM.currentViewModal = modalView;
+      M.Modal.getInstance(document.getElementById('admin-modal')).open();
+    },
+    loadDiscoveryP2p: async function() {
+      try {
+        const status = (await API.axios({
+          method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/status`
+        })).data;
+        this.discoveryP2p.status = status;
+        P2PIDENTITY.serverName = status.serverName || '';
+        P2PIDENTITY.serverDescription = status.serverDescription || '';
+        if (status.enabled === true) {
+          const cat = (await API.axios({
+            method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
+          })).data;
+          this.discoveryP2p.peers = cat.peers;
+          this.discoveryP2p.storage = cat.storage;
+          this.discoveryP2p.autoFetch = cat.autoFetch;
+        }
+      } catch (err) {
+        iziToast.error({ title: 'Failed to load discovery network status', position: 'topCenter', timeout: 3000 });
+      }
+      this.discoveryP2p.loaded = true;
+    },
+    discoveryFetchPeer: async function(endpointId) {
+      try {
+        iziToast.info({ title: 'Downloading peer snapshot…', position: 'topCenter', timeout: 2500 });
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-dbs/fetch`,
+          data: { endpointId }
+        });
+        iziToast.success({ title: 'Peer snapshot downloaded', position: 'topCenter', timeout: 3000 });
+      } catch (err) {
+        iziToast.error({
+          title: 'Download failed',
+          message: err.response?.data?.error || '',
+          position: 'topCenter', timeout: 4000
+        });
+      }
+      this.loadDiscoveryP2p();
+    },
+    discoveryRemovePeer: async function(endpointId) {
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-dbs/remove`,
+          data: { endpointId }
+        });
+      } catch (err) {
+        iziToast.error({ title: 'Remove failed', position: 'topCenter', timeout: 3000 });
+      }
+      this.loadDiscoveryP2p();
+    },
+    discoveryBytes: function(n) {
+      if (typeof n !== 'number' || !isFinite(n)) { return '?'; }
+      if (n >= 1073741824) { return (n / 1073741824).toFixed(1) + ' GB'; }
+      if (n >= 1048576) { return (n / 1048576).toFixed(1) + ' MB'; }
+      return Math.ceil(n / 1024) + ' KB';
+    }
+  }
+});
+
 const irohView = Vue.component('iroh-view', {
   data() {
     return {
@@ -7169,7 +7201,7 @@ function _initialViewFromHash() {
     'folders-view','users-view','db-view','advanced-view','info-view',
     'transcode-view','federation-view','dlna-view','subsonic-view','iroh-view',
     'torrent-view','logs-view','rpn-view','security-view','backup-view',
-    'lyrics-view',
+    'lyrics-view','discovery-view',
   ]);
   const raw = (location.hash || '').replace(/^#/, '');
   const name = raw.startsWith('view=') ? raw.slice(5) : raw;
@@ -7189,6 +7221,7 @@ const vm = new Vue({
     'dlna-view': dlnaView,
     'subsonic-view': subsonicView,
     'iroh-view': irohView,
+    'discovery-view': discoveryView,
     'torrent-view': torrentView,
     'logs-view': logsView,
     'rpn-view': rpnView,
@@ -8055,12 +8088,6 @@ const editAcoustidPerRunView = Vue.component('edit-acoustid-per-run-modal', {
     }
   }
 });
-
-// The p2p announce identity, shared between the Discovery Network card
-// (loadDiscoveryP2p fills it from the status route) and the description
-// modal below. One object referenced from both components' data() so a
-// save in the modal re-renders the card without a refetch.
-const P2PIDENTITY = { serverName: '', serverDescription: '' };
 
 const editP2pDescriptionView = Vue.component('edit-p2p-description-modal', {
   data() {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -2515,7 +2515,7 @@ const dbView = Vue.component('db-view', {
         zindex: 99999,
         layout: 2,
         maxWidth: 600,
-        title: `<b>${this.dbParams.collectDiscoveryData === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')} music-discovery data collection? (stores per-track audio fingerprint IDs + embeddings in a separate discovery.db you can export; disabling keeps existing data)</b>`,
+        title: `<b>${this.dbParams.collectDiscoveryData === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')} music-discovery data collection? (stores per-track audio fingerprint IDs + embeddings in a separate discovery.db you can export; disabling keeps existing data — but if the discovery network is enabled, new music will stop reaching your published snapshot)</b>`,
         position: 'center',
         buttons: [
           [`<button><b>${this.dbParams.collectDiscoveryData === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')}</b></button>`, (instance, toast) => {
@@ -6919,7 +6919,8 @@ const discoveryView = Vue.component('discovery-view', {
   data() {
     return {
       discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false },
-      p2pIdentity: P2PIDENTITY
+      p2pIdentity: P2PIDENTITY,
+      p2pToggling: false
     };
   },
   template: `
@@ -6932,9 +6933,24 @@ const discoveryView = Vue.component('discovery-view', {
                 <span class="card-title">Discovery Network (P2P)</span>
                 <div v-if="!discoveryP2p.loaded"><p>Loading…</p></div>
                 <div v-else-if="!discoveryP2p.status || discoveryP2p.status.enabled !== true">
-                  <p>Disabled. Set <code>discoveryP2p.enabled: true</code> in the config file and restart
-                  to join the discovery network — your server will share its (metadata-only) discovery
-                  snapshot and automatically download snapshots from other servers.</p>
+                  <p>Join the discovery network to get music recommendations from other people's
+                  libraries — the player's Discover panel gains a "From the network" section, and
+                  your server appears in the catalog other operators browse.</p>
+                  <p><b>What gets shared:</b> a <b>metadata-only</b> snapshot of your library —
+                  artist, title, duration, track IDs, and audio "sound fingerprint" embeddings.
+                  <b>Never any audio files.</b> Your server's name and description are visible to
+                  everyone on the network, and by default the snapshot is published to the public
+                  community network.</p>
+                  <p>Enabling this also turns on <b>music-discovery data collection</b> (the
+                  post-scan analysis that builds the embeddings) if it isn't already on. You can
+                  disable the network here at any time; collected data stays local until you
+                  re-enable it.</p>
+                  <p v-if="discoveryP2p.status && discoveryP2p.status.binaryFound === false" style="color: #b71c1c;">
+                    The p2p-sidecar binary was not found for this platform — the network is unavailable.
+                  </p>
+                  <a v-else v-on:click="enableP2p()" :class="{disabled: p2pToggling}" class="waves-effect waves-light btn green">
+                    {{ p2pToggling ? 'Enabling…' : 'Enable Discovery Network' }}
+                  </a>
                 </div>
                 <div v-else>
                   <p v-if="!discoveryP2p.status.binaryFound" style="color: #b71c1c;">
@@ -6944,7 +6960,7 @@ const discoveryView = Vue.component('discovery-view', {
                   <p><b>Announcing as:</b> {{ p2pIdentity.serverName }}
                     <span v-if="p2pIdentity.serverDescription"> — {{ p2pIdentity.serverDescription }}</span>
                     <span v-else style="color: #9e9e9e;"> — no description (other servers see only the name)</span>
-                    [<a v-on:click="openModal('edit-p2p-description-modal')">{{ t('admin.settings.edit') }}</a>]
+                    [<a v-on:click="openModal('edit-p2p-identity-modal')">{{ t('admin.settings.edit') }}</a>]
                   </p>
                   <p><b>Network:</b>
                     <span v-if="discoveryP2p.status.neighbors > 0" style="color: #2e7d32;">connected
@@ -6984,7 +7000,8 @@ const discoveryView = Vue.component('discovery-view', {
                   </table>
                   <p v-else>No peers heard yet — add a friend's ticket to <code>discoveryP2p.bootstrapPeers</code>
                   (or POST it to the join endpoint) and give gossip a minute.</p>
-                  <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]</p>
+                  <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]
+                  [<a v-on:click="disableP2p()" style="color: #b71c1c;">Disable</a>]</p>
                 </div>
               </div>
             </div>
@@ -6999,6 +7016,100 @@ const discoveryView = Vue.component('discovery-view', {
     openModal: function(modalView) {
       modVM.currentViewModal = modalView;
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
+    },
+    // The consent moment. What used to be "edit the config file and
+    // restart" is now this dialog — it must say what enabling actually
+    // does before anything is published.
+    enableP2p: function() {
+      iziToast.question({
+        timeout: 30000,
+        close: false,
+        overlayClose: true,
+        overlay: true,
+        displayMode: 'once',
+        id: 'question',
+        zindex: 99999,
+        layout: 2,
+        maxWidth: 600,
+        title: `<b>Join the discovery network?</b> Your server will publish a metadata-only snapshot of its music library (never audio files) to the public discovery network, with your server's name and description visible to everyone. Music-discovery data collection will also be enabled.`,
+        position: 'center',
+        buttons: [
+          [`<button><b>Enable</b></button>`, async (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+            this.p2pToggling = true;
+            try {
+              await API.axios({
+                method: 'POST',
+                url: `${API.url()}/api/v1/admin/discovery/p2p/enabled`,
+                data: { enabled: true }
+              });
+              iziToast.success({
+                title: 'Discovery network enabled',
+                message: 'Give the mesh a minute to weave in.',
+                position: 'topCenter', timeout: 4000
+              });
+              await this.loadDiscoveryP2p();
+              // Straight into naming the server: 'mStream' next to 18k
+              // other 'mStream's is the first thing everyone would want
+              // to change, so don't make them find the edit link.
+              this.openModal('edit-p2p-identity-modal');
+            } catch (err) {
+              iziToast.error({
+                title: 'Failed to enable the discovery network',
+                message: err.response?.data?.error || '',
+                position: 'topCenter', timeout: 6000
+              });
+              this.loadDiscoveryP2p();
+            } finally {
+              this.p2pToggling = false;
+            }
+          }, true],
+          [`<button>${t('admin.folders.goBack')}</button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+          }],
+        ]
+      });
+    },
+    disableP2p: function() {
+      iziToast.question({
+        timeout: 20000,
+        close: false,
+        overlayClose: true,
+        overlay: true,
+        displayMode: 'once',
+        id: 'question',
+        zindex: 99999,
+        layout: 2,
+        maxWidth: 600,
+        title: `<b>Leave the discovery network?</b> Your server stops announcing and downloading snapshots. Local discovery features (data collection, the Discover panel) keep working, and already-fetched peer data stays until removed.`,
+        position: 'center',
+        buttons: [
+          [`<button><b>${t('admin.settings.disableButton')}</b></button>`, async (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+            this.p2pToggling = true;
+            try {
+              await API.axios({
+                method: 'POST',
+                url: `${API.url()}/api/v1/admin/discovery/p2p/enabled`,
+                data: { enabled: false }
+              });
+              iziToast.success({ title: 'Discovery network disabled', position: 'topCenter', timeout: 3500 });
+            } catch (err) {
+              iziToast.error({
+                title: t('admin.settings.failed'),
+                message: err.response?.data?.error || '',
+                position: 'topCenter', timeout: 4000
+              });
+            } finally {
+              this.p2pToggling = false;
+              this.loadDiscoveryP2p();
+            }
+          }, true],
+          [`<button>${t('admin.folders.goBack')}</button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+          }],
+        ]
+      });
     },
     loadDiscoveryP2p: async function() {
       try {
@@ -8089,21 +8200,32 @@ const editAcoustidPerRunView = Vue.component('edit-acoustid-per-run-modal', {
   }
 });
 
-const editP2pDescriptionView = Vue.component('edit-p2p-description-modal', {
+// Name + description in one modal — the public identity other servers see
+// in their catalogs. Saves only what changed (each save re-announces
+// server-side, so a no-op field shouldn't cost a broadcast). Opened from
+// the Discovery page's identity line AND auto-opened right after enabling
+// the network, so a fresh server never sits in the catalog as 'mStream'.
+const editP2pIdentityView = Vue.component('edit-p2p-identity-modal', {
   data() {
     return {
       submitPending: false,
-      editValue: P2PIDENTITY.serverDescription
+      editName: P2PIDENTITY.serverName,
+      editDescription: P2PIDENTITY.serverDescription
     };
   },
   template: `
     <form @submit.prevent="updateParam">
       <div class="modal-content">
-        <h4>Server description</h4>
+        <h4>Server identity on the network</h4>
         <div class="input-field">
-          <textarea v-model="editValue" id="edit-p2p-description" class="materialize-textarea" maxlength="180"></textarea>
-          <label for="edit-p2p-description">Description ({{ editValue.length }}/180 characters)</label>
-          <span class="helper-text">Shown next to your server's name to everyone browsing the discovery network — say what's in your library so they can tell whether your DB is worth downloading. Announced immediately; the '|' character isn't allowed.</span>
+          <input v-model="editName" id="edit-p2p-name" required type="text" maxlength="64">
+          <label for="edit-p2p-name">Server name ({{ editName.length }}/64 characters)</label>
+          <span class="helper-text">How your server appears in every other server's catalog.</span>
+        </div>
+        <div class="input-field">
+          <textarea v-model="editDescription" id="edit-p2p-description" class="materialize-textarea" maxlength="180"></textarea>
+          <label for="edit-p2p-description">Description ({{ editDescription.length }}/180 characters)</label>
+          <span class="helper-text">Optional blurb next to the name — say what's in your library so others can tell whether your DB is worth downloading. Changes announce immediately; the '|' character isn't allowed.</span>
         </div>
       </div>
       <div class="modal-footer">
@@ -8119,26 +8241,43 @@ const editP2pDescriptionView = Vue.component('edit-p2p-description-modal', {
   },
   methods: {
     updateParam: async function() {
-      const value = this.editValue.trim();
-      if (value.includes('|')) {
+      const name = this.editName.trim();
+      const description = this.editDescription.trim();
+      if (name.includes('|') || description.includes('|')) {
         iziToast.warning({ title: `The '|' character is not allowed`, position: 'topCenter', timeout: 3500 });
+        return;
+      }
+      if (!name) {
+        iziToast.warning({ title: 'The server name must not be blank', position: 'topCenter', timeout: 3500 });
         return;
       }
       try {
         this.submitPending = true;
 
-        const res = await API.axios({
-          method: 'POST',
-          url: `${API.url()}/api/v1/admin/discovery/p2p/description`,
-          data: { description: value }
-        });
-
-        P2PIDENTITY.serverDescription = value;
+        let announced = false;
+        if (name !== P2PIDENTITY.serverName) {
+          const res = await API.axios({
+            method: 'POST',
+            url: `${API.url()}/api/v1/admin/discovery/p2p/name`,
+            data: { name }
+          });
+          P2PIDENTITY.serverName = name;
+          announced = res.data.announced === true;
+        }
+        if (description !== P2PIDENTITY.serverDescription) {
+          const res = await API.axios({
+            method: 'POST',
+            url: `${API.url()}/api/v1/admin/discovery/p2p/description`,
+            data: { description }
+          });
+          P2PIDENTITY.serverDescription = description;
+          announced = announced || res.data.announced === true;
+        }
 
         M.Modal.getInstance(document.getElementById('admin-modal')).close();
 
         iziToast.success({
-          title: res.data.announced === true
+          title: announced
             ? 'Updated — announced to the network'
             : 'Updated — will announce with the next snapshot',
           position: 'topCenter',

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -6951,6 +6951,7 @@ const discoveryView = Vue.component('discovery-view', {
                   <a v-else v-on:click="enableP2p()" :class="{disabled: p2pToggling}" class="waves-effect waves-light btn green">
                     {{ p2pToggling ? 'Enabling…' : 'Enable Discovery Network' }}
                   </a>
+                  <div v-if="p2pToggling" class="progress" style="max-width: 480px; margin: 10px 0 4px 0;"><div class="indeterminate"></div></div>
                 </div>
                 <div v-else>
                   <p v-if="!discoveryP2p.status.binaryFound" style="color: #b71c1c;">
@@ -6969,6 +6970,10 @@ const discoveryView = Vue.component('discovery-view', {
                       neighbors — the mesh weaves in within a minute or two of another server coming online</span>
                     <span v-else>not joined yet</span>
                   </p>
+                  <div v-if="meshSearching" style="max-width: 480px;">
+                    <div class="progress" style="margin: 4px 0 6px 0;"><div class="indeterminate"></div></div>
+                    <span style="color: #757575; font-size: 0.85em;">searching for peers — this page updates itself every few seconds</span>
+                  </div>
                   <p v-if="discoveryP2p.status.ticket"><b>Your ticket</b> — a friend pastes this into their
                   <code>discoveryP2p.bootstrapPeers</code> to befriend this server:<br>
                     <textarea readonly rows="2" style="width:100%; font-size: 0.8em;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>
@@ -7009,8 +7014,32 @@ const discoveryView = Vue.component('discovery-view', {
         </div>
       </div>
     </div>`,
+  computed: {
+    // The indeterminate "something is happening" state: the feature is on
+    // but the mesh hasn't produced a neighbor yet (sidecar starting, topic
+    // joining, or genuinely alone). Once a neighbor exists the numbers
+    // speak for themselves and the bar retires.
+    meshSearching: function() {
+      const s = this.discoveryP2p.status;
+      return !!(s && s.enabled === true
+        && (!s.running || !s.joined || (s.neighbors || 0) === 0));
+    },
+  },
   created: async function () {
     this.loadDiscoveryP2p();
+    // Keep the card live while it's on screen: gossip fills the catalog and
+    // the mesh weaves in over ~a minute, and nobody should have to mash
+    // Refresh to watch it. Quiet polls (no error toast) so a transient
+    // hiccup doesn't nag every 10 seconds; skipped while the tab is hidden
+    // and while an enable/disable is in flight.
+    this.pollTimer = setInterval(() => {
+      if (document.hidden || this.p2pToggling) { return; }
+      if (!this.discoveryP2p.status || this.discoveryP2p.status.enabled !== true) { return; }
+      this.loadDiscoveryP2p(true);
+    }, 10000);
+  },
+  beforeDestroy: function () {
+    if (this.pollTimer) { clearInterval(this.pollTimer); this.pollTimer = null; }
   },
   methods: {
     openModal: function(modalView) {
@@ -7111,7 +7140,7 @@ const discoveryView = Vue.component('discovery-view', {
         ]
       });
     },
-    loadDiscoveryP2p: async function() {
+    loadDiscoveryP2p: async function(quiet) {
       try {
         const status = (await API.axios({
           method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/status`
@@ -7128,7 +7157,9 @@ const discoveryView = Vue.component('discovery-view', {
           this.discoveryP2p.autoFetch = cat.autoFetch;
         }
       } catch (err) {
-        iziToast.error({ title: 'Failed to load discovery network status', position: 'topCenter', timeout: 3000 });
+        if (quiet !== true) {
+          iziToast.error({ title: 'Failed to load discovery network status', position: 'topCenter', timeout: 3000 });
+        }
       }
       this.discoveryP2p.loaded = true;
     },

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -284,6 +284,8 @@
   "admin.nav.config": "Config",
   "admin.nav.directories": "Directories",
   "admin.nav.users": "Users",
+  "admin.nav.discovery": "Discovery",
+  "admin.nav.features": "Features",
   "admin.nav.federation": "Federation",
   "admin.nav.server": "Server",
   "admin.nav.about": "About",


### PR DESCRIPTION
Re-lands #712, which was accidentally merged into its stacked base branch (`feat/discovery-db-description`) instead of master — so v6.17.0 shipped without the Admin-UI arc. Since #711 is already in master, this PR's diff is exactly #712's content. Full description, testing evidence, and live verification: see #712.

Contents: sidebar reorg (Config / Features / Server groups), the new Discovery page (deep-linkable, auto-polling with an indeterminate search bar), one-click runtime enable/disable of the p2p network (forces data collection on, same stack as boot via `discovery-p2p-stack.js`), the name+description identity modal, and the `.gitignore` repair for `model-cache/` + `docs/api.html`.

No Rust/sidecar changes — no binaries rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)