### PR TITLE
fix(backup): low-severity cleanup + deferred decisions (audit batch 6)

### DIFF
--- a/src/backup/manager.js
+++ b/src/backup/manager.js
@@ -271,21 +271,35 @@ export function scheduledWindowServed(lastRun, dailyAtHour, now) {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// Anacron-style catch-up: was a whole scheduled window MISSED — i.e. is
-// the most recent attempt older than yesterday's local date? A server
-// that was off during last night's window (NAS shut down overnight,
-// power cut) previously skipped that day silently and waited for the
-// NEXT night — a machine that's always off during its window never
-// backed up at all. Date-key comparison is lexicographic ('YYYY-MM-DD').
+// Anacron-style catch-up: was YESTERDAY's scheduled window missed? True
+// when the destination's most recent attempt ended before yesterday's
+// window MOMENT (yesterday's local date at daily_at_hour) — if any
+// attempt had served that window or anything after it, a newer row
+// would exist. A server that's off during its nightly window previously
+// skipped the day silently and waited for the NEXT night — a machine
+// that's ALWAYS off at its window never backed up at all.
+//
+// Compared against the window moment, not yesterday's date: a morning
+// catch-up run is dated the day it ran, and a date-only comparison
+// counted it as serving that day's window — so an always-off-at-window
+// machine got backups only every OTHER day, and a midnight-straddled
+// run masked the following day's missed window.
+//
+// Keyed on finished_at ?? started_at: a marathon run that STARTED days
+// ago but finished this morning did cover everything up to its finish —
+// firing a catch-up right behind it would be a pointless third walk.
+// (While it's still running, started_at applies and this returns true —
+// harmless: the dedup gate drops the trigger while the run is active.)
+//
 // Null lastAttempt is NOT a missed window: a freshly-created daily
 // destination waits for its first regular window rather than firing the
-// moment it's saved. (DST edge: now-24h can land an hour into the wrong
-// day around transitions — worst case the catch-up fires a day early or
-// late, which the once-per-day dedup absorbs.)
-export function missedDailyWindow(lastAttempt, now) {
+// moment it's saved.
+export function missedDailyWindow(lastAttempt, dailyAtHour, now) {
   if (!lastAttempt) { return false; }
-  const yesterdayKey = localDateKey(new Date(now.getTime() - DAY_MS));
-  return sqliteUtcToLocalDateKey(lastAttempt.started_at) < yesterdayKey;
+  const y = new Date(now.getTime() - DAY_MS);
+  const windowMoment = new Date(y.getFullYear(), y.getMonth(), y.getDate(), dailyAtHour);
+  const stamp = lastAttempt.finished_at || lastAttempt.started_at;
+  return new Date(stamp.replace(' ', 'T') + 'Z') < windowMoment;
 }
 
 // The full per-destination decision, pure + exported for unit tests.
@@ -308,7 +322,8 @@ export function missedDailyWindow(lastAttempt, now) {
 // second run walks an already-synced mirror, which is cheap.
 export function shouldTriggerScheduled(dest, lastAttempt, now) {
   if (dest.daily_at_hour == null) { return false; }
-  if (now.getHours() < dest.daily_at_hour && !missedDailyWindow(lastAttempt, now)) { return false; }
+  if (now.getHours() < dest.daily_at_hour
+      && !missedDailyWindow(lastAttempt, dest.daily_at_hour, now)) { return false; }
   return !scheduledWindowServed(lastAttempt, dest.daily_at_hour, now);
 }
 

--- a/src/backup/manager.js
+++ b/src/backup/manager.js
@@ -34,6 +34,12 @@ import * as taskQueue from '../db/task-queue.js';
 
 let scheduleTimer = null;
 let trashTimer = null;
+// The one-shot post-boot ticks are tracked too: reboot() re-runs init()
+// in the same process, and untracked timeouts from the previous cycle
+// would stack (harmless but sloppy — the guarded tick just no-ops) and,
+// unlike the intervals, could never be cleared by shutdown().
+let bootScheduleTimeout = null;
+let bootTrashTimeout = null;
 
 // Re-entrancy latches. setInterval doesn't queue calls — if a previous
 // tick's work is still in progress when the next interval fires, Node
@@ -86,13 +92,23 @@ export function init() {
     }
   });
 
+  // All four timers are unref'd: the backup scheduler should never be
+  // what keeps the process alive once the HTTP server has closed
+  // (matters for tests and clean shutdowns; production has the server
+  // holding the loop anyway).
   if (scheduleTimer) { clearInterval(scheduleTimer); }
   scheduleTimer = setInterval(runScheduleTickGuarded, SCHEDULE_TICK_MS);
-  setTimeout(runScheduleTickGuarded, POST_BOOT_SCHEDULE_DELAY_MS);
+  scheduleTimer.unref?.();
+  if (bootScheduleTimeout) { clearTimeout(bootScheduleTimeout); }
+  bootScheduleTimeout = setTimeout(runScheduleTickGuarded, POST_BOOT_SCHEDULE_DELAY_MS);
+  bootScheduleTimeout.unref?.();
 
   if (trashTimer) { clearInterval(trashTimer); }
   trashTimer = setInterval(runTrashTickGuarded, TRASH_TICK_MS);
-  setTimeout(runTrashTickGuarded, POST_BOOT_TRASH_DELAY_MS);
+  trashTimer.unref?.();
+  if (bootTrashTimeout) { clearTimeout(bootTrashTimeout); }
+  bootTrashTimeout = setTimeout(runTrashTickGuarded, POST_BOOT_TRASH_DELAY_MS);
+  bootTrashTimeout.unref?.();
 }
 
 // Re-entrancy-guarded wrappers around the two periodic ticks. If a
@@ -123,9 +139,13 @@ async function runTrashTickGuarded() {
   finally { trashRunning = false; }
 }
 
