### PR TITLE
feat(federation): read-only key auth at the wall + health endpoint

### DIFF
--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -1,0 +1,66 @@
+// Admin-side federation endpoints. Extracted from admin.js to keep that file
+// from accreting the federation surface — same pattern as admin-torrent.js:
+// exports a `register(mstream)` function called once during admin setup, so
+// every route here inherits the /api/v1/admin/* guard (admin role + network
+// gate) registered before it.
+//
+// This module owns the credential side of federation: minting read-only keys
+// scoped to selected libraries, listing/revoking them, and resetting a key's
+// TOFU endpoint binding (the "friend reinstalled and has a new iroh identity"
+// escape hatch). The endpoint lifecycle + ticket issuance and the peers CRUD
+// arrive with the federation endpoint itself.
+
+import Joi from 'joi';
+import winston from 'winston';
+import { joiValidate } from '../util/validation.js';
+import WebError from '../util/web-error.js';
+import * as db from '../db/manager.js';
+import * as fedDb from '../db/federation.js';
+
+export function register(mstream) {
+  mstream.get('/api/v1/admin/federation/keys', (req, res) => {
+    res.json(fedDb.getFederationKeys());
+  });
+
+  mstream.post('/api/v1/admin/federation/keys', (req, res) => {
+    const schema = Joi.object({
+      name: Joi.string().min(1).max(64).required(),
+      vpaths: Joi.array().items(Joi.string()).min(1).unique().required(),
+    });
+    joiValidate(schema, req.body);
+
+    // Resolve vpath names -> library ids up front so one unknown name fails
+    // the whole mint (grants are transactional in createFederationKey too).
+    const libraryIds = req.body.vpaths.map((name) => {
+      const lib = db.getLibraryByName(name);
+      if (!lib) { throw new WebError(`Unknown library: ${name}`, 404); }
+      return lib.id;
+    });
+
+    const minted = fedDb.createFederationKey(req.body.name, libraryIds);
+    winston.info(`[federation] ${req.user.username} minted key '${minted.name}' for libraries [${req.body.vpaths.join(', ')}]`);
+    res.json({ id: minted.id, name: minted.name, key: minted.key });
+  });
+
+  mstream.delete('/api/v1/admin/federation/keys/:id', (req, res) => {
+    const schema = Joi.object({ id: Joi.number().integer().min(1).required() });
+    joiValidate(schema, req.params);
+
+    if (!fedDb.deleteFederationKey(Number(req.params.id))) {
+      throw new WebError('Key not found', 404);
+    }
+    winston.info(`[federation] ${req.user.username} revoked key id=${req.params.id}`);
+    res.json({});
+  });
+
+  mstream.post('/api/v1/admin/federation/keys/:id/reset-binding', (req, res) => {
+    const schema = Joi.object({ id: Joi.number().integer().min(1).required() });
+    joiValidate(schema, req.params);
+
+    if (!fedDb.resetFederationKeyBinding(Number(req.params.id))) {
+      throw new WebError('Key not found', 404);
+    }
+    winston.info(`[federation] ${req.user.username} reset the endpoint binding on key id=${req.params.id}`);
+    res.json({});
+  });
+}

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -32,6 +32,8 @@ import * as nowPlaying from './subsonic/now-playing.js';
 // setup() below, after the admin guard is registered, so the torrent
 // routes inherit the same auth checks as every other /admin/* path.
 import * as adminTorrent from './admin-torrent.js';
+// Federation admin endpoints, same split (see admin-federation.js).
+import * as adminFederation from './admin-federation.js';
 
 import { getTransCodecs, getTransBitrates } from '../api/transcode.js';
 
