### PR TITLE
fix(backup): merge-walk data-loss hardening (audit batch 2)

### DIFF
--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -230,27 +230,44 @@ function partialName(targetBasename, srcSize, srcMtimeDate) {
     .update(targetBasename, 'utf8')
     .digest('hex')
     .slice(0, 12);
-  return `${PARTIAL_PREFIX}${targetHash}-${srcSize}-${srcMtimeDate.getTime()}`;
+  // The trailing -v2 versions the WRITE DISCIPLINE, not the format:
+  // v2 partials are written strictly sequentially (streamResume), so
+  // "size === srcSize" really means every byte is valid and finalising
+  // is safe. Unversioned partials were written with fs.copyFile, which
+  // on Windows (CopyFileW) pre-extends the file to full size before the
+  // data lands — a kill mid-copy left a full-size garbage-tail partial
+  // that the next run would have blind-finalised into a silently
+  // corrupt "complete" file. Old-name partials never match a v2 lookup
+  // and age out via the staleness sweep.
+  return `${PARTIAL_PREFIX}${targetHash}-${srcSize}-${srcMtimeDate.getTime()}-v2`;
 }
 
-// Stream-resume from `offset` bytes in `src` to the end of `partial`.
-// Used when a partial file from a previous interrupted run has fewer
-// bytes than the current source. We trust the bytes already in the
-// partial because the partial filename encodes the source's size+mtime;
-// a different source state would have produced a different partial
-// filename and we wouldn't be resuming this one.
+// Stream `src` into `partial` starting at `offset` bytes — offset 0 is
+// a fresh copy, offset > 0 resumes a previous interrupted run's partial.
+// We trust the bytes already in the partial because the partial filename
+// encodes the source's size+mtime; a different source state would have
+// produced a different partial filename and we wouldn't be resuming it.
 //
