### PR TITLE
feat(mdns): advertise iroh availability in the TXT record

### DIFF
--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -106,6 +106,11 @@ export function gatherInfo() {
     // Optional public URL so a portable player can reach home from anywhere —
     // reuse the relay URL the operator already configured if present.
     publicUrl: (config.program.rpn && config.program.rpn.url) ? config.program.rpn.url : '',
+    // Whether the Iroh remote-access tunnel is enabled. Advertised (capability
+    // flag only — no secret) so a LAN client like the app's Quick Connect can
+    // surface just the servers it can pair with for roaming. mDNS and Iroh are
+    // independent configs, so this is simply absent when Iroh is off.
+    irohEnabled: !!(config.program.iroh && config.program.iroh.enabled === true),
   };
 }
 
@@ -123,6 +128,8 @@ function txtEntries(i) {
     `api=v1`,
     `auth=apikey,jwt`,
   ];
+  // Capability flag: the Iroh remote-access tunnel is available for pairing.
+  if (i.irohEnabled) { entries.push(`iroh=1`); }
   if (i.publicUrl) { entries.push(`pub=${i.publicUrl}`); }
   return entries;
 }

--- a/test/mdns.test.mjs
+++ b/test/mdns.test.mjs
@@ -92,6 +92,14 @@ describe('mdns wire format', () => {
     assert.equal(alive.readUInt32BE(37), 4500);
     assert.equal(bye.readUInt32BE(37), 0);
   });
+
+  test('iroh=1 TXT entry is present only when irohEnabled', () => {
+    // Off by default (descriptor without the flag): no iroh capability advertised.
+    assert.ok(!buildAnnouncementPacket(info).includes(Buffer.from('iroh=1')));
+    // Enabled: the capability flag is carried so a LAN client can pair for roaming.
+    const withIroh = { ...info, irohEnabled: true };
+    assert.ok(buildAnnouncementPacket(withIroh).includes(Buffer.from('iroh=1')));
+  });
 });
 
 describe('mdns query handling', () => {


### PR DESCRIPTION
**⚠️ STACKED on #641 (`feat/mdns-discovery`) — after #641 merges, RETARGET this PR's base to master before merging it** (merging while the base still points at the branch strands the commits — this exact trap hit the app repo twice).

Adds `iroh=1` to the mDNS TXT record when iroh is enabled, so the app's Quick Connect can filter LAN discovery to servers that can hand out a roaming tunnel. The pairing code/secret is never broadcast — clients log in over LAN HTTP and fetch it over that authenticated connection (companion PR relaxes the `/api/v1/iroh/code` gate for authed admins). 17/17 mdns tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)