### PR TITLE
feat(federation): V57 schema, config block, and DB accessors

### DIFF
--- a/src/db/federation.js
+++ b/src/db/federation.js
@@ -1,0 +1,146 @@
+// Accessors for the federation tables (SCHEMA_V57): keys this server minted
+// for read-only peers, their per-key library grants, and the remote peers
+// this server can read. Tables live in mstream.db (admin-managed operational
+// state FK'd to libraries, same reasoning as backup_destinations), so
+// everything goes through db/manager.js's handle.
+//
+// Key format: 'fedk_' + 32 random bytes base64url. The prefix makes keys
+// self-identifying in logs and unambiguous vs JWTs at the auth wall.
+
+import crypto from 'crypto';
+import { getDB } from './manager.js';
+
+export const FEDERATION_KEY_PREFIX = 'fedk_';
+
+export function generateFederationKey() {
+  return FEDERATION_KEY_PREFIX + crypto.randomBytes(32).toString('base64url');
+}
+
+// ── Minted keys (inbound grants) ─────────────────────────────────────────────
+
+// Mint a key granting read-only access to the given library ids. The insert
+// and its grants are one transaction so a failed grant can't leave a key with
+// access to nothing (or worse, everything a later bug assumes).
+export function createFederationKey(name, libraryIds) {
+  const db = getDB();
+  const key = generateFederationKey();
+  db.exec('BEGIN');
+  try {
+    const result = db.prepare('INSERT INTO federation_keys (key, name) VALUES (?, ?)').run(key, name);
+    const keyId = Number(result.lastInsertRowid);
+    const grant = db.prepare('INSERT INTO federation_key_libraries (key_id, library_id) VALUES (?, ?)');
+    for (const libId of libraryIds) { grant.run(keyId, libId); }
+    db.exec('COMMIT');
+    return { id: keyId, key, name };
+  } catch (err) {
+    try { db.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
+    throw err;
+  }
+}
+
+// All minted keys with their granted library names aggregated (UI listing).
+export function getFederationKeys() {
+  return getDB().prepare(`
+    SELECT k.*,
+           (SELECT json_group_array(l.name)
+              FROM federation_key_libraries kl
+              JOIN libraries l ON l.id = kl.library_id
+             WHERE kl.key_id = k.id) AS library_names_json
+      FROM federation_keys k
+     ORDER BY k.created_at, k.id
+  `).all().map((row) => ({
+    ...row,
+    library_names: JSON.parse(row.library_names_json || '[]'),
+  }));
+}
+
+export function getFederationKeyById(id) {
+  return getDB().prepare('SELECT * FROM federation_keys WHERE id = ?').get(id);
+}
+
+// Auth-wall lookup: the presented credential -> the key row, or undefined.
+export function getFederationKeyByKey(key) {
+  return getDB().prepare('SELECT * FROM federation_keys WHERE key = ?').get(key);
+}
+
+// The libraries a key grants, as [{ id, name }] (auth wall + UI).
+export function getFederationKeyLibraries(keyId) {
+  return getDB().prepare(`
+    SELECT l.id, l.name
+      FROM federation_key_libraries kl
+      JOIN libraries l ON l.id = kl.library_id
+     WHERE kl.key_id = ?
+     ORDER BY l.name
+  `).all(keyId);
+}
+
+export function deleteFederationKey(id) {
+  return getDB().prepare('DELETE FROM federation_keys WHERE id = ?').run(id).changes > 0;
+}
+
+// TOFU: bind the key to the first endpoint that redeems it. Guarded WHERE so
+// a concurrent handshake can't re-bind an already-bound key — the caller must
+// re-read the row and reject on mismatch when this returns false.
+export function bindFederationKeyEndpoint(id, endpointId) {
+  return getDB().prepare(`
+    UPDATE federation_keys
+       SET bound_endpoint_id = ?, bound_at = datetime('now')
+     WHERE id = ? AND bound_endpoint_id IS NULL
+  `).run(endpointId, id).changes > 0;
+}
+
+// Admin "friend reinstalled" escape hatch: clear the TOFU binding without
+// re-minting (the next successful handshake re-binds).
+export function resetFederationKeyBinding(id) {
+  return getDB().prepare(`
+    UPDATE federation_keys
+       SET bound_endpoint_id = NULL, bound_at = NULL
+     WHERE id = ?
+  `).run(id).changes > 0;
+}
+
+// last_used touch, throttled in-process so the auth wall doesn't write a row
+// per request — one update per key per minute is plenty for a UI freshness
+// indicator.
+const LAST_USED_THROTTLE_MS = 60 * 1000;
+const lastTouched = new Map(); // keyId -> epoch ms of last write
+export function touchFederationKeyLastUsed(id) {
+  const now = Date.now();
+  const prev = lastTouched.get(id);
+  if (prev !== undefined && now - prev < LAST_USED_THROTTLE_MS) { return; }
+  lastTouched.set(id, now);
+  getDB().prepare(`UPDATE federation_keys SET last_used = datetime('now') WHERE id = ?`).run(id);
+}
+
+// ── Peers (outbound: servers we can read) ────────────────────────────────────
+
+export function addFederationPeer({ name, endpointTicket, apiKey }) {
+  const result = getDB().prepare(`
+    INSERT INTO federation_peers (name, endpoint_ticket, api_key) VALUES (?, ?, ?)
+  `).run(name, endpointTicket, apiKey);
+  return getFederationPeerById(Number(result.lastInsertRowid));
+}
+
+export function getFederationPeers() {
+  return getDB().prepare('SELECT * FROM federation_peers ORDER BY added_at, id').all();
+}
+
+export function getFederationPeerById(id) {
+  return getDB().prepare('SELECT * FROM federation_peers WHERE id = ?').get(id);
+}
+
+// Cache the latest health-check outcome for the admin UI. status 'ok' also
+// stamps last_seen; a failure only updates last_status so last_seen keeps
+// showing when the peer was last actually reachable.
+export function updateFederationPeerStatus(id, status) {
+  if (status === 'ok') {
+    return getDB().prepare(`
+      UPDATE federation_peers SET last_status = 'ok', last_seen = datetime('now') WHERE id = ?
+    `).run(id).changes > 0;
+  }
+  return getDB().prepare('UPDATE federation_peers SET last_status = ? WHERE id = ?').run(status, id).changes > 0;
+}
+
+export function deleteFederationPeer(id) {
+  return getDB().prepare('DELETE FROM federation_peers WHERE id = ?').run(id).changes > 0;
+}

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -53,7 +53,10 @@
 // V56 adds acoustid_lookups — the per-track attempt cache for the AcoustID
 // fingerprint identification pass (cooldowns so unmatched / undecodable
 // files aren't re-fingerprinted and re-queried every batch). See SCHEMA_V56.
-export const SCHEMA_VERSION = 56;
+// V57 adds the federation tables — keys this server minted for read-only
+// peers (federation_keys + per-key library grants) and the remote servers
+// this server can read (federation_peers). See SCHEMA_V57.
+export const SCHEMA_VERSION = 57;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2137,6 +2140,54 @@ export const SCHEMA_V56 = `
   );
 `;
 
+// ── Federation (ticket-paired read-only server federation) ─────────────────
+//
+// Two sides of a pairing, deliberately separate tables:
+//
+//   federation_keys      — keys THIS server minted. A key is the credential a
+//                          remote friend server presents (x-federation-key
+//                          header + the iroh pipe handshake) for read-only
+//                          access to the granted libraries. bound_endpoint_id
+//                          is TOFU state: NULL until the first successful
+//                          pipe handshake binds the key to that dialer's iroh
+//                          EndpointId; afterwards other endpoints are
+//                          rejected, so a leaked ticket dies on redemption.
+//   federation_key_libraries — per-key library grants. A join table (not a
+//                          JSON column) so ON DELETE CASCADE keeps grants
+//                          consistent when a key or a library is deleted, and
+//                          grants survive library renames.
+//   federation_peers     — remote servers THIS server can read: their iroh
+//                          EndpointTicket and the key THEY minted for us.
+//                          last_seen/last_status cache the latest health
+//                          check for the admin UI.
+export const SCHEMA_V57 = `
+  CREATE TABLE IF NOT EXISTS federation_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    last_used TEXT,
+    bound_endpoint_id TEXT,
+    bound_at TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS federation_key_libraries (
+    key_id INTEGER NOT NULL REFERENCES federation_keys(id) ON DELETE CASCADE,
+    library_id INTEGER NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    PRIMARY KEY (key_id, library_id)
+  );
+
+  CREATE TABLE IF NOT EXISTS federation_peers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    endpoint_ticket TEXT NOT NULL,
+    api_key TEXT NOT NULL UNIQUE,
+    added_at TEXT DEFAULT (datetime('now')),
+    last_seen TEXT,
+    last_status TEXT
+  );
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -2338,4 +2389,7 @@ export const MIGRATIONS = [
   // V56 adds the acoustid_lookups failure-cooldown ledger for the AcoustID
   // fingerprint pass. Pure new table — no rescan needed. See SCHEMA_V56.
   { version: 56, sql: SCHEMA_V56 },
+  // V57 adds the federation tables (minted keys + per-key library grants +
+  // known peers). Pure new tables — no rescan needed. See SCHEMA_V57.
+  { version: 57, sql: SCHEMA_V57 },
 ];

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -302,6 +302,24 @@ const irohOptions = Joi.object({
   shareCodePublic: Joi.boolean().default(false),
 });
 
+// Federation: ticket-paired read-only library sharing between mStream servers
+// over a dedicated iroh endpoint (ALPN mstream/federation/1). A THIRD iroh
+// persona, independent of the `iroh` tunnel above and the discovery sidecar —
+// its own secretKey, so the three EndpointIds stay unlinkable and each feature
+// toggles on its own. No discovery/gossip: pairing is ticket-swap only.
+//   secretKey  — base64 of 32 random bytes; the federation endpoint's identity.
+//                Auto-generated once and persisted (same precedent as the
+//                iroh block). Losing it changes the EndpointId and breaks
+//                every previously-issued federation ticket.
+//   serverName — display name embedded in minted tickets so the friend's
+//                add-peer UI can label this server; '' falls back to
+//                os.hostname() at mint time.
+const federationOptions = Joi.object({
+  enabled: Joi.boolean().default(false),
+  secretKey: Joi.string().optional(),
+  serverName: Joi.string().max(64).allow('').default(''),
+});
+
 // The music-discovery P2P layer (p2p-sidecar: iroh-blobs snapshot sharing
 // now, the gossip catalog next phase). Distinct from `iroh` above — that's
 // the remote-access tunnel with its own keypair; the sidecar keeps a
@@ -603,6 +621,7 @@ const schema = Joi.object({
     cert: Joi.string().allow('').optional()
   }).optional(),
   iroh: irohOptions.default(irohOptions.validate({}).value),
+  federation: federationOptions.default(federationOptions.validate({}).value),
   discoveryP2p: discoveryP2pOptions.default(discoveryP2pOptions.validate({}).value),
   dlna: dlnaOptions.default(dlnaOptions.validate({}).value),
   subsonic: subsonicOptions.default(subsonicOptions.validate({}).value),
@@ -679,6 +698,16 @@ export async function setup(configFileArg) {
     winston.info('Config file missing iroh secrets. Generating and saving');
     if (!programData.iroh.secretKey) { programData.iroh.secretKey = await asyncRandom(32); }
     if (!programData.iroh.connectSecret) { programData.iroh.connectSecret = await asyncRandom(32); }
+    await fs.writeFile(configFileArg, JSON.stringify(programData, null, 2), 'utf8');
+  }
+
+  // Federation endpoint identity — same generate-and-persist pattern as the
+  // iroh tunnel above, and deliberately a DIFFERENT key so the tunnel and
+  // federation EndpointIds stay unlinkable personas.
+  if (!programData.federation) { programData.federation = {}; }
+  if (!programData.federation.secretKey) {
+    winston.info('Config file missing federation secret. Generating and saving');
+    programData.federation.secretKey = await asyncRandom(32);
     await fs.writeFile(configFileArg, JSON.stringify(programData, null, 2), 'utf8');
   }
 

--- a/test/db/db-v57-federation.test.mjs
+++ b/test/db/db-v57-federation.test.mjs
@@ -1,0 +1,161 @@
+/**
+ * V57 federation tables: the migration is registered and lands, the grant
+ * join-table cascades on both parents (key delete and library delete), key
+ * uniqueness holds, and the accessor module round-trips keys/grants/peers
+ * (incl. the TOFU bind-once guard).
+ *
+ * Schema assertions run on a bare in-memory chain; the accessor suite
+ * bootstraps a temp DB via the canonical config.setup + initDB path (same
+ * harness as test/db/render-metadata-by-ids.test.mjs).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { SCHEMA_VERSION, MIGRATIONS } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+
+describe('V57 federation schema', () => {
+  test('is registered and the fresh chain lands on SCHEMA_VERSION', () => {
+    const entry = MIGRATIONS.find((m) => m.version === 57);
+    assert.ok(entry, 'V57 missing from MIGRATIONS');
+    assert.ok(!entry.rescanRequired, 'pure new tables must not force a rescan');
+
+    const db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    applyAllMigrations(db);
+    const { user_version: v } = db.prepare('PRAGMA user_version').get();
+    assert.equal(v, SCHEMA_VERSION);
+    for (const t of ['federation_keys', 'federation_key_libraries', 'federation_peers']) {
+      assert.ok(
+        db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(t),
+        `${t} missing`,
+      );
+    }
+    db.close();
+  });
+
+  test('grants cascade from both parents; duplicate keys are rejected', () => {
+    const db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    applyAllMigrations(db);
+    db.exec(`
+      INSERT INTO libraries (id, name, root_path) VALUES (1, 'music', '/music'), (2, 'vinyl', '/vinyl');
+      INSERT INTO federation_keys (id, key, name) VALUES (1, 'fedk_aaa', 'bob');
+      INSERT INTO federation_key_libraries (key_id, library_id) VALUES (1, 1), (1, 2);
+    `);
+
+    assert.throws(
+      () => db.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_aaa', 'mallory')`).run(),
+      /UNIQUE/,
+    );
+
+    db.prepare('DELETE FROM libraries WHERE id = 2').run();
+    assert.equal(db.prepare('SELECT COUNT(*) AS c FROM federation_key_libraries').get().c, 1);
+
+    db.prepare('DELETE FROM federation_keys WHERE id = 1').run();
+    assert.equal(db.prepare('SELECT COUNT(*) AS c FROM federation_key_libraries').get().c, 0);
+    db.close();
+  });
+});
+
+describe('federation db accessors', () => {
+  let tmpDir;
+  let fedDb;
+  let libMusic, libVinyl;
+
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-fed-db-'));
+    fsSync.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+    fsSync.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
+      storage: {
+        dbDirectory:       path.join(tmpDir, 'db'),
+        albumArtDirectory: path.join(tmpDir, 'art'),
+        logsDirectory:     path.join(tmpDir, 'logs'),
+      },
+      port: 0,
+    }, null, 2));
+
+    const config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    const dbManager = await import('../../src/db/manager.js');
+    dbManager.initDB();
+    fedDb = await import('../../src/db/federation.js');
+
+    const d = dbManager.getDB();
+    const num = (r) => Number(r.lastInsertRowid);
+    libMusic = num(d.prepare("INSERT INTO libraries (name, root_path) VALUES ('music', '/music')").run());
+    libVinyl = num(d.prepare("INSERT INTO libraries (name, root_path) VALUES ('vinyl', '/vinyl')").run());
+  });
+
+  after(async () => {
+    const dbManager = await import('../../src/db/manager.js');
+    try { dbManager.getDB()?.close?.(); } catch { /* may not expose close */ }
+    try { fsSync.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* windows file locks */ }
+    // config.setup pulls in modules with module-level timers (winston
+    // rotation, shared-playlist cleanup, etc.) that keep the loop alive; exit
+    // explicitly — same pattern as the other DB-backed tests. This describe is
+    // declared last in the file, so everything else has already run.
+    setImmediate(() => process.exit(0));
+  });
+
+  test('mint -> list -> lookup -> grants -> delete round-trip', () => {
+    const { id, key } = fedDb.createFederationKey("Bob's NAS", [libMusic, libVinyl]);
+    assert.match(key, /^fedk_[A-Za-z0-9_-]{43}$/);
+
+    const listed = fedDb.getFederationKeys().find((k) => k.id === id);
+    assert.deepEqual([...listed.library_names].sort(), ['music', 'vinyl']);
+
+    const row = fedDb.getFederationKeyByKey(key);
+    assert.equal(row.id, id);
+    assert.equal(row.bound_endpoint_id, null);
+
+    assert.deepEqual(
+      fedDb.getFederationKeyLibraries(id).map((l) => l.name).sort(),
+      ['music', 'vinyl'],
+    );
+
+    assert.equal(fedDb.deleteFederationKey(id), true);
+    assert.equal(fedDb.getFederationKeyByKey(key), undefined);
+  });
+
+  test('a failed grant rolls the whole mint back', () => {
+    assert.throws(() => fedDb.createFederationKey('half', [libMusic, 99999])); // 99999: no such library
+    assert.equal(fedDb.getFederationKeys().some((k) => k.name === 'half'), false);
+  });
+
+  test('TOFU binding binds once; reset re-arms it', () => {
+    const { id } = fedDb.createFederationKey('tofu', [libMusic]);
+    assert.equal(fedDb.bindFederationKeyEndpoint(id, 'endpoint-A'), true);
+    assert.equal(fedDb.bindFederationKeyEndpoint(id, 'endpoint-B'), false, 'second bind must not overwrite');
+    assert.equal(fedDb.getFederationKeyById(id).bound_endpoint_id, 'endpoint-A');
+
+    assert.equal(fedDb.resetFederationKeyBinding(id), true);
+    assert.equal(fedDb.getFederationKeyById(id).bound_endpoint_id, null);
+    assert.equal(fedDb.bindFederationKeyEndpoint(id, 'endpoint-B'), true);
+  });
+
+  test('peer CRUD + status cache', () => {
+    const peer = fedDb.addFederationPeer({ name: 'Alice', endpointTicket: 'endpointxyz', apiKey: 'fedk_theirs' });
+    assert.equal(peer.name, 'Alice');
+    assert.equal(peer.last_seen, null);
+
+    assert.equal(fedDb.updateFederationPeerStatus(peer.id, 'ok'), true);
+    let row = fedDb.getFederationPeerById(peer.id);
+    assert.equal(row.last_status, 'ok');
+    assert.ok(row.last_seen, 'ok stamps last_seen');
+
+    assert.equal(fedDb.updateFederationPeerStatus(peer.id, 'unreachable: timeout'), true);
+    row = fedDb.getFederationPeerById(peer.id);
+    assert.equal(row.last_status, 'unreachable: timeout');
+    assert.ok(row.last_seen, 'failure must not clear last_seen');
+
+    assert.equal(fedDb.deleteFederationPeer(peer.id), true);
+    assert.equal(fedDb.getFederationPeerById(peer.id), undefined);
+  });
+});

