### PR TITLE
fix(backup): close three silent data-loss paths from the audit (batch 1)

### DIFF
--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -299,8 +299,18 @@ async function probeDestMtimeFidelity() {
     destPath,
     TMP_PREFIX + 'mtime-probe-' + crypto.randomBytes(6).toString('hex'),
   );
+  // Stage 1: can we write at all? A writeFile failure (read-only
+  // remount, full disk, EACCES on the dest root) says nothing about
+  // mtime fidelity — keep the exact comparison (already-stamped files
+  // still compare exactly) and let the walk surface the real write
+  // errors per-file, where they'll carry the true error message.
   try {
     await fs.writeFile(probePath, 'mtime-probe');
+  } catch (_) {
+    return;
+  }
+  // Stage 2: does an explicit stamp survive a round-trip?
+  try {
     const want = new Date(PROBE_MTIME_MS);
     await fs.utimes(probePath, want, want);
     const st = await fs.stat(probePath);
@@ -314,6 +324,16 @@ async function probeDestMtimeFidelity() {
     mtimeWarningIssued = true;
     recordFileError('destination does not preserve file modification times; using size-based change detection for this run');
   }
+}
+
+// One stderr notice per run when the future-mtime clamp in
+// syncMatchedPair fires, so genuinely skewed setups stay visible in the
+// server log without inflating the run's fileErrors count.
+let futureMtimeNoticed = false;
+function noteFutureMtime(p) {
+  if (futureMtimeNoticed) { return; }
+  futureMtimeNoticed = true;
+  process.stderr.write(`Warning: source files carry mtimes in the future (e.g. ${p}); treating same-size dest copies as unchanged\n`);
 }
 
 // Stamp the source mtime onto a freshly-written dest file, tolerating
