### PR TITLE
feat(iroh): let an authed admin fetch the pairing code without shareCodePublic

### DIFF
--- a/src/api/iroh.js
+++ b/src/api/iroh.js
@@ -1,19 +1,25 @@
 // Non-admin Iroh API.
 //
-// Exposes the pairing code to ordinary users (the web player) — but ONLY when
-// the operator opts in via `iroh.shareCodePublic`. The code embeds the connect
-// secret, so by default it stays admin-only (src/api/admin.js). This endpoint
-// exists for public/demo servers that want anyone to be able to test an Iroh
-// connection. It is mounted AFTER the auth wall, so on a server with user
-// accounts it still requires login; on a public-mode (no-users) demo it's
-// effectively public, which is the intent.
+// Exposes the pairing code over the auth-walled (non-admin-network-gated) API so
+// a client can configure a roaming Iroh connection after a plain login. The code
+// embeds the connect secret, so it is only revealed to:
+//   * an authenticated ADMIN — the typical case: the server owner pairing their
+//     own device (e.g. LAN discovery → login → fetch code). Unlike the admin API
+//     (src/api/admin.js) this route has no admin-network gate, so it works from a
+//     phone on the LAN; the secret still only gates the tunnel pipe, not the API.
+//   * any authenticated user, when the operator opts in via `iroh.shareCodePublic`
+//     (public/demo servers that want anyone to be able to test an Iroh connection).
+// Mounted AFTER the auth wall, so on a server with user accounts it still requires
+// login; on a public-mode (no-users) demo with shareCodePublic it's effectively
+// public, which is the intent.
 
 import * as config from '../state/config.js';
 
 export function setup(mstream) {
   mstream.get('/api/v1/iroh/code', async (req, res) => {
     const enabled = config.program.iroh.enabled === true;
-    const shared = enabled && config.program.iroh.shareCodePublic === true;
+    const shared = enabled
+      && (config.program.iroh.shareCodePublic === true || req.user?.admin === true);
     if (!shared) {
       // Don't reveal the code; tell the client the feature isn't being shared.
       return res.json({ enabled, shared: false });


### PR DESCRIPTION
Half of the Quick Connect flow (see the companion app PR): a server owner pairing their own phone shouldn't have to flip `shareCodePublic` for everyone. `GET /api/v1/iroh/code` now allows `enabled && (shareCodePublic || req.user?.admin === true)`. The route has no admin-network gate (unlike `/api/v1/admin/iroh`) so it works from a LAN phone; the auth wall and connect-secret handshake are unchanged — the code is still never broadcast anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)