### PR TITLE
Enable local discovery collection by default

### DIFF
--- a/src/state/config.js
+++ b/src/state/config.js
@@ -105,10 +105,21 @@ const scanOptions = Joi.object({
   // + filter metadata) into the SEPARATE discovery.db (src/db/discovery-db.js)
   // — deliberately isolated from mstream.db so the dataset stays a single
   // shareable/deletable file (see discovery-export.js). Gates DB creation,
-  // the admin export surface, and the post-scan embedding worker
-  // (discovery-backfill.mjs). Default OFF: opt-in by design (a music
-  // library is identifying), and the embedding pass is CPU-heavy.
-  collectDiscoveryData: Joi.boolean().default(false),
+  // the admin export surface, the LOCAL similarity APIs (/api/v1/discovery/
+  // local/*, the Discover panel, Auto-DJ sonic mode), and the post-scan
+  // embedding worker (discovery-backfill.mjs) that fills the DB once a scan
+  // finishes.
+  //
+  // Default ON. This is LOCAL analysis only — nothing leaves the machine;
+  // PUBLISHING a snapshot to the discovery network is a separate opt-in
+  // (discoveryP2p.enabled, still default OFF), so a fresh install gets the
+  // local recommendation features without ever exposing its library. The
+  // pass is CPU-heavy but bounded (discoveryPerRun tracks per batch,
+  // re-enqueued while a backlog remains) and downloads its model weights
+  // once (~18 MB EffNet). Where the ML runtime is unavailable (e.g. the
+  // glibc-only onnxruntime on musl/Alpine) the worker degrades once,
+  // loudly, and stops. Set false to skip discovery collection entirely.
+  collectDiscoveryData: Joi.boolean().default(true),
   // Which embedding engine the discovery pass runs — a key into the model
   // registry in src/db/discovery-features-lib.js. Deliberately swappable:
   // rows are pinned per-model and the worker re-embeds rows whose pin

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -161,8 +161,15 @@ export async function startServer(opts = {}) {
     // really wants the downloader sets autoAlbumArt: true explicitly and
     // points the service base URLs at a local mock via env
     // (MSTREAM_*_BASE).
+    //
+    // collectDiscoveryData also defaults ON in config.js now — same guard
+    // idea: without this every scan would init discovery.db and fork the
+    // CPU-heavy embedding worker (onnxruntime + a one-time ~18MB model
+    // download), and unrelated suites would see the Discover panel/local
+    // similarity APIs light up. Discovery suites opt in by setting
+    // collectDiscoveryData: true (usually with discoveryModel: 'test-fake').
     ...extraConfig,
-    scanOptions: { autoAlbumArt: false, ...(extraConfig.scanOptions || {}) },
+    scanOptions: { autoAlbumArt: false, collectDiscoveryData: false, ...(extraConfig.scanOptions || {}) },
     // Same guard idea for the discovery network's community seeds — TWO
     // layers, both load-bearing:
     //  - seedListUrl → dead local port, so no test fetches GitHub;

--- a/test/integration/discovery-export.test.mjs
+++ b/test/integration/discovery-export.test.mjs
@@ -7,9 +7,10 @@
  *   GET  /api/v1/admin/db/discovery-export/manifest       current manifest
  *   GET  /api/v1/admin/db/discovery-export/download       the snapshot file (Range-capable)
  *
- * Two servers: one booted with the feature at its default (OFF) to prove the
- * opt-in flow and the 404s, one booted with collectDiscoveryData already ON
- * to prove boot-time initialization and a real data round-trip (rows seeded
+ * Two servers: one booted with collection OFF (the test harness forces it off
+ * — collectDiscoveryData defaults ON in config.js, see server.mjs) to prove
+ * the opt-in flow and the 404s, one booted with collectDiscoveryData already
+ * ON to prove boot-time initialization and a real data round-trip (rows seeded
  * directly into discovery.db, then pulled back out through the export
  * endpoints and verified byte-for-byte).
  *
@@ -25,21 +26,28 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { DatabaseSync } from 'node:sqlite';
 import { startServer } from '../helpers/server.mjs';
+import { getDefaults } from '../../src/state/config.js';
 
 function sha256(buf) {
   return crypto.createHash('sha256').update(buf).digest('hex');
 }
 
-describe('discovery export — feature off by default, opt-in via admin', () => {
+test('collectDiscoveryData defaults to true (local discovery on out of the box)', () => {
+  assert.equal(getDefaults().scanOptions.collectDiscoveryData, true);
+});
+
+describe('discovery export — collection off, opt-in flow via admin', () => {
   let server;
   const discoveryDbFile = () => path.join(server.tmpDir, 'db', 'discovery.db');
 
   before(async () => {
+    // The test harness forces collectDiscoveryData off (config default is ON)
+    // so this suite can exercise the enable-from-off flow.
     server = await startServer({ dlnaMode: 'disabled', waitForScan: false });
   });
   after(async () => { if (server) { await server.stop(); } });
 
-  test('collectDiscoveryData defaults to false and no discovery.db exists', async () => {
+  test('collection is off for this server and no discovery.db exists', async () => {
     const r = await fetch(`${server.baseUrl}/api/v1/admin/db/params`);
     assert.equal(r.status, 200);
     assert.equal((await r.json()).collectDiscoveryData, false);


### PR DESCRIPTION
## What

Flip `scanOptions.collectDiscoveryData` from `false` → **`true`** so a fresh install gets the **local Recommendation Engine** working out of the box once the initial scan finishes:

- the **Discover** panel (now-playing column),
- `POST /api/v1/discovery/local/similar/tracks` + `/similar/artists`,
- **Auto-DJ sonic mode**.

The post-scan embedding worker (`discovery-backfill.mjs`) builds `discovery.db` after each scan; the flag gates DB creation at boot, the local similarity index, the ping `discovery` flag that reveals the UI panel, and the admin export surface.

## Why this is safe to default on

**This is local analysis only — nothing leaves the machine.** *Publishing* a metadata snapshot to the P2P discovery network is a **separate** opt-in (`discoveryP2p.enabled`, still default **OFF**), so enabling collection never exposes the library. The old "opt-in because a library is identifying" rationale was really about publishing, not local analysis.

The embedding pass is:
- **bounded** — `discoveryPerRun` tracks per batch, re-enqueued while a backlog remains, runs last in the post-scan chain (cheapest passes finish first);
- **cheap to bootstrap** — downloads its ~18 MB EffNet weights once;
- **fail-safe** — where the ML runtime is unavailable (the glibc-only `onnxruntime` on musl/Alpine images) the worker degrades once, loudly, and stops (no per-batch spam).

Set `collectDiscoveryData: false` to skip it entirely.

## Test harness

`startServer` now forces `collectDiscoveryData: false` — the same **default-ON-in-prod / forced-off-in-tests** guard already used for `autoAlbumArt` — so unrelated suites don't init `discovery.db` or fork the embedding worker. Discovery suites keep opting in explicitly (usually with `discoveryModel: 'test-fake'`).

`discovery-export.test.mjs`: asserts the new `true` default via `getDefaults()`, and the opt-in-flow suite is reworded (it now runs from the harness-forced-off state, not the config default).

## Verification

- `getDefaults().scanOptions.collectDiscoveryData === true`, `discoveryP2p.enabled === false` ✔
- `node --test test/integration/discovery-export.test.mjs` → 10/10 ✔
- `node --test test/integration/discovery-similarity.test.mjs` → 15/15 ✔
- `eslint` clean on all changed files ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)