@@ -755,9 +775,21 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
   // The cost: a same-size source edit that also backdates the file's
   // mtime goes undetected on such destinations.
   if (destStat && destStat.isFile() && destStat.size === srcStat.size) {
-    const mtimeAgrees = destMtimeTrustworthy
-      ? Math.abs(destStat.mtimeMs - srcStat.mtimeMs) < MTIME_TOLERANCE_MS
-      : destStat.mtimeMs + MTIME_TOLERANCE_MS >= srcStat.mtimeMs;
+    let mtimeAgrees;
+    if (destMtimeTrustworthy) {
+      mtimeAgrees = Math.abs(destStat.mtimeMs - srcStat.mtimeMs) < MTIME_TOLERANCE_MS;
+    } else {
+      mtimeAgrees = destStat.mtimeMs + MTIME_TOLERANCE_MS >= srcStat.mtimeMs;
+      if (!mtimeAgrees && srcStat.mtimeMs > Date.now() + MTIME_TOLERANCE_MS) {
+        // Future-stamped source (wrong-clock rip, FAT TZ/DST shift, NFS
+        // server clock behind the source host): its stamp can never
+        // legitimately postdate this run's copy, so without this clamp
+        // the file would be trashed + recopied on EVERY run until wall
+        // time catches up with the stamp.
+        mtimeAgrees = true;
+        noteFutureMtime(srcChild);
+      }
+    }
     if (mtimeAgrees) {
       counts.filesUnchanged++;
       emitProgress();

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -265,6 +265,74 @@ async function streamResume(src, partial, srcSize, offset) {
   }
 }
 
+// ── Destination mtime fidelity ──────────────────────────────────────────────
+//
+// The "unchanged" fast-path compares source vs dest mtimes, and atomicCopy
+// stamps the source mtime onto every file it writes. Both assume the
+// destination filesystem can store an explicit timestamp. Some can't:
+// root-squash NFS returns EPERM (explicit utimes needs ownership /
+// CAP_FOWNER), SMB shares can deny FILE_WRITE_ATTRIBUTES, and some FUSE
+// backends return ENOSYS — or worse, report success and quietly keep
+// their own timestamp. On such destinations a naive mtime compare
+// classifies EVERY file as changed on EVERY run: the whole library gets
+// trashed + recopied each time, bloating .mstream-trash by a full
+// library size per run until retention prunes it.
+//
+// probeDestMtimeFidelity() detects this once per run with a throwaway
+// file: stamp a fixed past mtime, stat it back, compare. If the stamp
+// didn't take (or threw), destMtimeTrustworthy flips false and:
+//   - the unchanged check falls back to size + dest-not-older-than-source
+//     (see syncMatchedPair), so previously-landed files stay put;
+//   - setMtimeSafe suppresses per-file stamp errors (the copies are the
+//     backup; the timestamp is an optimisation for the next run's diff).
+// One file error is recorded so the run summary surfaces the condition
+// without a per-file flood.
+let destMtimeTrustworthy = true;
+let mtimeWarningIssued = false;
+
+// 2000-01-01T00:00:00Z — arbitrary fixed instant, far enough from "now"
+// that a filesystem ignoring the stamp can't pass the probe by accident.
+const PROBE_MTIME_MS = 946684800000;
+
+async function probeDestMtimeFidelity() {
+  const probePath = path.join(
+    destPath,
+    TMP_PREFIX + 'mtime-probe-' + crypto.randomBytes(6).toString('hex'),
+  );
+  try {
+    await fs.writeFile(probePath, 'mtime-probe');
+    const want = new Date(PROBE_MTIME_MS);
+    await fs.utimes(probePath, want, want);
+    const st = await fs.stat(probePath);
+    destMtimeTrustworthy = Math.abs(st.mtimeMs - PROBE_MTIME_MS) < MTIME_TOLERANCE_MS;
+  } catch (_) {
+    destMtimeTrustworthy = false;
+  } finally {
+    try { await fs.unlink(probePath); } catch (_) { /* best-effort cleanup */ }
+  }
+  if (!destMtimeTrustworthy) {
+    mtimeWarningIssued = true;
+    recordFileError('destination does not preserve file modification times; using size-based change detection for this run');
+  }
+}
+
+// Stamp the source mtime onto a freshly-written dest file, tolerating
+// failure. Aborting the copy over a failed stamp would throw away the
+// already-copied bytes and mean the file NEVER reaches the destination
+// (each run re-copies and re-discards it, while the run still reports
+// success). The bytes are the backup; the stamp only feeds the next
+// run's cheap diff — and when it can't be stored, the fidelity probe
+// above has already switched that diff to size-based.
+async function setMtimeSafe(p, mtime) {
+  try { await fs.utimes(p, mtime, mtime); }
+  catch (err) {
+    if (!mtimeWarningIssued) {
+      mtimeWarningIssued = true;
+      recordFileError(`utimes ${p}: ${err.message} — destination does not preserve modification times`);
+    }
+  }
+}
+
 // Atomic file copy: write to a sibling tmp/partial, rename onto target.
 // On the same filesystem the rename is atomic, so partial writes never
 // appear at the final path.
@@ -297,7 +365,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize) {
     const tmpPath = path.join(path.dirname(dest), tmpName);
     try {
       await fs.copyFile(src, tmpPath);
-      await fs.utimes(tmpPath, srcMtime, srcMtime);
+      await setMtimeSafe(tmpPath, srcMtime);
       await fs.rename(tmpPath, dest);
     } catch (err) {
       try { await fs.unlink(tmpPath); } catch (_) {}
@@ -319,7 +387,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize) {
   try {
     const partialStat = await fs.stat(partialPath);
     if (partialStat.size === srcSize) {
-      await fs.utimes(partialPath, srcMtime, srcMtime);
+      await setMtimeSafe(partialPath, srcMtime);
       await fs.rename(partialPath, dest);
       return 0;  // already-complete partial — finalised without writing
     }
@@ -343,7 +411,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize) {
   } else {
     await fs.copyFile(src, partialPath);
   }
-  await fs.utimes(partialPath, srcMtime, srcMtime);
+  await setMtimeSafe(partialPath, srcMtime);
   await fs.rename(partialPath, dest);
   return srcSize - resumeFrom;
 }
@@ -387,6 +455,14 @@ async function hasAnyFiles(dir) {
   catch (_) { return false; }
   for (const entry of entries) {
     if (entry.name.startsWith(TMP_PREFIX)) { continue; }
+    if (entry.name.startsWith(PARTIAL_PREFIX)) { continue; }
+    // Must mirror readSortedDir's exclude filtering. If excluded names
+    // counted as "populated", a dead mountpoint holding only OS litter
+    // (.DS_Store, Thumbs.db — the default excludes) would pass this
+    // guard while the merge-walk sees an empty source — and the walk
+    // would then sweep the ENTIRE destination into trash. Excluded
+    // directories are skipped whole, same as the walk does.
+    if (isExcluded(entry.name)) { continue; }
     if (entry.isFile()) { return true; }
     if (entry.isDirectory()) {
       if (await hasAnyFiles(path.join(dir, entry.name))) { return true; }
@@ -670,13 +746,23 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
   let destStat = null;
   try { destStat = await fs.stat(destChild); } catch (_) { /* fall through */ }
 
-  if (destStat
-      && destStat.isFile()
-      && destStat.size === srcStat.size
-      && Math.abs(destStat.mtimeMs - srcStat.mtimeMs) < MTIME_TOLERANCE_MS) {
-    counts.filesUnchanged++;
-    emitProgress();
-    return;
+  // Same-size files are "unchanged" when the mtimes agree. On
+  // destinations that can't store explicit timestamps (fidelity probe
+  // failed), dest files carry copy-time mtimes instead of the stamped
+  // source mtimes — an exact compare would recopy the whole library
+  // every run. Fall back to dest-not-older-than-source: a dest copy at
+  // least as new as the source's last edit was copied after that edit.
+  // The cost: a same-size source edit that also backdates the file's
+  // mtime goes undetected on such destinations.
+  if (destStat && destStat.isFile() && destStat.size === srcStat.size) {
+    const mtimeAgrees = destMtimeTrustworthy
+      ? Math.abs(destStat.mtimeMs - srcStat.mtimeMs) < MTIME_TOLERANCE_MS
+      : destStat.mtimeMs + MTIME_TOLERANCE_MS >= srcStat.mtimeMs;
+    if (mtimeAgrees) {
+      counts.filesUnchanged++;
+      emitProgress();
+      return;
+    }
   }
 
   // Source differs — move dest's old copy to trash, then write new.
@@ -777,6 +863,10 @@ async function trashDestEntry(destEntry, destDir, relPath) {
   } catch (err) {
     await emitAndExit({ event: 'error', message: `Destination unavailable: ${err.message}` }, 1);
   }
+
+  // Probe timestamp fidelity before the walk so the unchanged check
+  // knows which comparison to trust (see probeDestMtimeFidelity).
+  await probeDestMtimeFidelity();
 
   await syncDir(sourcePath, destPath, '');
 

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -649,9 +649,15 @@ export function getEffectiveExcludeGlobs(dest) {
 }
 
 
+// All destination getters join libraries for name/root_path AND the
+// per-library follow_symlinks flag — runBackupTask forwards it to the
+// backup worker as followSymlinks. If the flag is missing from the
+// SELECT, dest.follow_symlinks reads undefined → false, and symlinked
+// library content is silently omitted from every backup.
 export function getBackupDestinations() {
   return db.prepare(`
-    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path
+    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path,
+           l.follow_symlinks AS follow_symlinks
       FROM backup_destinations d
       JOIN libraries l ON l.id = d.library_id
      ORDER BY l.name, d.dest_path
@@ -660,7 +666,8 @@ export function getBackupDestinations() {
 
 export function getBackupDestinationById(id) {
   return db.prepare(`
-    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path
+    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path,
+           l.follow_symlinks AS follow_symlinks
       FROM backup_destinations d
       JOIN libraries l ON l.id = d.library_id
      WHERE d.id = ?
@@ -669,7 +676,8 @@ export function getBackupDestinationById(id) {
 
 export function getBackupDestinationsByLibrary(libraryId, { triggerType, enabledOnly = true } = {}) {
   let sql = `
-    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path
+    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path,
+           l.follow_symlinks AS follow_symlinks
       FROM backup_destinations d
       JOIN libraries l ON l.id = d.library_id
      WHERE d.library_id = ?
@@ -682,7 +690,8 @@ export function getBackupDestinationsByLibrary(libraryId, { triggerType, enabled
 
 export function getBackupDestinationsByTrigger(triggerType) {
   return db.prepare(`
-    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path
+    SELECT d.*, l.name AS library_name, l.root_path AS library_root_path,
+           l.follow_symlinks AS follow_symlinks
       FROM backup_destinations d
       JOIN libraries l ON l.id = d.library_id
      WHERE d.trigger_type = ? AND d.enabled = 1

--- a/test/fixtures/fail-utimes.cjs
+++ b/test/fixtures/fail-utimes.cjs
@@ -1,0 +1,13 @@
+// Fault-injection preload for backup-worker tests. Loaded into the
+// worker child process via NODE_OPTIONS=--require so every
+// fs.promises.utimes call fails the way a root-squash NFS / attribute-
+// denying SMB / ENOSYS FUSE destination would. The CJS `fs.promises`
+// object is the same object `import fs from 'fs/promises'` resolves to,
+// so patching it here is visible to the worker's ESM imports.
+const fs = require('fs');
+
+fs.promises.utimes = () => {
+  const err = new Error('EPERM: operation not permitted (fault injection: fail-utimes.cjs)');
+  err.code = 'EPERM';
+  return Promise.reject(err);
+};

--- a/test/integration/backup-worker.test.mjs
+++ b/test/integration/backup-worker.test.mjs
@@ -78,6 +78,27 @@ function errorEvent(events) {
   return events.find((e) => e.event === 'error') || null;
 }
 
+// Give a file an mtime `days` in the past (or negative for the future).
+// The injection tests MUST separate source mtimes from copy-time, or
+// they stop pinning anything: files written moments before the run land
+// within the worker's 2s mtime tolerance, so even a broken comparison
+// path looks correct.
+function shiftMtime(p, days) {
+  const t = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  fs.utimesSync(p, t, t);
+}
+
+// Force dest copies into the shape a timestamp-stripping destination
+// (Linux copyFile onto NFS/FUSE with utimes denied) leaves behind:
+// copy-time mtimes. Windows CopyFileEx preserves source mtimes, which
+// would otherwise mask a missing fidelity fallback on this platform.
+function forceCopyTimeMtimes(destDir) {
+  for (const rel of listFiles(destDir)) {
+    const now = new Date();
+    fs.utimesSync(path.join(destDir, rel), now, now);
+  }
+}
+
 // List a directory tree as sorted relative paths of regular files,
 // ignoring the worker's trash bucket.
 function listFiles(root, sub = '') {
@@ -203,12 +224,18 @@ describe('backup worker: destination that rejects utimes', () => {
     const src = path.join(root, 'src');
     const dest = path.join(root, 'dest');
     fs.mkdirSync(src, { recursive: true });
-    for (let i = 0; i < 3; i++) { fs.writeFileSync(path.join(src, `t${i}.mp3`), `data-${i}`); }
+    for (let i = 0; i < 3; i++) {
+      const p = path.join(src, `t${i}.mp3`);
+      fs.writeFileSync(p, `data-${i}`);
+      shiftMtime(p, 1);   // realistic library: files predate the run
+    }
 
     await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 }, { env: injectEnv });
-    // Dest copies now carry copy-time mtimes (stamps failed). Without the
-    // fidelity probe's size-based fallback, this run would classify every
-    // file as changed and trash + recopy the whole tree.
+    forceCopyTimeMtimes(dest);
+    // Dest copies now carry copy-time mtimes (a day newer than the
+    // source stamps). Without the fidelity probe's fallback, the exact
+    // compare would classify every file as changed and trash + recopy
+    // the whole tree on this and every following run.
     const run2 = await runWorker(
       { sourcePath: src, destPath: dest, retentionDays: 30 },
       { env: injectEnv },
@@ -230,13 +257,14 @@ describe('backup worker: destination that rejects utimes', () => {
     fs.mkdirSync(src, { recursive: true });
     fs.writeFileSync(path.join(src, 'grows.mp3'), 'v1');
     fs.writeFileSync(path.join(src, 'stable.mp3'), 'same');
+    shiftMtime(path.join(src, 'grows.mp3'), 1);
+    shiftMtime(path.join(src, 'stable.mp3'), 1);
 
     await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 }, { env: injectEnv });
+    forceCopyTimeMtimes(dest);
     // A size-changing edit must be picked up even with unfaithful dest
-    // mtimes. (Same-size edits additionally need a NEWER source mtime —
-    // exercised via the sleep below staying inside mtime tolerance is
-    // not reliable cross-FS, so only the size path is asserted here.)
-    await sleep(20);
+    // mtimes, while the untouched same-size file must ride the fallback
+    // (dest copy-time mtime >= source stamp) instead of churning.
     fs.writeFileSync(path.join(src, 'grows.mp3'), 'v2-bigger');
 
     const run2 = await runWorker(
@@ -247,6 +275,31 @@ describe('backup worker: destination that rejects utimes', () => {
     assert.equal(done.filesCopied, 1, 'the edited file must be recopied');
     assert.equal(done.filesUnchanged, 1, 'the untouched file must be left alone');
     assert.equal(fs.readFileSync(path.join(dest, 'grows.mp3'), 'utf8'), 'v2-bigger');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('future-stamped source files do not churn in fallback mode', async () => {
+    const root = makeTempRoot('inj4');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    const futureFile = path.join(src, 'future.mp3');
+    fs.writeFileSync(futureFile, 'wrong-clock-rip');
+    shiftMtime(futureFile, -1);   // stamped a day in the future
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 }, { env: injectEnv });
+    forceCopyTimeMtimes(dest);
+    // The dest copy is "older" than the source stamp and always will be
+    // until wall time passes it. Without the future-mtime clamp the file
+    // would be trashed + recopied on every run for the next day.
+    const run2 = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: injectEnv },
+    );
+    const done = doneEvent(run2.events);
+    assert.equal(done.filesUnchanged, 1, 'future-stamped file must not churn');
+    assert.equal(done.filesTrashed, 0);
+    assert.equal(fs.existsSync(path.join(dest, '.mstream-trash')), false);
     fs.rmSync(root, { recursive: true, force: true });
   });
 });
@@ -261,7 +314,9 @@ describe('backup destinations: follow_symlinks wiring', () => {
   // Same shape as a library whose content sits behind a link: one real
   // file at the root, one dir-link to content OUTSIDE the library root.
   // 'junction' works unprivileged on Windows and degrades to a plain
-  // symlink elsewhere.
+  // symlink elsewhere. Link creation failure only disables the
+  // end-to-end mirror tests — the library dirs and DB rows are created
+  // regardless, so the pure-SQL getter assertions always run.
   function makeLinkedLibrary(root, name) {
     const lib = path.join(root, name);
     const outside = path.join(root, `${name}-outside`);
@@ -269,7 +324,11 @@ describe('backup destinations: follow_symlinks wiring', () => {
     fs.mkdirSync(outside, { recursive: true });
     fs.writeFileSync(path.join(lib, 'a.mp3'), 'root-track');
     fs.writeFileSync(path.join(outside, 'b.mp3'), 'linked-track');
-    fs.symlinkSync(outside, path.join(lib, 'linked'), 'junction');
+    try {
+      fs.symlinkSync(outside, path.join(lib, 'linked'), 'junction');
+    } catch (_) {
+      linksWork = false;   // e.g. EPERM — E2E link tests will skip
+    }
     return lib;
   }
 
@@ -290,14 +349,8 @@ describe('backup destinations: follow_symlinks wiring', () => {
     dbManager.initDB();
     taskQueue = await import('../../src/db/task-queue.js');
 
-    let followRoot, noFollowRoot;
-    try {
-      followRoot = makeLinkedLibrary(testRoot, 'lib-follow');
-      noFollowRoot = makeLinkedLibrary(testRoot, 'lib-nofollow');
-    } catch (_) {
-      linksWork = false;   // e.g. EPERM — skip the end-to-end cases
-      return;
-    }
+    const followRoot = makeLinkedLibrary(testRoot, 'lib-follow');
+    const noFollowRoot = makeLinkedLibrary(testRoot, 'lib-nofollow');
     const db = dbManager.getDB();
     db.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES (?, ?, ?, 1)`)
       .run('lib-follow', followRoot, 'music');
@@ -324,8 +377,7 @@ describe('backup destinations: follow_symlinks wiring', () => {
     try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
   });
 
-  test('every destination getter surfaces the library follow_symlinks flag', (t) => {
-    if (!linksWork) { return t.skip('link creation unavailable on this host'); }
+  test('every destination getter surfaces the library follow_symlinks flag', () => {
     assert.equal(dbManager.getBackupDestinationById(destFollow).follow_symlinks, 1);
     assert.equal(dbManager.getBackupDestinationById(destNoFollow).follow_symlinks, 0);
     const all = dbManager.getBackupDestinations();

--- a/test/integration/backup-worker.test.mjs
+++ b/test/integration/backup-worker.test.mjs
@@ -1,0 +1,366 @@
+/**
+ * Backup-worker filesystem semantics (audit batch 1).
+ *
+ * The task-queue suite exercises queue mechanics; nothing previously
+ * asserted what the worker actually does to the destination tree. These
+ * tests drive src/backup/worker.mjs directly (spawned exactly like
+ * task-queue does — argv JSON, line-JSON events on stdout) and cover the
+ * three audit fixes:
+ *
+ *   1. Excluded-only source must NOT pass the empty-source guard.
+ *      A dead mountpoint holding only OS litter (.DS_Store, Thumbs.db —
+ *      the default excludes) previously passed hasAnyFiles() while the
+ *      merge-walk saw an empty source, sweeping the ENTIRE destination
+ *      into trash.
+ *   2. follow_symlinks wiring. The destination getters never SELECTed
+ *      libraries.follow_symlinks, so the worker always received
+ *      followSymlinks:false and silently skipped symlinked content.
+ *   3. utimes-hostile destinations. A failed mtime stamp used to abort
+ *      the copy AFTER the bytes were written (tmp unlinked), so files
+ *      never landed; and without the fidelity probe, files that DID land
+ *      would be trashed + recopied on every subsequent run. Injected via
+ *      test/fixtures/fail-utimes.cjs preloaded into the worker.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(REPO_ROOT, 'src', 'backup', 'worker.mjs');
+// NODE_OPTIONS parses backslashes as escapes — always hand it forward
+// slashes, which Node's module loader accepts on Windows too.
+const FAIL_UTIMES = path.join(REPO_ROOT, 'test', 'fixtures', 'fail-utimes.cjs').replace(/\\/g, '/');
+
+const DEFAULT_EXCLUDES = ['Thumbs.db', 'desktop.ini', '.DS_Store', '._*'];
+
+let envCounter = 0;
+function makeTempRoot(tag) {
+  const root = path.join(os.tmpdir(), `mstream-bw-${tag}-` + Date.now() + '-' + (envCounter++));
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+// Spawn the worker exactly as task-queue.js does (single JSON argv) and
+// collect its line-JSON events. Resolves with the exit code, the parsed
+// event list, and raw stderr.
+function runWorker(payload, { env = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WORKER, JSON.stringify(payload)], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let errOut = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.stderr.on('data', (d) => { errOut += d.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const events = out.split(/\r?\n/).filter(Boolean).map((line) => {
+        try { return JSON.parse(line); } catch (_) { return null; }
+      }).filter(Boolean);
+      resolve({ code, events, stderr: errOut });
+    });
+  });
+}
+
+function doneEvent(events) {
+  return events.find((e) => e.event === 'done') || null;
+}
+function errorEvent(events) {
+  return events.find((e) => e.event === 'error') || null;
+}
+
+// List a directory tree as sorted relative paths of regular files,
+// ignoring the worker's trash bucket.
+function listFiles(root, sub = '') {
+  const dir = path.join(root, sub);
+  if (!fs.existsSync(dir)) { return []; }
+  const acc = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '.mstream-trash') { continue; }
+    const rel = sub ? path.join(sub, entry.name) : entry.name;
+    if (entry.isDirectory()) { acc.push(...listFiles(root, rel)); }
+    else if (entry.isFile()) { acc.push(rel); }
+  }
+  return acc.sort();
+}
+
+// ── 1. Excluded-only source must not sweep the destination ─────────────────
+
+describe('backup worker: empty-source guard vs exclude globs', () => {
+  test('source holding only default-excluded litter refuses to run; dest untouched', async () => {
+    const root = makeTempRoot('guard');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    // The disconnected-mountpoint shape: no real files anywhere, just OS
+    // litter — including litter nested in a non-excluded subdirectory.
+    fs.mkdirSync(path.join(src, 'sub'), { recursive: true });
+    fs.writeFileSync(path.join(src, '.DS_Store'), 'litter');
+    fs.writeFileSync(path.join(src, 'Thumbs.db'), 'litter');
+    fs.writeFileSync(path.join(src, 'sub', 'desktop.ini'), 'litter');
+    fs.mkdirSync(dest, { recursive: true });
+    fs.writeFileSync(path.join(dest, 'precious-a.mp3'), 'aaaa');
+    fs.writeFileSync(path.join(dest, 'precious-b.mp3'), 'bbbb');
+
+    const { code, events } = await runWorker({
+      sourcePath: src, destPath: dest, retentionDays: 30,
+      excludeGlobs: DEFAULT_EXCLUDES,
+    });
+
+    assert.equal(code, 1, 'worker must exit 1 (fatal) instead of syncing');
+    const err = errorEvent(events);
+    assert.ok(err, 'a fatal error event must be emitted');
+    assert.match(err.message, /zero files/i);
+    assert.deepEqual(listFiles(dest), ['precious-a.mp3', 'precious-b.mp3'],
+      'destination files must be untouched');
+    assert.equal(fs.existsSync(path.join(dest, '.mstream-trash')), false,
+      'nothing may be trashed by a refused run');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('a single real file among the litter still syncs', async () => {
+    const root = makeTempRoot('guard-ok');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, '.DS_Store'), 'litter');
+    fs.writeFileSync(path.join(src, 'real.mp3'), 'music');
+
+    const { code, events } = await runWorker({
+      sourcePath: src, destPath: dest, retentionDays: 30,
+      excludeGlobs: DEFAULT_EXCLUDES,
+    });
+
+    assert.equal(code, 0);
+    assert.equal(doneEvent(events)?.filesCopied, 1);
+    assert.deepEqual(listFiles(dest), ['real.mp3'],
+      'the real file lands; excluded litter is not mirrored');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── 2. utimes-hostile destination (root-squash NFS / SMB / FUSE shape) ─────
+
+describe('backup worker: destination that rejects utimes', () => {
+  const injectEnv = { NODE_OPTIONS: `--require "${FAIL_UTIMES}"` };
+
+  test('control (no injection): copy run then unchanged run, no file errors', async () => {
+    const root = makeTempRoot('ctl');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    for (let i = 0; i < 3; i++) { fs.writeFileSync(path.join(src, `t${i}.mp3`), `data-${i}`); }
+
+    const run1 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    assert.equal(run1.code, 0);
+    assert.equal(doneEvent(run1.events)?.filesCopied, 3);
+    assert.equal(doneEvent(run1.events)?.fileErrors, 0);
+
+    const run2 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    assert.equal(run2.code, 0);
+    assert.equal(doneEvent(run2.events)?.filesUnchanged, 3, 'second run must skip all files');
+    assert.equal(doneEvent(run2.events)?.filesCopied, 0);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('files still land when every utimes call fails', async () => {
+    const root = makeTempRoot('inj1');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    for (let i = 0; i < 3; i++) { fs.writeFileSync(path.join(src, `t${i}.mp3`), `data-${i}`); }
+
+    const { code, events } = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: injectEnv },
+    );
+
+    assert.equal(code, 0, 'utimes failure is not fatal');
+    const done = doneEvent(events);
+    assert.equal(done.filesCopied, 3, 'all files must be copied');
+    assert.deepEqual(listFiles(dest), ['t0.mp3', 't1.mp3', 't2.mp3'],
+      'copies must land despite the failed stamps');
+    for (let i = 0; i < 3; i++) {
+      assert.equal(fs.readFileSync(path.join(dest, `t${i}.mp3`), 'utf8'), `data-${i}`);
+    }
+    // Exactly ONE warning for the whole run (the fidelity probe), not
+    // one per file.
+    assert.equal(done.fileErrors, 1, 'a single per-run warning, not a per-file flood');
+    assert.match(done.sampleErrorMessage, /modification times/i);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('second run treats landed files as unchanged (no trash+recopy churn)', async () => {
+    const root = makeTempRoot('inj2');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    for (let i = 0; i < 3; i++) { fs.writeFileSync(path.join(src, `t${i}.mp3`), `data-${i}`); }
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 }, { env: injectEnv });
+    // Dest copies now carry copy-time mtimes (stamps failed). Without the
+    // fidelity probe's size-based fallback, this run would classify every
+    // file as changed and trash + recopy the whole tree.
+    const run2 = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: injectEnv },
+    );
+
+    assert.equal(run2.code, 0);
+    const done = doneEvent(run2.events);
+    assert.equal(done.filesUnchanged, 3, 'landed files must be recognised as unchanged');
+    assert.equal(done.filesCopied, 0, 'no recopy churn');
+    assert.equal(done.filesTrashed, 0, 'no trash churn');
+    assert.equal(fs.existsSync(path.join(dest, '.mstream-trash')), false);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('source edits are still detected in size-based fallback mode', async () => {
+    const root = makeTempRoot('inj3');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'grows.mp3'), 'v1');
+    fs.writeFileSync(path.join(src, 'stable.mp3'), 'same');
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 }, { env: injectEnv });
+    // A size-changing edit must be picked up even with unfaithful dest
+    // mtimes. (Same-size edits additionally need a NEWER source mtime —
+    // exercised via the sleep below staying inside mtime tolerance is
+    // not reliable cross-FS, so only the size path is asserted here.)
+    await sleep(20);
+    fs.writeFileSync(path.join(src, 'grows.mp3'), 'v2-bigger');
+
+    const run2 = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: injectEnv },
+    );
+    const done = doneEvent(run2.events);
+    assert.equal(done.filesCopied, 1, 'the edited file must be recopied');
+    assert.equal(done.filesUnchanged, 1, 'the untouched file must be left alone');
+    assert.equal(fs.readFileSync(path.join(dest, 'grows.mp3'), 'utf8'), 'v2-bigger');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── 3. follow_symlinks reaches the worker ───────────────────────────────────
+
+describe('backup destinations: follow_symlinks wiring', () => {
+  let testRoot, dbManager, taskQueue;
+  let libFollow, destFollow, destNoFollow;
+  let linksWork = true;
+
+  // Same shape as a library whose content sits behind a link: one real
+  // file at the root, one dir-link to content OUTSIDE the library root.
+  // 'junction' works unprivileged on Windows and degrades to a plain
+  // symlink elsewhere.
+  function makeLinkedLibrary(root, name) {
+    const lib = path.join(root, name);
+    const outside = path.join(root, `${name}-outside`);
+    fs.mkdirSync(lib, { recursive: true });
+    fs.mkdirSync(outside, { recursive: true });
+    fs.writeFileSync(path.join(lib, 'a.mp3'), 'root-track');
+    fs.writeFileSync(path.join(outside, 'b.mp3'), 'linked-track');
+    fs.symlinkSync(outside, path.join(lib, 'linked'), 'junction');
+    return lib;
+  }
+
+  before(async () => {
+    testRoot = makeTempRoot('symlink');
+    fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+    fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+      storage: {
+        dbDirectory: path.join(testRoot, 'db'),
+        albumArtDirectory: path.join(testRoot, 'art'),
+        logsDirectory: path.join(testRoot, 'logs'),
+      },
+      port: 0,
+    }, null, 2));
+    const config = await import('../../src/state/config.js');
+    await config.setup(path.join(testRoot, 'config.json'));
+    dbManager = await import('../../src/db/manager.js');
+    dbManager.initDB();
+    taskQueue = await import('../../src/db/task-queue.js');
+
+    let followRoot, noFollowRoot;
+    try {
+      followRoot = makeLinkedLibrary(testRoot, 'lib-follow');
+      noFollowRoot = makeLinkedLibrary(testRoot, 'lib-nofollow');
+    } catch (_) {
+      linksWork = false;   // e.g. EPERM — skip the end-to-end cases
+      return;
+    }
+    const db = dbManager.getDB();
+    db.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES (?, ?, ?, 1)`)
+      .run('lib-follow', followRoot, 'music');
+    db.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES (?, ?, ?, 0)`)
+      .run('lib-nofollow', noFollowRoot, 'music');
+    dbManager.invalidateCache();
+    const idFollow = dbManager.getLibraryByName('lib-follow').id;
+    const idNoFollow = dbManager.getLibraryByName('lib-nofollow').id;
+    destFollow = dbManager.addBackupDestination({
+      libraryId: idFollow, destPath: path.join(testRoot, 'dest-follow'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+      excludeGlobs: [], interFileDelayMs: 0,
+    });
+    destNoFollow = dbManager.addBackupDestination({
+      libraryId: idNoFollow, destPath: path.join(testRoot, 'dest-nofollow'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+      excludeGlobs: [], interFileDelayMs: 0,
+    });
+    libFollow = idFollow;
+  });
+
+  after(() => {
+    if (dbManager) { dbManager.close(); }
+    try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
+  });
+
+  test('every destination getter surfaces the library follow_symlinks flag', (t) => {
+    if (!linksWork) { return t.skip('link creation unavailable on this host'); }
+    assert.equal(dbManager.getBackupDestinationById(destFollow).follow_symlinks, 1);
+    assert.equal(dbManager.getBackupDestinationById(destNoFollow).follow_symlinks, 0);
+    const all = dbManager.getBackupDestinations();
+    assert.ok(all.every((d) => d.follow_symlinks !== undefined),
+      'getBackupDestinations rows must carry follow_symlinks');
+    const byLib = dbManager.getBackupDestinationsByLibrary(libFollow, { enabledOnly: false });
+    assert.equal(byLib[0].follow_symlinks, 1);
+  });
+
+  test('follow_symlinks=1 library mirrors linked content end-to-end', async (t) => {
+    if (!linksWork) { return t.skip('link creation unavailable on this host'); }
+    taskQueue.addBackupTask(destFollow, 'manual');
+    await waitForIdle(taskQueue);
+    assert.equal(dbManager.getBackupHistory(destFollow, 1)[0]?.status, 'success');
+    const files = listFiles(path.join(testRoot, 'dest-follow'));
+    assert.deepEqual(files, ['a.mp3', path.join('linked', 'b.mp3')],
+      'linked content must be mirrored when the library follows symlinks');
+  });
+
+  test('follow_symlinks=0 library still skips linked content', async (t) => {
+    if (!linksWork) { return t.skip('link creation unavailable on this host'); }
+    taskQueue.addBackupTask(destNoFollow, 'manual');
+    await waitForIdle(taskQueue);
+    assert.equal(dbManager.getBackupHistory(destNoFollow, 1)[0]?.status, 'success');
+    const files = listFiles(path.join(testRoot, 'dest-nofollow'));
+    assert.deepEqual(files, ['a.mp3'],
+      'linked content must be skipped when the library does not follow symlinks');
+  });
+
+  async function waitForIdle(tq) {
+    const start = Date.now();
+    while (Date.now() - start < 60_000) {
+      if (tq.getActiveBackupRun() === null && tq.getQueueLength() === 0 && !tq.isScanning()) { return; }
+      await sleep(50);
+    }
+    throw new Error('Queue did not drain within 60s');
+  }
+});


### PR DESCRIPTION
Batch 1 of the backup-feature audit fixes: the three highest-severity silent data-loss paths, all of which reported green while losing or omitting data.

## Fixes

### 1. Empty-source guard defeated by exclude globs (`worker.mjs`)

`hasAnyFiles()` — the pre-flight that exists specifically to stop "library unmounted → sweep whole destination" — didn't apply `isExcluded()`, but the merge-walk does. A dead mountpoint holding only OS litter (`.DS_Store`, `Thumbs.db` — exactly the default excludes) passed the pre-flight, the walk then saw an empty source and moved the **entire destination** into `.mstream-trash` (or permanently unlinked it with `retention_days=0`), reporting success. That is the precise disaster scenario — source drive dies, Finder drops a `.DS_Store` in the empty mountpoint — the guard was written for.

The guard now mirrors `readSortedDir`'s filtering (excludes + partial-prefix), so an excluded-only source aborts with a fatal error and the destination is untouched.

### 2. `follow_symlinks` never reached the worker (`db/manager.js`)

The four backup-destination getters joined `libraries` but never SELECTed `follow_symlinks`, so `runBackupTask`'s `dest.follow_symlinks === 1` was always false. Libraries configured with `follow_symlinks=1` (NAS/Docker layouts) had all their symlinked content silently missing from every backup, every run green. All four getters now surface the flag.

### 3. utimes-hostile destinations (`worker.mjs`)

On destinations that refuse explicit timestamps (root-squash NFS, attribute-denying SMB shares, some FUSE backends), a failed `fs.utimes` aborted the copy **after** the bytes were written — the tmp was unlinked, so files never landed, every run re-copied and re-discarded the whole library, and the run still reported success.

Stamps are now best-effort (`setMtimeSafe`), paired with a once-per-run **mtime-fidelity probe**: a throwaway file is stamped with a fixed past mtime and stat'd back. If the stamp doesn't survive, the unchanged-check falls back from exact-mtime-match to size + dest-not-older-than-source, so landed files stay put instead of being trashed + recopied on every subsequent run (which would bloat `.mstream-trash` by a full library size per run). The pairing is deliberate — shipping the tolerant stamp alone would have converted "files never land" into that churn.

Follow-up hardening from adversarial review of the first commit:

- **Future-stamped sources** (wrong-clock rips, FAT TZ/DST shifts): in fallback mode a source mtime ahead of the destination clock failed the compare forever — one full trash+recopy of the file per run until wall time passed the stamp (reproduced by execution). Same-size sources stamped beyond *now* are clamped to unchanged, with a once-per-run stderr notice.
- **Probe stage separation**: a read-only or full destination failed the probe's `writeFile` and was misdiagnosed as "doesn't preserve timestamps," silently degrading change detection. Write failure now keeps exact comparison and lets the walk surface the real error.

## Tests

New worker-level harness (`test/integration/backup-worker.test.mjs`, 10 tests) that drives `worker.mjs` directly against temp trees — the first coverage of the worker's filesystem semantics:

- excluded-only source refusal + litter-with-real-file control
- utimes fault injection via a `NODE_OPTIONS --require` preload (`test/fixtures/fail-utimes.cjs`) patching `fs.promises.utimes`
- churn regression tests with **backdated source mtimes and forced copy-time dest mtimes** — files written moments before a run sit inside the worker's 2s mtime tolerance and pin nothing; verified the suite fails 3 tests against a probe-less worker and passes against the real one (Windows `CopyFileEx` preserves stamps and would otherwise mask this)
- end-to-end `follow_symlinks` wiring through the real task queue, using `junction`-type links (unprivileged on Windows, plain symlinks elsewhere), with graceful skip only for the link-dependent cases

Existing `task-queue.test.mjs` (21 tests) passes unchanged. No new lint errors (the 6 pre-existing `no-empty` in `worker.mjs` are untouched tree debt).

## Known limitation (deliberate, follow-up planned)

Fix 2 makes `followSymlinks` live for the first time, which exposes a pre-existing guard limitation: a library whose root content is **entirely** behind symlinks is refused by the empty-source guard (fail-closed, loud error) because `hasAnyFiles()` doesn't follow links. Previously such a library silently backed up nothing, or worse. Teaching the guard to follow links (with cycle protection) is audit finding #12, queued for batch 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