+// Called from server.js reboot() before the listener recycles; serveIt's
+// setup path re-runs init() afterwards, so this is a pause, not a stop.
 export function shutdown() {
   if (scheduleTimer) { clearInterval(scheduleTimer); scheduleTimer = null; }
   if (trashTimer) { clearInterval(trashTimer); trashTimer = null; }
+  if (bootScheduleTimeout) { clearTimeout(bootScheduleTimeout); bootScheduleTimeout = null; }
+  if (bootTrashTimeout) { clearTimeout(bootTrashTimeout); bootTrashTimeout = null; }
   // Active workers belong to task-queue; we don't kill them from here.
   // The kill-queue process-exit hook in src/state/kill-list.js handles
   // them on actual process termination.
@@ -140,17 +160,21 @@ export function shutdown() {
 // a backup is already queued or active. Per-destination try/catch so
 // one misbehaving destination doesn't prevent the rest from triggering
 // (defensive; triggerForDestination catches its own errors today).
-export function triggerForLibrary(libraryId) {
+export function triggerForLibrary(libraryId, triggerReason = 'after-scan') {
   let destinations;
   try {
-    destinations = db.getBackupDestinationsByLibrary(libraryId, { triggerType: 'after-scan' });
+    // The reason doubles as the trigger_type filter: only destinations
+    // configured FOR this kind of trigger fire. (Previously the second
+    // argument the init() callback passed was silently ignored and both
+    // values were hardcoded — same behavior, now honest about it.)
+    destinations = db.getBackupDestinationsByLibrary(libraryId, { triggerType: triggerReason });
   } catch (err) {
     winston.error(`Backup: failed to look up destinations for library ${libraryId}`, { stack: err });
     return;
   }
   for (const dest of destinations) {
     try {
-      triggerForDestination(dest.id, 'after-scan');
+      triggerForDestination(dest.id, triggerReason);
     } catch (err) {
       winston.error(`Backup: failed to trigger dest #${dest.id} for library ${libraryId}`, { stack: err });
     }
@@ -245,6 +269,49 @@ export function scheduledWindowServed(lastRun, dailyAtHour, now) {
       && sqliteUtcToLocalHour(lastRun.started_at) >= dailyAtHour;
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Anacron-style catch-up: was a whole scheduled window MISSED — i.e. is
+// the most recent attempt older than yesterday's local date? A server
+// that was off during last night's window (NAS shut down overnight,
+// power cut) previously skipped that day silently and waited for the
+// NEXT night — a machine that's always off during its window never
+// backed up at all. Date-key comparison is lexicographic ('YYYY-MM-DD').
+// Null lastAttempt is NOT a missed window: a freshly-created daily
+// destination waits for its first regular window rather than firing the
+// moment it's saved. (DST edge: now-24h can land an hour into the wrong
+// day around transitions — worst case the catch-up fires a day early or
+// late, which the once-per-day dedup absorbs.)
+export function missedDailyWindow(lastAttempt, now) {
+  if (!lastAttempt) { return false; }
+  const yesterdayKey = localDateKey(new Date(now.getTime() - DAY_MS));
+  return sqliteUtcToLocalDateKey(lastAttempt.started_at) < yesterdayKey;
+}
+
+// The full per-destination decision, pure + exported for unit tests.
+// One scheduled attempt per destination per local day. Keyed on the
+// most recent ATTEMPT of any status except 'skipped' (see
+// getLastBackupAttempt): keying on success alone meant a destination
+// whose drive is unplugged would fail in seconds and be re-triggered
+// on every 5-minute tick, piling up ~288 'failed' rows/day. A failed
+// daily run records the failure and waits for tomorrow's window; an
+// operator who wants an immediate retry uses the manual-run endpoint.
+// A 'running' row from today likewise blocks re-trigger (the dedup gate
+// would drop it anyway); dedup 'skipped' rows are excluded — they
+// record a no-op, not an attempt.
+//
+// The hour gate is bypassed when a whole window was MISSED (see
+// missedDailyWindow) so the backup runs promptly after boot instead of
+// waiting for tonight. Known consequence, accepted: on a catch-up day
+// the regular window fires too (the morning catch-up started before
+// daily_at_hour, so it doesn't satisfy scheduledWindowServed) — the
+// second run walks an already-synced mirror, which is cheap.
+export function shouldTriggerScheduled(dest, lastAttempt, now) {
+  if (dest.daily_at_hour == null) { return false; }
+  if (now.getHours() < dest.daily_at_hour && !missedDailyWindow(lastAttempt, now)) { return false; }
+  return !scheduledWindowServed(lastAttempt, dest.daily_at_hour, now);
+}
+
 // Exported for tests (the timers drive it in production).
 export function checkScheduledBackups() {
   let candidates;
@@ -257,30 +324,10 @@ export function checkScheduledBackups() {
   if (candidates.length === 0) { return; }
 
   const now = new Date();
-  const currentHour = now.getHours();
-
   for (const dest of candidates) {
-    if (dest.daily_at_hour == null) { continue; }
-    if (currentHour < dest.daily_at_hour) { continue; }
-
-    // One scheduled attempt per destination per local day. Key on the
-    // most recent ATTEMPT of any status except 'skipped' (see
-    // getLastBackupAttempt): keying on success alone meant a
-    // destination whose drive is unplugged would fail in seconds and be
-    // re-triggered on every 5-minute tick, piling up ~288 'failed'
-    // rows/day — exactly the history flooding the skip-row policy
-    // avoids elsewhere. A failed daily run now records the failure and
-    // waits for tomorrow's window; an operator who wants an immediate
-    // retry uses the manual-run endpoint (after-scan triggers also
-    // still fire independently). A 'running' row from today likewise
-    // blocks re-trigger (the dedup gate would drop it anyway). Dedup
-    // 'skipped' rows are excluded — they record a no-op, and letting
-    // one consume the window meant a Run-Now click during an active
-    // run could suppress the day's scheduled backup.
-    const last = db.getLastBackupAttempt(dest.id);
-    if (scheduledWindowServed(last, dest.daily_at_hour, now)) { continue; }
-
-    triggerForDestination(dest.id, 'scheduled');
+    if (shouldTriggerScheduled(dest, db.getLastBackupAttempt(dest.id), now)) {
+      triggerForDestination(dest.id, 'scheduled');
+    }
   }
 }
 
@@ -302,6 +349,21 @@ async function sweepAllTrash() {
     // Sweep them with a zero-day cutoff so residual trash drains.
     await sweepDestTrash(dest);
   }
+}
+
+// Windows long-path opt-in (\\?\ prefix). Sibling of worker.mjs's
+// maybeLongPath — duplicated because the worker is deliberately a
+// self-contained child script (node builtins only). Unlike the worker's
+// (which prefixes only near-MAX_PATH targets), this ALWAYS prefixes on
+// win32: the sweep hands fs.rm a short bucket ROOT whose children may
+// individually exceed 260 chars, and rm builds those child paths by
+// appending to the string we pass — so the root must carry the prefix.
+function maybeLongPath(p) {
+  if (process.platform !== 'win32') { return p; }
+  const abs = path.resolve(p);
+  if (abs.startsWith('\\\\?\\')) { return abs; }
+  if (abs.startsWith('\\\\')) { return '\\\\?\\UNC\\' + abs.slice(2); }
+  return '\\\\?\\' + abs;
 }
 
 // Exported for tests (the timers drive it in production).
@@ -334,7 +396,11 @@ export async function sweepDestTrash(dest) {
     const folderEndMs = Date.UTC(+m[1], +m[2] - 1, +m[3]) + DAY_MS;
     if (folderEndMs >= cutoffMs) { continue; }
 
-    const folderPath = path.join(trashRoot, entry.name);
+    // \\?\-prefix near MAX_PATH: the worker can now WRITE trash entries
+    // past 260 chars (it prefixes its rename targets), so the sweep must
+    // be able to REMOVE them. fs.rm builds child paths by appending to
+    // this string, so prefixing the bucket root covers its whole subtree.
+    const folderPath = maybeLongPath(path.join(trashRoot, entry.name));
     try {
       await fs.rm(folderPath, { recursive: true, force: true });
       winston.info(`Backup: pruned trash folder ${folderPath} (older than ${retentionDays} days)`);

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -56,6 +56,22 @@ const PARTIAL_PREFIX = '.mstream-partial-';
 // nobody rewrites the same track twice in two seconds.
 const MTIME_TOLERANCE_MS = 2000;
 
+// FAT-family filesystems store mtimes in LOCAL time, so after every DST
+// transition each stored timestamp reads back shifted by exactly ±1 hour.
+// Without a carve-out, the first run after a transition sees EVERY file
+// on a FAT/exFAT destination as changed and trash+recopies the entire
+// library — a surprise multi-hour run that also demands library-size
+// trash headroom, twice a year. Same trade rsync's --modify-window and
+// robocopy's /DST have made for decades: a delta of exactly ±3600s
+// (within the 2s slack) also counts as unchanged. Residual risk — a
+// same-size file genuinely modified exactly one hour apart to within 2s
+// — is vanishingly rare and identical to what those tools accept.
+const DST_SKEW_MS = 3600 * 1000;
+function mtimesAgree(deltaMs) {
+  return Math.abs(deltaMs) < MTIME_TOLERANCE_MS
+      || Math.abs(Math.abs(deltaMs) - DST_SKEW_MS) < MTIME_TOLERANCE_MS;
+}
+
 // Files smaller than this skip the resume-capable code path and use a
 // random-named tmp + plain fs.copyFile (which on most platforms uses a
 // fast-copy syscall like copy_file_range / clonefile / CopyFileEx).
@@ -353,6 +369,20 @@ function noteFutureMtime(p) {
   process.stderr.write(`Warning: source files carry mtimes in the future (e.g. ${p}); treating same-size dest copies as unchanged\n`);
 }
 
+// One stderr notice per run when the source ROOT contains a
+// .mstream-trash directory (this tree previously WAS a backup
+// destination, or was restored from one). Skipped, not mirrored:
+// copying it would commingle with the dest's own trash bucket, where
+// the retention sweep would silently age-and-delete data the user
+// believed was being backed up. Log-only (not a fileError) — the skip
+// is the correct steady state, not a per-run failure.
+let srcTrashNoticed = false;
+function noteSrcRootTrash() {
+  if (srcTrashNoticed) { return; }
+  srcTrashNoticed = true;
+  process.stderr.write(`Warning: source root contains a '${TRASH_DIR_NAME}' directory (was this tree previously a backup destination?) — skipped, not mirrored\n`);
+}
+
 // Stamp the source mtime onto a freshly-written dest file, tolerating
 // failure. Aborting the copy over a failed stamp would throw away the
 // already-copied bytes and mean the file NEVER reaches the destination
@@ -535,6 +565,24 @@ async function renameOverwrite(from, to) {
   }
 }
 
+// The trash path prepends '.mstream-trash/YYYY-MM-DD/' to the mirrored
+// relPath — ~26 extra chars. On Windows without LongPathsEnabled (the
+// Windows 10 default) a file whose LIVE dest path fits under the 260
+// MAX_PATH can therefore be mirrored fine but never trashed: every run
+// fails the same rename, a changed file is never refreshed, an orphan
+// is never removed. \\?\-prefixing the trash target opts those calls
+// into long-path support regardless of the registry setting. Only the
+// TARGET needs it — the live path fits by premise. Prefix applied only
+// near the limit so the common case stays on the normal parser.
+const WIN_MAX_PATH = 260;
+function maybeLongPath(p) {
+  if (process.platform !== 'win32' || p.length < WIN_MAX_PATH - 12) { return p; }
+  const abs = path.resolve(p);
+  if (abs.startsWith('\\\\?\\')) { return abs; }
+  if (abs.startsWith('\\\\')) { return '\\\\?\\UNC\\' + abs.slice(2); }
+  return '\\\\?\\' + abs;
+}
+
 // Move a dest file out of the live tree into the trash bucket for this
 // run's date. retentionDays === 0 short-circuits the bucket and unlinks
 // directly — opt-in for users who'd rather not pay the storage cost of
@@ -545,7 +593,7 @@ async function moveToTrash(destFile, relPath) {
     return;
   }
   const dateStamp = new Date().toISOString().slice(0, 10);
-  const trashTarget = path.join(destPath, TRASH_DIR_NAME, dateStamp, relPath);
+  const trashTarget = maybeLongPath(path.join(destPath, TRASH_DIR_NAME, dateStamp, relPath));
   await ensureDir(path.dirname(trashTarget));
   // If a previous run today already trashed this exact relPath (e.g. file
   // gets deleted, re-added, then deleted again same day), suffix the new
@@ -598,6 +646,11 @@ async function hasAnyFiles(dir, seenRealDirs = null, depth = 0) {
     // would then sweep the ENTIRE destination into trash. Excluded
     // directories are skipped whole, same as the walk does.
     if (isExcluded(entry.name)) { continue; }
+    // Mirror the walk's source-root trash filter too: a source whose
+    // only content is a leftover .mstream-trash bucket must read as
+    // EMPTY here, or the guard passes while the walk sees nothing —
+    // and sweeps the whole destination.
+    if (depth === 0 && entry.name === TRASH_DIR_NAME) { continue; }
     if (entry.isFile()) { return true; }
     if (entry.isDirectory()) {
       if (await hasAnyFiles(path.join(dir, entry.name), seenRealDirs, depth + 1)) { return true; }
@@ -626,16 +679,21 @@ async function hasAnyFiles(dir, seenRealDirs = null, depth = 0) {
 //   - TMP_PREFIX:     random-named in-flight buffers from atomicCopy.
 //   - PARTIAL_PREFIX: deterministic-named resumable partials (atomicCopy
 //                     looks them up by name via fs.stat, not by walking).
-//   - TRASH_DIR_NAME: our soft-delete bucket — only filtered at the dest
-//                     ROOT level, since a user could legitimately have a
-//                     folder named .mstream-trash deeper in their tree.
+//   - TRASH_DIR_NAME: our soft-delete bucket — filtered at BOTH roots
+//                     (dest: it's our own bucket; source: a tree that
+//                     previously was a backup destination must not have
+//                     its trash mirrored into ours, where the retention
+//                     sweep would silently delete it — see
+//                     noteSrcRootTrash). Deeper occurrences pass: a
+//                     user could legitimately have a folder named
+//                     .mstream-trash inside their tree.
 //
 // `hasBookkeeping` (returned alongside entries) signals whether any
 // PARTIAL/TMP entries were observed during the filter pass. syncDir
 // uses it to skip the cleanup readdir when there's nothing to clean
 // — a meaningful speedup on libraries with thousands of directories
 // that have no leftover bookkeeping (the common steady-state case).
-async function readSortedDir(dir, { isDestRoot } = { isDestRoot: false }) {
+async function readSortedDir(dir, { isDestRoot = false, isSrcRoot = false } = {}) {
   let entries;
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
@@ -648,7 +706,10 @@ async function readSortedDir(dir, { isDestRoot } = { isDestRoot: false }) {
   for (const entry of entries) {
     if (entry.name.startsWith(TMP_PREFIX)) { hasBookkeeping = true; continue; }
     if (entry.name.startsWith(PARTIAL_PREFIX)) { hasBookkeeping = true; continue; }
-    if (isDestRoot && entry.name === TRASH_DIR_NAME) { continue; }
+    if ((isDestRoot || isSrcRoot) && entry.name === TRASH_DIR_NAME) {
+      if (isSrcRoot) { noteSrcRootTrash(); }
+      continue;
+    }
     // Exclude patterns apply symmetrically on source AND dest. If we
     // filtered only on source, a previously-backed-up matching file
     // would survive on dest, then the merge-walk would treat it as
@@ -766,7 +827,7 @@ async function syncDir(srcDir, destDir, relPath) {
 
   let srcSorted;
   try {
-    const srcRead = await readSortedDir(srcDir);
+    const srcRead = await readSortedDir(srcDir, { isSrcRoot: isRoot });
     if (!srcRead.existed) {
       // The parent's readdir saw this directory but it's gone now — a
       // mid-run unmount or concurrent delete. Treating it as empty
@@ -980,10 +1041,15 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
     // (stale but stable) — no sweep, no prune (see claimSrcDir).
     if (!(await claimSrcDir(srcChild, childRel))) { return; }
     await syncDir(srcChild, destChild, childRel);
-    // After syncing, prune the dest dir if it's now empty (e.g. source had
-    // only directories that were themselves emptied into trash). Best-
-    // effort — fs.rmdir errors if non-empty, which we ignore.
-    try { await fs.rmdir(destChild); } catch (_) {}
+    // NO empty-dir prune here. The source directory exists (it's the
+    // matched pair we just recursed into), so its dest mirror should
+    // exist too — even empty. The old "rmdir if now empty" pruned the
+    // mirror of every empty source dir (placeholder album folders,
+    // dirs whose entire content is excluded by globs), which the next
+    // run recreated as source-only via ensureDir: a permanent
+    // create/delete flip-flop. Dest dirs whose SOURCE is gone are
+    // removed by trashDestEntry's dest-only path, which is the only
+    // prune a mirror needs.
     return;
   }
 
@@ -1004,9 +1070,18 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
   if (destStat && destStat.isFile() && destStat.size === srcStat.size) {
     let mtimeAgrees;
     if (destMtimeTrustworthy) {
-      mtimeAgrees = Math.abs(destStat.mtimeMs - srcStat.mtimeMs) < MTIME_TOLERANCE_MS;
+      // mtimesAgree also accepts exact ±1h deltas (FAT DST skew — see
+      // its comment). FAT destinations PASS the fidelity probe (utimes
+      // genuinely persists there), so this trusted branch is exactly
+      // where the twice-yearly skew would otherwise force a full
+      // trash+recopy of the library.
+      mtimeAgrees = mtimesAgree(destStat.mtimeMs - srcStat.mtimeMs);
     } else {
-      mtimeAgrees = destStat.mtimeMs + MTIME_TOLERANCE_MS >= srcStat.mtimeMs;
+      mtimeAgrees = destStat.mtimeMs + MTIME_TOLERANCE_MS >= srcStat.mtimeMs
+        // dest older than source by exactly the DST skew: same carve-out
+        // as the trusted branch (the dest-newer direction is already
+        // covered by dest-not-older-than-source).
+        || mtimesAgree(destStat.mtimeMs - srcStat.mtimeMs);
       if (!mtimeAgrees && srcStat.mtimeMs > Date.now() + MTIME_TOLERANCE_MS) {
         // Future-stamped source (wrong-clock rip, FAT TZ/DST shift, NFS
         // server clock behind the source host): its stamp can never
@@ -1073,7 +1148,16 @@ async function trashDestEntry(destEntry, destDir, relPath) {
       return;
     }
     for (const kid of kids) {
-      if (kid.name.startsWith(TMP_PREFIX)) { continue; }
+      // Bookkeeping is never resumable once its source dir is gone —
+      // unlink it here rather than skipping (which left a ghost dir the
+      // rmdir below could never remove, reprocessed silently forever)
+      // or trashing (which counted partials as user files and hauled
+      // never-finalised garbage into the deletion log).
+      if (kid.name.startsWith(TMP_PREFIX) || kid.name.startsWith(PARTIAL_PREFIX)) {
+        try { await fs.unlink(path.join(destChild, kid.name)); }
+        catch (err) { recordFileError(`remove orphan bookkeeping ${path.join(destChild, kid.name)}: ${err.message}`); }
+        continue;
+      }
       await trashDestEntry(kid, destChild, childRel);
     }
     // After recursion the dir should be empty; remove it.

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -1152,8 +1152,14 @@ async function trashDestEntry(destEntry, destDir, relPath) {
       // unlink it here rather than skipping (which left a ghost dir the
       // rmdir below could never remove, reprocessed silently forever)
       // or trashing (which counted partials as user files and hauled
-      // never-finalised garbage into the deletion log).
-      if (kid.name.startsWith(TMP_PREFIX) || kid.name.startsWith(PARTIAL_PREFIX)) {
+      // never-finalised garbage into the deletion log). FILES only:
+      // the worker only ever creates prefixed files, so a DIRECTORY
+      // wearing a bookkeeping prefix is hand-made user content — it
+      // falls through to the normal recursion below (unlink on a dir
+      // is EISDIR/EPERM, which would have made it a permanent per-run
+      // error AND an unremovable ghost).
+      if ((kid.name.startsWith(TMP_PREFIX) || kid.name.startsWith(PARTIAL_PREFIX))
+          && !kid.isDirectory()) {
         try { await fs.unlink(path.join(destChild, kid.name)); }
         catch (err) { recordFileError(`remove orphan bookkeeping ${path.join(destChild, kid.name)}: ${err.message}`); }
         continue;

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1875,9 +1875,19 @@ const BACKUP_WORKER_PATH = path.join(__dirname, '../backup/worker.mjs');
 //   true  — queued (or running, if the slot was free and it started immediately)
 //   false — dropped because of dedup
 // The caller is responsible for any 'skipped' history-row bookkeeping.
+//
+// KNOWN LIMITATION (accepted, 2026-07-10): the queue is in-memory only
+// and the history row is created when the run STARTS (runBackupTask),
+// not here — so a queued-but-not-started backup vanishes without trace
+// on a process restart. A manual "Run now" stuck behind a multi-hour
+// scan is the visible case; daily and after-scan triggers self-heal on
+// their next cadence. The info log below is the only breadcrumb.
+// Persisting queue state (a 'queued' status + boot recovery) was judged
+// not worth the schema/recovery complexity for that one case.
 export function addBackupTask(destinationId, triggerReason) {
   if (isBackupQueuedOrActive(destinationId)) { return false; }
   taskQueue.push({ task: 'backup', destinationId, triggerReason, id: nanoid(8) });
+  winston.info(`Backup: queued run for destination #${destinationId} (trigger=${triggerReason})`);
   nextTask();
   return true;
 }
@@ -2219,8 +2229,21 @@ export function resolveRescanEpochId(markerPath) {
 }
 
 export function runAfterBoot() {
-  // Clear any stale scan progress rows left from a previous crash
-  try { db.getDB()?.prepare('DELETE FROM scan_progress').run(); } catch (_) {}
+  // Clear any stale scan progress rows left from a previous crash.
+  // reboot() re-runs this WITHOUT exiting the process, so a scan worker
+  // can be genuinely alive right now — spare its row, or the admin
+  // progress UI goes blank for the rest of a possibly hours-long scan
+  // (the scanners INSERT their row once at startup and only UPDATE it
+  // after; a wiped row makes every later write a 0-row no-op). Same
+  // reboot-survivor guard the backup side has in markStaleBackupRunsFailed.
+  try {
+    const liveScanId = activeTask?.kind === 'scan' ? activeTask.taskObj.id : null;
+    if (liveScanId != null) {
+      db.getDB()?.prepare('DELETE FROM scan_progress WHERE scan_id != ?').run(liveScanId);
+    } else {
+      db.getDB()?.prepare('DELETE FROM scan_progress').run();
+    }
+  } catch (_) {}
 
   // Check if a migration flagged a force rescan. We DO NOT unlink the
   // marker here — it stays on disk until the queue drains after a

--- a/src/server.js
+++ b/src/server.js
@@ -536,6 +536,11 @@ export function reboot() {
     // never fires its callback, leaving the user with "server stopped
     // but never rebooted".
     remoteApi.stop();
+    // Pause the backup scheduler's timers (intervals + one-shot boot
+    // ticks). serveIt below re-runs backupManager.init(), which re-arms
+    // them — without this, each reboot left the old boot timeouts
+    // pending alongside the new ones.
+    backupManager.shutdown();
 
     // Tear down the Iroh tunnel. It binds its own UDP socket independent of the
     // HTTP server, so it doesn't block server.close(); we stop it to free the

--- a/test/integration/backup-batch6.test.mjs
+++ b/test/integration/backup-batch6.test.mjs
@@ -25,6 +25,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const WORKER = path.join(REPO_ROOT, 'src', 'backup', 'worker.mjs');
+// Forward slashes: NODE_OPTIONS eats backslashes on Windows.
+const FAIL_UTIMES = path.join(REPO_ROOT, 'test', 'fixtures', 'fail-utimes.cjs').replace(/\\/g, '/');
 
 let envCounter = 0;
 function makeTempRoot(tag) {
@@ -106,6 +108,41 @@ describe('batch6 worker: DST skew, orphan bookkeeping, empty dirs, source trash'
     }
   });
 
+  test('untrusted-mtime destinations honour the ±1h carve-out too (dest older by exactly 1h)', async () => {
+    const root = makeTempRoot('dstuntrusted');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(src, { recursive: true });
+      fs.writeFileSync(path.join(src, 'a.mp3'), 'data');
+      // Backdate the source well past tolerance so only the carve-out
+      // can save the shifted dest copy below.
+      const past = new Date(Date.now() - 7 * 24 * 3600 * 1000);
+      fs.utimesSync(path.join(src, 'a.mp3'), past, past);
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+      assert.equal(doneEvent(first.events).filesCopied, 1);
+
+      // Dest copy reads exactly 1h OLDER than the source (the DST-skew
+      // direction the untrusted branch's dest-not-older rule rejects).
+      const st = fs.statSync(path.join(dest, 'a.mp3'));
+      fs.utimesSync(path.join(dest, 'a.mp3'), st.atime, new Date(st.mtimeMs - 3600 * 1000));
+
+      // fail-utimes forces the fidelity probe to fail → untrusted branch.
+      const second = await runWorker(
+        { sourcePath: src, destPath: dest, retentionDays: 30 },
+        { env: { NODE_OPTIONS: `--require "${FAIL_UTIMES}"` } });
+      assert.equal(second.code, 0);
+      const done = doneEvent(second.events);
+      assert.equal(done.filesUnchanged, 1,
+        'exact -3600s on an mtime-dropping destination is DST skew, not a change');
+      assert.equal(done.filesCopied, 0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('orphan dir with leftover tmp/partial bookkeeping is fully removed, bookkeeping unlinked not trashed', async () => {
     const root = makeTempRoot('orphanbk');
     try {
@@ -134,10 +171,44 @@ describe('batch6 worker: DST skew, orphan bookkeeping, empty dirs, source trash'
         'the orphan dir must be fully removed, not survive as a ghost holding a stale tmp');
 
       // The deletion log holds the user file and ONLY the user file.
-      const today = new Date().toISOString().slice(0, 10);
-      const bucket = path.join(dest, '.mstream-trash', today, 'sub');
-      assert.deepEqual(fs.readdirSync(bucket).sort(), ['gone.mp3'],
+      // (Bucket name discovered by listing, not recomputed — the worker
+      // stamps it at trash time, and recomputing here would flake if a
+      // UTC midnight fell between the run and this assertion.)
+      const buckets = fs.readdirSync(path.join(dest, '.mstream-trash'));
+      assert.equal(buckets.length, 1);
+      assert.deepEqual(fs.readdirSync(path.join(dest, '.mstream-trash', buckets[0], 'sub')).sort(), ['gone.mp3'],
         'never-finalised bookkeeping must be unlinked, not hauled into the deletion log');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a hand-made DIRECTORY wearing a bookkeeping prefix inside an orphan dir trashes cleanly, no error loop', async () => {
+    const root = makeTempRoot('bkdir');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(path.join(src, 'sub'), { recursive: true });
+      fs.writeFileSync(path.join(src, 'keep.mp3'), 'keep');
+      fs.writeFileSync(path.join(src, 'sub', 'gone.mp3'), 'gone');
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+
+      // The worker only ever creates prefixed FILES — a prefixed
+      // DIRECTORY is hand-made user content. fs.unlink on it is
+      // EISDIR/EPERM; without the dirent-type check this became a
+      // permanent per-run fileError plus an unremovable ghost dir.
+      fs.mkdirSync(path.join(dest, 'sub', '.mstream-partial-fakedir'), { recursive: true });
+      fs.writeFileSync(path.join(dest, 'sub', '.mstream-partial-fakedir', 'inner.mp3'), 'x');
+      fs.rmSync(path.join(src, 'sub'), { recursive: true, force: true });
+
+      const second = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(second.code, 0);
+      const done = doneEvent(second.events);
+      assert.equal(done.fileErrors, 0, 'must not error-loop on a directory it cannot unlink');
+      assert.ok(!fs.existsSync(path.join(dest, 'sub')),
+        'the orphan dir (including the fake bookkeeping dir) must be fully removed');
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
@@ -221,17 +292,29 @@ describe('batch6 worker: DST skew, orphan bookkeeping, empty dirs, source trash'
 // ── Long paths (Windows MAX_PATH) ───────────────────────────────────────────
 
 describe('batch6 long paths: trash rename and sweep past MAX_PATH', () => {
-  // Build a relPath that keeps the LIVE dest path under 260 (mirrorable
-  // everywhere) while pushing the trash path (~+26 chars) past it.
-  function buildDeepRel(destRoot, fileName) {
+  // Pin the LIVE file path to exactly LIVE_LEN chars so that ONLY the
+  // trash path (+26: '.mstream-trash/YYYY-MM-DD/') crosses 260 — the
+  // code under test. Everything the worker touches un-prefixed stays
+  // inside every strict Win32 limit even with LongPathsEnabled=0:
+  // live dir <= 231 (< 248 CreateDirectoryW), atomicCopy's tmp sibling
+  // <= ~258 (< 260), live file 237 — while the trash target lands at
+  // 263. An earlier version let the live path float up to 255, which
+  // pushed the UNPREFIXED tmp sibling past 260 and would have failed
+  // run 1 on exactly the hosts the fix targets.
+  const LIVE_LEN = 237;
+  function buildDeepRel(destRoot) {
     const SEG = 's'.repeat(16);
     let rel = '';
+    // Leave room for a separator + a >=5-char filename after the segments.
     for (;;) {
       const next = rel ? path.join(rel, SEG) : SEG;
-      if (path.join(destRoot, next, fileName).length > 255) { break; }
+      if (path.join(destRoot, next).length + 1 + 5 > LIVE_LEN) { break; }
       rel = next;
     }
-    return rel;
+    const dirLen = path.join(destRoot, rel).length;
+    const nameLen = LIVE_LEN - dirLen - 1;
+    if (!rel || nameLen < 5) { return null; }   // pathologically long tmpdir
+    return { rel, fileName: 'f'.repeat(nameLen - 4) + '.mp3' };
   }
 
   test('a changed file whose trash path exceeds 260 chars is still trashed and refreshed', async (t) => {
@@ -239,13 +322,12 @@ describe('batch6 long paths: trash rename and sweep past MAX_PATH', () => {
     try {
       const src = path.join(root, 'src');
       const dest = path.join(root, 'dest');
-      const rel = buildDeepRel(dest, 'x.mp3');
-      if (path.join(dest, rel, 'x.mp3').length < 240) {
-        t.skip('temp root too deep to construct a near-MAX_PATH live path');
-        return;
-      }
+      const deep = buildDeepRel(dest);
+      if (!deep) { t.skip('tmpdir too long to pin a near-MAX_PATH live path'); return; }
+      const { rel, fileName } = deep;
+      assert.equal(path.join(dest, rel, fileName).length, LIVE_LEN);
       fs.mkdirSync(longPath(path.join(src, rel)), { recursive: true });
-      const srcFile = path.join(src, rel, 'x.mp3');
+      const srcFile = path.join(src, rel, fileName);
       fs.writeFileSync(longPath(srcFile), 'v1');
       // Backdate so the v2 edit is unambiguously newer than tolerance.
       const past = new Date(Date.now() - 60_000);
@@ -264,11 +346,14 @@ describe('batch6 long paths: trash rename and sweep past MAX_PATH', () => {
       assert.equal(done.filesTrashed, 1);
       assert.equal(done.filesCopied, 1);
 
-      const today = new Date().toISOString().slice(0, 10);
-      const trashed = path.join(dest, '.mstream-trash', today, rel, 'x.mp3');
+      // Bucket discovered by listing (not date-recomputed — avoids the
+      // UTC-midnight-rollover flake).
+      const buckets = fs.readdirSync(path.join(dest, '.mstream-trash'));
+      assert.equal(buckets.length, 1);
+      const trashed = path.join(dest, '.mstream-trash', buckets[0], rel, fileName);
       assert.ok(trashed.length > 260, `test must actually exceed MAX_PATH (got ${trashed.length})`);
       assert.ok(fs.existsSync(longPath(trashed)), 'the old copy must land in the deletion log');
-      assert.equal(fs.readFileSync(longPath(path.join(dest, rel, 'x.mp3')), 'utf8'), 'v2-changed');
+      assert.equal(fs.readFileSync(longPath(path.join(dest, rel, fileName)), 'utf8'), 'v2-changed');
     } finally {
       fs.rmSync(longPath(root), { recursive: true, force: true });
     }
@@ -278,14 +363,12 @@ describe('batch6 long paths: trash rename and sweep past MAX_PATH', () => {
     const root = makeTempRoot('lpsweep');
     try {
       const dest = path.join(root, 'dest');
-      const rel = buildDeepRel(dest, 'x.mp3');
-      if (path.join(dest, rel, 'x.mp3').length < 240) {
-        t.skip('temp root too deep to construct a near-MAX_PATH live path');
-        return;
-      }
+      const deep = buildDeepRel(dest);
+      if (!deep) { t.skip('tmpdir too long to pin a near-MAX_PATH live path'); return; }
+      const { rel, fileName } = deep;
       const bucket = path.join(dest, '.mstream-trash', '2020-01-01');
       fs.mkdirSync(longPath(path.join(bucket, rel)), { recursive: true });
-      fs.writeFileSync(longPath(path.join(bucket, rel, 'x.mp3')), 'old');
+      fs.writeFileSync(longPath(path.join(bucket, rel, fileName)), 'old');
 
       const manager = await import('../../src/backup/manager.js');
       await manager.sweepDestTrash({ dest_path: dest, retention_days: 7 });
@@ -312,12 +395,30 @@ describe('batch6 scheduler: missed-window catch-up decision', () => {
   const NOW = new Date(2026, 6, 10, 9, 0, 0);
   const DEST = { daily_at_hour: 23 };
 
-  test('missedDailyWindow: null/today/yesterday are not missed; older is', () => {
-    assert.equal(manager.missedDailyWindow(null, NOW), false, 'fresh destination waits for its first window');
-    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 10, 1), NOW), false, 'ran today');
-    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 9, 23), NOW), false, 'ran yesterday — normal cadence');
-    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 8, 23), NOW), true, 'a whole window was missed');
-    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 1, 23), NOW), true, 'off for a week');
+  test('missedDailyWindow: compares against yesterday\'s window MOMENT, keyed on finish time', () => {
+    assert.equal(manager.missedDailyWindow(null, 23, NOW), false, 'fresh destination waits for its first window');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 10, 1), 23, NOW), false, 'ran today');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 9, 23), 23, NOW), false, 'served yesterday\'s window — normal cadence');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 8, 23), 23, NOW), true, 'a whole window was missed');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 1, 23), 23, NOW), true, 'off for a week');
+    // The always-off-at-window machine: yesterday's attempt was a MORNING
+    // catch-up (hour 8), so yesterday's 23:00 window was ALSO missed. A
+    // date-only comparison called this served and halved the cadence to
+    // every other day.
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 9, 8), 23, NOW), true,
+      'a morning catch-up does not serve that evening\'s window — cadence stays daily');
+    // Marathon run: started days ago but FINISHED after yesterday's
+    // window — it covered everything up to its finish; no pointless
+    // catch-up walk right behind it.
+    const marathon = {
+      started_at: rowAtLocal(2026, 7, 8, 23).started_at,
+      finished_at: rowAtLocal(2026, 7, 10, 6).started_at,
+    };
+    assert.equal(manager.missedDailyWindow(marathon, 23, NOW), false,
+      'a run finishing this morning covered yesterday\'s window');
+    // Same run still in flight (no finished_at): reads as missed, which
+    // is harmless — the dedup gate drops the trigger while it runs.
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 8, 23), 23, NOW), true);
   });
 
   test('before the scheduled hour: strict wait normally, catch-up when a window was missed', () => {
@@ -329,6 +430,10 @@ describe('batch6 scheduler: missed-window catch-up decision', () => {
     // Server was off during last night's window: catch up right now.
     assert.equal(manager.shouldTriggerScheduled(DEST, rowAtLocal(2026, 7, 8, 23), NOW), true,
       'missed window triggers promptly after boot instead of waiting for tonight');
+    // And the machine that is off EVERY night still gets one backup per
+    // day: yesterday's morning catch-up doesn't mask last night's miss.
+    assert.equal(manager.shouldTriggerScheduled(DEST, rowAtLocal(2026, 7, 9, 8), NOW), true,
+      'daily cadence holds for always-off-at-window machines');
   });
 
   test('at/after the scheduled hour: once per local day, catch-up day runs twice (documented)', () => {

--- a/test/integration/backup-batch6.test.mjs
+++ b/test/integration/backup-batch6.test.mjs
@@ -1,0 +1,408 @@
+/**
+ * Backup low-severity cleanup + deferred decisions (audit batch 6).
+ *
+ * Four describes:
+ *   - Worker mirror semantics: FAT/DST ±1h mtime-skew carve-out, orphan-dir
+ *     bookkeeping cleanup, empty-dir mirror stability, source-root
+ *     .mstream-trash filtering (walk AND pre-flight guard in lockstep).
+ *   - Long paths: trash rename past Windows MAX_PATH (worker) and pruning
+ *     such buckets (manager sweep).
+ *   - Scheduler decisions: missedDailyWindow / shouldTriggerScheduled
+ *     matrix incl. the anacron catch-up and its documented
+ *     double-run-on-catch-up-day consequence.
+ *   - Crash recovery: markStaleBackupRunsFailed flip + exclusion.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(REPO_ROOT, 'src', 'backup', 'worker.mjs');
+
+let envCounter = 0;
+function makeTempRoot(tag) {
+  const rand = crypto.randomBytes(4).toString('hex');
+  const root = path.join(os.tmpdir(), `mstream-b6-${tag}-${rand}-` + (envCounter++));
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+// Mirror of the worker/manager \\?\ opt-in so the TEST can create and
+// inspect paths past MAX_PATH on Windows hosts without LongPathsEnabled.
+function longPath(p) {
+  if (process.platform !== 'win32') { return p; }
+  const abs = path.resolve(p);
+  if (abs.startsWith('\\\\?\\')) { return abs; }
+  if (abs.startsWith('\\\\')) { return '\\\\?\\UNC\\' + abs.slice(2); }
+  return '\\\\?\\' + abs;
+}
+
+function runWorker(payload, { env = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WORKER, JSON.stringify(payload)], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let errOut = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.stderr.on('data', (d) => { errOut += d.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const events = out.split(/\r?\n/).filter(Boolean).map((l) => {
+        try { return JSON.parse(l); } catch (_) { return null; }
+      }).filter(Boolean);
+      resolve({ code, events, stderr: errOut });
+    });
+  });
+}
+const doneEvent = (events) => events.find((e) => e.event === 'done') || null;
+
+// ── Worker mirror semantics ─────────────────────────────────────────────────
+
+describe('batch6 worker: DST skew, orphan bookkeeping, empty dirs, source trash', () => {
+  test('dest mtimes shifted by exactly ±1h (FAT DST skew) read as unchanged; ±30min does not', async () => {
+    const root = makeTempRoot('dst');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(src, { recursive: true });
+      for (const n of ['plus.mp3', 'minus.mp3', 'ctrl.mp3']) {
+        fs.writeFileSync(path.join(src, n), `data-${n}`);
+      }
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+      assert.equal(doneEvent(first.events).filesCopied, 3);
+
+      // Simulate the post-DST-transition read: FAT stores local time, so
+      // every stored mtime comes back shifted by exactly one hour.
+      const shift = (name, deltaSec) => {
+        const p = path.join(dest, name);
+        const st = fs.statSync(p);
+        fs.utimesSync(p, st.atime, new Date(st.mtimeMs + deltaSec * 1000));
+      };
+      shift('plus.mp3', 3600);
+      shift('minus.mp3', -3600);
+      shift('ctrl.mp3', 1800);   // NOT a DST offset — must still recopy
+
+      const second = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(second.code, 0);
+      const done = doneEvent(second.events);
+      assert.equal(done.filesUnchanged, 2,
+        'exact ±3600s deltas are FAT DST skew and must not trigger a recopy');
+      assert.equal(done.filesCopied, 1, 'the ±30min control file is genuinely changed');
+      assert.equal(done.filesTrashed, 1, 'only the control file gets trash+recopied');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('orphan dir with leftover tmp/partial bookkeeping is fully removed, bookkeeping unlinked not trashed', async () => {
+    const root = makeTempRoot('orphanbk');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(path.join(src, 'sub'), { recursive: true });
+      fs.writeFileSync(path.join(src, 'keep.mp3'), 'keep');
+      fs.writeFileSync(path.join(src, 'sub', 'gone.mp3'), 'gone');
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+
+      // A killed previous worker left bookkeeping behind, then the user
+      // removed the whole directory from the source.
+      fs.writeFileSync(path.join(dest, 'sub', '.mstream-tmp-deadbeef'), 'x');
+      fs.writeFileSync(path.join(dest, 'sub', '.mstream-partial-deadbeef-1-2-v2'), 'x');
+      fs.rmSync(path.join(src, 'sub'), { recursive: true, force: true });
+
+      const second = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(second.code, 0);
+      const done = doneEvent(second.events);
+      assert.equal(done.fileErrors, 0);
+      assert.equal(done.filesTrashed, 1,
+        'only the real file counts as trashed — bookkeeping must not inflate the count');
+      assert.ok(!fs.existsSync(path.join(dest, 'sub')),
+        'the orphan dir must be fully removed, not survive as a ghost holding a stale tmp');
+
+      // The deletion log holds the user file and ONLY the user file.
+      const today = new Date().toISOString().slice(0, 10);
+      const bucket = path.join(dest, '.mstream-trash', today, 'sub');
+      assert.deepEqual(fs.readdirSync(bucket).sort(), ['gone.mp3'],
+        'never-finalised bookkeeping must be unlinked, not hauled into the deletion log');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('an empty source directory keeps a stable dest mirror across runs (no create/delete flip-flop)', async () => {
+    const root = makeTempRoot('emptydir');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(path.join(src, 'placeholder-album'), { recursive: true });
+      fs.writeFileSync(path.join(src, 'a.mp3'), 'a');
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+      assert.ok(fs.existsSync(path.join(dest, 'placeholder-album')), 'run 1 mirrors the empty dir');
+
+      // Pre-fix, run 2's matched-pair prune rmdir'd it, and run 3
+      // recreated it — permanently oscillating.
+      const second = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(second.code, 0);
+      assert.ok(fs.existsSync(path.join(dest, 'placeholder-album')),
+        'run 2 must leave the mirror of an existing (empty) source dir in place');
+      const done = doneEvent(second.events);
+      assert.equal(done.filesCopied, 0);
+      assert.equal(done.filesTrashed, 0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('source-root .mstream-trash is skipped (not mirrored into the dest trash), deeper ones still mirror', async () => {
+    const root = makeTempRoot('srctrash');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(path.join(src, '.mstream-trash', '2026-01-01'), { recursive: true });
+      fs.writeFileSync(path.join(src, '.mstream-trash', '2026-01-01', 'old.mp3'), 'old');
+      fs.mkdirSync(path.join(src, 'sub', '.mstream-trash'), { recursive: true });
+      fs.writeFileSync(path.join(src, 'sub', '.mstream-trash', 'legit.mp3'), 'legit');
+      fs.writeFileSync(path.join(src, 'real.mp3'), 'real');
+
+      const { code, events, stderr } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(code, 0);
+      assert.equal(doneEvent(events).fileErrors, 0, 'the skip is a log-only warning, not a per-run failure');
+      assert.match(stderr, /source root contains/i);
+
+      assert.ok(fs.existsSync(path.join(dest, 'real.mp3')));
+      assert.ok(!fs.existsSync(path.join(dest, '.mstream-trash', '2026-01-01')),
+        'the source trash bucket must NOT commingle with the dest trash, where the sweep would delete it');
+      assert.ok(fs.existsSync(path.join(dest, 'sub', '.mstream-trash', 'legit.mp3')),
+        'a .mstream-trash folder DEEPER in the tree is legitimate user content and mirrors normally');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a source containing ONLY a trash bucket reads as empty to the guard — dest is refused, not swept', async () => {
+    const root = makeTempRoot('trashonly');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(path.join(src, '.mstream-trash', '2026-01-01'), { recursive: true });
+      fs.writeFileSync(path.join(src, '.mstream-trash', '2026-01-01', 'x.mp3'), 'x');
+      fs.mkdirSync(dest, { recursive: true });
+      fs.writeFileSync(path.join(dest, 'existing.mp3'), 'precious');
+
+      // If the walk filters the source-root trash but the pre-flight
+      // guard doesn't (or vice versa), this source passes the guard while
+      // the walk sees nothing — and sweeps the whole destination. The
+      // two MUST stay in lockstep.
+      const { code } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(code, 1, 'zero mirrorable files must refuse the run');
+      assert.ok(fs.existsSync(path.join(dest, 'existing.mp3')), 'the dest must be untouched');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Long paths (Windows MAX_PATH) ───────────────────────────────────────────
+
+describe('batch6 long paths: trash rename and sweep past MAX_PATH', () => {
+  // Build a relPath that keeps the LIVE dest path under 260 (mirrorable
+  // everywhere) while pushing the trash path (~+26 chars) past it.
+  function buildDeepRel(destRoot, fileName) {
+    const SEG = 's'.repeat(16);
+    let rel = '';
+    for (;;) {
+      const next = rel ? path.join(rel, SEG) : SEG;
+      if (path.join(destRoot, next, fileName).length > 255) { break; }
+      rel = next;
+    }
+    return rel;
+  }
+
+  test('a changed file whose trash path exceeds 260 chars is still trashed and refreshed', async (t) => {
+    const root = makeTempRoot('lp');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      const rel = buildDeepRel(dest, 'x.mp3');
+      if (path.join(dest, rel, 'x.mp3').length < 240) {
+        t.skip('temp root too deep to construct a near-MAX_PATH live path');
+        return;
+      }
+      fs.mkdirSync(longPath(path.join(src, rel)), { recursive: true });
+      const srcFile = path.join(src, rel, 'x.mp3');
+      fs.writeFileSync(longPath(srcFile), 'v1');
+      // Backdate so the v2 edit is unambiguously newer than tolerance.
+      const past = new Date(Date.now() - 60_000);
+      fs.utimesSync(longPath(srcFile), past, past);
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+      assert.equal(doneEvent(first.events).filesCopied, 1);
+
+      fs.writeFileSync(longPath(srcFile), 'v2-changed');
+
+      const second = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(second.code, 0);
+      const done = doneEvent(second.events);
+      assert.equal(done.fileErrors, 0, 'the near-MAX_PATH trash rename must not fail');
+      assert.equal(done.filesTrashed, 1);
+      assert.equal(done.filesCopied, 1);
+
+      const today = new Date().toISOString().slice(0, 10);
+      const trashed = path.join(dest, '.mstream-trash', today, rel, 'x.mp3');
+      assert.ok(trashed.length > 260, `test must actually exceed MAX_PATH (got ${trashed.length})`);
+      assert.ok(fs.existsSync(longPath(trashed)), 'the old copy must land in the deletion log');
+      assert.equal(fs.readFileSync(longPath(path.join(dest, rel, 'x.mp3')), 'utf8'), 'v2-changed');
+    } finally {
+      fs.rmSync(longPath(root), { recursive: true, force: true });
+    }
+  });
+
+  test('the retention sweep can prune a bucket containing >MAX_PATH entries', async (t) => {
+    const root = makeTempRoot('lpsweep');
+    try {
+      const dest = path.join(root, 'dest');
+      const rel = buildDeepRel(dest, 'x.mp3');
+      if (path.join(dest, rel, 'x.mp3').length < 240) {
+        t.skip('temp root too deep to construct a near-MAX_PATH live path');
+        return;
+      }
+      const bucket = path.join(dest, '.mstream-trash', '2020-01-01');
+      fs.mkdirSync(longPath(path.join(bucket, rel)), { recursive: true });
+      fs.writeFileSync(longPath(path.join(bucket, rel, 'x.mp3')), 'old');
+
+      const manager = await import('../../src/backup/manager.js');
+      await manager.sweepDestTrash({ dest_path: dest, retention_days: 7 });
+      assert.ok(!fs.existsSync(longPath(bucket)),
+        'a years-old bucket must be pruned even when its contents exceed MAX_PATH');
+    } finally {
+      fs.rmSync(longPath(root), { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Scheduler decisions ─────────────────────────────────────────────────────
+
+describe('batch6 scheduler: missed-window catch-up decision', () => {
+  let manager;
+  before(async () => { manager = await import('../../src/backup/manager.js'); });
+
+  // Build a backup_history-shaped row whose started_at (stored UTC)
+  // corresponds to the given LOCAL wall-clock moment — keeps every
+  // assertion TZ-independent.
+  const rowAtLocal = (y, mo, d, h, mi = 0) =>
+    ({ started_at: new Date(y, mo - 1, d, h, mi).toISOString().slice(0, 19).replace('T', ' ') });
+  // "now" for all cases: 2026-07-10 09:00 local, scheduled hour 23.
+  const NOW = new Date(2026, 6, 10, 9, 0, 0);
+  const DEST = { daily_at_hour: 23 };
+
+  test('missedDailyWindow: null/today/yesterday are not missed; older is', () => {
+    assert.equal(manager.missedDailyWindow(null, NOW), false, 'fresh destination waits for its first window');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 10, 1), NOW), false, 'ran today');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 9, 23), NOW), false, 'ran yesterday — normal cadence');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 8, 23), NOW), true, 'a whole window was missed');
+    assert.equal(manager.missedDailyWindow(rowAtLocal(2026, 7, 1, 23), NOW), true, 'off for a week');
+  });
+
+  test('before the scheduled hour: strict wait normally, catch-up when a window was missed', () => {
+    // 09:00 < 23 — normally nothing fires.
+    assert.equal(manager.shouldTriggerScheduled(DEST, rowAtLocal(2026, 7, 9, 23), NOW), false,
+      'yesterday ran fine — wait for tonight');
+    assert.equal(manager.shouldTriggerScheduled(DEST, null, NOW), false,
+      'a freshly-created destination must not fire the moment it is saved');
+    // Server was off during last night's window: catch up right now.
+    assert.equal(manager.shouldTriggerScheduled(DEST, rowAtLocal(2026, 7, 8, 23), NOW), true,
+      'missed window triggers promptly after boot instead of waiting for tonight');
+  });
+
+  test('at/after the scheduled hour: once per local day, catch-up day runs twice (documented)', () => {
+    const tonight = new Date(2026, 6, 10, 23, 5, 0);
+    assert.equal(manager.shouldTriggerScheduled(DEST, rowAtLocal(2026, 7, 9, 23), tonight), true,
+      'regular nightly fire');
+    assert.equal(manager.shouldTriggerScheduled(DEST, rowAtLocal(2026, 7, 10, 23, 2), tonight), false,
+      'already served tonight');
+    // The 09:00 catch-up run started before daily_at_hour, so it does not
+    // satisfy scheduledWindowServed — the regular window fires again
+    // tonight. Accepted consequence: the second run walks an
+    // already-synced mirror.
+    assert.equal(manager.shouldTriggerScheduled(DEST, rowAtLocal(2026, 7, 10, 9), tonight), true,
+      'catch-up day double-run is the documented trade-off');
+    assert.equal(manager.shouldTriggerScheduled({ daily_at_hour: null }, null, tonight), false,
+      'no scheduled hour, never fires');
+  });
+});
+
+// ── Crash recovery ──────────────────────────────────────────────────────────
+
+describe('batch6 db: markStaleBackupRunsFailed crash recovery', () => {
+  let testRoot, dbManager, destId;
+
+  before(async () => {
+    testRoot = makeTempRoot('crashdb');
+    fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+    fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+      storage: { dbDirectory: path.join(testRoot, 'db'), albumArtDirectory: path.join(testRoot, 'art'), logsDirectory: path.join(testRoot, 'logs') },
+      port: 0,
+    }));
+    const config = await import('../../src/state/config.js');
+    await config.setup(path.join(testRoot, 'config.json'));
+    dbManager = await import('../../src/db/manager.js');
+    dbManager.initDB();
+    const src = path.join(testRoot, 'lib');
+    fs.mkdirSync(src, { recursive: true });
+    dbManager.getDB().prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES (?, ?, ?, 0)`)
+      .run('lib', src, 'music');
+    dbManager.invalidateCache();
+    destId = dbManager.addBackupDestination({
+      libraryId: dbManager.getLibraryByName('lib').id, destPath: path.join(testRoot, 'dest'),
+      triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+      excludeGlobs: [], interFileDelayMs: 0,
+    });
+  });
+
+  after(() => {
+    if (dbManager) { dbManager.close(); }
+    try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
+  });
+
+  test('stale running rows flip to failed; the reboot-surviving run is spared', () => {
+    const mkRunning = () => dbManager.createBackupRunRow({
+      destinationId: destId, triggerReason: 'manual', status: 'running',
+    });
+    const stale1 = mkRunning();
+    const stale2 = mkRunning();
+    const live = mkRunning();   // the reboot()-surviving worker's row
+
+    const flipped = dbManager.markStaleBackupRunsFailed(live);
+    assert.equal(flipped, 2);
+
+    for (const id of [stale1, stale2]) {
+      const row = dbManager.getBackupHistoryRowById(id);
+      assert.equal(row.status, 'failed');
+      assert.equal(row.error_message, 'Interrupted by server restart');
+      assert.ok(row.finished_at, 'recovered rows must be finalised');
+    }
+    assert.equal(dbManager.getBackupHistoryRowById(live).status, 'running',
+      'the excluded (genuinely alive) run must be left running');
+
+    // Cold boot (no exclusion): everything running flips.
+    assert.equal(dbManager.markStaleBackupRunsFailed(null), 1);
+    assert.equal(dbManager.getBackupHistoryRowById(live).status, 'failed');
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -6441,7 +6441,7 @@ const backupView = Vue.component('backup-view', {
                     <div class="input-field col s6 m3">
                       <input v-model.number="retentionDays" id="backup-retention" type="number" min="0" class="validate">
                       <label for="backup-retention" class="active">Retention (days)</label>
-                      <span class="helper-text">0 = hard delete</span>
+                      <span class="helper-text">Days deleted/changed files stay recoverable in the backup's trash. 0 = no trash: old copies are deleted immediately and unrecoverably.</span>
                     </div>
                     <div class="input-field col s6 m3">
                       <input v-model.number="interFileDelayMs" id="backup-throttle" type="number" min="0" max="60000" class="validate">
@@ -9178,7 +9178,7 @@ const backupEditModal = Vue.component('backup-edit-modal', {
         <div class="input-field col s4 m2">
           <input v-model.number="retentionDays" id="backup-edit-retention" type="number" min="0" class="validate">
           <label for="backup-edit-retention" class="active">Retention (days)</label>
-          <span class="helper-text" style="font-size:11px">0 = hard delete</span>
+          <span class="helper-text" style="font-size:11px" title="Days deleted/changed files stay recoverable in the backup's trash before being purged">0 = no trash, deletes are immediate + permanent</span>
         </div>
         <div class="input-field col s4 m2">
           <input v-model.number="interFileDelayMs" id="backup-edit-throttle" type="number" min="0" max="60000" class="validate">


### PR DESCRIPTION
Batch 6 — the final code batch of the backup audit: the low-severity cleanup backlog plus the three deferred decisions (made 2026-07-10). Adversarially reviewed (20 raw findings → 12 refuted, 3 confirmed — all fixed in the follow-up commit).

## The three decisions, implemented

**FAT/DST skew: handled rsync-style.** FAT-family filesystems store mtimes in *local* time, so after every DST transition each stored stamp reads back shifted by exactly ±1h — previously the first run after a transition saw every file on a FAT/exFAT USB destination as changed and trash+recopied the entire library, twice a year, demanding library-size trash headroom. `mtimesAgree()` now also accepts deltas of exactly ±3600s within the 2s slack (the same trade `rsync --modify-window` and `robocopy /DST` have made for decades), in both the trusted branch (FAT passes the fidelity probe — that's exactly where the skew bit) and the untrusted fallback's dest-older direction.

**Retention 0: stays true hard-delete.** No behavior change — the helper text in both forms now spells out that deletions are immediate and unrecoverable, so nobody mistakes it for "trash with 0-day retention."

**Missed daily window: anacron-style catch-up.** The per-destination decision is now a pure, exported `shouldTriggerScheduled()`. A destination whose last attempt *ended before yesterday's window moment* (yesterday's local date at `daily_at_hour`) fires promptly after boot instead of silently skipping the day — so a NAS that's off overnight still gets its daily backup each morning. A freshly-created destination still waits for its first regular window. Documented, accepted consequence: on a catch-up day the regular window fires too (the second run walks an already-synced mirror, which is cheap).

## Cleanup sweep

- **Orphan-dir bookkeeping** (`trashDestEntry`): leftover `.mstream-tmp-*`/`.mstream-partial-*` *files* in a dir removed from the source are now unlinked — previously tmps were skipped (ghost dir whose `rmdir` failed silently forever) and partials were trashed as user files (never-finalised garbage in the deletion log, inflated `filesTrashed`).
- **Empty-dir flip-flop**: the matched-dir "prune if now empty" rmdir is gone. The source dir exists (it's the matched pair), so its mirror should too — the prune put every empty source dir (placeholder albums, all-excluded dirs) into a permanent create/delete oscillation. Dest dirs whose source is gone are still removed via the dest-only path.
- **Source-root `.mstream-trash`**: filtered from the walk (once-per-run stderr warning), so a tree that previously *was* a backup destination doesn't get its old trash mirrored into the new dest's bucket — where the retention sweep would silently age-and-delete data the user believed was backed up. `hasAnyFiles` mirrors the filter in lockstep (pinned by test: a trash-only source *refuses* with dest untouched, rather than passing the guard while the walk sees nothing and sweeps the dest). Deeper `.mstream-trash` dirs still mirror as ordinary content.
- **Windows MAX_PATH trash paths**: the trash target adds ~26 chars over the live path, so a file mirrorable at <260 chars could never be *trashed* — a changed file in a deep tree was never refreshed, every run. Trash renames near the limit now use a `\\?\`-prefixed target, and the manager's sweep prefixes bucket roots on win32 so it can prune what the worker writes. (Defense-in-depth: Node's internal path namespacing may already cover part of this — the prefix is correct under either reading.)
- **Reboot hygiene**: `runAfterBoot` spares the live scan's `scan_progress` row on reboot-without-exit (an admin settings change mid-scan previously blanked the progress UI for the rest of the scan); `backupManager.shutdown()` now clears the previously-untracked post-boot timeouts and is called from `reboot()` (which re-inits); all four scheduler timers are unref'd.
- **`triggerForLibrary`'s ignored argument** is now real (the reason doubles as the trigger-type filter — same behavior, now honest); **queued-runs-lost-on-restart** documented as an accepted limitation with an enqueue log breadcrumb (minimal option, per decision).

## Adversarial review round (commit 2)

- **Bookkeeping unlink had no dirent-type check** — a hand-made *directory* named `.mstream-partial-*` inside an orphan dir hit `fs.unlink` → EISDIR/EPERM every run: permanent per-run error + unremovable ghost (a regression vs master; verifiers repro'd it live). Now files-only; a prefixed directory falls through to normal recursion. Pinned.
- **Catch-up date-key granularity halved cadence** — verifier simulation showed an always-off-at-window machine backing up every *other* day (the morning catch-up's row date masked that evening's miss). `missedDailyWindow` now compares against yesterday's window *moment*, keyed on `finished_at ?? started_at` (a marathon run finishing this morning covered yesterday's window — no pointless walk right behind it). Pinned.
- **Untrusted-branch DST carve-out had zero coverage** (verifier mutation: deleting it left all 95 tests green) — new test drives it through the fail-utimes preload; mutation-pinned.
- Test hardening from split findings: the long-path test now *pins* the live path at 237 chars so only the trash target (263) crosses MAX_PATH — the earlier construction let the live path float to 255, which would have failed on exactly the strict hosts the fix targets; trash bucket names are discovered by `readdir` instead of recomputing the UTC date (midnight-rollover flake).

## Validation

13 tests in `backup-batch6.test.mjs`; 10 of 13 fail with the fixes reverted (the three passes are new-coverage-only: crash recovery + the long-path pair on long-paths-enabled hosts). Full backup + task-queue suites 56/56, backup-api 18/18, lint at master baseline. Rig smoke on the big server: see comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
