### PR TITLE
feat(federation): dial side — peer bridges, fedFetch, peers admin CRUD

### DIFF
--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -80,6 +80,9 @@ export function register(mstream) {
           secretKey: config.program.federation.secretKey,
         });
       } else {
+        // Peer bridges dial from this endpoint; drop them with it.
+        const client = await import('../state/federation-client.js');
+        client.stopAll();
         await federation.stop();
       }
       res.json({ enabled, available: true });
@@ -144,6 +147,83 @@ export function register(mstream) {
       throw new WebError('Key not found', 404);
     }
     winston.info(`[federation] ${req.user.username} reset the endpoint binding on key id=${req.params.id}`);
+    res.json({});
+  });
+
+  // ── Peers (servers this one can read) ──────────────────────────────
+
+  mstream.get('/api/v1/admin/federation/peers', (req, res) => {
+    res.json(fedDb.getFederationPeers());
+  });
+
+  mstream.post('/api/v1/admin/federation/peers', async (req, res) => {
+    const schema = Joi.object({
+      ticket: Joi.string().min(1).required(),
+      name: Joi.string().min(1).max(64).optional(),
+    });
+    joiValidate(schema, req.body);
+
+    let parsed;
+    try {
+      const federation = await import('../state/federation.js');
+      parsed = federation.parseFederationTicket(req.body.ticket);
+    } catch (err) {
+      winston.warn(`[federation] ${req.user.username} pasted an unparseable ticket: ${err.message}`);
+      throw new WebError(err.message, 400);
+    }
+
+    let peer;
+    try {
+      peer = fedDb.addFederationPeer({
+        name: req.body.name || parsed.name || 'Unnamed server',
+        endpointTicket: parsed.endpointTicket,
+        apiKey: parsed.apiKey,
+      });
+    } catch (err) {
+      if (/UNIQUE/.test(err.message)) { throw new WebError('This ticket is already added as a peer', 400); }
+      throw err;
+    }
+    winston.info(`[federation] ${req.user.username} added peer '${peer.name}' (id=${peer.id})`);
+
+    // Fire-and-forget first health check so the UI's status dot fills in
+    // without an extra click; the response returns immediately.
+    (async () => {
+      try {
+        const client = await import('../state/federation-client.js');
+        await client.testPeer(peer);
+      } catch (err) {
+        winston.warn(`[federation] initial test-connect for peer '${peer.name}' failed: ${err.message}`);
+      }
+    })();
+
+    res.json({ ...peer, ticketLibraries: parsed.libraries });
+  });
+
+  mstream.post('/api/v1/admin/federation/peers/:id/test', async (req, res) => {
+    const schema = Joi.object({ id: Joi.number().integer().min(1).required() });
+    joiValidate(schema, req.params);
+
+    const peer = fedDb.getFederationPeerById(Number(req.params.id));
+    if (!peer) { throw new WebError('Peer not found', 404); }
+
+    const client = await import('../state/federation-client.js');
+    const result = await client.testPeer(peer);
+    res.json({ ...result, peer: fedDb.getFederationPeerById(peer.id) });
+  });
+
+  mstream.delete('/api/v1/admin/federation/peers/:id', async (req, res) => {
+    const schema = Joi.object({ id: Joi.number().integer().min(1).required() });
+    joiValidate(schema, req.params);
+
+    const id = Number(req.params.id);
+    if (!fedDb.deleteFederationPeer(id)) {
+      throw new WebError('Peer not found', 404);
+    }
+    try {
+      const client = await import('../state/federation-client.js');
+      client.closePeerBridge(id);
+    } catch (_err) { /* nothing live to close */ }
+    winston.info(`[federation] ${req.user.username} removed peer id=${id}`);
     res.json({});
   });
 }

