### PR TITLE
fix(backup): batch-4 post-merge re-audit follow-ups (library-delete cancel + scheduler)

### DIFF
--- a/src/api/backup.js
+++ b/src/api/backup.js
@@ -433,10 +433,17 @@ export function setup(mstream) {
       }
     });
 
-    // A path change abandons the old location's .mstream-trash — the
-    // retention sweep only visits CURRENT dest paths. Deleting it here
-    // would destroy the user's deletion log, so just say it out loud.
     if (fields.dest_path !== undefined && fields.dest_path !== existing.dest_path) {
+      // A run in flight is still mirroring to the OLD path while the
+      // row (and the status card) now reports the new one — cancel it,
+      // same as DELETE. The next trigger runs against the new path.
+      const killed = backupManager.cancelBackupsForDestination(id);
+      if (killed) {
+        winston.info(`Backup: destination #${id} path changed with a run in flight — worker killed`);
+      }
+      // A path change abandons the old location's .mstream-trash — the
+      // retention sweep only visits CURRENT dest paths. Deleting it
+      // here would destroy the user's deletion log, so say it out loud.
       winston.warn(`Backup: destination #${id} moved from ${existing.dest_path} — its old .mstream-trash (if any) is no longer swept; remove it manually if unwanted`);
     }
 

--- a/src/backup/manager.js
+++ b/src/backup/manager.js
@@ -229,8 +229,9 @@ function sqliteUtcToLocalHour(s) {
 }
 
 // Has today's scheduled window ALREADY been served for this destination?
-// `lastRun` is the most recent history row of ANY status (see below), or
-// null. A run counts against today's window only when it both started on
+// `lastRun` is the most recent ATTEMPT row (any status except 'skipped'
+// — see getLastBackupAttempt), or null. A run counts against today's
+// window only when it both started on
 // today's local date AND started at or after the scheduled hour — the
 // latter guards the midnight-straddle case: a queue-delayed run enqueued
 // at 23:5x but started 00:0x lands on the NEW local day yet must not
