### PR TITLE
fix(backup): lifecycle, scheduler & error-surfacing hardening (audit batch 4)

### DIFF
--- a/src/api/backup.js
+++ b/src/api/backup.js
@@ -521,7 +521,7 @@ export function setup(mstream) {
       return res.json({ active: null, queueLength: backupManager.getQueueLength() });
     }
     const liveRow = db.getBackupHistoryRowById(activeRun.historyId);
-    const prevRun = db.getLastSuccessfulBackupBefore(activeRun.destinationId, activeRun.historyId);
+    const prevRun = db.getLastCountedBackupBefore(activeRun.destinationId, activeRun.historyId);
 
     // Sum of all entries the previous run processed (whether copied,
     // skipped-unchanged, or trashed-as-orphan). Same denominator the

--- a/src/api/backup.js
+++ b/src/api/backup.js
@@ -10,6 +10,7 @@
 import path from 'path';
 import fs from 'fs/promises';
 import os from 'os';
+import winston from 'winston';
 import Joi from 'joi';
 import * as db from '../db/manager.js';
 import * as backupManager from '../backup/manager.js';
@@ -432,6 +433,13 @@ export function setup(mstream) {
       }
     });
 
+    // A path change abandons the old location's .mstream-trash — the
+    // retention sweep only visits CURRENT dest paths. Deleting it here
+    // would destroy the user's deletion log, so just say it out loud.
+    if (fields.dest_path !== undefined && fields.dest_path !== existing.dest_path) {
+      winston.warn(`Backup: destination #${id} moved from ${existing.dest_path} — its old .mstream-trash (if any) is no longer swept; remove it manually if unwanted`);
+    }
+
     res.json(withLastRun(db.getBackupDestinationById(id)));
   });
 
@@ -440,6 +448,14 @@ export function setup(mstream) {
     const id = Number(req.params.id);
     const existing = db.getBackupDestinationById(id);
     if (!existing) { return res.status(404).json({ error: 'Destination not found' }); }
+    // Purge queued runs and kill the active worker BEFORE the row goes:
+    // otherwise a running backup kept mirroring for hours to a config
+    // the user just deleted, with its history row cascade-deleted out
+    // from under it (the status endpoint rendered a half-null ghost).
+    const killed = backupManager.cancelBackupsForDestination(id);
+    if (killed) {
+      winston.info(`Backup: destination #${id} deleted with a run in flight — worker killed`);
+    }
     db.deleteBackupDestination(id);
     res.json({});
   });
@@ -499,6 +515,11 @@ export function setup(mstream) {
       return res.json({ active: null, queueLength: backupManager.getQueueLength() });
     }
     const dest = db.getBackupDestinationById(activeRun.destinationId);
+    // Destination deleted while its worker is being torn down (the kill
+    // is asynchronous): report idle rather than a card of nulls.
+    if (!dest) {
+      return res.json({ active: null, queueLength: backupManager.getQueueLength() });
+    }
     const liveRow = db.getBackupHistoryRowById(activeRun.historyId);
     const prevRun = db.getLastSuccessfulBackupBefore(activeRun.destinationId, activeRun.historyId);
 
