### PR TITLE
Enrichment scan status API: GET /api/v1/scan/status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ removed.
 
 ### ✨ New features
 
+- **Enrichment scan status API.** `GET /api/v1/scan/status`
+  (authenticated, not admin-only) reports every post-scan enrichment
+  pass — waveforms, album-art download, lyrics backfill, BPM/key
+  analysis, discovery embeddings, AcoustID identification — in one
+  poll: enabled/disabled (with the reason), live queue state and
+  worker progress, a summary of the last run, and durable
+  done / remaining / outcome coverage counts scoped to the caller's
+  libraries. See `docs/openapi.yaml`.
 - **Subsonic REST API.** Phase-1 through Phase-3 handlers covering
   browsing (getArtists / getArtist / getAlbum / getAlbumList2 /
   getStarred2 / getPlaylists / getPlaylist / search2 / search3),

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1058,6 +1058,106 @@ paths:
                     description: True while a scan is in progress.
         "401": { $ref: "#/components/responses/Unauthorized" }
 
+  /api/v1/scan/status:
+    get:
+      tags: [Library]
+      summary: Enrichment scan status
+      description: >
+        One snapshot of every post-scan enrichment pass (waveforms, album-art
+        download, lyrics backfill, BPM/key analysis, discovery embeddings,
+        AcoustID identification): whether it is enabled (and why not), its
+        live queue state and progress, a summary of its last run, and durable
+        done/remaining/outcome coverage counts. Track- and album-scoped
+        coverage is filtered to the caller's accessible libraries; hash-keyed
+        passes (waveform, discovery) report scope 'global'.
+      responses:
+        "200":
+          description: Queue snapshot plus one entry per enrichment pass.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  queue:
+                    type: object
+                    properties:
+                      scanning:
+                        type: boolean
+                        description: True while a scan or backup holds the task slot (same semantic as /db/status `locked`).
+                      activeTask:
+                        type: string
+                        nullable: true
+                        description: Kind of the running task (scan / backup / an enrichment kind), or null when idle.
+                      queued:
+                        type: array
+                        items: { type: string }
+                        description: Kinds of the queued tasks, in queue order.
+                  totals:
+                    type: object
+                    nullable: true
+                    properties:
+                      tracks: { type: integer }
+                  enrichment:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        pass:
+                          type: string
+                          enum: [waveform, albumart, lyrics, audioanalysis, discovery, acoustid]
+                        enabled: { type: boolean }
+                        disabledReason:
+                          type: string
+                          nullable: true
+                          enum: [config, no-ffmpeg, no-api-key, no-binary, binary-unsupported, runtime-unavailable, null]
+                        state:
+                          type: string
+                          enum: [idle, queued, running, disabled]
+                        progress:
+                          type: object
+                          nullable: true
+                          description: Live progress of the running pass, from the worker's own progress events.
+                          properties:
+                            attempted: { type: integer }
+                            total: { type: integer, nullable: true }
+                        lastRun:
+                          type: object
+                          nullable: true
+                          description: Summary of the pass's last run this server lifetime.
+                          properties:
+                            finishedAt: { type: integer, description: Epoch ms. }
+                            outcome:
+                              type: string
+                              enum: [completed, failed, killed]
+                            hitCap:
+                              type: boolean
+                              description: True when the run stopped at its per-run cap with more work remaining.
+                            counts:
+                              type: object
+                              nullable: true
+                              description: The worker's completion counters (per-pass vocabulary, e.g. generated/updated/analyzed/matched, notFound, errors).
+                              additionalProperties: { type: integer }
+                        coverage:
+                          type: object
+                          nullable: true
+                          description: Durable library-wide counts (null when the pass's data source does not exist yet, e.g. discovery.db before first enable).
+                          properties:
+                            scope:
+                              type: string
+                              enum: [library, global]
+                            unit:
+                              type: string
+                              enum: [tracks, albums]
+                            done: { type: integer }
+                            remaining:
+                              type: integer
+                              description: Items the pass's worker would still select today, ignoring retry cooldowns.
+                            outcomes:
+                              type: object
+                              description: Attempt-ledger counts by outcome (per-pass vocabulary, e.g. notfound/error, nomatch/lowconf/undecodable).
+                              additionalProperties: { type: integer }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
   /api/v1/db/metadata:
     post:
       tags: [Library]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1063,6 +1063,106 @@ paths:
                     description: True while a scan is in progress.
         "401": { $ref: "#/components/responses/Unauthorized" }
 
+  /api/v1/scan/status:
+    get:
+      tags: [Library]
+      summary: Enrichment scan status
+      description: >
+        One snapshot of every post-scan enrichment pass (waveforms, album-art
+        download, lyrics backfill, BPM/key analysis, discovery embeddings,
+        AcoustID identification): whether it is enabled (and why not), its
+        live queue state and progress, a summary of its last run, and durable
+        done/remaining/outcome coverage counts. Track- and album-scoped
+        coverage is filtered to the caller's accessible libraries; hash-keyed
+        passes (waveform, discovery) report scope 'global'.
+      responses:
+        "200":
+          description: Queue snapshot plus one entry per enrichment pass.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  queue:
+                    type: object
+                    properties:
+                      scanning:
+                        type: boolean
+                        description: True while a scan or backup holds the task slot (same semantic as /db/status `locked`).
+                      activeTask:
+                        type: string
+                        nullable: true
+                        description: Kind of the running task (scan / backup / an enrichment kind), or null when idle.
+                      queued:
+                        type: array
+                        items: { type: string }
+                        description: Kinds of the queued tasks, in queue order.
+                  totals:
+                    type: object
+                    nullable: true
+                    properties:
+                      tracks: { type: integer }
+                  enrichment:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        pass:
+                          type: string
+                          enum: [waveform, albumart, lyrics, audioanalysis, discovery, acoustid]
+                        enabled: { type: boolean }
+                        disabledReason:
+                          type: string
+                          nullable: true
+                          enum: [config, no-ffmpeg, no-api-key, no-binary, binary-unsupported, runtime-unavailable, null]
+                        state:
+                          type: string
+                          enum: [idle, queued, running, disabled]
+                        progress:
+                          type: object
+                          nullable: true
+                          description: Live progress of the running pass, from the worker's own progress events.
+                          properties:
+                            attempted: { type: integer }
+                            total: { type: integer, nullable: true }
+                        lastRun:
+                          type: object
+                          nullable: true
+                          description: Summary of the pass's last run this server lifetime.
+                          properties:
+                            finishedAt: { type: integer, description: Epoch ms. }
+                            outcome:
+                              type: string
+                              enum: [completed, failed, killed]
+                            hitCap:
+                              type: boolean
+                              description: True when the run stopped at its per-run cap with more work remaining.
+                            counts:
+                              type: object
+                              nullable: true
+                              description: The worker's completion counters (per-pass vocabulary, e.g. generated/updated/analyzed/matched, notFound, errors).
+                              additionalProperties: { type: integer }
+                        coverage:
+                          type: object
+                          nullable: true
+                          description: Durable library-wide counts (null when the pass's data source does not exist yet, e.g. discovery.db before first enable).
+                          properties:
+                            scope:
+                              type: string
+                              enum: [library, global]
+                            unit:
+                              type: string
+                              enum: [tracks, albums]
+                            done: { type: integer }
+                            remaining:
+                              type: integer
+                              description: Items the pass's worker would still select today, ignoring retry cooldowns.
+                            outcomes:
+                              type: object
+                              description: Attempt-ledger counts by outcome (per-pass vocabulary, e.g. notfound/error, nomatch/lowconf/undecodable).
+                              additionalProperties: { type: integer }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
   /api/v1/db/metadata:
     post:
       tags: [Library]

--- a/src/api/scan.js
+++ b/src/api/scan.js
@@ -1,4 +1,4 @@
-// Library scan progress endpoint.
+// Library scan progress + enrichment status endpoints.
 //
 // Authenticated (not admin-only). Rows are filtered to the vpaths the caller
 // can see — admins additionally see pre-vpath "counting" rows where the
@@ -9,6 +9,8 @@
 
 import path from 'path';
 import * as db from '../db/manager.js';
+import * as dbQueue from '../db/task-queue.js';
+import { getEnrichmentCoverage } from '../db/enrichment-status-lib.js';
 
 export function setup(mstream) {
   mstream.get('/api/v1/scan/progress', (req, res) => {
@@ -29,5 +31,46 @@ export function setup(mstream) {
       // basename only — never expose absolute server paths
       currentFile: r.current_file ? path.basename(r.current_file) : null,
     })));
+  });
+
+  // ── Enrichment status ─────────────────────────────────────────────────────
+  //
+  // One poll answers three questions per enrichment pass (waveforms,
+  // album-art, lyrics, BPM/key, discovery embeddings, AcoustID):
+  //
+  //   Is it on?        enabled / disabledReason (config + environment gates)
+  //   Is it working?   state (idle|queued|running|disabled) + live progress
+  //                    from the worker's own progress events, plus a summary
+  //                    of the last run this process lifetime
+  //   How far along?   coverage — durable done/remaining/outcome counts from
+  //                    the DB (they survive restarts; see
+  //                    src/db/enrichment-status-lib.js)
+  //
+  // Authenticated like /scan/progress above, not admin-only: enrichment
+  // explains player-visible features (missing waveform, missing lyrics,
+  // no BPM pill), so every user gets to see it. Track/album-scoped
+  // coverage counts are filtered to the caller's accessible libraries;
+  // hash-keyed passes (waveform, discovery) are marked scope 'global'.
+  // The queue block mirrors what admins see in the dashboard but carries
+  // only task KINDS — no vpaths, no filepaths, nothing library-shaped.
+  mstream.get('/api/v1/scan/status', (req, res) => {
+    const stats = dbQueue.getAdminStats();
+    const coverage = getEnrichmentCoverage(db.getUserLibraryIds(req.user));
+
+    res.json({
+      queue: {
+        // isScanning() semantics: heavy disk work (scan or backup), the
+        // same "locked" bit /db/status reports. Enrichment passes are
+        // visible via activeTask/queued instead.
+        scanning: dbQueue.isScanning(),
+        activeTask: stats.activeTaskKind,
+        queued: stats.taskQueue.map((t) => t.task),
+      },
+      totals: coverage?.totals || null,
+      enrichment: dbQueue.getEnrichmentStatus().map((p) => ({
+        ...p,
+        coverage: coverage?.passes?.[p.pass] ?? null,
+      })),
+    });
   });
 }

