### PR TITLE
fix(backup): NFC/NFD matched-pair convergence (audit #6 — last open finding)

### DIFF
--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -979,10 +979,65 @@ async function syncSrcEntry(srcEntry, srcDir, destDir, relPath) {
   emitProgress();
 }
 
-// Both source and dest have an entry with the same name. Decide what to do.
+// One stderr notice per run when a Unicode-normalization convergence
+// rename fails (see convergeDestName) — the run still operates
+// correctly through the dest's existing bytes, so this is log-only.
+let nfdRenameNoticed = false;
+function noteNfdRenameFailure(p, err) {
+  if (nfdRenameNoticed) { return; }
+  nfdRenameNoticed = true;
+  process.stderr.write(`Warning: could not converge Unicode-normalization variant name ${p}: ${err.message}; operating via the existing name\n`);
+}
+
+// A matched pair whose names are byte-DIFFERENT differs purely in
+// Unicode normalization: toKey folds nothing but NFC, so case-different
+// names never pair (the deliberate case-insensitive-dest fold in the
+// two-phase walk is untouched by this). Converge the dest entry to the
+// source's bytes with a cheap same-directory rename and return the dest
+// path all subsequent operations should use.
+//
+// Why converge instead of just reading through srcEntry.name (the old
+// behaviour): on normalization-SENSITIVE filesystems (ext4, NTFS) the
+// source-bytes path simply doesn't exist when the dest was written in
+// NFD (rsync from a Mac is the classic source) — the stat was ENOENT,
+// the file was recopied in full under the NFC name, the NFD original
+// was never trashed, and later runs paired the equal sort keys in
+// arbitrary order, churning trash+recopy forever (audit finding #6).
+//
+// The true-sibling guard: if the source-bytes name already exists as a
+// DIFFERENT file (same-key duplicates from pre-fix churn are trashed by
+// phase 1 before matched pairs run, so this is a mid-run-creation
+// edge), never clobber it — operate through the dest's own bytes this
+// run. Same-inode "existence" (APFS resolves both spellings to one
+// file) proceeds with the rename, which just rewrites the stored
+// bytes. HFS+ re-normalizes on store, making the rename a harmless
+// per-run no-op. Rename failure falls back to the dest's own bytes:
+// correct mirror, just not yet converged.
+async function convergeDestName(destDir, destEntry, srcName) {
+  const destActual = path.join(destDir, destEntry.name);
+  if (destEntry.name === srcName) { return destActual; }
+  const destWanted = path.join(destDir, srcName);
+  try {
+    const [a, b] = await Promise.all([fs.stat(destActual), fs.stat(destWanted)]);
+    if (a.ino !== b.ino || a.dev !== b.dev) { return destActual; }   // true sibling — don't clobber
+  } catch (_) { /* destWanted missing — free to rename */ }
+  try {
+    await fs.rename(destActual, destWanted);
+    return destWanted;
+  } catch (err) {
+    noteNfdRenameFailure(destActual, err);
+    return destActual;
+  }
+}
+
+// Both source and dest have an entry with the same key. Decide what to do.
 async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
   const srcChild = path.join(srcDir, srcEntry.name);
-  const destChild = path.join(destDir, srcEntry.name);
+  // Byte-accurate dest path for the early branches that act on the
+  // EXISTING dest entry (link removal, type-mismatch trash) — built
+  // from destEntry.name, not srcEntry.name, so an NFD-named entry on a
+  // normalization-sensitive dest is actually reachable.
+  const destActual = path.join(destDir, destEntry.name);
   const childRel = relPath ? path.join(relPath, srcEntry.name) : srcEntry.name;
 
   let srcStat;
@@ -1013,10 +1068,10 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
   // copy of the file.
   if (destEntry.isSymbolicLink()) {
     try {
-      await removeDestLink(destChild);
+      await removeDestLink(destActual);
       counts.filesTrashed++;
     } catch (err) {
-      recordFileError(`remove link ${destChild}: ${err.message}`);
+      recordFileError(`remove link ${destActual}: ${err.message}`);
       return;
     }
     await syncSrcEntry(srcEntry, srcDir, destDir, relPath);
@@ -1035,6 +1090,11 @@ async function syncMatchedPair(srcEntry, destEntry, srcDir, destDir, relPath) {
     await syncSrcEntry(srcEntry, srcDir, destDir, relPath);
     return;
   }
+
+  // From here on the dest entry survives as this pair's mirror —
+  // converge its name to the source's bytes (no-op when they already
+  // match) and use whichever path convergeDestName settled on.
+  const destChild = await convergeDestName(destDir, destEntry, srcEntry.name);
 
   if (srcIsDir) {
     // A skipped alias/cycle leaves the existing dest dir exactly as-is

--- a/src/backup/worker.mjs
+++ b/src/backup/worker.mjs
@@ -893,8 +893,37 @@ async function syncDir(srcDir, destDir, relPath) {
       destOnly.push(d.entry);
       j++;
     } else {
-      matched.push([s.entry, d.entry]);
-      i++; j++;
+      // Equal keys — gather the FULL run on both sides before pairing.
+      // Runs are length 1 except when Unicode-normalization variants
+      // coexist as distinct entries (possible on ext4/NTFS). Pair
+      // byte-EQUAL names first, then remaining entries positionally:
+      // purely positional pairing depended on readdir order agreeing
+      // between the two directories, and ext4's per-dir hash seeds make
+      // it legally differ — cross-pairing (src-NFC with dest-NFD and
+      // vice versa) then routed each source's compare/copy through the
+      // OTHER variant's dest name and silently swapped the two files'
+      // contents on the mirror. Byte-preference also makes the
+      // duplicate-cleanup order deterministic: a source spelling always
+      // claims its byte-identical dest twin, and only true leftovers
+      // become convergence renames (src surplus) or orphans (dest
+      // surplus, trashed in phase 1 below).
+      const key = s.key;
+      const srcRun = [];
+      const destRun = [];
+      while (i < srcSorted.length && srcSorted[i].key === key) { srcRun.push(srcSorted[i].entry); i++; }
+      while (j < destSorted.length && destSorted[j].key === key) { destRun.push(destSorted[j].entry); j++; }
+      const destLeft = destRun.slice();
+      const srcLeft = [];
+      for (const se of srcRun) {
+        const ix = destLeft.findIndex((de) => de.name === se.name);
+        if (ix !== -1) { matched.push([se, destLeft[ix]]); destLeft.splice(ix, 1); }
+        else { srcLeft.push(se); }
+      }
+      for (const se of srcLeft) {
+        if (destLeft.length > 0) { matched.push([se, destLeft.shift()]); }
+        else { srcOnly.push(se); }
+      }
+      destOnly.push(...destLeft);
     }
   }
 
@@ -1005,14 +1034,18 @@ function noteNfdRenameFailure(p, err) {
 // arbitrary order, churning trash+recopy forever (audit finding #6).
 //
 // The true-sibling guard: if the source-bytes name already exists as a
-// DIFFERENT file (same-key duplicates from pre-fix churn are trashed by
-// phase 1 before matched pairs run, so this is a mid-run-creation
-// edge), never clobber it — operate through the dest's own bytes this
-// run. Same-inode "existence" (APFS resolves both spellings to one
-// file) proceeds with the rename, which just rewrites the stored
-// bytes. HFS+ re-normalizes on store, making the rename a harmless
-// per-run no-op. Rename failure falls back to the dest's own bytes:
-// correct mirror, just not yet converged.
+// DIFFERENT file, never clobber it — operate through the dest's own
+// bytes this run. With byte-preferring pairing in syncDir (a source
+// spelling always claims its byte-identical dest twin, and same-key
+// dest surplus is trashed in phase 1 before matched pairs run), no
+// snapshot layout can put a live foreign file at destWanted — this
+// guard survives purely as belt-and-braces for files created mid-run,
+// which also makes it unfalsifiable by fixture-based tests. Same-inode
+// "existence" (APFS resolves both spellings to one file) proceeds with
+// the rename, which just rewrites the stored bytes. HFS+ re-normalizes
+// on store, making the rename a harmless per-run no-op. Rename failure
+// falls back to the dest's own bytes: correct mirror, just not yet
+// converged.
 async function convergeDestName(destDir, destEntry, srcName) {
   const destActual = path.join(destDir, destEntry.name);
   if (destEntry.name === srcName) { return destActual; }

--- a/test/fixtures/reverse-readdir.cjs
+++ b/test/fixtures/reverse-readdir.cjs
@@ -1,0 +1,25 @@
+// Fault-injection preload for backup-worker tests. Reverses the results
+// of fs.promises.readdir for any path under REVERSE_READDIR_DIR —
+// simulating a destination filesystem whose enumeration order differs
+// from the source's (legal and real: ext4 orders readdir by per-
+// directory hash seeds, so two directories with identical names can
+// enumerate in different orders; NTFS is upcase-ordinal and always
+// agrees, which is why this shim is needed to exercise order-divergence
+// on the CI hosts at all). The CJS `fs.promises` object is the same
+// object `import fs from 'fs/promises'` resolves to, so the patch is
+// visible to the worker's ESM imports.
+const fs = require('fs');
+const path = require('path');
+
+const target = process.env.REVERSE_READDIR_DIR
+  ? path.resolve(process.env.REVERSE_READDIR_DIR)
+  : null;
+
+const orig = fs.promises.readdir;
+fs.promises.readdir = async function patchedReaddir(p, opts) {
+  const res = await orig.call(this, p, opts);
+  if (target && path.resolve(String(p)).startsWith(target)) {
+    return res.slice().reverse();
+  }
+  return res;
+};

--- a/test/integration/backup-nfd.test.mjs
+++ b/test/integration/backup-nfd.test.mjs
@@ -1,0 +1,202 @@
+/**
+ * Unicode-normalization pairing (audit finding #6 — the last open one).
+ *
+ * The merge-walk pairs entries by NFC key, but historically built every
+ * dest-side path from srcEntry.name. A dest written in NFD (rsync from a
+ * Mac is the classic source) on a normalization-SENSITIVE filesystem
+ * (ext4, NTFS) therefore stat'd ENOENT: the file was recopied in full
+ * under the NFC name, the NFD original was never trashed, and later
+ * runs paired the equal sort keys in arbitrary order — trash+recopy
+ * churn forever.
+ *
+ * The fix (convergeDestName): matched pairs with byte-different names
+ * operate through the dest's ACTUAL bytes and converge to the source's
+ * bytes with a cheap same-directory rename. These tests pin: no recopy,
+ * name convergence (file + directory subtree), churn-state cleanup, and
+ * two-run idempotence.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const WORKER = path.join(REPO_ROOT, 'src', 'backup', 'worker.mjs');
+
+// 'café.mp3' in composed and decomposed spellings — byte-different,
+// same NFC key. Guard the fixture itself so a source-file normalization
+// mishap can't silently turn these tests into name-equal no-ops.
+const NFC_NAME = 'café.mp3';
+const NFD_NAME = 'café.mp3';
+assert.notEqual(NFC_NAME, NFD_NAME);
+assert.equal(NFD_NAME.normalize('NFC'), NFC_NAME);
+
+const NFC_DIR = 'Béla Fleck';
+const NFD_DIR = 'Béla Fleck';
+
+let envCounter = 0;
+function makeTempRoot(tag) {
+  const rand = crypto.randomBytes(4).toString('hex');
+  const root = path.join(os.tmpdir(), `mstream-nfd-${tag}-${rand}-` + (envCounter++));
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function runWorker(payload) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WORKER, JSON.stringify(payload)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const events = out.split(/\r?\n/).filter(Boolean).map((l) => {
+        try { return JSON.parse(l); } catch (_) { return null; }
+      }).filter(Boolean);
+      resolve({ code, events });
+    });
+  });
+}
+const doneEvent = (events) => events.find((e) => e.event === 'done') || null;
+// Byte-exact directory listing (readdir returns stored bytes on ext4/
+// NTFS/APFS alike), excluding bookkeeping + trash.
+const liveNames = (dir) => fs.readdirSync(dir)
+  .filter((n) => n !== '.mstream-trash' && !n.startsWith('.mstream-tmp-') && !n.startsWith('.mstream-partial-'))
+  .sort();
+
+// Seed src/<name> and dest/<destName> with identical content and equal
+// mtimes (backdated past tolerance) — the "rsync'd from a Mac" state.
+function seedPair(root, srcName, destName, content) {
+  const src = path.join(root, 'src');
+  const dest = path.join(root, 'dest');
+  fs.mkdirSync(src, { recursive: true });
+  fs.mkdirSync(dest, { recursive: true });
+  const past = new Date(Date.now() - 90_000);
+  fs.writeFileSync(path.join(src, srcName), content);
+  fs.utimesSync(path.join(src, srcName), past, past);
+  fs.writeFileSync(path.join(dest, destName), content);
+  fs.utimesSync(path.join(dest, destName), past, past);
+  return { src, dest };
+}
+
+describe('NFD/NFC matched-pair convergence', () => {
+  test('NFD-named dest file: no recopy, name converges to source bytes, nothing trashed', async () => {
+    const root = makeTempRoot('file');
+    try {
+      const { src, dest } = seedPair(root, NFC_NAME, NFD_NAME, 'same-content');
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+      const done = doneEvent(first.events);
+      assert.equal(done.filesCopied, 0, 'identical content behind a normalization variant must NOT recopy');
+      assert.equal(done.filesUnchanged, 1);
+      assert.equal(done.filesTrashed, 0, 'the NFD original is this pair\'s mirror, not an orphan');
+      assert.equal(done.fileErrors, 0);
+      assert.deepEqual(liveNames(dest), [NFC_NAME],
+        'dest name must converge to the source\'s bytes (byte-exact readdir compare)');
+      assert.ok(!fs.existsSync(path.join(dest, '.mstream-trash')), 'no trash bucket for a pure rename');
+
+      const second = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      const done2 = doneEvent(second.events);
+      assert.equal(done2.filesCopied, 0);
+      assert.equal(done2.filesTrashed, 0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('NFD-named dest directory: subtree converges without copying', async () => {
+    const root = makeTempRoot('dir');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      const past = new Date(Date.now() - 90_000);
+      fs.mkdirSync(path.join(src, NFC_DIR), { recursive: true });
+      fs.mkdirSync(path.join(dest, NFD_DIR), { recursive: true });
+      // The child is itself NFD-named on dest — convergence must recurse.
+      fs.writeFileSync(path.join(src, NFC_DIR, NFC_NAME), 'track-content');
+      fs.utimesSync(path.join(src, NFC_DIR, NFC_NAME), past, past);
+      fs.writeFileSync(path.join(dest, NFD_DIR, NFD_NAME), 'track-content');
+      fs.utimesSync(path.join(dest, NFD_DIR, NFD_NAME), past, past);
+
+      const { code, events } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(code, 0);
+      const done = doneEvent(events);
+      assert.equal(done.filesCopied, 0, 'a matched dir tree must converge by rename, not recopy');
+      assert.equal(done.filesTrashed, 0);
+      assert.equal(done.fileErrors, 0);
+      assert.deepEqual(liveNames(dest), [NFC_DIR], 'directory name converged');
+      assert.deepEqual(liveNames(path.join(dest, NFC_DIR)), [NFC_NAME], 'child name converged');
+      assert.equal(fs.readFileSync(path.join(dest, NFC_DIR, NFC_NAME), 'utf8'), 'track-content');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('pre-fix churn state (both variants on dest) converges and stays converged', { skip: process.platform === 'darwin' ? 'APFS resolves both spellings to one file — the dual-entry state cannot exist' : false }, async () => {
+    const root = makeTempRoot('churn');
+    try {
+      // The state pre-fix runs left behind: the NFC copy (fresh, matches
+      // source) AND the NFD original (stale content) side by side.
+      const { src, dest } = seedPair(root, NFC_NAME, NFC_NAME, 'fresh-content');
+      fs.writeFileSync(path.join(dest, NFD_NAME), 'stale-old-content-longer');
+      assert.equal(liveNames(dest).length, 2, 'fixture must start with both spellings');
+
+      const first = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(first.code, 0);
+      assert.equal(doneEvent(first.events).fileErrors, 0);
+      assert.deepEqual(liveNames(dest), [NFC_NAME], 'exactly one converged entry survives');
+      assert.equal(fs.readFileSync(path.join(dest, NFC_NAME), 'utf8'), 'fresh-content',
+        'the surviving copy carries the source content');
+      // Whichever variant lost the pairing went through the deletion log.
+      const buckets = fs.readdirSync(path.join(dest, '.mstream-trash'));
+      assert.equal(buckets.length, 1, 'the duplicate was trashed, not silently unlinked');
+
+      const second = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      const done2 = doneEvent(second.events);
+      assert.equal(done2.filesCopied, 0, 'converged state must be stable — no churn');
+      assert.equal(done2.filesTrashed, 0);
+      assert.equal(done2.filesUnchanged, 1);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a genuine byte-exact sibling next to the variant is never clobbered by the convergence rename', async () => {
+    const root = makeTempRoot('sibling');
+    try {
+      // Adversarial layout: dest holds an NFD variant AND a distinct
+      // NFC-named file that is NOT in the dest readdir snapshot's
+      // matched set... simulate the mid-run-creation edge by pre-seeding
+      // both where the NFC one has DIFFERENT content and a DIFFERENT
+      // inode. Two-phase classifies the NFC one as this pair's partner
+      // (byte-equal) and the NFD one as a same-key duplicate — order
+      // varies — but under NO ordering may the rename overwrite a
+      // distinct inode: the run must end with the source content live
+      // and the displaced bytes in trash, never silently destroyed.
+      const { src, dest } = seedPair(root, NFC_NAME, NFD_NAME, 'content-A');
+      fs.writeFileSync(path.join(dest, NFC_NAME), 'content-B-distinct');
+
+      const { code, events } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(code, 0);
+      assert.equal(doneEvent(events).fileErrors, 0);
+      assert.deepEqual(liveNames(dest), [NFC_NAME]);
+      assert.equal(fs.readFileSync(path.join(dest, NFC_NAME), 'utf8'), 'content-A',
+        'live copy must mirror the source');
+      // Every displaced byte-stream is accounted for in the trash.
+      const bucket = path.join(dest, '.mstream-trash', fs.readdirSync(path.join(dest, '.mstream-trash'))[0]);
+      const trashed = fs.readdirSync(bucket);
+      assert.ok(trashed.length >= 1, 'the displaced duplicate landed in trash, not oblivion');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/integration/backup-nfd.test.mjs
+++ b/test/integration/backup-nfd.test.mjs
@@ -49,9 +49,13 @@ function makeTempRoot(tag) {
   return root;
 }
 
-function runWorker(payload) {
+// Forward slashes: NODE_OPTIONS eats backslashes on Windows.
+const REVERSE_READDIR = path.join(REPO_ROOT, 'test', 'fixtures', 'reverse-readdir.cjs').replace(/\\/g, '/');
+
+function runWorker(payload, { env = {} } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [WORKER, JSON.stringify(payload)], {
+      env: { ...process.env, ...env },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let out = '';
@@ -170,18 +174,15 @@ describe('NFD/NFC matched-pair convergence', () => {
     }
   });
 
-  test('a genuine byte-exact sibling next to the variant is never clobbered by the convergence rename', async () => {
+  test('a byte-exact dest twin wins the pairing deterministically; the variant is trashed as an orphan', async () => {
     const root = makeTempRoot('sibling');
     try {
-      // Adversarial layout: dest holds an NFD variant AND a distinct
-      // NFC-named file that is NOT in the dest readdir snapshot's
-      // matched set... simulate the mid-run-creation edge by pre-seeding
-      // both where the NFC one has DIFFERENT content and a DIFFERENT
-      // inode. Two-phase classifies the NFC one as this pair's partner
-      // (byte-equal) and the NFD one as a same-key duplicate — order
-      // varies — but under NO ordering may the rename overwrite a
-      // distinct inode: the run must end with the source content live
-      // and the displaced bytes in trash, never silently destroyed.
+      // Dest holds an NFD variant (stale) AND a byte-exact NFC twin
+      // with different content. Byte-preferring pairing means the NFC
+      // twin is ALWAYS this pair's partner (no readdir-order roulette)
+      // and the NFD variant is always the phase-1 orphan: the run must
+      // end with the source content live under the NFC name and every
+      // displaced byte-stream in trash, never silently destroyed.
       const { src, dest } = seedPair(root, NFC_NAME, NFD_NAME, 'content-A');
       fs.writeFileSync(path.join(dest, NFC_NAME), 'content-B-distinct');
 
@@ -195,6 +196,79 @@ describe('NFD/NFC matched-pair convergence', () => {
       const bucket = path.join(dest, '.mstream-trash', fs.readdirSync(path.join(dest, '.mstream-trash'))[0]);
       const trashed = fs.readdirSync(bucket);
       assert.ok(trashed.length >= 1, 'the displaced duplicate landed in trash, not oblivion');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('dual-spelling SOURCE never swaps contents, even when dest enumerates in reverse order', { skip: process.platform === 'darwin' ? 'APFS cannot hold both spellings as distinct files' : false }, async () => {
+    const root = makeTempRoot('crosspair');
+    try {
+      // The review-caught regression: a source that legitimately holds
+      // BOTH spellings as distinct files (a library merged from a
+      // Mac-rsync'd tree and a Linux-native one), dest correctly
+      // mirroring both. Positional equal-key pairing cross-paired when
+      // the two directories enumerated in different orders (legal on
+      // ext4: per-dir hash seeds) and SWAPPED the two files' contents
+      // on the mirror — silently, and stably. The reverse-readdir shim
+      // forces the divergent order deterministically; byte-preferring
+      // pairing must be immune to it.
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      fs.mkdirSync(src, { recursive: true });
+      fs.mkdirSync(dest, { recursive: true });
+      const past = new Date(Date.now() - 90_000);
+      for (const [name, content] of [[NFC_NAME, 'nfc-content-long-form'], [NFD_NAME, 'nfd-short']]) {
+        fs.writeFileSync(path.join(src, name), content);
+        fs.utimesSync(path.join(src, name), past, past);
+        fs.writeFileSync(path.join(dest, name), content);
+        fs.utimesSync(path.join(dest, name), past, past);
+      }
+      assert.equal(liveNames(src).length, 2, 'fixture needs both spellings as distinct source files');
+
+      const { code, events } = await runWorker(
+        { sourcePath: src, destPath: dest, retentionDays: 30 },
+        { env: { NODE_OPTIONS: `--require "${REVERSE_READDIR}"`, REVERSE_READDIR_DIR: dest } });
+      assert.equal(code, 0);
+      const done = doneEvent(events);
+      assert.equal(done.filesCopied, 0, 'a byte-correct mirror must not be recopied under ANY enumeration order');
+      assert.equal(done.filesTrashed, 0);
+      assert.equal(done.filesUnchanged, 2);
+      assert.equal(fs.readFileSync(path.join(dest, NFC_NAME), 'utf8'), 'nfc-content-long-form',
+        'NFC name keeps NFC content — no swap');
+      assert.equal(fs.readFileSync(path.join(dest, NFD_NAME), 'utf8'), 'nfd-short',
+        'NFD name keeps NFD content — no swap');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('NFD-named dest symlink colliding with a matched source dir is removed via its actual bytes', async () => {
+    const root = makeTempRoot('destlink');
+    try {
+      const src = path.join(root, 'src');
+      const dest = path.join(root, 'dest');
+      const target = path.join(root, 'link-target');
+      fs.mkdirSync(path.join(src, NFC_DIR), { recursive: true });
+      fs.writeFileSync(path.join(src, NFC_DIR, 'track.mp3'), 'real-track');
+      fs.mkdirSync(dest, { recursive: true });
+      fs.mkdirSync(target, { recursive: true });
+      fs.writeFileSync(path.join(target, 'canary.txt'), 'must-survive');
+      // A dest-side link whose stored name is the NFD spelling. The
+      // link-removal branch must reach it through its ACTUAL bytes —
+      // built from srcEntry.name it was ENOENT on normalization-
+      // sensitive filesystems, leaving the link in place forever with a
+      // per-run error.
+      fs.symlinkSync(target, path.join(dest, NFD_DIR), process.platform === 'win32' ? 'junction' : 'dir');
+
+      const { code, events } = await runWorker({ sourcePath: src, destPath: dest, retentionDays: 30 });
+      assert.equal(code, 0);
+      const done = doneEvent(events);
+      assert.equal(done.fileErrors, 0, 'the NFD-named link must be reachable and removed cleanly');
+      assert.deepEqual(liveNames(dest), [NFC_DIR], 'source dir materialised under source bytes');
+      assert.equal(fs.readFileSync(path.join(dest, NFC_DIR, 'track.mp3'), 'utf8'), 'real-track');
+      assert.equal(fs.readFileSync(path.join(target, 'canary.txt'), 'utf8'), 'must-survive',
+        'the link TARGET must never be touched');
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes the **last open finding (#6)** of the backup audit — everything else in the 53-finding ledger is fixed, accepted-partial, or an explicit won't-fix.

## The bug

The merge-walk pairs entries by NFC-normalized key but built every dest-side path from `srcEntry.name`. A destination tree written in NFD — rsync from a Mac is the classic source — on a normalization-*sensitive* filesystem (ext4, NTFS) therefore stat'd ENOENT for every matched pair: the file was **recopied in full under the NFC name**, the NFD original was **never trashed**, and later runs paired the equal sort keys in arbitrary readdir order, producing trash+recopy churn that never converged.

## The fix (commit 1)

- `syncMatchedPair`'s early branches (link removal) act through the dest entry's **actual bytes**.
- Pairs that survive to the file/dir paths go through `convergeDestName()`: byte-different matched names — which with a pure-NFC `toKey` means a normalization variant and *nothing else*; case-different names never pair, so batch 2's deliberate case-insensitive-dest fold is untouched — get a cheap same-directory rename to the source's bytes, and all downstream operations use the converged path. Directory pairs converge then recurse, so an NFD subtree straightens out top-down in one run with **zero copies**.
- A same-inode guard lets APFS (normalization-insensitive, byte-preserving) rewrite its stored bytes through the rename; rename failure degrades to correct-but-unconverged mirroring with one stderr warning per run.

## The review round (commit 2) — a real regression caught and rooted out

The adversarial review (14 findings → 10 refuted, 4 confirmed) live-repro'd a genuine regression in the first cut: a source that *legitimately holds both spellings as distinct files* (a library merged from Mac-rsync'd and Linux-native trees), mirrored onto a dest that enumerates in a different order (legal on ext4 — per-directory hash seeds), got **cross-paired** by the positional equal-key merge. The sibling guard then routed each pair through the *other* variant's name — silently and stably **swapping the two files' contents on the mirror**. Pre-fix master was accidentally correct here, so this was a regression of commit 1, not of master.

Fixed at the root rather than patching the guard: the merge now gathers the full equal-key run on both sides and **pairs byte-equal names first**, then remaining entries positionally. Cross-pairing becomes impossible under any enumeration order, and duplicate cleanup becomes deterministic (a source spelling always claims its byte-identical dest twin; dest surplus is always the phase-1 orphan). Equal-key runs are length 1 except when variants coexist, so the common path is untouched.

Also from the review: the dest-symlink rewiring got its own mutation-pinned test, and the sibling test was reframed as the deterministic-pairing pin it actually is (the no-clobber guard is provably mid-run-race-only belt-and-braces now — its comment says so honestly).

## Tests

6 tests in `backup-nfd.test.mjs` + a new `reverse-readdir.cjs` fixture that deterministically simulates ext4's order divergence (NTFS CI hosts can never produce it naturally):

- NFD dest file: 0 copied / 0 trashed, byte-exact readdir convergence assertion, idempotent second run
- NFD directory subtree: recursive convergence, zero copies
- Pre-fix churn state (both spellings on dest): collapses to one converged entry, duplicate in trash, stable after
- Byte-exact dest twin: wins the pairing deterministically, variant trashed as orphan
- **Dual-spelling source + reversed dest enumeration: no content swap, 0 copies** (fails 1/6 against commit 1 alone)
- NFD-named dest symlink/junction: removed via its actual bytes, target untouched

Pin-checked: the original 4 tests fail 0/4 against master; the cross-pairing test fails against commit 1; the symlink test fails with its hunk reverted. Full backup + task-queue suites 62/62, backup-api 18/18, lint at baseline. Rig smoke: see comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