@@ -596,6 +617,12 @@ export function setup(mstream) {
       try {
         const stat = await fs.stat(value.destPath);
         info.destExists = stat.isDirectory();
+        // The path itself resolved, so its parent directory necessarily
+        // exists. Set this before the isDirectory branch so a destPath
+        // that points at a regular FILE doesn't fall through with
+        // parentExists=false and trip the Windows "drive not mounted"
+        // warning further down.
+        info.parentExists = true;
         if (info.destExists) {
           const entries = await fs.readdir(value.destPath);
           // Ignore our own trash bucket when judging "empty" — a previous
@@ -606,7 +633,11 @@ export function setup(mstream) {
           if (!info.destIsEmpty) {
             warnings.push('Destination already contains files. Existing files with names matching source files will be replaced; the originals will be moved to .mstream-trash/ before being overwritten.');
           }
-          info.parentExists = true;
+        } else {
+          // Path exists but isn't a directory — the first backup run
+          // would fail at mkdir. Say so instead of leaving the operator
+          // to discover it when the run fails.
+          warnings.push('Destination path exists but is not a directory. Choose a directory; the backup will fail otherwise.');
         }
       } catch (err) {
         if (err.code === 'ENOENT') {

--- a/src/backup/manager.js
+++ b/src/backup/manager.js
@@ -222,7 +222,30 @@ function sqliteUtcToLocalDateKey(s) {
   return localDateKey(new Date(s.replace(' ', 'T') + 'Z'));
 }
 
-function checkScheduledBackups() {
+// Local hour a UTC 'YYYY-MM-DD HH:MM:SS' timestamp fell in — the other
+// half of the scheduler's "did this run belong to today's window?" test.
+function sqliteUtcToLocalHour(s) {
+  return new Date(s.replace(' ', 'T') + 'Z').getHours();
+}
+
+// Has today's scheduled window ALREADY been served for this destination?
+// `lastRun` is the most recent history row of ANY status (see below), or
+// null. A run counts against today's window only when it both started on
+// today's local date AND started at or after the scheduled hour — the
+// latter guards the midnight-straddle case: a queue-delayed run enqueued
+// at 23:5x but started 00:0x lands on the NEW local day yet must not
+// consume that day's slot, or a daily_at_hour=23 destination would
+// silently skip. Pure + exported so the hour arithmetic is unit-testable
+// without waiting for a specific wall-clock hour.
+export function scheduledWindowServed(lastRun, dailyAtHour, now) {
+  if (!lastRun) { return false; }
+  const todayKey = localDateKey(now);
+  return sqliteUtcToLocalDateKey(lastRun.started_at) === todayKey
+      && sqliteUtcToLocalHour(lastRun.started_at) >= dailyAtHour;
+}
+
+// Exported for tests (the timers drive it in production).
+export function checkScheduledBackups() {
   let candidates;
   try {
     candidates = db.getBackupDestinationsByTrigger('daily');
@@ -234,15 +257,24 @@ function checkScheduledBackups() {
 
   const now = new Date();
   const currentHour = now.getHours();
-  const todayKey = localDateKey(now);
 
   for (const dest of candidates) {
     if (dest.daily_at_hour == null) { continue; }
     if (currentHour < dest.daily_at_hour) { continue; }
 
-    // Already ran today (local time)? Skip until tomorrow's window.
-    const last = db.getLastSuccessfulBackup(dest.id);
-    if (last && sqliteUtcToLocalDateKey(last.started_at) === todayKey) { continue; }
+    // One scheduled attempt per destination per local day. Key on the
+    // most recent run of ANY status (not just 'success'): keying on
+    // success alone meant a destination whose drive is unplugged would
+    // fail in seconds and be re-triggered on every 5-minute tick,
+    // piling up ~288 'failed' rows/day — exactly the history flooding
+    // the skip-row policy avoids elsewhere. A failed daily run now
+    // records the failure and waits for tomorrow's window; an operator
+    // who wants an immediate retry uses the manual-run endpoint
+    // (after-scan triggers also still fire independently). A 'running'
+    // row from today likewise blocks re-trigger (the dedup gate would
+    // drop it anyway).
+    const last = db.getLastBackupRun(dest.id);
+    if (scheduledWindowServed(last, dest.daily_at_hour, now)) { continue; }
 
     triggerForDestination(dest.id, 'scheduled');
   }
@@ -259,12 +291,17 @@ async function sweepAllTrash() {
     return;
   }
   for (const dest of destinations) {
-    if (dest.retention_days <= 0) { continue; }  // hard-prune mode never writes to trash
+    // retention <= 0 (hard-prune mode) never WRITES to trash, but a
+    // destination switched to 0 after running with retention still
+    // carries the old era's dated buckets — previously orphaned
+    // forever because the sweep skipped these destinations entirely.
+    // Sweep them with a zero-day cutoff so residual trash drains.
     await sweepDestTrash(dest);
   }
 }
 
-async function sweepDestTrash(dest) {
+// Exported for tests (the timers drive it in production).
+export async function sweepDestTrash(dest) {
   const trashRoot = path.join(dest.dest_path, '.mstream-trash');
   let entries;
   try {
@@ -276,23 +313,35 @@ async function sweepDestTrash(dest) {
     return;
   }
 
-  const cutoffMs = Date.now() - (dest.retention_days * 24 * 60 * 60 * 1000);
+  const retentionDays = Math.max(dest.retention_days, 0);
+  const cutoffMs = Date.now() - (retentionDays * 24 * 60 * 60 * 1000);
+  const DAY_MS = 24 * 60 * 60 * 1000;
 
   for (const entry of entries) {
     if (!entry.isDirectory()) { continue; }
     const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(entry.name);
     if (!m) { continue; }
-    const folderMs = Date.UTC(+m[1], +m[2] - 1, +m[3]);
-    if (folderMs >= cutoffMs) { continue; }
+    // A bucket named for day D holds files trashed any time within D —
+    // up to D 23:59. Compare the bucket's END (start + 24h) against the
+    // cutoff so the youngest file in it is guaranteed the full
+    // retention window. Comparing the start pruned a bucket the moment
+    // day D fell past the cutoff, shorting files trashed late on D by
+    // up to ~24h (retention_days=1 gave them nearly nothing).
+    const folderEndMs = Date.UTC(+m[1], +m[2] - 1, +m[3]) + DAY_MS;
+    if (folderEndMs >= cutoffMs) { continue; }
 
     const folderPath = path.join(trashRoot, entry.name);
     try {
       await fs.rm(folderPath, { recursive: true, force: true });
-      winston.info(`Backup: pruned trash folder ${folderPath} (older than ${dest.retention_days} days)`);
+      winston.info(`Backup: pruned trash folder ${folderPath} (older than ${retentionDays} days)`);
     } catch (err) {
       winston.warn(`Backup trash sweep: failed to remove ${folderPath}: ${err.message}`);
     }
   }
+
+  // Best-effort: drop the now-empty trash root so a hard-prune (0)
+  // destination doesn't keep an empty .mstream-trash shell around.
+  try { await fs.rmdir(trashRoot); } catch (_) { /* non-empty or gone */ }
 }
 
 // ── Pass-through getters used by the API ────────────────────────────────────
@@ -303,3 +352,4 @@ async function sweepDestTrash(dest) {
 // (this module's only state is the timer latches above).
 export const getActiveBackupRun = taskQueue.getActiveBackupRun;
 export const getQueueLength = taskQueue.getQueueLength;
+export const cancelBackupsForDestination = taskQueue.cancelBackupsForDestination;

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -411,6 +411,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize, beforeReplace = null) {
     const tmpPath = path.join(path.dirname(dest), tmpName);
     try {
       await fs.copyFile(src, tmpPath);
+      await assertSrcUnchanged(src, srcMtime, srcSize);
       await setMtimeSafe(tmpPath, srcMtime);
       if (beforeReplace) { await beforeReplace(); }
       await renameOverwrite(tmpPath, dest);
@@ -477,6 +478,7 @@ async function atomicCopy(src, dest, srcMtime, srcSize, beforeReplace = null) {
   // fs.copyFile — to keep the size-equals-valid-bytes invariant that
   // makes the finalise path above safe (see streamResume's comment).
   await streamResume(src, partialPath, srcSize, resumeFrom);
+  await assertSrcUnchanged(src, srcMtime, srcSize);
   if (beforeReplace) { await beforeReplace(); }
   await renameOverwrite(partialPath, dest);
   await setMtimeSafe(dest, srcMtime);   // after the rename — see the finalise branch
@@ -496,6 +498,22 @@ async function removeDestLink(p) {
   catch (unlinkErr) {
     try { await fs.rmdir(p); }
     catch (_) { throw unlinkErr; }
+  }
+}
+
+// Torn-copy guard: a file being WRITTEN while we copy it (an upload
+// streaming in, a tagger rewriting in place) yields a dest copy that is
+// neither the old nor the new version — and because we stamp the
+// PRE-COPY mtime, the next run's unchanged-check can permanently
+// classify the torn copy as current. Re-stat the source after the bytes
+// are staged and refuse to finalise if it moved under us; the caller
+// records a per-file error and the NEXT run picks up the settled file.
+// The dest keeps its previous copy (staging happens before any
+// displacement), so nothing is lost — one run of lag, no torn mirror.
+async function assertSrcUnchanged(src, srcMtime, srcSize) {
+  const now = await fs.stat(src);
+  if (now.size !== srcSize || Math.abs(now.mtimeMs - srcMtime.getTime()) >= MTIME_TOLERANCE_MS) {
+    throw new Error('source changed during copy — will retry next run');
   }
 }
 

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -789,11 +789,19 @@ export function createBackupRunRow({ destinationId, triggerReason, status = 'run
 // dozens a day); 500 matches the history endpoint's maximum page size,
 // so pruning never removes anything the UI could still request. Called
 // on every row insert — the DELETE is a no-op until the cap is reached.
+//
+// A 'running' row is NEVER pruned: it belongs to a live worker that will
+// finalise it (finishBackupRunRow) and whose progress the status
+// endpoint reads back by id. Deleting it mid-run would turn those
+// updates into silent no-ops. In practice the newest row is the running
+// one so it sits safely at the top of the keep-window, but the explicit
+// guard makes that independent of how many rows pile in behind it.
 const BACKUP_HISTORY_MAX_ROWS = 500;
 export function pruneBackupHistory(destinationId) {
   db.prepare(`
     DELETE FROM backup_history
      WHERE destination_id = ?
+       AND status != 'running'
        AND id NOT IN (
          SELECT id FROM backup_history
           WHERE destination_id = ?
@@ -894,18 +902,22 @@ export function getBackupHistoryRowById(historyId) {
   return db.prepare('SELECT * FROM backup_history WHERE id = ?').get(historyId);
 }
 
-// Find the most recent SUCCESS-status history row for `destinationId`
-// strictly before `beforeHistoryId`. Used by the live-status endpoint
-// to estimate total work for the in-flight run: a steady-state
-// backup processes roughly the same total `(copied + unchanged +
-// trashed)` count as the previous successful run, so that figure is
-// our best zero-cost denominator for a progress bar. Returns null on
-// the first-ever run for a destination (UI then renders an
-// indeterminate spinner).
-export function getLastSuccessfulBackupBefore(destinationId, beforeHistoryId) {
+// Find the most recent COUNTED run for `destinationId` strictly before
+// `beforeHistoryId`, for the live-status progress denominator: a
+// steady-state backup processes roughly the same total
+// `(copied + unchanged + trashed)` count as its previous run, so that
+// figure is our best zero-cost estimate. 'partial' runs count here
+// (they processed nearly the whole library — a few per-file errors
+// barely move the denominator) even though they're excluded from
+// getLastSuccessfulBackup: without them, a destination with ONE
+// perpetually-failing file (a name illegal on the backup FS, a locked
+// track) would be 'partial' on every run and show an indeterminate
+// spinner forever. Returns null on the first-ever run (UI then renders
+// the spinner, correctly).
+export function getLastCountedBackupBefore(destinationId, beforeHistoryId) {
   return db.prepare(`
     SELECT * FROM backup_history
-     WHERE destination_id = ? AND status = 'success' AND id < ?
+     WHERE destination_id = ? AND status IN ('success', 'partial') AND id < ?
      ORDER BY started_at DESC, id DESC
      LIMIT 1
   `).get(destinationId, beforeHistoryId);

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -627,12 +627,29 @@ export function replaceTrackGenres(trackId, genreStr) {
 // ── Backup destinations + history (V26) ─────────────────────────────────────
 
 // Defaults applied when a destination's exclude_globs column is NULL.
-// Picked to match the OS detritus most music libraries pick up when
-// browsed via Explorer / Finder / indexer services. Lives here (rather
-// than in the API or worker) because both api/backup.js and the task-
-// queue's runBackupTask need to agree on the effective list, and db/
-// manager.js is the only module both already import.
-export const DEFAULT_BACKUP_EXCLUDE_GLOBS = ['Thumbs.db', 'desktop.ini', '.DS_Store', '._*'];
+// Two groups. First, the OS detritus most music libraries pick up from
+// being browsed via Explorer / Finder / indexer services. Second,
+// in-flight temp files: mStream's own writers drop these inside the
+// library while a backup may be walking it (album-art embed's
+// *.tmp_art*, yt-dlp remux's *.tmp.*, generic *.tmp), and torrent
+// clients keep in-progress downloads as *.part / *.!qb — mirroring
+// those meant every pass copied half-written files and then trashed
+// them as orphans on the next pass (churn that compounds on seedboxes,
+// where each completed torrent triggers an after-scan backup while its
+// neighbours are still downloading). Exclusion is symmetric
+// (source AND dest), so previously-mirrored temp junk simply stops
+// being maintained rather than being swept.
+//
+// Lives here (rather than in the API or worker) because both
+// api/backup.js and the task-queue's runBackupTask need to agree on
+// the effective list, and db/manager.js is the only module both
+// already import. NULL-column destinations pick the new list up
+// automatically; rows with custom patterns keep exactly what the
+// operator saved.
+export const DEFAULT_BACKUP_EXCLUDE_GLOBS = [
+  'Thumbs.db', 'desktop.ini', '.DS_Store', '._*',
+  '*.tmp', '*.tmp.*', '*.tmp_art*', '*.part', '*.!qb', '*.crdownload',
+];
 
 // Resolve a backup_destinations row's exclude_globs column into a
 // concrete string array. NULL in storage → defaults; JSON array →
@@ -748,13 +765,42 @@ export function deleteBackupDestination(id) {
 // updates counts via updateBackupRunProgress as it goes, and the manager
 // finalises the row with finishBackupRunRow when the worker exits.
 export function createBackupRunRow({ destinationId, triggerReason, status = 'running', errorMessage = null }) {
-  const finishedAt = status === 'running' ? null : new Date().toISOString();
+  // finished_at must use the same datetime('now') form as started_at and
+  // finishBackupRunRow ('YYYY-MM-DD HH:MM:SS', UTC). A JS
+  // new Date().toISOString() here produced a second, incompatible format
+  // for rows created already-finished (skipped / disabled-before-start):
+  // consumers normalise these timestamps with `s.replace(' ','T') + 'Z'`
+  // (sqliteUtcToLocalDateKey, the admin UI's formatTime), and an ISO
+  // value run through that gains a trailing 'ZZ' and parses to an
+  // Invalid Date. The interpolated branch is a fixed SQL literal —
+  // status is an internal enum, never user text.
+  const finishedSql = status === 'running' ? 'NULL' : "datetime('now')";
   const result = db.prepare(`
     INSERT INTO backup_history
       (destination_id, started_at, finished_at, status, trigger_reason, error_message)
-    VALUES (?, datetime('now'), ?, ?, ?, ?)
-  `).run(destinationId, finishedAt, status, triggerReason, errorMessage);
+    VALUES (?, datetime('now'), ${finishedSql}, ?, ?, ?)
+  `).run(destinationId, status, triggerReason, errorMessage);
+  pruneBackupHistory(destinationId);
   return Number(result.lastInsertRowid);
+}
+
+// Keep at most this many history rows per destination. Without a cap the
+// table grows one row per run forever (after-scan triggers alone can add
+// dozens a day); 500 matches the history endpoint's maximum page size,
+// so pruning never removes anything the UI could still request. Called
+// on every row insert — the DELETE is a no-op until the cap is reached.
+const BACKUP_HISTORY_MAX_ROWS = 500;
+export function pruneBackupHistory(destinationId) {
+  db.prepare(`
+    DELETE FROM backup_history
+     WHERE destination_id = ?
+       AND id NOT IN (
+         SELECT id FROM backup_history
+          WHERE destination_id = ?
+          ORDER BY id DESC
+          LIMIT ${BACKUP_HISTORY_MAX_ROWS}
+       )
+  `).run(destinationId, destinationId);
 }
 
 export function updateBackupRunProgress(historyId, { filesCopied, filesUnchanged, filesTrashed, bytesCopied }) {

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -901,6 +901,10 @@ export const SCHEMA_V28 = `
   -- status:
   --   'running' — worker is alive (or was when the row was written)
   --   'success' — finished cleanly
+  --   'partial' — exited 0 but some files failed (error_message carries
+  --               the count + a sample); rendered distinctly and NOT
+  --               counted as the last successful run for scheduling /
+  --               progress estimation
   --   'failed'  — worker errored or exited non-zero; error_message set
   --   'skipped' — another run was already in flight for this dest;
   --               recorded so the user sees why the trigger didn't

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -279,14 +279,24 @@ function bufferLines(stream, onLine) {
 function nextTask() {
   while (activeTask === null && taskQueue.length > 0) {
     const candidate = taskQueue.shift();
-    if (candidate.task === 'scan')          { runScan(candidate); }
-    else if (candidate.task === 'backup')   { runBackupTask(candidate); }
-    else if (candidate.task === 'waveform') { runWaveformTask(candidate); }
-    else if (candidate.task === 'albumart') { runAlbumArtTask(candidate); }
-    else if (candidate.task === 'lyrics')   { runLyricsTask(candidate); }
-    else if (candidate.task === 'audioanalysis') { runAudioAnalysisTask(candidate); }
-    else if (candidate.task === 'discovery') { runDiscoveryTask(candidate); }
-    else if (candidate.task === 'acoustid') { runAcoustidTask(candidate); }
+    // Per-task try/catch: nextTask runs inside child-process 'close'
+    // handlers, where a synchronous throw from a runX dispatcher (a DB
+    // hiccup while creating the history row, a bad task object) would
+    // surface as an uncaught exception and take down the whole server.
+    // Dropping the one broken task and moving on keeps the queue alive;
+    // the error is logged with the task payload for diagnosis.
+    try {
+      if (candidate.task === 'scan')          { runScan(candidate); }
+      else if (candidate.task === 'backup')   { runBackupTask(candidate); }
+      else if (candidate.task === 'waveform') { runWaveformTask(candidate); }
+      else if (candidate.task === 'albumart') { runAlbumArtTask(candidate); }
+      else if (candidate.task === 'lyrics')   { runLyricsTask(candidate); }
+      else if (candidate.task === 'audioanalysis') { runAudioAnalysisTask(candidate); }
+      else if (candidate.task === 'discovery') { runDiscoveryTask(candidate); }
+      else if (candidate.task === 'acoustid') { runAcoustidTask(candidate); }
+    } catch (err) {
+      winston.error(`Task dispatch failed for ${JSON.stringify(candidate)} — dropping the task`, { stack: err });
+    }
   }
 }
 
@@ -301,6 +311,13 @@ const ENRICHMENT_KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'di
 // cleanup both depend on "all queued and active work finished," which can
 // be triggered by either kind of close after the unified-queue change.
 function checkQueueDrainedSideEffects() {
+  // Never throw out of here: like nextTask, this runs inside child
+  // 'close' handlers where an escaped exception kills the server.
+  try { checkQueueDrainedSideEffectsInner(); }
+  catch (err) { winston.error('Queue-drained side effects failed', { stack: err }); }
+}
+
+function checkQueueDrainedSideEffectsInner() {
   // Enrichment passes (waveform decode, art download) don't count against
   // "drained": the side effects below are about the SCAN batch — the
   // passes change no library content the DLNA caches care about, and they
@@ -1873,6 +1890,29 @@ export function isBackupQueuedOrActive(destinationId) {
   return taskQueue.some((t) => t.task === 'backup' && t.destinationId === destinationId);
 }
 
+// Purge queued backups for a destination and kill its active worker if
+// one is running. Called by the DELETE route BEFORE the destination row
+// is removed — without this, a deleted destination's worker kept
+// mirroring (for hours, to a config the user just removed) while its
+// history row was cascade-deleted out from under it. The kill is
+// asynchronous: the worker's close handler fires shortly after, marks
+// the (already-deleted) row failed as a no-op, and releases the queue
+// slot. Returns true when an active worker was signalled.
+export function cancelBackupsForDestination(destinationId) {
+  for (let i = taskQueue.length - 1; i >= 0; i--) {
+    if (taskQueue[i].task === 'backup' && taskQueue[i].destinationId === destinationId) {
+      taskQueue.splice(i, 1);
+    }
+  }
+  if (activeTask?.kind === 'backup'
+      && activeTask.taskObj.destinationId === destinationId) {
+    winston.info(`Backup: killing active run for deleted destination #${destinationId}`);
+    activeTask.killFn();
+    return true;
+  }
+  return false;
+}
+
 export function getActiveBackupRun() {
   if (activeTask?.kind !== 'backup') { return null; }
   return {
@@ -2042,13 +2082,18 @@ function onBackupClose(forked, taskObj, historyId, code, signal, { lastEvent, fa
     activeTask = null;
   }
 
-  // Decide final status. Three cases:
+  // Decide final status. Four cases:
   //   1. Worker emitted {event:'error'} and exited 1 → 'failed'
   //   2. Worker exited non-zero / killed by signal     → 'failed'
   //      (covers crashes, OOM, killed by signal — including server
   //      shutdown via the kill list).
-  //   3. Worker exited 0                               → 'success',
-  //      annotated with file-error count if any per-file errors hit.
+  //   3. Worker exited 0 with per-file errors          → 'partial'.
+  //      Previously this was 'success' with an error annotation buried
+  //      in a hover tooltip — a run where EVERY file failed still
+  //      showed green and counted as the scheduler's "ran today".
+  //      'partial' renders distinctly and is excluded from
+  //      getLastSuccessfulBackup (progress estimation).
+  //   4. Worker exited 0 cleanly                       → 'success'.
   //
   // For signal kills `code` is null and `signal` carries the name —
   // we report the signal explicitly so a user looking at the history
@@ -2067,6 +2112,7 @@ function onBackupClose(forked, taskObj, historyId, code, signal, { lastEvent, fa
     errorMessage = `Worker exited with code ${code}`;
   } else if (lastEvent?.event === 'done' && lastEvent.fileErrors > 0) {
     const sample = lastEvent.sampleErrorMessage ? `; example: ${lastEvent.sampleErrorMessage}` : '';
+    status = 'partial';
     errorMessage = `${lastEvent.fileErrors} file error(s)${sample}`;
   }
 

--- a/test/fixtures/grow-during-copy.cjs
+++ b/test/fixtures/grow-during-copy.cjs
@@ -1,0 +1,20 @@
+// Fault-injection preload for backup-worker tests: simulates a source
+// file being WRITTEN while the worker copies it. Wraps fs.promises
+// .copyFile — after the real copy of a source path containing
+// env GROW_MATCH, it appends bytes to that SOURCE file, so the worker's
+// post-copy re-stat (assertSrcUnchanged) sees a size that no longer
+// matches the pre-copy stat. Models the torn-copy race deterministically
+// (append-after-copy is indistinguishable to the re-stat from
+// grew-during-copy).
+const fs = require('fs');
+
+const match = process.env.GROW_MATCH || '';
+const real = fs.promises.copyFile.bind(fs.promises);
+
+fs.promises.copyFile = async (src, dest, mode) => {
+  const r = await real(src, dest, mode);
+  if (match && String(src).includes(match)) {
+    fs.appendFileSync(src, 'MORE-BYTES-APPENDED-MID-COPY');
+  }
+  return r;
+};

--- a/test/integration/backup-api.test.mjs
+++ b/test/integration/backup-api.test.mjs
@@ -262,6 +262,58 @@ describe('backup API: validation hardening', () => {
     const junk = await api('GET', `/api/v1/admin/backup/destinations/${destAId}/history?limit=abc`);
     assert.ok(junk.json.history.length >= 3, 'junk limit falls back to the default');
   });
+
+  test('check-path warns when the destination is an existing FILE, not a dir', async () => {
+    const filePath = path.join(destsDir, 'a-file.txt');
+    fs.writeFileSync(filePath, 'not a directory');
+    const { status, json } = await api('POST', '/api/v1/admin/backup/check-path', {
+      libraryId: libAId, destPath: filePath,
+    });
+    assert.equal(status, 200);
+    assert.equal(json.info.parentExists, true,
+      'a resolvable file means its parent exists — must not trip the "drive not mounted" path');
+    assert.ok(json.warnings.some((w) => /not a directory/i.test(w)),
+      'the operator must be told the path is a file');
+    assert.equal(json.warnings.some((w) => /not appear to be mounted/i.test(w)), false,
+      'no spurious drive-not-mounted warning for an existing file');
+  });
+
+  test('deleting a destination mid-run cancels the worker and status goes idle', async () => {
+    await waitForIdle();
+    // A throttle keeps the run in flight long enough to delete it under.
+    const created = await api('POST', '/api/v1/admin/backup/destinations', {
+      libraryId: libAId, destPath: path.join(destsDir, 'delete-mid-run'),
+      triggerType: 'manual', interFileDelayMs: 400,
+    });
+    assert.equal(created.status, 200);
+    const did = created.json.id;
+
+    await api('POST', `/api/v1/admin/backup/destinations/${did}/run`);
+    // Wait for the run to actually be active.
+    let active = null;
+    for (let i = 0; i < 50; i++) {
+      const s = await api('GET', '/api/v1/admin/backup/status');
+      if (s.json.active && s.json.active.destinationId === did) { active = s.json.active; break; }
+      await sleep(50);
+    }
+    assert.ok(active, 'the backup must be active before we delete it');
+
+    const del = await api('DELETE', `/api/v1/admin/backup/destinations/${did}`);
+    assert.equal(del.status, 200);
+
+    // Status must not render a half-null ghost card for the deleted dest;
+    // it goes idle once the killed worker's close handler fires.
+    let wentIdle = false;
+    for (let i = 0; i < 100; i++) {
+      const s = await api('GET', '/api/v1/admin/backup/status');
+      if (!s.json.active || s.json.active.destinationId !== did) { wentIdle = true; break; }
+      // While transitioning, the active card must never carry null identity.
+      assert.notEqual(s.json.active.destPath, null, 'status must not expose a null-identity ghost card');
+      await sleep(50);
+    }
+    assert.ok(wentIdle, 'status must return to idle after the deleted run is killed');
+    await waitForIdle();
+  });
 });
 
 // ── worker defense-in-depth ─────────────────────────────────────────────────

--- a/test/integration/backup-batch4.test.mjs
+++ b/test/integration/backup-batch4.test.mjs
@@ -123,17 +123,56 @@ describe('batch4 db: history rows', () => {
     assert.equal(Number(dbManager.getLastBackupRun(destId).id), Number(partialId));
   });
 
+  test("'partial' DOES count as the progress denominator (getLastCountedBackupBefore)", () => {
+    const db = dbManager.getDB();
+    const d2 = dbManager.addBackupDestination({
+      libraryId: dbManager.getLibraryByName('lib').id, destPath: path.join(testRoot, 'dest-prog'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true, excludeGlobs: [], interFileDelayMs: 0,
+    });
+    const ins = db.prepare(`INSERT INTO backup_history (destination_id, started_at, finished_at, status, trigger_reason, files_copied)
+                            VALUES (?, datetime('now'), datetime('now'), ?, 'manual', ?)`);
+    // A destination whose only prior run was 'partial' (one perpetually
+    // failing file) must still get a progress denominator — otherwise the
+    // live bar shows an indeterminate spinner forever.
+    const partialId = ins.run(d2, 'partial', 42).lastInsertRowid;
+    const currentRun = ins.run(d2, 'running', 0).lastInsertRowid;
+    const prev = dbManager.getLastCountedBackupBefore(d2, Number(currentRun));
+    assert.ok(prev, 'a prior partial run must serve as the progress denominator');
+    assert.equal(Number(prev.id), Number(partialId));
+    assert.equal(prev.files_copied, 42);
+  });
+
+  test('pruneBackupHistory never deletes a live running row', () => {
+    const d3 = dbManager.addBackupDestination({
+      libraryId: dbManager.getLibraryByName('lib').id, destPath: path.join(testRoot, 'dest-prune'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true, excludeGlobs: [], interFileDelayMs: 0,
+    });
+    // Insert a running row first (lowest id), then push >500 finished rows
+    // behind it. The running row must survive despite being oldest.
+    const runningId = dbManager.createBackupRunRow({ destinationId: d3, triggerReason: 'manual', status: 'running' });
+    for (let i = 0; i < 510; i++) {
+      dbManager.createBackupRunRow({ destinationId: d3, triggerReason: 'manual', status: 'failed', errorMessage: 'x' });
+    }
+    assert.ok(dbManager.getBackupHistoryRowById(runningId),
+      'the live running row must never be pruned, even as the oldest row past the cap');
+  });
+
   test('history is pruned to the 500-row cap per destination', () => {
     const db = dbManager.getDB();
-    const before = db.prepare('SELECT COUNT(*) c FROM backup_history WHERE destination_id = ?').get(destId).c;
+    // Use a fresh destination so a leftover 'running' row from an earlier
+    // test (never pruned by design) doesn't skew the count.
+    const capDest = dbManager.addBackupDestination({
+      libraryId: dbManager.getLibraryByName('lib').id, destPath: path.join(testRoot, 'dest-cap'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true, excludeGlobs: [], interFileDelayMs: 0,
+    });
     // createBackupRunRow prunes on every insert; push well past the cap.
-    for (let i = 0; i < 520 - before; i++) {
-      dbManager.createBackupRunRow({ destinationId: destId, triggerReason: 'manual', status: 'failed', errorMessage: 'x' });
+    for (let i = 0; i < 560; i++) {
+      dbManager.createBackupRunRow({ destinationId: capDest, triggerReason: 'manual', status: 'failed', errorMessage: 'x' });
     }
-    const count = db.prepare('SELECT COUNT(*) c FROM backup_history WHERE destination_id = ?').get(destId).c;
-    assert.ok(count <= 500, `history must be capped at 500, got ${count}`);
+    const count = db.prepare('SELECT COUNT(*) c FROM backup_history WHERE destination_id = ?').get(capDest).c;
+    assert.equal(count, 500, `finished-run history must be capped at exactly 500, got ${count}`);
     // The cap keeps the NEWEST rows — the latest insert must survive.
-    const newest = dbManager.getLastBackupRun(destId);
+    const newest = dbManager.getLastBackupRun(capDest);
     assert.ok(newest, 'the most recent row must be retained');
   });
 });

--- a/test/integration/backup-batch4.test.mjs
+++ b/test/integration/backup-batch4.test.mjs
@@ -1,0 +1,328 @@
+/**
+ * Backup lifecycle / scheduler / error-surfacing (audit batch 4).
+ *
+ * Split into three describes:
+ *   - DB layer: finished_at timestamp format, history pruning cap,
+ *     'partial' status excluded from getLastSuccessfulBackup.
+ *   - Scheduler: the pure scheduledWindowServed() day/hour dedup
+ *     decision (one attempt per local day, any-status, midnight
+ *     straddle) and the trash-sweep off-by-one + retention-0 legacy
+ *     drain.
+ *   - Worker: 'partial' status on per-file errors, the torn-copy
+ *     guard, and the expanded default temp-file excludes.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(REPO_ROOT, 'src', 'backup', 'worker.mjs');
+
+const ISO_LIKE = /^\d{4}-\d{2}-\d{2}T/;                 // JS toISOString shape (bad)
+const SQLITE_DT = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;   // datetime('now') shape (good)
+
+let envCounter = 0;
+function makeTempRoot(tag) {
+  const root = path.join(os.tmpdir(), `mstream-b4-${tag}-` + Date.now() + '-' + (envCounter++));
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function runWorker(payload, { env = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WORKER, JSON.stringify(payload)], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let errOut = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.stderr.on('data', (d) => { errOut += d.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const events = out.split(/\r?\n/).filter(Boolean).map((l) => {
+        try { return JSON.parse(l); } catch (_) { return null; }
+      }).filter(Boolean);
+      resolve({ code, events, stderr: errOut });
+    });
+  });
+}
+const doneEvent = (events) => events.find((e) => e.event === 'done') || null;
+const liveNames = (dir) => (fs.existsSync(dir) ? fs.readdirSync(dir)
+  .filter((n) => n !== '.mstream-trash' && !n.startsWith('.mstream-tmp-') && !n.startsWith('.mstream-partial-'))
+  .sort() : []);
+
+// ── DB layer ────────────────────────────────────────────────────────────────
+
+describe('batch4 db: history rows', () => {
+  let testRoot, dbManager, destId;
+
+  before(async () => {
+    testRoot = makeTempRoot('db');
+    fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+    fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+      storage: { dbDirectory: path.join(testRoot, 'db'), albumArtDirectory: path.join(testRoot, 'art'), logsDirectory: path.join(testRoot, 'logs') },
+      port: 0,
+    }));
+    const config = await import('../../src/state/config.js');
+    await config.setup(path.join(testRoot, 'config.json'));
+    dbManager = await import('../../src/db/manager.js');
+    dbManager.initDB();
+    const src = path.join(testRoot, 'lib');
+    fs.mkdirSync(src, { recursive: true });
+    dbManager.getDB().prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES (?, ?, ?, 0)`)
+      .run('lib', src, 'music');
+    dbManager.invalidateCache();
+    const libId = dbManager.getLibraryByName('lib').id;
+    destId = dbManager.addBackupDestination({
+      libraryId: libId, destPath: path.join(testRoot, 'dest'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+      excludeGlobs: [], interFileDelayMs: 0,
+    });
+  });
+
+  after(() => {
+    if (dbManager) { dbManager.close(); }
+    try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
+  });
+
+  test("pre-finished rows write finished_at in datetime('now') format, not ISO", () => {
+    const id = dbManager.createBackupRunRow({
+      destinationId: destId, triggerReason: 'manual', status: 'skipped', errorMessage: 'busy',
+    });
+    const row = dbManager.getBackupHistoryRowById(id);
+    assert.match(row.finished_at, SQLITE_DT,
+      "skipped rows must use the SQLite datetime format so the UI's replace(' ','T')+'Z' parse works");
+    assert.doesNotMatch(row.finished_at, ISO_LIKE);
+    // Round-trips to a valid Date through the consumer normalisation.
+    const parsed = new Date(row.finished_at.replace(' ', 'T') + 'Z');
+    assert.ok(!Number.isNaN(parsed.getTime()), 'normalised timestamp must be a valid Date');
+  });
+
+  test("running rows leave finished_at NULL", () => {
+    const id = dbManager.createBackupRunRow({ destinationId: destId, triggerReason: 'manual', status: 'running' });
+    assert.equal(dbManager.getBackupHistoryRowById(id).finished_at, null);
+  });
+
+  test("'partial' is not counted as the last successful run", () => {
+    const db = dbManager.getDB();
+    const ins = db.prepare(`INSERT INTO backup_history (destination_id, started_at, finished_at, status, trigger_reason, files_copied)
+                            VALUES (?, datetime('now'), datetime('now'), ?, 'manual', ?)`);
+    ins.run(destId, 'success', 10);
+    const partialId = ins.run(destId, 'partial', 5).lastInsertRowid;
+    const lastSuccess = dbManager.getLastSuccessfulBackup(destId);
+    assert.equal(lastSuccess.files_copied, 10, 'the partial run must be skipped by getLastSuccessfulBackup');
+    // getLastBackupRun (used by the scheduler dedup) DOES see it.
+    assert.equal(Number(dbManager.getLastBackupRun(destId).id), Number(partialId));
+  });
+
+  test('history is pruned to the 500-row cap per destination', () => {
+    const db = dbManager.getDB();
+    const before = db.prepare('SELECT COUNT(*) c FROM backup_history WHERE destination_id = ?').get(destId).c;
+    // createBackupRunRow prunes on every insert; push well past the cap.
+    for (let i = 0; i < 520 - before; i++) {
+      dbManager.createBackupRunRow({ destinationId: destId, triggerReason: 'manual', status: 'failed', errorMessage: 'x' });
+    }
+    const count = db.prepare('SELECT COUNT(*) c FROM backup_history WHERE destination_id = ?').get(destId).c;
+    assert.ok(count <= 500, `history must be capped at 500, got ${count}`);
+    // The cap keeps the NEWEST rows — the latest insert must survive.
+    const newest = dbManager.getLastBackupRun(destId);
+    assert.ok(newest, 'the most recent row must be retained');
+  });
+});
+
+// ── Scheduler decision + trash sweep ─────────────────────────────────────────
+
+describe('batch4 scheduler: window-served decision', () => {
+  let manager;
+  // Fixed reference instant, expressed in LOCAL time so the test is
+  // TZ-independent: build the SQLite-UTC string from a known local Date.
+  const toSqliteUtc = (d) => d.toISOString().slice(0, 19).replace('T', ' ');
+
+  before(async () => {
+    // manager.js imports db/manager + task-queue; a prior describe already
+    // set config up in this process, so the singleton import is ready.
+    manager = await import('../../src/backup/manager.js');
+  });
+
+  test('null last run → window not served (fires)', () => {
+    assert.equal(manager.scheduledWindowServed(null, 3, new Date()), false);
+  });
+
+  test('a run earlier today at/after the hour → served (skips), any status', () => {
+    const now = new Date(2026, 6, 10, 14, 0, 0);           // local 14:00
+    const ranAt = new Date(2026, 6, 10, 13, 0, 0);          // local 13:00 today, hour 13 >= 3
+    for (const status of ['success', 'failed', 'partial', 'running']) {
+      assert.equal(
+        manager.scheduledWindowServed({ started_at: toSqliteUtc(ranAt), status }, 3, now),
+        true,
+        `${status} run earlier today must count as served — no per-tick retry`);
+    }
+  });
+
+  test('a run yesterday → not served (fires today)', () => {
+    const now = new Date(2026, 6, 10, 14, 0, 0);
+    const ranAt = new Date(2026, 6, 9, 23, 0, 0);
+    assert.equal(manager.scheduledWindowServed({ started_at: toSqliteUtc(ranAt), status: 'success' }, 3, now), false);
+  });
+
+  test('midnight-straddle: a run that slipped to 00:0x does NOT consume a daily_at_hour=23 slot', () => {
+    const now = new Date(2026, 6, 10, 23, 30, 0);          // local 23:30, window hour 23 open
+    const ranAt = new Date(2026, 6, 10, 0, 5, 0);          // local 00:05 today, hour 0 < 23
+    assert.equal(
+      manager.scheduledWindowServed({ started_at: toSqliteUtc(ranAt), status: 'success' }, 23, now),
+      false,
+      'a run started before the scheduled hour must not satisfy the window — else the 23:00 daily silently skips');
+  });
+
+  test('a run today at exactly the scheduled hour → served', () => {
+    const now = new Date(2026, 6, 10, 23, 30, 0);
+    const ranAt = new Date(2026, 6, 10, 23, 5, 0);         // hour 23 >= 23
+    assert.equal(manager.scheduledWindowServed({ started_at: toSqliteUtc(ranAt), status: 'failed' }, 23, now), true);
+  });
+});
+
+describe('batch4 scheduler: trash retention sweep', () => {
+  let manager;
+  before(async () => { manager = await import('../../src/backup/manager.js'); });
+
+  // Build a dest dir with dated trash buckets and run the real sweep.
+  function seedTrash(retentionDays, bucketDates) {
+    const root = makeTempRoot('trash');
+    const dest = path.join(root, 'dest');
+    const trash = path.join(dest, '.mstream-trash');
+    for (const d of bucketDates) {
+      fs.mkdirSync(path.join(trash, d), { recursive: true });
+      fs.writeFileSync(path.join(trash, d, 'old.mp3'), 'x');
+    }
+    return { root, dest, retentionDays };
+  }
+  const ymd = (daysAgo) => {
+    const ms = Date.UTC(2026, 6, 10) - daysAgo * 24 * 60 * 60 * 1000;
+    return new Date(ms).toISOString().slice(0, 10);
+  };
+
+  test('retention_days=1 keeps a bucket for its full window (off-by-one fix)', async () => {
+    // Pin "now" to 2026-07-10T12:00Z so the arithmetic is deterministic.
+    const realNow = Date.now;
+    Date.now = () => Date.UTC(2026, 6, 10, 12, 0, 0);
+    try {
+      // Yesterday's bucket (2026-07-09): its youngest file (trashed
+      // 07-09 23:59) is ~12h old — well within a 1-day window. The old
+      // start-of-bucket comparison pruned it the moment 07-09 fell past
+      // the cutoff, shorting those files.
+      const { root, dest, retentionDays } = seedTrash(1, [ymd(1), ymd(3)]);
+      await manager.sweepDestTrash({ dest_path: dest, retention_days: retentionDays });
+      assert.ok(fs.existsSync(path.join(dest, '.mstream-trash', ymd(1))),
+        'yesterday bucket must survive a 1-day retention');
+      assert.equal(fs.existsSync(path.join(dest, '.mstream-trash', ymd(3))), false,
+        '3-days-old bucket must be pruned');
+      fs.rmSync(root, { recursive: true, force: true });
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  test('retention_days=0 drains legacy trash buckets (previously orphaned forever)', async () => {
+    const realNow = Date.now;
+    Date.now = () => Date.UTC(2026, 6, 10, 12, 0, 0);
+    try {
+      const { root, dest } = seedTrash(0, [ymd(1), ymd(5)]);
+      await manager.sweepDestTrash({ dest_path: dest, retention_days: 0 });
+      assert.equal(fs.existsSync(path.join(dest, '.mstream-trash')),
+        false,
+        'a retention-0 destination must drain (and remove) leftover trash, not skip it');
+      fs.rmSync(root, { recursive: true, force: true });
+    } finally {
+      Date.now = realNow;
+    }
+  });
+});
+
+// ── Worker: partial status, torn-copy, excludes ──────────────────────────────
+
+describe('batch4 worker: partial status + torn-copy + temp excludes', () => {
+  test("a run with per-file errors reports done.status hints (fileErrors > 0)", async () => {
+    const root = makeTempRoot('partial');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'ok.mp3'), 'fine');
+    // A name invalid on the dest filesystem would fail per-file, but that
+    // is platform-specific; instead inject a copyFile failure for one
+    // file so the worker records a fileError and still exits 0.
+    fs.writeFileSync(path.join(src, 'FAILCOPY-bad.mp3'), 'nope');
+
+    const { code, events } = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: { NODE_OPTIONS: `--require "${path.join(REPO_ROOT, 'test', 'fixtures', 'fail-copyfile.cjs').replace(/\\/g, '/')}"` } },
+    );
+    assert.equal(code, 0, 'per-file errors are non-fatal — worker still exits 0');
+    const done = doneEvent(events);
+    assert.ok(done.fileErrors >= 1, 'the failed file must be counted');
+    assert.equal(liveNames(dest).includes('ok.mp3'), true, 'the good file still lands');
+    // task-queue maps (exit 0 && fileErrors>0) → status 'partial'; the
+    // worker just reports the count. Assert the signal it emits.
+    assert.ok(done.sampleErrorMessage, 'a sample error message must accompany the count');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('a file modified during copy is not finalised as a torn mirror', async () => {
+    const root = makeTempRoot('torn');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    const f = path.join(src, 'GROW-track.mp3');
+    fs.writeFileSync(f, 'v1');
+
+    await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+    // Change the file's content+size AND stamp its mtime to match the
+    // ORIGINAL, so only the post-copy re-stat (size check) catches it —
+    // then use the grow-during-copy fixture to enlarge it mid-copy.
+    fs.writeFileSync(f, 'v2-bigger-content');
+
+    const { code, events } = await runWorker(
+      { sourcePath: src, destPath: dest, retentionDays: 30 },
+      { env: { NODE_OPTIONS: `--require "${path.join(REPO_ROOT, 'test', 'fixtures', 'grow-during-copy.cjs').replace(/\\/g, '/')}"`, GROW_MATCH: 'GROW-track' } },
+    );
+    assert.equal(code, 0);
+    const done = doneEvent(events);
+    assert.ok(done.fileErrors >= 1, 'the torn copy must be recorded as a per-file error');
+    // The dest must hold the PREVIOUS good copy, never a torn one.
+    const destContent = fs.readFileSync(path.join(dest, 'GROW-track.mp3'), 'utf8');
+    assert.equal(destContent, 'v1', 'dest keeps the prior copy — no torn bytes finalised');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('default excludes skip in-flight temp files (no mirror, no churn)', async () => {
+    const root = makeTempRoot('excl');
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'real.mp3'), 'music');
+    fs.writeFileSync(path.join(src, 'cover.tmp_art.jpg'), 'inflight');
+    fs.writeFileSync(path.join(src, 'download.part'), 'inflight');
+    fs.writeFileSync(path.join(src, 'remux.tmp.opus'), 'inflight');
+    fs.writeFileSync(path.join(src, 'torrent.mp3.!qb'), 'inflight');
+
+    // Pass the DEFAULT globs explicitly (task-queue resolves NULL →
+    // defaults; here we mirror that by importing the constant).
+    const dbManager = await import('../../src/db/manager.js');
+    const { code, events } = await runWorker({
+      sourcePath: src, destPath: dest, retentionDays: 30,
+      excludeGlobs: dbManager.DEFAULT_BACKUP_EXCLUDE_GLOBS,
+    });
+    assert.equal(code, 0);
+    assert.deepEqual(liveNames(dest), ['real.mp3'],
+      'only the real track is mirrored; in-flight temp files are excluded');
+    assert.equal(doneEvent(events).filesCopied, 1);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/test/integration/task-queue.test.mjs
+++ b/test/integration/task-queue.test.mjs
@@ -313,6 +313,49 @@ describe('task-queue: backup-only behaviours', () => {
     await waitForIdle(taskQueue);
   });
 
+  test("a run with per-file errors is finalised as 'partial', not 'success'", async () => {
+    // Drive a REAL worker through the queue with one file that fails to
+    // copy (the fail-copyfile fixture throws ENOSPC for FAILCOPY paths —
+    // a per-file, non-fatal error, so the worker still exits 0). This
+    // pins the onBackupClose mapping the DB test can't: exit-0 +
+    // fileErrors>0 → 'partial'. Reverting that one line makes this fail.
+    const src = path.join(testRoot, 'partial-src');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'ok.mp3'), 'good');
+    fs.writeFileSync(path.join(src, 'FAILCOPY-bad.mp3'), 'bad');
+    dbManager.getDB().prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES (?, ?, ?, 0)`)
+      .run('partial-lib', src, 'music');
+    dbManager.invalidateCache();
+    const partialLibId = dbManager.getLibraryByName('partial-lib').id;
+    const dest = dbManager.addBackupDestination({
+      libraryId: partialLibId, destPath: path.join(testRoot, 'partial-dest'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+      excludeGlobs: [], interFileDelayMs: 0,
+    });
+
+    // The worker fork inherits process.env; set the preload just for the
+    // synchronous fork, then restore it. fail-copyfile only throws for
+    // FAILCOPY paths, so it can't disturb anything else.
+    const fixture = path.join(REPO_ROOT, 'test', 'fixtures', 'fail-copyfile.cjs').replace(/\\/g, '/');
+    const saved = process.env.NODE_OPTIONS;
+    process.env.NODE_OPTIONS = `${saved ? saved + ' ' : ''}--require "${fixture}"`;
+    try {
+      taskQueue.addBackupTask(dest, 'manual');   // synchronous fork captures NODE_OPTIONS
+    } finally {
+      if (saved === undefined) { delete process.env.NODE_OPTIONS; }
+      else { process.env.NODE_OPTIONS = saved; }
+    }
+    await waitForIdle(taskQueue);
+
+    const row = dbManager.getBackupHistory(dest, 1)[0];
+    assert.equal(row?.status, 'partial',
+      "a run that copied some files but hit per-file errors must be 'partial', not 'success'");
+    assert.match(row.error_message || '', /file error/i);
+    // 'partial' must not masquerade as the last successful run.
+    assert.equal(dbManager.getLastSuccessfulBackup(dest), undefined,
+      "'partial' must not be returned as the last successful run");
+  });
+
   test('cancelBackupsForDestination kills the active run and drops queued ones', async () => {
     // A slow throttle keeps the active run in flight long enough to
     // cancel it deterministically.

--- a/test/integration/task-queue.test.mjs
+++ b/test/integration/task-queue.test.mjs
@@ -312,6 +312,42 @@ describe('task-queue: backup-only behaviours', () => {
       'scheduled triggers during active run must NOT pile up history rows');
     await waitForIdle(taskQueue);
   });
+
+  test('cancelBackupsForDestination kills the active run and drops queued ones', async () => {
+    // A slow throttle keeps the active run in flight long enough to
+    // cancel it deterministically.
+    const active = dbManager.addBackupDestination({
+      libraryId: libId, destPath: path.join(testRoot, 'd10-cancel-active'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+      excludeGlobs: [], interFileDelayMs: 400,
+    });
+    const queued = dbManager.addBackupDestination({
+      libraryId: libId, destPath: path.join(testRoot, 'd10-cancel-queued'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+      excludeGlobs: [], interFileDelayMs: 400,
+    });
+    taskQueue.addBackupTask(active, 'manual');
+    taskQueue.addBackupTask(queued, 'manual');
+    await sleep(100);
+    assert.notEqual(taskQueue.getActiveBackupRun(), null, 'a run should be active');
+
+    // Cancel the queued destination first — it must vanish from the queue
+    // without touching the active run.
+    const killedQueued = taskQueue.cancelBackupsForDestination(queued);
+    assert.equal(killedQueued, false, 'cancelling a merely-queued dest kills no worker');
+    assert.equal(taskQueue.isBackupQueuedOrActive(queued), false, 'the queued task is dropped');
+
+    // Cancel the active destination — its worker is signalled.
+    const killedActive = taskQueue.cancelBackupsForDestination(active);
+    assert.equal(killedActive, true, 'cancelling the active dest signals its worker');
+
+    await waitForIdle(taskQueue);
+    // The killed active run records a failed row (signal kill), and the
+    // queued one never produced a run.
+    const activeHist = dbManager.getBackupHistory(active, 1)[0];
+    assert.equal(activeHist?.status, 'failed', 'the killed active run is marked failed');
+    assert.equal(dbManager.getBackupHistory(queued, 1).length, 0, 'the dropped queued run never ran');
+  });
 });
 
 // ── describe: scan + backup mutex ───────────────────────────────────────────

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -6728,6 +6728,7 @@ const backupView = Vue.component('backup-view', {
     statusColor(status) {
       return status === 'success' ? '#2e7d32'
            : status === 'failed' ? '#c62828'
+           : status === 'partial' ? '#e65100'
            : status === 'skipped' ? '#f57f17'
            : '#1976d2';
     },
@@ -9120,6 +9121,7 @@ const backupHistoryModal = Vue.component('backup-history-modal', {
     statusColor(status) {
       return status === 'success' ? '#2e7d32'
            : status === 'failed' ? '#c62828'
+           : status === 'partial' ? '#e65100'
            : status === 'skipped' ? '#f57f17'
            : '#1976d2';
     },


### PR DESCRIPTION
Batch 4 of the backup-feature audit fixes: the operational group — lifecycle, scheduler, error surfacing, and retention. Batches 1-3 (#724, #725, #726) hardened the worker and API; this closes the medium-severity findings that made a struggling backup look healthy. Also folds three fixes from the closed precursor PR #605.

## Fixes

### Lifecycle / crash-safety (`task-queue.js`, `api/backup.js`)

- **Queue-pump crash-proofing.** `nextTask` and `checkQueueDrainedSideEffects` run inside child-process `close` handlers; a synchronous throw there (a DB hiccup building a history row) took down the whole server. Both are now wrapped — the broken task is dropped and logged, the queue survives.
- **Delete-mid-run cancellation.** Deleting a destination with a run in flight now cancels it: `cancelBackupsForDestination` purges queued tasks and kills the active worker **before** the row is removed. Previously the worker kept mirroring for hours to a deleted config while its history row was cascade-deleted out from under it. The status endpoint also guards the brief teardown window — a deleted destination reports idle instead of a null-identity ghost card.

### Error surfacing (`task-queue.js`)

- A run that exits 0 **with per-file errors** is now `partial`, not `success`. Previously even a 100%-failed run showed green and counted as the scheduler's "ran today" baseline. `partial` renders distinctly (orange) and is excluded from `getLastSuccessfulBackup`.

### Scheduler (`backup/manager.js`)

- `checkScheduledBackups` keys on the last run of **any** status, not just the last success — an unplugged-drive destination that failed in seconds was re-triggered every 5-minute tick, ~288 failed rows/day. One attempt per local day now; manual + after-scan still fire, operator can retry manually. The day/hour dedup is extracted to a pure, unit-tested `scheduledWindowServed()` that also fixes the **midnight-straddle** case (a queue-delayed run that started 00:0x must not consume a `daily_at_hour=23` slot).

### Retention / growth (`db/manager.js`, `backup/manager.js`)

- `backup_history` is pruned to 500 rows/destination on every insert (matches the endpoint's max page size); the table previously grew unbounded. A live `running` row is never pruned.
- `createBackupRunRow`'s pre-finished rows (skipped / disabled-before-start) used `new Date().toISOString()`, a format the consumers' `replace(' ','T')+'Z'` parse turns into an **Invalid Date** in the admin UI. Unified on `datetime('now')`.
- **Trash-sweep off-by-one:** buckets are kept until their *end* (+24h) passes the cutoff, so files trashed late in a day get the full retention window (`retention_days=1` previously gave them near-zero). `retention_days=0` destinations now **drain** residual trash (and remove the empty shell) instead of orphaning old buckets forever.

### Worker (`worker.mjs`, `db/manager.js`)

- **Torn-copy guard.** `assertSrcUnchanged` re-stats the source after staging and refuses to finalise if size/mtime moved under us — a file written during the copy (upload, in-place tagger) no longer lands as a torn mirror stamped with the pre-copy mtime. The dest keeps its prior copy; the settled file is picked up next run.
- Default excludes gain the in-flight temp patterns mStream and torrent clients drop in-library (`*.tmp`, `*.tmp.*`, `*.tmp_art*`, `*.part`, `*.!qb`, `*.crdownload`) — these were mirrored then trashed as orphans every pass, churn that compounds on seedboxes.

### Folded from the closed PR #605

`finished_at` format unification, the daily retry-storm design (one attempt/day keyed on any-status), and the check-path warning when the destination is an existing **file** (previously a spurious "drive not mounted").

## Review round (second commit)

The adversarial review confirmed one real regression I introduced and two cheap hardening items, all fixed:

- **Confirmed regression:** the `success`→`partial` reclassification broke the live progress bar for any destination with one perpetually-failing file — the denominator lookup still filtered `status='success'`, giving a permanent indeterminate spinner. Fixed by widening the denominator to `success` OR `partial` (`getLastCountedBackupBefore`), keeping `getLastSuccessfulBackup` success-only for scheduling.
- `pruneBackupHistory` now explicitly skips `running` rows.
- The headline `partial` mapping had no test that failed on the parent — added a real end-to-end task-queue test (spawns a worker with a failing file; verified to fail when the mapping is reverted).

## Tests + validation

`backup-batch4.test.mjs` (16) + additions to `task-queue.test.mjs` and `backup-api.test.mjs`: DB format/prune/partial-exclusion/progress-denominator, the pure scheduler decision (incl. DST-adjacent hours + midnight straddle), trash-sweep off-by-one and retention-0 drain, delete-mid-run cancellation (queue-level and API end-to-end), check-path-file, and the real onBackupClose `partial` mapping. New fixture `grow-during-copy.cjs` drives the torn-copy race deterministically. Full backup suite 80/80; lint at master baseline.

Rig validation: smoke harness 20/20; a dedicated delete-mid-run test confirmed the worker is killed and reaped in ~0.2s with status going idle; `finished_at` confirmed in the SQLite format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