--- a/src/db/enrichment-status-lib.js
+++ b/src/db/enrichment-status-lib.js
@@ -1,0 +1,357 @@
+// Durable "how enriched is the library" coverage counts for the scan
+// status API (GET /api/v1/scan/status — src/api/scan.js).
+//
+// The task-queue registry answers "what is the queue doing right now";
+// this module answers "how much of the library has each pass actually
+// covered", straight from the DB (and the waveform cache dir), so the
+// numbers survive restarts and are meaningful even when a pass is
+// disabled. Each pass's `remaining` is grounded in the same eligibility
+// predicate its worker uses to pick work (see the per-pass builders),
+// minus the time-based cooldown terms — cooldowns move hour by hour and
+// would make "remaining" oscillate without the library changing; the
+// `outcomes` ledger map is what explains why remaining items aren't
+// being retried right now.
+//
+// Every builder is wrapped so one broken source (a locked discovery.db,
+// a permissions error on the waveform cache) nulls out ITS pass instead
+// of failing the endpoint.
+//
+// Costs: one aggregate scan over tracks/albums per pass (all COUNT/SUM,
+// no row materialisation — single-digit ms at 100k tracks) plus one
+// readdir of the waveform cache. Cheap, but not free at poll frequency —
+// so results are memoised for CACHE_TTL_MS per libIds set (the fs
+// readdir for WAVEFORM_FS_TTL_MS globally).
+
+import fs from 'fs';
+import path from 'path';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as db from './manager.js';
+import * as discoveryDb from './discovery-db.js';
+
+// Worker-mirror duration windows. Deliberately duplicated from the
+// enqueue pre-checks in task-queue.js (which themselves mirror the
+// worker defaults in *-backfill.mjs) rather than imported — this module
+// must stay import-light so the API layer can use it without pulling in
+// the whole queue/worker machinery.
+const ANALYSIS_MIN_DURATION_SEC = 30;
+const ANALYSIS_MAX_DURATION_SEC = 30 * 60;
+// The discovery pass shares the analysis window.
+const ACOUSTID_MIN_DURATION_SEC = 10;
+const ACOUSTID_MAX_DURATION_SEC = 2 * 60 * 60;
+
+const CACHE_TTL_MS = 5_000;
+const WAVEFORM_FS_TTL_MS = 60_000;
+
+// key = sorted libIds signature → { at, data }. Bounded: a burst of
+// distinct signatures (federation callers with per-key grants) clears
+// the map rather than growing it forever.
+const coverageCache = new Map();
+const COVERAGE_CACHE_MAX_ENTRIES = 64;
+
+let waveformFsCache = { at: 0, bins: 0, failed: 0 };
+
+// Tests poke config/library state between calls; give them (and the
+// admin force-refresh, if one ever ships) a way to drop the memo.
+export function invalidateCoverageCache() {
+  coverageCache.clear();
+  waveformFsCache = { at: 0, bins: 0, failed: 0 };
+}
+
+// `library_id IN (...)` filter for the caller's accessible libraries —
+// same contract as api/db.js#libraryFilter, minus the user plumbing (the
+// caller resolves libIds via db.getUserLibraryIds so this module stays
+// req-free). Empty access = `1=0`, matching libraryFilter.
+function libClause(column, libIds) {
+  if (libIds.length === 0) { return { clause: '1=0', params: [] }; }
+  return {
+    clause: `${column} IN (${libIds.map(() => '?').join(',')})`,
+    params: libIds,
+  };
+}
+
+// GROUP BY outcome over a per-hash attempt ledger, filtered to hashes
+// that belong to at least one accessible track. The OR pair inside
+// EXISTS is the canonical-identity join (COALESCE(audio_hash, file_hash)
+// = ledger key) split so both arms stay indexed probes
+// (idx_tracks_audio_hash / idx_tracks_hash).
+function outcomesForHashLedger(d, table, outcomeCol, libIds) {
+  const lib = libClause('t.library_id', libIds);
+  const rows = d.prepare(`
+    SELECT l.${outcomeCol} AS outcome, COUNT(*) AS n
+      FROM ${table} l
+     WHERE EXISTS (
+             SELECT 1 FROM tracks t
+              WHERE (t.audio_hash = l.audio_hash
+                     OR (t.audio_hash IS NULL AND t.file_hash = l.audio_hash))
+                AND ${lib.clause}
+           )
+     GROUP BY l.${outcomeCol}
+  `).all(...lib.params);
+  const out = {};
+  for (const r of rows) { out[r.outcome] = r.n; }
+  return out;
+}
+
+// ── Per-pass builders ───────────────────────────────────────────────────────
+
+function albumartCoverage(d, libIds) {
+  const lib = libClause('t.library_id', libIds);
+  // Same album pool as the downloader: named, non-ghost (has at least
+  // one track the caller can see). `done` = has a cover from ANY source
+  // (scanner-extracted or downloaded) — coverage is about the artifact,
+  // not who produced it.
+  const row = d.prepare(`
+    SELECT COUNT(*) AS eligible,
+           SUM(CASE WHEN al.album_art_file IS NOT NULL THEN 1 ELSE 0 END) AS done
+      FROM albums al
+     WHERE al.name IS NOT NULL AND TRIM(al.name) != ''
+       AND EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND ${lib.clause})
+  `).get(...lib.params);
+
+  const outcomeRows = d.prepare(`
+    SELECT l.outcome AS outcome, COUNT(*) AS n
+      FROM album_art_lookups l
+      JOIN albums al ON al.id = l.album_id
+     WHERE EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND ${lib.clause})
+     GROUP BY l.outcome
+  `).all(...lib.params);
+  const outcomes = {};
+  for (const r of outcomeRows) { outcomes[r.outcome] = r.n; }
+
+  const done = row.done || 0;
+  return {
+    scope: 'library',
+    unit: 'albums',
+    done,
+    remaining: (row.eligible || 0) - done,
+    eligible: row.eligible || 0,
+    outcomes,
+  };
+}
+
+function lyricsCoverage(d, libIds) {
+  const lib = libClause('t.library_id', libIds);
+  // `remaining` mirrors the backfill worker's pool: lyric-less AND
+  // lookup-able (title + artist). Lyric-less tracks missing either are
+  // structurally unfillable and belong to neither bucket.
+  const row = d.prepare(`
+    SELECT SUM(CASE WHEN t.lyrics_embedded IS NOT NULL OR t.lyrics_synced_lrc IS NOT NULL
+                    THEN 1 ELSE 0 END) AS done,
+           SUM(CASE WHEN t.lyrics_embedded IS NULL AND t.lyrics_synced_lrc IS NULL
+                     AND t.title IS NOT NULL AND TRIM(t.title) != ''
+                     AND t.artist_id IS NOT NULL
+                    THEN 1 ELSE 0 END) AS remaining
+      FROM tracks t
+     WHERE ${lib.clause}
+  `).get(...lib.params);
+
+  return {
+    scope: 'library',
+    unit: 'tracks',
+    done: row.done || 0,
+    remaining: row.remaining || 0,
+    // lyrics_cache.status vocabulary: 'hit' / 'notfound' / 'error'.
+    outcomes: outcomesForHashLedger(d, 'lyrics_cache', 'status', libIds),
+  };
+}
+
+function audioAnalysisCoverage(d, libIds) {
+  const lib = libClause('t.library_id', libIds);
+  // done = BOTH columns resolved (tag- or analysis-sourced); the worker's
+  // NULL gate keeps single-sided rows eligible, so they count as remaining
+  // when they fit the duration window.
+  const row = d.prepare(`
+    SELECT SUM(CASE WHEN t.bpm IS NOT NULL AND t.musical_key IS NOT NULL
+                    THEN 1 ELSE 0 END) AS done,
+           SUM(CASE WHEN (t.bpm IS NULL OR t.musical_key IS NULL)
+                     AND t.duration IS NOT NULL AND t.duration >= ? AND t.duration <= ?
+                     AND COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
+                    THEN 1 ELSE 0 END) AS remaining
+      FROM tracks t
+     WHERE ${lib.clause}
+  `).get(ANALYSIS_MIN_DURATION_SEC, ANALYSIS_MAX_DURATION_SEC, ...lib.params);
+
+  return {
+    scope: 'library',
+    unit: 'tracks',
+    done: row.done || 0,
+    remaining: row.remaining || 0,
+    // audio_analysis_lookups vocabulary: 'analyzed' / 'lowconf' / 'error'.
+    outcomes: outcomesForHashLedger(d, 'audio_analysis_lookups', 'outcome', libIds),
+  };
+}
+
+function acoustidCoverage(d, libIds) {
+  const lib = libClause('t.library_id', libIds);
+  const row = d.prepare(`
+    SELECT SUM(CASE WHEN t.mbz_recording_id IS NOT NULL THEN 1 ELSE 0 END) AS done,
+           SUM(CASE WHEN t.mbz_recording_id IS NOT NULL AND t.mbz_id_source = 'acoustid'
+                    THEN 1 ELSE 0 END) AS from_acoustid,
+           SUM(CASE WHEN t.mbz_recording_id IS NOT NULL AND t.mbz_id_source = 'tag'
+                    THEN 1 ELSE 0 END) AS from_tag,
+           SUM(CASE WHEN t.mbz_recording_id IS NULL
+                     AND COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
+                     AND t.duration IS NOT NULL AND t.duration >= ? AND t.duration <= ?
+                    THEN 1 ELSE 0 END) AS remaining
+      FROM tracks t
+     WHERE ${lib.clause}
+  `).get(ACOUSTID_MIN_DURATION_SEC, ACOUSTID_MAX_DURATION_SEC, ...lib.params);
+
+  return {
+    scope: 'library',
+    unit: 'tracks',
+    done: row.done || 0,
+    remaining: row.remaining || 0,
+    // Provenance split: MBIDs read from embedded tags vs derived by the
+    // fingerprint pass — the pass only ever moves the second number.
+    bySource: { tag: row.from_tag || 0, acoustid: row.from_acoustid || 0 },
+    // acoustid_lookups vocabulary: 'nomatch' / 'lowconf' / 'undecodable' /
+    // 'error'. Success writes no ledger row (the track just gains its MBID).
+    outcomes: outcomesForHashLedger(d, 'acoustid_lookups', 'outcome', libIds),
+  };
+}
+
+// Waveforms are cache FILES keyed by canonical hash, not DB rows — count
+// the artifacts themselves. Hash-keyed means library-access filtering
+// does not apply (a hash shared across two libraries has ONE .bin), so
+// this pass reports scope 'global'. `remaining` is derived
+// (hashes − bins − failed markers) and can under-count when .bins for
+// since-deleted tracks linger in the cache; it clamps at 0.
+function waveformCoverage(d, now) {
+  if (now - waveformFsCache.at > WAVEFORM_FS_TTL_MS) {
+    let bins = 0;
+    let failed = 0;
+    try {
+      for (const name of fs.readdirSync(config.program.storage.waveformCacheDirectory)) {
+        if (name.endsWith('.bin')) { bins++; }
+        else if (name.endsWith('.failed')) { failed++; }
+      }
+    } catch (err) {
+      // Missing dir = simply no waveforms generated yet (the pass creates
+      // it); anything else is worth a breadcrumb but not a broken endpoint.
+      if (err.code !== 'ENOENT') {
+        winston.warn(`waveform coverage: cache dir unreadable: ${err.message}`);
+      }
+      bins = 0;
+      failed = 0;
+    }
+    waveformFsCache = { at: now, bins, failed };
+  }
+
+  const row = d.prepare(`
+    SELECT COUNT(DISTINCT COALESCE(audio_hash, file_hash)) AS hashes
+      FROM tracks
+     WHERE COALESCE(audio_hash, file_hash) IS NOT NULL
+  `).get();
+
+  const { bins, failed } = waveformFsCache;
+  return {
+    scope: 'global',
+    unit: 'tracks',
+    done: bins,
+    remaining: Math.max(0, (row.hashes || 0) - bins - failed),
+    outcomes: failed > 0 ? { failed } : {},
+  };
+}
+
+// Discovery embeddings live in the separate discovery.db. No file on
+// disk = collection has never been enabled → null (the API shows the
+// pass as disabled with no coverage, which is the truth). Mirrors the
+// enqueue pre-check's ATTACH pattern — the main process's handle is
+// single-threaded, so the attach/detach can't interleave mid-statement
+// with the pre-check's.
+function discoveryCoverage() {
+  const ddb = discoveryDb.openDiscoveryDbIfExists();
+  if (!ddb) { return null; }
+  const model = config.program.scanOptions.discoveryModel;
+
+  const done = ddb.prepare(
+    'SELECT COUNT(*) AS n FROM discovery_tracks WHERE embedding IS NOT NULL AND model_id = ?'
+  ).get(model).n;
+
+  const libPath = path.join(config.program.storage.dbDirectory, 'mstream.db').replace(/'/g, "''");
+  ddb.exec(`ATTACH DATABASE '${libPath}' AS cov_lib`);
+  let remaining;
+  try {
+    // COUNT twin of the enqueue pre-check's LIMIT-1 eligibility probe:
+    // canonical hashes in the duration window with no current-model
+    // embedding. DISTINCT because discovery work is per-hash, not per-row.
+    remaining = ddb.prepare(`
+      SELECT COUNT(DISTINCT COALESCE(t.audio_hash, t.file_hash)) AS n
+        FROM cov_lib.tracks t
+       WHERE COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
+         AND t.duration IS NOT NULL AND t.duration >= ? AND t.duration <= ?
+         AND NOT EXISTS (
+               SELECT 1 FROM main.discovery_tracks dt
+                WHERE dt.audio_hash = COALESCE(t.audio_hash, t.file_hash)
+                  AND dt.embedding IS NOT NULL
+                  AND dt.model_id = ?
+             )
+    `).get(ANALYSIS_MIN_DURATION_SEC, ANALYSIS_MAX_DURATION_SEC, model).n;
+  } finally {
+    ddb.exec('DETACH DATABASE cov_lib');
+  }
+
+  const outcomeRows = ddb.prepare(
+    'SELECT outcome, COUNT(*) AS n FROM discovery_lookups GROUP BY outcome'
+  ).all();
+  const outcomes = {};
+  for (const r of outcomeRows) { outcomes[r.outcome] = r.n; }
+
+  return {
+    scope: 'global',
+    unit: 'tracks',
+    model,
+    done,
+    remaining,
+    outcomes,
+  };
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+// Coverage for every enrichment pass, memoised per accessible-library
+// set. Returns { totals: { tracks }, passes: { <kind>: {...}|null } };
+// null for the whole thing only when the library DB isn't open.
+// `force` drops the memo first (tests; admin refresh).
+export function getEnrichmentCoverage(libIds, { force = false } = {}) {
+  const d = db.getDB();
+  if (!d) { return null; }
+  const ids = Array.isArray(libIds) ? libIds : [];
+
+  const key = [...ids].sort((a, b) => a - b).join(',');
+  const now = Date.now();
+  if (force) { coverageCache.delete(key); }
+  const hit = coverageCache.get(key);
+  if (hit && now - hit.at <= CACHE_TTL_MS) { return hit.data; }
+
+  // One builder failing (locked discovery.db, mid-migration schema)
+  // nulls out its pass, never the endpoint.
+  const guard = (label, fn) => {
+    try { return fn(); } catch (err) {
+      winston.warn(`enrichment coverage: ${label} counts failed: ${err.message}`);
+      return null;
+    }
+  };
+
+  const lib = libClause('t.library_id', ids);
+  const data = {
+    totals: guard('totals', () => ({
+      tracks: d.prepare(`SELECT COUNT(*) AS n FROM tracks t WHERE ${lib.clause}`)
+        .get(...lib.params).n,
+    })),
+    passes: {
+      waveform: guard('waveform', () => waveformCoverage(d, now)),
+      albumart: guard('albumart', () => albumartCoverage(d, ids)),
+      lyrics: guard('lyrics', () => lyricsCoverage(d, ids)),
+      audioanalysis: guard('audioanalysis', () => audioAnalysisCoverage(d, ids)),
+      discovery: guard('discovery', () => discoveryCoverage()),
+      acoustid: guard('acoustid', () => acoustidCoverage(d, ids)),
+    },
+  };
+
+  if (coverageCache.size >= COVERAGE_CACHE_MAX_ENTRIES) { coverageCache.clear(); }
+  coverageCache.set(key, { at: now, data });
+  return data;
+}

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -13,6 +13,7 @@ import { launchWorker, workerReaperMarker } from '../util/worker-process.js';
 import { ffmpegBin, ensureFfmpeg } from '../util/ffmpeg-bootstrap.js';
 import * as dlnaApi from '../api/dlna.js';
 import * as discoveryDb from './discovery-db.js';
+import { invalidateCoverageCache } from './enrichment-status-lib.js';
 
 const __dirname = getDirname(import.meta.url);
 
@@ -305,6 +306,64 @@ function nextTask() {
 // effects below are about the SCAN batch), they don't surface as `locked`
 // (isScanning), and they run strictly serial like everything else.
 const ENRICHMENT_KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid'];
+
+// ── Enrichment status registry ──────────────────────────────────────────────
+//
+// Per-pass runtime state for the status API (GET /api/v1/scan/status).
+// The workers already narrate their lives as structured stdout events —
+// this registry just retains the latest one per pass instead of letting
+// it evaporate into the log. In-memory ON PURPOSE: unlike the library
+// scanner (a separate process that needs the scan_progress table as IPC),
+// enrichment events arrive in this process, and the queue they describe
+// is itself in-memory — a restart clears both consistently. Durable
+// "how enriched is the library" numbers come from the DB instead (see
+// src/db/enrichment-status-lib.js).
+//
+// Shape per kind:
+//   state    — 'idle' | 'queued' | 'running'. ('disabled' is derived at
+//              read time from the config gates; it never lives here, so a
+//              pass that is mid-run when its toggle flips off keeps
+//              reporting the truthful 'running' until it exits.)
+//   progress — { attempted, total } from the latest *Progress event, or
+//              null when not running.
+//   lastRun  — summary of the last time a worker actually ran this
+//              process lifetime, or null. Run-time gate bails (config
+//              flipped off while queued) deliberately do NOT overwrite
+//              it — the previous real run stays visible.
+const enrichmentStatus = {};
+for (const kind of ENRICHMENT_KINDS) {
+  enrichmentStatus[kind] = { state: 'idle', progress: null, lastRun: null };
+}
+
+function reportEnrichment(kind, patch) {
+  Object.assign(enrichmentStatus[kind], patch);
+}
+
+// Shared end-of-run bookkeeping for every enrichment closeOnce handler.
+// Must run BEFORE any hitCap re-enqueue in the same handler, so the
+// 'queued' state a re-enqueue sets isn't clobbered back to 'idle'.
+function finishEnrichment(kind, code, signal, completeEvt) {
+  // The pass just changed the world the coverage counts describe — drop
+  // the status API's memo so its next poll reflects the run immediately
+  // instead of after the TTL.
+  invalidateCoverageCache();
+  const counts = completeEvt ? { ...completeEvt } : null;
+  if (counts) { delete counts.event; delete counts.hitCap; }
+  reportEnrichment(kind, {
+    state: 'idle',
+    progress: null,
+    lastRun: {
+      finishedAt: Date.now(),
+      // 'killed' covers deliberate kills (shutdown, operator) — reported
+      // distinctly because it says nothing about the pass being broken.
+      outcome: signal ? 'killed' : (code === 0 ? 'completed' : 'failed'),
+      // More work remained when the per-run cap / wall-clock budget hit;
+      // the close handler queues a follow-up batch.
+      hitCap: !!(completeEvt && completeEvt.hitCap),
+      counts,
+    },
+  });
+}
 
 // Drained-queue side effects shared by onScanClose + onBackupClose.
 // Centralised here because the DLNA bump and the migration-rescan marker
@@ -610,6 +669,10 @@ function onScanClose(forkedScan, scanObj, code) {
     db.getDB()?.prepare('DELETE FROM scan_progress WHERE scan_id = ?').run(scanObj.id);
   } catch (_) {}
 
+  // A scan changes the track/album pools every coverage count is built
+  // over — drop the status API's memo like the enrichment passes do.
+  invalidateCoverageCache();
+
   // Merge FTS5 segments accumulated by this scan's writes. The triggers
   // create a fresh index segment per track-row write — over a long scan
   // these pile up and slow MATCH queries until the next merge runs on
@@ -717,10 +780,17 @@ export function addWaveformTask() {
   // One queued pass is enough — it sweeps the whole DB when it runs.
   if (taskQueue.some((t) => t.task === 'waveform')) { return; }
   taskQueue.push({ task: 'waveform', id: nanoid(8) });
+  // Before nextTask: dispatch is synchronous, and runWaveformTask owns the
+  // 'running' transition — set here so a task parked behind a long scan
+  // reads 'queued' the whole time it waits.
+  reportEnrichment('waveform', { state: 'queued' });
   nextTask();
 }
 
 function runWaveformTask(taskObj) {
+  // The task left the queue — whether it runs or gate-bails below, it is
+  // no longer 'queued'. A successful claim flips this to 'running'.
+  reportEnrichment('waveform', { state: 'idle', progress: null });
   // Re-check at run time: the admin toggle may have flipped while this
   // sat queued, and findRustParser() stays false for the process
   // lifetime once the binary was found dead.
@@ -751,11 +821,13 @@ function runWaveformTask(taskObj) {
   const killFn = () => { try { wfChild.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
   activeTask = { kind: 'waveform', taskObj, child: wfChild, killFn };
+  reportEnrichment('waveform', { state: 'running' });
 
   // Any stdout proves the binary knows the subcommand — the banner is
   // its first statement, printed before config parsing. Read by
   // closeOnce to tell "ran and failed" from "pre-dates --waveform-scan".
   let sawOutput = false;
+  let completeEvt = null;
   bufferLines(wfChild.stdout, (line) => {
     if (!line) { return; }
     sawOutput = true;
@@ -763,14 +835,20 @@ function runWaveformTask(taskObj) {
       try {
         const evt = JSON.parse(line);
         if (evt?.event === 'waveformScanStart') { return; }     // liveness banner
-        if (evt?.event === 'waveformScanProgress') { return; }  // too chatty for info
+        if (evt?.event === 'waveformScanProgress') {
+          // Too chatty for the log, but exactly what the status API wants.
+          reportEnrichment('waveform', { progress: { attempted: evt.done ?? 0, total: evt.total ?? null } });
+          return;
+        }
         if (evt?.event === 'waveformScanPlan') {
+          reportEnrichment('waveform', { progress: { attempted: 0, total: evt.total ?? null } });
           if (evt.total > 0) {
             winston.info(`Waveform pass: ${evt.total} track(s) need waveforms`);
           }
           return;
         }
         if (evt?.event === 'waveformScanComplete') {
+          completeEvt = evt;
           winston.info(
             `Waveform pass complete: ${evt.generated} generated, ` +
             `${evt.failed} failed (${evt.total} planned)`);
@@ -811,6 +889,7 @@ function runWaveformTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('waveform', code, signal, completeEvt);
     nextTask();
     checkQueueDrainedSideEffects();
   };
@@ -879,10 +958,12 @@ function addAlbumArtTask() {
   if (activeTask?.kind === 'albumart') { return; }
   if (taskQueue.some((t) => t.task === 'albumart')) { return; }
   taskQueue.push({ task: 'albumart', id: nanoid(8) });
+  reportEnrichment('albumart', { state: 'queued' });
   nextTask();
 }
 
 function runAlbumArtTask(taskObj) {
+  reportEnrichment('albumart', { state: 'idle', progress: null });
   const opts = config.program.scanOptions;
   // Re-check ALL the gates at run time: config may have flipped while
   // this sat queued, and run-time gating is what keeps every enqueue
@@ -917,8 +998,9 @@ function runAlbumArtTask(taskObj) {
   addToKillQueue(killFn);
   // `observers.hitCap` is set by the stdout 'albumArtComplete' event so
   // the close handler can decide whether to queue another batch.
-  const observers = { hitCap: false };
+  const observers = { hitCap: false, completeEvt: null };
   activeTask = { kind: 'albumart', taskObj, child: forked, killFn, observers };
+  reportEnrichment('albumart', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -927,6 +1009,7 @@ function runAlbumArtTask(taskObj) {
         const evt = JSON.parse(line);
         if (evt.event === 'albumArtComplete') {
           observers.hitCap = !!evt.hitCap;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Album-art download pass complete: ${evt.updated} fetched, `
               + `${evt.deduped} already-had, ${evt.notFound} not found, `
@@ -935,6 +1018,7 @@ function runAlbumArtTask(taskObj) {
           return;
         }
         if (evt.event === 'albumArtProgress') {
+          reportEnrichment('albumart', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Album-art download: ${evt.attempted}/${evt.total} albums attempted`);
           return;
         }
@@ -965,6 +1049,7 @@ function runAlbumArtTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('albumart', code, signal, observers.completeEvt);
     // hitCap: the worker stopped at maxPerRun with (probably) more to do —
     // queue another batch so a large first-run backlog drains in this idle
     // stretch, while still yielding the slot to any scan/backup queued
@@ -1034,10 +1119,12 @@ function addLyricsTask() {
   if (activeTask?.kind === 'lyrics') { return; }
   if (taskQueue.some((t) => t.task === 'lyrics')) { return; }
   taskQueue.push({ task: 'lyrics', id: nanoid(8) });
+  reportEnrichment('lyrics', { state: 'queued' });
   nextTask();
 }
 
 function runLyricsTask(taskObj) {
+  reportEnrichment('lyrics', { state: 'idle', progress: null });
   const opts = config.program.lyrics || {};
   // Re-check the gates at run time: config may have flipped while queued.
   if (opts.backfill !== true) { return; }
@@ -1066,8 +1153,9 @@ function runLyricsTask(taskObj) {
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
   // hitCap → re-enqueue another batch; updated → whether to optimise FTS.
-  const observers = { hitCap: false, updated: 0 };
+  const observers = { hitCap: false, updated: 0, completeEvt: null };
   activeTask = { kind: 'lyrics', taskObj, child: forked, killFn, observers };
+  reportEnrichment('lyrics', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1077,6 +1165,7 @@ function runLyricsTask(taskObj) {
         if (evt.event === 'lyricsComplete') {
           observers.hitCap = !!evt.hitCap;
           observers.updated = evt.updated || 0;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Lyrics backfill pass complete: ${evt.updated} added, `
               + `${evt.notFound} not found, ${evt.errors} error(s) (${evt.attempted} attempted)`);
@@ -1084,6 +1173,7 @@ function runLyricsTask(taskObj) {
           return;
         }
         if (evt.event === 'lyricsProgress') {
+          reportEnrichment('lyrics', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Lyrics backfill: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1114,6 +1204,7 @@ function runLyricsTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('lyrics', code, signal, observers.completeEvt);
     // Merge the FTS5 segments the lyrics writes accumulated (album-art never
     // touches an FTS-indexed column, so it skips this). Only on a successful
     // pass that actually added lyrics.
@@ -1214,10 +1305,12 @@ function addAudioAnalysisTask() {
   if (activeTask?.kind === 'audioanalysis') { return; }
   if (taskQueue.some((t) => t.task === 'audioanalysis')) { return; }
   taskQueue.push({ task: 'audioanalysis', id: nanoid(8) });
+  reportEnrichment('audioanalysis', { state: 'queued' });
   nextTask();
 }
 
 function runAudioAnalysisTask(taskObj) {
+  reportEnrichment('audioanalysis', { state: 'idle', progress: null });
   // Re-check the gate at run time: config may have flipped while this sat
   // queued (admin toggle), and ffmpeg may have gone away.
   if (config.program.scanOptions.analyzeBpm !== true) { return; }
@@ -1250,8 +1343,9 @@ function runAudioAnalysisTask(taskObj) {
 
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
-  const observers = { hitCap: false };
+  const observers = { hitCap: false, completeEvt: null };
   activeTask = { kind: 'audioanalysis', taskObj, child: forked, killFn, observers };
+  reportEnrichment('audioanalysis', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1260,6 +1354,7 @@ function runAudioAnalysisTask(taskObj) {
         const evt = JSON.parse(line);
         if (evt.event === 'audioAnalysisComplete') {
           observers.hitCap = !!evt.hitCap;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Audio-analysis pass complete: ${evt.analyzed} analysed, `
               + `${evt.lowconf} low-confidence, ${evt.errors} error(s) (${evt.attempted} attempted)`);
@@ -1267,6 +1362,7 @@ function runAudioAnalysisTask(taskObj) {
           return;
         }
         if (evt.event === 'audioAnalysisProgress') {
+          reportEnrichment('audioanalysis', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Audio-analysis: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1296,6 +1392,7 @@ function runAudioAnalysisTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('audioanalysis', code, signal, observers.completeEvt);
     // hitCap: the worker stopped at the per-run cap or wall-clock budget with
     // (probably) more to do — queue another batch so a large backlog drains in
     // this idle stretch while still yielding to any scan/backup queued
@@ -1394,10 +1491,12 @@ function addDiscoveryTask() {
   if (activeTask?.kind === 'discovery') { return; }
   if (taskQueue.some((t) => t.task === 'discovery')) { return; }
   taskQueue.push({ task: 'discovery', id: nanoid(8) });
+  reportEnrichment('discovery', { state: 'queued' });
   nextTask();
 }
 
 function runDiscoveryTask(taskObj) {
+  reportEnrichment('discovery', { state: 'idle', progress: null });
   // Re-check the gate at run time: config may have flipped while this sat
   // queued (admin toggle), and ffmpeg may have gone away.
   if (config.program.scanOptions.collectDiscoveryData !== true) { return; }
@@ -1431,8 +1530,9 @@ function runDiscoveryTask(taskObj) {
 
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
-  const observers = { hitCap: false };
+  const observers = { hitCap: false, completeEvt: null };
   activeTask = { kind: 'discovery', taskObj, child: forked, killFn, observers };
+  reportEnrichment('discovery', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1441,6 +1541,7 @@ function runDiscoveryTask(taskObj) {
         const evt = JSON.parse(line);
         if (evt.event === 'discoveryComplete') {
           observers.hitCap = !!evt.hitCap;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Discovery-embedding pass complete: ${evt.embedded} embedded, `
               + `${evt.errors} error(s) (${evt.attempted} attempted)`);
@@ -1448,6 +1549,7 @@ function runDiscoveryTask(taskObj) {
           return;
         }
         if (evt.event === 'discoveryProgress') {
+          reportEnrichment('discovery', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Discovery-embedding: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1490,6 +1592,7 @@ function runDiscoveryTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('discovery', code, signal, observers.completeEvt);
     // hitCap: stopped at the per-run cap or wall-clock budget with more to
     // do — queue another batch. Terminates: every attempt either writes an
     // embedding (drops out of the eligible set) or an error-cooldown row.
@@ -1575,10 +1678,12 @@ function addAcoustidTask() {
   if (activeTask?.kind === 'acoustid') { return; }
   if (taskQueue.some((t) => t.task === 'acoustid')) { return; }
   taskQueue.push({ task: 'acoustid', id: nanoid(8) });
+  reportEnrichment('acoustid', { state: 'queued' });
   nextTask();
 }
 
 function runAcoustidTask(taskObj) {
+  reportEnrichment('acoustid', { state: 'idle', progress: null });
   // Re-check gates at run time — config may have flipped while queued.
   if (config.program.scanOptions.analyzeAcoustid !== true) { return; }
   if (!config.program.scanOptions.acoustidApiKey) { return; }
@@ -1609,8 +1714,9 @@ function runAcoustidTask(taskObj) {
 
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
-  const observers = { hitCap: false, matched: 0 };
+  const observers = { hitCap: false, matched: 0, completeEvt: null };
   activeTask = { kind: 'acoustid', taskObj, child: forked, killFn, observers };
+  reportEnrichment('acoustid', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1620,6 +1726,7 @@ function runAcoustidTask(taskObj) {
         if (evt.event === 'acoustidComplete') {
           observers.hitCap = !!evt.hitCap;
           observers.matched = evt.matched || 0;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`AcoustID pass complete: ${evt.matched} identified, `
               + `${evt.nomatch} unknown to AcoustID, ${evt.lowconf} low-confidence, `
@@ -1628,6 +1735,7 @@ function runAcoustidTask(taskObj) {
           return;
         }
         if (evt.event === 'acoustidProgress') {
+          reportEnrichment('acoustid', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`AcoustID: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1657,6 +1765,7 @@ function runAcoustidTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('acoustid', code, signal, observers.completeEvt);
     if (code === 0 && !signal && observers.hitCap) {
       maybeEnqueueAcoustid();
     }
@@ -2210,6 +2319,76 @@ export function getAdminStats() {
     // a dashboard can see one in flight.
     activeTaskKind: activeTask?.kind || null,
   };
+}
+
+// Config/environment gates per enrichment pass, evaluated WITHOUT side
+// effects. Mirrors the checks each maybeEnqueueX/runXTask applies, minus
+// anything mutating: notably NO findRustParser() (its miss path can kick
+// off a five-minute `cargo build`) — the latched rustParserDisabled flag
+// is the strongest side-effect-free signal about the binary, and an
+// unprobed binary reads as available (the pass itself probes when it runs).
+// Reasons are ordered most-actionable-first: a config toggle the operator
+// can flip beats an environment condition they'd have to fix.
+function enrichmentGate(kind) {
+  const opts = config.program.scanOptions;
+  const off = (reason) => ({ enabled: false, reason });
+  const on = { enabled: true, reason: null };
+  switch (kind) {
+    case 'waveform':
+      if (opts.generateWaveforms === false) { return off('config'); }
+      if (waveformPassUnsupported) { return off('binary-unsupported'); }
+      if (rustParserDisabled) { return off('no-binary'); }
+      return on;
+    case 'albumart':
+      if (opts.autoAlbumArt === false || opts.skipImg === true) { return off('config'); }
+      if (Array.isArray(opts.albumArtServices) && opts.albumArtServices.length === 0) { return off('config'); }
+      return on;
+    case 'lyrics': {
+      const lyr = config.program.lyrics || {};
+      if (lyr.backfill !== true) { return off('config'); }
+      if (!Array.isArray(lyr.providers) || lyr.providers.length === 0) { return off('config'); }
+      return on;
+    }
+    case 'audioanalysis':
+      if (opts.analyzeBpm !== true) { return off('config'); }
+      if (!ffmpegBin()) { return off('no-ffmpeg'); }
+      return on;
+    case 'discovery':
+      if (opts.collectDiscoveryData !== true) { return off('config'); }
+      if (discoveryRuntimeUnavailable) { return off('runtime-unavailable'); }
+      if (!ffmpegBin()) { return off('no-ffmpeg'); }
+      return on;
+    case 'acoustid':
+      if (opts.analyzeAcoustid !== true) { return off('config'); }
+      if (!opts.acoustidApiKey) { return off('no-api-key'); }
+      if (rustParserDisabled) { return off('no-binary'); }
+      return on;
+    default:
+      return on;
+  }
+}
+
+// Snapshot of every enrichment pass for the status API
+// (GET /api/v1/scan/status). Defensive copies throughout, same contract
+// as getAdminStats. 'disabled' is derived here rather than stored: the
+// registry keeps the truthful runtime state, so a pass that is mid-run
+// when its toggle flips off reports 'running' until it exits, and a
+// re-enabled pass is instantly 'idle' again without an event.
+export function getEnrichmentStatus() {
+  return ENRICHMENT_KINDS.map((kind) => {
+    const s = enrichmentStatus[kind];
+    const gate = enrichmentGate(kind);
+    return {
+      pass: kind,
+      enabled: gate.enabled,
+      disabledReason: gate.reason,
+      state: s.state === 'idle' && !gate.enabled ? 'disabled' : s.state,
+      progress: s.progress ? { ...s.progress } : null,
+      lastRun: s.lastRun
+        ? { ...s.lastRun, counts: s.lastRun.counts ? { ...s.lastRun.counts } : null }
+        : null,
+    };
+  });
 }
 
 // Read the stable scan id for the in-flight migration-rescan epoch from

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -16,6 +16,7 @@ import * as dlnaApi from '../api/dlna.js';
 import * as discoveryDb from './discovery-db.js';
 import * as libraryWatcher from '../util/library-watcher.js';
 import * as waveformLib from './waveform-lib.js';
+import { invalidateCoverageCache } from './enrichment-status-lib.js';
 
 const __dirname = getDirname(import.meta.url);
 
@@ -367,6 +368,64 @@ function nextTask() {
 // effects below are about the SCAN batch), they don't surface as `locked`
 // (isScanning), and they run strictly serial like everything else.
 const ENRICHMENT_KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid'];
+
+// ── Enrichment status registry ──────────────────────────────────────────────
+//
+// Per-pass runtime state for the status API (GET /api/v1/scan/status).
+// The workers already narrate their lives as structured stdout events —
+// this registry just retains the latest one per pass instead of letting
+// it evaporate into the log. In-memory ON PURPOSE: unlike the library
+// scanner (a separate process that needs the scan_progress table as IPC),
+// enrichment events arrive in this process, and the queue they describe
+// is itself in-memory — a restart clears both consistently. Durable
+// "how enriched is the library" numbers come from the DB instead (see
+// src/db/enrichment-status-lib.js).
+//
+// Shape per kind:
+//   state    — 'idle' | 'queued' | 'running'. ('disabled' is derived at
+//              read time from the config gates; it never lives here, so a
+//              pass that is mid-run when its toggle flips off keeps
+//              reporting the truthful 'running' until it exits.)
+//   progress — { attempted, total } from the latest *Progress event, or
+//              null when not running.
+//   lastRun  — summary of the last time a worker actually ran this
+//              process lifetime, or null. Run-time gate bails (config
+//              flipped off while queued) deliberately do NOT overwrite
+//              it — the previous real run stays visible.
+const enrichmentStatus = {};
+for (const kind of ENRICHMENT_KINDS) {
+  enrichmentStatus[kind] = { state: 'idle', progress: null, lastRun: null };
+}
+
+function reportEnrichment(kind, patch) {
+  Object.assign(enrichmentStatus[kind], patch);
+}
+
+// Shared end-of-run bookkeeping for every enrichment closeOnce handler.
+// Must run BEFORE any hitCap re-enqueue in the same handler, so the
+// 'queued' state a re-enqueue sets isn't clobbered back to 'idle'.
+function finishEnrichment(kind, code, signal, completeEvt) {
+  // The pass just changed the world the coverage counts describe — drop
+  // the status API's memo so its next poll reflects the run immediately
+  // instead of after the TTL.
+  invalidateCoverageCache();
+  const counts = completeEvt ? { ...completeEvt } : null;
+  if (counts) { delete counts.event; delete counts.hitCap; }
+  reportEnrichment(kind, {
+    state: 'idle',
+    progress: null,
+    lastRun: {
+      finishedAt: Date.now(),
+      // 'killed' covers deliberate kills (shutdown, operator) — reported
+      // distinctly because it says nothing about the pass being broken.
+      outcome: signal ? 'killed' : (code === 0 ? 'completed' : 'failed'),
+      // More work remained when the per-run cap / wall-clock budget hit;
+      // the close handler queues a follow-up batch.
+      hitCap: !!(completeEvt && completeEvt.hitCap),
+      counts,
+    },
+  });
+}
 
 // Drained-queue side effects shared by onScanClose + onBackupClose.
 // Centralised here because the DLNA bump and the migration-rescan marker
@@ -784,6 +843,10 @@ function onScanClose(forkedScan, scanObj, code) {
     db.getDB()?.prepare('DELETE FROM scan_progress WHERE scan_id = ?').run(scanObj.id);
   } catch (_) {}
 
+  // A scan changes the track/album pools every coverage count is built
+  // over — drop the status API's memo like the enrichment passes do.
+  invalidateCoverageCache();
+
   // Merge FTS5 segments accumulated by this scan's writes. The triggers
   // create a fresh index segment per track-row write — over a long scan
   // these pile up and slow MATCH queries until the next merge runs on
@@ -891,10 +954,17 @@ export function addWaveformTask() {
   // One queued pass is enough — it sweeps the whole DB when it runs.
   if (taskQueue.some((t) => t.task === 'waveform')) { return; }
   taskQueue.push({ task: 'waveform', id: nanoid(8) });
+  // Before nextTask: dispatch is synchronous, and runWaveformTask owns the
+  // 'running' transition — set here so a task parked behind a long scan
+  // reads 'queued' the whole time it waits.
+  reportEnrichment('waveform', { state: 'queued' });
   nextTask();
 }
 
 function runWaveformTask(taskObj) {
+  // The task left the queue — whether it runs or gate-bails below, it is
+  // no longer 'queued'. A successful claim flips this to 'running'.
+  reportEnrichment('waveform', { state: 'idle', progress: null });
   // Re-check at run time: the admin toggle may have flipped while this
   // sat queued, and findRustParser() stays false for the process
   // lifetime once the binary was found dead.
@@ -925,11 +995,13 @@ function runWaveformTask(taskObj) {
   const killFn = () => { try { wfChild.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
   activeTask = { kind: 'waveform', taskObj, child: wfChild, killFn };
+  reportEnrichment('waveform', { state: 'running' });
 
   // Any stdout proves the binary knows the subcommand — the banner is
   // its first statement, printed before config parsing. Read by
   // closeOnce to tell "ran and failed" from "pre-dates --waveform-scan".
   let sawOutput = false;
+  let completeEvt = null;
   bufferLines(wfChild.stdout, (line) => {
     if (!line) { return; }
     sawOutput = true;
@@ -937,14 +1009,20 @@ function runWaveformTask(taskObj) {
       try {
         const evt = JSON.parse(line);
         if (evt?.event === 'waveformScanStart') { return; }     // liveness banner
-        if (evt?.event === 'waveformScanProgress') { return; }  // too chatty for info
+        if (evt?.event === 'waveformScanProgress') {
+          // Too chatty for the log, but exactly what the status API wants.
+          reportEnrichment('waveform', { progress: { attempted: evt.done ?? 0, total: evt.total ?? null } });
+          return;
+        }
         if (evt?.event === 'waveformScanPlan') {
+          reportEnrichment('waveform', { progress: { attempted: 0, total: evt.total ?? null } });
           if (evt.total > 0) {
             winston.info(`Waveform pass: ${evt.total} track(s) need waveforms`);
           }
           return;
         }
         if (evt?.event === 'waveformScanComplete') {
+          completeEvt = evt;
           winston.info(
             `Waveform pass complete: ${evt.generated} generated, ` +
             `${evt.failed} failed (${evt.total} planned)`);
@@ -985,6 +1063,7 @@ function runWaveformTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('waveform', code, signal, completeEvt);
     nextTask();
     checkQueueDrainedSideEffects();
   };
@@ -1053,10 +1132,12 @@ function addAlbumArtTask() {
   if (activeTask?.kind === 'albumart') { return; }
   if (taskQueue.some((t) => t.task === 'albumart')) { return; }
   taskQueue.push({ task: 'albumart', id: nanoid(8) });
+  reportEnrichment('albumart', { state: 'queued' });
   nextTask();
 }
 
 function runAlbumArtTask(taskObj) {
+  reportEnrichment('albumart', { state: 'idle', progress: null });
   const opts = config.program.scanOptions;
   // Re-check ALL the gates at run time: config may have flipped while
   // this sat queued, and run-time gating is what keeps every enqueue
@@ -1091,8 +1172,9 @@ function runAlbumArtTask(taskObj) {
   addToKillQueue(killFn);
   // `observers.hitCap` is set by the stdout 'albumArtComplete' event so
   // the close handler can decide whether to queue another batch.
-  const observers = { hitCap: false };
+  const observers = { hitCap: false, completeEvt: null };
   activeTask = { kind: 'albumart', taskObj, child: forked, killFn, observers };
+  reportEnrichment('albumart', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1101,6 +1183,7 @@ function runAlbumArtTask(taskObj) {
         const evt = JSON.parse(line);
         if (evt.event === 'albumArtComplete') {
           observers.hitCap = !!evt.hitCap;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Album-art download pass complete: ${evt.updated} fetched, `
               + `${evt.deduped} already-had, ${evt.notFound} not found, `
@@ -1109,6 +1192,7 @@ function runAlbumArtTask(taskObj) {
           return;
         }
         if (evt.event === 'albumArtProgress') {
+          reportEnrichment('albumart', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Album-art download: ${evt.attempted}/${evt.total} albums attempted`);
           return;
         }
@@ -1139,6 +1223,7 @@ function runAlbumArtTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('albumart', code, signal, observers.completeEvt);
     // hitCap: the worker stopped at maxPerRun with (probably) more to do —
     // queue another batch so a large first-run backlog drains in this idle
     // stretch, while still yielding the slot to any scan/backup queued
@@ -1208,10 +1293,12 @@ function addLyricsTask() {
   if (activeTask?.kind === 'lyrics') { return; }
   if (taskQueue.some((t) => t.task === 'lyrics')) { return; }
   taskQueue.push({ task: 'lyrics', id: nanoid(8) });
+  reportEnrichment('lyrics', { state: 'queued' });
   nextTask();
 }
 
 function runLyricsTask(taskObj) {
+  reportEnrichment('lyrics', { state: 'idle', progress: null });
   const opts = config.program.lyrics || {};
   // Re-check the gates at run time: config may have flipped while queued.
   if (opts.backfill !== true) { return; }
@@ -1240,8 +1327,9 @@ function runLyricsTask(taskObj) {
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
   // hitCap → re-enqueue another batch; updated → whether to optimise FTS.
-  const observers = { hitCap: false, updated: 0 };
+  const observers = { hitCap: false, updated: 0, completeEvt: null };
   activeTask = { kind: 'lyrics', taskObj, child: forked, killFn, observers };
+  reportEnrichment('lyrics', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1251,6 +1339,7 @@ function runLyricsTask(taskObj) {
         if (evt.event === 'lyricsComplete') {
           observers.hitCap = !!evt.hitCap;
           observers.updated = evt.updated || 0;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Lyrics backfill pass complete: ${evt.updated} added, `
               + `${evt.notFound} not found, ${evt.errors} error(s) (${evt.attempted} attempted)`);
@@ -1258,6 +1347,7 @@ function runLyricsTask(taskObj) {
           return;
         }
         if (evt.event === 'lyricsProgress') {
+          reportEnrichment('lyrics', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Lyrics backfill: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1288,6 +1378,7 @@ function runLyricsTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('lyrics', code, signal, observers.completeEvt);
     // Merge the FTS5 segments the lyrics writes accumulated (album-art never
     // touches an FTS-indexed column, so it skips this). Only on a successful
     // pass that actually added lyrics.
@@ -1388,10 +1479,12 @@ function addAudioAnalysisTask() {
   if (activeTask?.kind === 'audioanalysis') { return; }
   if (taskQueue.some((t) => t.task === 'audioanalysis')) { return; }
   taskQueue.push({ task: 'audioanalysis', id: nanoid(8) });
+  reportEnrichment('audioanalysis', { state: 'queued' });
   nextTask();
 }
 
 function runAudioAnalysisTask(taskObj) {
+  reportEnrichment('audioanalysis', { state: 'idle', progress: null });
   // Re-check the gate at run time: config may have flipped while this sat
   // queued (admin toggle), and ffmpeg may have gone away.
   if (config.program.scanOptions.analyzeBpm !== true) { return; }
@@ -1424,8 +1517,9 @@ function runAudioAnalysisTask(taskObj) {
 
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
-  const observers = { hitCap: false };
+  const observers = { hitCap: false, completeEvt: null };
   activeTask = { kind: 'audioanalysis', taskObj, child: forked, killFn, observers };
+  reportEnrichment('audioanalysis', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1434,6 +1528,7 @@ function runAudioAnalysisTask(taskObj) {
         const evt = JSON.parse(line);
         if (evt.event === 'audioAnalysisComplete') {
           observers.hitCap = !!evt.hitCap;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Audio-analysis pass complete: ${evt.analyzed} analysed, `
               + `${evt.lowconf} low-confidence, ${evt.errors} error(s) (${evt.attempted} attempted)`);
@@ -1441,6 +1536,7 @@ function runAudioAnalysisTask(taskObj) {
           return;
         }
         if (evt.event === 'audioAnalysisProgress') {
+          reportEnrichment('audioanalysis', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Audio-analysis: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1470,6 +1566,7 @@ function runAudioAnalysisTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('audioanalysis', code, signal, observers.completeEvt);
     // hitCap: the worker stopped at the per-run cap or wall-clock budget with
     // (probably) more to do — queue another batch so a large backlog drains in
     // this idle stretch while still yielding to any scan/backup queued
@@ -1568,10 +1665,12 @@ function addDiscoveryTask() {
   if (activeTask?.kind === 'discovery') { return; }
   if (taskQueue.some((t) => t.task === 'discovery')) { return; }
   taskQueue.push({ task: 'discovery', id: nanoid(8) });
+  reportEnrichment('discovery', { state: 'queued' });
   nextTask();
 }
 
 function runDiscoveryTask(taskObj) {
+  reportEnrichment('discovery', { state: 'idle', progress: null });
   // Re-check the gate at run time: config may have flipped while this sat
   // queued (admin toggle), and ffmpeg may have gone away.
   if (config.program.scanOptions.collectDiscoveryData !== true) { return; }
@@ -1605,8 +1704,9 @@ function runDiscoveryTask(taskObj) {
 
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
-  const observers = { hitCap: false };
+  const observers = { hitCap: false, completeEvt: null };
   activeTask = { kind: 'discovery', taskObj, child: forked, killFn, observers };
+  reportEnrichment('discovery', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1615,6 +1715,7 @@ function runDiscoveryTask(taskObj) {
         const evt = JSON.parse(line);
         if (evt.event === 'discoveryComplete') {
           observers.hitCap = !!evt.hitCap;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`Discovery-embedding pass complete: ${evt.embedded} embedded, `
               + `${evt.errors} error(s) (${evt.attempted} attempted)`);
@@ -1622,6 +1723,7 @@ function runDiscoveryTask(taskObj) {
           return;
         }
         if (evt.event === 'discoveryProgress') {
+          reportEnrichment('discovery', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`Discovery-embedding: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1668,6 +1770,7 @@ function runDiscoveryTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('discovery', code, signal, observers.completeEvt);
     // hitCap: stopped at the per-run cap or wall-clock budget with more to
     // do — queue another batch. Terminates: every attempt either writes an
     // embedding (drops out of the eligible set) or an error-cooldown row.
@@ -1753,10 +1856,12 @@ function addAcoustidTask() {
   if (activeTask?.kind === 'acoustid') { return; }
   if (taskQueue.some((t) => t.task === 'acoustid')) { return; }
   taskQueue.push({ task: 'acoustid', id: nanoid(8) });
+  reportEnrichment('acoustid', { state: 'queued' });
   nextTask();
 }
 
 function runAcoustidTask(taskObj) {
+  reportEnrichment('acoustid', { state: 'idle', progress: null });
   // Re-check gates at run time — config may have flipped while queued.
   if (config.program.scanOptions.analyzeAcoustid !== true) { return; }
   if (!config.program.scanOptions.acoustidApiKey) { return; }
@@ -1787,8 +1892,9 @@ function runAcoustidTask(taskObj) {
 
   const killFn = () => { try { forked.kill(); } catch (_) { /* already gone */ } };
   addToKillQueue(killFn);
-  const observers = { hitCap: false, matched: 0 };
+  const observers = { hitCap: false, matched: 0, completeEvt: null };
   activeTask = { kind: 'acoustid', taskObj, child: forked, killFn, observers };
+  reportEnrichment('acoustid', { state: 'running' });
 
   bufferLines(forked.stdout, (line) => {
     if (!line) { return; }
@@ -1798,6 +1904,7 @@ function runAcoustidTask(taskObj) {
         if (evt.event === 'acoustidComplete') {
           observers.hitCap = !!evt.hitCap;
           observers.matched = evt.matched || 0;
+          observers.completeEvt = evt;
           if (evt.attempted > 0) {
             winston.info(`AcoustID pass complete: ${evt.matched} identified, `
               + `${evt.nomatch} unknown to AcoustID, ${evt.lowconf} low-confidence, `
@@ -1806,6 +1913,7 @@ function runAcoustidTask(taskObj) {
           return;
         }
         if (evt.event === 'acoustidProgress') {
+          reportEnrichment('acoustid', { progress: { attempted: evt.attempted ?? 0, total: evt.total ?? null } });
           winston.info(`AcoustID: ${evt.attempted}/${evt.total} tracks attempted`);
           return;
         }
@@ -1835,6 +1943,7 @@ function runAcoustidTask(taskObj) {
       removeFromKillQueue(activeTask.killFn);
       activeTask = null;
     }
+    finishEnrichment('acoustid', code, signal, observers.completeEvt);
     if (code === 0 && !signal && observers.hitCap) {
       maybeEnqueueAcoustid();
     }
@@ -2430,6 +2539,76 @@ export function getAdminStats() {
     // a dashboard can see one in flight.
     activeTaskKind: activeTask?.kind || null,
   };
+}
+
+// Config/environment gates per enrichment pass, evaluated WITHOUT side
+// effects. Mirrors the checks each maybeEnqueueX/runXTask applies, minus
+// anything mutating: notably NO findRustParser() (its miss path can kick
+// off a five-minute `cargo build`) — the latched rustParserDisabled flag
+// is the strongest side-effect-free signal about the binary, and an
+// unprobed binary reads as available (the pass itself probes when it runs).
+// Reasons are ordered most-actionable-first: a config toggle the operator
+// can flip beats an environment condition they'd have to fix.
+function enrichmentGate(kind) {
+  const opts = config.program.scanOptions;
+  const off = (reason) => ({ enabled: false, reason });
+  const on = { enabled: true, reason: null };
+  switch (kind) {
+    case 'waveform':
+      if (opts.generateWaveforms === false) { return off('config'); }
+      if (waveformPassUnsupported) { return off('binary-unsupported'); }
+      if (rustParserDisabled) { return off('no-binary'); }
+      return on;
+    case 'albumart':
+      if (opts.autoAlbumArt === false || opts.skipImg === true) { return off('config'); }
+      if (Array.isArray(opts.albumArtServices) && opts.albumArtServices.length === 0) { return off('config'); }
+      return on;
+    case 'lyrics': {
+      const lyr = config.program.lyrics || {};
+      if (lyr.backfill !== true) { return off('config'); }
+      if (!Array.isArray(lyr.providers) || lyr.providers.length === 0) { return off('config'); }
+      return on;
+    }
+    case 'audioanalysis':
+      if (opts.analyzeBpm !== true) { return off('config'); }
+      if (!ffmpegBin()) { return off('no-ffmpeg'); }
+      return on;
+    case 'discovery':
+      if (opts.collectDiscoveryData !== true) { return off('config'); }
+      if (discoveryRuntimeUnavailable) { return off('runtime-unavailable'); }
+      if (!ffmpegBin()) { return off('no-ffmpeg'); }
+      return on;
+    case 'acoustid':
+      if (opts.analyzeAcoustid !== true) { return off('config'); }
+      if (!opts.acoustidApiKey) { return off('no-api-key'); }
+      if (rustParserDisabled) { return off('no-binary'); }
+      return on;
+    default:
+      return on;
+  }
+}
+
+// Snapshot of every enrichment pass for the status API
+// (GET /api/v1/scan/status). Defensive copies throughout, same contract
+// as getAdminStats. 'disabled' is derived here rather than stored: the
+// registry keeps the truthful runtime state, so a pass that is mid-run
+// when its toggle flips off reports 'running' until it exits, and a
+// re-enabled pass is instantly 'idle' again without an event.
+export function getEnrichmentStatus() {
+  return ENRICHMENT_KINDS.map((kind) => {
+    const s = enrichmentStatus[kind];
+    const gate = enrichmentGate(kind);
+    return {
+      pass: kind,
+      enabled: gate.enabled,
+      disabledReason: gate.reason,
+      state: s.state === 'idle' && !gate.enabled ? 'disabled' : s.state,
+      progress: s.progress ? { ...s.progress } : null,
+      lastRun: s.lastRun
+        ? { ...s.lastRun, counts: s.lastRun.counts ? { ...s.lastRun.counts } : null }
+        : null,
+    };
+  });
 }
 
 // Read the stable scan id for the in-flight migration-rescan epoch from

--- a/test/db/enrichment-coverage.test.mjs
+++ b/test/db/enrichment-coverage.test.mjs
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for src/db/enrichment-status-lib.js — the durable coverage
+ * counts behind GET /api/v1/scan/status.
+ *
+ * The counting rules are the contract here: each pass's `remaining` must
+ * mirror its worker's eligibility predicate (duration windows, NULL
+ * gates, hashless exclusion), `done` counts the artifact regardless of
+ * which writer produced it, library filtering must scope track/album
+ * passes to the caller's accessible libraries while hash-keyed passes
+ * (waveform, discovery) stay global, and ledger outcome maps must only
+ * count hashes that still resolve to an accessible track. All of that is
+ * pinned against a hand-seeded DB where every expected number is
+ * derivable by eye from the seed block.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let testRoot;
+let config;
+let dbManager;
+let discoveryDb;
+let coverageLib;
+let L1;
+let L2;
+
+// Seeded expectations reference these — see the before() block.
+const NOW_SEC = Math.floor(Date.now() / 1000);
+
+before(async () => {
+  testRoot = path.join(os.tmpdir(), `mstream-enrich-cov-${Date.now()}`);
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(testRoot, 'waveforms'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+      waveformCacheDirectory: path.join(testRoot, 'waveforms'),
+    },
+    port: 0,
+  }, null, 2));
+
+  config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  dbManager = await import('../../src/db/manager.js');
+  dbManager.initDB();
+  discoveryDb = await import('../../src/db/discovery-db.js');
+  coverageLib = await import('../../src/db/enrichment-status-lib.js');
+
+  const d = dbManager.getDB();
+
+  d.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES ('lib1', ?, 'music', 0)`)
+    .run(path.join(testRoot, 'lib1'));
+  d.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES ('lib2', ?, 'music', 0)`)
+    .run(path.join(testRoot, 'lib2'));
+  dbManager.invalidateCache();
+  L1 = dbManager.getLibraryByName('lib1').id;
+  L2 = dbManager.getLibraryByName('lib2').id;
+
+  const artistId = Number(d.prepare(`INSERT INTO artists (name) VALUES ('Seeder')`).run().lastInsertRowid);
+
+  // Albums: AL1 has art, AL2 lacks it, AL3 lives in lib2 only, AL4 is
+  // blank-named (excluded from the downloader's pool), AL5 is a ghost
+  // with no tracks (also excluded).
+  const album = (name, art) => Number(
+    d.prepare('INSERT INTO albums (name, album_art_file) VALUES (?, ?)').run(name, art).lastInsertRowid);
+  const AL1 = album('With Art', 'cover1.jpg');
+  const AL2 = album('No Art', null);
+  const AL3 = album('Other Lib', null);
+  const AL4 = album('   ', null);
+  album('Ghost — no tracks', null);
+
+  // Tracks. The per-pass expectations, by eye:
+  //   T1 fully enriched: lyrics, bpm+key, tag MBID, in-window duration.
+  //   T2 enriched by nothing: the one in-window remaining for every pass.
+  //   T3 hashless + 5s: structurally ineligible everywhere.
+  //   T4 4000s (outside the 30min analysis window, inside acoustid's 2h),
+  //      artist-less (lyrics-ineligible), bpm-only (analysis not done).
+  //   T5 in lib2: acoustid-sourced MBID; invisible to lib1-scoped counts.
+  const insTrack = d.prepare(`
+    INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, duration,
+                        file_hash, audio_hash, bpm, musical_key,
+                        lyrics_embedded, lyrics_synced_lrc, mbz_recording_id, mbz_id_source)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+  insTrack.run('t1.mp3', L1, 'Song1', artistId, AL1, 200, 'f1', 'h1', 120, '8A', 'la la', null, 'mbid-1', 'tag');
+  insTrack.run('t2.mp3', L1, 'Song2', artistId, AL2, 200, 'f2', 'h2', null, null, null, null, null, null);
+  insTrack.run('t3.mp3', L1, null, null, AL4, 5, null, null, null, null, null, null, null, null);
+  insTrack.run('t4.mp3', L1, 'Song4', null, null, 4000, 'f4', 'h4', 100, null, null, null, null, null);
+  insTrack.run('t5.mp3', L2, 'Other', artistId, AL3, 200, 'f5', 'h5', null, null, null, null, 'mbid-5', 'acoustid');
+
+  // Attempt ledgers. The lib2-scoped album_art error row and the orphan
+  // lyrics_cache hit must be filtered out of lib1-scoped outcome maps.
+  d.prepare(`INSERT INTO album_art_lookups (album_id, last_attempt_at, outcome) VALUES (?, ?, 'notfound')`)
+    .run(AL2, NOW_SEC);
+  d.prepare(`INSERT INTO album_art_lookups (album_id, last_attempt_at, outcome) VALUES (?, ?, 'error')`)
+    .run(AL3, NOW_SEC);
+  d.prepare(`INSERT INTO audio_analysis_lookups (audio_hash, last_attempt_at, outcome) VALUES ('h2', ?, 'error')`)
+    .run(NOW_SEC);
+  d.prepare(`INSERT INTO acoustid_lookups (audio_hash, last_attempt_at, outcome) VALUES ('h2', ?, 'nomatch')`)
+    .run(NOW_SEC);
+  d.prepare(`INSERT INTO lyrics_cache (audio_hash, status, fetched_at) VALUES ('h2', 'notfound', ?)`)
+    .run(Date.now());
+  d.prepare(`INSERT INTO lyrics_cache (audio_hash, status, fetched_at) VALUES ('h-orphan', 'hit', ?)`)
+    .run(Date.now());
+
+  // Waveform cache artifacts: 2 bins + 1 failed marker; the .bin.tmp is
+  // an in-flight temp file the counter must ignore. Global hash pool is
+  // h1/h2/h4/h5 (T3 is hashless) → remaining = 4 − 2 − 1 = 1.
+  const wf = config.program.storage.waveformCacheDirectory;
+  fs.writeFileSync(path.join(wf, 'h1.bin'), Buffer.alloc(8));
+  fs.writeFileSync(path.join(wf, 'h2.bin'), Buffer.alloc(8));
+  fs.writeFileSync(path.join(wf, 'h4.failed'), '');
+  fs.writeFileSync(path.join(wf, 'h5.bin.tmp'), Buffer.alloc(8));
+
+  // Discovery: h1 embedded under the CURRENT model → done. h5 embedded
+  // under a stale model → still remaining (the worker re-embeds it).
+  // In-window hashes lacking a current-model embedding: h2, h5 → 2.
+  const ddb = discoveryDb.initDiscoveryDb();
+  const model = config.program.scanOptions.discoveryModel;
+  const insEmb = ddb.prepare(`
+    INSERT INTO discovery_tracks (audio_hash, updated_at, export_id, model_id, embedding)
+    VALUES (?, ?, ?, ?, ?)`);
+  insEmb.run('h1', 1, 'anon:h1', model, Buffer.alloc(16));
+  insEmb.run('h5', 2, 'anon:h5', 'legacy-model', Buffer.alloc(16));
+  ddb.prepare(`INSERT INTO discovery_lookups (audio_hash, last_attempt_at, outcome) VALUES ('h2', ?, 'error')`)
+    .run(NOW_SEC);
+});
+
+after(() => {
+  if (discoveryDb) { discoveryDb.closeDiscoveryDb(); }
+  if (dbManager) { dbManager.close(); }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
+  // Repo convention for suites that boot the real DB: without this the
+  // SQLite handle keeps the test runner alive.
+  setImmediate(() => process.exit(0));
+});
+
+function coverage(libIds) {
+  return coverageLib.getEnrichmentCoverage(libIds, { force: true });
+}
+
+describe('enrichment coverage: lib1-scoped counts', () => {
+  test('totals count only accessible tracks', () => {
+    assert.equal(coverage([L1]).totals.tracks, 4);
+  });
+
+  test('albumart: named albums with accessible tracks; done = has art', () => {
+    const c = coverage([L1]).passes.albumart;
+    assert.equal(c.scope, 'library');
+    assert.equal(c.eligible, 2, 'AL1 + AL2 (blank-named, trackless, lib2-only excluded)');
+    assert.equal(c.done, 1);
+    assert.equal(c.remaining, 1);
+    assert.deepEqual(c.outcomes, { notfound: 1 }, "lib2's error row must not leak in");
+  });
+
+  test('lyrics: done = has lyrics; remaining = lyric-less AND lookup-able', () => {
+    const c = coverage([L1]).passes.lyrics;
+    assert.equal(c.done, 1, 'T1');
+    assert.equal(c.remaining, 1, 'T2 only — T3 lacks a title, T4 lacks an artist');
+    assert.deepEqual(c.outcomes, { notfound: 1 }, 'orphan-hash cache rows must not count');
+  });
+
+  test('audioanalysis: done needs BOTH bpm and key; remaining honours the duration window', () => {
+    const c = coverage([L1]).passes.audioanalysis;
+    assert.equal(c.done, 1, 'T1 — T4 has bpm but no key');
+    assert.equal(c.remaining, 1, 'T2 only — T4 is outside the 30min window, T3 is hashless');
+    assert.deepEqual(c.outcomes, { error: 1 });
+  });
+
+  test('acoustid: done split by provenance; remaining honours its wider window', () => {
+    const c = coverage([L1]).passes.acoustid;
+    assert.equal(c.done, 1);
+    assert.deepEqual(c.bySource, { tag: 1, acoustid: 0 }, 'T5 is lib2-only');
+    assert.equal(c.remaining, 2, 'T2 and T4 (4000s fits the 2h acoustid window)');
+    assert.deepEqual(c.outcomes, { nomatch: 1 });
+  });
+
+  test('waveform: global artifact counts; temp files ignored', () => {
+    const c = coverage([L1]).passes.waveform;
+    assert.equal(c.scope, 'global');
+    assert.equal(c.done, 2, 'h1.bin + h2.bin — the .bin.tmp must not count');
+    assert.equal(c.remaining, 1, '4 global hashes − 2 bins − 1 failed');
+    assert.deepEqual(c.outcomes, { failed: 1 });
+  });
+
+  test('discovery: current-model embeddings only; stale-model rows stay remaining', () => {
+    const c = coverage([L1]).passes.discovery;
+    assert.equal(c.scope, 'global');
+    assert.equal(c.model, config.program.scanOptions.discoveryModel);
+    assert.equal(c.done, 1, 'h1 — the legacy-model h5 row does not count');
+    assert.equal(c.remaining, 2, 'h2 + h5 (h4 is outside the duration window)');
+    assert.deepEqual(c.outcomes, { error: 1 });
+  });
+});
+
+describe('enrichment coverage: scope and caching', () => {
+  test('widening access to both libraries widens the counts', () => {
+    const c = coverage([L1, L2]);
+    assert.equal(c.totals.tracks, 5);
+    assert.equal(c.passes.albumart.eligible, 3);
+    assert.deepEqual(c.passes.albumart.outcomes, { notfound: 1, error: 1 });
+    assert.deepEqual(c.passes.acoustid.bySource, { tag: 1, acoustid: 1 });
+  });
+
+  test('empty library access zeroes the library-scoped counts', () => {
+    const c = coverage([]);
+    assert.equal(c.totals.tracks, 0);
+    assert.equal(c.passes.albumart.eligible, 0);
+    assert.equal(c.passes.lyrics.remaining, 0);
+    // Hash-keyed passes are global on purpose.
+    assert.equal(c.passes.waveform.done, 2);
+  });
+
+  test('results are memoised per library set until forced', () => {
+    const first = coverage([L1]);           // force:true primes a fresh entry
+    const d = dbManager.getDB();
+    d.prepare(`INSERT INTO tracks (filepath, library_id, title) VALUES ('t-late.mp3', ?, 'Late')`).run(L1);
+
+    const cached = coverageLib.getEnrichmentCoverage([L1]);
+    assert.equal(cached.totals.tracks, first.totals.tracks,
+      'within the TTL the memo answers, not the DB');
+
+    const fresh = coverageLib.getEnrichmentCoverage([L1], { force: true });
+    assert.equal(fresh.totals.tracks, first.totals.tracks + 1,
+      'force must re-read the DB');
+  });
+});

--- a/test/integration/enrichment-status.test.mjs
+++ b/test/integration/enrichment-status.test.mjs
@@ -1,0 +1,241 @@
+/**
+ * Integration tests for the task-queue enrichment status registry
+ * (getEnrichmentStatus in src/db/task-queue.js) — the live half of
+ * GET /api/v1/scan/status.
+ *
+ * What gets pinned:
+ *   - the initial snapshot: all six passes present, config gates mapped
+ *     to enabled/disabledReason/state (including the environment reasons
+ *     'no-api-key' and 'no-ffmpeg', which are deterministic here because
+ *     nothing in this process ever runs ensureFfmpeg);
+ *   - queued → running → idle transitions driven through the REAL queue:
+ *     a slow backup holds the serial slot so the queued state is
+ *     observable, then the real rust waveform pass runs against an empty
+ *     DB (no network, no fixtures needed — completes with zero counts);
+ *   - a run-time gate bail (toggle flipped off while the task sat
+ *     queued) returns the pass to idle WITHOUT overwriting the last real
+ *     run's summary;
+ *   - defensive copies: mutating a returned snapshot must not poison the
+ *     registry.
+ *
+ * Strategy mirrors test/integration/task-queue.test.mjs: import the
+ * production modules, drive the public queue API, assert on queue state.
+ */
+
+import { describe, before, after, beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+let testRoot;
+let config;
+let dbManager;
+let taskQueue;
+let libId;
+
+const KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid'];
+
+function statusOf(kind) {
+  const entry = taskQueue.getEnrichmentStatus().find((p) => p.pass === kind);
+  assert.ok(entry, `getEnrichmentStatus must report '${kind}'`);
+  return entry;
+}
+
+async function waitFor(predicate, { timeoutMs = 30_000, intervalMs = 50 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) { return true; }
+    await sleep(intervalMs);
+  }
+  return false;
+}
+
+async function waitForIdle() {
+  const ok = await waitFor(
+    () => taskQueue.getActiveBackupRun() === null
+       && taskQueue.getQueueLength() === 0
+       && !taskQueue.isScanning()
+       && taskQueue.getAdminStats().activeTaskKind === null,
+    { timeoutMs: 60_000 },
+  );
+  if (!ok) {
+    throw new Error('Queue did not drain within 60s — test likely leaked state');
+  }
+}
+
+function addSlowBackupHold(label) {
+  const dest = dbManager.addBackupDestination({
+    libraryId: libId, destPath: path.join(testRoot, label),
+    triggerType: 'manual', dailyAtHour: null, retentionDays: 7, enabled: true,
+    excludeGlobs: [], interFileDelayMs: 300,
+  });
+  taskQueue.addBackupTask(dest, 'manual');
+  return dest;
+}
+
+before(async () => {
+  testRoot = path.join(os.tmpdir(), `mstream-enrich-status-${Date.now()}`);
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+      // Without this the real waveform pass below would write into the
+      // REPO's default waveform-cache/ — shared, persistent state.
+      waveformCacheDirectory: path.join(testRoot, 'waveforms'),
+    },
+    port: 0,
+  }, null, 2));
+
+  config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  dbManager = await import('../../src/db/manager.js');
+  dbManager.initDB();
+  taskQueue = await import('../../src/db/task-queue.js');
+
+  // A small file tree for the backup worker that holds the queue slot.
+  const lib = path.join(testRoot, 'src-lib');
+  fs.mkdirSync(lib, { recursive: true });
+  for (let i = 0; i < 4; i++) {
+    fs.writeFileSync(path.join(lib, `track-${i}.mp3`), Buffer.alloc(1024, i));
+  }
+  dbManager.getDB().prepare(
+    `INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES ('status-lib', ?, 'music', 0)`
+  ).run(lib);
+  dbManager.invalidateCache();
+  libId = dbManager.getLibraryByName('status-lib').id;
+});
+
+after(async () => {
+  if (taskQueue) { await waitForIdle(); }
+  if (dbManager) { dbManager.close(); }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_) { /* cleanup */ }
+  setImmediate(() => process.exit(0));
+});
+
+beforeEach(async () => {
+  await waitForIdle();
+});
+
+describe('enrichment status: initial snapshot and gates', () => {
+  test('reports all six passes with the full field set', () => {
+    const all = taskQueue.getEnrichmentStatus();
+    assert.deepEqual(all.map((p) => p.pass), KINDS);
+    for (const p of all) {
+      for (const key of ['pass', 'enabled', 'disabledReason', 'state', 'progress', 'lastRun']) {
+        assert.ok(key in p, `'${p.pass}' entry must carry '${key}'`);
+      }
+    }
+  });
+
+  test('default config gates: waveform + albumart on; the opt-ins off', () => {
+    assert.deepEqual(
+      Object.fromEntries(taskQueue.getEnrichmentStatus()
+        .map((p) => [p.pass, [p.enabled, p.disabledReason, p.state]])),
+      {
+        waveform:      [true,  null,        'idle'],
+        albumart:      [true,  null,        'idle'],
+        lyrics:        [false, 'config',    'disabled'],
+        audioanalysis: [false, 'config',    'disabled'],
+        // collectDiscoveryData defaults ON, but ensureFfmpeg never ran in
+        // this process — the environment reason must win over 'idle'.
+        discovery:     [false, 'no-ffmpeg', 'disabled'],
+        acoustid:      [false, 'config',    'disabled'],
+      });
+  });
+
+  test('gate flips are reflected live, with reasons ordered config-first', () => {
+    const opts = config.program.scanOptions;
+    const savedKey = opts.acoustidApiKey;
+    try {
+      opts.analyzeAcoustid = true;
+      assert.equal(statusOf('acoustid').enabled, true,
+        'the shipped default API key satisfies the key gate');
+
+      opts.acoustidApiKey = '';
+      assert.deepEqual(
+        [statusOf('acoustid').enabled, statusOf('acoustid').disabledReason],
+        [false, 'no-api-key']);
+
+      config.program.lyrics.backfill = true;
+      assert.equal(statusOf('lyrics').enabled, true,
+        'default providers list satisfies the lyrics gate');
+
+      opts.generateWaveforms = false;
+      assert.deepEqual(
+        [statusOf('waveform').state, statusOf('waveform').disabledReason],
+        ['disabled', 'config']);
+    } finally {
+      opts.analyzeAcoustid = false;
+      opts.acoustidApiKey = savedKey;
+      opts.generateWaveforms = true;
+      config.program.lyrics.backfill = false;
+    }
+  });
+});
+
+describe('enrichment status: lifecycle through the real queue', () => {
+  test('queued behind a held slot, then a real run lands in lastRun', async () => {
+    addSlowBackupHold('hold-queued');
+    await sleep(100);
+    assert.notEqual(taskQueue.getActiveBackupRun(), null, 'backup should hold the slot');
+
+    taskQueue.addWaveformTask();
+    assert.equal(statusOf('waveform').state, 'queued',
+      'a waveform task parked behind the backup must read queued');
+
+    await waitForIdle();
+
+    // The rust pass really ran (empty DB → plans zero, exits 0).
+    const wf = statusOf('waveform');
+    assert.equal(wf.state, 'idle');
+    assert.equal(wf.progress, null);
+    assert.equal(wf.lastRun?.outcome, 'completed');
+    assert.equal(wf.lastRun?.hitCap, false);
+    assert.deepEqual(wf.lastRun?.counts, { generated: 0, failed: 0, total: 0 },
+      'counts must be the waveformScanComplete payload minus event/hitCap');
+    assert.equal(typeof wf.lastRun?.finishedAt, 'number');
+  });
+
+  test('a run-time gate bail returns to idle without clobbering lastRun', async () => {
+    // Seed a real lastRun first (fast: empty DB).
+    taskQueue.addWaveformTask();
+    await waitForIdle();
+    const seeded = statusOf('waveform').lastRun;
+    assert.equal(seeded?.outcome, 'completed', 'precondition: a real run recorded');
+
+    // Queue another pass behind a held slot, then flip the toggle off so
+    // dispatch gate-bails instead of running.
+    addSlowBackupHold('hold-bail');
+    await sleep(100);
+    taskQueue.addWaveformTask();
+    assert.equal(statusOf('waveform').state, 'queued');
+    config.program.scanOptions.generateWaveforms = false;
+    try {
+      await waitForIdle();
+      const wf = statusOf('waveform');
+      assert.equal(wf.state, 'disabled', 'bailed + gate off reads disabled');
+      assert.deepEqual(wf.lastRun, seeded,
+        'a skipped dispatch must not overwrite the last real run');
+    } finally {
+      config.program.scanOptions.generateWaveforms = true;
+    }
+    assert.equal(statusOf('waveform').state, 'idle',
+      're-enabling restores idle without any event');
+  });
+
+  test('snapshots are defensive copies', async () => {
+    taskQueue.addWaveformTask();
+    await waitForIdle();
+    const a = statusOf('waveform');
+    assert.ok(a.lastRun?.counts, 'precondition: a completed run with counts');
+    a.state = 'poisoned';
+    a.lastRun.counts.generated = 999;
+    const b = statusOf('waveform');
+    assert.equal(b.state, 'idle', 'top-level fields must be insulated');
+    assert.equal(b.lastRun.counts.generated, 0, 'nested counts must be insulated');
+  });
+});

--- a/test/integration/scan-status.test.mjs
+++ b/test/integration/scan-status.test.mjs
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for GET /api/v1/scan/status — the enrichment status
+ * endpoint (queue snapshot + per-pass gates/state/lastRun + durable
+ * coverage counts).
+ *
+ * Runs against a real booted server: the boot scan indexes the shared
+ * fixture library, and — because generateWaveforms defaults on and the
+ * repo ships a rust-parser prebuilt — the waveform enrichment pass
+ * genuinely runs behind it, so the test can assert a real lastRun and
+ * real coverage numbers end-to-end. The other passes stay disabled by
+ * config (the server helper forces autoAlbumArt/collectDiscoveryData
+ * off; lyrics/BPM/AcoustID default off), which pins the disabledReason
+ * mapping over HTTP.
+ *
+ * Library filtering: coverage counts are scoped by the caller's
+ * accessible libraries — a user with no vpaths must see zeroed
+ * library-scoped counts (and totals), while hash-keyed passes stay
+ * global by design.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { startServer } from '../helpers/server.mjs';
+
+const ADMIN    = { username: 'admin',  password: 'pw-admin' };
+const NOACCESS = { username: 'novpath', password: 'pw-novpath', vpaths: [] };
+
+let server;
+let adminJwt;
+let noAccessJwt;
+
+async function login(user) {
+  const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: user.username, password: user.password }),
+  });
+  return (await r.json()).token;
+}
+
+async function getStatus(jwt) {
+  const r = await fetch(`${server.baseUrl}/api/v1/scan/status`, {
+    headers: { 'x-access-token': jwt },
+  });
+  assert.equal(r.status, 200);
+  return r.json();
+}
+
+before(async () => {
+  server = await startServer({
+    dlnaMode: 'disabled',
+    users: [
+      { ...ADMIN, admin: true },
+      NOACCESS,
+    ],
+  });
+  adminJwt = await login(ADMIN);
+  noAccessJwt = await login(NOACCESS);
+
+  // Let the post-scan enrichment chain settle: the waveform pass runs
+  // for real over the fixtures. Poll the endpoint itself — it's the
+  // component under test AND the only authenticated view of the queue.
+  const start = Date.now();
+  for (;;) {
+    const body = await getStatus(adminJwt);
+    const wf = body.enrichment.find((p) => p.pass === 'waveform');
+    if (body.queue.activeTask === null && body.queue.queued.length === 0 && wf.lastRun) { break; }
+    if (Date.now() - start > 90_000) {
+      throw new Error('enrichment queue did not settle within 90s');
+    }
+    await sleep(200);
+  }
+});
+
+after(async () => {
+  if (server) { await server.stop(); }
+});
+
+describe('GET /api/v1/scan/status', () => {
+  test('requires authentication', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/scan/status`);
+    assert.equal(r.status, 401);
+  });
+
+  test('reports the queue snapshot and all six passes', async () => {
+    const body = await getStatus(adminJwt);
+
+    assert.deepEqual(body.queue, { scanning: false, activeTask: null, queued: [] },
+      'settled server: no heavy work, nothing queued');
+    assert.ok(body.totals.tracks > 0, 'fixture library was scanned');
+
+    assert.deepEqual(
+      body.enrichment.map((p) => p.pass),
+      ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid']);
+    for (const p of body.enrichment) {
+      for (const key of ['enabled', 'disabledReason', 'state', 'progress', 'lastRun', 'coverage']) {
+        assert.ok(key in p, `'${p.pass}' entry must carry '${key}'`);
+      }
+    }
+  });
+
+  test('config-disabled passes surface state=disabled with reason=config', async () => {
+    const body = await getStatus(adminJwt);
+    // The server helper forces autoAlbumArt + collectDiscoveryData off;
+    // lyrics backfill, analyzeBpm and analyzeAcoustid default off.
+    for (const kind of ['albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid']) {
+      const p = body.enrichment.find((e) => e.pass === kind);
+      assert.equal(p.enabled, false, `${kind} should be disabled in the test config`);
+      assert.equal(p.disabledReason, 'config');
+      assert.equal(p.state, 'disabled');
+    }
+  });
+
+  test('the waveform pass really ran: lastRun + coverage agree with the library', async () => {
+    const body = await getStatus(adminJwt);
+    const wf = body.enrichment.find((p) => p.pass === 'waveform');
+
+    assert.equal(wf.enabled, true);
+    assert.equal(wf.state, 'idle');
+    assert.equal(wf.lastRun.outcome, 'completed');
+    assert.ok(wf.lastRun.counts.generated > 0, 'fixtures should have produced waveforms');
+
+    assert.equal(wf.coverage.scope, 'global');
+    assert.ok(wf.coverage.done > 0, 'generated .bins must show up as durable coverage');
+    assert.equal(wf.coverage.done + wf.coverage.remaining + (wf.coverage.outcomes.failed || 0),
+      body.totals.tracks,
+      'bins + backlog + failed markers account for every fixture hash');
+  });
+
+  test('coverage carries per-pass backlogs grounded in worker eligibility', async () => {
+    const body = await getStatus(adminJwt);
+    const byPass = Object.fromEntries(body.enrichment.map((p) => [p.pass, p]));
+
+    // Fixtures embed artist/title but no lyrics — all lookup-able.
+    assert.equal(byPass.lyrics.coverage.done, 0);
+    assert.equal(byPass.lyrics.coverage.remaining, body.totals.tracks);
+
+    // Fixtures are 1-second clips: below the analysis (30s) and AcoustID
+    // (10s) duration floors, so neither pass has anything to do — the
+    // backlog must NOT count structurally ineligible tracks.
+    assert.equal(byPass.audioanalysis.coverage.remaining, 0);
+    assert.equal(byPass.acoustid.coverage.remaining, 0);
+
+    // Fixture albums ship no cover art.
+    assert.ok(byPass.albumart.coverage.eligible > 0);
+    assert.equal(byPass.albumart.coverage.done, 0);
+
+    // Discovery has never been enabled → no discovery.db → no coverage.
+    assert.equal(byPass.discovery.coverage, null);
+  });
+
+  test('library-scoped coverage is filtered by the caller\'s access', async () => {
+    const body = await getStatus(noAccessJwt);
+
+    assert.equal(body.totals.tracks, 0, 'no vpaths → no visible tracks');
+    const byPass = Object.fromEntries(body.enrichment.map((p) => [p.pass, p]));
+    assert.equal(byPass.albumart.coverage.eligible, 0);
+    assert.equal(byPass.lyrics.coverage.remaining, 0);
+    assert.deepEqual(byPass.acoustid.coverage.bySource, { tag: 0, acoustid: 0 });
+
+    // Hash-keyed passes are global by design — the same numbers every
+    // caller sees (waveforms are shared cache artifacts, not library rows).
+    assert.ok(byPass.waveform.coverage.done > 0);
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of the enrichment status work: a single authenticated endpoint, **`GET /api/v1/scan/status`**, that shows users the status of all six post-scan enrichment passes — waveforms, album-art download, lyrics backfill, BPM/key analysis, discovery embeddings, and AcoustID identification.

Each pass answers three questions in one poll:

| Question | Source | Fields |
|---|---|---|
| Is it on? | config + environment gates, evaluated side-effect-free | `enabled`, `disabledReason` (`config`, `no-ffmpeg`, `no-api-key`, `no-binary`, `binary-unsupported`, `runtime-unavailable`) |
| Is it working? | new in-memory registry in task-queue.js | `state` (idle/queued/running/disabled), live `progress` from the worker's own events, `lastRun` (outcome, hitCap, completion counters) |
| How far along? | durable DB counts (survive restarts) | `coverage`: `done` / `remaining` / `outcomes`, grounded in each worker's eligibility predicate |

Plus a `queue` block (active task kind, queued kinds, the `scanning` bit) so clients don't need the admin dashboard to know why a pass is waiting.

## Design notes

- **The workers already narrate everything as structured stdout events** (`*Progress` / `*Complete`); task-queue.js consumed them for winston logging and dropped them. The registry just retains the latest event per pass — no new IPC, no worker changes.
- **In-memory on purpose**: the queue the live state describes is itself in-memory, so a restart clears both consistently. The durable half (`coverage`) comes from the DB via the new `src/db/enrichment-status-lib.js`.
- **Gates never mutate**: notably no `findRustParser()` (its miss path can kick off a 5-minute `cargo build`); the latched flags are the strongest side-effect-free signal.
- **`remaining` mirrors each worker's eligibility query** (duration windows, NULL gates, hashless exclusion) minus the time-based cooldown terms, which would make the number oscillate without the library changing; the `outcomes` ledger map explains why remaining items aren't being retried.
- **Library-scoped where the data is** (`lyrics`, `albumart`, `audioanalysis`, `acoustid` filter to the caller's accessible libraries); hash-keyed passes (`waveform`, `discovery`) are honestly marked `scope: "global"`.
- **Coverage is memoised (5s / 60s for the waveform readdir)** and invalidated whenever a scan or enrichment pass closes, so a completed pass is visible on the next poll.
- A run-time gate bail (toggle flipped off while a task sat queued) returns the pass to idle **without** overwriting the last real run's summary.

Authenticated but deliberately **not admin-only**: enrichment explains player-visible features (missing waveform, missing lyrics, no BPM pill). The queue block carries task kinds only — no vpaths or filepaths.

Docs: OpenAPI entry + CHANGELOG. Phase 2 (webapp UI on top of this endpoint) is a separate PR.

## Tests

22 new tests, all passing locally (Node 24, macOS):

- `test/db/enrichment-coverage.test.mjs` — hand-seeded counting rules: per-pass eligibility windows, provenance splits, ledger outcome filtering (orphan hashes and other-library rows must not leak), library scoping, memoisation.
- `test/integration/enrichment-status.test.mjs` — registry lifecycle through the **real queue**: queued behind a held slot, a genuine rust `--waveform-scan` run landing in `lastRun`, run-time gate bail, defensive copies, gate flips.
- `test/integration/scan-status.test.mjs` — HTTP surface against a booted server: auth, shape, disabled reasons, real waveform coverage agreeing with the fixture library, zeroed counts for a no-vpath user.

Regression suites re-run green: task-queue (23), admin-scan-params (17), admin-lyrics-settings (5), album-art-downloader (17), audio-analysis-backfill (11), acoustid-backfill (7), discovery-backfill (11). `redocly lint` still validates; eslint clean on touched files (the 6 empty-block errors in task-queue.js pre-exist on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
