### PR TITLE
feat(genres): model-generated genres join the real genre tables (PR A)

### DIFF
--- a/src/db/genre-sync.js
+++ b/src/db/genre-sync.js
@@ -1,0 +1,188 @@
+// Model-genre sync — feeds the discovery model's style predictions
+// (discovery_tracks.genre_tags, e.g. "Electronic---Synthwave") into the real
+// genre tables as track_genres rows with source='model' (V57), so genre
+// browse / filtering / Auto-DJ genre mode work on untagged libraries.
+//
+// Shape of the reconcile (deliberately a FULL pass, not incremental): both
+// scanners wipe a track's track_genres rows on every re-parse
+// (deleteTrackGenres → re-insert from tags), taking any model rows with
+// them — so the sync must be able to heal from nothing at any time. It is
+// idempotent and cheap (one read per table + set-diffs in memory; writes
+// only for actual deltas inside a single transaction), and the task-queue
+// triggers it exactly where the data can have moved: after a discovery
+// embedding batch lands, and after a scan batch that changed the DB.
+//
+// Hierarchy: each "Genre---Style" tag links BOTH levels — the style row
+// ("Synthwave", genres.parent='Electronic') and the parent row
+// ("Electronic", parent NULL) — so the flat genre page stays rich while
+// the parent column gives the browse UI its two-level structure. Genre
+// rows are reused case-insensitively (the V34 case-folded vocabulary
+// convention); a reused row's parent is backfilled only when NULL, never
+// overwritten (a style name that appears under two taxonomy parents keeps
+// its first-seen parent rather than churning).
+//
+// Provenance rules: 'tag' wins — the sync only INSERT OR IGNOREs, so a
+// link the scanner owns is never re-labelled 'model'; and it only ever
+// DELETEs rows it owns (source='model'). Tracks whose canonical hash has
+// no row under the ACTIVE model are left untouched (mid model-migration
+// their links would otherwise flap: removed now, re-added after re-embed).
+
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as db from './manager.js';
+import * as discoveryDb from './discovery-db.js';
+
+// Parse one genre_tags JSON payload into [{ name, parent }] entries —
+// both hierarchy levels, deduped, junk-hardened (the format is also
+// network-facing via peer snapshots, so never trust it blindly).
+export function parseGenreTags(json) {
+  let tags;
+  try {
+    tags = JSON.parse(json);
+  } catch (_e) {
+    return null;   // malformed → caller skips the row
+  }
+  if (!Array.isArray(tags)) { return null; }
+
+  const out = new Map();   // lower(name) → { name, parent }
+  for (const raw of tags) {
+    if (typeof raw !== 'string') { continue; }
+    const sep = raw.indexOf('---');
+    const parent = sep > 0 ? raw.slice(0, sep).trim() : null;
+    const style = (sep >= 0 ? raw.slice(sep + 3) : raw).trim();
+    if (style) {
+      const key = style.toLowerCase();
+      if (!out.has(key)) { out.set(key, { name: style, parent: parent || null }); }
+    }
+    if (parent) {
+      const key = parent.toLowerCase();
+      if (!out.has(key)) { out.set(key, { name: parent, parent: null }); }
+    }
+  }
+  return [...out.values()];
+}
+
+/**
+ * The reconcile core — injectable handles so tests can drive raw
+ * DatabaseSync instances without booting the managers.
+ *
+ * @param {DatabaseSync} mainDb   mstream.db (writes happen here)
+ * @param {DatabaseSync} ddb      discovery.db (read-only use)
+ * @param {string}       modelId  active model pin — only its rows sync
+ * @returns stats { rows, tracks, linksAdded, linksRemoved, genresCreated }
+ */
+export function reconcileModelGenres(mainDb, ddb, modelId) {
+  const stats = { rows: 0, tracks: 0, linksAdded: 0, linksRemoved: 0, genresCreated: 0 };
+
+  const discRows = ddb.prepare(`
+    SELECT audio_hash, genre_tags FROM discovery_tracks
+    WHERE embedding IS NOT NULL AND model_id = ? AND genre_tags IS NOT NULL
+  `).all(modelId);
+  if (discRows.length === 0) { return stats; }
+
+  // hash → [track ids]: duplicate files share one canonical hash and all
+  // get the same links. One pass instead of per-row COALESCE lookups
+  // (which can't use the hash indexes).
+  const tracksByHash = new Map();
+  for (const t of mainDb.prepare(
+    'SELECT id, COALESCE(audio_hash, file_hash) AS h FROM tracks WHERE audio_hash IS NOT NULL OR file_hash IS NOT NULL'
+  ).all()) {
+    if (!tracksByHash.has(t.h)) { tracksByHash.set(t.h, []); }
+    tracksByHash.get(t.h).push(t.id);
+  }
+
+  // Case-insensitive genre vocabulary (V34 convention).
+  const genreByLc = new Map();
+  for (const g of mainDb.prepare('SELECT id, name, parent FROM genres').all()) {
+    genreByLc.set(g.name.toLowerCase(), g);
+  }
+
+  // The links this sync owns.
+  const modelLinks = new Map();   // track_id → Set(genre_id)
+  for (const l of mainDb.prepare(
+    "SELECT track_id, genre_id FROM track_genres WHERE source = 'model'"
+  ).all()) {
+    if (!modelLinks.has(l.track_id)) { modelLinks.set(l.track_id, new Set()); }
+    modelLinks.get(l.track_id).add(l.genre_id);
+  }
+
+  const insGenre = mainDb.prepare('INSERT INTO genres (name, parent) VALUES (?, ?)');
+  const setParent = mainDb.prepare('UPDATE genres SET parent = ? WHERE id = ? AND parent IS NULL');
+  const insLink = mainDb.prepare(
+    "INSERT OR IGNORE INTO track_genres (track_id, genre_id, source) VALUES (?, ?, 'model')"
+  );
+  const delLink = mainDb.prepare(
+    "DELETE FROM track_genres WHERE track_id = ? AND genre_id = ? AND source = 'model'"
+  );
+
+  const ensureGenre = (entry) => {
+    const key = entry.name.toLowerCase();
+    let row = genreByLc.get(key);
+    if (!row) {
+      const res = insGenre.run(entry.name, entry.parent);
+      row = { id: Number(res.lastInsertRowid), name: entry.name, parent: entry.parent };
+      genreByLc.set(key, row);
+      stats.genresCreated++;
+    } else if (entry.parent && row.parent == null) {
+      setParent.run(entry.parent, row.id);
+      row.parent = entry.parent;
+    }
+    return row.id;
+  };
+
+  mainDb.exec('BEGIN IMMEDIATE');
+  try {
+    for (const dr of discRows) {
+      const trackIds = tracksByHash.get(dr.audio_hash);
+      if (!trackIds) { continue; }   // no library file for this hash (removed track)
+      const entries = parseGenreTags(dr.genre_tags);
+      if (entries === null) { continue; }   // malformed payload — leave links as-is
+      stats.rows++;
+
+      const desired = new Set(entries.map(ensureGenre));
+      for (const trackId of trackIds) {
+        stats.tracks++;
+        const existing = modelLinks.get(trackId) || new Set();
+        for (const gid of desired) {
+          if (existing.has(gid)) { continue; }
+          // OR IGNORE: a 'tag' link for the same pair blocks the insert —
+          // tag wins, changes tells us whether the row actually landed.
+          stats.linksAdded += insLink.run(trackId, gid).changes;
+        }
+        for (const gid of existing) {
+          if (desired.has(gid)) { continue; }
+          stats.linksRemoved += delLink.run(trackId, gid).changes;
+        }
+      }
+    }
+    mainDb.exec('COMMIT');
+  } catch (err) {
+    mainDb.exec('ROLLBACK');
+    throw err;
+  }
+
+  return stats;
+}
+
+/**
+ * Production entry point — config-gated, resolves the managed handles.
+ * Returns the reconcile stats, or null when the feature (or a store) is
+ * unavailable. Callers wrap in try/catch and log; this never throws for
+ * "feature off" states.
+ */
+export function syncModelGenres() {
+  const scanOpts = config.program?.scanOptions;
+  if (scanOpts?.collectDiscoveryData !== true || scanOpts?.modelGenres !== true) { return null; }
+  const mainDb = db.getDB();
+  const ddb = discoveryDb.openDiscoveryDbIfExists();
+  if (!mainDb || !ddb) { return null; }
+
+  const started = Date.now();
+  const stats = reconcileModelGenres(mainDb, ddb, scanOpts.discoveryModel);
+  if (stats.linksAdded || stats.linksRemoved || stats.genresCreated) {
+    winston.info(
+      `model-genre sync: +${stats.linksAdded}/-${stats.linksRemoved} links, `
+      + `${stats.genresCreated} new genres across ${stats.tracks} tracks (${Date.now() - started} ms)`);
+  }
+  return stats;
+}

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -53,7 +53,11 @@
 // V56 adds acoustid_lookups — the per-track attempt cache for the AcoustID
 // fingerprint identification pass (cooldowns so unmatched / undecodable
 // files aren't re-fingerprinted and re-queried every batch). See SCHEMA_V56.