@@ -263,17 +264,20 @@ export function checkScheduledBackups() {
     if (currentHour < dest.daily_at_hour) { continue; }
 
     // One scheduled attempt per destination per local day. Key on the
-    // most recent run of ANY status (not just 'success'): keying on
-    // success alone meant a destination whose drive is unplugged would
-    // fail in seconds and be re-triggered on every 5-minute tick,
-    // piling up ~288 'failed' rows/day — exactly the history flooding
-    // the skip-row policy avoids elsewhere. A failed daily run now
-    // records the failure and waits for tomorrow's window; an operator
-    // who wants an immediate retry uses the manual-run endpoint
-    // (after-scan triggers also still fire independently). A 'running'
-    // row from today likewise blocks re-trigger (the dedup gate would
-    // drop it anyway).
-    const last = db.getLastBackupRun(dest.id);
+    // most recent ATTEMPT of any status except 'skipped' (see
+    // getLastBackupAttempt): keying on success alone meant a
+    // destination whose drive is unplugged would fail in seconds and be
+    // re-triggered on every 5-minute tick, piling up ~288 'failed'
+    // rows/day — exactly the history flooding the skip-row policy
+    // avoids elsewhere. A failed daily run now records the failure and
+    // waits for tomorrow's window; an operator who wants an immediate
+    // retry uses the manual-run endpoint (after-scan triggers also
+    // still fire independently). A 'running' row from today likewise
+    // blocks re-trigger (the dedup gate would drop it anyway). Dedup
+    // 'skipped' rows are excluded — they record a no-op, and letting
+    // one consume the window meant a Run-Now click during an active
+    // run could suppress the day's scheduled backup.
+    const last = db.getLastBackupAttempt(dest.id);
     if (scheduledWindowServed(last, dest.daily_at_hour, now)) { continue; }
 
     triggerForDestination(dest.id, 'scheduled');

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -876,6 +876,12 @@ export function markStaleBackupRunsFailed(excludeHistoryId = null) {
   return result.changes;
 }
 
+// "Last fully-clean run" — no production caller since the scheduler
+// moved to getLastBackupAttempt and progress estimation to
+// getLastCountedBackupBefore. Kept (and pinned by tests) because the
+// success-only semantic is the natural next UI surface ("last verified
+// good backup: <date>") and its absence is what the 'partial' status
+// exists to make visible.
 export function getLastSuccessfulBackup(destinationId) {
   return db.prepare(`
     SELECT * FROM backup_history
@@ -889,6 +895,24 @@ export function getLastBackupRun(destinationId) {
   return db.prepare(`
     SELECT * FROM backup_history
      WHERE destination_id = ?
+     ORDER BY started_at DESC, id DESC
+     LIMIT 1
+  `).get(destinationId);
+}
+
+// The most recent row that represents an actual ATTEMPT to run —
+// everything except 'skipped'. Skip rows record a dedup NO-OP ("you
+// clicked Run Now while a run was in flight"), and the daily scheduler
+// must not let one consume the day's window: a manual click at 23:05
+// while an after-scan run from 22:50 was still active would otherwise
+// silently suppress a daily_at_hour=23 backup (the active run itself
+// doesn't block — its 22:xx start is before the scheduled hour — but
+// the skip row's 23:05 stamp does). The UI's last-run cell keeps using
+// getLastBackupRun above, where showing the skip IS the point.
+export function getLastBackupAttempt(destinationId) {
+  return db.prepare(`
+    SELECT * FROM backup_history
+     WHERE destination_id = ? AND status != 'skipped'
      ORDER BY started_at DESC, id DESC
      LIMIT 1
   `).get(destinationId);

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -902,9 +902,10 @@ export const SCHEMA_V28 = `
   --   'running' — worker is alive (or was when the row was written)
   --   'success' — finished cleanly
   --   'partial' — exited 0 but some files failed (error_message carries
-  --               the count + a sample); rendered distinctly and NOT
-  --               counted as the last successful run for scheduling /
-  --               progress estimation
+  --               the count + a sample); rendered distinctly (orange).
+  --               Counts as a scheduler attempt and as the progress
+  --               denominator; excluded only from "last successful
+  --               run" semantics
   --   'failed'  — worker errored or exited non-zero; error_message set
   --   'skipped' — another run was already in flight for this dest;
   --               recorded so the user sees why the trigger didn't

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1973,7 +1973,28 @@ function runBackupTask(taskObj) {
     interFileDelayMs: dest.inter_file_delay_ms || 0,
   };
 
-  const forked = launchWorker('backup', BACKUP_WORKER_PATH, JSON.stringify(jsonLoad));
+  // launchWorker can THROW synchronously for some spawn failures
+  // (ENOMEM/EPERM-class errors throw instead of emitting 'error' —
+  // only the EACCES/EAGAIN/EMFILE/ENFILE/ENOENT family defers). The
+  // history row above already exists; letting the throw escape to
+  // nextTask's catch would orphan it as 'running' forever — never
+  // pruned (running rows are exempt), never flipped until the next
+  // boot's crash recovery, and silently consuming the day's scheduled
+  // window. Finalise the row as failed and re-throw for nextTask's
+  // dispatch log. activeTask isn't claimed until attachBackupHandlers,
+  // so there's nothing else to unwind here.
+  let forked;
+  try {
+    forked = launchWorker('backup', BACKUP_WORKER_PATH, JSON.stringify(jsonLoad));
+  } catch (err) {
+    try {
+      db.finishBackupRunRow(historyId, {
+        status: 'failed',
+        errorMessage: `Worker launch failed: ${err.message}`,
+      });
+    } catch (_) { /* row finalisation is best-effort here */ }
+    throw err;
+  }
   winston.info(`Backup: started run #${historyId} for ${dest.dest_path} (trigger=${taskObj.triggerReason})`);
 
   const observers = attachBackupHandlers(forked, taskObj, historyId);
@@ -2090,9 +2111,11 @@ function onBackupClose(forked, taskObj, historyId, code, signal, { lastEvent, fa
   //   3. Worker exited 0 with per-file errors          → 'partial'.
   //      Previously this was 'success' with an error annotation buried
   //      in a hover tooltip — a run where EVERY file failed still
-  //      showed green and counted as the scheduler's "ran today".
-  //      'partial' renders distinctly and is excluded from
-  //      getLastSuccessfulBackup (progress estimation).
+  //      showed green. 'partial' renders distinctly (orange). It still
+  //      COUNTS as a scheduler attempt (one try per day either way)
+  //      and as the progress denominator (getLastCountedBackupBefore —
+  //      it processed roughly the whole library); it is only excluded
+  //      from "last successful run" semantics.
   //   4. Worker exited 0 cleanly                       → 'success'.
   //
   // For signal kills `code` is null and `signal` carries the name —

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -114,8 +114,29 @@ export async function removeDirectory(vpath) {
   const library = db.getLibraryByName(vpath);
   if (!library) { throw new Error(`'${vpath}' not found`); }
 
+  // Cancel this library's backups BEFORE the cascade below destroys
+  // their backup_destinations rows. Without this, an in-flight backup
+  // worker became a phantom: it kept mirroring for hours, held the
+  // strictly-serial queue slot (blocking the rescan an admin typically
+  // runs right after re-adding a library), and was fully invisible —
+  // the status endpoint reports idle once the destination row is gone
+  // and the worker's history updates land on a cascade-deleted row.
+  // Same failure mode the destination-DELETE route guards against;
+  // this is the second path to it.
+  try {
+    for (const dest of db.getBackupDestinationsByLibrary(library.id, { enabledOnly: false })) {
+      const killed = dbQueue.cancelBackupsForDestination(dest.id);
+      if (killed) {
+        winston.info(`Backup: library '${vpath}' deleted with a run in flight for destination #${dest.id} — worker killed`);
+      }
+    }
+  } catch (err) {
+    winston.error(`Backup: failed to cancel backups for deleted library '${vpath}'`, { stack: err });
+  }
+
   const d = db.getDB();
   // CASCADE will delete tracks and user_libraries entries
+  // (and backup_destinations + their backup_history).
   d.prepare('DELETE FROM libraries WHERE id = ?').run(library.id);
 
   // Clean up orphan albums / artists / genres left over after the

--- a/test/integration/backup-api.test.mjs
+++ b/test/integration/backup-api.test.mjs
@@ -278,40 +278,106 @@ describe('backup API: validation hardening', () => {
       'no spurious drive-not-mounted warning for an existing file');
   });
 
-  test('deleting a destination mid-run cancels the worker and status goes idle', async () => {
-    await waitForIdle();
-    // A throttle keeps the run in flight long enough to delete it under.
+  // Start a slow run (many files + heavy throttle → minutes of natural
+  // runtime) so cancellation is observable: /api/v1/db/status `locked`
+  // reflects the queue's activeTask slot directly, which the backup
+  // status endpoint's ghost-guard deliberately hides for deleted
+  // destinations. If the cancel is ever removed, `locked` stays true
+  // for the run's natural length and these tests time out — verified
+  // by mutation (the earlier version of this test passed even with the
+  // cancel deleted, because the ghost-guard alone made status idle).
+  async function startSlowRun(libraryRoot, libraryId, destPath) {
+    for (let i = 0; i < 40; i++) {
+      fs.writeFileSync(path.join(libraryRoot, `slow-${String(i).padStart(2, '0')}.mp3`), `slow-${i}`);
+    }
     const created = await api('POST', '/api/v1/admin/backup/destinations', {
-      libraryId: libAId, destPath: path.join(destsDir, 'delete-mid-run'),
-      triggerType: 'manual', interFileDelayMs: 400,
+      libraryId, destPath, triggerType: 'manual', interFileDelayMs: 800,
     });
     assert.equal(created.status, 200);
     const did = created.json.id;
-
     await api('POST', `/api/v1/admin/backup/destinations/${did}/run`);
-    // Wait for the run to actually be active.
     let active = null;
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 100; i++) {
       const s = await api('GET', '/api/v1/admin/backup/status');
       if (s.json.active && s.json.active.destinationId === did) { active = s.json.active; break; }
       await sleep(50);
     }
-    assert.ok(active, 'the backup must be active before we delete it');
+    assert.ok(active, 'the backup must be active before cancellation is exercised');
+    return did;
+  }
+
+  async function assertQueueFreesWithin(ms, what) {
+    const start = Date.now();
+    while (Date.now() - start < ms) {
+      try {
+        const r = await fetch(`${server.baseUrl}/api/v1/db/status`, {
+          headers: { 'x-access-token': token },
+        });
+        const j = await r.json();
+        if (!j.locked) { return; }
+      } catch (_) {
+        // The library-DELETE path reboots the HTTP server (recycles the
+        // listener) after cancelling backups — a transient connection
+        // gap here is that reboot, not a failure. Keep polling; the
+        // server returns on the same port and the worker (killed before
+        // the reboot) is already gone.
+      }
+      await sleep(200);
+    }
+    assert.fail(`${what}: queue slot still held after ${ms}ms — the worker was not cancelled`);
+  }
+
+  test('deleting a destination mid-run cancels the worker and frees the queue', async () => {
+    await waitForIdle();
+    const did = await startSlowRun(libARoot, libAId, path.join(destsDir, 'delete-mid-run'));
 
     const del = await api('DELETE', `/api/v1/admin/backup/destinations/${did}`);
     assert.equal(del.status, 200);
 
-    // Status must not render a half-null ghost card for the deleted dest;
-    // it goes idle once the killed worker's close handler fires.
-    let wentIdle = false;
-    for (let i = 0; i < 100; i++) {
-      const s = await api('GET', '/api/v1/admin/backup/status');
-      if (!s.json.active || s.json.active.destinationId !== did) { wentIdle = true; break; }
-      // While transitioning, the active card must never carry null identity.
-      assert.notEqual(s.json.active.destPath, null, 'status must not expose a null-identity ghost card');
-      await sleep(50);
-    }
-    assert.ok(wentIdle, 'status must return to idle after the deleted run is killed');
+    // The discriminating assertion: the ~32s natural run must be gone
+    // from the queue slot within seconds.
+    await assertQueueFreesWithin(10_000, 'destination DELETE');
+
+    // And the status endpoint never rendered a half-null ghost card.
+    const s = await api('GET', '/api/v1/admin/backup/status');
+    assert.ok(!s.json.active || s.json.active.destPath !== null,
+      'status must not expose a null-identity ghost card');
+    await waitForIdle();
+  });
+
+  test('PATCHing dest_path mid-run cancels the worker (old-path writes stop)', async () => {
+    await waitForIdle();
+    const did = await startSlowRun(libARoot, libAId, path.join(destsDir, 'patch-mid-run'));
+
+    const patch = await api('PATCH', `/api/v1/admin/backup/destinations/${did}`, {
+      destPath: path.join(destsDir, 'patch-mid-run-NEW'),
+    });
+    assert.equal(patch.status, 200);
+
+    // The in-flight worker was mirroring the OLD path while the row now
+    // reports the new one — it must be cancelled, not left writing.
+    await assertQueueFreesWithin(10_000, 'destination PATCH');
+    await waitForIdle();
+  });
+
+  test('deleting a LIBRARY mid-run cancels its backups (cascade path)', async () => {
+    await waitForIdle();
+    // Use libB — this destroys the library, so it must run last.
+    const did = await startSlowRun(libBRoot, libBId, path.join(destsDir, 'lib-delete-mid-run'));
+
+    const del = await api('DELETE', '/api/v1/admin/directory', { vpath: 'libB' });
+    assert.equal(del.status, 200);
+
+    // Pre-fix, the cascade orphaned the worker: invisible (ghost-guard
+    // reports idle), unkillable (its destination row is gone so the
+    // destination-DELETE route 404s), holding the serial queue slot
+    // for the run's natural length. This path also reboots the HTTP
+    // server, so the poller tolerates the reboot's connection gap.
+    await assertQueueFreesWithin(20_000, 'library DELETE');
+
+    const s = await api('GET', '/api/v1/admin/backup/status');
+    assert.equal(s.json.active, null, 'no phantom run may survive a library delete');
+    void did;
     await waitForIdle();
   });
 });

--- a/test/integration/backup-batch4.test.mjs
+++ b/test/integration/backup-batch4.test.mjs
@@ -14,6 +14,7 @@
 
 import { describe, before, after, test } from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -29,7 +30,12 @@ const SQLITE_DT = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;   // datetime('now') 
 
 let envCounter = 0;
 function makeTempRoot(tag) {
-  const root = path.join(os.tmpdir(), `mstream-b4-${tag}-` + Date.now() + '-' + (envCounter++));
+  // Random suffix rather than Date.now(): the trash-sweep tests PIN
+  // Date.now, which would make these names deterministic across test
+  // invocations — two parallel/successive runs would rmSync each
+  // other's live trees.
+  const rand = crypto.randomBytes(4).toString('hex');
+  const root = path.join(os.tmpdir(), `mstream-b4-${tag}-${rand}-` + (envCounter++));
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
   return root;
@@ -142,6 +148,36 @@ describe('batch4 db: history rows', () => {
     assert.equal(prev.files_copied, 42);
   });
 
+  test('getLastBackupAttempt ignores skipped rows so they cannot consume the daily window', async () => {
+    const manager = await import('../../src/backup/manager.js');
+    const d4 = dbManager.addBackupDestination({
+      libraryId: dbManager.getLibraryByName('lib').id, destPath: path.join(testRoot, 'dest-sched'),
+      triggerType: 'daily', dailyAtHour: 23, retentionDays: 7, enabled: true, excludeGlobs: [], interFileDelayMs: 0,
+    });
+    const ins = dbManager.getDB().prepare(`INSERT INTO backup_history (destination_id, started_at, finished_at, status, trigger_reason)
+                            VALUES (?, ?, ?, ?, 'manual')`);
+    // An after-scan run active from 22:50 (local hour 22), then a manual
+    // Run-Now dedup-skip at 23:05 (hour 23) — the exact suppression
+    // scenario. Both rows are "today"; only the skip is at/after hour 23.
+    // NB: started_at is stored UTC; this test asserts the row-selection
+    // filter (status != 'skipped'), which is TZ-independent.
+    ins.run(d4, '2026-07-10 22:50:00', '2026-07-10 22:59:00', 'running');
+    const skipId = ins.run(d4, '2026-07-10 23:05:00', '2026-07-10 23:05:00', 'skipped').lastInsertRowid;
+
+    // getLastBackupRun (the UI last-run cell) sees the skip — correct there.
+    assert.equal(Number(dbManager.getLastBackupRun(d4).id), Number(skipId));
+    // The scheduler's attempt lookup skips it, returning the running row.
+    // This is the fix: keying on the skip would let its hour-23 stamp
+    // satisfy scheduledWindowServed and suppress the daily run, even
+    // though the skip records a NO-OP, not an attempt.
+    const attempt = dbManager.getLastBackupAttempt(d4);
+    assert.equal(attempt.status, 'running');
+    assert.equal(attempt.started_at, '2026-07-10 22:50:00');
+    // Sanity: manager import is wired (scheduledWindowServed is exercised
+    // exhaustively with literal rows in the window-served describe).
+    assert.equal(typeof manager.scheduledWindowServed, 'function');
+  });
+
   test('pruneBackupHistory never deletes a live running row', () => {
     const d3 = dbManager.addBackupDestination({
       libraryId: dbManager.getLibraryByName('lib').id, destPath: path.join(testRoot, 'dest-prune'),
@@ -227,6 +263,7 @@ describe('batch4 scheduler: window-served decision', () => {
     assert.equal(manager.scheduledWindowServed({ started_at: toSqliteUtc(ranAt), status: 'failed' }, 23, now), true);
   });
 });
+
 
 describe('batch4 scheduler: trash retention sweep', () => {
   let manager;
@@ -322,9 +359,10 @@ describe('batch4 worker: partial status + torn-copy + temp excludes', () => {
     fs.writeFileSync(f, 'v1');
 
     await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
-    // Change the file's content+size AND stamp its mtime to match the
-    // ORIGINAL, so only the post-copy re-stat (size check) catches it —
-    // then use the grow-during-copy fixture to enlarge it mid-copy.
+    // Rewrite the file so run 2 treats it as changed and re-copies it;
+    // the grow-during-copy fixture then appends bytes right after the
+    // copyFile, so the post-copy re-stat sees a size that no longer
+    // matches the pre-copy stat and the guard must refuse to finalise.
     fs.writeFileSync(f, 'v2-bigger-content');
 
     const { code, events } = await runWorker(


### PR DESCRIPTION
Follow-ups from a **fresh post-merge re-audit** of PR #727 (batch 4). That batch was authored and reviewed while the session was on a weaker model, and its review's lifecycle/cancellation lens had returned zero findings — so I re-ran the audit with skeptical eyes and explicitly re-litigated the previously-rejected findings. It surfaced one HIGH, two MEDIUM, and several lows; this PR closes the substantive ones.

## HIGH — library deletion orphaned in-flight backups

Batch 4 wired `cancelBackupsForDestination` into `DELETE /backup/destinations/:id`, but missed the **other** path that destroys destination rows: `DELETE /api/v1/admin/directory` → `removeDirectory` → `DELETE FROM libraries` cascades away the `backup_destinations` + `backup_history` rows (FK `ON DELETE CASCADE`) with no cancellation.

An active worker became a **phantom**: it kept mirroring for hours to a config the user just removed, held the strictly-serial queue slot (blocking the rescan admins typically run right after re-adding a library), was invisible (the status endpoint's ghost-guard reports idle once the destination row is gone; the worker's progress/finalise writes land on a cascade-deleted row as silent no-ops), and was unstoppable short of a server restart. This is the exact failure mode batch 4's own comments describe as the reason the destination-DELETE route got the cancel call — the library-DELETE route reaches the identical DB state and was missed.

`removeDirectory` now cancels each of the library's destinations before the cascade (`util/admin.js` already imports the task queue — no import cycle).

## MEDIUM — manual `skipped` rows consumed the daily window

The scheduler keyed its once-per-day gate on `getLastBackupRun` (most recent row of **any** status). A Run-Now click that gets dedup-dropped while a run is active writes a `skipped` row stamped `now`. So: an after-scan run active from 22:50 (hour 22), a manual Run-Now at 23:05 → a `skipped` row at hour 23 → `scheduledWindowServed` sees hour 23 ≥ 23 → the `daily_at_hour=23` backup is suppressed for the day, even though the skip records a **no-op**, not an attempt.

New `getLastBackupAttempt` (`status != 'skipped'`) is what the scheduler keys on now; `getLastBackupRun` still drives the UI's last-run cell, where showing the skip is the point.

## MEDIUM — the delete-mid-run test couldn't fail

The batch-4 delete-mid-run test asserted only that the status endpoint went idle — which the ghost-guard makes true whether or not the worker was actually cancelled (confirmed by mutation: the test passed with the cancel deleted). Rewritten to assert the **serial queue slot** (`/api/v1/db/status` `locked`) frees within seconds of a ~32-second natural run, which only happens if the worker is genuinely killed. Pinned by mutation (0/3 with cancel removed). Added matching tests for PATCH-dest_path-mid-run and the library-delete cascade path.

## Also fixed

- **PATCH of `dest_path` mid-run** now cancels the in-flight worker — it was still writing the OLD path while the row (and status card) reported the new one.
- **Worker-launch throw** after `createBackupRunRow` no longer orphans a `running` history row. Some spawn failures throw synchronously rather than emitting `error`; the row would have been stranded `running` forever (never pruned — running rows are exempt — and consuming the daily window until the next boot's crash recovery). It's now finalised `failed` before the throw propagates to `nextTask`'s dispatch log.
- **Stale docs** corrected: the task-queue and schema comments claimed `partial` is excluded from scheduling/progress, but batch 4's own follow-up (getLastCountedBackupBefore) made it count for both — only "last successful run" semantics exclude it. Noted that `getLastSuccessfulBackup` now has no production caller.
- **Test hygiene:** `makeTempRoot` uses a random suffix (the pinned `Date.now` in the trash-sweep tests had made the old `Date.now()`-based dir names deterministic across runs, so parallel/successive runs could `rmSync` each other's live trees); the torn-copy test comment corrected to describe what the test actually does (it references an mtime-stamping step that doesn't exist).

## Re-audit rejections (unanimous 0/2, no change)

- "retention-0 destroys the deletion log within the hour" — by design and documented (`0 = hard delete`).
- "DELETE bypasses `withDestWriteLock`" — unreachable; the DELETE handler is synchronous through the row removal.

## Validation

Full backup suite 83/83 (17 API + 17 batch4 + task-queue + worker suites); lint at master baseline; the three cancellation tests verified to fail 0/3 when the cancel is removed. Rig smoke pending on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