@@ -1777,6 +1779,7 @@ export function setup(mstream) {
   // file, so they inherit the lockAdmin / admin-only checks at the
   // top of this function.
   adminTorrent.register(mstream);
+  adminFederation.register(mstream);
 
 
   mstream.post("/api/v1/admin/ssl", async (req, res) => {

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -6,6 +6,7 @@ import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
 import * as shared from '../api/shared.js';
 import { isActiveJukeboxToken } from '../api/remote.js';
+import * as federationAuth from './federation-auth.js';
 import WebError from '../util/web-error.js';
 
 export function setup(mstream) {
@@ -50,6 +51,17 @@ export function setup(mstream) {
   });
 
   mstream.use((req, res, next) => {
+    // Handle federation keys FIRST — ordering is load-bearing. On a no-users
+    // server the public-mode branch below hands EVERY request a full-access
+    // user, so a federation request that reached it would silently escape its
+    // library scoping. The key is a raw `fedk_…` credential (not a JWT), so
+    // it rides its own header and never touches jwt.verify.
+    const fedKey = req.headers['x-federation-key'];
+    if (typeof fedKey === 'string' && fedKey.length > 0) {
+      req.user = federationAuth.authenticateFederationKey(fedKey, req);
+      return next();
+    }
+
     const allUsers = db.getAllUsers();
 
     // Handle No Users (public access mode)

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -1,0 +1,99 @@
+// Federation-key authentication for the auth wall (src/api/auth.js).
+//
+// A federated peer presents its minted key in the `x-federation-key` header
+// on every HTTP request (the key is NOT a JWT — it never touches jwt.verify).
+// The wall calls authenticateFederationKey() as its FIRST branch, before the
+// public-mode branch: on a no-users server the public branch would otherwise
+// hand every request a full-access user, silently bypassing federation
+// scoping.
+//
+// A validated key resolves to a synthetic read-only req.user:
+//   - admin false + every allow_* flag 0 → all write handlers refuse
+//     (the same construction the jukebox-token branch uses);
+//   - vpaths / libraryIds restricted to the key's granted libraries →
+//     getVPathInfo, the /media/:vpath static gate, and libraryFilter scope
+//     browse/stream/download automatically;
+//   - id null → no users-table row; user_metadata joins simply match nothing.
+//     db/manager.getUserLibraryIds honors the explicit libraryIds override
+//     BEFORE its public-mode branch, so the null id can't fall into
+//     all-libraries public mode.
+//
+// Defense-in-depth: on top of the read-only user, requests are limited to an
+// explicit allowlist of read routes (same idea as the share-token path
+// whitelist), so a future write endpoint that forgets a permission check is
+// still unreachable with a federation key.
+
+import winston from 'winston';
+import WebError from '../util/web-error.js';
+import * as config from '../state/config.js';
+import * as fedDb from '../db/federation.js';
+
+// Read routes a federation key may call. Exact "METHOD path" matches plus
+// GET-only prefixes for the static media/art trees. Deliberately excludes
+// rated/recently-played/most-played (per-user stats — meaningless and
+// privacy-adjacent for a foreign reader) and every write route.
+const ALLOWED_EXACT = new Set([
+  'GET /api/v1/db/status',
+  'POST /api/v1/db/metadata',
+  'POST /api/v1/db/metadata/batch',
+  'GET /api/v1/db/artists',
+  'POST /api/v1/db/artists',
+  'POST /api/v1/db/artists-albums',
+  'GET /api/v1/db/albums',
+  'POST /api/v1/db/albums',
+  'GET /api/v1/db/genres',
+  'POST /api/v1/db/genres',
+  'POST /api/v1/db/genre-songs',
+  'POST /api/v1/db/album-songs',
+  'POST /api/v1/db/recent/added',
+  'POST /api/v1/db/search',
+  'GET /api/v1/federation/health',
+]);
+const ALLOWED_GET_PREFIXES = ['/media/', '/album-art/'];
+
+export function isFederationPathAllowed(req) {
+  if (ALLOWED_EXACT.has(`${req.method} ${req.path}`)) { return true; }
+  if (req.method === 'GET' && ALLOWED_GET_PREFIXES.some((p) => req.path.startsWith(p))) { return true; }
+  return false;
+}
+
+// Validate a presented key and build the synthetic read-only req.user.
+// Throws WebError 401 (bad/inert key) or 403 (valid key, off-limits route).
+export function authenticateFederationKey(key, req) {
+  // Feature off = every minted key is inert, even over plain LAN HTTP. The
+  // key is the credential and the iroh endpoint just a rendezvous, so the
+  // enabled flag has to gate here, not only at the endpoint.
+  if (config.program.federation.enabled !== true) {
+    winston.warn(`[federation] rejected key auth from ${req.ip} on ${req.path}: federation is disabled`);
+    throw new WebError('Authentication Error', 401);
+  }
+
+  const row = fedDb.getFederationKeyByKey(key);
+  if (!row) {
+    // A wrong key at this wall is a probing signal, same as an invalid JWT.
+    winston.warn(`[federation] rejected unknown key from ${req.ip} on ${req.path}`);
+    throw new WebError('Authentication Error', 401);
+  }
+
+  if (!isFederationPathAllowed(req)) {
+    winston.warn(`[federation] key '${row.name}' denied off-allowlist route ${req.method} ${req.path} from ${req.ip}`);
+    throw new WebError('Forbidden', 403);
+  }
+
+  const grants = fedDb.getFederationKeyLibraries(row.id);
+  fedDb.touchFederationKeyLastUsed(row.id);
+
+  return {
+    id: null,
+    username: `federation:${row.name}`,
+    federation: true,
+    federationKeyId: row.id,
+    admin: false,
+    vpaths: grants.map((g) => g.name),
+    libraryIds: grants.map((g) => g.id),
+    allow_upload: 0,
+    allow_mkdir: 0,
+    allow_file_modify: 0,
+    allow_server_audio: 0,
+  };
+}

--- a/src/api/federation.js
+++ b/src/api/federation.js
@@ -1,0 +1,24 @@
+// Peer-facing federation API (mounted behind the auth wall).
+//
+// One endpoint for now: the health/identity probe a federated peer hits to
+// test the pairing and learn what it was granted. The peer authenticates
+// with its x-federation-key header (see api/federation-auth.js), so
+// req.user.vpaths IS the key's live grant list — a grant change on this
+// server shows up on the peer's next health check without re-pairing.
+//
+// Regular logged-in users can also hit this route; they just see their own
+// vpaths, which they already know. Harmless.
+
+import os from 'os';
+import packageJson from '../../package.json' with { type: 'json' };
+import * as config from '../state/config.js';
+
+export function setup(mstream) {
+  mstream.get('/api/v1/federation/health', (req, res) => {
+    res.json({
+      server: packageJson.version,
+      name: config.program.federation.serverName || os.hostname(),
+      libraries: req.user.vpaths,
+    });
+  });
+}

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -470,6 +470,13 @@ export function getAllLibraries() {
 }
 
 export function getUserLibraryIds(user) {
+  // Explicit grant override — federation keys (api/federation-auth.js) build
+  // a synthetic user with id=null and the granted library ids attached.
+  // Checked BEFORE the public-mode branch: isPublicMode(null id) is true, so
+  // without this ordering a federation caller would silently see EVERY
+  // library on a no-users server. Nothing else sets libraryIds, so this is
+  // inert for regular users and the sentinel.
+  if (user && Array.isArray(user.libraryIds)) { return user.libraryIds; }
   // Public mode (no user, or pinned to the anonymous sentinel by auth.js)
   // — every library is visible. Without this branch, the sentinel id (a
   // real integer with zero rows in user_libraries) would fall through to

--- a/src/server.js
+++ b/src/server.js
@@ -30,6 +30,7 @@ import * as dbManager from './db/manager.js';
 import * as discoveryDb from './db/discovery-db.js';
 import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // scanner.js removed — parser now writes directly to SQLite
+import * as federationApi from './api/federation.js';
 import * as ytdlApi from './api/ytdl.js';
 import * as torrentApi from './api/torrent.js';
 import * as dlnaApi from './api/dlna.js';
@@ -310,6 +311,7 @@ export async function serveIt(configFile) {
   scrobblerApi.setup(mstream);
   remoteApi.setupAfterAuth(mstream, server);
   sharedApi.setupAfterSecurity(mstream);
+  federationApi.setup(mstream);
   ytdlApi.setup(mstream);
   torrentApi.setup(mstream);
   albumArtApi.setup(mstream);

--- a/test/integration/federation-e2e.test.mjs
+++ b/test/integration/federation-e2e.test.mjs
@@ -1,0 +1,198 @@
+/**
+ * Federation read-only keys end-to-end over plain HTTP (no iroh needed —
+ * the key is the credential; the endpoint is just a rendezvous):
+ *
+ * Scenario A (server WITH users, federation enabled):
+ *   - admin mints a key scoped to one library via the admin API
+ *   - health returns exactly the granted library list
+ *   - db browse is scoped (granted-lib artists only), /media serves granted
+ *     files and 404s ungranted ones
+ *   - writes and off-allowlist reads are 403; bogus/missing keys are 401
+ *   - revocation kills the key on the next request; reset-binding 404s on
+ *     unknown ids
+ *
+ * Scenario B (NO users = public mode, federation enabled) — the
+ * branch-ordering pin: public mode grants anonymous requests everything, but
+ * a federation key must STILL be scoped to its grants. If the wall checked
+ * public mode first, the key would silently see every library.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { startServer } from '../helpers/server.mjs';
+
+async function makeLibDir(prefix, fileName, content) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  await fs.writeFile(path.join(dir, fileName), content, 'utf8');
+  return dir;
+}
+
+const fedHeaders = (key, extra = {}) => ({ 'x-federation-key': key, 'Content-Type': 'application/json', ...extra });
+
+describe('federation keys e2e (server with users)', () => {
+  let srv, sharedDir, privateDir, adminToken, fedKey, keyId;
+
+  before(async () => {
+    sharedDir = await makeLibDir('mstream-fed-shared-', 'hello.txt', 'hello from shared');
+    privateDir = await makeLibDir('mstream-fed-private-', 'secret.txt', 'do not leak');
+
+    srv = await startServer({
+      extraFolders: { shared: sharedDir, private: privateDir },
+      extraConfig: { federation: { enabled: true } },
+      users: [{ username: 'boss', password: 'pw', admin: true, vpaths: ['testlib', 'shared', 'private'] }],
+    });
+
+    const login = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'boss', password: 'pw' }),
+    });
+    adminToken = (await login.json()).token;
+
+    const mint = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ name: "Bob's NAS", vpaths: ['shared'] }),
+    });
+    assert.equal(mint.status, 200);
+    ({ key: fedKey, id: keyId } = await mint.json());
+    assert.match(fedKey, /^fedk_/);
+  });
+
+  after(async () => {
+    await srv?.stop();
+    for (const d of [sharedDir, privateDir]) {
+      if (d) { await fs.rm(d, { recursive: true, force: true }).catch(() => {}); }
+    }
+  });
+
+  test('health reports the granted libraries only', async () => {
+    const r = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(fedKey) });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.deepEqual(j.libraries, ['shared']);
+    assert.ok(j.server, 'reports a server version');
+    assert.ok(j.name, 'reports a display name');
+  });
+
+  test('db browse is scoped to the granted library', async () => {
+    const r = await fetch(`${srv.baseUrl}/api/v1/db/artists`, {
+      method: 'POST', headers: fedHeaders(fedKey), body: '{}',
+    });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    // 'shared' holds only hello.txt — the fixture artists live in testlib,
+    // which this key was NOT granted.
+    assert.deepEqual(j.artists, []);
+
+    // Sanity check the assertion has teeth: the admin sees fixture artists.
+    const full = await fetch(`${srv.baseUrl}/api/v1/db/artists`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: '{}',
+    });
+    assert.ok((await full.json()).artists.length > 0, 'fixture library should have artists');
+  });
+
+  test('/media serves granted files and 404s ungranted vpaths', async () => {
+    const ok = await fetch(`${srv.baseUrl}/media/shared/hello.txt`, { headers: fedHeaders(fedKey) });
+    assert.equal(ok.status, 200);
+    assert.equal(await ok.text(), 'hello from shared');
+
+    const priv = await fetch(`${srv.baseUrl}/media/private/secret.txt`, { headers: fedHeaders(fedKey) });
+    assert.equal(priv.status, 404);
+
+    const testlib = await fetch(`${srv.baseUrl}/media/testlib/`, { headers: fedHeaders(fedKey) });
+    assert.equal(testlib.status, 404);
+  });
+
+  test('writes and off-allowlist reads are 403', async () => {
+    const write = await fetch(`${srv.baseUrl}/api/v1/db/rate-song`, {
+      method: 'POST', headers: fedHeaders(fedKey), body: JSON.stringify({ filepath: 'x', rating: 5 }),
+    });
+    assert.equal(write.status, 403);
+
+    const perUserRead = await fetch(`${srv.baseUrl}/api/v1/db/rated`, { headers: fedHeaders(fedKey) });
+    assert.equal(perUserRead.status, 403);
+
+    const admin = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, { headers: fedHeaders(fedKey) });
+    assert.equal(admin.status, 403);
+  });
+
+  test('bogus and missing credentials are 401', async () => {
+    const bogus = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders('fedk_wrong') });
+    assert.equal(bogus.status, 401);
+
+    const none = await fetch(`${srv.baseUrl}/api/v1/federation/health`);
+    assert.equal(none.status, 401);
+  });
+
+  test('reset-binding 404s on an unknown key id', async () => {
+    const r = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/424242/reset-binding`, {
+      method: 'POST', headers: { 'x-access-token': adminToken },
+    });
+    assert.equal(r.status, 404);
+  });
+
+  test('revocation kills the key on the next request', async () => {
+    const del = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/${keyId}`, {
+      method: 'DELETE', headers: { 'x-access-token': adminToken },
+    });
+    assert.equal(del.status, 200);
+
+    const r = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(fedKey) });
+    assert.equal(r.status, 401);
+  });
+});
+
+describe('federation keys e2e (public mode — the branch-ordering pin)', () => {
+  let srv, sharedDir, privateDir, fedKey;
+
+  before(async () => {
+    sharedDir = await makeLibDir('mstream-fed-pub-shared-', 'hello.txt', 'public shared');
+    privateDir = await makeLibDir('mstream-fed-pub-private-', 'secret.txt', 'public private');
+
+    // No users -> every anonymous request gets the full-access public user.
+    srv = await startServer({
+      extraFolders: { shared: sharedDir, private: privateDir },
+      extraConfig: { federation: { enabled: true } },
+    });
+
+    // Public mode: the admin API is open, so mint without a token.
+    const mint = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'pub-peer', vpaths: ['shared'] }),
+    });
+    assert.equal(mint.status, 200);
+    ({ key: fedKey } = await mint.json());
+  });
+
+  after(async () => {
+    await srv?.stop();
+    for (const d of [sharedDir, privateDir]) {
+      if (d) { await fs.rm(d, { recursive: true, force: true }).catch(() => {}); }
+    }
+  });
+
+  test('anonymous requests see everything, the federation key stays scoped', async () => {
+    // Anonymous (public user): full access, proving the server IS wide open.
+    const anon = await fetch(`${srv.baseUrl}/media/private/secret.txt`);
+    assert.equal(anon.status, 200);
+
+    // Federation key: still only its grant. If the wall ran the public-mode
+    // branch first this would be 200 — the exact bug this test pins.
+    const health = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(fedKey) });
+    assert.equal(health.status, 200);
+    assert.deepEqual((await health.json()).libraries, ['shared']);
+
+    const priv = await fetch(`${srv.baseUrl}/media/private/secret.txt`, { headers: fedHeaders(fedKey) });
+    assert.equal(priv.status, 404);
+
+    const ok = await fetch(`${srv.baseUrl}/media/shared/hello.txt`, { headers: fedHeaders(fedKey) });
+    assert.equal(ok.status, 200);
+  });
+});

--- a/test/unit/federation-auth.test.mjs
+++ b/test/unit/federation-auth.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Federation-key auth building blocks that don't need a running server:
+ *
+ *  - the read-route allowlist matrix (exact matches, GET-only prefixes,
+ *    everything else refused);
+ *  - the feature-off gate: with federation.enabled=false every key is inert
+ *    (401 before any DB lookup), even over plain LAN HTTP;
+ *  - the getUserLibraryIds explicit-grant override: a synthetic user carrying
+ *    libraryIds short-circuits BEFORE the public-mode branch (id null would
+ *    otherwise read as public mode = every library).
+ *
+ * The full path through a real server (wall ordering, vpath scoping on
+ * /media and db routes, revocation) lives in
+ * test/integration/federation-e2e.test.mjs.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { isFederationPathAllowed, authenticateFederationKey } from '../../src/api/federation-auth.js';
+import { getUserLibraryIds } from '../../src/db/manager.js';
+import * as config from '../../src/state/config.js';
+
+const req = (method, p) => ({ method, path: p, ip: '127.0.0.1' });
+
+describe('federation route allowlist', () => {
+  test('allows the read surface', () => {
+    for (const [m, p] of [
+      ['GET', '/api/v1/db/status'],
+      ['POST', '/api/v1/db/metadata'],
+      ['POST', '/api/v1/db/metadata/batch'],
+      ['GET', '/api/v1/db/artists'],
+      ['POST', '/api/v1/db/artists'],
+      ['POST', '/api/v1/db/artists-albums'],
+      ['GET', '/api/v1/db/albums'],
+      ['POST', '/api/v1/db/albums'],
+      ['GET', '/api/v1/db/genres'],
+      ['POST', '/api/v1/db/genres'],
+      ['POST', '/api/v1/db/genre-songs'],
+      ['POST', '/api/v1/db/album-songs'],
+      ['POST', '/api/v1/db/recent/added'],
+      ['POST', '/api/v1/db/search'],
+      ['GET', '/api/v1/federation/health'],
+      ['GET', '/media/music/album/track.mp3'],
+      ['GET', '/album-art/abc123.jpg'],
+    ]) {
+      assert.equal(isFederationPathAllowed(req(m, p)), true, `${m} ${p} should be allowed`);
+    }
+  });
+
+  test('refuses writes, admin, per-user reads, and non-GET statics', () => {
+    for (const [m, p] of [
+      ['POST', '/api/v1/db/rate-song'],
+      ['GET', '/api/v1/db/rated'],
+      ['POST', '/api/v1/db/stats/recently-played'],
+      ['POST', '/api/v1/playlist/save'],
+      ['GET', '/api/v1/admin/federation/keys'],
+      ['POST', '/api/v1/file-explorer'],
+      ['GET', '/api/v1/download/zip'],
+      ['POST', '/media/music/album/track.mp3'], // static trees are GET-only
+      ['POST', '/album-art/abc123.jpg'],
+      ['GET', '/api/v1/auth/login'],
+      ['GET', '/'],
+    ]) {
+      assert.equal(isFederationPathAllowed(req(m, p)), false, `${m} ${p} should be refused`);
+    }
+  });
+});
+
+describe('federation disabled gate', () => {
+  let tmpDir;
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-fed-auth-'));
+    await config.setup(path.join(tmpDir, 'config.json')); // defaults: federation.enabled=false
+  });
+  after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+  test('rejects any key with 401 while federation.enabled=false', () => {
+    assert.throws(
+      () => authenticateFederationKey('fedk_anything', req('GET', '/api/v1/federation/health')),
+      (err) => err.status === 401 && /Authentication/.test(err.message),
+    );
+  });
+});
+
+describe('getUserLibraryIds explicit-grant override', () => {
+  test('libraryIds wins before the public-mode branch (no DB needed)', () => {
+    // id:null would read as public mode; the override must short-circuit
+    // first — this call touching the libraries cache would throw here since
+    // no DB is initialized in this process.
+    assert.deepEqual(getUserLibraryIds({ id: null, libraryIds: [5, 7] }), [5, 7]);
+    assert.deepEqual(getUserLibraryIds({ id: null, libraryIds: [] }), [], 'empty grants stay empty');
+  });
+});


### PR DESCRIPTION
## What this does

Makes the minted federation keys **work as credentials**. A federated peer sends its key in a dedicated `x-federation-key` header on every HTTP request; the auth wall resolves it to a synthetic **read-only user scoped to exactly the granted libraries**. The key is a raw `fedk_…` string, not a JWT — it rides its own header and never touches `jwt.verify`.

Notably, this makes keys fully usable over plain LAN HTTP already: the key is the credential, the iroh endpoint (next PR) is just the rendezvous transport. That's also what makes this PR independently testable end-to-end.

## The security-critical part (please eyeball this ordering)

The federation branch runs **first** in the wall middleware, *before* the no-users/public-mode branch. On a server with zero users, the public branch hands every request a full-access user — so if a federation request ever reached it, the key's library scoping would be silently bypassed. There's a dedicated e2e test pinning this: a public-mode server where anonymous requests see everything, but the federation key stays caged to its grant.

Same idea one layer down: `getUserLibraryIds()` treated a null user id as public mode (= all libraries), and the synthetic federation user has `id: null`. It now honors an explicit `libraryIds` grant array *before* the public-mode check. Nothing else sets that field, so the change is inert for every existing caller — also unit-tested.

## How scoping works

The synthetic user is the jukebox-token construction: `admin: false`, all `allow_*` flags 0, `vpaths`/`libraryIds` pinned to the key's grants. That alone scopes everything, because the existing gates all key off those fields: `getVPathInfo` throws on ungranted vpaths, `/media/:vpath` 404s them, and `libraryFilter` constrains every db browse query.

On top, defense-in-depth: an explicit **allowlist of read routes** (db browse/search/metadata, GET `/media/` + `/album-art/`, and the health probe) modeled on the share-token path whitelist. Off-allowlist → 403, so a future write endpoint that forgets a permission check is still unreachable with a federation key. Deliberately excluded: per-user stats routes (rated/recently-played) — meaningless and privacy-adjacent for a foreign reader.

## Also in here

- `GET /api/v1/federation/health` — the peer's test-connection target; returns version, display name, and the key's **live** grant list (grant changes show up on the peer's next check without re-pairing)
- Admin routes (admin-torrent registration pattern): mint a key for selected vpaths, list, revoke, and reset the TOFU binding. Joi → 400, unknown vpath/id → 404
- `federation.enabled === false` keeps every key inert with a 401, even over LAN

## Verification

- E2e over real HTTP (spawned servers): health grant list, scoped `/db/artists`, granted `/media` 200 vs ungranted 404, writes + off-allowlist reads 403, bogus/missing key 401, revocation kills the key on the next request, and the public-mode ordering pin
- Unit: full allowlist matrix, the disabled-flag gate, the `getUserLibraryIds` override edges
- Existing auth-sensitive suites (public-mode privacy/library-filter, admin access) pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)