-export const SCHEMA_VERSION = 56;
+// V57 adds genre provenance — track_genres.source ('tag' | 'model') so the
+// discovery model's style predictions can join the real genre tables
+// without being confused with file tags, and genres.parent for the model
+// taxonomy's two-level hierarchy. See SCHEMA_V57.
+export const SCHEMA_VERSION = 57;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2137,6 +2141,28 @@ export const SCHEMA_V56 = `
   );
 `;
 
+// ── Genre provenance — model-generated genres ───────────────────────────────
+//
+// track_genres.source records where a genre link came from:
+//   'tag'   — file tags, written by the scanners. The column DEFAULT, so
+//             neither scanner needs changing: their INSERTs keep working
+//             and land as tag-sourced rows.
+//   'model' — the discovery embedding model's style predictions
+//             (discovery_tracks.genre_tags), written by the reconcile in
+//             src/db/genre-sync.js.
+// The (track_id, genre_id) primary key is unchanged — a genre links once
+// per track, and tag wins on collision (the sync only INSERT OR IGNOREs).
+//
+// genres.parent carries the model taxonomy's parent for style-level rows
+// ("Synthwave" → "Electronic", from the Discogs "Genre---Style" tag
+// format). Tag-sourced genres keep NULL; a tag genre whose name collides
+// with a model style simply gains its parent (backfill-only — the sync
+// never overwrites a non-NULL parent).
+export const SCHEMA_V57 = `
+  ALTER TABLE track_genres ADD COLUMN source TEXT NOT NULL DEFAULT 'tag';
+  ALTER TABLE genres ADD COLUMN parent TEXT;
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -2338,4 +2364,8 @@ export const MIGRATIONS = [
   // V56 adds the acoustid_lookups failure-cooldown ledger for the AcoustID
   // fingerprint pass. Pure new table — no rescan needed. See SCHEMA_V56.
   { version: 56, sql: SCHEMA_V56 },
+  // V57: genre provenance (track_genres.source + genres.parent) for
+  // model-generated genres. Pure column adds with defaults — existing
+  // rows become 'tag'-sourced, no rescan needed. See SCHEMA_V57.
+  { version: 57, sql: SCHEMA_V57 },
 ];

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -13,6 +13,7 @@ import { launchWorker, workerReaperMarker } from '../util/worker-process.js';
 import { ffmpegBin, ensureFfmpeg } from '../util/ffmpeg-bootstrap.js';
 import * as dlnaApi from '../api/dlna.js';
 import * as discoveryDb from './discovery-db.js';
+import { syncModelGenres } from './genre-sync.js';
 
 const __dirname = getDirname(import.meta.url);
 
@@ -78,6 +79,11 @@ let scanIntervalTimer = null;
 // in a batch — skipped on fully-unchanged rescans so control points aren't
 // poked for nothing.
 let anyScansChanged = false;
+// One-shot: run the model-genre sync on the first queue drain after boot,
+// even when nothing changed — a fully-embedded, unchanged library trips
+// neither the scan-changed nor the new-embeddings trigger, so a user
+// enabling modelGenres (or upgrading into V57) gets their first sync here.
+let bootGenreSyncPending = true;
 // Set in onScanClose after a clean scan; consumed in
 // checkQueueDrainedSideEffects to enqueue the album-art download pass once
 // the whole scan batch has drained. Module-level because the enqueue point
@@ -315,6 +321,27 @@ function checkQueueDrainedSideEffects() {
   // but only if some scan in the just-drained batch actually changed the
   // DB. Backups don't change library content, so they don't set the flag.
   // Safe to call whether or not DLNA is enabled.
+  // Model-genre sync triggers, cheapest-sufficient set (the sync itself is
+  // idempotent and no-ops when the feature is off):
+  //   • scan batch changed the DB — a re-parse wipes each changed track's
+  //     track_genres rows (including model-sourced ones) and may queue no
+  //     discovery work at all (tag edit → same audio hash → nothing to
+  //     embed), so heal from the existing discovery data here.
+  //   • first drain after boot — a fully-embedded, unchanged library never
+  //     trips the other triggers, so a user enabling the feature (or
+  //     upgrading into it) would otherwise wait for the next library
+  //     change before their first sync.
+  // (The third trigger lives in the discovery pass's closeOnce: new
+  // embeddings mean new genre_tags.)
+  if (anyScansChanged || bootGenreSyncPending) {
+    bootGenreSyncPending = false;
+    try {
+      syncModelGenres();
+    } catch (err) {
+      winston.warn(`model-genre sync on queue drain failed: ${err.message}`);
+    }
+  }
+
   if (anyScansChanged) {
     anyScansChanged = false;
     dlnaApi.bumpSystemUpdateID();
@@ -1464,6 +1491,14 @@ function runDiscoveryTask(taskObj) {
     // discovery network. No-ops unless p2p is enabled and the dataset
     // actually advanced past the last announced snapshot.
     if (code === 0 && !signal && !taskQueue.some((t) => t.task === 'discovery')) {
+      // New embeddings mean new genre_tags — reconcile them into the real
+      // genre tables before announcing the snapshot (the sync is local
+      // mstream.db work; it doesn't change what gets published).
+      try {
+        syncModelGenres();
+      } catch (err) {
+        winston.warn(`model-genre sync after embedding pass failed: ${err.message}`);
+      }
       import('../state/discovery-p2p.js')
         .then((p2p) => p2p.maybeAutoPublishSnapshot())
         .catch((err) => winston.warn(`discovery auto-publish after embedding pass failed: ${err.message}`));

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -121,6 +121,14 @@ const scanOptions = Joi.object({
   // runBudget and re-enqueues while a backlog remains — this just bounds
   // one batch. Mirrors analyzeBpmPerRun.
   discoveryPerRun: Joi.number().integer().min(1).max(10000).default(50),
+  // Feed the discovery model's style predictions (discovery_tracks.
+  // genre_tags) into the real genre tables as track_genres rows with
+  // source='model' (src/db/genre-sync.js) — genre browse / filtering /
+  // Auto-DJ genre mode all start working on untagged libraries. Default
+  // ON but inert until collectDiscoveryData is enabled; the flag exists
+  // for users who want embeddings/network WITHOUT the model touching
+  // their genre vocabulary.
+  modelGenres: Joi.boolean().default(true),
   autoAlbumArt: Joi.boolean().default(true),
   // What the post-scan album-art downloader targets. 'missing' (default):
   // only albums with no cover at all — the fill-in-the-blanks pass.

--- a/test/db/genre-sync.test.mjs
+++ b/test/db/genre-sync.test.mjs
@@ -1,0 +1,284 @@
+/**
+ * Model-genre sync tests — V57 provenance columns + the reconcile in
+ * src/db/genre-sync.js that feeds discovery_tracks.genre_tags into the
+ * real genre tables as source='model' rows.
+ *
+ * Uses the injectable core (reconcileModelGenres) against a fresh
+ * in-memory mstream.db (full migrations) and a temp-file discovery.db, so
+ * no server boot and no manager singletons for the main side. Covers:
+ *
+ *   - V57 shape: track_genres.source default 'tag', genres.parent.
+ *   - parseGenreTags: two-level split, dedup, junk hardening.
+ *   - linking both hierarchy levels; duplicate files sharing one hash.
+ *   - case-insensitive genre reuse + parent backfill (never overwrite).
+ *   - 'tag' wins on collision; sync only deletes rows it owns.
+ *   - idempotence; stale-link removal when predictions change; healing
+ *     after a scanner-style track_genres wipe.
+ *   - inactive-model rows / unknown hashes / malformed JSON are skipped.
+ */
+
+import { describe, test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { SCHEMA_VERSION, MIGRATIONS } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+import { parseGenreTags, reconcileModelGenres } from '../../src/db/genre-sync.js';
+import { initDiscoveryDb, closeDiscoveryDb } from '../../src/db/discovery-db.js';
+
+const MODEL = 'test-model';
+const EMB = Buffer.from(new Float32Array([1, 0, 0, 0]).buffer);
+
+let tmpDir;
+let ddb;
+
+function freshMain() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  applyAllMigrations(db);
+  db.exec(`
+    INSERT INTO libraries (id, name, root_path) VALUES (1, 'music', '/music');
+    INSERT INTO tracks (id, filepath, library_id, title, audio_hash, file_hash) VALUES
+      (100, 'a/one.mp3',  1, 'One',       'h1', 'f1'),
+      (101, 'a/two.mp3',  1, 'Two',       NULL, 'h2'),
+      (102, 'a/copy.mp3', 1, 'One Copy',  'h1', 'f3'),
+      (103, 'a/four.mp3', 1, 'Four',      'h4', 'f4');
+  `);
+  return db;
+}
+
+let seq = 0;
+function seedDiscoveryRow(hash, genreTags, modelId = MODEL) {
+  ddb.prepare(`
+    INSERT INTO discovery_tracks
+      (audio_hash, updated_at, export_id, artist, title, duration, model_id, model_version, embedding, genre_tags)
+    VALUES (?, ?, ?, 'Artist', 'Title', 120, ?, '1', ?, ?)
+  `).run(hash, ++seq, `anon:${hash}:${seq}`, modelId,
+    EMB, genreTags === null ? null : JSON.stringify(genreTags));
+}
+
+function modelLinks(db, trackId) {
+  return db.prepare(`
+    SELECT g.name FROM track_genres tg JOIN genres g ON g.id = tg.genre_id
+    WHERE tg.track_id = ? AND tg.source = 'model' ORDER BY g.name
+  `).all(trackId).map((r) => r.name);
+}
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-genre-sync-'));
+  ddb = initDiscoveryDb(path.join(tmpDir, 'discovery.db'));
+});
+
+after(() => {
+  closeDiscoveryDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  ddb.exec('DELETE FROM discovery_tracks');
+});
+
+// ── V57 schema shape ────────────────────────────────────────────────────────
+
+describe('V57 schema shape', () => {
+  test('SCHEMA_VERSION covers V57 and the migration is registered', () => {
+    assert.ok(SCHEMA_VERSION >= 57, `SCHEMA_VERSION = ${SCHEMA_VERSION}`);
+    const v57 = MIGRATIONS.find((m) => m.version === 57);
+    assert.ok(v57, 'missing v57 migration');
+    assert.match(v57.sql, /ALTER TABLE track_genres ADD COLUMN source/i);
+    assert.ok(!v57.rescanRequired, 'pure column adds — no rescan');
+  });
+
+  test('track_genres.source defaults to tag; genres.parent exists', () => {
+    const db = freshMain();
+    db.exec(`
+      INSERT INTO genres (name) VALUES ('Rock');
+      INSERT INTO track_genres (track_id, genre_id) VALUES (100, 1);
+    `);
+    const link = db.prepare('SELECT source FROM track_genres WHERE track_id = 100').get();
+    assert.equal(link.source, 'tag', 'scanner-style inserts land as tag-sourced');
+    const g = db.prepare('SELECT parent FROM genres WHERE name = ?').get('Rock');
+    assert.equal(g.parent, null);
+    db.close();
+  });
+});
+
+// ── parseGenreTags ──────────────────────────────────────────────────────────
+
+describe('parseGenreTags', () => {
+  test('splits Genre---Style into both levels with parent linkage', () => {
+    assert.deepEqual(parseGenreTags('["Electronic---Synthwave"]'), [
+      { name: 'Synthwave', parent: 'Electronic' },
+      { name: 'Electronic', parent: null },
+    ]);
+  });
+
+  test('dedups shared parents and repeated styles case-insensitively', () => {
+    const out = parseGenreTags('["Electronic---Synthwave", "Electronic---Chillwave", "electronic---SYNTHWAVE"]');
+    assert.deepEqual(out.map((e) => e.name).sort(), ['Chillwave', 'Electronic', 'Synthwave']);
+  });
+
+  test('single-level tags pass through with no parent', () => {
+    assert.deepEqual(parseGenreTags('["Ambient"]'), [{ name: 'Ambient', parent: null }]);
+  });
+
+  test('junk is skipped or rejected: non-strings, blanks, malformed JSON', () => {
+    assert.deepEqual(parseGenreTags('[42, "  ", "Rock", null]'), [{ name: 'Rock', parent: null }]);
+    assert.equal(parseGenreTags('{"not":"array"}'), null);
+    assert.equal(parseGenreTags('not json'), null);
+  });
+});
+
+// ── reconcile core ──────────────────────────────────────────────────────────
+
+describe('reconcileModelGenres', () => {
+  test('links both levels for every track sharing the canonical hash', () => {
+    const db = freshMain();
+    seedDiscoveryRow('h1', ['Electronic---Synthwave']);
+    const stats = reconcileModelGenres(db, ddb, MODEL);
+
+    assert.deepEqual(modelLinks(db, 100), ['Electronic', 'Synthwave']);
+    assert.deepEqual(modelLinks(db, 102), ['Electronic', 'Synthwave'], 'duplicate file gets the same links');
+    assert.deepEqual(modelLinks(db, 103), [], 'unrelated track untouched');
+    const style = db.prepare('SELECT parent FROM genres WHERE name = ?').get('Synthwave');
+    assert.equal(style.parent, 'Electronic');
+    assert.equal(stats.genresCreated, 2);
+    assert.equal(stats.linksAdded, 4);
+    db.close();
+  });
+
+  test('file_hash fallback resolves tracks with no audio_hash', () => {
+    const db = freshMain();
+    seedDiscoveryRow('h2', ['Ambient']);
+    reconcileModelGenres(db, ddb, MODEL);
+    assert.deepEqual(modelLinks(db, 101), ['Ambient']);
+    db.close();
+  });
+
+  test('reuses existing genre rows case-insensitively and backfills parent', () => {
+    const db = freshMain();
+    db.exec("INSERT INTO genres (name) VALUES ('electronic')");
+    seedDiscoveryRow('h1', ['Electronic---Synthwave']);
+    const stats = reconcileModelGenres(db, ddb, MODEL);
+
+    assert.equal(stats.genresCreated, 1, 'only Synthwave is new');
+    const rows = db.prepare("SELECT name, parent FROM genres WHERE name COLLATE NOCASE = 'electronic'").all();
+    assert.equal(rows.length, 1, 'no duplicate case-variant row');
+    db.close();
+  });
+
+  test('never overwrites an existing non-NULL parent', () => {
+    const db = freshMain();
+    db.exec("INSERT INTO genres (name, parent) VALUES ('Synthwave', 'Electro')");
+    seedDiscoveryRow('h1', ['Electronic---Synthwave']);
+    reconcileModelGenres(db, ddb, MODEL);
+    const g = db.prepare("SELECT parent FROM genres WHERE name = 'Synthwave'").get();
+    assert.equal(g.parent, 'Electro', 'first-seen parent is kept');
+    db.close();
+  });
+
+  test("tag wins on collision — the pair keeps source='tag'", () => {
+    const db = freshMain();
+    db.exec(`
+      INSERT INTO genres (name) VALUES ('Synthwave');
+      INSERT INTO track_genres (track_id, genre_id, source) VALUES (100, 1, 'tag');
+    `);
+    seedDiscoveryRow('h1', ['Electronic---Synthwave']);
+    reconcileModelGenres(db, ddb, MODEL);
+
+    const link = db.prepare(
+      'SELECT source FROM track_genres tg JOIN genres g ON g.id = tg.genre_id WHERE tg.track_id = 100 AND g.name = ?'
+    ).get('Synthwave');
+    assert.equal(link.source, 'tag');
+    db.close();
+  });
+
+  test('idempotent: a second run makes zero changes', () => {
+    const db = freshMain();
+    seedDiscoveryRow('h1', ['Electronic---Synthwave']);
+    reconcileModelGenres(db, ddb, MODEL);
+    const stats = reconcileModelGenres(db, ddb, MODEL);
+    assert.equal(stats.linksAdded, 0);
+    assert.equal(stats.linksRemoved, 0);
+    assert.equal(stats.genresCreated, 0);
+    db.close();
+  });
+
+  test('removes stale model links when predictions change, keeps tag links', () => {
+    const db = freshMain();
+    db.exec(`
+      INSERT INTO genres (name) VALUES ('Rock');
+      INSERT INTO track_genres (track_id, genre_id, source) VALUES (100, 1, 'tag');
+    `);
+    seedDiscoveryRow('h1', ['Electronic---Synthwave']);
+    reconcileModelGenres(db, ddb, MODEL);
+
+    ddb.exec('DELETE FROM discovery_tracks');
+    seedDiscoveryRow('h1', ['Electronic---Chillwave']);
+    const stats = reconcileModelGenres(db, ddb, MODEL);
+
+    assert.deepEqual(modelLinks(db, 100), ['Chillwave', 'Electronic']);
+    assert.ok(stats.linksRemoved >= 1, 'Synthwave link dropped');
+    const tagLink = db.prepare(
+      "SELECT COUNT(*) AS n FROM track_genres WHERE track_id = 100 AND source = 'tag'"
+    ).get();
+    assert.equal(tagLink.n, 1, 'tag-sourced Rock link untouched');
+    db.close();
+  });
+
+  test('heals a scanner-style track_genres wipe', () => {
+    const db = freshMain();
+    seedDiscoveryRow('h1', ['Electronic---Synthwave']);
+    reconcileModelGenres(db, ddb, MODEL);
+    db.exec('DELETE FROM track_genres');   // what deleteTrackGenres does per re-parsed track
+    reconcileModelGenres(db, ddb, MODEL);
+    assert.deepEqual(modelLinks(db, 100), ['Electronic', 'Synthwave']);
+    db.close();
+  });
+
+  test('an empty prediction list clears the model links it owns', () => {
+    const db = freshMain();
+    seedDiscoveryRow('h1', ['Ambient']);
+    reconcileModelGenres(db, ddb, MODEL);
+    assert.deepEqual(modelLinks(db, 100), ['Ambient']);
+
+    ddb.exec('DELETE FROM discovery_tracks');
+    seedDiscoveryRow('h1', []);
+    reconcileModelGenres(db, ddb, MODEL);
+    assert.deepEqual(modelLinks(db, 100), []);
+    db.close();
+  });
+
+  test('rows pinned to another model are ignored (mid-migration stability)', () => {
+    const db = freshMain();
+    seedDiscoveryRow('h1', ['Ambient']);
+    reconcileModelGenres(db, ddb, MODEL);
+
+    // The active model flips; h1's row now belongs to the OLD pin. Its
+    // links must neither update nor be torn down until re-embedding lands.
+    const stats = reconcileModelGenres(db, ddb, 'other-model');
+    assert.equal(stats.rows, 0);
+    assert.deepEqual(modelLinks(db, 100), ['Ambient'], 'links stay until the new pin covers the track');
+    db.close();
+  });
+
+  test('unknown hashes and malformed payloads are skipped without damage', () => {
+    const db = freshMain();
+    seedDiscoveryRow('gone-from-library', ['Ambient']);
+    ddb.prepare(`
+      INSERT INTO discovery_tracks
+        (audio_hash, updated_at, export_id, artist, title, duration, model_id, model_version, embedding, genre_tags)
+      VALUES ('h1', ?, 'anon:h1:bad', 'A', 'T', 120, ?, '1', ?, 'not valid json')
+    `).run(++seq, MODEL, EMB);
+    seedDiscoveryRow('h4', ['Rock']);
+
+    const stats = reconcileModelGenres(db, ddb, MODEL);
+    assert.deepEqual(modelLinks(db, 103), ['Rock'], 'healthy rows still process');
+    assert.deepEqual(modelLinks(db, 100), [], 'malformed row leaves its tracks alone');
+    assert.equal(stats.rows, 1, 'only the healthy, mapped row counts');
+    db.close();
+  });
+});


### PR DESCRIPTION
# Model-generated genres → the real genre system (PR A: schema + sync)

The discovery model already predicts styles for every embedded track (EffNet's 400-style activations → `discovery_tracks.genre_tags`, e.g. `"Electronic---Synthwave"`). This PR feeds those predictions into the canonical `genres`/`track_genres` tables — so **genre browse, genre-songs, Subsonic `getGenres`, DLNA genre containers, and Auto-DJ's genre mode all start working on untagged libraries**, with zero changes to any of those readers.

## V57 — provenance columns (pure adds, no rescan)

- **`track_genres.source`** (`'tag'` default | `'model'`) — the default means **neither scanner changes**: their inserts keep landing as tag-sourced rows. The `(track_id, genre_id)` PK is unchanged, so a genre links once per track; **tag wins** on collision (the sync only `INSERT OR IGNORE`s) and the sync only ever deletes rows it owns.
- **`genres.parent`** — the Discogs taxonomy parent for style rows (`Synthwave` → `Electronic`). Each `Genre---Style` tag links **both levels**, so the flat genre page stays rich while the parent column gives PR B's two-level browse its structure. Genre rows are reused case-insensitively (the V34 convention); a colliding tag genre just gains its parent — backfill-only, never overwritten.

## The sync (`src/db/genre-sync.js`)

A **full idempotent reconcile**, deliberately not incremental: both scanners wipe a track's `track_genres` rows on every re-parse (`deleteTrackGenres` → re-insert from tags), taking model rows with them — so the sync must be able to heal from nothing at any time. One read per table + in-memory set-diffs, writes only actual deltas in one transaction — measured **8 ms** for the smoke library. Only rows pinned to the **active model** reconcile, so a mid-model-migration library doesn't flap links off and back on.

**Triggers** (task-queue), the cheapest set that covers every way the data moves:

1. Discovery pass `closeOnce` — new embeddings mean new predictions.
2. Scan-changed queue drain — heals re-parse wipes, including tag-only edits that queue **no** discovery work (same audio hash → nothing to embed → trigger 1 never fires).
3. One-shot first drain after boot — a fully-embedded, unchanged library trips neither of the above, so enabling the feature (or upgrading into V57) syncs immediately.

**Config**: `scanOptions.modelGenres`, default ON but inert until `collectDiscoveryData` — an off-switch for users who want embeddings/network without the model touching their genre vocabulary.

## Deliberately deferred

- **Activation scores** — the `genre_tags` JSON shape is network-facing (exports, peer snapshots), so carrying scores is a cross-version compat decision for its own PR. The worker's ≥0.1/top-5 threshold is already the quality gate.
- **PR B** — API/UI surface: `source`/`parent` in `getGenres`, the two-level Genres browse, provenance styling.

## Verified

- **17 new tests** (`test/db/genre-sync.test.mjs`): V57 shape + defaults, tag parsing (both-level split, dedup, junk hardening), dup-files-share-a-hash fan-out, case-insensitive reuse, parent backfill-only, tag-wins, idempotence, stale-link removal, scanner-wipe healing, empty predictions clearing owned links, inactive-model stability, malformed payloads skipped without damage.
- Schema-sensitive db suites re-run green (75 tests), full suite run before push.
- **Live smoke** on the real untagged 18-track library: V56→V57 migration on boot, the one-shot boot trigger synced `+97/-0 links, 19 new genres … (8 ms)`, hierarchy correct (`Synthwave→Electronic`, `K-pop→Pop`); `/db/genres` returned 19 genres with counts, `/db/genre-songs` served 15 Synthwave tracks, and an **Auto-DJ genre whitelist on `['Vaporwave']` picked correctly** — on a library with zero genre tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