--- a/src/server.js
+++ b/src/server.js
@@ -543,6 +543,8 @@ export function reboot() {
     // stay a no-op when the native module was never loaded.
     import('./state/iroh.js').then((m) => m.stop()).catch(() => {});
     // Same for the federation endpoint — its own UDP socket + relay conn.
+    // Peer bridges (loopback servers + outbound conns) go down with it.
+    import('./state/federation-client.js').then((m) => m.stopAll()).catch(() => {});
     import('./state/federation.js').then((m) => m.stop()).catch(() => {});
 
     // Close the server. server.close() waits for every in-flight HTTP

--- a/src/state/federation-client.js
+++ b/src/state/federation-client.js
@@ -1,0 +1,146 @@
+// Dial side of federation: read a PEER's libraries through its iroh endpoint.
+//
+// Shape: one lazy loopback bridge per peer. We dial the peer once
+// (state/federation.js connectToPeer — from OUR bound endpoint, so the peer's
+// TOFU binding sees a stable EndpointId), then run a 127.0.0.1 ephemeral-port
+// net.Server whose every accepted socket becomes one QUIC bi-stream bridged
+// to the peer (the proven scripts/mstream-iroh-client.mjs pattern). Plain
+// fetch() against the loopback port then speaks normal HTTP to the peer —
+// keep-alive, range requests for the future pull-backup worker, everything —
+// and fedFetch() stamps the peer's x-federation-key header on each request.
+//
+// Lifecycle: bridges build on first use, tear down after 5 idle minutes
+// (no open sockets), and self-heal — a dead peer connection surfaces as a
+// failed fetch/openBi, which drops the cached bridge so the next call
+// redials. stopAll() runs on reboot/disable next to federation.stop().
+
+import net from 'net';
+import winston from 'winston';
+import { bridge } from './iroh-common.js';
+import * as federation from './federation.js';
+import * as fedDb from '../db/federation.js';
+
+const IDLE_TEARDOWN_MS = 5 * 60 * 1000;
+const HEALTH_TIMEOUT_MS = 15 * 1000;
+
+// peerId -> { port, baseUrl, server, conn, activeSockets, idleTimer }
+const bridges = new Map();
+// peerId -> Promise<entry> for a dial in progress, so concurrent fedFetch
+// calls share one connection instead of racing two (and leaking one).
+const pending = new Map();
+
+function armIdleTimer(entry, peerId) {
+  clearTimeout(entry.idleTimer);
+  entry.idleTimer = setTimeout(() => {
+    if (entry.activeSockets === 0) {
+      winston.debug(`[federation] peer bridge ${peerId} idle — tearing down`);
+      closePeerBridge(peerId);
+    }
+  }, IDLE_TEARDOWN_MS);
+  // Never hold the process open just to keep an idle timer.
+  if (entry.idleTimer.unref) { entry.idleTimer.unref(); }
+}
+
+// Ensure a live loopback bridge to the peer; resolves to { port, baseUrl }.
+// Rejects when the peer is unreachable or the handshake is rejected.
+export function getPeerBridge(peer) {
+  const existing = bridges.get(peer.id);
+  if (existing) { return existing; }
+  const inFlight = pending.get(peer.id);
+  if (inFlight) { return inFlight; }
+  const p = buildBridge(peer).finally(() => pending.delete(peer.id));
+  pending.set(peer.id, p);
+  return p;
+}
+
+async function buildBridge(peer) {
+  const conn = await federation.connectToPeer(peer.endpoint_ticket, peer.api_key);
+
+  const entry = { port: 0, baseUrl: '', server: null, conn, activeSockets: 0, idleTimer: null };
+  entry.server = net.createServer((socket) => {
+    entry.activeSockets += 1;
+    clearTimeout(entry.idleTimer);
+    socket.once('close', () => {
+      entry.activeSockets -= 1;
+      if (entry.activeSockets === 0) { armIdleTimer(entry, peer.id); }
+    });
+    conn.openBi().then((bi) => {
+      bridge(socket, bi);
+    }).catch((err) => {
+      // openBi failing is the dead-connection signal — drop the bridge so
+      // the next fedFetch redials instead of hitting a zombie.
+      winston.debug(`[federation] peer ${peer.id} openBi failed (${err?.message}) — dropping bridge`);
+      socket.destroy();
+      closePeerBridge(peer.id);
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    entry.server.once('error', reject);
+    entry.server.listen(0, '127.0.0.1', resolve);
+  });
+  entry.port = entry.server.address().port;
+  entry.baseUrl = `http://127.0.0.1:${entry.port}`;
+  armIdleTimer(entry, peer.id);
+
+  bridges.set(peer.id, entry);
+  winston.info(`[federation] peer bridge up: peer ${peer.id} ('${peer.name}') on ${entry.baseUrl}`);
+  return entry;
+}
+
+// fetch() against a peer, with the federation key stamped on. One transparent
+// retry on a transport-level failure (dead cached connection): the failed
+// bridge is dropped and rebuilt fresh before giving up.
+export async function fedFetch(peer, apiPath, opts = {}) {
+  for (let attempt = 0; ; attempt++) {
+    const { baseUrl } = await getPeerBridge(peer);
+    try {
+      return await fetch(baseUrl + apiPath, {
+        ...opts,
+        headers: { ...(opts.headers || {}), 'x-federation-key': peer.api_key },
+      });
+    } catch (err) {
+      closePeerBridge(peer.id);
+      if (attempt >= 1) { throw err; }
+      winston.debug(`[federation] fedFetch to peer ${peer.id} failed (${err?.message}) — redialing once`);
+    }
+  }
+}
+
+// Health-check a peer and cache the outcome on its row (the admin UI's
+// status dot). Returns { ok: true, health } or { ok: false, error }.
+export async function testPeer(peer) {
+  try {
+    const res = await fedFetch(peer, '/api/v1/federation/health', {
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const summary = `http ${res.status}`;
+      fedDb.updateFederationPeerStatus(peer.id, summary);
+      return { ok: false, error: summary };
+    }
+    const health = await res.json();
+    fedDb.updateFederationPeerStatus(peer.id, 'ok');
+    return { ok: true, health };
+  } catch (err) {
+    // Trim transport noise to something the UI can show in a status cell.
+    const summary = `unreachable: ${String(err?.message || err).slice(0, 120)}`;
+    fedDb.updateFederationPeerStatus(peer.id, summary);
+    return { ok: false, error: summary };
+  }
+}
+
+export function closePeerBridge(peerId) {
+  const entry = bridges.get(peerId);
+  if (!entry) { return; }
+  bridges.delete(peerId);
+  clearTimeout(entry.idleTimer);
+  try { entry.server.close(); } catch (_err) { /* already down */ }
+  try { entry.conn.close(0n, Array.from(Buffer.from('bye'))); } catch (_err) { /* already gone */ }
+}
+
+export function stopAll() {
+  for (const peerId of [...bridges.keys()]) {
+    closePeerBridge(peerId);
+  }
+}

--- a/test/integration/federation-dial.test.mjs
+++ b/test/integration/federation-dial.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * Dial side of federation, end-to-end over real iroh:
+ *
+ * Server A = a real spawned mStream (startServer helper) with federation
+ * enabled and a key minted over its admin API. Server B = THIS test process,
+ * bootstrapped with the canonical config.setup + initDB harness and its own
+ * federation endpoint. B adds A's ticket as a peer, then reads A through the
+ * loopback bridge: health (grant list), scoped db browse, and a /media file —
+ * all over QUIC with the x-federation-key header stamped by fedFetch.
+ *
+ * Also pins: bridge reuse (second fetch, same conn), testPeer's status
+ * caching, and closePeerBridge + redial self-healing.
+ *
+ * Skips when @number0/iroh has no prebuilt binary here (both sides need it).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { startServer } from '../helpers/server.mjs';
+
+let available = true;
+try { await import('@number0/iroh'); } catch { available = false; }
+
+describe('federation dial side (B reads A over iroh)', { skip: available ? false : 'no @number0/iroh binary for this platform' }, () => {
+  let tmpDir, srvA, sharedDir;
+  let federation, fedClient, fedDb;
+  let peer;
+
+  before(async () => {
+    // ── Server A: real mStream with a shared library + minted key ──
+    sharedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-dial-shared-'));
+    await fs.writeFile(path.join(sharedDir, 'hello.txt'), 'hello over iroh', 'utf8');
+
+    srvA = await startServer({
+      extraFolders: { shared: sharedDir },
+      extraConfig: { federation: { enabled: true } },
+    });
+
+    // Public mode on A — mint without a token.
+    const mint = await fetch(`${srvA.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'server-b', vpaths: ['shared'] }),
+    });
+    assert.equal(mint.status, 200);
+    const minted = await mint.json();
+    assert.ok(minted.ticket, "server A should issue a ticket (endpoint up — binary was importable here)");
+
+    // ── Server B: this process ──
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-dial-b-'));
+    fsSync.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+    fsSync.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
+      storage: {
+        dbDirectory:       path.join(tmpDir, 'db'),
+        albumArtDirectory: path.join(tmpDir, 'art'),
+        logsDirectory:     path.join(tmpDir, 'logs'),
+      },
+      port: 0,
+    }, null, 2));
+    const config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    const dbManager = await import('../../src/db/manager.js');
+    dbManager.initDB();
+    federation = await import('../../src/state/federation.js');
+    fedClient = await import('../../src/state/federation-client.js');
+    fedDb = await import('../../src/db/federation.js');
+
+    // B's own endpoint — dials must come from a stable bound identity.
+    const irohCommon = await import('../../src/state/iroh-common.js');
+    await federation.start({ targetPort: 1, secretKey: irohCommon.generateSecretKey(), awaitOnline: false });
+
+    // B stores A as a peer, exactly as the add-peer admin route would.
+    const parsed = federation.parseFederationTicket(minted.ticket);
+    peer = fedDb.addFederationPeer({
+      name: parsed.name || 'server-a',
+      endpointTicket: parsed.endpointTicket,
+      apiKey: parsed.apiKey,
+    });
+  });
+
+  after(async () => {
+    fedClient?.stopAll();
+    await federation?.stop();
+    await srvA?.stop();
+    for (const d of [tmpDir, sharedDir]) {
+      if (d) { try { fsSync.rmSync(d, { recursive: true, force: true }); } catch { /* windows locks */ } }
+    }
+    setImmediate(() => process.exit(0));
+  });
+
+  test('health over the bridge reports the granted libraries', async () => {
+    const res = await fedClient.fedFetch(peer, '/api/v1/federation/health');
+    assert.equal(res.status, 200);
+    const health = await res.json();
+    assert.deepEqual(health.libraries, ['shared']);
+  });
+
+  test('db browse and /media work through the same bridge (reuse)', async () => {
+    const browse = await fedClient.fedFetch(peer, '/api/v1/db/artists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    assert.equal(browse.status, 200);
+    assert.deepEqual((await browse.json()).artists, []); // fixture artists live in ungranted testlib
+
+    const file = await fedClient.fedFetch(peer, '/media/shared/hello.txt');
+    assert.equal(file.status, 200);
+    assert.equal(await file.text(), 'hello over iroh');
+
+    const ungranted = await fedClient.fedFetch(peer, '/media/testlib/');
+    assert.equal(ungranted.status, 404);
+  });
+
+  test('testPeer caches ok status on the row', async () => {
+    const result = await fedClient.testPeer(peer);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.health.libraries, ['shared']);
+    const row = fedDb.getFederationPeerById(peer.id);
+    assert.equal(row.last_status, 'ok');
+    assert.ok(row.last_seen);
+  });
+
+  test('a dropped bridge self-heals on the next fetch', async () => {
+    fedClient.closePeerBridge(peer.id);
+    const res = await fedClient.fedFetch(peer, '/api/v1/federation/health');
+    assert.equal(res.status, 200);
+  });
+
+  test('a peer with a revoked key reports unreachable and caches the failure', async () => {
+    const bogus = fedDb.addFederationPeer({
+      name: 'bogus',
+      endpointTicket: peer.endpoint_ticket, // A's real endpoint...
+      apiKey: 'fedk_never-minted',          // ...but a key A doesn't know
+    });
+    const result = await fedClient.testPeer(bogus);
+    assert.equal(result.ok, false);
+    const row = fedDb.getFederationPeerById(bogus.id);
+    assert.match(row.last_status, /unreachable/);
+    assert.equal(row.last_seen, null, 'never-reachable peer has no last_seen');
+  });
+});

--- a/test/integration/federation-e2e.test.mjs
+++ b/test/integration/federation-e2e.test.mjs
@@ -23,7 +23,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { startServer } from '../helpers/server.mjs';
-import { parseFederationTicket } from '../../src/state/federation.js';
+import { parseFederationTicket, buildFederationTicket } from '../../src/state/federation.js';
 
 async function makeLibDir(prefix, fileName, content) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
@@ -164,6 +164,51 @@ describe('federation keys e2e (server with users)', () => {
     assert.equal(parsed.apiKey, fedKey);
     assert.deepEqual(parsed.libraries, ['shared']);
     assert.ok(parsed.endpointTicket.length > 0);
+  });
+
+  test('peer admin routes: add/parse errors, duplicates, list, test 404, remove', async () => {
+    const adminH = { 'Content-Type': 'application/json', 'x-access-token': adminToken };
+
+    const garbage = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers`, {
+      method: 'POST', headers: adminH, body: JSON.stringify({ ticket: 'not-a-ticket' }),
+    });
+    assert.equal(garbage.status, 400);
+
+    // Syntactically valid ticket pointing nowhere — adding succeeds (the
+    // endpoint string is opaque until dialed); the async first health check
+    // just fails quietly.
+    const fakeTicket = buildFederationTicket({
+      endpointTicket: 'endpointfake', key: 'fedk_fake-peer-key', serverName: 'Fake Friend', libraries: ['x'],
+    });
+    const add = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers`, {
+      method: 'POST', headers: adminH, body: JSON.stringify({ ticket: fakeTicket }),
+    });
+    assert.equal(add.status, 200);
+    const added = await add.json();
+    assert.equal(added.name, 'Fake Friend');
+    assert.deepEqual(added.ticketLibraries, ['x']);
+
+    const dup = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers`, {
+      method: 'POST', headers: adminH, body: JSON.stringify({ ticket: fakeTicket }),
+    });
+    assert.equal(dup.status, 400);
+
+    const list = await (await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers`, { headers: adminH })).json();
+    assert.ok(list.some((p) => p.id === added.id));
+
+    const testMissing = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers/424242/test`, {
+      method: 'POST', headers: adminH,
+    });
+    assert.equal(testMissing.status, 404);
+
+    const del = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers/${added.id}`, {
+      method: 'DELETE', headers: adminH,
+    });
+    assert.equal(del.status, 200);
+    const delAgain = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers/${added.id}`, {
+      method: 'DELETE', headers: adminH,
+    });
+    assert.equal(delAgain.status, 404);
   });
 
   test('revocation kills the key on the next request', async () => {


### PR DESCRIPTION
## What this does

The other half of the pipe. #732 + #733 made this server **readable** — mint a key, accept inbound dials. This PR makes it a **reader**: paste a friend's `mstrfed1:` ticket, and this server can browse and stream their granted libraries over iroh. It's the first PR where two mStream servers actually talk end to end.

## The shape — a loopback bridge per peer, then plain `fetch()`

`src/state/federation-client.js` deliberately avoids inventing an RPC layer. Each peer gets one lazy bridge:

- Dial the peer **once, from our bound federation endpoint** (not a throwaway — the peer's TOFU binding needs to see the same EndpointId every reconnect), then run a `127.0.0.1` ephemeral-port `net.Server` where every accepted socket becomes a QUIC bi-stream bridged to the peer. This is the proven `scripts/mstream-iroh-client.mjs` pattern promoted to production.
- From there it's normal HTTP against a loopback port: keep-alive, streaming bodies, and **range requests** — which is exactly what the future pull-backup worker needs.
- `fedFetch(peer, path, opts)` = ensure bridge + stamp `x-federation-key` + **one transparent retry** on transport-level failure (drops the dead cached bridge, redials fresh, then gives up honestly).

Lifecycle details that matter:
- Concurrent first calls **share one in-flight dial** (a pending-promise map) instead of racing two connections and leaking one.
- Bridges tear down after **5 idle minutes** (unref'd timer — never holds the process open) and self-heal: a dead peer connection surfaces as a failed `fetch`/`openBi`, which evicts the bridge so the next call redials.
- `stopAll()` is wired into `reboot()` and the admin disable toggle, right next to `federation.stop()` — bridges dial from that endpoint, so they go down with it.

## Peers admin CRUD (`/api/v1/admin/federation/peers`)

- **POST** — Joi-validated; parses the ticket (garbage → 400 carrying the parser's actionable message), duplicate ticket → clean 400 via the UNIQUE constraint. Name precedence: explicit body override → ticket's embedded server name → `'Unnamed server'`. Fires a **non-blocking first health check** so the UI's status dot fills in without an extra click, and echoes the ticket's advertised libraries back for the paste-preview.
- **POST `/:id/test`** — health check over `fedFetch`, caches `last_seen`/`last_status` on the row (what the UI status cell reads), returns the fresh row.
- **DELETE** — removes the row and closes any live bridge.
- **GET** — list with cached status.

## Verification

New `test/integration/federation-dial.test.mjs` spins up **two real in-process iroh endpoints** — a stub "peer A" running the accept loop from #733, and this server's dial side (auto-skips where the native binary is absent):
- health over the bridge reports the granted libraries
- db browse and `/media` work through the **same** bridge (connection reuse)
- `testPeer` caches `ok` on the row
- a dropped bridge **self-heals** on the next fetch
- a peer holding a revoked key reports unreachable and caches the failure

The e2e suite (from #732) grows a peers-CRUD pass: garbage ticket → 400, add → 200 with `ticketLibraries` echoed, duplicate → 400, list, test on a missing id → 404, remove → 200 then 404.

With this merged the connection layer is functionally complete — what's left (final PR) is the admin UI and API docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
