### PR TITLE
test: deflake sonic pool coverage + heavy-boot readiness timeout

### DIFF
--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -31,10 +31,17 @@ function findFreePort() {
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
-async function waitForReady(baseUrl, timeoutMs = 30_000) {
+// The timeout is a ceiling, not a wait: healthy boots return as soon as the
+// API answers, and a crashed boot bails immediately via getExitError. 90s
+// because heavy discovery suites (onnxruntime + iroh sidecar init) have blown
+// a 30s budget on loaded windows-latest CI runners ("server not ready within
+// 30000ms: fetch failed"), taking every test in the file down with them.
+async function waitForReady(baseUrl, { timeoutMs = 90_000, getExitError = () => null } = {}) {
   const start = Date.now();
   let lastErr;
   while (Date.now() - start < timeoutMs) {
+    const exitErr = getExitError();
+    if (exitErr) { throw new Error(exitErr); }
     try {
       const r = await fetch(`${baseUrl}/api/`);
       if (r.status < 500) { return; }
@@ -44,7 +51,9 @@ async function waitForReady(baseUrl, timeoutMs = 30_000) {
   throw new Error(`server not ready within ${timeoutMs}ms: ${lastErr?.message || 'unknown'}`);
 }
 
-async function waitForScanComplete(baseUrl, timeoutMs = 30_000) {
+// Same loaded-CI-runner ceiling as waitForReady — the scan (plus the
+// embedding pass some discovery suites run behind it) shares the risk.
+async function waitForScanComplete(baseUrl, timeoutMs = 90_000) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -56,7 +65,7 @@ async function waitForScanComplete(baseUrl, timeoutMs = 30_000) {
     } catch { /* retry */ }
     await sleep(50);
   }
-  throw new Error('initial scan did not complete within timeout');
+  throw new Error(`initial scan did not complete within ${timeoutMs}ms`);
 }
 
 /**
@@ -217,7 +226,7 @@ export async function startServer(opts = {}) {
   });
 
   try {
-    await waitForReady(baseUrl);
+    await waitForReady(baseUrl, { getExitError: () => exitedEarly });
   } catch (err) {
     try { proc.kill('SIGKILL'); } catch { /* already gone */ }
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});

--- a/test/integration/random-sonic.test.mjs
+++ b/test/integration/random-sonic.test.mjs
@@ -92,7 +92,14 @@ async function pick(body, user = 'admin') {
 }
 
 // Repeated picks — the route returns ONE random song per call, so pool
-// membership is asserted over many draws.
+// membership/coverage is asserted over many draws. Draws are independent:
+// the server trims a fed-back ignoreList to ≤ half the pool size
+// (pickRandomNonIgnored in src/api/random.js), so exclusion can't
+// deterministically drain a pool. Full-coverage draw counts are therefore
+// sized so a miss is astronomically unlikely —
+//   P(miss) ≤ poolSize · ((poolSize-1)/poolSize)^draws
+// ≈ 2e-11 for 64 draws over a 3-pool, ≈ 2e-12 for 40 over a 2-pool.
+// (24 draws over a 3-pool was ~2e-4 — it flaked on CI.)
 async function pickTitles(body, n, user = 'admin') {
   const titles = new Set();
   for (let i = 0; i < n; i++) {
@@ -209,7 +216,7 @@ describe('sonic threshold pool', () => {
     // minSimilarity 0.85 → pool = {Rise 0.95, Lib2 Song 0.9}; the seed's own
     // cos of 1.0 is in range but seeds are excluded by contract.
     const body = { similarTo: [SEED_PATH], minSimilarity: 0.85 };
-    const titles = await pickTitles(body, 16);
+    const titles = await pickTitles(body, 40);
     assert.deepEqual([...titles].sort(), ['Lib2 Song', 'Rise']);
 
     const { body: one } = await pick(body);
@@ -222,8 +229,16 @@ describe('sonic threshold pool', () => {
 
   test('lower threshold widens the pool', async () => {
     // 0.75 additionally admits Highway (cos 0.8); Neon (0.5) and every
-    // un-embedded track stay out.
-    const titles = await pickTitles({ similarTo: [SEED_PATH], minSimilarity: 0.75 }, 24);
+    // un-embedded track stay out. poolSize pins the boundary exactly and
+    // deterministically — a leak (Neon or an un-embedded track in range)
+    // or a missing member would change the count — and the draws then pin
+    // WHICH three tracks the pool holds.
+    const body = { similarTo: [SEED_PATH], minSimilarity: 0.75 };
+    const { status, body: probe } = await pick(body);
+    assert.equal(status, 200);
+    assert.equal(probe.sonic.poolSize, 3,
+      'exactly Rise/Lib2 Song/Highway — Neon (0.5) and un-embedded tracks stay out');
+    const titles = await pickTitles(body, 64);
     assert.deepEqual([...titles].sort(), ['Highway', 'Lib2 Song', 'Rise']);
   });
 
@@ -303,7 +318,7 @@ describe('multi-seed centroid', () => {
     assert.equal(single.status, 400, 'single seed at 0.97 has an empty pool');
 
     const body = { similarTo: [SEED_PATH, NEON_PATH], minSimilarity: 0.97 };
-    const titles = await pickTitles(body, 24);
+    const titles = await pickTitles(body, 64);
     assert.deepEqual([...titles].sort(), ['Highway', 'Lib2 Song', 'Rise'],
       'both seeds excluded, centroid-reachable tracks included');
 


### PR DESCRIPTION
Two pre-existing tests have flaked on `full-ci` runs of unrelated backup PRs and blocked merges. Both fixes are test-only; no product code changes.

## 1. `random-sonic` — coverage-by-luck over a 3-track pool

`sonic threshold pool › lower threshold widens the pool` asserted that all 3 pool titles appear in **24 independent random draws** — a ~2×10⁻⁴ miss probability, which hit on PR #740 (ubuntu shard 3/3, run 29139599930: 'Rise' never drawn).

The `ignoreList`-drain approach doesn't work here: the server trims a fed-back ignore list to ≤ half the pool size (`pickRandomNonIgnored` in `src/api/random.js`), so exclusion can never deterministically exhaust a 3-track pool. Instead:

- **New deterministic boundary assertion**: `sonic.poolSize === 3` on the first request — fails immediately if Neon (cos 0.5) or any un-embedded track leaks into the range, or if a pool member drops out. The Neon/un-embedded "stay OUT" checks no longer depend on random draws at all.
- **Coverage draws re-sized**: 24 → 64 draws (miss ≈ 2×10⁻¹¹). Sibling tests with the same weakness also hardened: `picks only land inside the pool` 16 → 40 draws over its 2-pool (≈ 2×10⁻¹²), multi-seed centroid 24 → 64.

No assertion was weakened — every exact-set `deepEqual`, the seed-exclusion contract, and the existing poolSize/cosine checks survive or got stronger.

## 2. `discovery-p2p` — 30s readiness budget vs heavy boots

On windows-latest shard 1/3 (PR #728, run 29112856667) the suite died with `server not ready within 30000ms: fetch failed` — onnxruntime + iroh sidecar init intermittently exceed 30s on loaded runners, taking ~10 tests down with one slow boot.

- `waitForReady` / `waitForScanComplete` ceilings raised 30s → 90s in `test/helpers/server.mjs`. These are poll ceilings, not waits: healthy boots return the moment the API answers, so local runs are unaffected.
- `waitForReady` now bails immediately when the child process has already exited — genuinely crashed boots fail *faster* than before instead of burning the full window.

## Verification

- `npx eslint` clean on both files.
- Stability loops: **25/25** runs of `random-sonic.test.mjs` and **20/20** runs of `discovery-p2p.test.mjs` (36 tests/run, all sidecar suites executing, none skipped) pass locally on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)