### PR TITLE
feat(federation): stream proxy — "From your peers" rows are now playable (discovery-over-federation P4)

### DIFF
--- a/src/api/discovery-federation.js
+++ b/src/api/discovery-federation.js
@@ -40,6 +40,26 @@ const PEER_LIMIT_CAP = 100;
 // surface in `searched.unreachable`, not as an error.
 const PEER_TIMEOUT_MS = 4000;
 
+// AbortSignal.timeout on the fetch only bounds the HTTP request THROUGH an
+// established bridge — a dead peer stalls in the iroh DIAL that rebuilds
+// the bridge first, which the signal never covers (measured ~29s against a
+// stopped peer in the 2026-07-11 WAN smoke). Race the whole fedFetch call
+// against a deadline instead; a dial that eventually succeeds in the
+// background still warms the bridge for the next query.
+export async function fedFetchWithDeadline(fedClient, peer, apiPath, opts, ms) {
+  let timer;
+  try {
+    return await Promise.race([
+      fedClient.fedFetch(peer, apiPath, opts),
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`no answer within ${ms}ms (dial included)`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export function setup(mstream) {
   // Similar-but-not-owned tracks across the federated peers.
   //   filePath        the local seed track ("<vpath>/<relpath>")
@@ -86,12 +106,13 @@ export function setup(mstream) {
     // the iroh machinery, which stays cold until a peer is actually dialed.
     const fedClient = await import('../state/federation-client.js');
     const answers = await Promise.allSettled(peers.map(async (peer) => {
-      const r = await fedClient.fedFetch(peer, '/api/v1/federation/discovery/similar', {
+      const r = await fedFetchWithDeadline(fedClient, peer, '/api/v1/federation/discovery/similar', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: payload,
+        // Still useful: bounds the response-body read once headers arrive.
         signal: AbortSignal.timeout(PEER_TIMEOUT_MS),
-      });
+      }, PEER_TIMEOUT_MS);
       if (!r.ok) { throw new Error(`http ${r.status}`); }
       return r.json();
     }));

--- a/src/api/federation-stream.js
+++ b/src/api/federation-stream.js
@@ -22,6 +22,7 @@ import { Readable } from 'node:stream';
 import winston from 'winston';
 import * as config from '../state/config.js';
 import * as fedDb from '../db/federation.js';
+import { fedFetchWithDeadline } from './discovery-federation.js';
 import WebError from '../util/web-error.js';
 
 // Request headers forwarded verbatim — seeking needs range/if-range, and
@@ -30,6 +31,9 @@ const FORWARD_REQ = ['range', 'if-range', 'if-none-match', 'if-modified-since', 
 // Response headers the audio element + seek logic need, copied from the
 // peer. Everything else (cookies, server identity) stays behind.
 const FORWARD_RES = ['content-type', 'content-length', 'content-range', 'accept-ranges', 'etag', 'last-modified'];
+// Dial + response-header budget (matches testPeer's health timeout). The
+// BODY has no deadline — tracks stream for minutes.
+const HEADER_DEADLINE_MS = 15 * 1000;
 
 export function setup(mstream) {
   mstream.get('/api/v1/federation/peers/:id/stream/*path', async (req, res) => {
@@ -55,7 +59,12 @@ export function setup(mstream) {
     const fedClient = await import('../state/federation-client.js');
     let upstream;
     try {
-      upstream = await fedClient.fedFetch(peer, `/media/${remotePath}`, { headers });
+      // Deadline covers the dial + header phase ONLY (see
+      // fedFetchWithDeadline) — once headers are back, the body may stream
+      // for as long as the track lasts. Without it, playing a track whose
+      // peer just went offline hangs the request in the iroh dial (~29s
+      // measured) instead of failing crisply.
+      upstream = await fedFetchWithDeadline(fedClient, peer, `/media/${remotePath}`, { headers }, HEADER_DEADLINE_MS);
     } catch (err) {
       winston.warn(`[federation] stream proxy: peer '${peer.name}' (id=${peer.id}) unreachable for '${remotePath}': ${err.message}`);
       throw new WebError('Peer unreachable', 502);

--- a/src/api/federation-stream.js
+++ b/src/api/federation-stream.js
@@ -1,0 +1,84 @@
+// The streaming face of federation: play a PEER's track through this
+// server. Discovery-over-federation phase 4 — this is what turns the
+// Discover panel's "From your peers" rows from leads into playable songs.
+//
+// GET /api/v1/federation/peers/:id/stream/<vpath-path>
+//
+// Normal local-user auth (the same `?token=` query the /media and
+// /transcode audio URLs ride — the wall reads it for every route), and NOT
+// on the federation-key allowlist, so a peer can never chain proxies
+// through us. The handler is a thin byte pipe: forward the range and
+// conditional request headers to the peer's /media/<path> over the
+// federation bridge, copy the streaming response headers back, pipe the
+// body. The PEER's auth wall + key grants decide what is actually readable
+// — this server adds no local path judgement beyond URL hygiene, because
+// the path lives in the peer's vpath namespace, not ours.
+//
+// Deliberately out of scope (degrade, don't pretend): transcode, waveform,
+// lyrics, and stats for remote tracks — every one of those resolves paths
+// against the LOCAL library.
+
+import { Readable } from 'node:stream';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as fedDb from '../db/federation.js';
+import WebError from '../util/web-error.js';
+
+// Request headers forwarded verbatim — seeking needs range/if-range, and
+// the browser's cache revalidation rides the conditionals.
+const FORWARD_REQ = ['range', 'if-range', 'if-none-match', 'if-modified-since', 'accept'];
+// Response headers the audio element + seek logic need, copied from the
+// peer. Everything else (cookies, server identity) stays behind.
+const FORWARD_RES = ['content-type', 'content-length', 'content-range', 'accept-ranges', 'etag', 'last-modified'];
+
+export function setup(mstream) {
+  mstream.get('/api/v1/federation/peers/:id/stream/*path', async (req, res) => {
+    if (config.program.federation.enabled !== true) {
+      throw new WebError('federation is disabled (config: federation.enabled)', 403);
+    }
+    const peer = fedDb.getFederationPeerById(Number(req.params.id));
+    if (!peer) { throw new WebError('Peer not found', 404); }
+
+    // Express 5 named wildcards hand back decoded segments (an array);
+    // re-encode each so the upstream URL survives spaces, #, %, ? in
+    // filenames exactly like the webapp's own /media escaping does.
+    const segments = Array.isArray(req.params.path) ? req.params.path : String(req.params.path).split('/');
+    const remotePath = segments.map(encodeURIComponent).join('/');
+
+    const headers = {};
+    for (const h of FORWARD_REQ) {
+      if (req.headers[h]) { headers[h] = req.headers[h]; }
+    }
+
+    // Loaded lazily like every other fedFetch caller — federation-client
+    // pulls in the iroh machinery, cold until a peer is actually dialed.
+    const fedClient = await import('../state/federation-client.js');
+    let upstream;
+    try {
+      upstream = await fedClient.fedFetch(peer, `/media/${remotePath}`, { headers });
+    } catch (err) {
+      winston.warn(`[federation] stream proxy: peer '${peer.name}' (id=${peer.id}) unreachable for '${remotePath}': ${err.message}`);
+      throw new WebError('Peer unreachable', 502);
+    }
+
+    res.status(upstream.status);
+    for (const h of FORWARD_RES) {
+      const v = upstream.headers.get(h);
+      if (v) { res.setHeader(h, v); }
+    }
+    if (!upstream.body) { return res.end(); }
+
+    const body = Readable.fromWeb(upstream.body);
+    // A dropped player connection (seek, skip, tab close) must tear down
+    // the upstream read too — else abandoned streams keep pulling bytes
+    // over the bridge until the file ends.
+    res.on('close', () => { body.destroy(); });
+    body.on('error', (err) => {
+      // Mid-stream transport failure: headers are gone already, so all we
+      // can do is cut the response and log why.
+      winston.warn(`[federation] stream proxy: body from peer '${peer.name}' (id=${peer.id}) failed mid-stream: ${err.message}`);
+      res.destroy();
+    });
+    body.pipe(res);
+  });
+}

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,7 @@ import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // scanner.js removed — parser now writes directly to SQLite
 import * as federationApi from './api/federation.js';
 import * as federationDiscoveryApi from './api/federation-discovery.js';
+import * as federationStreamApi from './api/federation-stream.js';
 import * as ytdlApi from './api/ytdl.js';
 import * as torrentApi from './api/torrent.js';
 import * as dlnaApi from './api/dlna.js';
@@ -316,6 +317,7 @@ export async function serveIt(configFile) {
   sharedApi.setupAfterSecurity(mstream);
   federationApi.setup(mstream);
   federationDiscoveryApi.setup(mstream);
+  federationStreamApi.setup(mstream);
   ytdlApi.setup(mstream);
   torrentApi.setup(mstream);
   albumArtApi.setup(mstream);

--- a/test/integration/federation-discovery-aggregate.test.mjs
+++ b/test/integration/federation-discovery-aggregate.test.mjs
@@ -259,6 +259,23 @@ describe('discovery federation aggregate (B queries A over iroh)', { skip: avail
     assert.equal((await api(srvB, 'POST', '/api/v1/admin/federation/peers/424242/discovery', { enabled: true })).status, 404);
   });
 
+  // SECOND-TO-LAST — kills server A for good (nothing after this dials it).
+  // Regression for the 2026-07-11 WAN smoke finding: AbortSignal.timeout
+  // only bounds the HTTP request through an ESTABLISHED bridge; a dead
+  // peer used to stall ~29s in the iroh redial, which the aggregator's
+  // Promise.all turned into a whole-panel hang. fedFetchWithDeadline races
+  // the dial too, so a dead peer now costs at most the peer timeout.
+  test('a dead peer resolves unreachable within the deadline, not the dial timeout', async () => {
+    await srvA.stop();
+    const t0 = Date.now();
+    const { status, body } = await aggregate({ filePath: SEED_PATH });
+    const elapsed = Date.now() - t0;
+    assert.equal(status, 200);
+    assert.deepEqual(body.searched, { peers: 0, unreachable: 1, mismatched: 0 });
+    assert.deepEqual(body.results, []);
+    assert.ok(elapsed < 8000, `answered in ${elapsed}ms — must be bounded by the 4s peer deadline, not a ~29s dial hang`);
+  });
+
   // LAST — flips B's live federation config off.
   test('federation disabled → aggregate and stream proxy both 403', async () => {
     const off = await api(srvB, 'POST', '/api/v1/admin/federation', { enabled: false });

--- a/test/integration/federation-discovery-aggregate.test.mjs
+++ b/test/integration/federation-discovery-aggregate.test.mjs
@@ -203,6 +203,39 @@ describe('discovery federation aggregate (B queries A over iroh)', { skip: avail
     assert.deepEqual(body.results.map((r) => r.title), ['Remote Hit']);
   });
 
+  test('stream proxy pipes a peer track byte-exact, with range support', async () => {
+    const { body } = await aggregate({ filePath: SEED_PATH });
+    const hit = body.results.find((r) => r.title === 'Remote Hit');
+    assert.ok(hit, 'aggregate supplies the streamable filepath');
+    const streamUrl = `${srvB.baseUrl}/api/v1/federation/peers/${hit.peer.id}/stream/${hit.filepath}`;
+
+    const full = await fetch(streamUrl);
+    assert.equal(full.status, 200);
+    assert.match(full.headers.get('content-type') || '', /audio|octet/);
+    const bytes = Buffer.from(await full.arrayBuffer());
+    const original = fs.readFileSync(path.join(sharedDir, 'Remote_Hit.mp3'));
+    assert.equal(bytes.length, original.length);
+    assert.ok(bytes.equals(original), 'proxied bytes match the file on the peer');
+
+    // Seeking = range passthrough in both directions.
+    const part = await fetch(streamUrl, { headers: { range: 'bytes=0-99' } });
+    assert.equal(part.status, 206);
+    assert.match(part.headers.get('content-range') || '', /^bytes 0-99\//);
+    const partBytes = Buffer.from(await part.arrayBuffer());
+    assert.equal(partBytes.length, 100);
+    assert.ok(partBytes.equals(original.subarray(0, 100)));
+  });
+
+  test('stream proxy: unknown peer 404s locally; ungranted library relays the peer 404', async () => {
+    const unknownPeer = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/424242/stream/shared/x.mp3`);
+    assert.equal(unknownPeer.status, 404);
+
+    // testlib is NOT granted to either key — the PEER's wall answers 404
+    // (unknown-or-forbidden look identical there) and we relay it.
+    const ungranted = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerIds[0]}/stream/testlib/01.mp3`);
+    assert.equal(ungranted.status, 404);
+  });
+
   test('use_discovery toggle round-trips: off → skipped + flag drops, on → back', async () => {
     for (const id of peerIds) {
       const r = await api(srvB, 'POST', `/api/v1/admin/federation/peers/${id}/discovery`, { enabled: false });
@@ -227,10 +260,12 @@ describe('discovery federation aggregate (B queries A over iroh)', { skip: avail
   });
 
   // LAST — flips B's live federation config off.
-  test('federation disabled → 403 before any seed resolution', async () => {
+  test('federation disabled → aggregate and stream proxy both 403', async () => {
     const off = await api(srvB, 'POST', '/api/v1/admin/federation', { enabled: false });
     assert.equal(off.status, 200);
     const r = await aggregate({ filePath: SEED_PATH });
     assert.equal(r.status, 403);
+    const s = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerIds[0]}/stream/shared/Remote_Hit.mp3`);
+    assert.equal(s.status, 403);
   });
 });

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -260,6 +260,18 @@ const VUEPLAYERCORE = (() => {
           this.discover.seedTitle = '';
           return;
         }
+        // A federated track is playing: its path lives in the PEER's vpath
+        // namespace, so local seed resolution can't work. Clear rather than
+        // show the previous song's results as if they belonged here.
+        if (song.federation) {
+          this.discover.tracks = [];
+          this.discover.artists = [];
+          this.discover.p2p.tracks = [];
+          this.discover.fed.tracks = [];
+          this.discover.notAnalyzed = false;
+          this.discover.seedTitle = (song.metadata && song.metadata.title) || '';
+          return;
+        }
         // Keep it lean: no discovery traffic while the panel is collapsed.
         // Remember there's something new to fetch for when it opens.
         if (this.discover.collapsed) {
@@ -326,6 +338,17 @@ const VUEPLAYERCORE = (() => {
             this.discover.fed.tracks = [];
           }
         }
+      },
+      // ── "From your peers" rows ─────────────────────────────────────
+      // Playable since phase 4: the row queues through the federation
+      // stream proxy. Lite metadata comes straight off the fed result so
+      // the queue + now-playing card render without any local lookup.
+      queueDiscoverFed: function (ft) {
+        mstreamModule.addFederationSongWizard(ft.peer, ft.filepath, {
+          title: ft.title || '',
+          artist: ft.artist || '',
+          duration: ft.duration || null,
+        }, true);
       },
       // ── "From the network" rows ────────────────────────────────────
       // Not playable (the track lives on someone else's server) — clicking
@@ -889,6 +912,29 @@ const VUEPLAYERCORE = (() => {
     }
   };
 
+  // Queue a track that lives on a FEDERATED PEER. It plays through this
+  // server's stream proxy (/api/v1/federation/peers/:id/stream/…), so the
+  // browser needs nothing but its normal token. Deliberately NOT routed
+  // through addSongWizard: no transcode rerouting, no waveform prefetch,
+  // no live-playlist save, no metadata lookup — every one of those
+  // resolves paths against the LOCAL library, and this path lives in the
+  // peer's vpath namespace. The `federation` marker on the song object is
+  // what the degrade guards key on (waveform skip, Discover clear).
+  mstreamModule.addFederationSongWizard = (peer, remotePath, metadata, autoPlayOff) => {
+    let escaped = remotePath.replace(/\%/g, '%25').replace(/\#/g, '%23').replace(/\?/g, '%3F');
+    if (escaped.charAt(0) === '/') { escaped = escaped.substr(1); }
+    let url = `${MSTREAMAPI.currentServer.host}api/v1/federation/peers/${peer.id}/stream/${escaped}?`;
+    if (MSTREAMAPI.currentServer.token) { url += 'token=' + MSTREAMAPI.currentServer.token; }
+    MSTREAMPLAYER.addSong({
+      url: url,
+      rawFilePath: remotePath,
+      filepath: remotePath,
+      metadata: metadata || {},
+      authToken: MSTREAMAPI.currentServer.token,
+      federation: { peerId: peer.id, peerName: peer.name || 'peer' },
+    }, autoPlayOff);
+  };
+
   mstreamModule.clearQueue = async() => {
     MSTREAMPLAYER.clearPlaylist();
     if (mstreamModule.livePlaylist.name) {
@@ -949,8 +995,11 @@ const VUEPLAYERCORE = (() => {
   }
 
   async function _fetchWaveform(filepath) {
-    // Skip radio/external streams and empty paths
-    if (!filepath || /^https?:\/\//i.test(filepath)) {
+    // Skip radio/external streams, federated tracks, and empty paths — a
+    // peer's filepath means nothing to the local waveform API (it resolves
+    // against OUR libraries), so treat it like an external stream.
+    const cur = MSTREAMPLAYER.getCurrentSong();
+    if (!filepath || /^https?:\/\//i.test(filepath) || (cur && cur.federation)) {
       _waveformData = null;
       _waveformFp = null;
       _setWaveformReady(false);

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -922,9 +922,10 @@
                   </div>
                 </div>
                 <!-- From your peers: live similarity answers from the servers
-                     this one is PAIRED with (Admin → Federation). Leads for
-                     now — row click copies "Artist - Title"; these become
-                     playable once the federation stream proxy lands. The
+                     this one is PAIRED with (Admin → Federation). PLAYABLE —
+                     row click queues the track through this server's
+                     federation stream proxy; the link-out icon opens the
+                     MusicBrainz recording page when known. The
                      newArtistsOnly toggle is shared with the network section;
                      it renders here only when that section is hidden. -->
                 <div v-if="discover.fed.available && !discover.fed.disabled" class="discover-network discover-peers">
@@ -936,7 +937,7 @@
                   </div>
                   <div v-if="discover.fed.tracks.length" class="discover-rows">
                     <div v-for="ft in discover.fed.tracks" :key="ft.peer.id + ':' + ft.filepath" class="discover-row pointer"
-                         v-on:click="copyDiscoverP2p(ft)" :title="Math.round(ft.similarity * 100) + '% match — on ' + (ft.peer.name || 'a paired server') + '. Click to copy.'">
+                         v-on:click="queueDiscoverFed(ft)" :title="Math.round(ft.similarity * 100) + '% match — on ' + (ft.peer.name || 'a paired server') + '. Add to queue.'">
                       <div class="discover-match"><div class="discover-match-fill discover-match-fill-fed" :style="{ height: Math.max(15, Math.round(ft.similarity * 100)) + '%' }"></div></div>
                       <div class="discover-row-info">
                         <div class="discover-row-title">{{ ft.title || '(untitled)' }}</div>
@@ -948,6 +949,9 @@
                          v-on:click.stop title="Open on MusicBrainz">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><path fill="currentColor" d="M14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7zM5 5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h12c1.1 0 2-.9 2-2v-7h-2v7H5V7h7V5H5z"/></svg>
                       </a>
+                      <div class="discover-add" title="Add to queue">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 11h8v2h-8v8h-2v-8H3v-2h8V3h2v8z"/></svg>
+                      </div>
                     </div>
                   </div>
                   <div v-else-if="discover.fed.searchedPeers === 0 && discover.fed.unreachable > 0" class="discover-hint" data-i18n="discover.peers.unreachable">


### PR DESCRIPTION
Phase 4 of discovery-over-federation (plan: `~/.claude/plans/federation-discovery-bridge.md`) — the payoff phase. Requires nothing new on the peer: it streams through the grants #739's endpoint already relies on.

## Server

**`GET /api/v1/federation/peers/:id/stream/<vpath-path>`** ([federation-stream.js](../blob/feat/federation-stream-proxy/src/api/federation-stream.js)) — a thin byte pipe over `fedFetch`:
- Forwards `range`/`if-range`/conditionals to the peer's `/media/<path>`; copies back the streaming headers (`content-type/length/range`, `accept-ranges`, `etag`, `last-modified`); pipes the body with teardown on client disconnect (an abandoned seek must not keep pulling bytes over the bridge).
- Normal local-user auth via the same `?token=` query every audio URL uses; **not** on the federation-key allowlist, so a peer can never chain proxies through us.
- No local path judgement beyond per-segment re-encoding — the path lives in the **peer's** vpath namespace and its wall + key grants decide readability. Unknown peer → 404 local; peer 404s relay; unreachable → 502; federation off → 403.

## Webapp

- Fed Discover rows now **queue** (click or the + icon) instead of copying; MusicBrainz link stays.
- New `addFederationSongWizard` — deliberately not `addSongWizard`: no transcode rerouting, waveform prefetch, live-playlist save, or metadata lookup (all resolve LOCAL paths). Lite metadata from the fed row renders the queue entry and now-playing card directly.
- The song object carries a `federation: {peerId, peerName}` marker, and the degrade guards key on it: the waveform fetcher treats remote tracks like external streams (no 404 spam), and the Discover panel clears rather than showing the previous song's results while a peer track plays. Rating/lyrics for remote tracks fail with the existing error paths (documented degrade, per plan).

## Verification

- **e2e** (two real servers over iroh, extends the aggregate suite — 9/9): proxied bytes are **byte-identical** to the file on the peer; `bytes=0-99` → 206 + correct `content-range` + exact first 100 bytes; unknown-peer 404, ungranted-library 404 relay; federation-off 403 for both aggregate and stream.
- **Live browser run** on the two-server rig: clicked the "Remote Hit" row → queued with the proxy URL + federation marker → advanced to it → the audio stack pulled `206 Partial Content` through the proxy and **the track played to completion** (player `currentTime` reached full duration); now-playing card and tab title showed "Remote Hit - Nova"; waveform requests fired only for the local track; zero console errors.

Phase 5 (snapshot fallback) stays deferred per the plan — this closes the arc the user asked about: federated discovery results you can actually play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)