### PR TITLE
refactor(iroh): extract shared plumbing into iroh-common.js

### DIFF
--- a/src/state/iroh-common.js
+++ b/src/state/iroh-common.js
@@ -1,0 +1,189 @@
+// Shared iroh plumbing (@number0/iroh v1), used by every in-process iroh
+// endpoint: the remote-access tunnel (src/state/iroh.js) and the federation
+// endpoint (src/state/federation.js). Three groups live here:
+//
+//  1. The lazy native-module loader (+ the Bun-standalone .node staging) and
+//     the selfTest() smoke check the build CI runs.
+//  2. The byte pumps coupling an iroh QUIC bi-stream to a Node TCP socket —
+//     subtle backpressure/teardown code (see the Reset(0) note on bridge())
+//     that must not be duplicated per consumer.
+//  3. The versioned ticket envelope `<prefix><version>:<base64url(JSON)>`
+//     shared by the tunnel pairing code (`mstr1:`, docs/iroh-pairing-code.md)
+//     and the federation ticket (`mstrfed1:`, docs/federation-ticket.md).
+//
+// --- v1 API notes ---
+//  * Bind with Endpoint.bind({secretKey, alpns}); POLL endpoint.acceptNext().
+//  * recv.read(limit) RETURNS a byte array (EOF == empty array); writeAll()/
+//    connect() take Array<number>, NOT Buffers. reset()/stop() take bigint.
+
+import net from 'net';
+import crypto from 'crypto';
+import winston from 'winston';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { appRoot, isBunStandalone } from '../util/esm-helpers.js';
+
+export const READ_CHUNK = 64 * 1024;
+
+export const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Lazily import the native module exactly once. Kept out of module scope so a
+// missing/unloadable binary only surfaces when a feature is actually used.
+let irohMod = null;
+export async function loadIroh() {
+  if (!irohMod) {
+    // Under a Bun `--compile` standalone binary, @number0/iroh's NAPI-RS loader
+    // can't resolve its platform package from the virtual node_modules, so point
+    // it at the prebuilt .node shipped next to the executable (staged into
+    // bin/iroh/ by scripts/build-bun.mjs). The loader honours
+    // NAPI_RS_NATIVE_LIBRARY_PATH ahead of its built-in resolution. No-op under
+    // Node/Electron, where normal node_modules resolution applies.
+    if (isBunStandalone && !process.env.NAPI_RS_NATIVE_LIBRARY_PATH) {
+      try {
+        const dir = join(appRoot, 'bin', 'iroh');
+        const node = existsSync(dir) && readdirSync(dir).find((f) => f.endsWith('.node'));
+        if (node) { process.env.NAPI_RS_NATIVE_LIBRARY_PATH = join(dir, node); }
+      } catch { /* fall back to the loader's default resolution */ }
+    }
+    irohMod = await import('@number0/iroh');
+  }
+  return irohMod;
+}
+
+// Smoke check for the `iroh-selftest` worker (build CI + local build
+// verification). Forces the native binding to load and confirms it's the real
+// addon: a failed dlopen makes loadIroh() throw, so reaching the export check
+// proves THIS binary loaded the shipped .node.
+export async function selfTest() {
+  const iroh = await loadIroh();
+  const exports = Object.keys(iroh).length;
+  if (exports === 0) { throw new Error('iroh module loaded but exposed no exports'); }
+  return {
+    exports,
+    nativePath: process.env.NAPI_RS_NATIVE_LIBRARY_PATH || '(default resolution)',
+  };
+}
+
+// Normalize a secret given as a Buffer/Uint8Array/Array or a base64 string.
+export function asBuffer(secret) {
+  if (typeof secret === 'string') { return Buffer.from(secret, 'base64'); }
+  return Buffer.from(secret);
+}
+
+// Generate a fresh 32-byte secret (endpoint identity keys, pipe secrets).
+// Returns a Buffer.
+export function generateSecretKey() {
+  return crypto.randomBytes(32);
+}
+
+// ---------------------------------------------------------------------------
+// Generic byte pumps bridging an Iroh bi-stream <-> a Node TCP socket.
+// ---------------------------------------------------------------------------
+
+// Drain an Iroh recv stream into a TCP socket. v1 read(limit) returns a byte
+// array; an empty array signals clean EOF. On clean EOF we half-close the socket
+// (socket.end — NOT destroy) so an in-flight response keeps flowing. Errors
+// propagate so bridge() can tear down the partner direction.
+export async function pumpRecvToSocket(recv, socket) {
+  for (;;) {
+    const chunk = await recv.read(READ_CHUNK);
+    if (chunk.length === 0) { break; }
+    if (!socket.write(Buffer.from(chunk))) {
+      await new Promise((resolve) => {
+        const done = () => { socket.off('drain', done); socket.off('close', done); resolve(); };
+        socket.once('drain', done);
+        socket.once('close', done);
+      });
+    }
+    if (socket.destroyed || socket.writableEnded) { break; }
+  }
+  if (!socket.destroyed) { socket.end(); }
+}
+
+// Pump a TCP socket into an Iroh send stream (backpressure via async iteration).
+// v1 writeAll wants Array<number>. Errors propagate so bridge() disposes the partner.
+export async function pumpSocketToSend(socket, send) {
+  for await (const chunk of socket) {
+    await send.writeAll(Array.from(chunk));
+  }
+  await send.finish();
+}
+
+// Couple a connected TCP socket and an Iroh bi-stream into a full-duplex tunnel.
+// If EITHER direction errors, dispose() force-tears-down both halves so the
+// partner can't park. dispose() is idempotent and also runs once both settle.
+export function bridge(socket, bi) {
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) { return; }
+    disposed = true;
+    try { socket.destroy(); } catch (_err) { /* already gone */ }
+    bi.recv.stop(0n).catch(() => {});
+    bi.send.reset(0n).catch(() => {});
+  };
+  // dispose() is the ABNORMAL-teardown path only. On clean completion each pump
+  // closes its own half gracefully (recv EOF -> socket.end(); socket EOF ->
+  // send.finish()), and we must NOT then reset()/stop() the streams: a reset
+  // racing the peer's final read surfaces as a spurious "Reset(0)" on the other
+  // end (truncating/erroring an otherwise-complete response). So only dispose
+  // when a direction ERRORS — that tears down the partner so it can't park.
+  socket.once('error', (err) => { winston.debug(`[iroh] tunnel socket error: ${err.message}`); dispose(); });
+  pumpRecvToSocket(bi.recv, socket).catch((err) => { winston.debug(`[iroh] recv->socket pump ended: ${err?.message}`); dispose(); });
+  pumpSocketToSend(socket, bi.send).catch((err) => { winston.debug(`[iroh] socket->send pump ended: ${err?.message}`); dispose(); });
+}
+
+// Wire one accepted Iroh bi-stream to a fresh TCP connection to the backend.
+export function bridgeStreamToBackend(bi, targetHost, targetPort) {
+  const socket = net.connect({ host: targetHost, port: targetPort });
+  let started = false;
+  socket.once('connect', () => { started = true; bridge(socket, bi); });
+  socket.once('error', (err) => {
+    if (started) { return; } // bridge() now owns teardown
+    winston.warn(`[iroh] backend connect failed (${targetHost}:${targetPort}): ${err.message}`);
+    bi.send.reset(0n).catch(() => {});
+    bi.recv.stop(0n).catch(() => {});
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Versioned ticket envelope: "<prefix><version>:<base64url(JSON payload)>".
+// ---------------------------------------------------------------------------
+
+// Build an envelope string. The payload is any JSON-serializable object;
+// field validation is the caller's job (each ticket type owns its fields).
+export function buildEnvelope(prefix, version, payload) {
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${prefix}${version}:${body}`;
+}
+
+// Parse an envelope -> { version, payload }. Pure (no native module needed).
+//   prefix     required literal prefix, e.g. 'mstr' or 'mstrfed'.
+//   maxVersion highest version this build understands; newer is rejected with
+//              an actionable error.
+//   allowBare  accept a bare base64url(JSON) body with no prefix as implicit
+//              v1 (the tunnel pairing code's legacy form). Default false.
+//   label      human label used in error messages, e.g. 'pairing code'.
+// Callers validate the payload's required fields and throw their own
+// `Invalid <label> (missing fields)` so the error wording stays per-ticket.
+export function parseEnvelope(code, { prefix, maxVersion, allowBare = false, label = 'ticket' } = {}) {
+  const str = String(code).trim();
+  let version = 1;
+  let body = str;
+  const m = str.match(new RegExp(`^${prefix}(\\d+):(.*)$`, 's'));
+  if (m) {
+    version = Number(m[1]);
+    body = m[2];
+  } else if (!allowBare) {
+    throw new Error(`Invalid ${label}`);
+  }
+  if (version > maxVersion) {
+    throw new Error(`${label.charAt(0).toUpperCase()}${label.slice(1)} is version ${version}; this build supports up to v${maxVersion}. Update to a newer version.`);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+  } catch (err) {
+    throw new Error(`Invalid ${label}`, { cause: err });
+  }
+  return { version, payload };
+}

--- a/src/state/iroh.js
+++ b/src/state/iroh.js
@@ -26,130 +26,42 @@
 // the boot site wraps start() in try/catch and simply leaves the feature off if
 // the binary can't load.
 //
-// --- v1 API notes ---
-//  * Bind with Endpoint.bind({secretKey, alpns}); POLL endpoint.acceptNext().
-//  * recv.read(limit) RETURNS a byte array (EOF == empty array); writeAll()/
-//    connect() take Array<number>, NOT Buffers. reset()/stop() take bigint.
+// The native loader, the byte pumps, and the ticket-envelope helpers are shared
+// with the federation endpoint — they live in src/state/iroh-common.js and are
+// re-exported here so existing consumers (tests, scripts, admin API) keep their
+// import paths.
 
-import net from 'net';
 import crypto from 'crypto';
 import winston from 'winston';
-import { existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { appRoot, isBunStandalone } from '../util/esm-helpers.js';
+import {
+  loadIroh,
+  asBuffer,
+  delay,
+  bridgeStreamToBackend,
+  buildEnvelope,
+  parseEnvelope,
+} from './iroh-common.js';
+
+// Shared plumbing re-exported for existing consumers.
+export {
+  selfTest,
+  pumpRecvToSocket,
+  pumpSocketToSend,
+  bridge,
+  generateSecretKey,
+} from './iroh-common.js';
 
 // ALPN for the mStream tunnel — both ends must present identical bytes.
 // v1 wants ALPNs as Array<number>. Bump the version if framing changes.
 export const TUNNEL_ALPN = Array.from(Buffer.from('mstream/tunnel/2'));
 
-const READ_CHUNK = 64 * 1024;
 const HANDSHAKE_LIMIT = 256; // max bytes accepted for the auth handshake
 
-const delay = (ms) => new Promise((r) => setTimeout(r, ms));
-
-// Lazily import the native module exactly once. Kept out of module scope so a
-// missing/unloadable binary only surfaces when the feature is actually used.
-let irohMod = null;
-async function loadIroh() {
-  if (!irohMod) {
-    // Under a Bun `--compile` standalone binary, @number0/iroh's NAPI-RS loader
-    // can't resolve its platform package from the virtual node_modules, so point
-    // it at the prebuilt .node shipped next to the executable (staged into
-    // bin/iroh/ by scripts/build-bun.mjs). The loader honours
-    // NAPI_RS_NATIVE_LIBRARY_PATH ahead of its built-in resolution. No-op under
-    // Node/Electron, where normal node_modules resolution applies.
-    if (isBunStandalone && !process.env.NAPI_RS_NATIVE_LIBRARY_PATH) {
-      try {
-        const dir = join(appRoot, 'bin', 'iroh');
-        const node = existsSync(dir) && readdirSync(dir).find((f) => f.endsWith('.node'));
-        if (node) { process.env.NAPI_RS_NATIVE_LIBRARY_PATH = join(dir, node); }
-      } catch { /* fall back to the loader's default resolution */ }
-    }
-    irohMod = await import('@number0/iroh');
-  }
-  return irohMod;
-}
-
-// Smoke check for the `iroh-selftest` worker (build CI + local build
-// verification). Forces the native binding to load and confirms it's the real
-// addon: a failed dlopen makes loadIroh() throw, so reaching the export check
-// proves THIS binary loaded the shipped .node.
-export async function selfTest() {
-  const iroh = await loadIroh();
-  const exports = Object.keys(iroh).length;
-  if (exports === 0) { throw new Error('iroh module loaded but exposed no exports'); }
-  return {
-    exports,
-    nativePath: process.env.NAPI_RS_NATIVE_LIBRARY_PATH || '(default resolution)',
-  };
-}
-
-// Normalize a secret given as a Buffer/Uint8Array/Array or a base64 string.
-function asBuffer(secret) {
-  if (typeof secret === 'string') { return Buffer.from(secret, 'base64'); }
-  return Buffer.from(secret);
-}
-
 // Server state
+let irohMod = null;         // the loaded native module (set by start/connectTunnel)
 let endpoint = null;        // the live Iroh endpoint (null when stopped)
 let endpointIdStr = null;   // cached base32 EndpointId string
 let connectSecretBuf = null; // Buffer the handshake compares against
-
-// ---------------------------------------------------------------------------
-// Generic byte pumps bridging an Iroh bi-stream <-> a Node TCP socket.
-// ---------------------------------------------------------------------------
-
-// Drain an Iroh recv stream into a TCP socket. v1 read(limit) returns a byte
-// array; an empty array signals clean EOF. On clean EOF we half-close the socket
-// (socket.end — NOT destroy) so an in-flight response keeps flowing. Errors
-// propagate so bridge() can tear down the partner direction.
-export async function pumpRecvToSocket(recv, socket) {
-  for (;;) {
-    const chunk = await recv.read(READ_CHUNK);
-    if (chunk.length === 0) { break; }
-    if (!socket.write(Buffer.from(chunk))) {
-      await new Promise((resolve) => {
-        const done = () => { socket.off('drain', done); socket.off('close', done); resolve(); };
-        socket.once('drain', done);
-        socket.once('close', done);
-      });
-    }
-    if (socket.destroyed || socket.writableEnded) { break; }
-  }
-  if (!socket.destroyed) { socket.end(); }
-}
-
-// Pump a TCP socket into an Iroh send stream (backpressure via async iteration).
-// v1 writeAll wants Array<number>. Errors propagate so bridge() disposes the partner.
-export async function pumpSocketToSend(socket, send) {
-  for await (const chunk of socket) {
-    await send.writeAll(Array.from(chunk));
-  }
-  await send.finish();
-}
-
-// Couple a connected TCP socket and an Iroh bi-stream into a full-duplex tunnel.
-// If EITHER direction errors, dispose() force-tears-down both halves so the
-// partner can't park. dispose() is idempotent and also runs once both settle.
-export function bridge(socket, bi) {
-  let disposed = false;
-  const dispose = () => {
-    if (disposed) { return; }
-    disposed = true;
-    try { socket.destroy(); } catch (_err) { /* already gone */ }
-    bi.recv.stop(0n).catch(() => {});
-    bi.send.reset(0n).catch(() => {});
-  };
-  // dispose() is the ABNORMAL-teardown path only. On clean completion each pump
-  // closes its own half gracefully (recv EOF -> socket.end(); socket EOF ->
-  // send.finish()), and we must NOT then reset()/stop() the streams: a reset
-  // racing the peer's final read surfaces as a spurious "Reset(0)" on the other
-  // end (truncating/erroring an otherwise-complete response). So only dispose
-  // when a direction ERRORS — that tears down the partner so it can't park.
-  socket.once('error', (err) => { winston.debug(`[iroh] tunnel socket error: ${err.message}`); dispose(); });
-  pumpRecvToSocket(bi.recv, socket).catch((err) => { winston.debug(`[iroh] recv->socket pump ended: ${err?.message}`); dispose(); });
-  pumpSocketToSend(socket, bi.send).catch((err) => { winston.debug(`[iroh] socket->send pump ended: ${err?.message}`); dispose(); });
-}
 
 // ---------------------------------------------------------------------------
 // Composite ticket (what the QR encodes): EndpointTicket + connectSecret.
@@ -164,9 +76,10 @@ export const PAIRING_VERSION = 1; // highest pairing-code version this build emi
 
 // Build the pairing code the QR carries. v1 payload = { t: <EndpointTicket>, s: <secret base64> }.
 export function buildCompositeTicket(ticketStr, secret) {
-  const payload = { t: ticketStr, s: asBuffer(secret).toString('base64') };
-  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  return `${PAIRING_PREFIX}${PAIRING_VERSION}:${body}`;
+  return buildEnvelope(PAIRING_PREFIX, PAIRING_VERSION, {
+    t: ticketStr,
+    s: asBuffer(secret).toString('base64'),
+  });
 }
 
 // Parse a pairing code -> { version, ticket: <EndpointTicket string>, secret: <base64 string> }.
@@ -174,23 +87,12 @@ export function buildCompositeTicket(ticketStr, secret) {
 // for back-compat, a bare base64url(JSON) body (treated as implicit v1). Rejects
 // a version newer than this build understands with an actionable error.
 export function parseCompositeTicket(code) {
-  const str = String(code).trim();
-  let version = 1;
-  let body = str;
-  const m = str.match(/^mstr(\d+):(.*)$/s);
-  if (m) {
-    version = Number(m[1]);
-    body = m[2];
-  }
-  if (version > PAIRING_VERSION) {
-    throw new Error(`Pairing code is version ${version}; this build supports up to v${PAIRING_VERSION}. Update to a newer version.`);
-  }
-  let payload;
-  try {
-    payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
-  } catch (err) {
-    throw new Error('Invalid pairing code', { cause: err });
-  }
+  const { version, payload } = parseEnvelope(code, {
+    prefix: PAIRING_PREFIX,
+    maxVersion: PAIRING_VERSION,
+    allowBare: true, // legacy bare base64url(JSON) codes = implicit v1
+    label: 'pairing code',
+  });
   if (!payload || typeof payload.t !== 'string' || typeof payload.s !== 'string') {
     throw new Error('Invalid pairing code (missing fields)');
   }
@@ -200,19 +102,6 @@ export function parseCompositeTicket(code) {
 // ---------------------------------------------------------------------------
 // Server side
 // ---------------------------------------------------------------------------
-
-// Wire one accepted Iroh bi-stream to a fresh TCP connection to the backend.
-function bridgeStreamToBackend(bi, targetHost, targetPort) {
-  const socket = net.connect({ host: targetHost, port: targetPort });
-  let started = false;
-  socket.once('connect', () => { started = true; bridge(socket, bi); });
-  socket.once('error', (err) => {
-    if (started) { return; } // bridge() now owns teardown
-    winston.warn(`[iroh] backend connect failed (${targetHost}:${targetPort}): ${err.message}`);
-    bi.send.reset(0n).catch(() => {});
-    bi.recv.stop(0n).catch(() => {});
-  });
-}
 
 // Validate the shared-secret handshake on a freshly-accepted connection. The
 // client's FIRST bi-stream carries the secret; we compare constant-time and
@@ -287,7 +176,8 @@ export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, c
   if (!targetPort) { throw new Error('iroh.start: targetPort is required'); }
   if (!connectSecret) { throw new Error('iroh.start: connectSecret is required'); }
 
-  const { Endpoint } = await loadIroh();
+  irohMod = await loadIroh();
+  const { Endpoint } = irohMod;
   connectSecretBuf = asBuffer(connectSecret);
 
   const options = { alpns: [TUNNEL_ALPN] };
@@ -330,12 +220,6 @@ export async function stop() {
   connectSecretBuf = null;
 }
 
-// Generate a fresh 32-byte secret (used for both the endpoint key and the
-// connect secret). Returns a Buffer.
-export function generateSecretKey() {
-  return crypto.randomBytes(32);
-}
-
 // ---------------------------------------------------------------------------
 // Client side (used by the dev scripts and, later, the desktop/mobile clients).
 // ---------------------------------------------------------------------------
@@ -345,7 +229,8 @@ export function generateSecretKey() {
 // and hand them to bridge(). Throws on auth failure / unreachable server.
 export async function connectTunnel(compositeTicket, { awaitOnline = true } = {}) {
   const { ticket, secret } = parseCompositeTicket(compositeTicket);
-  const { Endpoint, EndpointTicket } = await loadIroh();
+  irohMod = await loadIroh();
+  const { Endpoint, EndpointTicket } = irohMod;
 
   const client = await Endpoint.bind({});
   // Cross-network: establish our own home relay BEFORE dialing, else the first

--- a/test/unit/iroh-envelope.test.mjs
+++ b/test/unit/iroh-envelope.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * Versioned ticket-envelope helpers shared by the tunnel pairing code and the
+ * federation ticket. Pure functions (no native module needed), so these always
+ * run. The tunnel-specific wrapper behavior (field validation, legacy bare
+ * codes) stays covered by iroh-ticket.test.mjs.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildEnvelope, parseEnvelope } from '../../src/state/iroh-common.js';
+
+describe('iroh ticket envelope', () => {
+  test('round-trips a payload under a prefix + version', () => {
+    const s = buildEnvelope('mstrfed', 1, { t: 'endpointabc', k: 'fedk_xyz' });
+    assert.match(s, /^mstrfed1:/);
+    const { version, payload } = parseEnvelope(s, { prefix: 'mstrfed', maxVersion: 1, label: 'federation ticket' });
+    assert.equal(version, 1);
+    assert.deepEqual(payload, { t: 'endpointabc', k: 'fedk_xyz' });
+  });
+
+  test('rejects a missing prefix unless allowBare', () => {
+    const bare = Buffer.from(JSON.stringify({ a: 1 })).toString('base64url');
+    assert.throws(
+      () => parseEnvelope(bare, { prefix: 'mstrfed', maxVersion: 1, label: 'federation ticket' }),
+      /Invalid federation ticket/,
+    );
+    const { version, payload } = parseEnvelope(bare, { prefix: 'mstr', maxVersion: 1, allowBare: true, label: 'pairing code' });
+    assert.equal(version, 1); // bare body = implicit v1
+    assert.deepEqual(payload, { a: 1 });
+  });
+
+  test('a ticket from one prefix fails cleanly in the other parser', () => {
+    const fed = buildEnvelope('mstrfed', 1, { t: 'x', k: 'y' });
+    // 'mstr' + allowBare: 'mstrfed1:...' is not ^mstr\d+: so it falls to the
+    // bare-body path and fails JSON parsing — the tunnel parser can't half-read
+    // a federation ticket.
+    assert.throws(
+      () => parseEnvelope(fed, { prefix: 'mstr', maxVersion: 1, allowBare: true, label: 'pairing code' }),
+      /Invalid pairing code/,
+    );
+    const tun = buildEnvelope('mstr', 1, { t: 'x', s: 'y' });
+    assert.throws(
+      () => parseEnvelope(tun, { prefix: 'mstrfed', maxVersion: 1, label: 'federation ticket' }),
+      /Invalid federation ticket/,
+    );
+  });
+
+  test('rejects a newer version with an actionable error naming the label', () => {
+    const s = buildEnvelope('mstrfed', 9, { t: 'x' });
+    assert.throws(
+      () => parseEnvelope(s, { prefix: 'mstrfed', maxVersion: 1, label: 'federation ticket' }),
+      /Federation ticket is version 9.*supports up to v1.*[Uu]pdate/s,
+    );
+  });
+
+  test('rejects garbage bodies with the label in the message', () => {
+    assert.throws(
+      () => parseEnvelope('mstrfed1:!!!not-base64-json!!!', { prefix: 'mstrfed', maxVersion: 1, label: 'federation ticket' }),
+      /Invalid federation ticket/,
+    );
+  });
+});


### PR DESCRIPTION
## What this does

Pure refactor preparing for the federation endpoint (next PR in the series): the pieces of the iroh remote-access tunnel that federation needs verbatim move out of `src/state/iroh.js` into a new shared module, `src/state/iroh-common.js`. **No behavior change** — `iroh.js` re-exports the same public surface, so every existing consumer (admin API, selftest worker, dev scripts, tests) keeps its import paths untouched.

## Moved verbatim into `iroh-common.js`

- **`loadIroh()`** — the lazy native-module import, including the Bun-standalone `.node` staging via `NAPI_RS_NATIVE_LIBRARY_PATH`, plus `selfTest()` for the build CI
- **The byte pumps** — `pumpRecvToSocket` / `pumpSocketToSend` / `bridge` / `bridgeStreamToBackend`, the QUIC-bi-stream ⇄ TCP-socket coupling. This code carries a subtle teardown invariant (the Reset(0)-race note: dispose only on ERROR, never after clean completion, or the peer sees a truncated response) — exactly the kind of thing that must not exist in two copies
- `asBuffer`, `generateSecretKey`, `delay`, `READ_CHUNK`

## Generalized: the ticket envelope

`parseCompositeTicket`'s envelope mechanics become two reusable helpers:

- `buildEnvelope(prefix, version, payload)` → `` `<prefix><version>:<base64url(JSON)>` ``
- `parseEnvelope(str, { prefix, maxVersion, allowBare, label })` → `{ version, payload }`

The tunnel's `mstr1:` pairing code becomes a thin wrapper (`prefix: 'mstr'`, `allowBare: true` for the legacy bare-body form, same error strings as before). The upcoming federation ticket reuses the same parser with `prefix: 'mstrfed'` — and the prefixes are mutually unparseable, so a ticket pasted into the wrong UI fails cleanly. Payload field validation stays in each wrapper so error wording stays per-ticket-type.

## Verification

- Existing iroh tests pass **unchanged** (`iroh-ticket`, `iroh-config`, and the live `iroh-handshake` integration test against a real endpoint)
- New `test/unit/iroh-envelope.test.mjs` covers the generalized helpers: round-trip, bare-body handling, cross-prefix rejection in both directions, version-too-new errors naming the right label
- An import smoke check asserts `iroh.js` still exposes the identical 17-symbol surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)