### PR TITLE
feat(federation): inbound iroh endpoint with TOFU key handshake

### DIFF
--- a/docs/federation-ticket.md
+++ b/docs/federation-ticket.md
@@ -1,0 +1,83 @@
+# mStream Federation Ticket (`mstrfed<V>:`)
+
+The string two admins swap to pair their servers for read-only federation.
+Sibling spec to [iroh-pairing-code.md](iroh-pairing-code.md) — same envelope
+mechanics, different payload and, importantly, a different trust model (see
+[Security](#security)).
+
+Builder/parser: `buildFederationTicket` / `parseFederationTicket` in
+`src/state/federation.js`, on top of the shared envelope helpers in
+`src/state/iroh-common.js`.
+
+## Envelope
+
+```
+mstrfed<V>:<base64url(JSON payload)>
+```
+
+- `mstrfed` — literal prefix. Distinct from the tunnel pairing code's `mstr`
+  so a ticket pasted into the wrong UI fails cleanly (`mstrfed1:` never
+  matches `^mstr(\d+):`, and vice versa).
+- `<V>` — integer payload version. This build emits and understands **v1**.
+  A parser MUST reject a version newer than it understands with an
+  actionable "update your server" error.
+- No bare-body legacy form: unlike the tunnel pairing code, a missing prefix
+  is invalid (this is a brand-new format with no deployed history).
+
+## v1 payload
+
+```jsonc
+{
+  "t": "endpoint…",        // REQUIRED — the minting server's federation
+                           // EndpointTicket (iroh: node id + relay +
+                           // direct addresses)
+  "k": "fedk_…",           // REQUIRED — the minted read-only API key
+                           // ('fedk_' + 32 random bytes base64url)
+  "n": "Paul's mStream",   // optional — display name for the add-peer UI
+  "l": ["Music", "Vinyl"]  // optional — granted library (vpath) names.
+                           // Informational preview only: the live grant
+                           // list comes from GET /api/v1/federation/health
+                           // after pairing.
+}
+```
+
+Parsers MUST ignore unknown fields (forward compatibility) and MUST reject a
+payload missing `t` or `k`.
+
+## Pairing flow
+
+1. Admin A mints a key on server A (admin → Federation → New ticket),
+   choosing which libraries it grants. The response carries the full
+   `mstrfed1:` ticket.
+2. A sends the ticket to admin B over a private channel.
+3. B pastes it into server B's add-peer UI. B's server stores the peer row
+   and dials A's endpoint (ALPN `mstream/federation/1`), presenting `k` on
+   the first bi-stream.
+4. A verifies the key, **binds it to B's EndpointId (TOFU)**, and replies
+   `OK`. Every subsequent bi-stream is a plain TCP-over-QUIC bridge to A's
+   HTTP server; B authenticates each HTTP request with the
+   `x-federation-key: fedk_…` header.
+5. For mutual federation, B mints a ticket for A the same way. The two
+   directions are fully independent grants.
+
+## Security
+
+- **The ticket carries a standing credential.** Unlike the tunnel QR (whose
+  secret only gates the pipe, with mStream's login wall still behind it),
+  `k` IS the API credential for the granted libraries. Swap tickets over a
+  private channel (in person, E2E-encrypted chat), not a public paste.
+- **TOFU burn-on-redeem.** The first endpoint to complete the handshake owns
+  the key; afterwards the same key from any other endpoint is rejected and
+  logged. A ticket that leaks after the legitimate peer redeemed it is dead
+  on arrival. A ticket that leaks *before* redemption is a race — revoke and
+  re-mint if in doubt.
+- **Scope.** The key resolves to a synthetic read-only user restricted to
+  the granted libraries (`api/federation-auth.js`): no writes, no admin, no
+  other libraries, plus a route allowlist as defense-in-depth.
+- **Revocation** is per-key: deleting the key kills the pipe handshake,
+  every HTTP request, and any live connections. Rotating the server's
+  `federation.secretKey` changes its EndpointId and invalidates the `t` in
+  every issued ticket (peers must re-add).
+- **"Friend reinstalled" case:** their endpoint identity changed, so TOFU
+  rejects them. The admin UI's reset-binding action clears the binding
+  without re-minting; the next successful handshake re-binds.

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -4,25 +4,100 @@
 // every route here inherits the /api/v1/admin/* guard (admin role + network
 // gate) registered before it.
 //
-// This module owns the credential side of federation: minting read-only keys
-// scoped to selected libraries, listing/revoking them, and resetting a key's
-// TOFU endpoint binding (the "friend reinstalled and has a new iroh identity"
-// escape hatch). The endpoint lifecycle + ticket issuance and the peers CRUD
-// arrive with the federation endpoint itself.
+// This module owns:
+//   - the endpoint lifecycle: status + live enable/disable (the endpoint is
+//     independent of the HTTP server, so no reboot — mirror of the iroh
+//     tunnel admin routes);
+//   - the credential side: minting read-only keys scoped to selected
+//     libraries, listing them (with their swap-ready mstrfed1: tickets when
+//     the endpoint is up), revoking (which also severs live pipes), and
+//     resetting a key's TOFU endpoint binding (the "friend reinstalled and
+//     has a new iroh identity" escape hatch).
 
+import os from 'os';
 import Joi from 'joi';
 import winston from 'winston';
 import { joiValidate } from '../util/validation.js';
 import WebError from '../util/web-error.js';
+import * as config from '../state/config.js';
+import * as admin from '../util/admin.js';
 import * as db from '../db/manager.js';
 import * as fedDb from '../db/federation.js';
 
+// Build the swap-ready ticket for a minted key, or null when the endpoint
+// isn't running (native module missing / feature off).
+async function ticketForKey(keyRow) {
+  try {
+    const federation = await import('../state/federation.js');
+    const endpointTicket = federation.getEndpointTicket();
+    if (!endpointTicket) { return null; }
+    return federation.buildFederationTicket({
+      endpointTicket,
+      key: keyRow.key,
+      serverName: config.program.federation.serverName || os.hostname(),
+      libraries: keyRow.library_names,
+    });
+  } catch (_err) {
+    return null; // native binary not present on this platform
+  }
+}
+
 export function register(mstream) {
-  mstream.get('/api/v1/admin/federation/keys', (req, res) => {
-    res.json(fedDb.getFederationKeys());
+  mstream.get('/api/v1/admin/federation', async (req, res) => {
+    const enabled = config.program.federation.enabled === true;
+    let available = true;
+    let endpointId = null;
+    let relayUrl = null;
+    try {
+      const federation = await import('../state/federation.js');
+      endpointId = federation.getEndpointId();
+      if (endpointId) {
+        const addr = federation.getEndpointAddr();
+        relayUrl = addr ? addr.relayUrl() : null;
+      }
+    } catch (_err) {
+      available = false; // native binary not present on this platform
+    }
+    res.json({ enabled, available, running: endpointId !== null, endpointId, online: relayUrl !== null, relayUrl });
   });
 
-  mstream.post('/api/v1/admin/federation/keys', (req, res) => {
+  mstream.post('/api/v1/admin/federation', async (req, res) => {
+    const schema = Joi.object({ enabled: Joi.boolean().required() });
+    joiValidate(schema, req.body);
+    const enabled = req.body.enabled;
+
+    const raw = await admin.loadFile(config.configFile);
+    if (!raw.federation) { raw.federation = {}; }
+    raw.federation.enabled = enabled;
+    await admin.saveFile(raw, config.configFile);
+    config.program.federation.enabled = enabled;
+
+    try {
+      const federation = await import('../state/federation.js');
+      if (enabled) {
+        await federation.start({
+          targetPort: config.program.port,
+          secretKey: config.program.federation.secretKey,
+        });
+      } else {
+        await federation.stop();
+      }
+      res.json({ enabled, available: true });
+    } catch (err) {
+      winston.error('[federation] admin toggle failed — endpoint unavailable on this platform', { stack: err });
+      res.json({ enabled, available: false });
+    }
+  });
+
+  mstream.get('/api/v1/admin/federation/keys', async (req, res) => {
+    const keys = fedDb.getFederationKeys();
+    for (const k of keys) {
+      k.ticket = await ticketForKey(k);
+    }
+    res.json(keys);
+  });
+
+  mstream.post('/api/v1/admin/federation/keys', async (req, res) => {
     const schema = Joi.object({
       name: Joi.string().min(1).max(64).required(),
       vpaths: Joi.array().items(Joi.string()).min(1).unique().required(),
@@ -39,16 +114,24 @@ export function register(mstream) {
 
     const minted = fedDb.createFederationKey(req.body.name, libraryIds);
     winston.info(`[federation] ${req.user.username} minted key '${minted.name}' for libraries [${req.body.vpaths.join(', ')}]`);
-    res.json({ id: minted.id, name: minted.name, key: minted.key });
+    const ticket = await ticketForKey({ ...minted, library_names: req.body.vpaths });
+    res.json({ id: minted.id, name: minted.name, key: minted.key, ticket });
   });
 
-  mstream.delete('/api/v1/admin/federation/keys/:id', (req, res) => {
+  mstream.delete('/api/v1/admin/federation/keys/:id', async (req, res) => {
     const schema = Joi.object({ id: Joi.number().integer().min(1).required() });
     joiValidate(schema, req.params);
 
     if (!fedDb.deleteFederationKey(Number(req.params.id))) {
       throw new WebError('Key not found', 404);
     }
+    // Sever any live pipes riding this key — new handshakes and HTTP
+    // requests already fail on the deleted row.
+    try {
+      const federation = await import('../state/federation.js');
+      const closed = federation.closeConnectionsForKey(Number(req.params.id));
+      if (closed > 0) { winston.info(`[federation] closed ${closed} live connection(s) for revoked key id=${req.params.id}`); }
+    } catch (_err) { /* native binary not present — nothing live to close */ }
     winston.info(`[federation] ${req.user.username} revoked key id=${req.params.id}`);
     res.json({});
   });

--- a/src/server.js
+++ b/src/server.js
@@ -473,6 +473,22 @@ export async function serveIt(configFile) {
       }
     }
 
+    // Federation endpoint (opt-in; default off) — the third iroh persona,
+    // independent of the tunnel above and the discovery sidecar below. Same
+    // lazy-load contract: a platform without the native binary just logs and
+    // leaves the feature off.
+    if (config.program.federation.enabled) {
+      try {
+        const federation = await import('./state/federation.js');
+        await federation.start({
+          targetPort: config.program.port,
+          secretKey: config.program.federation.secretKey,
+        });
+      } catch (err) {
+        winston.error('[federation] endpoint unavailable on this platform — feature disabled', { stack: err });
+      }
+    }
+
     // Discovery-network gossip catalog (opt-in; default off, and also
     // toggleable at runtime through the admin Discovery page — both paths
     // run the SAME stack in state/discovery-p2p-stack.js). Detached +
@@ -526,6 +542,8 @@ export function reboot() {
     // socket + relay connection. Lazy-imported to match the boot path and to
     // stay a no-op when the native module was never loaded.
     import('./state/iroh.js').then((m) => m.stop()).catch(() => {});
+    // Same for the federation endpoint — its own UDP socket + relay conn.
+    import('./state/federation.js').then((m) => m.stop()).catch(() => {});
 
     // Close the server. server.close() waits for every in-flight HTTP
     // request AND every idle keep-alive socket to drain. The admin

--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -1,0 +1,338 @@
+// Federation endpoint — the THIRD iroh persona (@number0/iroh v1), alongside
+// the remote-access tunnel (state/iroh.js) and the discovery sidecar. Its own
+// secretKey (config.federation.secretKey), its own ALPN, no discovery/gossip:
+// pairing is ticket-swap only.
+//
+// Shape: same TCP-over-QUIC tunnel as state/iroh.js — accepted bi-streams
+// bridge to the local mStream HTTP server, so a paired peer speaks plain HTTP
+// (range requests, keep-alive) and authenticates every request with its
+// x-federation-key header at the auth wall (api/federation-auth.js).
+//
+// The pipe gate differs from the tunnel's fixed shared secret: the FIRST
+// bi-stream carries the peer's minted federation key. The server looks it up
+// in federation_keys and TOFU-binds the dialer's EndpointId on first use —
+// after the legitimate peer redeems its ticket, the same key from any other
+// endpoint is rejected (and logged loudly: that's the credential-theft
+// signal). Revoking the key kills the pipe handshake, every HTTP request
+// (per-request wall lookup), and any LIVE connections via the registry below.
+//
+// Outbound dialing (connectToPeer) uses the SAME bound endpoint, not a
+// throwaway like the tunnel client — the peer's TOFU binding needs a stable
+// dialer EndpointId across reconnects.
+//
+// PORTABILITY: identical lazy-load contract to the tunnel — importing this
+// module never throws; a missing native binary surfaces in start() and the
+// boot site leaves the feature off.
+
+import winston from 'winston';
+import {
+  loadIroh,
+  asBuffer,
+  delay,
+  bridgeStreamToBackend,
+  buildEnvelope,
+  parseEnvelope,
+} from './iroh-common.js';
+import * as fedDb from '../db/federation.js';
+
+// ALPN — both ends must present identical bytes; Array<number> per the v1
+// binding. Bump the version if the handshake framing changes.
+export const FEDERATION_ALPN = Array.from(Buffer.from('mstream/federation/1'));
+
+const HANDSHAKE_LIMIT = 128; // fedk_ keys are 48 chars; anything bigger is garbage
+const CONNECT_TIMEOUT_MS = 25000;
+
+// Failed-handshake backoff, per remote EndpointId. The endpoint is publicly
+// dialable and there's no global rate limiter, so after BACKOFF_THRESHOLD
+// consecutive failures a remote is dropped on sight for BACKOFF_MS. In-memory
+// only — a reboot forgives, which is fine for what this guards against
+// (scripted retry loops, not offline attacks on a 256-bit key).
+const BACKOFF_THRESHOLD = 5;
+const BACKOFF_MS = 60 * 1000;
+const failedHandshakes = new Map(); // remoteId -> { fails, blockedUntil }
+
+// Server state
+let irohMod = null;
+let endpoint = null;
+let endpointIdStr = null;
+
+// Live authorized connections per key id, so revoking a key can sever its
+// open pipes instead of waiting for the peer to reconnect and fail.
+const liveConns = new Map(); // keyId -> Set<conn>
+
+// ---------------------------------------------------------------------------
+// Federation ticket: "mstrfed<V>:<base64url(JSON)>". Payload:
+//   t  (required) this server's federation EndpointTicket string
+//   k  (required) the minted read-only API key ('fedk_…')
+//   n  (optional) server display name, for the friend's add-peer preview
+//   l  (optional) granted vpath names — informational; the health endpoint
+//                 is the live source of truth after pairing
+// Unknown fields are ignored (forward compat). Spec: docs/federation-ticket.md.
+// Unlike the tunnel QR, this carries a STANDING credential — swap it over a
+// private channel; TOFU burn-on-redeem + per-key revocation are the backstops.
+// ---------------------------------------------------------------------------
+
+export const FEDERATION_TICKET_PREFIX = 'mstrfed';
+export const FEDERATION_TICKET_VERSION = 1;
+
+export function buildFederationTicket({ endpointTicket, key, serverName, libraries }) {
+  const payload = { t: endpointTicket, k: key };
+  if (serverName) { payload.n = serverName; }
+  if (Array.isArray(libraries) && libraries.length > 0) { payload.l = libraries; }
+  return buildEnvelope(FEDERATION_TICKET_PREFIX, FEDERATION_TICKET_VERSION, payload);
+}
+
+// Pure (no native module). Throws on garbage, a missing prefix (no bare-body
+// legacy for a brand-new format), a too-new version, or missing fields.
+export function parseFederationTicket(str) {
+  const { version, payload } = parseEnvelope(str, {
+    prefix: FEDERATION_TICKET_PREFIX,
+    maxVersion: FEDERATION_TICKET_VERSION,
+    allowBare: false,
+    label: 'federation ticket',
+  });
+  if (!payload || typeof payload.t !== 'string' || typeof payload.k !== 'string') {
+    throw new Error('Invalid federation ticket (missing fields)');
+  }
+  return {
+    version,
+    endpointTicket: payload.t,
+    apiKey: payload.k,
+    name: typeof payload.n === 'string' ? payload.n : null,
+    libraries: Array.isArray(payload.l) ? payload.l.filter((x) => typeof x === 'string') : [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Inbound: accept loop + key handshake with TOFU
+// ---------------------------------------------------------------------------
+
+function isBackedOff(remote) {
+  const entry = failedHandshakes.get(remote);
+  if (!entry) { return false; }
+  if (entry.blockedUntil && entry.blockedUntil > Date.now()) { return true; }
+  if (entry.blockedUntil && entry.blockedUntil <= Date.now()) { failedHandshakes.delete(remote); }
+  return false;
+}
+
+function recordHandshakeFailure(remote) {
+  const entry = failedHandshakes.get(remote) || { fails: 0, blockedUntil: 0 };
+  entry.fails += 1;
+  if (entry.fails >= BACKOFF_THRESHOLD) {
+    entry.blockedUntil = Date.now() + BACKOFF_MS;
+    winston.warn(`[federation] backing off ${remote} for ${BACKOFF_MS / 1000}s after ${entry.fails} failed handshakes`);
+  }
+  failedHandshakes.set(remote, entry);
+}
+
+// First bi-stream carries the raw key. Look it up, enforce/establish the TOFU
+// binding, reply OK/NO. Returns the key row on success, null otherwise.
+async function authenticateConnection(conn, remote) {
+  const authBi = await conn.acceptBi();
+  const sent = Buffer.from(await authBi.recv.readToEnd(HANDSHAKE_LIMIT)).toString('utf8');
+
+  let keyRow = sent.startsWith(fedDb.FEDERATION_KEY_PREFIX) ? fedDb.getFederationKeyByKey(sent) : undefined;
+  let ok = false;
+  if (!keyRow) {
+    winston.warn(`[federation] rejected connection from ${remote}: unknown key`);
+  } else {
+    if (keyRow.bound_endpoint_id === null) {
+      // TOFU: first redemption binds the key to this dialer. The guarded
+      // UPDATE loses gracefully if a concurrent handshake (or a revoke)
+      // got there first — either way, re-read and require an exact match.
+      if (fedDb.bindFederationKeyEndpoint(keyRow.id, remote)) {
+        winston.info(`[federation] key '${keyRow.name}' bound to endpoint ${remote} (first use)`);
+      }
+      keyRow = fedDb.getFederationKeyById(keyRow.id);
+    }
+    ok = Boolean(keyRow && keyRow.bound_endpoint_id === remote);
+    if (keyRow && !ok) {
+      // The one log line that matters most: a KNOWN key from the WRONG
+      // endpoint means the ticket leaked (or the friend reinstalled — the
+      // admin reset-binding action covers that case).
+      winston.warn(`[federation] rejected key '${keyRow.name}' from ${remote}: bound to ${keyRow.bound_endpoint_id} (possible leaked ticket)`);
+    }
+  }
+
+  try {
+    await authBi.send.writeAll(Array.from(Buffer.from(ok ? 'OK' : 'NO')));
+    await authBi.send.finish();
+  } catch (_err) { /* peer may have hung up */ }
+  return ok ? keyRow : null;
+}
+
+function trackConn(keyId, conn) {
+  if (!liveConns.has(keyId)) { liveConns.set(keyId, new Set()); }
+  liveConns.get(keyId).add(conn);
+}
+
+function untrackConn(keyId, conn) {
+  const set = liveConns.get(keyId);
+  if (!set) { return; }
+  set.delete(conn);
+  if (set.size === 0) { liveConns.delete(keyId); }
+}
+
+// Best-effort severing of a revoked key's open pipes. The DB row is already
+// gone by the time this runs, so new handshakes and HTTP requests fail on
+// their own; this just stops an existing tunnel from coasting on keep-alives.
+export function closeConnectionsForKey(keyId) {
+  const set = liveConns.get(keyId);
+  if (!set) { return 0; }
+  let closed = 0;
+  for (const conn of set) {
+    try { conn.close(1n, Array.from(Buffer.from('revoked'))); closed += 1; } catch (_err) { /* already gone */ }
+  }
+  liveConns.delete(keyId);
+  return closed;
+}
+
+// Per-connection loop: bridge each subsequent bi-stream to the local HTTP
+// server until the connection closes (identical to the tunnel).
+async function acceptConnection(conn, targetHost, targetPort) {
+  for (;;) {
+    let bi;
+    try {
+      bi = await conn.acceptBi();
+    } catch (_err) {
+      break; // connection closed by peer / transport error
+    }
+    bridgeStreamToBackend(bi, targetHost, targetPort);
+  }
+}
+
+async function runAcceptLoop(targetHost, targetPort) {
+  for (;;) {
+    let incoming;
+    try {
+      incoming = await endpoint.acceptNext();
+    } catch (_err) {
+      break; // endpoint closing
+    }
+    if (incoming === null) { break; } // endpoint closed
+    (async () => {
+      let remote = '(unknown)';
+      try {
+        const accepting = await incoming.accept();
+        const conn = await accepting.connect();
+        try { remote = conn.remoteId().toString(); } catch (_err) { /* noop */ }
+        if (isBackedOff(remote)) {
+          try { conn.close(1n, Array.from(Buffer.from('backoff'))); } catch (_err) { /* noop */ }
+          return;
+        }
+        const keyRow = await authenticateConnection(conn, remote);
+        if (!keyRow) {
+          recordHandshakeFailure(remote);
+          try { conn.close(1n, Array.from(Buffer.from('unauthorized'))); } catch (_err) { /* noop */ }
+          return;
+        }
+        failedHandshakes.delete(remote);
+        trackConn(keyRow.id, conn);
+        winston.info(`[federation] peer connection authorized: key '${keyRow.name}' from ${remote}`);
+        try {
+          await acceptConnection(conn, targetHost, targetPort);
+        } finally {
+          untrackConn(keyRow.id, conn);
+        }
+        winston.info(`[federation] peer connection closed: key '${keyRow.name}' (${remote})`);
+      } catch (err) {
+        winston.debug(`[federation] incoming connection dropped (${remote}): ${err?.message}`);
+      }
+    })();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+// Start the federation endpoint.
+//   targetPort  (required) local mStream HTTP port accepted streams bridge to.
+//   targetHost  backend host, default loopback.
+//   secretKey   32-byte endpoint identity (config.federation.secretKey).
+//   awaitOnline wait (bounded) for a home relay so issued tickets carry relay
+//               info (default true).
+// Returns { endpointId }. Throws if the native module can't load.
+export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, awaitOnline = true } = {}) {
+  if (endpoint) { return { endpointId: endpointIdStr }; }
+  if (!targetPort) { throw new Error('federation.start: targetPort is required'); }
+
+  irohMod = await loadIroh();
+  const { Endpoint } = irohMod;
+
+  const options = { alpns: [FEDERATION_ALPN] };
+  if (secretKey) { options.secretKey = Array.from(asBuffer(secretKey)); }
+  endpoint = await Endpoint.bind(options);
+  endpointIdStr = endpoint.id().toString();
+
+  if (awaitOnline) {
+    await Promise.race([endpoint.online().catch(() => {}), delay(8000)]);
+  }
+
+  runAcceptLoop(targetHost, targetPort); // detached; ends when the endpoint closes
+  winston.info(`[federation] endpoint up — endpointId=${endpointIdStr} -> ${targetHost}:${targetPort}`);
+  return { endpointId: endpointIdStr };
+}
+
+export function getEndpointId() { return endpointIdStr; }
+
+export function getEndpointAddr() {
+  if (!endpoint) { return null; }
+  return endpoint.addr();
+}
+
+// This server's federation EndpointTicket string (goes into minted tickets),
+// or null when the endpoint isn't running.
+export function getEndpointTicket() {
+  if (!endpoint || !irohMod) { return null; }
+  return irohMod.EndpointTicket.fromAddr(endpoint.addr()).toString();
+}
+
+export async function stop() {
+  if (!endpoint) { return; }
+  try { await endpoint.close(); } catch (_err) { /* best effort */ }
+  endpoint = null;
+  endpointIdStr = null;
+  liveConns.clear();
+  failedHandshakes.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Outbound: dial a peer from THIS endpoint (stable identity for their TOFU)
+// ---------------------------------------------------------------------------
+
+// Connect to a peer's federation endpoint and complete the key handshake.
+// Requires the local endpoint to be running (federation.enabled) — dialing
+// from a throwaway endpoint would present a different EndpointId every time
+// and trip the peer's TOFU binding.
+// Returns the open conn; callers open bi-streams per TCP connection and hand
+// them to bridge() (see state/federation-client.js).
+export async function connectToPeer(endpointTicketStr, apiKey) {
+  if (!endpoint) { throw new Error('federation endpoint is not running (enable federation first)'); }
+  const addr = irohMod.EndpointTicket.fromString(endpointTicketStr).endpointAddr();
+  const conn = await Promise.race([
+    endpoint.connect(addr, FEDERATION_ALPN),
+    new Promise((_r, rej) => setTimeout(() => rej(new Error(`connect timed out after ${CONNECT_TIMEOUT_MS / 1000}s`)), CONNECT_TIMEOUT_MS)),
+  ]);
+
+  // Key handshake on the first bi-stream. The server rejects by CLOSING with
+  // reason "unauthorized"/"backoff", which can surface as a thrown transport
+  // error instead of a readable non-OK body — same wrapped-read handling as
+  // the tunnel client.
+  const authBi = await conn.openBi();
+  await authBi.send.writeAll(Array.from(Buffer.from(apiKey)));
+  await authBi.send.finish();
+  let resp;
+  try {
+    resp = Buffer.from(await authBi.recv.readToEnd(8)).toString('utf8');
+  } catch (err) {
+    if (/unauthorized|backoff|revoked/i.test(err?.message || '')) {
+      throw new Error('federation handshake rejected (bad or revoked key)', { cause: err });
+    }
+    throw err;
+  }
+  if (resp !== 'OK') {
+    throw new Error('federation handshake rejected (bad or revoked key)');
+  }
+  return conn;
+}

--- a/test/integration/federation-e2e.test.mjs
+++ b/test/integration/federation-e2e.test.mjs
@@ -23,6 +23,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { startServer } from '../helpers/server.mjs';
+import { parseFederationTicket } from '../../src/state/federation.js';
 
 async function makeLibDir(prefix, fileName, content) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
@@ -135,6 +136,34 @@ describe('federation keys e2e (server with users)', () => {
       method: 'POST', headers: { 'x-access-token': adminToken },
     });
     assert.equal(r.status, 404);
+  });
+
+  test('admin status reflects the booted endpoint; minted keys carry swap-ready tickets', async () => {
+    const r = await fetch(`${srv.baseUrl}/api/v1/admin/federation`, {
+      headers: { 'x-access-token': adminToken },
+    });
+    assert.equal(r.status, 200);
+    const status = await r.json();
+    assert.equal(status.enabled, true);
+
+    if (!status.available) {
+      // No @number0/iroh binary on this platform — the HTTP side of
+      // federation still works (everything above), tickets are just null.
+      return;
+    }
+    assert.equal(status.running, true, 'boot wiring should have started the endpoint');
+    assert.ok(status.endpointId, 'running endpoint reports its id');
+
+    const keys = await (await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      headers: { 'x-access-token': adminToken },
+    })).json();
+    const mine = keys.find((k) => k.id === keyId);
+    assert.ok(mine, 'minted key is listed');
+    assert.match(mine.ticket, /^mstrfed1:/);
+    const parsed = parseFederationTicket(mine.ticket);
+    assert.equal(parsed.apiKey, fedKey);
+    assert.deepEqual(parsed.libraries, ['shared']);
+    assert.ok(parsed.endpointTicket.length > 0);
   });
 
   test('revocation kills the key on the next request', async () => {

--- a/test/integration/federation-handshake.test.mjs
+++ b/test/integration/federation-handshake.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * In-process federation endpoint: the key handshake gates the pipe, TOFU
+ * binds a key to its first redeemer, and authorized streams bridge plain
+ * HTTP to the backend. Exercises the lazy native load + accept/auth loop +
+ * the shared byte pumps against a real iroh endpoint.
+ *
+ * Needs a real DB for the key lookups, so it bootstraps the canonical
+ * config.setup + initDB harness into a temp dir (and process.exit()s in
+ * teardown like the other DB-backed suites).
+ *
+ * Skips automatically if @number0/iroh has no prebuilt binary here.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let available = true;
+try { await import('@number0/iroh'); } catch { available = false; }
+
+describe('federation endpoint handshake', { skip: available ? false : 'no @number0/iroh binary for this platform' }, () => {
+  let tmpDir, stub, stubPort;
+  let federation, fedDb, iroh; // modules
+  let endpointTicketStr;
+  let keyGood; // { id, key }
+  const clients = []; // throwaway dial endpoints to close in teardown
+
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-fed-hs-'));
+    fsSync.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+    fsSync.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
+      storage: {
+        dbDirectory:       path.join(tmpDir, 'db'),
+        albumArtDirectory: path.join(tmpDir, 'art'),
+        logsDirectory:     path.join(tmpDir, 'logs'),
+      },
+      port: 0,
+    }, null, 2));
+
+    const config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    const dbManager = await import('../../src/db/manager.js');
+    dbManager.initDB();
+    fedDb = await import('../../src/db/federation.js');
+    federation = await import('../../src/state/federation.js');
+    iroh = await import('../../src/state/iroh-common.js');
+
+    const d = dbManager.getDB();
+    const libId = Number(d.prepare("INSERT INTO libraries (name, root_path) VALUES ('music', '/music')").run().lastInsertRowid);
+    keyGood = fedDb.createFederationKey('good-peer', [libId]);
+
+    stub = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, path: req.url }));
+    });
+    await new Promise((r) => stub.listen(0, '127.0.0.1', r));
+    stubPort = stub.address().port;
+
+    await federation.start({
+      targetPort: stubPort,
+      secretKey: iroh.generateSecretKey(),
+      awaitOnline: false,
+    });
+    endpointTicketStr = federation.getEndpointTicket();
+    assert.ok(endpointTicketStr, 'endpoint ticket available once started');
+  });
+
+  after(async () => {
+    for (const c of clients) { try { await c.close(); } catch { /* gone */ } }
+    await federation?.stop();
+    if (stub) { stub.close(); }
+    try { fsSync.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* windows file locks */ }
+    // config.setup + initDB leave module-level timers running; exit like the
+    // other DB-backed suites.
+    setImmediate(() => process.exit(0));
+  });
+
+  // Dial the endpoint from a fresh throwaway client and run the key
+  // handshake. Returns { client, conn, resp } — resp is '' when the server
+  // closed instead of replying. Mirrors the tunnel client's wrapped read.
+  async function dial(key) {
+    const { Endpoint, EndpointTicket } = await import('@number0/iroh');
+    const client = await Endpoint.bind({});
+    clients.push(client);
+    const addr = EndpointTicket.fromString(endpointTicketStr).endpointAddr();
+    const conn = await client.connect(addr, federation.FEDERATION_ALPN);
+    const authBi = await conn.openBi();
+    await authBi.send.writeAll(Array.from(Buffer.from(key)));
+    await authBi.send.finish();
+    let resp = '';
+    try {
+      resp = Buffer.from(await authBi.recv.readToEnd(8)).toString('utf8');
+    } catch { /* server closed the connection — treated as a rejection */ }
+    return { client, conn, resp };
+  }
+
+  test('correct key completes the handshake, TOFU-binds, and tunnels HTTP', async () => {
+    const { client, conn, resp } = await dial(keyGood.key);
+    assert.equal(resp, 'OK');
+
+    // TOFU: the key row is now bound to THIS client's endpoint id.
+    const row = fedDb.getFederationKeyById(keyGood.id);
+    assert.equal(row.bound_endpoint_id, client.id().toString());
+
+    // A subsequent bi-stream is a plain HTTP bridge to the stub backend.
+    const bi = await conn.openBi();
+    await bi.send.writeAll(Array.from(Buffer.from('GET /probe HTTP/1.0\r\nConnection: close\r\n\r\n')));
+    await bi.send.finish();
+    const chunks = [];
+    for (;;) { const c = await bi.recv.read(65536); if (c.length === 0) { break; } chunks.push(Buffer.from(c)); }
+    const httpResp = Buffer.concat(chunks).toString('utf8');
+    assert.match(httpResp, /200/);
+    assert.match(httpResp, /\/probe/);
+  });
+
+  test('the same key from a different endpoint is rejected (TOFU)', async () => {
+    const { resp } = await dial(keyGood.key); // dial() binds a NEW endpoint every time
+    assert.notEqual(resp, 'OK');
+  });
+
+  test('an unknown key is rejected', async () => {
+    const { resp } = await dial('fedk_does-not-exist');
+    assert.notEqual(resp, 'OK');
+  });
+
+  test('a revoked key is rejected at the pipe', async () => {
+    const revoked = fedDb.createFederationKey('revoked-peer', []);
+    fedDb.deleteFederationKey(revoked.id);
+    const { resp } = await dial(revoked.key);
+    assert.notEqual(resp, 'OK');
+  });
+
+  test('closeConnectionsForKey severs a live authorized pipe', async () => {
+    const fresh = fedDb.createFederationKey('sever-me', []);
+    const { conn, resp } = await dial(fresh.key);
+    assert.equal(resp, 'OK');
+
+    const closed = federation.closeConnectionsForKey(fresh.id);
+    assert.equal(closed, 1);
+
+    // The severed connection can't carry new streams: opening/using one must
+    // fail (surface differs by timing — openBi may throw, or the stream
+    // errors on first use).
+    await assert.rejects(async () => {
+      const bi = await conn.openBi();
+      await bi.send.writeAll(Array.from(Buffer.from('GET / HTTP/1.0\r\n\r\n')));
+      await bi.send.finish();
+      await bi.recv.readToEnd(64);
+    });
+  });
+});

--- a/test/unit/federation-ticket.test.mjs
+++ b/test/unit/federation-ticket.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * Federation ticket (mstrfed<V>:) encode/parse round-trip. Pure functions —
+ * no native module needed. Spec: docs/federation-ticket.md.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildFederationTicket, parseFederationTicket } from '../../src/state/federation.js';
+import { buildCompositeTicket } from '../../src/state/iroh.js';
+
+describe('federation ticket (mstrfed envelope)', () => {
+  test('round-trips endpoint ticket + key + name + libraries, emits mstrfed1:', () => {
+    const ticket = buildFederationTicket({
+      endpointTicket: 'endpointaaaabbbbcccc',
+      key: 'fedk_0123456789',
+      serverName: "Paul's mStream",
+      libraries: ['Music', 'Vinyl Rips'],
+    });
+    assert.match(ticket, /^mstrfed1:/);
+
+    const parsed = parseFederationTicket(ticket);
+    assert.equal(parsed.version, 1);
+    assert.equal(parsed.endpointTicket, 'endpointaaaabbbbcccc');
+    assert.equal(parsed.apiKey, 'fedk_0123456789');
+    assert.equal(parsed.name, "Paul's mStream");
+    assert.deepEqual(parsed.libraries, ['Music', 'Vinyl Rips']);
+  });
+
+  test('name and libraries are optional', () => {
+    const ticket = buildFederationTicket({ endpointTicket: 'endpointx', key: 'fedk_y' });
+    const parsed = parseFederationTicket(ticket);
+    assert.equal(parsed.name, null);
+    assert.deepEqual(parsed.libraries, []);
+  });
+
+  test('ignores unknown payload fields (forward compat)', () => {
+    const body = Buffer.from(JSON.stringify({ t: 'endpointz', k: 'fedk_z', zzz: { future: true } })).toString('base64url');
+    const parsed = parseFederationTicket(`mstrfed1:${body}`);
+    assert.equal(parsed.endpointTicket, 'endpointz');
+  });
+
+  test('rejects a newer version with an actionable error', () => {
+    const body = Buffer.from(JSON.stringify({ t: 'x', k: 'y' })).toString('base64url');
+    assert.throws(() => parseFederationTicket(`mstrfed2:${body}`), /version 2.*supports up to v1.*[Uu]pdate/s);
+  });
+
+  test('rejects missing required fields', () => {
+    const noKey = 'mstrfed1:' + Buffer.from(JSON.stringify({ t: 'only-endpoint' })).toString('base64url');
+    assert.throws(() => parseFederationTicket(noKey), /Invalid federation ticket/);
+  });
+
+  test('rejects garbage and bare (prefix-less) bodies', () => {
+    assert.throws(() => parseFederationTicket('not-a-ticket!!'), /Invalid federation ticket/);
+    const bare = Buffer.from(JSON.stringify({ t: 'x', k: 'y' })).toString('base64url');
+    assert.throws(() => parseFederationTicket(bare), /Invalid federation ticket/, 'no bare-body legacy for a new format');
+  });
+
+  test('a tunnel pairing code fails cleanly in the federation parser', () => {
+    const tunnelCode = buildCompositeTicket('endpointabc', Buffer.alloc(32, 1));
+    assert.throws(() => parseFederationTicket(tunnelCode), /Invalid federation ticket/);
+  });
+});


### PR DESCRIPTION
## What this does

Stands up the **third iroh endpoint** — the transport that lets a paired peer actually reach this server. It's a separate persona from the remote-access tunnel and the discovery sidecar: its own ALPN (`mstream/federation/1`), its own `federation.secretKey`, so the three EndpointIds stay unlinkable and each feature toggles independently. Pairing is ticket-swap only — no discovery, no gossip.

Until now (PR #732) keys worked over plain LAN HTTP; this PR gives them their NAT-traversing, end-to-end-encrypted transport.

## The pipe gate — TOFU, not a shared secret

Same TCP-over-QUIC shape as the tunnel (authorized bi-streams bridge plain HTTP to the local server), but the gate is different. The tunnel uses one fixed shared secret; federation uses the **minted key itself**, bound trust-on-first-use:

- The peer sends its `fedk_…` key on the first bi-stream. The server looks it up in `federation_keys`.
- **First redemption binds the key to that dialer's iroh EndpointId** (`bound_endpoint_id`). From then on, the same key presented from *any other endpoint* is rejected and logged as a possible leaked ticket.
- So a ticket that leaks *after* the legitimate peer redeems it is dead on arrival — the attacker's EndpointId won't match.

Revoking a key (PR #732's admin route) kills three things at once: new pipe handshakes fail, every HTTP request 401s at the wall, and **any live connection riding that key is severed** via an in-memory per-key connection registry. A small per-remote failed-handshake backoff (5 strikes → 60s) guards the publicly-dialable endpoint since mStream has no global rate limiter.

## Also in here

- **`mstrfed1:` ticket format** — build/parse on the shared envelope helpers from PR #730, distinct prefix so a federation ticket and a tunnel pairing code fail cleanly in each other's parsers. Spec: `docs/federation-ticket.md`. Carries a standing credential (unlike the tunnel QR), so the doc is blunt about swapping over a private channel.
- **`connectToPeer()`** — the outbound dial, from this *same* bound endpoint (not a throwaway), so the peer's TOFU binding sees a stable identity across reconnects. (The dial side proper lands in the next PR.)
- **Boot + reboot wiring** next to the tunnel's — lazy-loaded, non-fatal: a platform with no prebuilt `@number0/iroh` binary just logs and leaves the feature off.
- **Admin `GET/POST /api/v1/admin/federation`** — status + live enable/disable (endpoint is independent of the HTTP server, so no reboot), mirroring the iroh tunnel routes. Minted-key listings now include the swap-ready ticket when the endpoint is up; revoke now also severs live connections.

## Verification

Integration tests drive a **real in-process endpoint** (auto-skip where the native binary is absent):
- correct key → handshake OK + an HTTP request round-trips through the pipe to a stub backend
- **TOFU**: a second, different endpoint presenting the same key is rejected
- an unknown key and a revoked key are both rejected at the pipe
- `closeConnectionsForKey` severs a live authorized connection (the revoke path)

Plus the e2e suite (from #732) now also asserts the booted endpoint reports running status and that minted keys carry a parseable `mstrfed1:` ticket.

## Note

I ran a separate adversarial security review of the now-merged auth PR (#732); if it surfaces anything it'll come as a follow-up fix, independent of this endpoint PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)