### PR TITLE
feat(federation): caller-side discovery aggregator over federated peers (discovery-over-federation P2)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5993,6 +5993,7 @@ paths:
                     added_at: { type: string }
                     last_seen: { type: string, nullable: true }
                     last_status: { type: string, nullable: true }
+                    use_discovery: { type: integer, description: "1 = the Discover panel may send this peer similarity queries (outbound discovery-over-federation); 0 = opted out" }
         "405": { $ref: "#/components/responses/AdminLocked" }
     post:
       tags: [Federation]
@@ -6022,6 +6023,32 @@ paths:
         - { name: id, in: path, required: true, schema: { type: integer } }
       responses:
         "200": { $ref: "#/components/responses/EmptySuccess" }
+        "404": { description: Peer not found. }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/peers/{id}/discovery:
+    post:
+      tags: [Federation]
+      summary: Toggle outbound discovery queries for one peer
+      description: |
+        Sets `use_discovery` — whether this server's Discover panel may send
+        the peer similarity queries (seed-track embedding vectors). Outbound
+        only; answering the peer's inbound queries is governed by the
+        libraries its key was granted, not by this flag.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled: { type: boolean }
+      responses:
+        "200":
+          description: The updated peer row.
         "404": { description: Peer not found. }
         "405": { $ref: "#/components/responses/AdminLocked" }
 

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -211,6 +211,21 @@ export function register(mstream) {
     res.json({ ...result, peer: fedDb.getFederationPeerById(peer.id) });
   });
 
