### PR TITLE
fix(discovery): musl/Alpine onnxruntime — degrade once loudly, glibc container path

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -41,6 +41,14 @@ restart, or pass your own config with `-j <path>`:
 * **Alpine / musl Linux** — use the `*-musl` bundle (the glibc Linux build can't
   run on musl). Bun's musl binary needs the GNU C++ runtime: `apk add libstdc++`.
   For transcoding/waveforms also `apk add ffmpeg`.
+  **Known limitation:** the discovery/recommendation embedding model runs on
+  onnxruntime, which ships glibc-only binaries — it cannot load on musl (and
+  Alpine's `gcompat` shim is not sufficient: onnxruntime needs fortified glibc
+  symbols the shim doesn't implement). Everything else works, but
+  recommendations/Discover/sonic Auto-DJ won't build their data on musl —
+  including Alpine-based Docker images. Use a glibc system or a Debian/Ubuntu-
+  based image for that feature; the server detects this case, logs one clear
+  error, and disables the embedding pass instead of retrying it.
 * The fast Rust library scanner needs glibc ≥ 2.34 on glibc systems; on older
   glibc it automatically falls back to a portable static build, so scanning stays
   fast. ffmpeg (transcoding/waveforms) is auto-downloaded on first use, or

--- a/src/db/discovery-backfill.mjs
+++ b/src/db/discovery-backfill.mjs
@@ -52,6 +52,11 @@ import {
 import { createEmbedder, analyzeFile, EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL } from './discovery-features-lib.js';
 
 const SCHEMA_GUARD_EXIT = 3;
+// Exit contract with task-queue.js: the environment can't load
+// onnxruntime-node at all (missing optional dep, or musl/Alpine where the
+// glibc-only binaries can never load) — the queue latches the pass off
+// until restart instead of retrying an identical failure every batch.
+const RUNTIME_UNAVAILABLE_EXIT = 4;
 
 // discovery-db.js logs through winston; a forked child has no transports
 // configured, and winston prints a noisy meta-warning per call in that
@@ -327,5 +332,8 @@ run()
   .catch((err) => {
     emit({ event: 'error', message: err?.message || String(err) });
     try { db.close(); } catch (_) { /* best-effort */ }
-    process.exit(1);
+    // dependencyMissing (set by createEmbedder): onnxruntime-node absent
+    // or unloadable here — a structural failure that repeats identically
+    // every batch, so tell the queue to latch the pass off until restart.
+    process.exit(err?.dependencyMissing === true ? RUNTIME_UNAVAILABLE_EXIT : 1);
   });

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -237,7 +237,14 @@ async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
     // fails at runtime and lands in the catch below.
     ort = (await import('onnxruntime-node')).default;
   } catch (err) {
-    const e = new Error(`onnxruntime-node is not installed — the '${spec.weights.filename}' embedding model cannot run (${err.message})`);
+    // Distinguish "the package isn't there" from "it's there but this OS
+    // can't load it" — the latter is the Alpine/musl case (onnxruntime
+    // ships glibc-only binaries; gcompat doesn't cover its fortified
+    // symbols), where the only fix is a glibc-based image.
+    const muslHint = /ld-linux|Error relocating|ERR_DLOPEN/i.test(`${err.message} ${err.code || ''}`)
+      ? ' — this system cannot load onnxruntime’s glibc binaries (musl/Alpine containers are not supported; use a glibc-based image such as Debian/Ubuntu)'
+      : '';
+    const e = new Error(`onnxruntime-node is not available — the '${spec.weights.filename}' embedding model cannot run${muslHint} (${err.message})`);
     e.dependencyMissing = true;
     throw e;
   }

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1317,8 +1317,16 @@ const DISCOVERY_MAX_DURATION_SEC = 30 * 60;
 // eligible track already has a current-model embedding. Exported so the
 // admin collect-discovery-data toggle routes through the same gates as the
 // scan-drain trigger.
+// Latched true when the embedding worker reports the environment can't
+// load onnxruntime-node at all (exit code 4 — e.g. musl/Alpine images,
+// where onnxruntime's glibc-only binaries can never load). A structural
+// failure, identical on every retry, so the pass stays off until restart
+// instead of failing (and error-logging) on every scan drain.
+let discoveryRuntimeUnavailable = false;
+
 export function maybeEnqueueDiscovery() {
   if (config.program.scanOptions.collectDiscoveryData !== true) { return; }
+  if (discoveryRuntimeUnavailable) { return; }
   if (!ffmpegBin()) {
     winston.info('Discovery-embedding pass deferred — waiting for ffmpeg to resolve');
     retryWhenFfmpegResolves(maybeEnqueueDiscovery);
@@ -1444,6 +1452,19 @@ function runDiscoveryTask(taskObj) {
       winston.info(`Discovery-embedding pass terminated by ${signal}`);
     } else if (code === 3) {
       winston.warn('Discovery-embedding pass aborted: library schema changed under it (another instance migrating?)');
+    } else if (code === 4) {
+      // The environment can't load onnxruntime-node at all (worker exit
+      // contract: RUNTIME_UNAVAILABLE_EXIT). Retrying every batch would
+      // fail identically and spam the log — latch it off until restart.
+      // Seen in the wild on Alpine/musl containers: onnxruntime ships
+      // glibc-only binaries, and gcompat doesn't cover its fortified
+      // symbols, so a glibc-based image is the only fix.
+      discoveryRuntimeUnavailable = true;
+      winston.error(
+        'Discovery-embedding pass halted: this environment cannot load onnxruntime-node, '
+        + 'so the embedding model cannot run (musl/Alpine containers lack the required glibc). '
+        + 'Recommendations will not build here — use a glibc-based image (e.g. Debian/Ubuntu). '
+        + 'The pass is disabled until the server restarts.');
     } else if (code !== 0 && code !== null) {
       winston.warn(`Discovery-embedding pass exited with code ${code}`);
     }

--- a/test/smoke/docker/Dockerfile.mstream
+++ b/test/smoke/docker/Dockerfile.mstream
@@ -8,11 +8,18 @@
 #   /music* dirs (library content shared with the daemons via the
 #   same source volume so file-existence checks line up).
 
-FROM node:22-alpine
+# glibc base (NOT alpine): onnxruntime-node — the discovery embedding
+# runtime — ships glibc-only binaries. On musl the loader fails outright
+# (`ld-linux-x86-64.so.2: No such file or directory`), and Alpine's
+# gcompat shim doesn't help (onnxruntime needs fortified glibc symbols
+# like __vsnprintf_chk that gcompat doesn't implement; verified 2026-07).
+# bookworm-slim runs the full EffNet inference correctly.
+FROM node:22-bookworm-slim
 
-# Build tools needed by node:sqlite (better-sqlite3 in some deps) +
-# the better-sqlite native bindings. Alpine ships these in build-base.
-RUN apk add --no-cache build-base python3
+# Build tools needed by native npm bindings in some deps.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential python3 \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/test/smoke/docker/Dockerfile.mstream.dockerignore
+++ b/test/smoke/docker/Dockerfile.mstream.dockerignore
@@ -1,0 +1,18 @@
+# Trim the build context. The repo includes a worktrees dir, image
+# caches, Electron build output, etc. — none of it belongs in the
+# all-Docker smoke image.
+node_modules
+.git
+.claude
+.vscode
+dist
+image-cache
+waveform-cache
+save
+bin
+rust-parser/target
+rust-server-audio/target
+docs/api.html
+*.log
+TODO.md
+test/smoke/docker


### PR DESCRIPTION
# musl/Alpine can't run onnxruntime — degrade once (loudly), fix the container path

Found on a production Alpine (linuxserver.io) mStream container: the discovery-embedding worker died at import on every batch —

```
Error loading shared library ld-linux-x86-64.so.2: No such file or directory
(needed by .../onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime.so.1)
```

onnxruntime-node ships **glibc-only** binaries; musl has no glibc loader. The worker exited 1, the queue re-enqueued it after every scan drain, and the log filled with identical errors while the server silently never built any recommendation data — the whole v6.16 headline feature is inert on Alpine images.

## The shim is not a fix (tested)

Validated in containers with the real 18 MB EffNet model and a real inference run:

| environment | result |
|---|---|
| `node:22-alpine` | `ERR_DLOPEN_FAILED` — no glibc loader |
| `node:22-alpine` + `gcompat` + `libstdc++` | still fails: onnxruntime needs fortified glibc symbols (`__vsnprintf_chk`, `__memcpy_chk`, …) that gcompat doesn't implement |
| `node:22-bookworm-slim` | **works** — full inference, 1280-d embeddings + 400 activations |

glibc base images are the only fix. The linuxserver.io image builds on `baseimage-alpine`, so truly fixing *that* image needs a base change in their repo — this PR makes mStream behave sanely in the environment meanwhile, and fixes our own container path.

## Changes

- **Degrade once, loudly**: `discovery-backfill.mjs` exits with a distinct code (`4`) when the failure is the structural `dependencyMissing` class; `task-queue.js` latches the pass **off until restart** with one clear error naming the cause and remedy — no more per-batch retry spam. Other failure classes keep the existing retry behavior.
- **Clearer diagnosis**: the embedder load error now distinguishes "package missing" from "present but unloadable on this libc" and says what to do about it.
- **`test/smoke/docker/Dockerfile.mstream` → `node:22-bookworm-slim`** — the validated-working base, so the in-repo container path can exercise the discovery stack. Validated end-to-end: image built, booted with `collectDiscoveryData` on, and the embedding pass ran real inferences inside the container.
- **`Dockerfile.mstream.dockerignore`** (new): BuildKit only honors a co-located ignore named `<Dockerfile>.dockerignore`, so the existing `.dockerignore` never applied with the repo-root build context — `COPY . .` could clobber the image's Linux `node_modules` with the host's.
- **docs/install.md**: the musl limitation documented under the existing Alpine platform note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
