### PR TITLE
fix(backup): API validation hardening (audit batch 3)

### DIFF
--- a/src/api/backup.js
+++ b/src/api/backup.js
@@ -82,7 +82,12 @@ function requireDailyHour(body) {
 // the normalisation is free for paths that don't need it.
 const CASE_FOLD = process.platform === 'win32' || process.platform === 'darwin';
 function normForCompare(p) {
-  let r = path.resolve(p).normalize('NFC') + path.sep;
+  let r = path.resolve(p).normalize('NFC');
+  // Conditional: path.resolve KEEPS the trailing separator for drive
+  // roots ('D:\') and adds one to UNC share roots — blind appending
+  // doubles it ('d:\\'), and a doubled-separator prefix matches nothing,
+  // silently exempting whole-drive library roots from every check.
+  if (!r.endsWith(path.sep)) { r += path.sep; }
   if (CASE_FOLD) { r = r.toLowerCase(); }
   return r;
 }
@@ -111,13 +116,46 @@ async function resolveRealPath(p) {
   return path.resolve(p);   // nothing exists / resolver quirk — lexical fallback
 }
 
+// fs.realpath against an unreachable network path can block for tens of
+// seconds (SMB/NFS timeouts), and these checks run on interactive admin
+// routes — check-path fires on a keystroke debounce, and one dead-NAS
+// destination row would stall EVERY create/PATCH/check-path request
+// while its stored path is resolved. Bound each resolution and fall
+// back to the lexical spelling: a hung resolver must not freeze the
+// admin panel, and the worker's run-time guard re-checks against live
+// filesystem state anyway.
+const REALPATH_TIMEOUT_MS = 1500;
+function resolveRealPathBounded(p) {
+  return Promise.race([
+    resolveRealPath(p),
+    new Promise((resolve) => {
+      const t = setTimeout(() => resolve(path.resolve(p)), REALPATH_TIMEOUT_MS);
+      if (t.unref) { t.unref(); }
+    }),
+  ]);
+}
+
+// Overlap validation awaits filesystem calls between reading the
+// destinations snapshot and writing the row, so two concurrent
+// create/PATCH requests could each miss the other's in-flight insert
+// and both land (SQLite's UNIQUE only catches byte-identical
+// same-library duplicates). Serialise the validate+write sections
+// through a single promise chain — admin CRUD is rare enough that this
+// costs nothing.
+let destWriteChain = Promise.resolve();
+function withDestWriteLock(fn) {
+  const run = destWriteChain.then(fn, fn);
+  destWriteChain = run.then(() => {}, () => {});
+  return run;
+}
+
 // Reject configurations that would create an obvious mirror loop:
 // dest path inside the source library (each backup would copy the
 // previous backup) or vice versa (deleting from dest would propagate
 // into the source library on the next sweep).
 async function checkPathContainment(libraryRoot, destPath) {
-  const lib = normForCompare(await resolveRealPath(libraryRoot));
-  const dest = normForCompare(await resolveRealPath(destPath));
+  const lib = normForCompare(await resolveRealPathBounded(libraryRoot));
+  const dest = normForCompare(await resolveRealPathBounded(destPath));
   if (dest.startsWith(lib)) {
     throw new WebError('Destination path is inside the source library — would create a recursion loop', 400);
   }
@@ -137,11 +175,11 @@ async function checkPathContainment(libraryRoot, destPath) {
 // differently" duplicates that the byte-exact UNIQUE(library_id,
 // dest_path) constraint misses.
 async function checkDestOverlaps(destPath, { libraryId, excludeDestId = null } = {}) {
-  const dest = normForCompare(await resolveRealPath(destPath));
+  const dest = normForCompare(await resolveRealPathBounded(destPath));
 
   for (const lib of db.getAllLibraries()) {
     if (lib.id === libraryId) { continue; }   // own root: checkPathContainment's clearer messages
-    const root = normForCompare(await resolveRealPath(lib.root_path));
+    const root = normForCompare(await resolveRealPathBounded(lib.root_path));
     if (dest.startsWith(root) || root.startsWith(dest)) {
       throw new WebError(`Destination path overlaps library "${lib.name}" (${lib.root_path}) — the backup would be scanned as library content`, 400);
     }
@@ -149,7 +187,7 @@ async function checkDestOverlaps(destPath, { libraryId, excludeDestId = null } =
 
   for (const other of db.getBackupDestinations()) {
     if (excludeDestId !== null && other.id === excludeDestId) { continue; }
-    const otherPath = normForCompare(await resolveRealPath(other.dest_path));
+    const otherPath = normForCompare(await resolveRealPathBounded(other.dest_path));
     if (dest === otherPath) {
       throw new WebError(`A destination already uses this path (destination #${other.id} for library "${other.library_name}")`, 409);
     }
@@ -286,32 +324,36 @@ export function setup(mstream) {
       return res.status(400).json({ error: 'destPath must be an absolute path' });
     }
 
-    await checkPathContainment(library.root_path, value.destPath);
-    await checkDestOverlaps(value.destPath, { libraryId: value.libraryId });
+    // Validation + insert run under the write lock so a concurrent
+    // create/PATCH can't slip an overlapping row in between our
+    // snapshot and our insert (see withDestWriteLock).
+    const dest = await withDestWriteLock(async () => {
+      await checkPathContainment(library.root_path, value.destPath);
+      await checkDestOverlaps(value.destPath, { libraryId: value.libraryId });
 
-    let id;
-    try {
-      id = db.addBackupDestination({
-        libraryId: value.libraryId,
-        destPath: value.destPath,
-        triggerType: value.triggerType,
-        dailyAtHour: value.dailyAtHour,
-        retentionDays: value.retentionDays,
-        enabled: value.enabled,
-        // Caller-provided list goes straight in; omitted → null (defaults
-        // applied lazily at read time via parseExcludeGlobs).
-        excludeGlobs: value.excludeGlobs,
-        interFileDelayMs: value.interFileDelayMs,
-      });
-    } catch (err) {
-      // UNIQUE(library_id, dest_path) collision → friendly 409.
-      if (/UNIQUE/.test(err.message)) {
-        return res.status(409).json({ error: 'A destination already exists for this library + path' });
+      let id;
+      try {
+        id = db.addBackupDestination({
+          libraryId: value.libraryId,
+          destPath: value.destPath,
+          triggerType: value.triggerType,
+          dailyAtHour: value.dailyAtHour,
+          retentionDays: value.retentionDays,
+          enabled: value.enabled,
+          // Caller-provided list goes straight in; omitted → null (defaults
+          // applied lazily at read time via parseExcludeGlobs).
+          excludeGlobs: value.excludeGlobs,
+          interFileDelayMs: value.interFileDelayMs,
+        });
+      } catch (err) {
+        // UNIQUE(library_id, dest_path) collision → friendly 409.
+        if (/UNIQUE/.test(err.message)) {
+          throw new WebError('A destination already exists for this library + path', 409);
+        }
+        throw err;
       }
-      throw err;
-    }
-
-    const dest = db.getBackupDestinationById(id);
+      return db.getBackupDestinationById(id);
+    });
     res.json(withLastRun(dest));
   });
 
@@ -348,11 +390,6 @@ export function setup(mstream) {
       if (!path.isAbsolute(value.destPath)) {
         return res.status(400).json({ error: 'destPath must be an absolute path' });
       }
-      await checkPathContainment(existing.library_root_path, value.destPath);
-      await checkDestOverlaps(value.destPath, {
-        libraryId: existing.library_id,
-        excludeDestId: id,
-      });
       fields.dest_path = value.destPath;
     }
     if (value.triggerType !== undefined) { fields.trigger_type = value.triggerType; }
@@ -376,14 +413,24 @@ export function setup(mstream) {
     };
     requireDailyHour(merged);
 
-    try {
-      db.updateBackupDestination(id, fields);
-    } catch (err) {
-      if (/UNIQUE/.test(err.message)) {
-        return res.status(409).json({ error: 'A destination already exists for this library + path' });
+    // Path validation + update under the write lock, same as create.
+    await withDestWriteLock(async () => {
+      if (value.destPath !== undefined) {
+        await checkPathContainment(existing.library_root_path, value.destPath);
+        await checkDestOverlaps(value.destPath, {
+          libraryId: existing.library_id,
+          excludeDestId: id,
+        });
       }
-      throw err;
-    }
+      try {
+        db.updateBackupDestination(id, fields);
+      } catch (err) {
+        if (/UNIQUE/.test(err.message)) {
+          throw new WebError('A destination already exists for this library + path', 409);
+        }
+        throw err;
+      }
+    });
 
     res.json(withLastRun(db.getBackupDestinationById(id)));
   });
@@ -492,6 +539,11 @@ export function setup(mstream) {
     const schema = Joi.object({
       libraryId: Joi.number().integer().required(),
       destPath: Joi.string().required(),
+      // The destination being EDITED, so the preview can self-exclude
+      // exactly like PATCH does. Without this, the edit dialog's
+      // preview of a destination's own unchanged path reports
+      // "already uses this path" and the Save gate never opens.
+      excludeDestId: Joi.number().integer().optional(),
     });
     const { value } = joiValidate(schema, req.body);
 
@@ -528,7 +580,10 @@ export function setup(mstream) {
     // what create/PATCH would reject, or the UI's submit gate lies.
     if (errors.length === 0) {
       try {
-        await checkDestOverlaps(value.destPath, { libraryId: value.libraryId });
+        await checkDestOverlaps(value.destPath, {
+          libraryId: value.libraryId,
+          excludeDestId: value.excludeDestId ?? null,
+        });
       } catch (err) {
         errors.push(err.message);
       }

--- a/src/api/backup.js
+++ b/src/api/backup.js
@@ -14,6 +14,7 @@ import Joi from 'joi';
 import * as db from '../db/manager.js';
 import * as backupManager from '../backup/manager.js';
 import { joiValidate } from '../util/validation.js';
+import WebError from '../util/web-error.js';
 
 const TRIGGER_TYPES = ['after-scan', 'daily', 'manual'];
 
@@ -52,18 +53,17 @@ function validateExcludeGlobs(globs) {
 
 // Daily-at-hour is required when triggerType=daily, optional otherwise.
 // Validated together rather than as a Joi conditional so the error
-// message is clearer.
+// message is clearer. WebError so the global handler answers 400 —
+// a plain Error here used to surface as a bare 500 'Server Error'
+// with the message swallowed.
 function requireDailyHour(body) {
   if (body.triggerType === 'daily' && (body.dailyAtHour == null)) {
-    throw new Error("dailyAtHour is required when triggerType is 'daily'");
+    throw new WebError("dailyAtHour is required when triggerType is 'daily'", 400);
   }
 }
 
-// Reject configurations that would create an obvious mirror loop:
-// dest path inside the source library (each backup would copy the
-// previous backup) or vice versa (deleting from dest would propagate
-// into the source library on the next sweep). Compares with trailing-
-// separator normalisation so /music isn't seen as a prefix of /musical.
+// Path comparison normalisation, shared by every containment/overlap
+// check below. Trailing-separator so /music isn't a prefix of /musical.
 //
 // Case-folded on Windows AND macOS because both NTFS/exFAT/FAT32 and
 // the default APFS/HFS+ are case-INSENSITIVE — `C:\Music` and
@@ -80,20 +80,82 @@ function requireDailyHour(body) {
 // without normalisation can miss a match (the same logical filename
 // in NFC and NFD forms differs as raw bytes). NFC is idempotent so
 // the normalisation is free for paths that don't need it.
-function checkPathContainment(libraryRoot, destPath) {
-  const caseFold = process.platform === 'win32' || process.platform === 'darwin';
-  const norm = (p) => {
-    let r = path.resolve(p).normalize('NFC') + path.sep;
-    if (caseFold) { r = r.toLowerCase(); }
-    return r;
-  };
-  const lib = norm(libraryRoot);
-  const dest = norm(destPath);
+const CASE_FOLD = process.platform === 'win32' || process.platform === 'darwin';
+function normForCompare(p) {
+  let r = path.resolve(p).normalize('NFC') + path.sep;
+  if (CASE_FOLD) { r = r.toLowerCase(); }
+  return r;
+}
+
+// Resolve a path to its REAL location before comparing: a symlink or
+// junction anywhere in the chain is what containment must be judged
+// against, not the lexical spelling — `/backup` pointing into `/music`
+// passes every string comparison while creating exactly the recursion
+// loop the checks exist to prevent. The path may not exist yet (a fresh
+// dest is created on the first run), so walk up to the deepest EXISTING
+// ancestor, realpath that, and re-append the not-yet-existing tail.
+async function resolveRealPath(p) {
+  let probe = path.resolve(p);
+  const tail = [];
+  for (let i = 0; i < 64; i++) {
+    try {
+      const real = await fs.realpath(probe);
+      return tail.length > 0 ? path.join(real, ...tail) : real;
+    } catch (_) {
+      const parent = path.dirname(probe);
+      if (parent === probe) { break; }
+      tail.unshift(path.basename(probe));
+      probe = parent;
+    }
+  }
+  return path.resolve(p);   // nothing exists / resolver quirk — lexical fallback
+}
+
+// Reject configurations that would create an obvious mirror loop:
+// dest path inside the source library (each backup would copy the
+// previous backup) or vice versa (deleting from dest would propagate
+// into the source library on the next sweep).
+async function checkPathContainment(libraryRoot, destPath) {
+  const lib = normForCompare(await resolveRealPath(libraryRoot));
+  const dest = normForCompare(await resolveRealPath(destPath));
   if (dest.startsWith(lib)) {
-    throw new Error('Destination path is inside the source library — would create a recursion loop');
+    throw new WebError('Destination path is inside the source library — would create a recursion loop', 400);
   }
   if (lib.startsWith(dest)) {
-    throw new Error('Source library is inside the destination path — would propagate edits back to the library');
+    throw new WebError('Source library is inside the destination path — would propagate edits back to the library', 400);
+  }
+}
+
+// Cross-object overlap validation. A destination may not overlap ANY
+// library root (a backup tree inside another library gets scanned and
+// indexed as music, then possibly re-backed-up), nor ANY other
+// destination (two mirror jobs sharing a hierarchy each classify the
+// other's files as orphans and repeatedly destroy each other's mirror —
+// a nested destination's .mstream-trash reads as just another orphan
+// dir to the outer job). Path equality after real-path resolution and
+// case/separator normalisation also catches the "same path spelled
+// differently" duplicates that the byte-exact UNIQUE(library_id,
+// dest_path) constraint misses.
+async function checkDestOverlaps(destPath, { libraryId, excludeDestId = null } = {}) {
+  const dest = normForCompare(await resolveRealPath(destPath));
+
+  for (const lib of db.getAllLibraries()) {
+    if (lib.id === libraryId) { continue; }   // own root: checkPathContainment's clearer messages
+    const root = normForCompare(await resolveRealPath(lib.root_path));
+    if (dest.startsWith(root) || root.startsWith(dest)) {
+      throw new WebError(`Destination path overlaps library "${lib.name}" (${lib.root_path}) — the backup would be scanned as library content`, 400);
+    }
+  }
+
+  for (const other of db.getBackupDestinations()) {
+    if (excludeDestId !== null && other.id === excludeDestId) { continue; }
+    const otherPath = normForCompare(await resolveRealPath(other.dest_path));
+    if (dest === otherPath) {
+      throw new WebError(`A destination already uses this path (destination #${other.id} for library "${other.library_name}")`, 409);
+    }
+    if (dest.startsWith(otherPath) || otherPath.startsWith(dest)) {
+      throw new WebError(`Destination path overlaps destination #${other.id} (${other.dest_path}) — nested mirror jobs repeatedly destroy each other's copies`, 400);
+    }
   }
 }
 
@@ -189,7 +251,11 @@ export function setup(mstream) {
   });
 
   // ── Create a destination ─────────────────────────────────────────
-  mstream.post('/api/v1/admin/backup/destinations', (req, res) => {
+  //
+  // Async handler: the containment/overlap checks realpath the world,
+  // and their WebError rejections flow to the global error handler
+  // (Express 5 forwards async rejections).
+  mstream.post('/api/v1/admin/backup/destinations', async (req, res) => {
     const schema = Joi.object({
       libraryId: Joi.number().integer().required(),
       destPath: Joi.string().required(),
@@ -220,11 +286,8 @@ export function setup(mstream) {
       return res.status(400).json({ error: 'destPath must be an absolute path' });
     }
 
-    try {
-      checkPathContainment(library.root_path, value.destPath);
-    } catch (err) {
-      return res.status(400).json({ error: err.message });
-    }
+    await checkPathContainment(library.root_path, value.destPath);
+    await checkDestOverlaps(value.destPath, { libraryId: value.libraryId });
 
     let id;
     try {
@@ -253,7 +316,7 @@ export function setup(mstream) {
   });
 
   // ── Update a destination (partial) ───────────────────────────────
-  mstream.patch('/api/v1/admin/backup/destinations/:id', (req, res) => {
+  mstream.patch('/api/v1/admin/backup/destinations/:id', async (req, res) => {
     const id = Number(req.params.id);
     const existing = db.getBackupDestinationById(id);
     if (!existing) { return res.status(404).json({ error: 'Destination not found' }); }
@@ -285,11 +348,11 @@ export function setup(mstream) {
       if (!path.isAbsolute(value.destPath)) {
         return res.status(400).json({ error: 'destPath must be an absolute path' });
       }
-      try {
-        checkPathContainment(existing.library_root_path, value.destPath);
-      } catch (err) {
-        return res.status(400).json({ error: err.message });
-      }
+      await checkPathContainment(existing.library_root_path, value.destPath);
+      await checkDestOverlaps(value.destPath, {
+        libraryId: existing.library_id,
+        excludeDestId: id,
+      });
       fields.dest_path = value.destPath;
     }
     if (value.triggerType !== undefined) { fields.trigger_type = value.triggerType; }
@@ -358,7 +421,9 @@ export function setup(mstream) {
     const existing = db.getBackupDestinationById(id);
     if (!existing) { return res.status(404).json({ error: 'Destination not found' }); }
 
-    const limit = Math.min(Number(req.query.limit) || 50, 500);
+    // Clamp to [1, 500] integers. Fractionals reach SQLite's LIMIT as-is
+    // and negatives mean UNLIMITED there — both bypassed the cap.
+    const limit = Math.min(Math.max(Math.trunc(Number(req.query.limit)) || 50, 1), 500);
     res.json({ history: db.getBackupHistory(id, limit) });
   });
 
@@ -453,7 +518,17 @@ export function setup(mstream) {
 
     if (errors.length === 0) {
       try {
-        checkPathContainment(library.root_path, value.destPath);
+        await checkPathContainment(library.root_path, value.destPath);
+      } catch (err) {
+        errors.push(err.message);
+      }
+    }
+
+    // Overlap checks are hard errors too — the preview must agree with
+    // what create/PATCH would reject, or the UI's submit gate lies.
+    if (errors.length === 0) {
+      try {
+        await checkDestOverlaps(value.destPath, { libraryId: value.libraryId });
       } catch (err) {
         errors.push(err.message);
       }

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -1123,32 +1123,44 @@ async function trashDestEntry(destEntry, destDir, relPath) {
     }, 1);
   }
 
-  // Ensure dest exists. mkdir -p handles a fresh-formatted backup drive
-  // on its first run; failure here means the path is unreachable
-  // (unmounted, permission denied, parent missing on a read-only mount).
-  try {
-    await ensureDir(destPath);
-  } catch (err) {
-    await emitAndExit({ event: 'error', message: `Destination unavailable: ${err.message}` }, 1);
-  }
-
   // Defense-in-depth against symlinked configs: containment is validated
   // at configuration time (api/backup.js realpaths both sides), but a
   // link anywhere in either chain can change AFTER the destination was
   // saved. If source and dest now resolve into the same hierarchy,
   // refuse — mirroring into the library, or sweeping the library as
   // "dest orphans", is the loop the config-time check exists to prevent.
-  // realpath failure skips the check (resolver quirks must not block
-  // backups; the config-time validation remains the primary guard).
-  let realSrc = null;
-  let realDest = null;
-  try {
-    realSrc = await fs.realpath(sourcePath);
-    realDest = await fs.realpath(destPath);
-  } catch (_) { /* resolver quirk — config-time check is the guard */ }
-  if (realSrc !== null && realDest !== null) {
+  //
+  // Runs BEFORE ensureDir: the dest may not exist yet, so resolve via
+  // walk-up (deepest existing ancestor's realpath + the lexical tail,
+  // mirroring api/backup.js's resolveRealPath) — mkdir'ing first would
+  // create real directories INSIDE the library through the swapped
+  // link before the guard fires. Walk-up never throws; a resolver
+  // quirk degrades to the lexical spelling, same as at config time.
+  const resolveWalkUp = async (p) => {
+    let probe = path.resolve(p);
+    const tail = [];
+    for (let i = 0; i < 64; i++) {
+      try {
+        const real = await fs.realpath(probe);
+        return tail.length > 0 ? path.join(real, ...tail) : real;
+      } catch (_) {
+        const parent = path.dirname(probe);
+        if (parent === probe) { break; }
+        tail.unshift(path.basename(probe));
+        probe = parent;
+      }
+    }
+    return path.resolve(p);
+  };
+  const realSrc = await resolveWalkUp(sourcePath);
+  const realDest = await resolveWalkUp(destPath);
+  {
     const fold = (p) => {
-      let r = p.normalize('NFC') + path.sep;
+      let r = p.normalize('NFC');
+      // Conditional append: realpath keeps the trailing separator for
+      // drive roots ('C:\'); doubling it would match nothing and
+      // silently exempt whole-drive libraries from the guard.
+      if (!r.endsWith(path.sep)) { r += path.sep; }
       if (process.platform === 'win32' || process.platform === 'darwin') { r = r.toLowerCase(); }
       return r;
     };
@@ -1160,6 +1172,15 @@ async function trashDestEntry(destEntry, destDir, relPath) {
         message: `Destination resolves into the source library hierarchy (source: ${realSrc}, destination: ${realDest}) — refusing to run`,
       }, 1);
     }
+  }
+
+  // Ensure dest exists. mkdir -p handles a fresh-formatted backup drive
+  // on its first run; failure here means the path is unreachable
+  // (unmounted, permission denied, parent missing on a read-only mount).
+  try {
+    await ensureDir(destPath);
+  } catch (err) {
+    await emitAndExit({ event: 'error', message: `Destination unavailable: ${err.message}` }, 1);
   }
 
   // Probe timestamp fidelity before the walk so the unchanged check

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -1132,6 +1132,36 @@ async function trashDestEntry(destEntry, destDir, relPath) {
     await emitAndExit({ event: 'error', message: `Destination unavailable: ${err.message}` }, 1);
   }
 
+  // Defense-in-depth against symlinked configs: containment is validated
+  // at configuration time (api/backup.js realpaths both sides), but a
+  // link anywhere in either chain can change AFTER the destination was
+  // saved. If source and dest now resolve into the same hierarchy,
+  // refuse — mirroring into the library, or sweeping the library as
+  // "dest orphans", is the loop the config-time check exists to prevent.
+  // realpath failure skips the check (resolver quirks must not block
+  // backups; the config-time validation remains the primary guard).
+  let realSrc = null;
+  let realDest = null;
+  try {
+    realSrc = await fs.realpath(sourcePath);
+    realDest = await fs.realpath(destPath);
+  } catch (_) { /* resolver quirk — config-time check is the guard */ }
+  if (realSrc !== null && realDest !== null) {
+    const fold = (p) => {
+      let r = p.normalize('NFC') + path.sep;
+      if (process.platform === 'win32' || process.platform === 'darwin') { r = r.toLowerCase(); }
+      return r;
+    };
+    const s = fold(realSrc);
+    const d = fold(realDest);
+    if (s.startsWith(d) || d.startsWith(s)) {
+      await emitAndExit({
+        event: 'error',
+        message: `Destination resolves into the source library hierarchy (source: ${realSrc}, destination: ${realDest}) — refusing to run`,
+      }, 1);
+    }
+  }
+
   // Probe timestamp fidelity before the walk so the unchanged check
   // knows which comparison to trust (see probeDestMtimeFidelity).
   await probeDestMtimeFidelity();

--- a/test/integration/backup-api.test.mjs
+++ b/test/integration/backup-api.test.mjs
@@ -222,6 +222,26 @@ describe('backup API: validation hardening', () => {
     assert.ok(json.errors.some((e) => /overlaps destination/i.test(e)));
   });
 
+  test('check-path self-excludes for the edit flow (own unchanged path is OK)', async () => {
+    // The edit dialog previews the destination's OWN current path on
+    // open. Without excludeDestId the equality check matches the
+    // destination's own row and the Save gate never opens — every
+    // existing destination's edit dialog would be bricked.
+    const withExclude = await api('POST', '/api/v1/admin/backup/check-path', {
+      libraryId: libAId, destPath: path.join(destsDir, 'backA'), excludeDestId: destAId,
+    });
+    assert.equal(withExclude.status, 200);
+    assert.equal(withExclude.json.ok, true,
+      'previewing a destination against its own path must not self-collide');
+
+    // The create flow (no excludeDestId) must still catch the duplicate.
+    const withoutExclude = await api('POST', '/api/v1/admin/backup/check-path', {
+      libraryId: libAId, destPath: path.join(destsDir, 'backA'),
+    });
+    assert.equal(withoutExclude.json.ok, false);
+    assert.ok(withoutExclude.json.errors.some((e) => /already uses this path/i.test(e)));
+  });
+
   test('history limit is clamped to [1, 500] integers', async () => {
     await waitForIdle();   // boot scans may still hold the queue
     for (let i = 0; i < 3; i++) {
@@ -247,31 +267,41 @@ describe('backup API: validation hardening', () => {
 // ── worker defense-in-depth ─────────────────────────────────────────────────
 
 describe('backup worker: run-time containment guard', () => {
-  test('dest resolving into the source hierarchy refuses to run', async () => {
+  test('dest resolving into the source hierarchy refuses to run, before any mkdir', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-bwguard-'));
-    const src = path.join(root, 'src');
-    fs.mkdirSync(path.join(src, 'sub'), { recursive: true });
-    fs.writeFileSync(path.join(src, 'track.mp3'), 'data');
-    // The config-time check passed when this destination was saved;
-    // the link was swapped afterwards.
-    const dest = path.join(root, 'dest-link');
-    fs.symlinkSync(path.join(src, 'sub'), dest, 'junction');
+    try {
+      const src = path.join(root, 'src');
+      fs.mkdirSync(path.join(src, 'sub'), { recursive: true });
+      fs.writeFileSync(path.join(src, 'track.mp3'), 'data');
+      // The config-time check passed when this destination was saved;
+      // the link was swapped afterwards. The NOT-YET-EXISTING tail
+      // ('mirror') forces the guard's walk-up resolution AND pins the
+      // guard-before-ensureDir ordering: mkdir'ing first would create a
+      // real directory inside the library through the link.
+      const link = path.join(root, 'dest-link');
+      fs.symlinkSync(path.join(src, 'sub'), link, 'junction');
+      const dest = path.join(link, 'mirror');
 
-    const result = await new Promise((resolve, reject) => {
-      const child = spawn(process.execPath,
-        [WORKER, JSON.stringify({ sourcePath: src, destPath: dest, retentionDays: 30 })],
-        { stdio: ['ignore', 'pipe', 'pipe'] });
-      let out = '';
-      child.stdout.on('data', (d) => { out += d.toString(); });
-      child.on('error', reject);
-      child.on('close', (code) => resolve({ code, out }));
-    });
+      const result = await new Promise((resolve, reject) => {
+        const child = spawn(process.execPath,
+          [WORKER, JSON.stringify({ sourcePath: src, destPath: dest, retentionDays: 30 })],
+          { stdio: ['ignore', 'pipe', 'pipe'] });
+        let out = '';
+        // Watchdog: if the guard ever regresses, the worker would start
+        // a real (potentially unbounded, self-recursive) mirror run —
+        // kill it instead of hanging the suite while it floods the disk.
+        const killer = setTimeout(() => child.kill('SIGKILL'), 30_000);
+        child.stdout.on('data', (d) => { out += d.toString(); });
+        child.on('error', (err) => { clearTimeout(killer); reject(err); });
+        child.on('close', (code) => { clearTimeout(killer); resolve({ code, out }); });
+      });
 
-    assert.equal(result.code, 1, 'worker must refuse instead of mirroring the library into itself');
-    assert.match(result.out, /resolves into the source library/i);
-    // Nothing may have been mirrored through the link.
-    assert.deepEqual(fs.readdirSync(path.join(src, 'sub')), [],
-      'the linked-into subdir must be untouched');
-    fs.rmSync(root, { recursive: true, force: true });
+      assert.equal(result.code, 1, 'worker must refuse instead of mirroring the library into itself');
+      assert.match(result.out, /resolves into the source library/i);
+      assert.deepEqual(fs.readdirSync(path.join(src, 'sub')), [],
+        'the linked-into subdir must be untouched — the guard must fire before ensureDir');
+    } finally {
+      try { fs.rmSync(root, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
+    }
   });
 });

--- a/test/integration/backup-api.test.mjs
+++ b/test/integration/backup-api.test.mjs
@@ -1,0 +1,277 @@
+/**
+ * Backup admin-API validation hardening (audit batch 3).
+ *
+ * Drives a REAL server (test/helpers/server.mjs) with two extra
+ * libraries and exercises the create/PATCH/check-path validation
+ * surface end-to-end:
+ *
+ *   - checkPathContainment resolves symlinks/junctions before comparing
+ *     — a dest path that RESOLVES into a library root is rejected even
+ *     though its lexical spelling passes every string check.
+ *   - Cross-object overlap validation: a destination may not overlap
+ *     any OTHER library's root (backup trees would be scanned as
+ *     music), nor any other destination (nested mirror jobs repeatedly
+ *     destroy each other's copies). Equality after normalisation also
+ *     catches trailing-separator duplicates the byte-exact UNIQUE
+ *     constraint misses.
+ *   - requireDailyHour surfaces as 400 (was an uncaught plain Error
+ *     -> 500 'Server Error' with the message swallowed).
+ *   - The history `limit` query param is clamped to [1, 500] integers
+ *     (negatives meant UNLIMITED to SQLite; fractionals passed through).
+ *   - check-path (the UI's preview) reports the same hard errors that
+ *     create/PATCH enforce.
+ *
+ * Plus the worker-side defense-in-depth guard (direct spawn, no
+ * server): a dest that resolves into the source hierarchy at RUN time
+ * — e.g. a link swapped after the destination was configured — refuses
+ * to run.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { startServer } from '../helpers/server.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(REPO_ROOT, 'src', 'backup', 'worker.mjs');
+
+const ADMIN = { username: 'backup-admin', password: 'pw-backup' };
+
+describe('backup API: validation hardening', () => {
+  let server, token, root, libAId, libBId;
+  let libARoot, libBRoot, destsDir;
+  let destAId;   // canonical pre-existing destination used by overlap tests
+
+  async function api(method, p, body) {
+    const r = await fetch(`${server.baseUrl}${p}`, {
+      method,
+      headers: { 'Content-Type': 'application/json', 'x-access-token': token },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    let json = null;
+    try { json = await r.json(); } catch (_) { /* non-JSON error body */ }
+    return { status: r.status, json };
+  }
+
+  async function waitForIdle(timeoutMs = 60_000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const { json } = await api('GET', '/api/v1/admin/backup/status');
+      if (json && json.active === null && json.queueLength === 0) { return; }
+      await sleep(100);
+    }
+    throw new Error('backup/scan queue did not drain');
+  }
+
+  before(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-bapi-'));
+    libARoot = path.join(root, 'libs', 'A');
+    libBRoot = path.join(root, 'libs', 'B');
+    destsDir = path.join(root, 'dests');
+    fs.mkdirSync(path.join(libARoot, 'sub'), { recursive: true });
+    fs.mkdirSync(libBRoot, { recursive: true });
+    fs.mkdirSync(destsDir, { recursive: true });
+    // Tiny fake tracks so manual runs have something to mirror.
+    fs.writeFileSync(path.join(libARoot, 'a1.mp3'), 'a1');
+    fs.writeFileSync(path.join(libARoot, 'a2.mp3'), 'a2');
+    fs.writeFileSync(path.join(libBRoot, 'b1.mp3'), 'b1');
+
+    server = await startServer({
+      waitForScan: false,
+      users: [{ ...ADMIN, admin: true, vpaths: ['testlib', 'libA', 'libB'] }],
+      extraFolders: { libA: libARoot, libB: libBRoot },
+    });
+
+    const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ADMIN),
+    });
+    token = (await r.json()).token;
+    assert.ok(token, 'admin login must succeed');
+
+    const dirs = await api('GET', '/api/v1/admin/directories');
+    libAId = dirs.json.libA.id;
+    libBId = dirs.json.libB.id;
+    assert.ok(libAId && libBId);
+  });
+
+  after(async () => {
+    if (server) { await server.stop(); }
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
+  });
+
+  test('control: a clean destination is accepted', async () => {
+    const { status, json } = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libAId, destPath: path.join(destsDir, 'backA'), triggerType: 'manual',
+    });
+    assert.equal(status, 200);
+    destAId = json.id;
+    assert.ok(destAId);
+  });
+
+  test('dest path that RESOLVES into the library root is rejected (symlink bypass)', async () => {
+    const evil = path.join(root, 'evil-link');
+    fs.symlinkSync(path.join(libARoot, 'sub'), evil, 'junction');
+    const { status, json } = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libAId, destPath: evil, triggerType: 'manual',
+    });
+    assert.equal(status, 400,
+      'lexically-disjoint path resolving inside the library must be rejected');
+    assert.match(json.error, /inside the source library/i);
+  });
+
+  test('a not-yet-existing dest whose PARENT resolves into the library is rejected', async () => {
+    const evil = path.join(root, 'evil-link2');
+    fs.symlinkSync(libARoot, evil, 'junction');
+    const { status, json } = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libAId, destPath: path.join(evil, 'brand-new-dir'), triggerType: 'manual',
+    });
+    assert.equal(status, 400, 'walk-up realpath must resolve the existing ancestor');
+    assert.match(json.error, /inside the source library/i);
+  });
+
+  test('dest inside a DIFFERENT library root is rejected', async () => {
+    const { status, json } = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libAId, destPath: path.join(libBRoot, 'backup'), triggerType: 'manual',
+    });
+    assert.equal(status, 400,
+      'pre-batch-3 this was accepted and the backup tree got scanned as music');
+    assert.match(json.error, /overlaps library "libB"/i);
+  });
+
+  test('same path for another library is rejected as a duplicate', async () => {
+    const { status, json } = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libBId, destPath: path.join(destsDir, 'backA'), triggerType: 'manual',
+    });
+    assert.equal(status, 409, 'UNIQUE only covers the same library — cross-library needs the overlap check');
+    assert.match(json.error, /already uses this path/i);
+  });
+
+  test('trailing-separator spelling of an existing dest path is rejected', async () => {
+    const { status } = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libBId, destPath: path.join(destsDir, 'backA') + path.sep, triggerType: 'manual',
+    });
+    assert.equal(status, 409, 'normalisation must collapse trailing-separator variants');
+  });
+
+  test('dest nested inside another destination is rejected (both directions)', async () => {
+    const nested = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libBId, destPath: path.join(destsDir, 'backA', 'nested'), triggerType: 'manual',
+    });
+    assert.equal(nested.status, 400,
+      'pre-batch-3 the outer job swept the inner mirror as orphans every run');
+    assert.match(nested.json.error, /overlaps destination/i);
+
+    const parent = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libBId, destPath: destsDir, triggerType: 'manual',
+    });
+    assert.equal(parent.status, 400);
+    assert.match(parent.json.error, /overlaps destination/i);
+  });
+
+  test('PATCH destPath gets the same overlap validation, excluding itself', async () => {
+    const created = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libBId, destPath: path.join(destsDir, 'backB'), triggerType: 'manual',
+    });
+    assert.equal(created.status, 200);
+    const destBId = created.json.id;
+
+    const bad = await api('PATCH', `/api/v1/admin/backup/destinations/${destBId}`, {
+      destPath: path.join(destsDir, 'backA', 'sub'),
+    });
+    assert.equal(bad.status, 400);
+    assert.match(bad.json.error, /overlaps destination/i);
+
+    // Re-asserting its own current path must NOT self-collide.
+    const self = await api('PATCH', `/api/v1/admin/backup/destinations/${destBId}`, {
+      destPath: path.join(destsDir, 'backB'),
+    });
+    assert.equal(self.status, 200, 'a destination must not overlap-collide with itself');
+  });
+
+  test('daily without an hour is a 400, not a 500', async () => {
+    const create = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libBId, destPath: path.join(destsDir, 'daily'), triggerType: 'daily',
+    });
+    assert.equal(create.status, 400, 'pre-batch-3 this surfaced as 500 Server Error');
+    assert.match(create.json.error, /dailyAtHour is required/i);
+
+    const created = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libBId, destPath: path.join(destsDir, 'daily'), triggerType: 'daily', dailyAtHour: 3,
+    });
+    assert.equal(created.status, 200);
+    const patch = await api('PATCH', `/api/v1/admin/backup/destinations/${created.json.id}`, {
+      dailyAtHour: null,
+    });
+    assert.equal(patch.status, 400, 'clearing the hour while daily must be a client error');
+    assert.match(patch.json.error, /dailyAtHour is required/i);
+  });
+
+  test('check-path preview reports the same hard errors as create', async () => {
+    const { status, json } = await api('POST', '/api/v1/admin/backup/check-path', {
+      libraryId: libBId, destPath: path.join(destsDir, 'backA', 'nested'),
+    });
+    assert.equal(status, 200);
+    assert.equal(json.ok, false, 'preview must agree with what create would reject');
+    assert.ok(json.errors.some((e) => /overlaps destination/i.test(e)));
+  });
+
+  test('history limit is clamped to [1, 500] integers', async () => {
+    await waitForIdle();   // boot scans may still hold the queue
+    for (let i = 0; i < 3; i++) {
+      const run = await api('POST', `/api/v1/admin/backup/destinations/${destAId}/run`);
+      assert.equal(run.status, 200);
+      await waitForIdle();
+    }
+    const all = await api('GET', `/api/v1/admin/backup/destinations/${destAId}/history`);
+    assert.ok(all.json.history.length >= 3, 'three runs must have recorded history');
+
+    const neg = await api('GET', `/api/v1/admin/backup/destinations/${destAId}/history?limit=-1`);
+    assert.equal(neg.json.history.length, 1,
+      'negative limit must clamp to 1 — SQLite treats LIMIT -1 as UNLIMITED');
+
+    const frac = await api('GET', `/api/v1/admin/backup/destinations/${destAId}/history?limit=1.9`);
+    assert.equal(frac.json.history.length, 1, 'fractional limit must truncate');
+
+    const junk = await api('GET', `/api/v1/admin/backup/destinations/${destAId}/history?limit=abc`);
+    assert.ok(junk.json.history.length >= 3, 'junk limit falls back to the default');
+  });
+});
+
+// ── worker defense-in-depth ─────────────────────────────────────────────────
+
+describe('backup worker: run-time containment guard', () => {
+  test('dest resolving into the source hierarchy refuses to run', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-bwguard-'));
+    const src = path.join(root, 'src');
+    fs.mkdirSync(path.join(src, 'sub'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'track.mp3'), 'data');
+    // The config-time check passed when this destination was saved;
+    // the link was swapped afterwards.
+    const dest = path.join(root, 'dest-link');
+    fs.symlinkSync(path.join(src, 'sub'), dest, 'junction');
+
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath,
+        [WORKER, JSON.stringify({ sourcePath: src, destPath: dest, retentionDays: 30 })],
+        { stdio: ['ignore', 'pipe', 'pipe'] });
+      let out = '';
+      child.stdout.on('data', (d) => { out += d.toString(); });
+      child.on('error', reject);
+      child.on('close', (code) => resolve({ code, out }));
+    });
+
+    assert.equal(result.code, 1, 'worker must refuse instead of mirroring the library into itself');
+    assert.match(result.out, /resolves into the source library/i);
+    // Nothing may have been mirrored through the link.
+    assert.deepEqual(fs.readdirSync(path.join(src, 'sub')), [],
+      'the linked-into subdir must be untouched');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -9289,7 +9289,14 @@ const backupEditModal = Vue.component('backup-edit-modal', {
         const res = await API.axios({
           method: 'POST',
           url: `${API.url()}/api/v1/admin/backup/check-path`,
-          data: { libraryId: this.destination.library_id, destPath: this.destPath },
+          data: {
+            libraryId: this.destination.library_id,
+            destPath: this.destPath,
+            // Self-exclude, exactly like the PATCH this dialog submits —
+            // otherwise previewing the destination's own unchanged path
+            // reports "already uses this path" and Save never enables.
+            excludeDestId: this.destination.id,
+          },
         });
         this.checkErrors = res.data.errors || [];
         this.checkWarnings = res.data.warnings || [];


### PR DESCRIPTION
Batch 3 of the backup-feature audit fixes: the API validation group. Batches 1 (#724) and 2 (#725) hardened the worker; this one closes the configuration-time holes that let dangerous destinations be saved in the first place.

## Fixes

### 1. Containment checks resolve symlinks (`api/backup.js`)

`checkPathContainment` compared lexically-resolved strings, so a destPath (or library root) that is a symlink/junction into the other side passed every check while creating exactly the recursion loop it exists to prevent. Both sides now resolve through `resolveRealPath`: walk up to the deepest **existing** ancestor, `fs.realpath` it, re-append the not-yet-existing tail — a fresh destination doesn't exist before its first run, but its eventual real location is what containment must be judged against.

### 2. Cross-object overlap validation (new `checkDestOverlaps`)

Previously only the destination's own library was checked. Now rejected, on create, PATCH, and in the check-path preview:

- **dest overlapping any other library root** (400) — the backup tree was scanned and indexed as music, then potentially re-backed-up
- **dest equal to any other destination** (409) — after real-path resolution and case/separator normalisation, which also catches the trailing-slash/case duplicates the byte-exact `UNIQUE(library_id, dest_path)` misses
- **dest nested inside / containing another destination** (400) — nested mirror jobs classify each other's files as orphans and repeatedly destroy each other's copies; a nested destination's `.mstream-trash` reads as just another orphan dir to the outer job

### 3. Run-time defense-in-depth in the worker

Links can change *after* a destination was validated. The worker now walk-up-resolves source and dest at startup — **before** any `mkdir` — and refuses fatally when they land in the same hierarchy.

### 4. Error-code and parameter hygiene

- `requireDailyHour` throws `WebError(400)` — a daily destination without an hour used to surface as an uncaught plain Error → 500 with the message swallowed (create + PATCH handlers are async now; Express 5 forwards rejections to the global handler)
- History `limit` clamped to [1, 500] integers — negative values meant **unlimited** to SQLite's `LIMIT`, fractionals passed through raw

## Review round (second commit)

The adversarial review pass confirmed six root defects in the first commit, all fixed:

- **Critical: `check-path` had no self-exclusion.** The edit dialog previews the destination's own current path on open; the new overlap check matched the destination's own row and returned "already uses this path" — permanently disabling Save for **every existing destination**. Both verifiers repro'd end-to-end. `check-path` now accepts `excludeDestId` (mirroring PATCH) and the edit modal sends it.
- Drive-root paths (`D:\`, POSIX `/`, UNC share roots) were silently exempt from every check: `path.resolve` keeps the trailing separator on roots, so the unconditional `+ path.sep` doubled it and the prefix matched nothing. Separator now appended conditionally in `normForCompare` and the worker's `fold()`.
- The worker guard ran after `ensureDir` — a swapped link still got real directories mkdir'd inside the library before the refusal. Guard now runs first, with walk-up resolution for not-yet-existing dests.
- One offline network destination stalled every backup admin endpoint (serial unbounded `realpath`; check-path fires per keystroke debounce) — resolutions bounded at 1.5s with lexical fallback.
- Concurrent create/PATCH could both pass validation and insert overlapping rows (awaits between snapshot and insert) — validate+write now serialises through a promise chain.
- The worker-guard test could hang indefinitely if the guard regressed — 30s SIGKILL watchdog, `finally` cleanup, and the dest now uses a non-existent tail so the test pins walk-up resolution and guard-before-mkdir ordering.

## Tests + validation

`test/integration/backup-api.test.mjs` (13 tests) drives a **real server**: junction-based bypass attempts, walk-up resolution for brand-new dest dirs, cross-library duplicates, nesting both directions, PATCH self-exclusion, check-path parity (both edit and create flows), the 500→400s, the limit clamp, and the worker guard via direct spawn. Full suite 60/60 across the backup/task-queue files; lint at master baseline.

Rig validation: standard smoke harness 20/20 (the harness's create/reuse flow exercised the new validation against real `/media` paths — no upgrade false-positives), plus six targeted API checks against the rig's live config, including edit-flow self-exclusion and PATCH-of-unrelated-fields on a pre-existing destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