-// Opens the partial with 'r+' (read-write, must exist) and writes with
-// an explicit position rather than relying on 'a' mode's append-at-end
-// semantics — Windows in particular has historical quirks around
-// FILE_APPEND_DATA + Node's libuv write path that can result in writes
-// landing at the file pointer (offset 0 by default) instead of EOF.
-// Explicit positions are simpler to reason about and portable.
+// ALL large-file writes go through here (fresh copies included, not just
+// resumes) because strictly-sequential positional writes maintain the
+// invariant the finalise path depends on: the partial's size always
+// equals its count of VALID bytes. fs.copyFile cannot guarantee that —
+// Windows' CopyFileW pre-extends the destination to full size before
+// the data arrives, so a kill mid-copy left a full-size garbage-tail
+// partial that the next run finalised into a corrupt "complete" file.
+//
+// Opens the partial with 'r+' when resuming (must exist) or 'w' for a
+// fresh copy (create/truncate), and writes with an explicit position
+// rather than relying on 'a' mode's append-at-end semantics — Windows
+// in particular has historical quirks around FILE_APPEND_DATA + Node's
+// libuv write path that can result in writes landing at the file
+// pointer (offset 0 by default) instead of EOF. Explicit positions are
+// simpler to reason about and portable.
 async function streamResume(src, partial, srcSize, offset) {
   let reader, writer;
   try {
     reader = await fs.open(src, 'r');
-    writer = await fs.open(partial, 'r+');
+    writer = await fs.open(partial, offset > 0 ? 'r+' : 'w');
     const buf = Buffer.alloc(256 * 1024);
     let pos = offset;
     while (pos < srcSize) {
@@ -376,7 +393,16 @@ async function setMtimeSafe(p, mtime) {
 // the suffix that needed to be written, and the "finalise an already-
 // complete partial" path counts zero. A user looking at the run summary
 // then sees actual disk-write volume, not nominal file size.
-async function atomicCopy(src, dest, srcMtime, srcSize) {
+//
+// `beforeReplace` (optional async hook) runs after the new content is
+// FULLY staged (tmp/partial complete, mtime stamped) and immediately
+// before the rename onto `dest`. syncMatchedPair uses it to move the
+// old dest copy to trash at the last possible moment — trashing before
+// staging (the pre-batch-2 order) meant an ENOSPC mid-copy left the
+// destination without a live copy of exactly the files that changed.
+// If the hook throws, the rename never happens: the old dest copy is
+// untouched and a large file's staged partial survives for resume.
+async function atomicCopy(src, dest, srcMtime, srcSize, beforeReplace = null) {
   await ensureDir(path.dirname(dest));
 
   if (srcSize < RESUME_MIN_SIZE) {
@@ -386,6 +412,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize) {
     try {
       await fs.copyFile(src, tmpPath);
       await setMtimeSafe(tmpPath, srcMtime);
+      if (beforeReplace) { await beforeReplace(); }
       await fs.rename(tmpPath, dest);
     } catch (err) {
       try { await fs.unlink(tmpPath); } catch (_) {}
@@ -402,12 +429,23 @@ async function atomicCopy(src, dest, srcMtime, srcSize) {
   // Look for a resumable partial. If one exists with the same encoded
   // source state and a sane size (>0 and ≤ srcSize), resume from there.
   // If it's exactly srcSize, the previous run completed the bytes but
-  // crashed before the rename — just finalise.
+  // crashed before the rename — just finalise. Trusting size === srcSize
+  // as "every byte valid" is sound for v2 partials because they're
+  // written strictly sequentially (see streamResume).
+  //
+  // Only the stat probe is inside the catch. Pre-batch-2 the whole
+  // finalise branch shared it, so a failed finalise RENAME was silently
+  // swallowed and fell through to a full fresh copy — every run re-paid
+  // the entire copy for that file, forever. Now the rename's error
+  // propagates to the caller's per-file error accounting.
   let resumeFrom = 0;
-  try {
-    const partialStat = await fs.stat(partialPath);
+  let partialStat = null;
+  try { partialStat = await fs.stat(partialPath); }
+  catch (_) { /* no partial yet — fresh copy */ }
+  if (partialStat) {
     if (partialStat.size === srcSize) {
       await setMtimeSafe(partialPath, srcMtime);
+      if (beforeReplace) { await beforeReplace(); }
       await fs.rename(partialPath, dest);
       return 0;  // already-complete partial — finalised without writing
     }
@@ -418,7 +456,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize) {
       // unusable, blow it away and start fresh.
       try { await fs.unlink(partialPath); } catch (_) {}
     }
-  } catch (_) { /* no partial yet — fall through to fresh copy */ }
+  }
 
   // Note on error handling: we deliberately DO NOT wrap in try/unlink
   // like the small-file path. The whole point of a resumable partial is
@@ -426,14 +464,25 @@ async function atomicCopy(src, dest, srcMtime, srcSize) {
   // this one left off; deleting on failure would defeat that. The
   // staleness sweep at the end of each dir's syncDir handles cleanup
   // for partials whose source no longer matches.
-  if (resumeFrom > 0) {
-    await streamResume(src, partialPath, srcSize, resumeFrom);
-  } else {
-    await fs.copyFile(src, partialPath);
-  }
+  //
+  // Fresh copies (resumeFrom 0) stream through streamResume too — NOT
+  // fs.copyFile — to keep the size-equals-valid-bytes invariant that
+  // makes the finalise path above safe (see streamResume's comment).
+  await streamResume(src, partialPath, srcSize, resumeFrom);
   await setMtimeSafe(partialPath, srcMtime);
+  if (beforeReplace) { await beforeReplace(); }
   await fs.rename(partialPath, dest);
   return srcSize - resumeFrom;
+}
+
+// Remove a dest-side symlink/junction WITHOUT touching its target —
+// deleting a link only removes the reparse point / inode reference.
+// fs.unlink handles file symlinks everywhere and junctions on modern
+// Node/Windows; some Windows configurations report EPERM for directory
+// links, where fs.rmdir removes the reparse point instead.
+async function removeDestLink(p) {
+  try { await fs.unlink(p); }
+  catch (_) { await fs.rmdir(p); }
 }
 
 // Move a dest file out of the live tree into the trash bucket for this
@@ -469,7 +518,17 @@ async function moveToTrash(destFile, relPath) {
 // is empty after walk" safety net. Catches the common library-disconnected
 // failure (mount point exists but is empty) before merge-walk would start
 // trashing dest entries.
-async function hasAnyFiles(dir) {
+async function hasAnyFiles(dir, seenRealDirs = null) {
+  if (followSymlinks) {
+    // Link-following turns the tree into a graph — track each visited
+    // directory's REAL path so a link cycle (a → b → a) terminates
+    // instead of recursing forever.
+    if (seenRealDirs === null) { seenRealDirs = new Set(); }
+    let real;
+    try { real = await fs.realpath(dir); } catch (_) { return false; }
+    if (seenRealDirs.has(real)) { return false; }
+    seenRealDirs.add(real);
+  }
   let entries;
   try { entries = await fs.readdir(dir, { withFileTypes: true }); }
   catch (_) { return false; }
@@ -485,12 +544,23 @@ async function hasAnyFiles(dir) {
     if (isExcluded(entry.name)) { continue; }
     if (entry.isFile()) { return true; }
     if (entry.isDirectory()) {
-      if (await hasAnyFiles(path.join(dir, entry.name))) { return true; }
+      if (await hasAnyFiles(path.join(dir, entry.name), seenRealDirs)) { return true; }
     }
-    // Symlinks: we don't follow here even if followSymlinks=true — this
-    // pre-flight is just a "library plausibly mounted" check, and a
-    // symlink-only directory is an exotic enough edge case that the user
-    // probably wants the empty-source guard to fire anyway.
+    if (followSymlinks && entry.isSymbolicLink()) {
+      // The walk (statForWalk → fs.stat) follows links when the library
+      // is configured to, so this guard must follow them too — otherwise
+      // a library whose content sits entirely behind links can never
+      // back up: the guard refuses with "zero files" while the walk
+      // would have mirrored it fine. With followSymlinks=false, links
+      // stay invisible here, matching the walk's lstat-and-skip.
+      let st = null;
+      try { st = await fs.stat(path.join(dir, entry.name)); }
+      catch (_) { /* broken link — ignore */ }
+      if (st?.isFile()) { return true; }
+      if (st?.isDirectory()) {
+        if (await hasAnyFiles(path.join(dir, entry.name), seenRealDirs)) { return true; }
+      }
+    }
   }
   return false;
 }
@@ -599,12 +669,45 @@ async function cleanupOrphanBookkeeping(dir) {
 //   both, types match → file: compare and copy if different;
 //                       dir:  recurse
 //   both, types differ → trash dest entry, then process src entry
+// Cycle protection for link-following libraries. With followSymlinks
+// the source "tree" is really a graph: statForWalk follows links, so a
+// link pointing at an ancestor recurses forever. Track every source
+// directory's REAL path; a revisit is either a cycle (skip, or hang) or
+// two links aliasing the same directory (skip the second — the content
+// is already mirrored under its first path; a per-dir error records the
+// skipped alias). Bounded at one Set entry per source directory, and
+// only populated for followSymlinks libraries.
+const walkedSrcRealDirs = new Set();
+
 async function syncDir(srcDir, destDir, relPath) {
   const isRoot = relPath === '';
 
+  if (followSymlinks) {
+    let real = null;
+    try { real = await fs.realpath(srcDir); }
+    catch (_) { /* vanished — the readSortedDir existed-check below reports it */ }
+    if (real !== null) {
+      if (walkedSrcRealDirs.has(real)) {
+        recordFileError(`skipping source dir already visited via another link (cycle or alias): ${srcDir}`);
+        return;
+      }
+      walkedSrcRealDirs.add(real);
+    }
+  }
+
   let srcSorted;
   try {
-    srcSorted = (await readSortedDir(srcDir)).entries;
+    const srcRead = await readSortedDir(srcDir);
+    if (!srcRead.existed) {
+      // The parent's readdir saw this directory but it's gone now — a
+      // mid-run unmount or concurrent delete. Treating it as empty
+      // (the pre-batch-2 behaviour: ENOENT → entries: []) would sweep
+      // the entire matching dest subtree into trash. Leave dest alone
+      // and let the next run reconcile from settled state.
+      recordFileError(`source dir vanished mid-run: ${srcDir}`);
+      return;
+    }
+    srcSorted = srcRead.entries;
   } catch (err) {
     recordFileError(`readdir source ${srcDir}: ${err.message}`);
     return;
@@ -624,30 +727,55 @@ async function syncDir(srcDir, destDir, relPath) {
     destSorted = [];
   }
 
+  // Classify the whole merge BEFORE acting on it, then perform ALL
+  // dest-only trashes before any source-only copies. On case-insensitive
+  // destinations (NTFS, default APFS) a case-only rename makes the same
+  // physical file appear as BOTH a source-only and a dest-only entry
+  // (merge keys are NFC- but not case-folded). With interleaved
+  // copy-then-trash ordering, trashing the stale dest name resolved —
+  // case-insensitively — to the FRESHLY-COPIED file and removed it: the
+  // backup lost the file until the next run (an entire subtree when a
+  // directory was case-renamed). Trash-first moves the old bytes to
+  // trash and lands the fresh copy afterwards, at the cost of a full
+  // recopy on case-only renames. (Two source names differing only by
+  // case still collapse to one file on such destinations — a filesystem
+  // limitation we don't try to paper over.) The three lists hold
+  // dirents for ONE directory, so the O(max files in one dir) memory
+  // bound of the merge-walk is unchanged.
+  const destOnly = [];
+  const srcOnly = [];
+  const matched = [];
   let i = 0, j = 0;
   while (i < srcSorted.length || j < destSorted.length) {
     const s = srcSorted[i];
     const d = destSorted[j];
 
     if (!s) {
-      // Dest-only — orphan, regardless of type
-      await trashDestEntry(d.entry, destDir, relPath);
+      destOnly.push(d.entry);
       j++;
     } else if (!d) {
-      // Source-only — copy/recurse
-      await syncSrcEntry(s.entry, srcDir, destDir, relPath);
+      srcOnly.push(s.entry);
       i++;
     } else if (s.key < d.key) {
-      await syncSrcEntry(s.entry, srcDir, destDir, relPath);
+      srcOnly.push(s.entry);
       i++;
     } else if (s.key > d.key) {
-      await trashDestEntry(d.entry, destDir, relPath);
+      destOnly.push(d.entry);
       j++;
     } else {
-      // Same name — process the matched pair
-      await syncMatchedPair(s.entry, d.entry, srcDir, destDir, relPath);
+      matched.push([s.entry, d.entry]);
       i++; j++;
     }
+  }
+
+  for (const entry of destOnly) {
+    await trashDestEntry(entry, destDir, relPath);
+  }
+  for (const [srcEntry, destEntry] of matched) {
+    await syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath);
+  }
+  for (const entry of srcOnly) {
+    await syncSrcEntry(entry, srcDir, destDir, relPath);
   }
 
   // Sweep stale bookkeeping files — but only if readSortedDir actually
@@ -738,6 +866,30 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
     return;
   }
 
+  // Dest side is a link (file symlink or directory junction): NEVER
+  // operate through it — remove the link itself and materialise the
+  // source entry as real content. Without this, a dest dir-link
+  // colliding with a same-named source dir sent the walk THROUGH the
+  // link (the type-mismatch branch below skipped the link, ensureDir
+  // no-op'd because the link stats as a dir, and syncDir then mirrored
+  // into and trashed "orphans" out of whatever the link targeted —
+  // verified against arbitrary directories, including the source
+  // library itself). A dest file-link pointing back at the source file
+  // was equally bad in the matched-file path: fs.stat follows the link,
+  // so it validated as "unchanged" and the backup never held a real
+  // copy of the file.
+  if (destEntry.isSymbolicLink()) {
+    try {
+      await removeDestLink(destChild);
+      counts.filesTrashed++;
+    } catch (err) {
+      recordFileError(`remove link ${destChild}: ${err.message}`);
+      return;
+    }
+    await syncSrcEntry(srcEntry, srcDir, destDir, relPath);
+    return;
+  }
+
   // Type mismatch — e.g. source is a file but dest has a directory at the
   // same name, because the user reorganised their library. Trash whatever
   // is on dest (recursively, if it's a dir), then process source as new.
@@ -797,19 +949,25 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
     }
   }
 
-  // Source differs — move dest's old copy to trash, then write new.
-  if (destStat && destStat.isFile()) {
-    try {
-      await moveToTrash(destChild, childRel);
-      counts.filesTrashed++;
-    } catch (err) {
-      recordFileError(`trash ${destChild}: ${err.message}`);
-      return;
-    }
-  }
+  // Source differs — stage the replacement FIRST, and only displace the
+  // old dest copy once the new bytes are fully staged (atomicCopy's
+  // beforeReplace hook runs between staging and the final rename).
+  // Trash-then-copy — the pre-batch-2 order — meant an ENOSPC or any
+  // other mid-copy failure left the destination without a live copy of
+  // exactly the files that changed. With retention 0 the old copy needs
+  // no explicit unlink at all: the rename replaces it atomically, so
+  // there is no window where neither version exists.
+  const oldExists = !!(destStat && destStat.isFile());
+  const preserveOld = !oldExists ? null
+    : retentionDays <= 0
+      ? () => { counts.filesTrashed++; }
+      : async () => {
+        await moveToTrash(destChild, childRel);
+        counts.filesTrashed++;
+      };
 
   try {
-    const bytesWritten = await atomicCopy(srcChild, destChild, srcStat.mtime, srcStat.size);
+    const bytesWritten = await atomicCopy(srcChild, destChild, srcStat.mtime, srcStat.size, preserveOld);
     counts.filesCopied++;
     counts.bytesCopied += bytesWritten;
     if (bytesWritten > 0) { await throttleAfterCopy(); }
@@ -844,8 +1002,25 @@ async function trashDestEntry(destEntry, destDir, relPath) {
     return;
   }
 
-  // Skip non-regular files on dest (sockets, devices, symlinks). They
-  // didn't come from our worker and we don't want to fight them.
+  // Dest-side links get removed, not kept: deleting a link never
+  // touches its target, so unlike sockets/devices this is safe — and
+  // leaving them (pre-batch-2 behaviour) kept the dest an unfaithful
+  // mirror, blocked parent-dir pruning forever (rmdir ENOTEMPTY every
+  // run), and armed the traversal bug in syncMatchedPair if the source
+  // later gained a same-named directory.
+  if (destEntry.isSymbolicLink()) {
+    try {
+      await removeDestLink(destChild);
+      counts.filesTrashed++;
+    } catch (err) {
+      recordFileError(`remove link ${destChild}: ${err.message}`);
+    }
+    emitProgress();
+    return;
+  }
+
+  // Skip non-regular files on dest (sockets, devices). They didn't
+  // come from our worker and we don't want to fight them.
   if (!destEntry.isFile()) { return; }
 
   try {

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -413,7 +413,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize, beforeReplace = null) {
       await fs.copyFile(src, tmpPath);
       await setMtimeSafe(tmpPath, srcMtime);
       if (beforeReplace) { await beforeReplace(); }
-      await fs.rename(tmpPath, dest);
+      await renameOverwrite(tmpPath, dest);
     } catch (err) {
       try { await fs.unlink(tmpPath); } catch (_) {}
       throw err;
@@ -444,9 +444,17 @@ async function atomicCopy(src, dest, srcMtime, srcSize, beforeReplace = null) {
   catch (_) { /* no partial yet — fresh copy */ }
   if (partialStat) {
     if (partialStat.size === srcSize) {
-      await setMtimeSafe(partialPath, srcMtime);
       if (beforeReplace) { await beforeReplace(); }
-      await fs.rename(partialPath, dest);
+      await renameOverwrite(partialPath, dest);
+      // Stamp AFTER the rename, on dest. Stamping the partial first
+      // would give it the source's (typically months-old) mtime — and
+      // if the rename then failed, cleanupOrphanBookkeeping's 7-day
+      // staleness sweep would delete the fully-staged partial as an
+      // orphan, re-paying the entire copy next run. The partial keeps
+      // its natural write-time mtime (always fresh) until it actually
+      // becomes the dest file. A crash between rename and stamp costs
+      // one spurious trash+recopy next run — cheap by comparison.
+      await setMtimeSafe(dest, srcMtime);
       return 0;  // already-complete partial — finalised without writing
     }
     if (partialStat.size > 0 && partialStat.size < srcSize) {
@@ -469,9 +477,9 @@ async function atomicCopy(src, dest, srcMtime, srcSize, beforeReplace = null) {
   // fs.copyFile — to keep the size-equals-valid-bytes invariant that
   // makes the finalise path above safe (see streamResume's comment).
   await streamResume(src, partialPath, srcSize, resumeFrom);
-  await setMtimeSafe(partialPath, srcMtime);
   if (beforeReplace) { await beforeReplace(); }
-  await fs.rename(partialPath, dest);
+  await renameOverwrite(partialPath, dest);
+  await setMtimeSafe(dest, srcMtime);   // after the rename — see the finalise branch
   return srcSize - resumeFrom;
 }
 
@@ -479,10 +487,34 @@ async function atomicCopy(src, dest, srcMtime, srcSize, beforeReplace = null) {
 // deleting a link only removes the reparse point / inode reference.
 // fs.unlink handles file symlinks everywhere and junctions on modern
 // Node/Windows; some Windows configurations report EPERM for directory
-// links, where fs.rmdir removes the reparse point instead.
+// links, where fs.rmdir removes the reparse point instead. When BOTH
+// fail, the ORIGINAL unlink error propagates: for a file symlink the
+// rmdir fallback dies with a misleading ENOTDIR while the real cause
+// (permissions, busy handle) is the unlink's.
 async function removeDestLink(p) {
   try { await fs.unlink(p); }
-  catch (_) { await fs.rmdir(p); }
+  catch (unlinkErr) {
+    try { await fs.rmdir(p); }
+    catch (_) { throw unlinkErr; }
+  }
+}
+
+// Rename with a Windows read-only fallback. fs.rename cannot replace a
+// target carrying FILE_ATTRIBUTE_READONLY (EPERM/EACCES) — an attribute
+// fs.copyFile happily propagates from read-only source files, so a
+// mirrored library CAN hold read-only dest entries. The pre-batch-2
+// unlink-based replacement cleared the attribute implicitly; keep that
+// as a fallback while preserving the atomic rename for the normal case.
+// If the fallback can't fix it either, the ORIGINAL rename error
+// propagates.
+async function renameOverwrite(from, to) {
+  try { await fs.rename(from, to); }
+  catch (err) {
+    if (err.code !== 'EPERM' && err.code !== 'EACCES') { throw err; }
+    try { await fs.unlink(to); }
+    catch (_) { throw err; }
+    await fs.rename(from, to);
+  }
 }
 
 // Move a dest file out of the live tree into the trash bucket for this
@@ -518,16 +550,22 @@ async function moveToTrash(destFile, relPath) {
 // is empty after walk" safety net. Catches the common library-disconnected
 // failure (mount point exists but is empty) before merge-walk would start
 // trashing dest entries.
-async function hasAnyFiles(dir, seenRealDirs = null) {
+async function hasAnyFiles(dir, seenRealDirs = null, depth = 0) {
   if (followSymlinks) {
     // Link-following turns the tree into a graph — track each visited
     // directory's REAL path so a link cycle (a → b → a) terminates
-    // instead of recursing forever.
+    // instead of recursing forever. realpath failure is tolerated (some
+    // mounts fail it while readdir works; refusing would fatally block
+    // the whole library) — the depth cap backstops runaway cycles then.
+    if (depth > MAX_WALK_DEPTH) { return false; }
     if (seenRealDirs === null) { seenRealDirs = new Set(); }
-    let real;
-    try { real = await fs.realpath(dir); } catch (_) { return false; }
-    if (seenRealDirs.has(real)) { return false; }
-    seenRealDirs.add(real);
+    let real = null;
+    try { real = await fs.realpath(dir); }
+    catch (_) { /* resolver quirk — keep walking, depth cap protects */ }
+    if (real !== null) {
+      if (seenRealDirs.has(real)) { return false; }
+      seenRealDirs.add(real);
+    }
   }
   let entries;
   try { entries = await fs.readdir(dir, { withFileTypes: true }); }
@@ -544,7 +582,7 @@ async function hasAnyFiles(dir, seenRealDirs = null) {
     if (isExcluded(entry.name)) { continue; }
     if (entry.isFile()) { return true; }
     if (entry.isDirectory()) {
-      if (await hasAnyFiles(path.join(dir, entry.name), seenRealDirs)) { return true; }
+      if (await hasAnyFiles(path.join(dir, entry.name), seenRealDirs, depth + 1)) { return true; }
     }
     if (followSymlinks && entry.isSymbolicLink()) {
       // The walk (statForWalk → fs.stat) follows links when the library
@@ -558,7 +596,7 @@ async function hasAnyFiles(dir, seenRealDirs = null) {
       catch (_) { /* broken link — ignore */ }
       if (st?.isFile()) { return true; }
       if (st?.isDirectory()) {
-        if (await hasAnyFiles(path.join(dir, entry.name), seenRealDirs)) { return true; }
+        if (await hasAnyFiles(path.join(dir, entry.name), seenRealDirs, depth + 1)) { return true; }
       }
     }
   }
@@ -671,29 +709,42 @@ async function cleanupOrphanBookkeeping(dir) {
 //   both, types differ → trash dest entry, then process src entry
 // Cycle protection for link-following libraries. With followSymlinks
 // the source "tree" is really a graph: statForWalk follows links, so a
-// link pointing at an ancestor recurses forever. Track every source
-// directory's REAL path; a revisit is either a cycle (skip, or hang) or
-// two links aliasing the same directory (skip the second — the content
-// is already mirrored under its first path; a per-dir error records the
-// skipped alias). Bounded at one Set entry per source directory, and
-// only populated for followSymlinks libraries.
+// link pointing at an ancestor recurses forever. Before walking INTO a
+// source directory, claim its real path; a second claim is either a
+// cycle (skip, or hang forever) or two links aliasing the same
+// directory (skip the second — its content is already mirrored under
+// the first path; the recorded error keeps the skipped alias visible,
+// and its dest counterpart is left untouched rather than swept).
+//
+// Claims happen at the CALL SITES, before any dest-side mkdir — a
+// skipped alias must never materialise an empty dest dir (it would
+// oscillate: created this run, orphaned the next). The depth cap
+// backstops the realpath-failure case: some mounts fail realpath while
+// readdir works fine, and refusing to walk them would block whole
+// libraries over a resolver quirk. Only consulted for followSymlinks
+// libraries; plain trees are cycle-free by construction.
 const walkedSrcRealDirs = new Set();
+const MAX_WALK_DEPTH = 128;
+
+async function claimSrcDir(srcDir, relPath) {
+  if (!followSymlinks) { return true; }
+  if (relPath && relPath.split(path.sep).length > MAX_WALK_DEPTH) {
+    recordFileError(`source dir exceeds max walk depth (${MAX_WALK_DEPTH}): ${srcDir}`);
+    return false;
+  }
+  let real;
+  try { real = await fs.realpath(srcDir); }
+  catch (_) { return true; }   // resolver quirk — walk anyway, depth cap protects
+  if (walkedSrcRealDirs.has(real)) {
+    recordFileError(`skipping source dir already visited via another link (cycle or alias): ${srcDir}`);
+    return false;
+  }
+  walkedSrcRealDirs.add(real);
+  return true;
+}
 
 async function syncDir(srcDir, destDir, relPath) {
   const isRoot = relPath === '';
-
-  if (followSymlinks) {
-    let real = null;
-    try { real = await fs.realpath(srcDir); }
-    catch (_) { /* vanished — the readSortedDir existed-check below reports it */ }
-    if (real !== null) {
-      if (walkedSrcRealDirs.has(real)) {
-        recordFileError(`skipping source dir already visited via another link (cycle or alias): ${srcDir}`);
-        return;
-      }
-      walkedSrcRealDirs.add(real);
-    }
-  }
 
   let srcSorted;
   try {
@@ -823,6 +874,9 @@ async function syncSrcEntry(srcEntry, srcDir, destDir, relPath) {
   if (stat.isSymbolicLink()) { return; }
 
   if (stat.isDirectory()) {
+    // Claim BEFORE ensureDir — a skipped alias/cycle must not leave an
+    // empty dest dir behind (see claimSrcDir).
+    if (!(await claimSrcDir(srcChild, childRel))) { return; }
     try { await ensureDir(destChild); }
     catch (err) {
       recordFileError(`mkdir ${destChild}: ${err.message}`);
@@ -904,6 +958,9 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
   }
 
   if (srcIsDir) {
+    // A skipped alias/cycle leaves the existing dest dir exactly as-is
+    // (stale but stable) — no sweep, no prune (see claimSrcDir).
+    if (!(await claimSrcDir(srcChild, childRel))) { return; }
     await syncDir(srcChild, destChild, childRel);
     // After syncing, prune the dest dir if it's now empty (e.g. source had
     // only directories that were themselves emptied into trash). Best-
@@ -958,16 +1015,20 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
   // no explicit unlink at all: the rename replaces it atomically, so
   // there is no window where neither version exists.
   const oldExists = !!(destStat && destStat.isFile());
-  const preserveOld = !oldExists ? null
-    : retentionDays <= 0
-      ? () => { counts.filesTrashed++; }
-      : async () => {
-        await moveToTrash(destChild, childRel);
-        counts.filesTrashed++;
-      };
+  // retention>0: the hook counts when moveToTrash actually displaced the
+  // old copy — even if the rename after it fails, the old copy IS in
+  // trash, so the count stays truthful. retention<=0: nothing displaces
+  // the old copy until the rename itself lands (no hook needed at all;
+  // renameOverwrite replaces atomically), so count only on success.
+  const preserveOld = (!oldExists || retentionDays <= 0) ? null
+    : async () => {
+      await moveToTrash(destChild, childRel);
+      counts.filesTrashed++;
+    };
 
   try {
     const bytesWritten = await atomicCopy(srcChild, destChild, srcStat.mtime, srcStat.size, preserveOld);
+    if (oldExists && retentionDays <= 0) { counts.filesTrashed++; }
     counts.filesCopied++;
     counts.bytesCopied += bytesWritten;
     if (bytesWritten > 0) { await throttleAfterCopy(); }
@@ -1075,6 +1136,9 @@ async function trashDestEntry(destEntry, destDir, relPath) {
   // knows which comparison to trust (see probeDestMtimeFidelity).
   await probeDestMtimeFidelity();
 
+  // Seed the cycle-protection set with the root's real path so a link
+  // deeper in the tree pointing back AT the root is caught.
+  await claimSrcDir(sourcePath, '');
   await syncDir(sourcePath, destPath, '');
 
   emitProgress(true);

--- a/test/fixtures/fail-copyfile.cjs
+++ b/test/fixtures/fail-copyfile.cjs
@@ -1,0 +1,17 @@
+// Fault-injection preload for backup-worker tests: fs.copyFile throws
+// ENOSPC for any source path containing 'FAILCOPY', simulating a
+// destination running out of space mid-run. Used to assert the
+// trash-after-staging ordering: a failed replacement copy must leave
+// the OLD dest copy live and untouched.
+const fs = require('fs');
+
+const real = fs.promises.copyFile.bind(fs.promises);
+
+fs.promises.copyFile = (src, dest, mode) => {
+  if (String(src).includes('FAILCOPY')) {
+    const err = new Error('ENOSPC: no space left on device (fault injection: fail-copyfile.cjs)');
+    err.code = 'ENOSPC';
+    return Promise.reject(err);
+  }
+  return real(src, dest, mode);
+};

--- a/test/fixtures/fail-partial-write.cjs
+++ b/test/fixtures/fail-partial-write.cjs
@@ -1,0 +1,23 @@
+// Fault-injection preload for backup-worker tests: kills the worker
+// process mid-way through a FRESH large-file streaming copy (the fourth
+// 256KB write to a .mstream-partial-* file opened with 'w'), simulating
+// a crash / power loss during a big copy. The partial left behind must
+// contain exactly the bytes that were written — the sequential-write
+// invariant the resume/finalise paths depend on.
+const fs = require('fs');
+
+const realOpen = fs.promises.open.bind(fs.promises);
+let writes = 0;
+
+fs.promises.open = async (p, flags, mode) => {
+  const handle = await realOpen(p, flags, mode);
+  if (String(p).includes('.mstream-partial-') && String(flags) === 'w') {
+    const realWrite = handle.write.bind(handle);
+    handle.write = (...args) => {
+      writes++;
+      if (writes > 3) { process.exit(137); }
+      return realWrite(...args);
+    };
+  }
+  return handle;
+};

--- a/test/fixtures/fail-rename-once.cjs
+++ b/test/fixtures/fail-rename-once.cjs
@@ -1,0 +1,19 @@
+// Fault-injection preload for backup-worker tests: the FIRST rename onto
+// a destination path containing 'FAILRENAME' throws EACCES, later ones
+// succeed. Simulates a transient finalise failure after a large file's
+// partial is fully staged — the next run must finalise the surviving
+// complete partial without re-copying any bytes.
+const fs = require('fs');
+
+const real = fs.promises.rename.bind(fs.promises);
+let fired = false;
+
+fs.promises.rename = (a, b) => {
+  if (!fired && String(b).includes('FAILRENAME')) {
+    fired = true;
+    const err = new Error('EACCES: permission denied (fault injection: fail-rename-once.cjs)');
+    err.code = 'EACCES';
+    return Promise.reject(err);
+  }
+  return real(a, b);
+};

--- a/test/fixtures/vanish-readdir.cjs
+++ b/test/fixtures/vanish-readdir.cjs
@@ -1,0 +1,23 @@
+// Fault-injection preload for backup-worker tests: deletes the directory
+// named by env VANISH_DIR immediately before its Nth readdir (default
+// 2nd), so the readdir sees ENOENT — simulating a source directory that
+// the parent listing saw but that unmounted/vanished before the child
+// walk reached it. Call #1 is the worker's hasAnyFiles pre-flight pass;
+// call #2 is the merge-walk's readSortedDir.
+const fs = require('fs');
+const path = require('path');
+
+const target = process.env.VANISH_DIR ? path.resolve(process.env.VANISH_DIR) : '';
+const fireOn = Number(process.env.VANISH_ON_CALL || 2);
+const real = fs.promises.readdir.bind(fs.promises);
+let calls = 0;
+
+fs.promises.readdir = (p, opts) => {
+  if (target && path.resolve(String(p)) === target) {
+    calls++;
+    if (calls === fireOn) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  }
+  return real(p, opts);
+};

--- a/test/integration/backup-worker-batch2.test.mjs
+++ b/test/integration/backup-worker-batch2.test.mjs
@@ -106,6 +106,12 @@ function oldPartialName(basename, size, mtimeDate) {
   return `.mstream-partial-${hash}-${size}-${mtimeDate.getTime()}`;
 }
 
+// Mirrors worker.mjs partialName exactly (v2) — for planting a complete
+// staged partial to drive the finalise branch.
+function v2PartialName(basename, size, mtimeDate) {
+  return `${oldPartialName(basename, size, mtimeDate)}-v2`;
+}
+
 // ── two-phase walk: case-only renames ───────────────────────────────────────
 
 describe('batch2: case-only renames survive on any destination', () => {
@@ -311,8 +317,18 @@ describe('batch2: large-file partials are crash-safe', () => {
     const src = path.join(root, 'src');
     const dest = path.join(root, 'dest');
     fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(dest, { recursive: true });
     const big = path.join(src, 'FAILRENAME-big.mp3');
     fs.writeFileSync(big, crypto.randomBytes(BIG));
+    const st = fs.statSync(big);
+    // Plant an already-COMPLETE v2 partial (valid bytes), as left behind
+    // by a previous run that crashed after staging. This drives run 1
+    // into the FINALISE branch — whose rename failure the pre-batch-2
+    // catch swallowed before silently re-paying a full fresh copy. That
+    // fallback made a fresh-copy scenario pass surface assertions on the
+    // old code too, so the test must start from a planted partial to
+    // actually discriminate.
+    fs.copyFileSync(big, path.join(dest, v2PartialName('FAILRENAME-big.mp3', st.size, st.mtime)));
 
     const run1 = await runWorker(
       { sourcePath: src, destPath: dest, retentionDays: 30 },
@@ -321,6 +337,8 @@ describe('batch2: large-file partials are crash-safe', () => {
     assert.equal(run1.code, 0);
     assert.equal(doneEvent(run1.events).fileErrors, 1,
       'the failed finalise must be recorded — pre-batch-2 the resume-lookup catch swallowed it');
+    assert.equal(doneEvent(run1.events).bytesCopied, 0,
+      'no bytes may be written — pre-batch-2 the swallowed error fell through to a full fresh copy');
     assert.equal(fs.existsSync(path.join(dest, 'FAILRENAME-big.mp3')), false);
     const partials = fs.readdirSync(dest).filter((n) => n.startsWith('.mstream-partial-'));
     assert.equal(partials.length, 1, 'fully-staged partial must survive the failed rename');
@@ -331,6 +349,29 @@ describe('batch2: large-file partials are crash-safe', () => {
     assert.equal(doneEvent(run2.events).bytesCopied, 0,
       'the complete partial must be finalised without re-copying — pre-batch-2 every run re-paid the full copy');
     assert.equal(sha(path.join(dest, 'FAILRENAME-big.mp3')), sha(big));
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('read-only dest file can still be replaced (retention 0 atomic replace)', async (t) => {
+    if (process.platform !== 'win32') { return t.skip('FILE_ATTRIBUTE_READONLY rename-over semantics are Windows-specific'); }
+    const root = makeTempRoot('readonly');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 't.mp3'), 'v1');
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 0 });
+    // fs.copyFile propagates the read-only attribute from read-only
+    // sources, so mirrored libraries can legitimately hold read-only
+    // dest entries; simulate one directly.
+    fs.chmodSync(path.join(dest, 't.mp3'), 0o444);
+    fs.writeFileSync(path.join(src, 't.mp3'), 'v2-longer');
+
+    const run2 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 0 });
+    assert.equal(doneEvent(run2.events).fileErrors, 0,
+      'plain rename cannot replace a read-only target on Windows — the unlink fallback must kick in');
+    assert.equal(fs.readFileSync(path.join(dest, 't.mp3'), 'utf8'), 'v2-longer');
+    assert.equal(doneEvent(run2.events).filesTrashed, 1, 'the replacement is counted once, on success');
     fs.rmSync(root, { recursive: true, force: true });
   });
 });
@@ -426,6 +467,38 @@ describe('batch2: link-following libraries pass the guard and walk safely', () =
     assert.equal(code, 0, 'walk must terminate on cycles — batch 1 made followSymlinks live, so cycles became reachable');
     assert.equal(fs.readFileSync(path.join(dest, 'a', 'track.mp3'), 'utf8'), 'real-track');
     assert.ok(doneEvent(events).fileErrors >= 1, 'the skipped cycle should be recorded');
+    // The discriminating assertion: without real cycle protection the
+    // walk recurses ~31 junction hops before ELOOP, materialising a
+    // deep dest/a/loop/loop/... chain (and terminating only by luck).
+    assert.equal(fs.existsSync(path.join(dest, 'a', 'loop')), false,
+      'the cycle link must not materialise ANY dest dir');
     try { fs.rmSync(root, { recursive: true, force: true }); } catch (_) { /* cycle cleanup */ }
+  });
+
+  test('two links aliasing one dir: first wins, loser stays absent and stable across runs', async () => {
+    const root = makeTempRoot('alias');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    const shared = path.join(root, 'shared');
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(shared, { recursive: true });
+    fs.writeFileSync(path.join(shared, 'song.mp3'), 'shared-track');
+    fs.symlinkSync(shared, path.join(src, 'genreA'), 'junction');
+    fs.symlinkSync(shared, path.join(src, 'genreB'), 'junction');
+
+    // Three runs: state must be IDENTICAL each time — the alias skip
+    // fires before ensureDir, so the losing alias never materialises an
+    // empty dest dir (which used to oscillate created/pruned per run).
+    for (let i = 1; i <= 3; i++) {
+      const run = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30, followSymlinks: true });
+      assert.equal(run.code, 0);
+      assert.equal(fs.readFileSync(path.join(dest, 'genreA', 'song.mp3'), 'utf8'), 'shared-track',
+        `run ${i}: first alias (sort order) must be mirrored`);
+      assert.equal(fs.existsSync(path.join(dest, 'genreB')), false,
+        `run ${i}: losing alias must not materialise a dest dir`);
+      assert.equal(doneEvent(run.events).fileErrors, 1,
+        `run ${i}: the skipped alias stays visible as exactly one file error`);
+    }
+    fs.rmSync(root, { recursive: true, force: true });
   });
 });

--- a/test/integration/backup-worker-batch2.test.mjs
+++ b/test/integration/backup-worker-batch2.test.mjs
@@ -1,0 +1,431 @@
+/**
+ * Backup-worker batch-2 semantics (audit batch 2).
+ *
+ * Extends the batch-1 harness pattern (drive src/backup/worker.mjs
+ * directly against temp trees, fault-inject via NODE_OPTIONS preloads)
+ * to pin the merge-walk data-loss fixes:
+ *
+ *   - Two-phase walk: all dest-only trashes happen before source-only
+ *     copies, so a case-only rename on a case-insensitive destination
+ *     can no longer trash the freshly-copied file (or a whole subtree
+ *     for a renamed directory).
+ *   - Dest-side symlinks/junctions are removed, never operated through
+ *     — a dest link colliding with a source dir used to redirect
+ *     mirroring AND orphan-trashing into the link target.
+ *   - Replacement copies stage fully before the old dest copy is
+ *     displaced (ENOSPC mid-copy used to destroy the only backup copy
+ *     of exactly the files that changed).
+ *   - Large-file crash-safety: fresh copies stream sequentially so an
+ *     interrupted partial always equals its valid bytes (fs.copyFile on
+ *     Windows pre-extends — a kill left a full-size garbage partial the
+ *     next run finalised into silent corruption); unversioned (pre-v2)
+ *     partials are never trusted; a failed finalise rename surfaces
+ *     instead of triggering a silent full recopy every run.
+ *   - A source dir that vanishes mid-run (unmount) no longer reads as
+ *     "empty" and sweeps the matching dest subtree.
+ *   - The empty-source guard and the walk follow links (cycle-safe)
+ *     when the library's followSymlinks flag is set.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(REPO_ROOT, 'src', 'backup', 'worker.mjs');
+const FIXTURES = path.join(REPO_ROOT, 'test', 'fixtures').replace(/\\/g, '/');
+
+const BIG = 17 * 1024 * 1024;   // over RESUME_MIN_SIZE (16MB)
+
+let envCounter = 0;
+function makeTempRoot(tag) {
+  const root = path.join(os.tmpdir(), `mstream-b2-${tag}-` + Date.now() + '-' + (envCounter++));
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function runWorker(payload, { env = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WORKER, JSON.stringify(payload)], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let errOut = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.stderr.on('data', (d) => { errOut += d.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const events = out.split(/\r?\n/).filter(Boolean).map((line) => {
+        try { return JSON.parse(line); } catch (_) { return null; }
+      }).filter(Boolean);
+      resolve({ code, events, stderr: errOut });
+    });
+  });
+}
+
+function doneEvent(events) { return events.find((e) => e.event === 'done') || null; }
+function errorEvent(events) { return events.find((e) => e.event === 'error') || null; }
+
+function sha(p) { return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex'); }
+
+// Live dest names at one level, ignoring trash + bookkeeping.
+function liveNames(dir) {
+  if (!fs.existsSync(dir)) { return []; }
+  return fs.readdirSync(dir)
+    .filter((n) => n !== '.mstream-trash' && !n.startsWith('.mstream-tmp-') && !n.startsWith('.mstream-partial-'))
+    .sort();
+}
+
+function findInTrash(dest, basename) {
+  const trash = path.join(dest, '.mstream-trash');
+  if (!fs.existsSync(trash)) { return null; }
+  const stack = [trash];
+  while (stack.length) {
+    const d = stack.pop();
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) { stack.push(p); }
+      else if (e.name === basename || e.name.startsWith(basename + '.')) { return p; }
+    }
+  }
+  return null;
+}
+
+// Mirrors worker.mjs partialName WITHOUT the -v2 suffix — the pre-batch-2
+// name — for the "unversioned partials are never trusted" regression.
+function oldPartialName(basename, size, mtimeDate) {
+  const hash = crypto.createHash('sha1').update(basename, 'utf8').digest('hex').slice(0, 12);
+  return `.mstream-partial-${hash}-${size}-${mtimeDate.getTime()}`;
+}
+
+// ── two-phase walk: case-only renames ───────────────────────────────────────
+
+describe('batch2: case-only renames survive on any destination', () => {
+  test('file rename a.mp3 -> A.mp3: fresh copy lands, old bytes in trash', async () => {
+    const root = makeTempRoot('case-file');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'a.mp3'), 'track-content');
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    fs.renameSync(path.join(src, 'a.mp3'), path.join(src, 'A.mp3'));
+    const run2 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+
+    assert.equal(run2.code, 0);
+    assert.deepEqual(liveNames(dest), ['A.mp3'],
+      'dest must hold exactly the renamed file — pre-batch-2 the trash of the stale name removed the fresh copy on case-insensitive destinations');
+    assert.equal(fs.readFileSync(path.join(dest, 'A.mp3'), 'utf8'), 'track-content');
+    assert.ok(findInTrash(dest, 'a.mp3'), 'old-name copy must be preserved in trash');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('dir rename band -> Band: subtree intact under the new name', async () => {
+    const root = makeTempRoot('case-dir');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(path.join(src, 'band', 'album'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'band', 'album', 'x.mp3'), 'x-content');
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    fs.renameSync(path.join(src, 'band'), path.join(src, 'Band'));
+    const run2 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+
+    assert.equal(run2.code, 0);
+    assert.deepEqual(liveNames(dest), ['Band'],
+      'pre-batch-2 the whole just-synced subtree was trashed on case-insensitive destinations');
+    assert.equal(fs.readFileSync(path.join(dest, 'Band', 'album', 'x.mp3'), 'utf8'), 'x-content');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── dest-side links ─────────────────────────────────────────────────────────
+
+describe('batch2: dest-side links are removed, never traversed', () => {
+  test('dest dir-link colliding with source dir: link target untouched, real dir mirrored', async () => {
+    const root = makeTempRoot('junction');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    const victim = path.join(root, 'victim');
+    fs.mkdirSync(path.join(src, 'linked'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'linked', 'song.mp3'), 'real-song');
+    fs.mkdirSync(path.join(victim, 'sub'), { recursive: true });
+    fs.writeFileSync(path.join(victim, 'doc.txt'), 'precious');
+    fs.writeFileSync(path.join(victim, 'sub', 'photo.jpg'), 'precious-2');
+    fs.mkdirSync(dest, { recursive: true });
+    fs.symlinkSync(victim, path.join(dest, 'linked'), 'junction');
+
+    const { code } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+
+    assert.equal(code, 0);
+    assert.equal(fs.readFileSync(path.join(victim, 'doc.txt'), 'utf8'), 'precious',
+      'link target must be untouched — pre-batch-2 the walk trashed "orphans" out of it');
+    assert.equal(fs.readFileSync(path.join(victim, 'sub', 'photo.jpg'), 'utf8'), 'precious-2');
+    assert.equal(fs.lstatSync(path.join(dest, 'linked')).isSymbolicLink(), false,
+      'dest entry must be a real directory now');
+    assert.equal(fs.readFileSync(path.join(dest, 'linked', 'song.mp3'), 'utf8'), 'real-song');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('dest-only dir-link is removed (target untouched), parent stays prunable', async () => {
+    const root = makeTempRoot('stale-link');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    const victim = path.join(root, 'victim');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'keep.mp3'), 'keep');
+    fs.mkdirSync(victim, { recursive: true });
+    fs.writeFileSync(path.join(victim, 'data.txt'), 'safe');
+    fs.mkdirSync(dest, { recursive: true });
+    fs.symlinkSync(victim, path.join(dest, 'stale-link'), 'junction');
+
+    const { code } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+
+    assert.equal(code, 0);
+    assert.equal(fs.existsSync(path.join(dest, 'stale-link')), false,
+      'dest-only link must be removed — pre-batch-2 it persisted forever');
+    assert.equal(fs.readFileSync(path.join(victim, 'data.txt'), 'utf8'), 'safe');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('dest file-link pointing at the source file is replaced by a real copy', async (t) => {
+    const root = makeTempRoot('file-link');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(dest, { recursive: true });
+    fs.writeFileSync(path.join(src, 'song.mp3'), 'the-song');
+    try {
+      fs.symlinkSync(path.join(src, 'song.mp3'), path.join(dest, 'song.mp3'), 'file');
+    } catch (_) {
+      fs.rmSync(root, { recursive: true, force: true });
+      return t.skip('file symlinks unavailable on this host');
+    }
+
+    const { code, events } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+
+    assert.equal(code, 0);
+    assert.equal(doneEvent(events).filesCopied, 1,
+      'pre-batch-2 fs.stat followed the link to the source file and validated it as "unchanged"');
+    assert.equal(fs.lstatSync(path.join(dest, 'song.mp3')).isSymbolicLink(), false);
+    assert.equal(fs.readFileSync(path.join(dest, 'song.mp3'), 'utf8'), 'the-song');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── staging order under failure ─────────────────────────────────────────────
+
+describe('batch2: replacement copies stage before the old copy is displaced', () => {
+  const injectEnv = { NODE_OPTIONS: `--require "${FIXTURES}/fail-copyfile.cjs"` };
+
+  test('failed replacement copy leaves the old dest copy live', async () => {
+    const root = makeTempRoot('enospc');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    const f = path.join(src, 'FAILCOPY-track.mp3');
+    fs.writeFileSync(f, 'version-1');
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    fs.writeFileSync(f, 'version-2-longer');   // size + mtime change
+
+    const run2 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 }, { env: injectEnv });
+    assert.equal(run2.code, 0);
+    assert.equal(doneEvent(run2.events).fileErrors, 1);
+    assert.equal(fs.readFileSync(path.join(dest, 'FAILCOPY-track.mp3'), 'utf8'), 'version-1',
+      'old copy must stay live when the replacement copy fails — pre-batch-2 it was already in trash');
+    assert.equal(doneEvent(run2.events).filesTrashed, 0, 'nothing may be displaced on a failed copy');
+
+    const run3 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    assert.equal(fs.readFileSync(path.join(dest, 'FAILCOPY-track.mp3'), 'utf8'), 'version-2-longer');
+    assert.ok(findInTrash(dest, 'FAILCOPY-track.mp3'), 'old version reaches trash once the replacement lands');
+    assert.equal(doneEvent(run3.events).filesTrashed, 1);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── large-file crash-safety ─────────────────────────────────────────────────
+
+describe('batch2: large-file partials are crash-safe', () => {
+  test('interrupted fresh copy leaves a valid-bytes partial; next run resumes it', async () => {
+    const root = makeTempRoot('bigkill');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    const big = path.join(src, 'big.mp3');
+    fs.writeFileSync(big, crypto.randomBytes(BIG));
+
+    const run1 = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: { NODE_OPTIONS: `--require "${FIXTURES}/fail-partial-write.cjs"` } },
+    );
+    assert.notEqual(run1.code, 0, 'worker must have been killed mid-copy');
+
+    const partials = fs.readdirSync(dest).filter((n) => n.startsWith('.mstream-partial-'));
+    assert.equal(partials.length, 1, 'an interrupted partial must survive for resume');
+    const pStat = fs.statSync(path.join(dest, partials[0]));
+    assert.ok(pStat.size > 0 && pStat.size < BIG,
+      `partial size must equal valid bytes written (got ${pStat.size}) — fs.copyFile on Windows pre-extended to full size with a garbage tail`);
+    const srcPrefix = fs.readFileSync(big).subarray(0, pStat.size);
+    const partialBytes = fs.readFileSync(path.join(dest, partials[0]));
+    assert.ok(srcPrefix.equals(partialBytes), 'every byte in the partial must be valid source data');
+
+    const run2 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    assert.equal(run2.code, 0);
+    assert.equal(sha(path.join(dest, 'big.mp3')), sha(big), 'resumed file must be byte-identical');
+    assert.ok(doneEvent(run2.events).bytesCopied < BIG,
+      'second run must resume the partial, not re-copy the whole file');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('full-size unversioned (pre-v2) partial is never blind-finalised', async () => {
+    const root = makeTempRoot('oldpartial');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(dest, { recursive: true });
+    const big = path.join(src, 'big.mp3');
+    fs.writeFileSync(big, crypto.randomBytes(BIG));
+    const st = fs.statSync(big);
+    // The pre-batch-2 crash shape: a full-size partial whose tail is
+    // garbage (CopyFileW pre-extension), under the OLD unversioned name.
+    fs.writeFileSync(path.join(dest, oldPartialName('big.mp3', st.size, st.mtime)), crypto.randomBytes(BIG));
+
+    const { code } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    assert.equal(code, 0);
+    assert.equal(sha(path.join(dest, 'big.mp3')), sha(big),
+      'dest must be copied fresh from source — pre-batch-2 the garbage partial was renamed in as "complete"');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('failed finalise rename surfaces, and the next run finalises without re-copying', async () => {
+    const root = makeTempRoot('renamefail');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    const big = path.join(src, 'FAILRENAME-big.mp3');
+    fs.writeFileSync(big, crypto.randomBytes(BIG));
+
+    const run1 = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: { NODE_OPTIONS: `--require "${FIXTURES}/fail-rename-once.cjs"` } },
+    );
+    assert.equal(run1.code, 0);
+    assert.equal(doneEvent(run1.events).fileErrors, 1,
+      'the failed finalise must be recorded — pre-batch-2 the resume-lookup catch swallowed it');
+    assert.equal(fs.existsSync(path.join(dest, 'FAILRENAME-big.mp3')), false);
+    const partials = fs.readdirSync(dest).filter((n) => n.startsWith('.mstream-partial-'));
+    assert.equal(partials.length, 1, 'fully-staged partial must survive the failed rename');
+    assert.equal(fs.statSync(path.join(dest, partials[0])).size, BIG);
+
+    const run2 = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    assert.equal(run2.code, 0);
+    assert.equal(doneEvent(run2.events).bytesCopied, 0,
+      'the complete partial must be finalised without re-copying — pre-batch-2 every run re-paid the full copy');
+    assert.equal(sha(path.join(dest, 'FAILRENAME-big.mp3')), sha(big));
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── source vanishes mid-run ─────────────────────────────────────────────────
+
+describe('batch2: source dir vanishing mid-run does not sweep the dest subtree', () => {
+  test('ENOENT on a child readdir skips the subtree instead of trashing it', async () => {
+    const root = makeTempRoot('vanish');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    const sub = path.join(src, 'vanish-sub');
+    fs.mkdirSync(sub, { recursive: true });
+    fs.writeFileSync(path.join(sub, 'track.mp3'), 'still-here');
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    assert.equal(fs.readFileSync(path.join(dest, 'vanish-sub', 'track.mp3'), 'utf8'), 'still-here');
+
+    // Fixture deletes the source subdir right before its 2nd readdir:
+    // call #1 is hasAnyFiles' pre-flight, call #2 is the merge-walk.
+    const run2 = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: { NODE_OPTIONS: `--require "${FIXTURES}/vanish-readdir.cjs"`, VANISH_DIR: sub } },
+    );
+
+    assert.equal(run2.code, 0);
+    assert.ok(doneEvent(run2.events).fileErrors >= 1);
+    assert.match(run2.stderr, /vanished/i);
+    assert.equal(fs.readFileSync(path.join(dest, 'vanish-sub', 'track.mp3'), 'utf8'), 'still-here',
+      'dest subtree must be untouched — pre-batch-2 the vanished dir read as empty and the subtree was trashed');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── follow-links guard + walk ───────────────────────────────────────────────
+
+describe('batch2: link-following libraries pass the guard and walk safely', () => {
+  test('all-links root backs up when followSymlinks=true', async () => {
+    const root = makeTempRoot('alllinks');
+    const src = path.join(root, 'src');
+    const outside = path.join(root, 'outside');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(outside, { recursive: true });
+    fs.writeFileSync(path.join(outside, 'track.mp3'), 'linked-track');
+    fs.symlinkSync(outside, path.join(src, 'linked'), 'junction');
+
+    const { code } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30, followSymlinks: true });
+    assert.equal(code, 0,
+      'guard must follow links when the library does — pre-batch-2 it refused with "zero files"');
+    assert.equal(fs.readFileSync(path.join(dest, 'linked', 'track.mp3'), 'utf8'), 'linked-track');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('all-links root still refused when followSymlinks=false (fail-closed)', async () => {
+    const root = makeTempRoot('alllinks-off');
+    const src = path.join(root, 'src');
+    const outside = path.join(root, 'outside');
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(outside, { recursive: true });
+    fs.writeFileSync(path.join(outside, 'track.mp3'), 'linked-track');
+    fs.symlinkSync(outside, path.join(src, 'linked'), 'junction');
+
+    const { code, events } = await runWorker({ sourcePath: src, destPath: path.join(root, 'dest'), retentionDays: 30, followSymlinks: false });
+    assert.equal(code, 1);
+    assert.match(errorEvent(events).message, /zero files/i);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('link cycle with no files terminates and is refused', async () => {
+    const root = makeTempRoot('cycle-empty');
+    const src = path.join(root, 'src');
+    const a = path.join(src, 'a');
+    fs.mkdirSync(a, { recursive: true });
+    fs.symlinkSync(a, path.join(a, 'loop'), 'junction');
+
+    const { code, events } = await runWorker({ sourcePath: src, destPath: path.join(root, 'dest'), retentionDays: 30, followSymlinks: true });
+    assert.equal(code, 1, 'cycle-only source must terminate (not hang) and be refused as empty');
+    assert.match(errorEvent(events).message, /zero files/i);
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch (_) { /* cycle cleanup */ }
+  });
+
+  test('link cycle alongside real content mirrors the content and skips the loop', async () => {
+    const root = makeTempRoot('cycle-full');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    const a = path.join(src, 'a');
+    fs.mkdirSync(a, { recursive: true });
+    fs.writeFileSync(path.join(a, 'track.mp3'), 'real-track');
+    fs.symlinkSync(a, path.join(a, 'loop'), 'junction');
+
+    const { code, events } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30, followSymlinks: true });
+    assert.equal(code, 0, 'walk must terminate on cycles — batch 1 made followSymlinks live, so cycles became reachable');
+    assert.equal(fs.readFileSync(path.join(dest, 'a', 'track.mp3'), 'utf8'), 'real-track');
+    assert.ok(doneEvent(events).fileErrors >= 1, 'the skipped cycle should be recorded');
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch (_) { /* cycle cleanup */ }
+  });
+});


### PR DESCRIPTION
Batch 2 of the backup-feature audit fixes: the merge-walk data-loss group. Batch 1 was #724; this batch rewrites the walk's ordering and the large-file copy machinery, so it carries the heaviest test load of the series.

## Fixes

### 1. Two-phase walk — case-only renames no longer lose files (`worker.mjs`)

On case-insensitive destinations (NTFS, default APFS) a case-only rename (`a.mp3` → `A.mp3`) makes the same physical file appear as both a source-only and a dest-only entry (merge keys are NFC- but not case-folded). The interleaved copy-then-trash order let the trash of the stale dest name resolve — case-insensitively — to the **freshly-copied file** and remove it: the backup lost the file until the next run, or an entire subtree when a directory was case-renamed. Each directory's merge is now classified first, then all dest-only trashes run before any source-only copies. Cost: a full recopy on case-only renames — correctness over cleverness.

### 2. Dest-side symlinks/junctions are removed, never operated through

A dest dir-link colliding with a same-named source dir sent the walk *through* the link: mirroring into and trashing "orphans" out of whatever the link targeted — verified in the audit against arbitrary directories, including the source library itself. A dest file-link pointing back at the source file validated as "unchanged" via stat-follow, so the backup never held a real copy. Dest links are now removed (unlink, rmdir fallback for Windows junctions; the original error surfaces if both fail) and the source entry is materialised as real content. Dest-only stale links — which previously persisted forever and blocked parent-dir pruning — are cleaned up the same way.

### 3. Replacement copies stage before the old copy is displaced

`syncMatchedPair` used to trash the old dest copy *then* copy the replacement — an ENOSPC mid-run destroyed the only backup copies of exactly the files that changed. `atomicCopy` now takes a `beforeReplace` hook that runs after the new content is fully staged, immediately before the rename. With `retention_days=0` the rename replaces atomically — no unlink window at all — via a new `renameOverwrite` helper that also handles Windows' rename-over-read-only EPERM (an attribute `fs.copyFile` propagates from read-only sources; the old unlink path cleared it implicitly).

### 4. Large-file crash-safety: no more garbage-partial finalisation

`CopyFileW` pre-extends the destination to full size before data lands, so a worker kill mid-copy left a full-size garbage-tail partial that the next run blind-finalised into a silently corrupt "complete" file — discovered only when the backup is needed. Fresh large copies now stream sequentially through `streamResume` (positional writes), so a partial's size always equals its valid bytes. Partial names carry a `-v2` suffix: unversioned (pre-fix) partials never match the lookup and age out via the staleness sweep. The mtime stamp lands on **dest after the rename** — stamping the partial first gave it the source's months-old mtime, and a failed rename then fed the fully-staged partial to the 7-day staleness sweep.

### 5. Finalise failures surface

The resume-lookup catch used to swallow a failed finalise rename and fall through to a fresh full copy — every run re-paid the entire copy, forever, invisibly. Only the stat probe sits in the catch now; rename errors reach the per-file error accounting.

### 6. Mid-run source unmount can't sweep the dest subtree

`readSortedDir`'s `existed` flag was computed but never checked: a source dir that vanished between the parent's listing and its own readdir was treated as *empty*, sweeping the entire matching dest subtree into trash. It's now skipped with a recorded error.

### 7. Link-following is now safe end-to-end

Batch 1 made `followSymlinks` live, which exposed two gaps: the empty-source guard refused libraries whose content sits entirely behind links ("zero files"), and link cycles — now reachable — recursed until ELOOP, materialising junk dirs. Both the guard and the walk now follow links with realpath-based cycle protection (`claimSrcDir`, claimed **before** any dest mkdir so a skipped alias never materialises an oscillating empty dir), tolerate realpath-hostile mounts (depth cap as backstop), and record skipped aliases visibly.

## Review + tests

The batch went through the same adversarial review as #724; the review confirmed 12 findings in the new code (several by live repro) — all fixed in the second commit. Notably, two of the original tests **passed on the parent commit too** (the old swallow-and-recopy fallback satisfied their surface assertions; ELOOP terminated cycles by luck). Both were rewritten to start from discriminating state and verified to fail 3/3 against the parent worker and pass against the fixed one.

16 new tests (`backup-worker-batch2.test.mjs`) with four fault-injection preloads (`fail-copyfile`, `fail-partial-write`, `fail-rename-once`, `vanish-readdir`). Full suite: 47/47 across the worker/task-queue suites; lint unchanged from master baseline.

Rig validation: standard smoke harness 20/20 against a real 200-file/2.9GB library (including kill/recovery and the batch-1 dest tree carrying over with zero churn — upgrade path exercised), plus a real-ext4 dest-symlink collision scenario: link target untouched, entry replaced with a real mirrored directory, stale dest-only link removed, zero file errors.

## Known limitations (deliberate)

- Case-only renames cost a full recopy of the renamed entry (correct-but-not-clever; a case-folded pairing pass could avoid it later).
- Two links aliasing the same source dir: the first (sort order) wins; the loser is skipped with a per-run file error and its dest counterpart is left untouched. Documented in `claimSrcDir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
