### PR TITLE
feat(federation): vector-seed discovery endpoint for federated peers (discovery-over-federation P1)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5836,7 +5836,7 @@ paths:
                         artist: { type: string, nullable: true }
                         title: { type: string, nullable: true }
                         duration: { type: number, nullable: true }
-                        similarity: { type: number, description: Cosine vs the query vector, 4 decimals }
+                        similarity: { type: number, description: "Cosine vs the query vector, 4 decimals" }
                         genreTags:
                           type: array
                           nullable: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5769,6 +5769,83 @@ paths:
                   libraries:
                     type: array
                     items: { type: string }
+                  discovery:
+                    type: object
+                    nullable: true
+                    description: |
+                      Discovery-over-federation capability. `null` when this
+                      server cannot answer vector similarity queries (data
+                      collection off, or nothing embedded yet). Otherwise it
+                      names the model space the peer's query vectors must
+                      live in.
+                    properties:
+                      modelId: { type: string, description: Active embedding model id }
+                      modelVersion: { type: string, nullable: true }
+                      dim: { type: integer, description: Embedding dimension (float32 count per vector) }
+                      analyzedCount: { type: integer, description: Embedded tracks in the index }
+
+  /api/v1/federation/discovery/similar:
+    post:
+      tags: [Federation]
+      summary: Vector-seed similarity query (machine-facing)
+      description: |
+        Discovery-over-federation, peer side: the caller (a federated peer)
+        sends the embedding vector of one of ITS OWN tracks and this server
+        answers with its most similar tracks, scoped to the caller's granted
+        libraries. No novelty filtering happens here — the caller drops
+        tracks it already owns. A model-id mismatch is a soft 200 with
+        `modelMismatch: true` (vectors from different models are
+        incomparable), so a fan-out caller can skip the peer gracefully.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [embedding, modelId]
+              properties:
+                embedding:
+                  type: string
+                  format: byte
+                  description: |
+                    Base64 of `dim` × float32 little-endian (see the
+                    /federation/health discovery block for `dim`). Should be
+                    L2-normalized; the server re-normalizes defensively.
+                modelId: { type: string, description: The caller's embedding model id — must match this server's }
+                limit: { type: integer, default: 25, maximum: 100 }
+      responses:
+        "200":
+          description: Ranked similar tracks within the granted libraries, or a modelMismatch soft answer.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  model:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      version: { type: string, nullable: true }
+                  modelMismatch: { type: boolean, description: Present (true) only when the declared model differs }
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        filepath: { type: string, description: "vpath-form path within a granted library (streamable via /media)" }
+                        artist: { type: string, nullable: true }
+                        title: { type: string, nullable: true }
+                        duration: { type: number, nullable: true }
+                        similarity: { type: number, description: Cosine vs the query vector, 4 decimals }
+                        genreTags:
+                          type: array
+                          nullable: true
+                          items: { type: string }
+                        recordingMbid: { type: string, nullable: true }
+        "400":
+          description: Malformed vector (wrong length for the model space, non-finite values, zero vector, bad base64).
+        "403":
+          description: Discovery data collection is disabled on this server.
 
   /api/v1/admin/federation:
     get:

