### PR TITLE
docs(discovery): Alpine ≥3.24 CAN run embeddings — system onnxruntime recipe

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -41,14 +41,22 @@ restart, or pass your own config with `-j <path>`:
 * **Alpine / musl Linux** — use the `*-musl` bundle (the glibc Linux build can't
   run on musl). Bun's musl binary needs the GNU C++ runtime: `apk add libstdc++`.
   For transcoding/waveforms also `apk add ffmpeg`.
-  **Known limitation:** the discovery/recommendation embedding model runs on
-  onnxruntime, which ships glibc-only binaries — it cannot load on musl (and
-  Alpine's `gcompat` shim is not sufficient: onnxruntime needs fortified glibc
-  symbols the shim doesn't implement). Everything else works, but
-  recommendations/Discover/sonic Auto-DJ won't build their data on musl —
-  including Alpine-based Docker images. Use a glibc system or a Debian/Ubuntu-
-  based image for that feature; the server detects this case, logs one clear
-  error, and disables the embedding pass instead of retrying it.
+  **Discovery/recommendations on musl:** the embedding model runs on
+  onnxruntime, whose npm package bundles glibc-only binaries — they cannot
+  load on musl, and Alpine's `gcompat` shim alone is not sufficient (the
+  bundled runtime needs fortified glibc symbols the shim doesn't implement).
+  The server detects this case, logs one clear error, and disables the
+  embedding pass instead of retrying it. Two ways to make it work:
+  * **glibc system or image** (Debian/Ubuntu base) — just works.
+  * **Alpine ≥ 3.24** — the community repo packages a native musl
+    onnxruntime matching the 1.24 line mStream uses. Install the runtime
+    plus the shim for the thin npm binding, then point the binding at the
+    system library (verified: full EffNet inference passes):
+    ```shell
+    apk add gcompat libstdc++ onnxruntime
+    ln -sf /usr/lib/libonnxruntime.so.1 \
+      node_modules/onnxruntime-node/bin/napi-v6/linux/x64/libonnxruntime.so.1
+    ```
 * The fast Rust library scanner needs glibc ≥ 2.34 on glibc systems; on older
   glibc it automatically falls back to a portable static build, so scanning stays
   fast. ffmpeg (transcoding/waveforms) is auto-downloaded on first use, or

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -242,7 +242,7 @@ async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
     // ships glibc-only binaries; gcompat doesn't cover its fortified
     // symbols), where the only fix is a glibc-based image.
     const muslHint = /ld-linux|Error relocating|ERR_DLOPEN/i.test(`${err.message} ${err.code || ''}`)
-      ? ' — this system cannot load onnxruntime’s glibc binaries (musl/Alpine containers are not supported; use a glibc-based image such as Debian/Ubuntu)'
+      ? ' — this system cannot load onnxruntime’s bundled glibc binaries (musl/Alpine: use a glibc-based image, or on Alpine ≥3.24 apk add gcompat libstdc++ onnxruntime and symlink the system libonnxruntime over the bundled one — see docs/install.md)'
       : '';
     const e = new Error(`onnxruntime-node is not available — the '${spec.weights.filename}' embedding model cannot run${muslHint} (${err.message})`);
     e.dependencyMissing = true;


### PR DESCRIPTION
Follow-up to #718 (this commit raced the merge): Alpine 3.24's community repo packages a native musl onnxruntime 1.24.4 — the same 1.24 line our npm binding pins. Clean-room validated in an alpine:3.24 container with the real EffNet model: \pk add gcompat libstdc++ onnxruntime\ + symlink \/usr/lib/libonnxruntime.so.1\ over the bundled one → full inference passes. install.md documents the recipe alongside the glibc-image path, and the musl error hint now points at both. Also the basis for linuxserver/docker-mstream#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)