+  // Per-peer opt-out for OUTBOUND discovery queries (sending this peer our
+  // seed vectors from the Discover panel). The inbound direction has no
+  // flag — see the SCHEMA_V58 comment.
+  mstream.post('/api/v1/admin/federation/peers/:id/discovery', (req, res) => {
+    joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), req.params);
+    joiValidate(Joi.object({ enabled: Joi.boolean().required() }), req.body);
+
+    const id = Number(req.params.id);
+    if (!fedDb.setFederationPeerUseDiscovery(id, req.body.enabled)) {
+      throw new WebError('Peer not found', 404);
+    }
+    winston.info(`[federation] ${req.user.username} turned discovery ${req.body.enabled ? 'on' : 'off'} for peer id=${id}`);
+    res.json(fedDb.getFederationPeerById(id));
+  });
+
   mstream.delete('/api/v1/admin/federation/peers/:id', async (req, res) => {
     const schema = Joi.object({ id: Joi.number().integer().min(1).required() });
     joiValidate(schema, req.params);

--- a/src/api/discovery-federation.js
+++ b/src/api/discovery-federation.js
@@ -1,0 +1,151 @@
+// Discovery-over-federation, caller side: find music you DON'T have on the
+// servers you PAIRED with, that sounds like music you DO have — and unlike
+// the public p2p network's metadata-only leads, every result lives inside a
+// library the peer granted us, so it is streamable over the same bridge.
+//
+// Namespace contract (by data source, like the rest of the discovery API):
+//   /api/v1/discovery/local/*        your own library (in-memory index)
+//   /api/v1/discovery/p2p/*          fetched public-network snapshots
+//   /api/v1/discovery/federation/*   live queries to federated peers (this)
+//
+// Flow per request: resolve the local seed track, pull ITS embedding from
+// discovery.db, fan the raw vector out to every peer with use_discovery on
+// (POST /api/v1/federation/discovery/similar via fedFetch, bounded by a
+// per-peer timeout), then merge: caller-side novelty chain
+// (db/discovery-novelty.js), cross-peer dedupe, sort, cap.
+//
+// Privacy note, stated where the code sends it: the seed VECTOR leaves the
+// machine, to peers the admin explicitly paired with — that is the deal the
+// per-peer use_discovery toggle governs. The public-network contract
+// ("queries never leave the machine", api/discovery-p2p.js) is unchanged.
+
+import Joi from 'joi';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as discoveryDb from '../db/discovery-db.js';
+import * as fedDb from '../db/federation.js';
+import { localIdentitySets, isNovel, norm } from '../db/discovery-novelty.js';
+import { resolveSeedTrack } from './discovery.js';
+import { joiValidate } from '../util/validation.js';
+import WebError from '../util/web-error.js';
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+// Ask each peer for more than we'll show: the novelty chain and cross-peer
+// dedupe run AFTER the peers answer, so headroom keeps a heavily-filtered
+// answer from coming up short. Capped at the peer endpoint's own MAX_LIMIT.
+const HEADROOM = 3;
+const PEER_LIMIT_CAP = 100;
+// A slow peer must not hold the Discover panel hostage; unreachable peers
+// surface in `searched.unreachable`, not as an error.
+const PEER_TIMEOUT_MS = 4000;
+
+export function setup(mstream) {
+  // Similar-but-not-owned tracks across the federated peers.
+  //   filePath        the local seed track ("<vpath>/<relpath>")
+  //   limit           max results (default 10, cap 50)
+  //   newArtistsOnly  also drop artists the local library already has
+  mstream.post('/api/v1/discovery/federation/similar', async (req, res) => {
+    if (config.program.federation.enabled !== true) {
+      throw new WebError('federation is disabled (config: federation.enabled)', 403);
+    }
+    const schema = Joi.object({
+      filePath: Joi.string().required(),
+      limit: Joi.number().integer().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+      newArtistsOnly: Joi.boolean().default(false),
+    });
+    const { value: { filePath, limit, newArtistsOnly } } = joiValidate(schema, req.body);
+
+    // Same resolution + uniform-404 + probe logging as the local/p2p routes.
+    const seedRow = resolveSeedTrack(req, filePath, 'discovery/federation/similar');
+    const canonHash = seedRow.audio_hash || seedRow.file_hash;
+
+    if (!discoveryDb.openDiscoveryDbIfExists()) {
+      throw new WebError('discovery data collection has never been enabled — no embeddings to search with', 404);
+    }
+    const seed = discoveryDb.getDiscoveryDb().prepare(`
+      SELECT embedding, model_id FROM discovery_tracks WHERE audio_hash = ?
+    `).get(canonHash);
+    if (!seed || !seed.embedding) {
+      throw new WebError('track has no embedding yet — the analysis pass has not processed it', 404);
+    }
+
+    const query = { filePath, modelId: seed.model_id, newArtistsOnly };
+    const peers = fedDb.getFederationPeers().filter((p) => p.use_discovery === 1);
+    if (peers.length === 0) {
+      return res.json({ query, searched: { peers: 0, unreachable: 0, mismatched: 0 }, results: [] });
+    }
+
+    const payload = JSON.stringify({
+      embedding: Buffer.from(seed.embedding.buffer, seed.embedding.byteOffset, seed.embedding.byteLength).toString('base64'),
+      modelId: seed.model_id,
+      limit: Math.min(PEER_LIMIT_CAP, limit * HEADROOM),
+    });
+
+    // Loaded lazily like the admin routes do — federation-client pulls in
+    // the iroh machinery, which stays cold until a peer is actually dialed.
+    const fedClient = await import('../state/federation-client.js');
+    const answers = await Promise.allSettled(peers.map(async (peer) => {
+      const r = await fedClient.fedFetch(peer, '/api/v1/federation/discovery/similar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        signal: AbortSignal.timeout(PEER_TIMEOUT_MS),
+      });
+      if (!r.ok) { throw new Error(`http ${r.status}`); }
+      return r.json();
+    }));
+
+    const searched = { peers: 0, unreachable: 0, mismatched: 0 };
+    const exclude = localIdentitySets();
+    const merged = [];
+    for (const [i, outcome] of answers.entries()) {
+      const peer = peers[i];
+      if (outcome.status === 'rejected') {
+        searched.unreachable += 1;
+        winston.warn(`discovery federation similar: peer '${peer.name}' (id=${peer.id}) failed: ${outcome.reason?.message}`);
+        continue;
+      }
+      if (outcome.value.modelMismatch) { searched.mismatched += 1; continue; }
+      searched.peers += 1;
+      for (const r of outcome.value.results || []) {
+        if (!isNovel(exclude, {
+          artist: r.artist,
+          title: r.title,
+          recordingMbid: r.recordingMbid,
+          similarityVsSeed: r.similarity,
+        }, { newArtistsOnly })) { continue; }
+        merged.push({
+          artist: r.artist,
+          title: r.title,
+          duration: r.duration,
+          similarity: r.similarity,
+          genreTags: r.genreTags,
+          recordingMbid: r.recordingMbid,
+          // filepath is the PEER's vpath-form path — the handle a future
+          // stream proxy plays, and provenance the panel can show today.
+          filepath: r.filepath,
+          peer: { id: peer.id, name: peer.name },
+        });
+      }
+    }
+
+    // Cross-peer dedupe: two peers holding the same song should surface it
+    // once (highest similarity wins — walk in sorted order). Keyed by MBID
+    // when present AND normalized artist+title, so a tagged copy on one
+    // peer dedupes an untagged copy on another whenever the names agree.
+    merged.sort((a, b) => b.similarity - a.similarity);
+    const seen = new Set();
+    const results = [];
+    for (const r of merged) {
+      if (results.length >= limit) { break; }
+      const keys = [`a:${norm(r.artist)} ${norm(r.title)}`];
+      if (r.recordingMbid) { keys.push(`m:${r.recordingMbid}`); }
+      if (keys.some((k) => seen.has(k))) { continue; }
+      for (const k of keys) { seen.add(k); }
+      results.push(r);
+    }
+
+    res.json({ query, searched, results });
+  });
+}

--- a/src/api/discovery-p2p.js
+++ b/src/api/discovery-p2p.js
@@ -19,26 +19,21 @@
 // search filters peer rows to the query track's model_id, so a network mid
 // model-migration degrades to fewer results, never to garbage rankings.
 //
-// The novelty filter (the point of the feature) is a chain, because no
-// single identity signal covers every library:
-//   1. recording MBID match        exact, when both sides are tagged
-//   2. normalized artist+title     the pragmatic fallback
-//   3. near-duplicate embedding    cosine ≥ NEAR_DUP vs the QUERY track
-//                                  catches untagged re-encodes of it
-// plus opt-in `newArtistsOnly`, which drops every artist the local library
-// already knows — the "introduce me to someone new" mode.
+// The novelty filter (the point of the feature) lives in
+// src/db/discovery-novelty.js — shared with the discovery-over-federation
+// aggregator (api/discovery-federation.js), which runs the exact same
+// caller-side chain over live peer answers instead of fetched snapshots.
 
 import Joi from 'joi';
 import winston from 'winston';
 import * as config from '../state/config.js';
-import * as db from '../db/manager.js';
 import * as discoveryDb from '../db/discovery-db.js';
 import * as peerDbs from '../state/discovery-peer-dbs.js';
+import { localIdentitySets, isNovel } from '../db/discovery-novelty.js';
 import { resolveSeedTrack } from './discovery.js';
 import { joiValidate } from '../util/validation.js';
 import WebError from '../util/web-error.js';
 
-const NEAR_DUP = 0.99;
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
 
@@ -46,37 +41,6 @@ function requireP2p() {
   if (!config.program.discoveryP2p.enabled) {
     throw new WebError('discovery P2P is disabled (config: discoveryP2p.enabled)', 403);
   }
-}
-
-// "The Beatles" / "beatles" / "The  Beatles!" all collide — good enough for
-// an exclusion filter (false positives here just hide a result, never rank
-// a wrong one).
-function norm(s) {
-  return String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
-}
-
-// The local library's identity sets for the novelty filter. Built per
-// request — two indexed scans over a 10k-track library are a few ms, and a
-// live cache would need scanner invalidation hooks for marginal gain.
-function localIdentitySets() {
-  const sets = { mbids: new Set(), artistTitles: new Set(), artists: new Set() };
-  const rows = db.getDB().prepare(`
-    SELECT a.name AS artist, t.title AS title
-    FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id
-  `).all();
-  for (const r of rows) {
-    const artist = norm(r.artist);
-    if (artist) { sets.artists.add(artist); }
-    sets.artistTitles.add(`${artist} ${norm(r.title)}`);
-  }
-  // MBIDs live in discovery.db (populated by tagging/analysis passes).
-  if (discoveryDb.openDiscoveryDbIfExists()) {
-    const mbids = discoveryDb.getDiscoveryDb().prepare(
-      'SELECT recording_mbid FROM discovery_tracks WHERE recording_mbid IS NOT NULL'
-    ).all();
-    for (const r of mbids) { sets.mbids.add(r.recording_mbid); }
-  }
-  return sets;
 }
 
 export function setup(mstream) {
@@ -134,11 +98,12 @@ export function setup(mstream) {
         const off = i * dim;
         for (let k = 0; k < dim; k++) { dot += q[k] * space.matrix[off + k]; }
 
-        if (dot >= NEAR_DUP) { continue; } // same recording, different encode
-        const artist = norm(space.artists[i]);
-        if (space.mbids[i] && exclude.mbids.has(space.mbids[i])) { continue; }
-        if (exclude.artistTitles.has(`${artist} ${norm(space.titles[i])}`)) { continue; }
-        if (newArtistsOnly && artist && exclude.artists.has(artist)) { continue; }
+        if (!isNovel(exclude, {
+          artist: space.artists[i],
+          title: space.titles[i],
+          recordingMbid: space.mbids[i],
+          similarityVsSeed: dot,
+        }, { newArtistsOnly })) { continue; }
 
         results.push({
           artist: space.artists[i],

--- a/src/api/playlist.js
+++ b/src/api/playlist.js
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
+import * as fedDb from '../db/federation.js';
 import * as transcode from './transcode.js';
 import { joiValidate, resolveId } from '../util/validation.js';
 import WebError from '../util/web-error.js';
@@ -41,6 +42,12 @@ export function setup(mstream) {
       // Same contract for the panel's "From the network" section
       // (/api/v1/discovery/p2p/*): no flag, no probes.
       discoveryP2p: config.program.discoveryP2p.enabled === true,
+      // And again for "From your peers" (/api/v1/discovery/federation/*):
+      // needs local embeddings (the seed vector comes from our discovery.db)
+      // plus at least one federated peer that hasn't opted out of discovery.
+      federationDiscovery: config.program.federation.enabled === true
+        && config.program.scanOptions.collectDiscoveryData === true
+        && fedDb.getFederationPeers().some((p) => p.use_discovery === 1),
       vpathMetaData: {}
     };
 

--- a/src/db/discovery-novelty.js
+++ b/src/db/discovery-novelty.js
@@ -1,0 +1,62 @@
+// The novelty filter shared by every "music you DON'T have" surface —
+// /api/v1/discovery/p2p/similar (fetched peer snapshots) and
+// /api/v1/discovery/federation/similar (live queries to federated peers).
+//
+// It always runs on the CALLER's side: only this machine knows what this
+// library holds, and shipping its identity sets to a peer would leak the
+// library wholesale. The filter is a chain because no single identity
+// signal covers every collection:
+//   1. recording MBID match        exact, when both sides are tagged
+//   2. normalized artist+title     the pragmatic fallback
+//   3. near-duplicate similarity   cosine ≥ NEAR_DUP vs the QUERY track —
+//                                  catches untagged re-encodes of it
+// plus opt-in `newArtistsOnly`, which drops every artist the local library
+// already knows — the "introduce me to someone new" mode.
+
+import * as db from './manager.js';
+import * as discoveryDb from './discovery-db.js';
+
+export const NEAR_DUP = 0.99;
+
+// "The Beatles" / "beatles" / "The  Beatles!" all collide — good enough for
+// an exclusion filter (false positives here just hide a result, never rank
+// a wrong one).
+export function norm(s) {
+  return String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// The local library's identity sets. Built per request — two indexed scans
+// over a 10k-track library are a few ms, and a live cache would need
+// scanner invalidation hooks for marginal gain.
+export function localIdentitySets() {
+  const sets = { mbids: new Set(), artistTitles: new Set(), artists: new Set() };
+  const rows = db.getDB().prepare(`
+    SELECT a.name AS artist, t.title AS title
+    FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id
+  `).all();
+  for (const r of rows) {
+    const artist = norm(r.artist);
+    if (artist) { sets.artists.add(artist); }
+    sets.artistTitles.add(`${artist} ${norm(r.title)}`);
+  }
+  // MBIDs live in discovery.db (populated by tagging/analysis passes).
+  if (discoveryDb.openDiscoveryDbIfExists()) {
+    const mbids = discoveryDb.getDiscoveryDb().prepare(
+      'SELECT recording_mbid FROM discovery_tracks WHERE recording_mbid IS NOT NULL'
+    ).all();
+    for (const r of mbids) { sets.mbids.add(r.recording_mbid); }
+  }
+  return sets;
+}
+
+// One candidate through the chain. `similarityVsSeed` is the candidate's
+// cosine vs the QUERY track (however the caller obtained it — a local dot
+// product for p2p, the peer's reported similarity for federation).
+export function isNovel(sets, { artist, title, recordingMbid, similarityVsSeed }, { newArtistsOnly = false } = {}) {
+  if (similarityVsSeed >= NEAR_DUP) { return false; }   // same recording, different encode
+  if (recordingMbid && sets.mbids.has(recordingMbid)) { return false; }
+  const a = norm(artist);
+  if (sets.artistTitles.has(`${a} ${norm(title)}`)) { return false; }
+  if (newArtistsOnly && a && sets.artists.has(a)) { return false; }
+  return true;
+}

--- a/src/db/federation.js
+++ b/src/db/federation.js
@@ -141,6 +141,13 @@ export function updateFederationPeerStatus(id, status) {
   return getDB().prepare('UPDATE federation_peers SET last_status = ? WHERE id = ?').run(status, id).changes > 0;
 }
 
+// The outbound discovery-over-federation opt-out (V58): whether OUR Discover
+// panel may send this peer similarity queries. See api/discovery-federation.js.
+export function setFederationPeerUseDiscovery(id, enabled) {
+  return getDB().prepare('UPDATE federation_peers SET use_discovery = ? WHERE id = ?')
+    .run(enabled ? 1 : 0, id).changes > 0;
+}
+
 export function deleteFederationPeer(id) {
   return getDB().prepare('DELETE FROM federation_peers WHERE id = ?').run(id).changes > 0;
 }

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -56,7 +56,9 @@
 // V57 adds the federation tables — keys this server minted for read-only
 // peers (federation_keys + per-key library grants) and the remote servers
 // this server can read (federation_peers). See SCHEMA_V57.
-export const SCHEMA_VERSION = 57;
+// V58 adds federation_peers.use_discovery — the per-peer opt-out for
+// outbound discovery-over-federation queries. See SCHEMA_V58.
+export const SCHEMA_VERSION = 58;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2188,6 +2190,20 @@ export const SCHEMA_V57 = `
   );
 `;
 
+// ── Discovery over federation (per-peer opt-out) ────────────────────────────
+//
+// use_discovery gates the OUTBOUND direction only: whether this server sends
+// similarity queries (seed-track embedding vectors) to that peer from the
+// Discover panel. Sending a vector tells the peer what you're listening to,
+// so cautious pairings can switch it off per peer. Default ON: pairing
+// already exposes comparable activity (the peer sees every browse and
+// stream request we make against it). The INBOUND direction needs no flag —
+// answering a peer's vector query exposes nothing beyond what the key's
+// library grants already allow it to download outright.
+export const SCHEMA_V58 = `
+  ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
+`;
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -2392,4 +2408,8 @@ export const MIGRATIONS = [
   // V57 adds the federation tables (minted keys + per-key library grants +
   // known peers). Pure new tables — no rescan needed. See SCHEMA_V57.
   { version: 57, sql: SCHEMA_V57 },
+  // V58 adds federation_peers.use_discovery, the per-peer opt-out for
+  // outbound discovery-over-federation queries. Additive column with a
+  // default — no rescan needed. See SCHEMA_V58.
+  { version: 58, sql: SCHEMA_V58 },
 ];

--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,7 @@ import * as downloadApi from './api/download.js';
 import * as adminApi from './api/admin.js';
 import * as irohApi from './api/iroh.js';
 import * as discoveryP2pApi from './api/discovery-p2p.js';
+import * as discoveryFederationApi from './api/discovery-federation.js';
 import * as remoteApi from './api/remote.js';
 import * as sharedApi from './api/shared.js';
 import * as scrobblerApi from './api/scrobbler.js';
@@ -302,6 +303,7 @@ export async function serveIt(configFile) {
   irohApi.setup(mstream);
   discoveryApi.setup(mstream);
   discoveryP2pApi.setup(mstream);
+  discoveryFederationApi.setup(mstream);
   dbApi.setup(mstream);
   searchApi.setup(mstream);
   randomApi.setup(mstream);

--- a/test/integration/federation-discovery-aggregate.test.mjs
+++ b/test/integration/federation-discovery-aggregate.test.mjs
@@ -1,0 +1,236 @@
+/**
+ * Discovery-over-federation, caller side (phase 2), end-to-end over real
+ * iroh: POST /api/v1/discovery/federation/similar.
+ *
+ * Server A (remote peer): federation + discovery ON ('test-fake'), one
+ * 'shared' library whose tracks carry handcrafted 4-d vectors chosen to
+ * exercise every caller-side filter at once:
+ *   'Remote Hit'    by Nova     cos 0.9    → the novel result
+ *   'Be Somebody'   by Icarus   cos 0.8    → artist+title B owns → dropped
+ *   'Brand New Cut' by Vosto    cos 0.7    → novel, but Vosto is a B artist
+ *                                            → dropped under newArtistsOnly
+ *   'Dup Encode'    by Copycat  cos ≈0.999 → near-dup of the seed → dropped
+ *
+ * Server B (caller): federation + discovery ON, default fixture testlib,
+ * its 'Be Somebody' seeded as the query vector's owner. B adds A TWICE
+ * (two minted keys → two peer rows, same endpoint), so the cross-peer
+ * dedupe is proven end-to-end: searched.peers = 2, every song once.
+ *
+ * Also pins: the ping `federationDiscovery` flag contract, the per-peer
+ * use_discovery toggle round-trip, and the federation-disabled 403 (done
+ * LAST — it flips B's live config off).
+ *
+ * Skips when @number0/iroh has no prebuilt binary here (both sides need it).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { startServer } from '../helpers/server.mjs';
+
+let available = true;
+try { await import('@number0/iroh'); } catch { available = false; }
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FFMPEG = process.platform === 'win32'
+  ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
+  : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');
+
+// ── handcrafted vector space (4-d unit vectors; cosines vs SEED are exact) ──
+const vec = (...xs) => {
+  const v = new Float32Array(xs);
+  const n = Math.sqrt(v.reduce((s, x) => s + x * x, 0)) || 1;
+  return v.map((x) => x / n);
+};
+const blob = (v) => Buffer.from(v.buffer, v.byteOffset, v.byteLength);
+
+const SEED = vec(1, 0, 0, 0);                       // B's 'Be Somebody'
+const REMOTE = [
+  // [title, artist, vector, mbid, tags]
+  ['Remote Hit', 'Nova', vec(0.9, 0.436, 0, 0), 'mbid-remote-hit', ['Test---StyleZ']],
+  ['Be Somebody', 'Icarus', vec(0.8, 0.6, 0, 0), null, null],
+  ['Brand New Cut', 'Vosto', vec(0.7, 0.714, 0, 0), null, null],
+  ['Dup Encode', 'Copycat', vec(0.999, 0.0447, 0, 0), null, null],
+];
+
+const SEED_PATH = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
+
+let srvA, srvB, sharedDir;
+const peerIds = [];
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(FFMPEG, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    p.stderr.on('data', (d) => { stderr += d.toString(); });
+    p.on('error', reject);
+    p.on('close', (code) => code === 0 ? resolve() : reject(new Error(`ffmpeg ${code}: ${stderr.slice(-200)}`)));
+  });
+}
+
+// Both servers run PUBLIC mode (no users) — admin routes need no token.
+async function api(srv, method, route, body) {
+  const r = await fetch(`${srv.baseUrl}${route}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+
+const aggregate = (body) => api(srvB, 'POST', '/api/v1/discovery/federation/similar', body);
+
+function seedDiscoveryDb(srv, rows) {
+  const mdb = new DatabaseSync(path.join(srv.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+  const trackByTitle = (title) => mdb.prepare(`
+    SELECT COALESCE(t.audio_hash, t.file_hash) AS hash, a.name AS artist, t.duration
+    FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id WHERE t.title = ?
+  `).get(title);
+  const ddb = new DatabaseSync(path.join(srv.tmpDir, 'db', 'discovery.db'));
+  try {
+    const ins = ddb.prepare(`
+      INSERT INTO discovery_tracks
+        (audio_hash, updated_at, export_id, recording_mbid, artist, title, duration, model_id, model_version, embedding, genre_tags)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 'test-fake', '1', ?, ?)
+    `);
+    let seq = 0;
+    for (const [title, v, mbid, tags] of rows) {
+      const t = trackByTitle(title);
+      assert.ok(t?.hash, `fixture track '${title}' must exist with a hash`);
+      ins.run(t.hash, ++seq, `anon:${title.replace(/\s/g, '')}`, mbid, t.artist, title, t.duration ?? 120,
+        blob(v), tags ? JSON.stringify(tags) : null);
+    }
+    ddb.prepare("UPDATE discovery_meta SET value = ? WHERE key = 'row_seq'").run(String(seq));
+    ddb.prepare("INSERT OR REPLACE INTO discovery_meta (key, value) VALUES ('embedding_model_version', '1')").run();
+  } finally {
+    ddb.close();
+    mdb.close();
+  }
+}
+
+describe('discovery federation aggregate (B queries A over iroh)', { skip: available ? false : 'no @number0/iroh binary for this platform' }, () => {
+  before(async () => {
+    sharedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-fedagg-'));
+    let freq = 400;
+    for (const [title, artist] of REMOTE) {
+      await runFfmpeg([
+        '-nostdin', '-y', '-loglevel', 'error',
+        '-f', 'lavfi', '-i', `sine=frequency=${freq += 55}:duration=2`,
+        '-metadata', `artist=${artist}`, '-metadata', `title=${title}`, '-metadata', `album=${artist} Album`,
+        '-ac', '1', path.join(sharedDir, `${title.replace(/\s/g, '_')}.mp3`),
+      ]);
+    }
+
+    [srvA, srvB] = await Promise.all([
+      startServer({
+        dlnaMode: 'disabled',
+        extraFolders: { shared: sharedDir },
+        extraConfig: {
+          federation: { enabled: true },
+          scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' },
+        },
+      }),
+      startServer({
+        dlnaMode: 'disabled',
+        extraConfig: {
+          federation: { enabled: true },
+          scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' },
+        },
+      }),
+    ]);
+
+    seedDiscoveryDb(srvA, REMOTE.map(([title, , v, mbid, tags]) => [title, v, mbid, tags]));
+    seedDiscoveryDb(srvB, [['Be Somebody', SEED, null, null]]);
+
+    // Two keys on A → two peer rows on B (same endpoint) = the cross-peer
+    // dedupe fixture. Public mode, so minting needs no token.
+    for (const name of ['peer-one', 'peer-two']) {
+      const mint = await api(srvA, 'POST', '/api/v1/admin/federation/keys', { name, vpaths: ['shared'] });
+      assert.equal(mint.status, 200);
+      assert.ok(mint.body.ticket, 'A must issue a ticket (endpoint up)');
+      const added = await api(srvB, 'POST', '/api/v1/admin/federation/peers', { ticket: mint.body.ticket, name });
+      assert.equal(added.status, 200);
+      peerIds.push(added.body.id);
+    }
+  });
+
+  after(async () => {
+    await Promise.all([srvA?.stop(), srvB?.stop()]);
+    fs.rmSync(sharedDir, { recursive: true, force: true });
+  });
+
+  test('ping advertises federationDiscovery while an opted-in peer exists', async () => {
+    const { status, body } = await api(srvB, 'GET', '/api/v1/ping');
+    assert.equal(status, 200);
+    assert.equal(body.federationDiscovery, true);
+    assert.equal(body.discovery, true, 'sanity: local discovery flag rides the same ping');
+  });
+
+  test('aggregates, novelty-filters, and dedupes across both peer rows', async () => {
+    const { status, body } = await aggregate({ filePath: SEED_PATH });
+    assert.equal(status, 200);
+    assert.deepEqual(body.query, { filePath: SEED_PATH, modelId: 'test-fake', newArtistsOnly: false });
+    assert.deepEqual(body.searched, { peers: 2, unreachable: 0, mismatched: 0 });
+
+    const titles = body.results.map((r) => r.title);
+    assert.deepEqual(titles, ['Remote Hit', 'Brand New Cut'],
+      'descending cosine; owned artist+title and the near-dup are gone; two peers, each song once');
+
+    const hit = body.results[0];
+    assert.ok(Math.abs(hit.similarity - 0.9) < 1e-3);
+    assert.equal(hit.artist, 'Nova');
+    assert.equal(hit.recordingMbid, 'mbid-remote-hit');
+    assert.deepEqual(hit.genreTags, ['Test---StyleZ']);
+    assert.ok(hit.filepath.startsWith('shared/'), 'the peer-side vpath path rides along for the future stream proxy');
+    assert.ok(peerIds.includes(hit.peer.id), 'results carry which peer answered');
+    assert.ok(Math.abs(body.results[1].similarity - 0.7) < 2e-3);
+  });
+
+  test('newArtistsOnly also drops known-artist tracks', async () => {
+    const { body } = await aggregate({ filePath: SEED_PATH, newArtistsOnly: true });
+    assert.deepEqual(body.results.map((r) => r.title), ['Remote Hit'],
+      "Vosto is a testlib artist B already knows; Nova isn't");
+  });
+
+  test('limit caps the merged ranking', async () => {
+    const { body } = await aggregate({ filePath: SEED_PATH, limit: 1 });
+    assert.deepEqual(body.results.map((r) => r.title), ['Remote Hit']);
+  });
+
+  test('use_discovery toggle round-trips: off → skipped + flag drops, on → back', async () => {
+    for (const id of peerIds) {
+      const r = await api(srvB, 'POST', `/api/v1/admin/federation/peers/${id}/discovery`, { enabled: false });
+      assert.equal(r.status, 200);
+      assert.equal(r.body.use_discovery, 0);
+    }
+    const off = await aggregate({ filePath: SEED_PATH });
+    assert.deepEqual(off.body.searched, { peers: 0, unreachable: 0, mismatched: 0 });
+    assert.deepEqual(off.body.results, []);
+    assert.equal((await api(srvB, 'GET', '/api/v1/ping')).body.federationDiscovery, false,
+      'every peer opted out → the panel gets no flag, sends no probes');
+
+    const back = await api(srvB, 'POST', `/api/v1/admin/federation/peers/${peerIds[0]}/discovery`, { enabled: true });
+    assert.equal(back.body.use_discovery, 1);
+    const on = await aggregate({ filePath: SEED_PATH });
+    assert.deepEqual(on.body.searched, { peers: 1, unreachable: 0, mismatched: 0 });
+    assert.deepEqual(on.body.results.map((r) => r.title), ['Remote Hit', 'Brand New Cut']);
+  });
+
+  test('unknown peer id on the toggle is 404', async () => {
+    assert.equal((await api(srvB, 'POST', '/api/v1/admin/federation/peers/424242/discovery', { enabled: true })).status, 404);
+  });
+
+  // LAST — flips B's live federation config off.
+  test('federation disabled → 403 before any seed resolution', async () => {
+    const off = await api(srvB, 'POST', '/api/v1/admin/federation', { enabled: false });
+    assert.equal(off.status, 200);
+    const r = await aggregate({ filePath: SEED_PATH });
+    assert.equal(r.status, 403);
+  });
+});

--- a/test/unit/discovery-novelty.test.mjs
+++ b/test/unit/discovery-novelty.test.mjs
@@ -1,0 +1,58 @@
+/**
+ * The shared caller-side novelty chain (src/db/discovery-novelty.js) —
+ * pure logic, no DB. localIdentitySets() (which reads the DBs) is covered
+ * end-to-end by the p2p and federation integration suites; here we pin the
+ * chain's decisions against handcrafted identity sets.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { norm, isNovel, NEAR_DUP } from '../../src/db/discovery-novelty.js';
+
+describe('norm', () => {
+  test('case, punctuation, and whitespace collide; null-ish → empty', () => {
+    assert.equal(norm('The  Beatles!'), 'thebeatles');
+    assert.equal(norm('the beatles'), 'thebeatles');
+    assert.equal(norm('Röyksopp'), 'ryksopp', 'non-ascii letters are stripped, consistently for both sides');
+    assert.equal(norm(null), '');
+    assert.equal(norm(undefined), '');
+  });
+});
+
+describe('isNovel', () => {
+  const sets = {
+    mbids: new Set(['mbid-owned']),
+    artistTitles: new Set([`${norm('Icarus')} ${norm('Be Somebody')}`]),
+    artists: new Set([norm('Icarus')]),
+  };
+  const candidate = (over = {}) => ({
+    artist: 'Nova', title: 'Fresh Track', recordingMbid: null, similarityVsSeed: 0.9, ...over,
+  });
+
+  test('a genuinely new track passes', () => {
+    assert.equal(isNovel(sets, candidate()), true);
+  });
+
+  test('near-duplicate of the seed is dropped, boundary inclusive', () => {
+    assert.equal(isNovel(sets, candidate({ similarityVsSeed: NEAR_DUP })), false);
+    assert.equal(isNovel(sets, candidate({ similarityVsSeed: 0.9899 })), true);
+  });
+
+  test('owned recording MBID is dropped', () => {
+    assert.equal(isNovel(sets, candidate({ recordingMbid: 'mbid-owned' })), false);
+    assert.equal(isNovel(sets, candidate({ recordingMbid: 'mbid-unknown' })), true);
+  });
+
+  test('owned artist+title is dropped, however it is spelled', () => {
+    assert.equal(isNovel(sets, candidate({ artist: 'ICARUS!', title: 'be somebody' })), false);
+    assert.equal(isNovel(sets, candidate({ artist: 'Icarus', title: 'Different Song' })), true,
+      'same artist alone is fine without newArtistsOnly');
+  });
+
+  test('newArtistsOnly drops every known artist but keeps unknown-artist rows', () => {
+    assert.equal(isNovel(sets, candidate({ artist: 'Icarus', title: 'Different Song' }), { newArtistsOnly: true }), false);
+    assert.equal(isNovel(sets, candidate(), { newArtistsOnly: true }), true);
+    assert.equal(isNovel(sets, candidate({ artist: null, title: 'Anon Track' }), { newArtistsOnly: true }), true,
+      'empty artist never matches the known-artist set');
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -3275,6 +3275,21 @@ const federationView = Vue.component('federation-view', {
       }
       this.setRowPending(peer.id, false);
     },
+    async toggleDiscovery(peer) {
+      this.setRowPending(peer.id, true);
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/federation/peers/${peer.id}/discovery`,
+          data: { enabled: peer.use_discovery !== 1 },
+        });
+      } catch (e) {
+        iziToast.error({ title: 'Error', message: 'Failed to update the peer.' });
+      }
+      // Refresh either way so the checkbox always mirrors the server's truth.
+      await ADMINDATA.getFederationPeers();
+      this.setRowPending(peer.id, false);
+    },
     statusDot(peer) {
       if (peer.last_status === 'ok') { return '#2e7d32'; }
       if (peer.last_status) { return '#c62828'; }
@@ -3352,13 +3367,19 @@ const federationView = Vue.component('federation-view', {
             <div class="card-content">
               <span class="card-title">Peers — Servers You Can Read</span>
               <table v-if="peers.list.length > 0" class="striped">
-                <thead><tr><th></th><th>Name</th><th>Status</th><th>Last seen</th><th style="width:200px"></th></tr></thead>
+                <thead><tr><th></th><th>Name</th><th>Status</th><th>Last seen</th><th>Discovery</th><th style="width:200px"></th></tr></thead>
                 <tbody>
                   <tr v-for="p in peers.list" :key="p.id">
                     <td><span :style="{color: statusDot(p)}" style="font-size:1.4em">●</span></td>
                     <td>{{ p.name }}</td>
                     <td style="font-size:0.85em">{{ p.last_status || 'never tested' }}</td>
                     <td>{{ fmtDate(p.last_seen) }}</td>
+                    <td>
+                      <label title="Let the Discover panel ask this peer for similar music. Queries reveal what you're listening to — to this peer only.">
+                        <input type="checkbox" :checked="p.use_discovery === 1" :disabled="rowPending[p.id]" v-on:change="toggleDiscovery(p)"/>
+                        <span></span>
+                      </label>
+                    </td>
                     <td class="right-align">
                       <a class="btn-flat btn-small waves-effect" :class="{disabled: rowPending[p.id]}" v-on:click="testPeer(p)">Test</a>
                       <a class="btn-small red lighten-1 waves-effect" :class="{disabled: rowPending[p.id]}" v-on:click="removePeer(p)">Remove</a>


### PR DESCRIPTION
Stacked on #739 (the phase-1 re-land; base is `feat/federation-discovery-endpoint`). **Merge #739 into master first, then retarget/merge this one** — bottom-up, deleting each branch at merge time, so nothing strands like #738 did.

Phase 2 of discovery-over-federation (plan: `~/.claude/plans/federation-discovery-bridge.md`): the **caller side**. With phase 1 a server can *answer* vector queries; with this one it can *ask* — the Discover panel's data source for "From your peers" (phase 3) is now live at the API level.

## What's new

**`POST /api/v1/discovery/federation/similar`** (local users; NOT on the federation-key allowlist — no relay loops)
- Resolves the local seed track (same uniform-404 path as the local/p2p routes), pulls its embedding from discovery.db, and fans the raw vector out to every opted-in peer via `fedFetch` — `Promise.allSettled`, 4s per-peer timeout, 3× limit headroom.
- Merge is caller-side: the novelty chain, then **cross-peer dedupe** (recording MBID + normalized artist+title keys, highest similarity wins), sort, cap. `searched: {peers, unreachable, mismatched}` gives the panel honest empty states.
- Results carry `peer: {id, name}` and the peer's vpath `filepath` — provenance today, the stream-proxy handle in phase 4.

**`src/db/discovery-novelty.js`** — the MBID → artist+title → near-dup → newArtistsOnly chain extracted from the p2p route and shared verbatim by both callers (p2p behavior unchanged; its suite is green).

**V58 + per-peer toggle** — `federation_peers.use_discovery` (default **ON**: pairing already exposes every browse/stream to the peer; the toggle is the opt-out for cautious pairings — outbound only, inbound is governed by key grants). Admin route `POST /peers/:id/discovery`, peers-card checkbox with an honest tooltip, openapi for both.

**ping `federationDiscovery` flag** — true only when federation is on, local embeddings exist, and ≥1 peer is opted in. Same no-flag-no-probes contract as `discovery`/`discoveryP2p`.

## Tests

- New `federation-discovery-aggregate.test.mjs` — **two real spawned servers over iroh** (skip-guarded like the dial suite). B adds A *twice* (two minted keys, same endpoint), so cross-peer dedupe is proven end-to-end: `searched.peers = 2`, each song once. Vectors are handcrafted so one query exercises every filter simultaneously (novel hit kept at cos 0.9, owned artist+title dropped, near-dup 0.999 dropped, known-artist dropped only under `newArtistsOnly`). Also pins the ping flag contract, the toggle round-trip (off → skipped + flag drops → back on), toggle 404, and federation-disabled 403.
- New `discovery-novelty.test.mjs` — the pure chain against handcrafted identity sets (boundary-inclusive near-dup, null-artist handling, spelling collisions).
- Reruns green: discovery-p2p 42/42 (refactored route), federation-e2e 11/11 on the V58 schema, phase-1 suite 8/8, schema-chain tests self-heal (fresh chain lands on `SCHEMA_VERSION = 58`).
- Lint clean (the `server.js` no-empty is pre-existing tree debt); redocly: spec valid.

Note: the peers-card checkbox is exercised through its route by the e2e; I didn't click-test the Vue template itself (it clones the adjacent Test/Remove row patterns). Open question resolved by default: `use_discovery` defaults ON per the plan's recommendation — flip the default in V58 if you'd rather ship opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)