--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -74,7 +74,9 @@ export function resolveSeedTrack(req, filePath, routeTag) {
 
 // Resolve a canonical hash to a track row THIS user may see. Returns null
 // when every copy of that audio lives outside the user's libraries.
-function resolveVisible(uid, filter, canonHash) {
+// Exported for the federation vector-seed route (api/federation-discovery.js),
+// which scopes a peer's results the same way.
+export function resolveVisible(uid, filter, canonHash) {
   const params = uid ? [uid, canonHash, ...filter.params] : [canonHash, ...filter.params];
   return d().prepare(`
     ${trackQuery(uid)}

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -54,6 +54,7 @@ const ALLOWED_EXACT = new Set([
   'POST /api/v1/file-explorer/recursive',
   'POST /api/v1/file-explorer/m3u',
   'GET /api/v1/federation/health',
+  'POST /api/v1/federation/discovery/similar',
 ]);
 const ALLOWED_GET_PREFIXES = ['/media/', '/album-art/'];
 

--- a/src/api/federation-discovery.js
+++ b/src/api/federation-discovery.js
@@ -1,0 +1,105 @@
+// Discovery-over-federation, peer side (mounted behind the auth wall).
+//
+// POST /api/v1/federation/discovery/similar is machine-facing: a federated
+// peer sends the raw embedding vector of one of ITS tracks and this server
+// answers with its most similar tracks, scoped to the caller's granted
+// libraries. No novelty filtering happens here — this server cannot know
+// what the caller's library holds, and shipping the caller's identity sets
+// over would leak it — so the response is a plain top-K ranking the caller
+// filters on its side.
+//
+// Vectors only compare within one model space, so the request declares the
+// caller's model id. A mismatch is a soft 200 `modelMismatch` answer, not an
+// error: the caller fans out to several peers and treats a mismatched peer
+// as "no results", while its admin UI can still surface why.
+//
+// Grant scoping is the same machinery the local similar routes use —
+// libraryFilter(req.user) + resolveVisible(). The federation wall's
+// synthetic user carries the key's granted libraryIds, so a key granted
+// library A never sees a ranked track whose only copy lives in library B.
+// Regular logged-in users may also call this; they get results scoped to
+// their own vpaths, which /discovery/local/* already gives them anyway.
+
+import Joi from 'joi';
+import * as sim from '../db/discovery-similarity.js';
+import * as discoveryDb from '../db/discovery-db.js';
+import { requireIndex, resolveVisible } from './discovery.js';
+import { renderMetadataObj, libraryFilter } from './db.js';
+import { joiValidate } from '../util/validation.js';
+import WebError from '../util/web-error.js';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export function setup(mstream) {
+  mstream.post('/api/v1/federation/discovery/similar', (req, res) => {
+    const schema = Joi.object({
+      // Base64 of dim × float32 little-endian (dim advertised in the
+      // /federation/health discovery block).
+      embedding: Joi.string().base64().required(),
+      modelId: Joi.string().required(),
+      limit: Joi.number().integer().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+    });
+    const { value: body } = joiValidate(schema, req.body);
+
+    const index = requireIndex();   // 403 while discovery is off/unavailable
+    const model = { id: index.modelId, version: index.modelVersion };
+
+    if (body.modelId !== index.modelId) {
+      return res.json({ model, modelMismatch: true, results: [] });
+    }
+
+    // Index exists but holds zero vectors (nothing embedded yet): a valid
+    // empty answer — and there is no dim to validate the query against.
+    if (index.dim === null) {
+      return res.json({ model, results: [] });
+    }
+
+    const raw = Buffer.from(body.embedding, 'base64');
+    if (raw.length !== index.dim * 4) {
+      throw new WebError(`embedding must be ${index.dim} float32 values (little-endian), got ${raw.length} bytes`, 400);
+    }
+    // Aligned copy — a Buffer's byteOffset isn't guaranteed 4-byte aligned.
+    const ab = new ArrayBuffer(raw.length);
+    new Uint8Array(ab).set(raw);
+    const q = new Float32Array(ab);
+
+    let sumSq = 0;
+    for (let i = 0; i < q.length; i++) {
+      if (!Number.isFinite(q[i])) { throw new WebError('embedding contains non-finite values', 400); }
+      sumSq += q[i] * q[i];
+    }
+    const norm = Math.sqrt(sumSq);
+    if (norm === 0) { throw new WebError('embedding is a zero vector', 400); }
+    // The index vectors are L2-normalized at write time; "similarity" below
+    // only means cosine if the query is normalized too. Callers should send
+    // unit vectors, but a scaled one costs nothing to fix here.
+    for (let i = 0; i < q.length; i++) { q[i] /= norm; }
+
+    const filter = libraryFilter(req.user);
+    const uid = req.user?.id;
+    // recording_mbid isn't part of the in-memory index; PK lookups for the
+    // few rows that make the cut are cheap. The caller's novelty chain
+    // (MBID → artist+title → near-dup) wants it.
+    const ddb = discoveryDb.openDiscoveryDbIfExists() ? discoveryDb.getDiscoveryDb() : null;
+    const mbidStmt = ddb ? ddb.prepare('SELECT recording_mbid FROM discovery_tracks WHERE audio_hash = ?') : null;
+
+    const results = [];
+    for (const { entry, similarity } of sim.rankTracks(index, q, null)) {
+      if (results.length >= body.limit) { break; }
+      const row = resolveVisible(uid, filter, entry.hash);
+      if (!row) { continue; }   // no copy inside the caller's granted libraries
+      results.push({
+        filepath: renderMetadataObj(row).filepath,
+        artist: row.artist_name || null,
+        title: row.title || null,
+        duration: row.duration ?? null,
+        similarity: Math.round(similarity * 10000) / 10000,
+        genreTags: entry.genreTags,
+        recordingMbid: mbidStmt ? (mbidStmt.get(entry.hash)?.recording_mbid || null) : null,
+      });
+    }
+
+    res.json({ model, results });
+  });
+}

--- a/src/api/federation.js
+++ b/src/api/federation.js
@@ -1,17 +1,43 @@
 // Peer-facing federation API (mounted behind the auth wall).
 //
-// One endpoint for now: the health/identity probe a federated peer hits to
-// test the pairing and learn what it was granted. The peer authenticates
-// with its x-federation-key header (see api/federation-auth.js), so
-// req.user.vpaths IS the key's live grant list — a grant change on this
-// server shows up on the peer's next health check without re-pairing.
+// The health/identity probe a federated peer hits to test the pairing and
+// learn what it was granted. The peer authenticates with its
+// x-federation-key header (see api/federation-auth.js), so req.user.vpaths
+// IS the key's live grant list — a grant change on this server shows up on
+// the peer's next health check without re-pairing. It also advertises the
+// discovery capability block, so a peer knows whether (and in which model
+// space) it can send vector queries (api/federation-discovery.js).
 //
 // Regular logged-in users can also hit this route; they just see their own
 // vpaths, which they already know. Harmless.
 
 import os from 'os';
+import winston from 'winston';
 import packageJson from '../../package.json' with { type: 'json' };
 import * as config from '../state/config.js';
+import * as sim from '../db/discovery-similarity.js';
+
+// What a peer needs before sending vector queries: can this server answer
+// at all, and in which model space. null = don't bother querying. The index
+// is rowversion-cached, so this is only expensive on the first call after a
+// dataset change — the same build the first similarity query would pay.
+function discoveryCapability() {
+  if (config.program.scanOptions.collectDiscoveryData !== true) { return null; }
+  let index;
+  try {
+    index = sim.getIndex();
+  } catch (err) {
+    winston.warn(`[federation] discovery capability unavailable: ${err.message}`);
+    return null;
+  }
+  if (!index || index.dim === null) { return null; }   // no store, or zero vectors
+  return {
+    modelId: index.modelId,
+    modelVersion: index.modelVersion,
+    dim: index.dim,
+    analyzedCount: index.entries.length,
+  };
+}
 
 export function setup(mstream) {
   mstream.get('/api/v1/federation/health', (req, res) => {
@@ -19,6 +45,7 @@ export function setup(mstream) {
       server: packageJson.version,
       name: config.program.federation.serverName || os.hostname(),
       libraries: req.user.vpaths,
+      discovery: discoveryCapability(),
     });
   });
 }

--- a/src/server.js
+++ b/src/server.js
@@ -31,6 +31,7 @@ import * as discoveryDb from './db/discovery-db.js';
 import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // scanner.js removed — parser now writes directly to SQLite
 import * as federationApi from './api/federation.js';
+import * as federationDiscoveryApi from './api/federation-discovery.js';
 import * as ytdlApi from './api/ytdl.js';
 import * as torrentApi from './api/torrent.js';
 import * as dlnaApi from './api/dlna.js';
@@ -312,6 +313,7 @@ export async function serveIt(configFile) {
   remoteApi.setupAfterAuth(mstream, server);
   sharedApi.setupAfterSecurity(mstream);
   federationApi.setup(mstream);
+  federationDiscoveryApi.setup(mstream);
   ytdlApi.setup(mstream);
   torrentApi.setup(mstream);
   albumArtApi.setup(mstream);

--- a/test/integration/federation-discovery.test.mjs
+++ b/test/integration/federation-discovery.test.mjs
@@ -1,0 +1,261 @@
+/**
+ * Discovery-over-federation, peer side (phase 1):
+ * POST /api/v1/federation/discovery/similar + the /federation/health
+ * discovery capability block (src/api/federation-discovery.js).
+ *
+ * Strategy (the discovery-similarity playbook): boot a real server with
+ * federation enabled and discovery ON under the 'test-fake' model, two
+ * libraries — 'shared' (granted to the federation key) and the fixture
+ * 'testlib' (NOT granted) — then seed discovery.db with handcrafted 4-d
+ * unit vectors keyed to real scanned tracks so every cosine is exact.
+ *
+ * The scoping assertion is the sharp one: the single highest-cosine vector
+ * in the whole index belongs to the UNGRANTED library and must never
+ * appear in the key's results, while an admin JWT (whose vpaths span both
+ * libraries) sees it at rank 1 through the very same route.
+ *
+ * A second server (federation on, discovery off) pins the gating: health
+ * advertises discovery:null and the similar route is 403.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { startServer } from '../helpers/server.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FFMPEG = process.platform === 'win32'
+  ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
+  : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+
+const ADMIN = { username: 'admin', password: 'pw-admin' };
+
+// ── handcrafted vector space (4-d, unit vectors) ────────────────────────────
+const vec = (...xs) => {
+  const v = new Float32Array(xs);
+  const n = Math.sqrt(v.reduce((s, x) => s + x * x, 0)) || 1;
+  return v.map((x) => x / n);
+};
+const dot = (a, b) => { let s = 0; for (let i = 0; i < a.length; i++) s += a[i] * b[i]; return s; };
+const blob = (v) => Buffer.from(v.buffer, v.byteOffset, v.byteLength);
+const b64 = (v) => blob(v).toString('base64');
+
+const Q = vec(1, 0, 0, 0);                    // the peer's query vector
+const V = {
+  ungranted: vec(0.98, 0.199, 0, 0),          // testlib — Be Somebody   cos ≈ 0.98 (index top!)
+  alpha: vec(0.9, 0.436, 0, 0),               // shared  — Alpha Song    cos ≈ 0.9
+  beta: vec(0.6, 0.8, 0, 0),                  // shared  — Beta Song     cos = 0.6
+};
+
+let server;      // federation + discovery on, seeded
+let offServer;   // federation on, discovery off
+let sharedDir;
+let fedKey;      // granted ['shared'] on `server`
+let offKey;      // any key on `offServer`
+let adminToken;
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(FFMPEG, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    p.stderr.on('data', (d) => { stderr += d.toString(); });
+    p.on('error', reject);
+    p.on('close', (code) => code === 0 ? resolve() : reject(new Error(`ffmpeg ${code}: ${stderr.slice(-200)}`)));
+  });
+}
+
+async function makeTrack(dir, file, freq, artist, title) {
+  await runFfmpeg([
+    '-nostdin', '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', `sine=frequency=${freq}:duration=2`,
+    '-metadata', `artist=${artist}`, '-metadata', `title=${title}`, '-metadata', `album=${artist} Album`,
+    '-ac', '1', path.join(dir, file),
+  ]);
+}
+
+async function loginAdmin(srv) {
+  const r = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(ADMIN),
+  });
+  return (await r.json()).token;
+}
+
+async function mintKey(srv, token, vpaths) {
+  const r = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-access-token': token },
+    body: JSON.stringify({ name: 'Peer', vpaths }),
+  });
+  assert.equal(r.status, 200);
+  const { key } = await r.json();
+  assert.match(key, /^fedk_/);
+  return key;
+}
+
+const fedHeaders = (key) => ({ 'x-federation-key': key, 'Content-Type': 'application/json' });
+
+async function similar(srv, headers, body) {
+  const r = await fetch(`${srv.baseUrl}/api/v1/federation/discovery/similar`, {
+    method: 'POST', headers, body: JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+
+describe('federation discovery similar (peer side)', () => {
+  before(async () => {
+    sharedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-feddisc-'));
+    await makeTrack(sharedDir, 'alpha.mp3', 440, 'Ana', 'Alpha Song');
+    await makeTrack(sharedDir, 'beta.mp3', 880, 'Ben', 'Beta Song');
+
+    [server, offServer] = await Promise.all([
+      startServer({
+        dlnaMode: 'disabled',
+        extraConfig: {
+          federation: { enabled: true },
+          scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' },
+        },
+        extraFolders: { shared: sharedDir },
+        users: [{ ...ADMIN, admin: true, vpaths: ['testlib', 'shared'] }],
+      }),
+      startServer({
+        dlnaMode: 'disabled',
+        waitForScan: false,
+        extraConfig: { federation: { enabled: true } },
+        users: [{ ...ADMIN, admin: true, vpaths: ['testlib'] }],
+      }),
+    ]);
+
+    adminToken = await loginAdmin(server);
+    fedKey = await mintKey(server, adminToken, ['shared']);
+    offKey = await mintKey(offServer, await loginAdmin(offServer), ['testlib']);
+
+    // Seed discovery.db with the crafted vectors, keyed to real scanned rows.
+    const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+    const trackByTitle = (title) => mdb.prepare(`
+      SELECT COALESCE(t.audio_hash, t.file_hash) AS hash, a.name AS artist, t.duration
+      FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id WHERE t.title = ?
+    `).get(title);
+    const rowsToSeed = [
+      ['Be Somebody', V.ungranted, null, null],
+      ['Alpha Song', V.alpha, 'mbid-alpha-123', ['Test---StyleA', 'Test---StyleB']],
+      ['Beta Song', V.beta, null, null],
+    ];
+    const ddb = new DatabaseSync(path.join(server.tmpDir, 'db', 'discovery.db'));
+    try {
+      const ins = ddb.prepare(`
+        INSERT INTO discovery_tracks
+          (audio_hash, updated_at, export_id, recording_mbid, artist, title, duration, model_id, model_version, embedding, genre_tags)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 'test-fake', '1', ?, ?)
+      `);
+      let seq = 0;
+      for (const [title, v, mbid, tags] of rowsToSeed) {
+        const t = trackByTitle(title);
+        assert.ok(t?.hash, `fixture track '${title}' must exist with a hash`);
+        ins.run(t.hash, ++seq, `anon:${title.replace(/\s/g, '')}`, mbid, t.artist, title, t.duration ?? 120,
+          blob(v), tags ? JSON.stringify(tags) : null);
+      }
+      ddb.prepare("UPDATE discovery_meta SET value = ? WHERE key = 'row_seq'").run(String(seq));
+      ddb.prepare("INSERT OR REPLACE INTO discovery_meta (key, value) VALUES ('embedding_model_version', '1')").run();
+    } finally {
+      ddb.close();
+      mdb.close();
+    }
+  });
+
+  after(async () => {
+    await Promise.all([server?.stop(), offServer?.stop()]);
+    fs.rmSync(sharedDir, { recursive: true, force: true });
+  });
+
+  test('health advertises the discovery capability block', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(fedKey) });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.deepEqual(j.libraries, ['shared']);
+    assert.deepEqual(j.discovery, { modelId: 'test-fake', modelVersion: '1', dim: 4, analyzedCount: 3 });
+  });
+
+  test('ranks by exact cosines within the granted library only', async () => {
+    const { status, body } = await similar(server, fedHeaders(fedKey), { embedding: b64(Q), modelId: 'test-fake' });
+    assert.equal(status, 200);
+    assert.deepEqual(body.model, { id: 'test-fake', version: '1' });
+    assert.ok(!body.modelMismatch);
+
+    const titles = body.results.map((r) => r.title);
+    assert.deepEqual(titles, ['Alpha Song', 'Beta Song'], 'granted-library tracks in descending cosine order');
+    assert.ok(!titles.includes('Be Somebody'), 'the index-topping UNGRANTED track must never appear');
+
+    for (const [i, expected] of [dot(Q, V.alpha), dot(Q, V.beta)].entries()) {
+      assert.ok(Math.abs(body.results[i].similarity - expected) < 1e-3,
+        `result ${i}: ${body.results[i].similarity} ≈ ${expected}`);
+    }
+    for (const r of body.results) {
+      assert.ok(r.filepath.startsWith('shared/'), `filepath ${r.filepath} stays inside the grant`);
+      assert.ok(typeof r.duration === 'number');
+    }
+    assert.equal(body.results[0].artist, 'Ana');
+    assert.equal(body.results[0].recordingMbid, 'mbid-alpha-123');
+    assert.deepEqual(body.results[0].genreTags, ['Test---StyleA', 'Test---StyleB']);
+    assert.equal(body.results[1].recordingMbid, null);
+    assert.equal(body.results[1].genreTags, null);
+  });
+
+  test('respects limit', async () => {
+    const { body } = await similar(server, fedHeaders(fedKey), { embedding: b64(Q), modelId: 'test-fake', limit: 1 });
+    assert.deepEqual(body.results.map((r) => r.title), ['Alpha Song']);
+  });
+
+  test('normalizes a scaled query vector defensively', async () => {
+    const scaled = new Float32Array([7, 0, 0, 0]);   // same direction as Q, magnitude 7
+    const { status, body } = await similar(server, fedHeaders(fedKey), { embedding: b64(scaled), modelId: 'test-fake' });
+    assert.equal(status, 200);
+    assert.ok(Math.abs(body.results[0].similarity - dot(Q, V.alpha)) < 1e-3,
+      'similarity is cosine, not a raw dot product against the scaled vector');
+  });
+
+  test('model mismatch is a soft 200 answer', async () => {
+    const { status, body } = await similar(server, fedHeaders(fedKey), { embedding: b64(Q), modelId: 'some-other-model' });
+    assert.equal(status, 200);
+    assert.equal(body.modelMismatch, true);
+    assert.deepEqual(body.results, []);
+    assert.equal(body.model.id, 'test-fake', 'the answer names this server\'s model space');
+  });
+
+  test('malformed vectors are 400s', async () => {
+    const cases = [
+      { embedding: b64(new Float32Array([1, 0, 0])), modelId: 'test-fake' },        // 12 bytes ≠ dim×4
+      { embedding: b64(new Float32Array([NaN, 0, 0, 0])), modelId: 'test-fake' },   // non-finite
+      { embedding: b64(new Float32Array([0, 0, 0, 0])), modelId: 'test-fake' },     // zero vector
+      { embedding: '!!!not-base64!!!', modelId: 'test-fake' },                      // Joi base64
+      { embedding: b64(Q) },                                                        // missing modelId
+    ];
+    for (const body of cases) {
+      const r = await similar(server, fedHeaders(fedKey), body);
+      assert.equal(r.status, 400, JSON.stringify(body).slice(0, 60));
+    }
+  });
+
+  test('a regular admin JWT sees its own broader scope through the same route', async () => {
+    const { status, body } = await similar(server,
+      { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      { embedding: b64(Q), modelId: 'test-fake' });
+    assert.equal(status, 200);
+    assert.deepEqual(body.results.map((r) => r.title), ['Be Somebody', 'Alpha Song', 'Beta Song'],
+      'admin vpaths span both libraries, so the testlib track leads');
+  });
+
+  test('discovery-off server: health capability null, similar 403', async () => {
+    const health = await fetch(`${offServer.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(offKey) });
+    assert.equal(health.status, 200);
+    assert.equal((await health.json()).discovery, null);
+
+    const r = await similar(offServer, fedHeaders(offKey), { embedding: b64(Q), modelId: 'test-fake' });
+    assert.equal(r.status, 403);
+  });
+});

