### PR TITLE
fix(p2p-sidecar): actually exit on stdin EOF — writer task hung shutdown forever

### DIFF
--- a/p2p-sidecar/src/main.rs
+++ b/p2p-sidecar/src/main.rs
@@ -225,10 +225,18 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    tokio::runtime::Builder::new_multi_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .build()?
-        .block_on(run(data_dir))
+        .build()?;
+    let result = rt.block_on(run(data_dir));
+    // tokio's stdin is an uncancellable blocking read on a pool thread, and
+    // plain Drop waits for in-flight blocking work: after an explicit
+    // `shutdown` command (stdin still open) that wait would hang until the
+    // parent next wrote a line. Bounded shutdown keeps the no-orphan promise
+    // on every exit path; on the EOF path no read is pending and this is
+    // instant.
+    rt.shutdown_timeout(Duration::from_secs(1));
+    result
 }
 
 async fn run(data_dir: PathBuf) -> Result<()> {
@@ -268,9 +276,15 @@ async fn run(data_dir: PathBuf) -> Result<()> {
     // Single writer task owns stdout; handlers post JSON values to it. Keeps
     // concurrent responses from interleaving mid-line.
     let (out_tx, mut out_rx) = mpsc::unbounded_channel::<Value>();
+    // The writer exits on a JSON `null` sentinel, NOT on channel close: a
+    // sender clone lives inside the Arc<Node> (shared with the gossip loops,
+    // which never finish), so the channel can never close — awaiting that
+    // was exactly the shutdown hang this replaced. Handlers only ever send
+    // objects, so `null` is unambiguous.
     let writer = tokio::spawn(async move {
         let mut stdout = tokio::io::stdout();
         while let Some(v) = out_rx.recv().await {
+            if v.is_null() { break; }
             let mut line = v.to_string();
             line.push('\n');
             if stdout.write_all(line.as_bytes()).await.is_err() { break; }
@@ -335,11 +349,20 @@ async fn run(data_dir: PathBuf) -> Result<()> {
         }
     }
 
+    // Cleanup is bounded end to end: the no-orphan promise in the header
+    // outranks graceful network goodbyes, and the parent SIGKILLs 5s after
+    // closing stdin anyway (discovery-p2p.js stop()), so everything here
+    // must finish well inside that.
     eprintln!("[p2p-sidecar] shutting down");
-    let _ = node.router.shutdown().await;
-    node.endpoint.close().await;
-    drop(out_tx);
-    let _ = writer.await;
+    let _ = tokio::time::timeout(Duration::from_secs(3), async {
+        let _ = node.router.shutdown().await;
+        node.endpoint.close().await;
+    })
+    .await;
+    // Drain stdout (the channel is FIFO, so everything queued ahead of the
+    // sentinel — including the `shutdown` response — is flushed), then exit.
+    let _ = out_tx.send(Value::Null);
+    let _ = tokio::time::timeout(Duration::from_secs(1), writer).await;
     Ok(())
 }
 

--- a/p2p-sidecar/tests/stdin_eof_exit.rs
+++ b/p2p-sidecar/tests/stdin_eof_exit.rs
@@ -1,0 +1,48 @@
+// Regression test for the no-orphan guarantee (see the SHAPE note in
+// src/main.rs): the process must exit ON ITS OWN within a bounded time of
+// stdin EOF. It used to hang forever in post-loop cleanup — the stdout
+// writer waited for its mpsc channel to close, but a sender clone lives
+// inside the Arc<Node> shared with the never-ending gossip loops, so close
+// never came and a dead parent left an orphan.
+//
+// Real binary, real endpoint bind (loopback UDP only — no peers, no external
+// network needed). Offline hosts just eat the sidecar's bounded relay wait
+// (~8s), so the budget below sits well above that but far below "forever".
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[test]
+fn exits_on_stdin_eof() {
+    let dir = std::env::temp_dir().join(format!("p2p-sidecar-eof-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir); // stale state from a crashed prior run
+    std::fs::create_dir_all(&dir).expect("create temp data dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_p2p-sidecar"))
+        .arg("--data-dir")
+        .arg(&dir)
+        .stdin(Stdio::null()) // immediate EOF — the "parent died" signal
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sidecar");
+
+    // Startup (bind + store load + up-to-8s offline relay wait) plus the
+    // bounded cleanup must all fit. 30s is generous headroom for slow CI;
+    // the bug this guards against was an infinite hang, not slowness.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_dir_all(&dir);
+            panic!("sidecar still alive 30s after stdin EOF — orphan-prevention is broken");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    };
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(status.success(), "sidecar exited abnormally: {status}");
+}


### PR DESCRIPTION
## What

The p2p-sidecar's orphan-prevention guarantee was broken. The header in `p2p-sidecar/src/main.rs` promises "the process exits when stdin closes — the parent dying can never leave an orphan", and `src/state/discovery-p2p.js` relies on it. Empirically the process printed `[p2p-sidecar] shutting down` on EOF and then stayed alive forever.

## Root cause

An eprintln bisect of the cleanup path showed `router.shutdown()` and `endpoint.close()` complete instantly — the hang was `writer.await`. The stdout writer task exits only when its mpsc channel closes, which requires every sender to drop. But a sender clone lives inside the `Arc<Node>` — held by `run()` itself across the await, and by the never-terminating gossip loops (`receive_loop` / `announce_loop` / `holds_loop`) once `join` has run. `drop(out_tx)` only dropped the local clone, so the channel could never close.

## Fix

All three changes keep cleanup **bounded**, so the no-orphan promise holds on every exit path:

- **Sentinel-based writer shutdown**: cleanup sends a JSON `null` sentinel; the writer breaks on it instead of waiting for channel close. The channel is FIFO, so everything queued ahead of the sentinel — including the `shutdown` RPC response the parent waits on — is still flushed. Handlers only ever send objects, so `null` is unambiguous.
- **Bounded network teardown**: `router.shutdown()` + `endpoint.close()` capped at 3s (defense against slow iroh teardown with live peers), stdout flush capped at 1s. Total worst case stays inside the parent's 5s post-`stdin.end()` SIGKILL grace.
- **Bounded runtime shutdown**: `main()` now ends with `rt.shutdown_timeout(1s)` instead of implicit runtime drop. This fixes a second latent hang on the explicit `shutdown`-command path: tokio's stdin is an uncancellable blocking read and plain drop waits for in-flight blocking work, so with stdin still open the drop would hang until the parent wrote another line.

## Regression test

`p2p-sidecar/tests/stdin_eof_exit.rs` spawns the real binary with stdin at EOF and fails unless it exits cleanly within 30s. It runs under the existing `cargo test` step in `build-p2p-sidecar.yml`, and needs no network peers (loopback UDP bind only; offline hosts just eat the sidecar's bounded ~8s relay wait).

## Verification (macOS arm64)

- `./target/release/p2p-sidecar --data-dir "$(mktemp -d)" </dev/null` — exits on its own, rc=0, ~4s total (was: never exits, killed after 20s+).
- `shutdown` command with stdin held open (`tail -f /dev/null` feeding the pipe) — exits on its own with `{"id":1,"ok":true}` flushed to stdout first.
- `cargo test`: 11 existing unit tests + the new integration test all pass.

## Reviewer notes

- The committed prebuilts in `bin/p2p-sidecar/` still carry the bug until CI rebuilds them on push to master (source-only PR, per this repo's sidecar shipping model).
- No JS changes needed: `discovery-p2p.js` `stop()` already does shutdown-RPC → `stdin.end()` → SIGKILL fallback; both of its graceful layers now actually work, and the orphan case (parent killed, no SIGKILL timer running) is the one this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)