--- a/test/unit/federation-config.test.mjs
+++ b/test/unit/federation-config.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * Config: the federation endpoint key is auto-generated and persisted on
+ * first boot, stays stable across reloads, and doesn't clobber pre-existing
+ * values — and it's a DIFFERENT key than the iroh tunnel's (unlinkable
+ * personas). Mirrors test/unit/iroh-config.test.mjs.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as config from '../../src/state/config.js';
+
+let tmpDir;
+function freshConfigPath(name) { return path.join(tmpDir, name); }
+
+describe('federation config secrets', () => {
+  before(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-fed-cfg-')); });
+  after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+  test('generates + persists a 32-byte secretKey distinct from the tunnel key, default off', async () => {
+    const f = freshConfigPath('a.json');
+    await config.setup(f);
+    assert.equal(config.program.federation.enabled, false);
+    assert.equal(config.program.federation.serverName, '');
+    assert.equal(Buffer.from(config.program.federation.secretKey, 'base64').length, 32);
+    assert.notEqual(config.program.federation.secretKey, config.program.iroh.secretKey);
+
+    const raw = JSON.parse(fs.readFileSync(f, 'utf8'));
+    assert.equal(raw.federation.secretKey, config.program.federation.secretKey);
+  });
+
+  test('key is stable across a second setup of the same file', async () => {
+    const f = freshConfigPath('b.json');
+    await config.setup(f);
+    const key1 = config.program.federation.secretKey;
+    await config.setup(f);
+    assert.equal(config.program.federation.secretKey, key1);
+  });
+
+  test('does not clobber pre-existing federation values', async () => {
+    const f = freshConfigPath('c.json');
+    const preKey = Buffer.alloc(32, 9).toString('base64');
+    fs.writeFileSync(f, JSON.stringify({ federation: { enabled: true, secretKey: preKey, serverName: 'My Server' } }));
+    await config.setup(f);
+    assert.equal(config.program.federation.enabled, true);
+    assert.equal(config.program.federation.secretKey, preKey);
+    assert.equal(config.program.federation.serverName, 'My Server');
+  });
+
+  test('a stale syncthing-era federation config still validates (allowUnknown)', async () => {
+    const f = freshConfigPath('d.json');
+    fs.writeFileSync(f, JSON.stringify({
+      federation: { enabled: false, folder: '/old/sync/folder', federateUsersMode: false },
+      storage: { syncConfigDirectory: path.join(tmpDir, 'old-sync') },
+    }));
+    await config.setup(f); // must not throw
+    assert.equal(config.program.federation.enabled, false);
+    assert.ok(config.program.federation.secretKey, 'secretKey still auto-generated alongside stale keys');
+  });
+});


### PR DESCRIPTION
## What this does

The dormant foundation for federation v2 — ticket-paired **read-only library sharing** between mStream servers over a dedicated iroh endpoint. Nothing consumes any of this yet; the feature stays default-off and invisible until the auth/endpoint PRs stack on top.

## Schema — migration V57 (pure new tables, no rescan)

Two sides of a pairing, deliberately separate:

- **`federation_keys`** — keys THIS server minted. A key (`fedk_` + 32 random bytes base64url) is the credential a friend's server will present for read-only access. `bound_endpoint_id`/`bound_at` hold the TOFU state: NULL until the first successful handshake binds the key to that dialer's iroh EndpointId, after which other endpoints get rejected — so a leaked ticket dies once the legitimate peer redeems it.
- **`federation_key_libraries`** — per-key library grants. A join table rather than a JSON column so `ON DELETE CASCADE` keeps grants consistent when a key *or a library* is deleted, and grants survive library renames.
- **`federation_peers`** — remote servers this one can read: their endpoint ticket, the key they minted for us, and a `last_seen`/`last_status` health-check cache for the admin UI.

## DB accessors (`src/db/federation.js`)

- Key mint (key + grants in one transaction — a failed grant rolls the mint back), list-with-library-names, exact-match lookup for the auth wall, revoke
- TOFU bind with a guarded `WHERE bound_endpoint_id IS NULL` so a concurrent handshake can't re-bind, plus the admin reset ("friend reinstalled" escape hatch)
- `last_used` touch throttled in-process to one write per key per minute
- Peer CRUD; an `ok` status stamps `last_seen`, failures don't clear it

## Config

New `federation.{enabled, secretKey, serverName}` Joi block. The 32-byte `secretKey` (endpoint identity) auto-generates and persists on first boot — same pattern as the tunnel's — and is deliberately a **different key**, so the tunnel, discovery, and federation EndpointIds stay unlinkable personas. Old syncthing-era config keys still pass validation (covered by a test).

## ⚠️ Migration-number coordination

Open PR #716 (model genres) also claims V57. Whichever merges second renumbers above the other (the usual skip-numbering step) — flagging so the ordering is a conscious choice.

## Verification

- `test/db/db-v57-federation.test.mjs`: migration registered, fresh chain lands on `SCHEMA_VERSION`, cascade deletes from both parents, key uniqueness, full accessor round-trips incl. the TOFU bind-once guard
- `test/unit/federation-config.test.mjs`: secretKey auto-gen/persist/stability, no clobbering, distinct-from-tunnel-key, stale-config compatibility
- Schema-sensitive suites (`db-fts5-schema`, scanner schema guard) pass with the version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)