--- a/test/unit/federation-auth.test.mjs
+++ b/test/unit/federation-auth.test.mjs
@@ -47,6 +47,7 @@ describe('federation route allowlist', () => {
       ['POST', '/api/v1/file-explorer/recursive'],
       ['POST', '/api/v1/file-explorer/m3u'],
       ['GET', '/api/v1/federation/health'],
+      ['POST', '/api/v1/federation/discovery/similar'],
       ['GET', '/media/music/album/track.mp3'],
       ['GET', '/album-art/abc123.jpg'],
     ]) {


### PR DESCRIPTION
Stacked on #736 → #735 (base is `feat/federation-file-explorer`; retargets down the chain as the stack merges bottom-up).

Phase 1 of discovery-over-federation (plan: `~/.claude/plans/federation-discovery-bridge.md`): the **peer side**. Instead of downloading a peer's discovery.db snapshot, a federated server will query similarity live — this PR makes a server able to *answer* those queries. Nothing calls it in-product yet (inert-until-consumer; phase 2 adds the caller-side aggregator).

## What's new

**`POST /api/v1/federation/discovery/similar`** (machine-facing, on the federation-key allowlist)
- Request: `{ embedding: <base64 f32le>, modelId, limit ≤100 }` — the caller's seed-track vector (~7 KB for 1280-d).
- Ranks against the existing in-memory index (`rankTracks`), resolves rows through `libraryFilter`/`resolveVisible` — **the synthetic federation user's granted `libraryIds` scope results for free**, same property the file-explorer PR leaned on.
- Results carry `filepath` (streamable via `/media` within the grant), artist/title/duration, cosine `similarity`, model `genreTags`, and `recordingMbid` (for the caller's novelty chain). **No peer-side novelty filtering** — the peer can't know the caller's library, and shipping identity sets would leak it.
- Model mismatch → soft `200 {modelMismatch: true}` (different vector spaces are incomparable; fan-out callers skip gracefully). Malformed vectors (wrong length, NaN/Inf, zero, bad base64) → 400. Discovery off → 403 via `requireIndex()`.
- Queries are defensively L2-normalized so `similarity` always means cosine.

**Health capability block** — `GET /api/v1/federation/health` now returns `discovery: { modelId, modelVersion, dim, analyzedCount } | null`, so a peer can pre-check whether (and in which model space) vector queries will work.

Also: `resolveVisible` exported from api/discovery.js, allowlist + unit-matrix entries, openapi docs for both surfaces.

## Tests

New `test/integration/federation-discovery.test.mjs` (8 tests, the discovery-similarity handcrafted-vector playbook): real server with federation + `test-fake` model, exact-cosine ranking, and the sharp scoping assertion — **the highest-cosine track in the whole index lives in an ungranted library and never appears for the key**, while an admin JWT sees it at rank 1 through the same route. Plus limit, scaled-vector normalization, soft model mismatch, five 400 shapes, and a discovery-off server pinning `discovery: null` + 403.

Full run: federation unit + new integration + federation-e2e + discovery-similarity = 38/38 green; changed files lint clean (the `server.js` no-empty hit is pre-existing tree debt, verified against HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)