### PR TITLE
Enrichment status UI: admin panel card + player top-bar chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,11 @@ removed.
   poll: enabled/disabled (with the reason), live queue state and
   worker progress, a summary of the last run, and durable
   done / remaining / outcome coverage counts scoped to the caller's
-  libraries. See `docs/openapi.yaml`.
+  libraries. See `docs/openapi.yaml`. Surfaced in two UIs: an
+  **Enrichment Status card** on the admin Database page (per-pass
+  state badge, live progress, last-run summary, coverage bars with
+  outcome breakdowns), and a quiet blue chip in the main UI's top bar
+  while a pass is running.
 - **Subsonic REST API.** Phase-1 through Phase-3 handlers covering
   browsing (getArtists / getArtist / getAlbum / getAlbumList2 /
   getStarred2 / getPlaylists / getPlaylist / search2 / search3),
@@ -236,6 +240,12 @@ removed.
 
 ### 🐛 Bug fixes
 
+- The main UI's top-bar scan progress cards now actually appear on
+  locally-served sessions. The widget required a truthy
+  `currentServer.host` before polling, but host is the empty string
+  whenever the webapp is served by the same mStream instance it talks
+  to (the normal setup) — so the cards only ever showed for
+  configured-remote servers.
 - Scanner no longer pre-DELETEs the old tracks row before
   re-parsing. `INSERT OR REPLACE` + CASCADE handles the swap
   atomically, so a parse failure (malformed tags, I/O error)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,9 @@ removed.
   libraries. See `docs/openapi.yaml`. Surfaced in two UIs: an
   **Enrichment Status card** on the admin Database page (per-pass
   on/off switch, state badge, live progress, last-run summary,
-  coverage bars with outcome breakdowns), and a quiet blue chip in the
-  main UI's top bar while a pass is running. The card's switches are
+  coverage bars with outcome breakdowns — plus live per-library
+  metadata-scan progress under the queue line while a scan runs), and
+  a quiet blue chip in the main UI's top bar while a pass is running. The card's switches are
   now the single home for enabling/disabling each pass — the old
   scattered toggle rows (DB Scan Settings, Album Art Lookup's "Auto
   Lookup", the Lyrics page's backfill row) are gone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,12 +71,13 @@ removed.
   poll: enabled/disabled (with the reason), live queue state and
   worker progress, a summary of the last run, and durable
   done / remaining / outcome coverage counts scoped to the caller's
-  libraries. See `docs/openapi.yaml`. Surfaced in two UIs: an
-  **Enrichment Status card** on the admin Database page (per-pass
-  on/off switch, state badge, live progress, last-run summary,
-  coverage bars with outcome breakdowns — plus live per-library
-  metadata-scan progress under the queue line while a scan runs), and
-  a quiet blue chip in the main UI's top bar while a pass is running. The card's switches are
+  libraries. See `docs/openapi.yaml`. Surfaced in two UIs: on the
+  admin Database page, the **Scan Queue & Stats card** now carries the
+  live task-queue line and per-library metadata-scan progress (bar,
+  counts, current file), with an **Enrichment Status card** below it
+  (per-pass on/off switch, state badge, live progress, last-run
+  summary, coverage bars with outcome breakdowns); and a quiet blue
+  chip in the main UI's top bar while a pass is running. The card's switches are
   now the single home for enabling/disabling each pass — the old
   scattered toggle rows (DB Scan Settings, Album Art Lookup's "Auto
   Lookup", the Lyrics page's backfill row) are gone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,12 @@ removed.
   done / remaining / outcome coverage counts scoped to the caller's
   libraries. See `docs/openapi.yaml`. Surfaced in two UIs: an
   **Enrichment Status card** on the admin Database page (per-pass
-  state badge, live progress, last-run summary, coverage bars with
-  outcome breakdowns), and a quiet blue chip in the main UI's top bar
-  while a pass is running.
+  on/off switch, state badge, live progress, last-run summary,
+  coverage bars with outcome breakdowns), and a quiet blue chip in the
+  main UI's top bar while a pass is running. The card's switches are
+  now the single home for enabling/disabling each pass — the old
+  scattered toggle rows (DB Scan Settings, Album Art Lookup's "Auto
+  Lookup", the Lyrics page's backfill row) are gone.
 - **Subsonic REST API.** Phase-1 through Phase-3 handlers covering
   browsing (getArtists / getArtist / getAlbum / getAlbumList2 /
   getStarred2 / getPlaylists / getPlaylist / search2 / search3),

--- a/webapp/admin/index.css
+++ b/webapp/admin/index.css
@@ -260,3 +260,54 @@ tr.backup-row-active:hover { background: #bbdefb; }
 .seed-drop-zone.is-busy {
   opacity: 0.85;
 }
+
+/* ── Enrichment status card (db-view) ─────────────────────────────────── */
+
+.enrich-table td {
+  vertical-align: top;
+}
+
+.enrich-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+
+.enrich-badge-running  { background: #2e7d32; color: #fff; }
+.enrich-badge-queued   { background: #1565c0; color: #fff; }
+.enrich-badge-idle     { background: #3a3a47; color: #ddd; }
+.enrich-badge-disabled { background: #2a2a34; color: #888; border: 1px solid #505061; }
+
+.enrich-muted {
+  color: #999;
+}
+
+.enrich-failed {
+  color: #ef5350;
+  font-weight: bold;
+}
+
+.enrich-bar {
+  position: relative;
+  height: 5px;
+  max-width: 220px;
+  margin: 6px 0 4px 0;
+  background: #3a3a47;
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.enrich-bar-fill {
+  height: 100%;
+  background: #66bb6a;
+  border-radius: 99px;
+  transition: width 0.8s ease-out;
+}
+
+.enrich-bar-coverage {
+  margin: 0 0 4px 0;
+}

--- a/webapp/admin/index.css
+++ b/webapp/admin/index.css
@@ -267,6 +267,11 @@ tr.backup-row-active:hover { background: #bbdefb; }
   vertical-align: top;
 }
 
+/* Materialize switch, sans the side-label gutters it assumes. */
+.enrich-switch label .lever {
+  margin: 0;
+}
+
 .enrich-badge {
   display: inline-block;
   padding: 2px 8px;

--- a/webapp/admin/index.css
+++ b/webapp/admin/index.css
@@ -316,3 +316,50 @@ tr.backup-row-active:hover { background: #bbdefb; }
 .enrich-bar-coverage {
   margin: 0 0 4px 0;
 }
+
+/* Live per-library scan rows (GET /api/v1/scan/progress) shown under
+   the queue line while a scan runs. */
+.enrich-scan-row {
+  max-width: 460px;
+  margin: 2px 0 12px 0;
+}
+
+.enrich-scan-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.enrich-scan-pct {
+  font-size: 12px;
+  font-weight: bold;
+  color: #66bb6a;
+}
+
+.enrich-scan-row .enrich-bar-scan {
+  max-width: none;
+  margin: 4px 0;
+}
+
+.enrich-scan-file {
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Indeterminate shimmer for the counting phase (no expected total yet) —
+   same movement as the player top bar's spc-fill-ind, green like the
+   card's other bars. */
+.enrich-bar-ind {
+  position: absolute;
+  inset: 0;
+  width: 40%;
+  background: linear-gradient(90deg, transparent, #66bb6a, transparent);
+  animation: enrich-shimmer 1.8s ease-in-out infinite;
+}
+
+@keyframes enrich-shimmer {
+  0%   { transform: translateX(-250%); }
+  100% { transform: translateX(350%); }
+}

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1911,7 +1911,13 @@ const dbView = Vue.component('db-view', {
       sharedPlaylists: ADMINDATA.sharedPlaylists,
       sharedPlaylistsTS: ADMINDATA.sharedPlaylistUpdated,
       isPullingStats: false,
-      isPullingShared: false
+      isPullingShared: false,
+      // Latest GET /api/v1/scan/status payload (queue + per-pass
+      // enrichment status + coverage). Null until the first poll lands;
+      // stale-but-shown on transient poll failures (same philosophy as
+      // the player's scan-progress widget — a blip shouldn't blank the
+      // panel).
+      enrichStatus: null
     };
   },
   template: `
@@ -2072,6 +2078,64 @@ const dbView = Vue.component('db-view', {
                 <pre v-else>
                   {{dbStats}}
                 </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col s12">
+            <div class="card">
+              <div class="card-content">
+                <span class="card-title">Enrichment Status</span>
+                <p v-if="!enrichStatus" class="enrich-muted">Loading…</p>
+                <template v-else>
+                  <p>
+                    <template v-if="enrichStatus.queue.activeTask">
+                      Now running: <b>{{ passLabel(enrichStatus.queue.activeTask) }}</b><span v-if="enrichStatus.queue.queued.length"> · {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})</span>
+                    </template>
+                    <template v-else-if="enrichStatus.queue.queued.length">
+                      {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})
+                    </template>
+                    <template v-else>
+                      Task queue idle<span v-if="enrichStatus.totals"> · {{ enrichStatus.totals.tracks.toLocaleString() }} tracks indexed</span>
+                    </template>
+                  </p>
+                  <table class="enrich-table">
+                    <thead>
+                      <tr>
+                        <th>Pass</th>
+                        <th>Status</th>
+                        <th>Last run</th>
+                        <th>Coverage</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="p in enrichStatus.enrichment" v-bind:key="p.pass">
+                        <td><b>{{ passLabel(p.pass) }}</b></td>
+                        <td>
+                          <span class="enrich-badge" v-bind:class="'enrich-badge-' + p.state">{{ stateLabel(p) }}</span>
+                          <div v-if="p.state === 'running' && p.progress && p.progress.total" class="enrich-bar">
+                            <div class="enrich-bar-fill" v-bind:style="{ width: pctOf(p.progress.attempted, p.progress.total) + '%' }"></div>
+                          </div>
+                          <span v-if="p.state === 'running' && p.progress" class="enrich-muted">{{ p.progress.attempted.toLocaleString() }} / {{ p.progress.total ? p.progress.total.toLocaleString() : '?' }}</span>
+                        </td>
+                        <td>
+                          <span v-if="p.lastRun" v-bind:class="{ 'enrich-failed': p.lastRun.outcome === 'failed' }">{{ lastRunSummary(p.lastRun) }}</span>
+                          <span v-else class="enrich-muted">—</span>
+                        </td>
+                        <td>
+                          <template v-if="p.coverage">
+                            <div class="enrich-bar enrich-bar-coverage">
+                              <div class="enrich-bar-fill" v-bind:style="{ width: pctOf(p.coverage.done, p.coverage.done + p.coverage.remaining) + '%' }"></div>
+                            </div>
+                            {{ p.coverage.done.toLocaleString() }} / {{ (p.coverage.done + p.coverage.remaining).toLocaleString() }} {{ p.coverage.unit }}<span class="enrich-muted">{{ outcomesSummary(p.coverage.outcomes) }}</span>
+                          </template>
+                          <span v-else class="enrich-muted">—</span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </template>
               </div>
             </div>
           </div>
@@ -2683,7 +2747,97 @@ const dbView = Vue.component('db-view', {
     openModal: function(modalView) {
       modVM.currentViewModal = modalView;
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
+    },
+    fetchEnrichStatus: async function() {
+      try {
+        const res = await API.axios({
+          method: 'GET',
+          url: `${API.url()}/api/v1/scan/status`
+        });
+        this.enrichStatus = res.data;
+      } catch (err) {
+        // Polling: keep showing the last snapshot through transient
+        // failures rather than toasting every few seconds.
+      }
+    },
+    passLabel: function(kind) {
+      return {
+        scan: 'Library Scan',
+        backup: 'Backup',
+        waveform: 'Waveforms',
+        albumart: 'Album Art',
+        lyrics: 'Lyrics',
+        audioanalysis: 'BPM / Key',
+        discovery: 'Discovery Embeddings',
+        acoustid: 'AcoustID IDs',
+      }[kind] || kind;
+    },
+    stateLabel: function(p) {
+      if (p.state === 'disabled') {
+        // Config-off is the unremarkable case — keep the badge terse.
+        // Environment reasons are the surprising ones worth spelling out.
+        if (p.disabledReason === 'config') { return 'Off'; }
+        const reason = {
+          'no-ffmpeg': 'waiting for ffmpeg',
+          'no-api-key': 'no API key',
+          'no-binary': 'rust-parser unavailable',
+          'binary-unsupported': 'rust-parser outdated',
+          'runtime-unavailable': 'ML runtime unavailable',
+        }[p.disabledReason] || p.disabledReason;
+        return `Off — ${reason}`;
+      }
+      return { idle: 'Idle', queued: 'Queued', running: 'Running' }[p.state] || p.state;
+    },
+    pctOf: function(part, whole) {
+      if (!whole) { return 0; }
+      return Math.min(100, Math.round((part / whole) * 100));
+    },
+    // "45 fetched · 3 not found · 1 error" from a lastRun.counts /
+    // coverage.outcomes object. Vocabulary differs per pass; unknown keys
+    // fall through verbatim so a new worker counter still renders.
+    countsSummary: function(counts) {
+      const labels = {
+        generated: 'generated', updated: 'fetched', deduped: 'already had',
+        analyzed: 'analysed', embedded: 'embedded', matched: 'identified',
+        found: 'found', hit: 'found',
+        notFound: 'not found', notfound: 'not found', nomatch: 'no match',
+        lowconf: 'low-confidence', undecodable: 'undecodable',
+        failed: 'failed', errors: 'errors', error: 'errors',
+        attempted: 'attempted', total: 'planned',
+      };
+      return Object.entries(counts || {})
+        .filter(([k, v]) => v > 0 && k !== 'attempted' && k !== 'total')
+        .map(([k, v]) => `${v.toLocaleString()} ${labels[k] || k}`)
+        .join(' · ');
+    },
+    outcomesSummary: function(outcomes) {
+      const s = this.countsSummary(outcomes);
+      return s ? ` · ${s}` : '';
+    },
+    lastRunSummary: function(lastRun) {
+      const head = { completed: 'Completed', failed: 'FAILED', killed: 'Stopped' }[lastRun.outcome] || lastRun.outcome;
+      const ago = this.timeAgo(lastRun.finishedAt);
+      const counts = this.countsSummary(lastRun.counts);
+      const tail = counts || (lastRun.outcome === 'completed' ? 'nothing to do' : '');
+      return `${head} ${ago}${tail ? ' — ' + tail : ''}${lastRun.hitCap ? ' · more queued' : ''}`;
+    },
+    timeAgo: function(epochMs) {
+      const s = Math.max(0, Math.round((Date.now() - epochMs) / 1000));
+      if (s < 60) { return 'just now'; }
+      if (s < 3600) { return `${Math.round(s / 60)}m ago`; }
+      if (s < 86400) { return `${Math.round(s / 3600)}h ago`; }
+      return `${Math.round(s / 86400)}d ago`;
     }
+  },
+  created: function() {
+    this.fetchEnrichStatus();
+    // 4s keeps the running pass's progress feeling live without leaning
+    // on the server: the endpoint's coverage counts are memoised
+    // server-side, so a poll between passes is two cheap map reads.
+    this.enrichTimer = setInterval(() => { this.fetchEnrichStatus(); }, 4000);
+  },
+  beforeDestroy: function() {
+    if (this.enrichTimer) { clearInterval(this.enrichTimer); }
   }
 });
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1919,9 +1919,9 @@ const dbView = Vue.component('db-view', {
       // panel).
       enrichStatus: null,
       // Live per-library rows from GET /api/v1/scan/progress — empty
-      // between scans. Rendered under the queue line so the page that
-      // starts a scan also shows it moving (the player top bar renders
-      // the same rows for everyone else).
+      // between scans. Rendered in the Scan Queue & Stats card so the
+      // page that starts a scan also shows it moving (the player top
+      // bar renders the same rows for everyone else).
       scanProgress: [],
       // Local mirror of config.lyrics.backfill for the card's lyrics
       // switch — same late-added-key reactivity dodge lyrics-view uses
@@ -2068,6 +2068,29 @@ const dbView = Vue.component('db-view', {
             <div class="card">
               <div class="card-content">
                 <span class="card-title">{{ t('admin.db.scanQueueStats') }}</span>
+                <p v-if="enrichStatus">
+                  <template v-if="enrichStatus.queue.activeTask">
+                    Now running: <b>{{ passLabel(enrichStatus.queue.activeTask) }}</b><span v-if="enrichStatus.queue.queued.length"> · {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})</span>
+                  </template>
+                  <template v-else-if="enrichStatus.queue.queued.length">
+                    {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})
+                  </template>
+                  <template v-else>
+                    Task queue idle<span v-if="enrichStatus.totals"> · {{ enrichStatus.totals.tracks.toLocaleString() }} tracks indexed</span>
+                  </template>
+                </p>
+                <div v-for="sp in scanProgress" v-bind:key="sp.vpath" class="enrich-scan-row">
+                  <div class="enrich-scan-head">
+                    <b>{{ sp.vpath }}</b>
+                    <span class="enrich-scan-pct">{{ sp.pct != null ? sp.pct + '%' : 'Counting…' }}</span>
+                    <span class="enrich-muted">{{ sp.expected ? sp.scanned.toLocaleString() + ' / ' + sp.expected.toLocaleString() : sp.scanned.toLocaleString() + ' files' }}</span>
+                  </div>
+                  <div class="enrich-bar enrich-bar-scan">
+                    <div v-if="sp.pct != null" class="enrich-bar-fill" v-bind:style="{ width: sp.pct + '%' }"></div>
+                    <div v-else class="enrich-bar-ind"></div>
+                  </div>
+                  <div v-if="sp.currentFile" class="enrich-muted enrich-scan-file">{{ sp.currentFile }}</div>
+                </div>
                 <a v-on:click="scanDB" class="waves-effect waves-light btn">{{ t('admin.db.startScan') }}</a>
                 <a v-on:click="forceRescan" class="waves-effect waves-light btn orange">{{ t('admin.db.forceRescan') }}</a>
                 <a v-on:click="pullStats" class="waves-effect waves-light btn">{{ t('admin.db.pullStats') }}</a>
@@ -2088,29 +2111,6 @@ const dbView = Vue.component('db-view', {
                 <span class="card-title">Enrichment Status</span>
                 <p v-if="!enrichStatus" class="enrich-muted">Loading…</p>
                 <template v-else>
-                  <p>
-                    <template v-if="enrichStatus.queue.activeTask">
-                      Now running: <b>{{ passLabel(enrichStatus.queue.activeTask) }}</b><span v-if="enrichStatus.queue.queued.length"> · {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})</span>
-                    </template>
-                    <template v-else-if="enrichStatus.queue.queued.length">
-                      {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})
-                    </template>
-                    <template v-else>
-                      Task queue idle<span v-if="enrichStatus.totals"> · {{ enrichStatus.totals.tracks.toLocaleString() }} tracks indexed</span>
-                    </template>
-                  </p>
-                  <div v-for="sp in scanProgress" v-bind:key="sp.vpath" class="enrich-scan-row">
-                    <div class="enrich-scan-head">
-                      <b>{{ sp.vpath }}</b>
-                      <span class="enrich-scan-pct">{{ sp.pct != null ? sp.pct + '%' : 'Counting…' }}</span>
-                      <span class="enrich-muted">{{ sp.expected ? sp.scanned.toLocaleString() + ' / ' + sp.expected.toLocaleString() : sp.scanned.toLocaleString() + ' files' }}</span>
-                    </div>
-                    <div class="enrich-bar enrich-bar-scan">
-                      <div v-if="sp.pct != null" class="enrich-bar-fill" v-bind:style="{ width: sp.pct + '%' }"></div>
-                      <div v-else class="enrich-bar-ind"></div>
-                    </div>
-                    <div v-if="sp.currentFile" class="enrich-muted enrich-scan-file">{{ sp.currentFile }}</div>
-                  </div>
                   <table class="enrich-table">
                     <thead>
                       <tr>

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1911,7 +1911,13 @@ const dbView = Vue.component('db-view', {
       sharedPlaylists: ADMINDATA.sharedPlaylists,
       sharedPlaylistsTS: ADMINDATA.sharedPlaylistUpdated,
       isPullingStats: false,
-      isPullingShared: false
+      isPullingShared: false,
+      // Latest GET /api/v1/scan/status payload (queue + per-pass
+      // enrichment status + coverage). Null until the first poll lands;
+      // stale-but-shown on transient poll failures (same philosophy as
+      // the player's scan-progress widget — a blip shouldn't blank the
+      // panel).
+      enrichStatus: null
     };
   },
   template: `
@@ -2090,6 +2096,64 @@ const dbView = Vue.component('db-view', {
                 <pre v-else>
                   {{dbStats}}
                 </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col s12">
+            <div class="card">
+              <div class="card-content">
+                <span class="card-title">Enrichment Status</span>
+                <p v-if="!enrichStatus" class="enrich-muted">Loading…</p>
+                <template v-else>
+                  <p>
+                    <template v-if="enrichStatus.queue.activeTask">
+                      Now running: <b>{{ passLabel(enrichStatus.queue.activeTask) }}</b><span v-if="enrichStatus.queue.queued.length"> · {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})</span>
+                    </template>
+                    <template v-else-if="enrichStatus.queue.queued.length">
+                      {{ enrichStatus.queue.queued.length }} queued ({{ enrichStatus.queue.queued.map(passLabel).join(', ') }})
+                    </template>
+                    <template v-else>
+                      Task queue idle<span v-if="enrichStatus.totals"> · {{ enrichStatus.totals.tracks.toLocaleString() }} tracks indexed</span>
+                    </template>
+                  </p>
+                  <table class="enrich-table">
+                    <thead>
+                      <tr>
+                        <th>Pass</th>
+                        <th>Status</th>
+                        <th>Last run</th>
+                        <th>Coverage</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="p in enrichStatus.enrichment" v-bind:key="p.pass">
+                        <td><b>{{ passLabel(p.pass) }}</b></td>
+                        <td>
+                          <span class="enrich-badge" v-bind:class="'enrich-badge-' + p.state">{{ stateLabel(p) }}</span>
+                          <div v-if="p.state === 'running' && p.progress && p.progress.total" class="enrich-bar">
+                            <div class="enrich-bar-fill" v-bind:style="{ width: pctOf(p.progress.attempted, p.progress.total) + '%' }"></div>
+                          </div>
+                          <span v-if="p.state === 'running' && p.progress" class="enrich-muted">{{ p.progress.attempted.toLocaleString() }} / {{ p.progress.total ? p.progress.total.toLocaleString() : '?' }}</span>
+                        </td>
+                        <td>
+                          <span v-if="p.lastRun" v-bind:class="{ 'enrich-failed': p.lastRun.outcome === 'failed' }">{{ lastRunSummary(p.lastRun) }}</span>
+                          <span v-else class="enrich-muted">—</span>
+                        </td>
+                        <td>
+                          <template v-if="p.coverage">
+                            <div class="enrich-bar enrich-bar-coverage">
+                              <div class="enrich-bar-fill" v-bind:style="{ width: pctOf(p.coverage.done, p.coverage.done + p.coverage.remaining) + '%' }"></div>
+                            </div>
+                            {{ p.coverage.done.toLocaleString() }} / {{ (p.coverage.done + p.coverage.remaining).toLocaleString() }} {{ p.coverage.unit }}<span class="enrich-muted">{{ outcomesSummary(p.coverage.outcomes) }}</span>
+                          </template>
+                          <span v-else class="enrich-muted">—</span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </template>
               </div>
             </div>
           </div>
@@ -2798,7 +2862,97 @@ const dbView = Vue.component('db-view', {
     openModal: function(modalView) {
       modVM.currentViewModal = modalView;
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
+    },
+    fetchEnrichStatus: async function() {
+      try {
+        const res = await API.axios({
+          method: 'GET',
+          url: `${API.url()}/api/v1/scan/status`
+        });
+        this.enrichStatus = res.data;
+      } catch (err) {
+        // Polling: keep showing the last snapshot through transient
+        // failures rather than toasting every few seconds.
+      }
+    },
+    passLabel: function(kind) {
+      return {
+        scan: 'Library Scan',
+        backup: 'Backup',
+        waveform: 'Waveforms',
+        albumart: 'Album Art',
+        lyrics: 'Lyrics',
+        audioanalysis: 'BPM / Key',
+        discovery: 'Discovery Embeddings',
+        acoustid: 'AcoustID IDs',
+      }[kind] || kind;
+    },
+    stateLabel: function(p) {
+      if (p.state === 'disabled') {
+        // Config-off is the unremarkable case — keep the badge terse.
+        // Environment reasons are the surprising ones worth spelling out.
+        if (p.disabledReason === 'config') { return 'Off'; }
+        const reason = {
+          'no-ffmpeg': 'waiting for ffmpeg',
+          'no-api-key': 'no API key',
+          'no-binary': 'rust-parser unavailable',
+          'binary-unsupported': 'rust-parser outdated',
+          'runtime-unavailable': 'ML runtime unavailable',
+        }[p.disabledReason] || p.disabledReason;
+        return `Off — ${reason}`;
+      }
+      return { idle: 'Idle', queued: 'Queued', running: 'Running' }[p.state] || p.state;
+    },
+    pctOf: function(part, whole) {
+      if (!whole) { return 0; }
+      return Math.min(100, Math.round((part / whole) * 100));
+    },
+    // "45 fetched · 3 not found · 1 error" from a lastRun.counts /
+    // coverage.outcomes object. Vocabulary differs per pass; unknown keys
+    // fall through verbatim so a new worker counter still renders.
+    countsSummary: function(counts) {
+      const labels = {
+        generated: 'generated', updated: 'fetched', deduped: 'already had',
+        analyzed: 'analysed', embedded: 'embedded', matched: 'identified',
+        found: 'found', hit: 'found',
+        notFound: 'not found', notfound: 'not found', nomatch: 'no match',
+        lowconf: 'low-confidence', undecodable: 'undecodable',
+        failed: 'failed', errors: 'errors', error: 'errors',
+        attempted: 'attempted', total: 'planned',
+      };
+      return Object.entries(counts || {})
+        .filter(([k, v]) => v > 0 && k !== 'attempted' && k !== 'total')
+        .map(([k, v]) => `${v.toLocaleString()} ${labels[k] || k}`)
+        .join(' · ');
+    },
+    outcomesSummary: function(outcomes) {
+      const s = this.countsSummary(outcomes);
+      return s ? ` · ${s}` : '';
+    },
+    lastRunSummary: function(lastRun) {
+      const head = { completed: 'Completed', failed: 'FAILED', killed: 'Stopped' }[lastRun.outcome] || lastRun.outcome;
+      const ago = this.timeAgo(lastRun.finishedAt);
+      const counts = this.countsSummary(lastRun.counts);
+      const tail = counts || (lastRun.outcome === 'completed' ? 'nothing to do' : '');
+      return `${head} ${ago}${tail ? ' — ' + tail : ''}${lastRun.hitCap ? ' · more queued' : ''}`;
+    },
+    timeAgo: function(epochMs) {
+      const s = Math.max(0, Math.round((Date.now() - epochMs) / 1000));
+      if (s < 60) { return 'just now'; }
+      if (s < 3600) { return `${Math.round(s / 60)}m ago`; }
+      if (s < 86400) { return `${Math.round(s / 3600)}h ago`; }
+      return `${Math.round(s / 86400)}d ago`;
     }
+  },
+  created: function() {
+    this.fetchEnrichStatus();
+    // 4s keeps the running pass's progress feeling live without leaning
+    // on the server: the endpoint's coverage counts are memoised
+    // server-side, so a poll between passes is two cheap map reads.
+    this.enrichTimer = setInterval(() => { this.fetchEnrichStatus(); }, 4000);
+  },
+  beforeDestroy: function() {
+    if (this.enrichTimer) { clearInterval(this.enrichTimer); }
   }
 });
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1918,6 +1918,11 @@ const dbView = Vue.component('db-view', {
       // the player's scan-progress widget — a blip shouldn't blank the
       // panel).
       enrichStatus: null,
+      // Live per-library rows from GET /api/v1/scan/progress — empty
+      // between scans. Rendered under the queue line so the page that
+      // starts a scan also shows it moving (the player top bar renders
+      // the same rows for everyone else).
+      scanProgress: [],
       // Local mirror of config.lyrics.backfill for the card's lyrics
       // switch — same late-added-key reactivity dodge lyrics-view uses
       // (ADMINDATA.lyricsParams gains keys after this component has
@@ -2094,6 +2099,18 @@ const dbView = Vue.component('db-view', {
                       Task queue idle<span v-if="enrichStatus.totals"> · {{ enrichStatus.totals.tracks.toLocaleString() }} tracks indexed</span>
                     </template>
                   </p>
+                  <div v-for="sp in scanProgress" v-bind:key="sp.vpath" class="enrich-scan-row">
+                    <div class="enrich-scan-head">
+                      <b>{{ sp.vpath }}</b>
+                      <span class="enrich-scan-pct">{{ sp.pct != null ? sp.pct + '%' : 'Counting…' }}</span>
+                      <span class="enrich-muted">{{ sp.expected ? sp.scanned.toLocaleString() + ' / ' + sp.expected.toLocaleString() : sp.scanned.toLocaleString() + ' files' }}</span>
+                    </div>
+                    <div class="enrich-bar enrich-bar-scan">
+                      <div v-if="sp.pct != null" class="enrich-bar-fill" v-bind:style="{ width: sp.pct + '%' }"></div>
+                      <div v-else class="enrich-bar-ind"></div>
+                    </div>
+                    <div v-if="sp.currentFile" class="enrich-muted enrich-scan-file">{{ sp.currentFile }}</div>
+                  </div>
                   <table class="enrich-table">
                     <thead>
                       <tr>
@@ -2849,15 +2866,18 @@ const dbView = Vue.component('db-view', {
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
     },
     fetchEnrichStatus: async function() {
-      try {
-        const res = await API.axios({
-          method: 'GET',
-          url: `${API.url()}/api/v1/scan/status`
-        });
-        this.enrichStatus = res.data;
-      } catch (err) {
-        // Polling: keep showing the last snapshot through transient
-        // failures rather than toasting every few seconds.
+      // Two GETs per tick: /scan/status (queue + passes + coverage) and
+      // /scan/progress (live per-library rows, empty between scans).
+      // Guarded separately so a transient failure on one keeps the other
+      // fresh; both keep their last snapshot through failures rather
+      // than toasting every few seconds.
+      const [status, progress] = await Promise.allSettled([
+        API.axios({ method: 'GET', url: `${API.url()}/api/v1/scan/status` }),
+        API.axios({ method: 'GET', url: `${API.url()}/api/v1/scan/progress` }),
+      ]);
+      if (status.status === 'fulfilled') { this.enrichStatus = status.value.data; }
+      if (progress.status === 'fulfilled' && Array.isArray(progress.value.data)) {
+        this.scanProgress = progress.value.data;
       }
     },
     passLabel: function(kind) {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1907,10 +1907,8 @@ const dbView = Vue.component('db-view', {
   data() {
     return {
       dbParams: ADMINDATA.dbParams,
-      dbStats: '',
       sharedPlaylists: ADMINDATA.sharedPlaylists,
       sharedPlaylistsTS: ADMINDATA.sharedPlaylistUpdated,
-      isPullingStats: false,
       isPullingShared: false,
       // Latest GET /api/v1/scan/status payload (queue + per-pass
       // enrichment status + coverage). Null until the first poll lands;
@@ -2093,13 +2091,6 @@ const dbView = Vue.component('db-view', {
                 </div>
                 <a v-on:click="scanDB" class="waves-effect waves-light btn">{{ t('admin.db.startScan') }}</a>
                 <a v-on:click="forceRescan" class="waves-effect waves-light btn orange">{{ t('admin.db.forceRescan') }}</a>
-                <a v-on:click="pullStats" class="waves-effect waves-light btn">{{ t('admin.db.pullStats') }}</a>
-                <div v-if="isPullingStats === true">
-                  <svg class="spinner" width="65px" height="65px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg"><circle class="spinner-path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle></svg>
-                </div>
-                <pre v-else>
-                  {{dbStats}}
-                </pre>
               </div>
             </div>
           </div>
@@ -2204,25 +2195,6 @@ const dbView = Vue.component('db-view', {
       </div>
     </div>`,
   methods: {
-    pullStats: async function() {
-      try {
-        this.isPullingStats = true;
-        const res = await API.axios({
-          method: 'GET',
-          url: `${API.url()}/api/v1/admin/db/scan/stats`
-        });
-
-        this.dbStats = res.data
-      } catch (err) {
-        iziToast.error({
-          title: t('admin.db.pullDataFailed'),
-          position: 'topCenter',
-          timeout: 3500
-        });
-      } finally {
-        this.isPullingStats = false;
-      }
-    },
     loadShared: async function() {
       try {
         this.isPullingShared = true;

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1917,7 +1917,12 @@ const dbView = Vue.component('db-view', {
       // stale-but-shown on transient poll failures (same philosophy as
       // the player's scan-progress widget — a blip shouldn't blank the
       // panel).
-      enrichStatus: null
+      enrichStatus: null,
+      // Local mirror of config.lyrics.backfill for the card's lyrics
+      // switch — same late-added-key reactivity dodge lyrics-view uses
+      // (ADMINDATA.lyricsParams gains keys after this component has
+      // already observed the bare object).
+      lyricsBackfill: false
     };
   },
   template: `
@@ -1956,27 +1961,9 @@ const dbView = Vue.component('db-view', {
                       </td>
                     </tr>
                     <tr>
-                      <td><b>Generate waveforms after scans:</b> {{dbParams.generateWaveforms}}</td>
-                      <td>
-                        [<a v-on:click="toggleGenerateWaveforms()">{{ t('admin.settings.edit') }}</a>]
-                      </td>
-                    </tr>
-                    <tr>
-                      <td><b>Analyse BPM + key (essentia, post-scan):</b> {{dbParams.analyzeBpm}}</td>
-                      <td>
-                        [<a v-on:click="toggleAnalyzeBpm()">{{ t('admin.settings.edit') }}</a>]
-                      </td>
-                    </tr>
-                    <tr>
                       <td><b>BPM/key tracks analysed per pass:</b> {{dbParams.analyzeBpmPerRun}}</td>
                       <td>
                         [<a v-on:click="openModal('edit-analyze-bpm-per-run-modal')">{{ t('admin.settings.edit') }}</a>]
-                      </td>
-                    </tr>
-                    <tr>
-                      <td><b>Identify tracks via AcoustID (fingerprint &rarr; MusicBrainz ID, post-scan):</b> {{dbParams.analyzeAcoustid}}</td>
-                      <td>
-                        [<a v-on:click="toggleAnalyzeAcoustid()">{{ t('admin.settings.edit') }}</a>]
                       </td>
                     </tr>
                     <tr>
@@ -2004,18 +1991,13 @@ const dbView = Vue.component('db-view', {
                       </td>
                     </tr>
                     <tr>
-                      <td><b>Collect music-discovery data (separate discovery.db):</b> {{dbParams.collectDiscoveryData}}</td>
-                      <td>
-                        [<a v-on:click="toggleCollectDiscoveryData()">{{ t('admin.settings.edit') }}</a>]
-                        [<a v-on:click="exportDiscoveryData()">Export</a>]
-                      </td>
-                    </tr>
-                    <tr>
                       <td>
                         <b>Discovery embedding model:</b> {{dbParams.discoveryModel}}
                         <span v-if="dbParams.discoveryModel === 'effnet-discogs'"> — Discogs-EffNet by MTG-UPF (CC BY-NC-SA 4.0, non-commercial)</span>
                       </td>
-                      <td></td>
+                      <td>
+                        [<a v-on:click="exportDiscoveryData()">Export</a>]
+                      </td>
                     </tr>
                     <tr>
                       <td><b>Discovery tracks embedded per pass:</b> {{dbParams.discoveryPerRun}}</td>
@@ -2034,12 +2016,6 @@ const dbView = Vue.component('db-view', {
                 <span class="card-title">{{ t('admin.db.albumArtLookup') }}</span>
                 <table>
                   <tbody>
-                    <tr>
-                      <td><b>{{ t('admin.db.autoLookup') }}</b> {{ dbParams.autoAlbumArt ? t('admin.settings.enabled') : t('admin.settings.disabled') }}</td>
-                      <td>
-                        [<a v-on:click="toggleAutoAlbumArt()">{{ t('admin.settings.edit') }}</a>]
-                      </td>
-                    </tr>
                     <tr>
                       <td><b>{{ t('admin.db.autoArtMode') }}</b> {{ dbParams.autoAlbumArtMode === 'all' ? t('admin.db.autoArtModeAll') : t('admin.db.autoArtModeMissing') }}</td>
                       <td>
@@ -2122,6 +2098,7 @@ const dbView = Vue.component('db-view', {
                     <thead>
                       <tr>
                         <th>Pass</th>
+                        <th>Enabled</th>
                         <th>Status</th>
                         <th>Last run</th>
                         <th>Coverage</th>
@@ -2130,6 +2107,14 @@ const dbView = Vue.component('db-view', {
                     <tbody>
                       <tr v-for="p in enrichStatus.enrichment" v-bind:key="p.pass">
                         <td><b>{{ passLabel(p.pass) }}</b></td>
+                        <td>
+                          <div class="switch enrich-switch">
+                            <label>
+                              <input type="checkbox" v-bind:checked="passEnabled(p.pass)" v-on:click.prevent="togglePass(p.pass)">
+                              <span class="lever"></span>
+                            </label>
+                          </div>
+                        </td>
                         <td>
                           <span class="enrich-badge" v-bind:class="'enrich-badge-' + p.state">{{ stateLabel(p) }}</span>
                           <div v-if="p.state === 'running' && p.progress && p.progress.total" class="enrich-bar">
@@ -2887,6 +2872,51 @@ const dbView = Vue.component('db-view', {
         acoustid: 'AcoustID IDs',
       }[kind] || kind;
     },
+    // The card's per-pass switches bind to the CONFIG toggle for each
+    // pass, not the status API's combined gate — a pass switched on but
+    // blocked by its environment keeps its switch on while the badge
+    // explains ("Off — waiting for ffmpeg"). Lyrics is the odd one out:
+    // its toggle lives in config.lyrics, mirrored in lyricsBackfill.
+    passEnabled: function(kind) {
+      if (kind === 'lyrics') { return this.lyricsBackfill === true; }
+      return this.dbParams[{
+        waveform: 'generateWaveforms',
+        albumart: 'autoAlbumArt',
+        audioanalysis: 'analyzeBpm',
+        discovery: 'collectDiscoveryData',
+        acoustid: 'analyzeAcoustid',
+      }[kind]] === true;
+    },
+    // Dispatch to the same handlers the old settings rows used —
+    // passes with side effects worth a beat of thought (CPU-heavy BPM,
+    // external AcoustID calls, discovery collection) keep their
+    // confirm dialogs; album art and lyrics flip directly. The switch
+    // renders from config state, so it only visibly flips after the
+    // POST (and any confirm) succeeds.
+    togglePass: function(kind) {
+      ({
+        waveform: this.toggleGenerateWaveforms,
+        albumart: this.toggleAutoAlbumArt,
+        lyrics: this.toggleLyricsBackfill,
+        audioanalysis: this.toggleAnalyzeBpm,
+        discovery: this.toggleCollectDiscoveryData,
+        acoustid: this.toggleAnalyzeAcoustid,
+      }[kind]).call(this);
+    },
+    toggleLyricsBackfill: function() {
+      const next = !this.lyricsBackfill;
+      API.axios({
+        method: 'POST',
+        url: `${API.url()}/api/v1/admin/lyrics/backfill`,
+        data: { backfill: next }
+      }).then(() => {
+        this.lyricsBackfill = next;
+        Vue.set(ADMINDATA.lyricsParams, 'backfill', next);
+        iziToast.success({ title: t('admin.settings.updated'), position: 'topCenter', timeout: 3500 });
+      }).catch(() => {
+        iziToast.error({ title: t('admin.settings.failed'), position: 'topCenter', timeout: 3500 });
+      });
+    },
     stateLabel: function(p) {
       if (p.state === 'disabled') {
         // Config-off is the unremarkable case — keep the badge terse.
@@ -2950,6 +2980,12 @@ const dbView = Vue.component('db-view', {
     // on the server: the endpoint's coverage counts are memoised
     // server-side, so a poll between passes is two cheap map reads.
     this.enrichTimer = setInterval(() => { this.fetchEnrichStatus(); }, 4000);
+    // Seed the card's lyrics switch. Until (or if never) resolved the
+    // switch just shows off — the badge still tells the truth from the
+    // status poll.
+    ADMINDATA.getLyricsParams().then(() => {
+      this.lyricsBackfill = ADMINDATA.lyricsParams.backfill === true;
+    }).catch(() => { /* toggle stays off; badge still accurate */ });
   },
   beforeDestroy: function() {
     if (this.enrichTimer) { clearInterval(this.enrichTimer); }
@@ -2962,8 +2998,8 @@ const lyricsView = Vue.component('lyrics-view', {
       loaded: false,
       // Local mirrors of config.lyrics, populated in created() so the
       // template binds to reactive data fields (not late-added keys on
-      // the shared ADMINDATA object).
-      backfill: false,
+      // the shared ADMINDATA object). The backfill on/off switch lives
+      // in the Database view's Enrichment Status card.
       writeSidecar: false,
       providers: { lrclib: true, netease: false, kugou: false },
     };
@@ -2976,15 +3012,9 @@ const lyricsView = Vue.component('lyrics-view', {
             <div class="card">
               <div class="card-content">
                 <span class="card-title">Lyrics Backfill</span>
-                <p>After each library scan, proactively look up lyrics for tracks that don't already have them (from their tags or a sidecar file). Off by default.</p>
+                <p>After each library scan, proactively look up lyrics for tracks that don't already have them (from their tags or a sidecar file). Off by default — the on/off switch lives in Database &rarr; Enrichment Status.</p>
                 <table v-if="loaded">
                   <tbody>
-                    <tr>
-                      <td><b>Backfill lyrics after scans:</b> {{ backfill ? 'Enabled' : 'Disabled' }}</td>
-                      <td>
-                        [<a v-on:click="toggleBackfill()">edit</a>]
-                      </td>
-                    </tr>
                     <tr>
                       <td><b>Write fetched lyrics to sidecar files (.lrc next to each track):</b> {{ writeSidecar ? 'Enabled' : 'Disabled' }}</td>
                       <td>
@@ -3015,7 +3045,6 @@ const lyricsView = Vue.component('lyrics-view', {
   created: async function () {
     try {
       await ADMINDATA.getLyricsParams();
-      this.backfill = !!ADMINDATA.lyricsParams.backfill;
       this.writeSidecar = !!ADMINDATA.lyricsParams.writeSidecar;
       const list = Array.isArray(ADMINDATA.lyricsParams.providers) ? ADMINDATA.lyricsParams.providers : ['lrclib'];
       this.providers = {
@@ -3029,20 +3058,6 @@ const lyricsView = Vue.component('lyrics-view', {
     this.loaded = true;
   },
   methods: {
-    toggleBackfill: function () {
-      const next = !this.backfill;
-      API.axios({
-        method: 'POST',
-        url: `${API.url()}/api/v1/admin/lyrics/backfill`,
-        data: { backfill: next }
-      }).then(() => {
-        this.backfill = next;
-        Vue.set(ADMINDATA.lyricsParams, 'backfill', next);
-        iziToast.success({ title: 'Saved', position: 'topCenter', timeout: 2000 });
-      }).catch(() => {
-        iziToast.error({ title: 'Update failed', position: 'topCenter', timeout: 3000 });
-      });
-    },
     toggleWriteSidecar: function () {
       const next = !this.writeSidecar;
       API.axios({

--- a/webapp/alpha/scan-progress.js
+++ b/webapp/alpha/scan-progress.js
@@ -1,24 +1,63 @@
 // Top-bar scan progress indicator for the main UI.
 // Polls GET /api/v1/scan/progress and renders one `.spc-card` per active scan.
 // Empty response → empty wrap → no visible UI (zero layout impact when idle).
+//
+// Also polls GET /api/v1/scan/status (every other tick — enrichment
+// passes move slower than scans) and renders one quiet chip while an
+// enrichment pass (waveforms, album-art, lyrics, BPM/key, discovery,
+// AcoustID) is running. The task queue is strictly serial, so at most
+// one enrichment chip can ever show.
 
 (function () {
   const POLL_INTERVAL_MS = 3000;
+  // /scan/status is fetched every Nth tick: enrichment passes are
+  // minutes-long background work — 6s freshness is plenty, and it keeps
+  // the extra request volume at half the scan poll's.
+  const STATUS_EVERY_N_TICKS = 2;
   let timer = null;
+  let tickCount = 0;
+  // Latest running enrichment pass entry (from body.enrichment) or null.
+  // Kept between status polls so the chip doesn't flicker on the scan-only
+  // ticks in between.
+  let enrichRunning = null;
+
+  const ENRICH_LABELS = {
+    waveform: 'Waveforms',
+    albumart: 'Album art',
+    lyrics: 'Lyrics',
+    audioanalysis: 'BPM / key',
+    discovery: 'Discovery',
+    acoustid: 'AcoustID',
+  };
 
   function escapeHtml(s) {
     return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
       .replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
-  function render(scans) {
+  function renderEnrichChip(enrich) {
+    if (!enrich) { return ''; }
+    const label = ENRICH_LABELS[enrich.pass] || enrich.pass;
+    const prog = enrich.progress;
+    const pct = prog && prog.total ? Math.min(100, Math.round((prog.attempted / prog.total) * 100)) : null;
+    const bar = pct != null
+      ? `<div class="spc-fill" style="width:${pct}%"></div>`
+      : `<div class="spc-fill-ind"></div>`;
+    const countTxt = prog && prog.total
+      ? `${prog.attempted.toLocaleString()} / ${prog.total.toLocaleString()}`
+      : '';
+    return `<div class="spc-card spc-enrich" title="Post-scan enrichment pass">
+      <span class="spc-dot"></span>
+      <span class="spc-vpath">${escapeHtml(label)}</span>
+      <div class="spc-track">${bar}</div>
+      <span class="spc-count">${escapeHtml(countTxt)}</span>
+    </div>`;
+  }
+
+  function render(scans, enrich) {
     const wrap = document.getElementById('scan-progress-wrap');
     if (!wrap) { return; }
-    if (!Array.isArray(scans) || scans.length === 0) {
-      wrap.innerHTML = '';
-      return;
-    }
-    wrap.innerHTML = scans.map(sp => {
+    const scanCards = Array.isArray(scans) ? scans.map(sp => {
       const pctTxt = sp.pct != null ? `${sp.pct}%` : 'Counting…';
       const bar = sp.pct != null
         ? `<div class="spc-fill" style="width:${sp.pct}%"></div>`
@@ -36,18 +75,44 @@
         <span class="spc-pct">${escapeHtml(pctTxt)}</span>
         <span class="spc-count">${escapeHtml(countTxt)}</span>
       </div>`;
-    }).join('');
+    }) : [];
+    // A running scan and a running enrichment pass are mutually exclusive
+    // (strictly serial task queue), but render both defensively — worst
+    // case during a transition the chip trails the scan card by one tick.
+    wrap.innerHTML = scanCards.join('') + renderEnrichChip(enrich);
+  }
+
+  function authedServer() {
+    const server = (typeof MSTREAMAPI !== 'undefined') ? MSTREAMAPI.currentServer : null;
+    // host is '' on same-origin sessions (m.js builds RELATIVE urls off it
+    // everywhere — see its lyrics/album-art fetches), so requiring a truthy
+    // host here silently disabled the whole widget for locally-served
+    // logins; only the token is actually load-bearing.
+    if (!server || !server.token) { return null; }
+    return server;
+  }
+
+  async function fetchEnrichStatus(server) {
+    const res = await fetch(server.host + 'api/v1/scan/status', {
+      headers: { 'x-access-token': server.token },
+    });
+    if (!res.ok) { return; }
+    const body = await res.json();
+    enrichRunning = (body.enrichment || []).find(p => p.state === 'running') || null;
   }
 
   async function tick() {
     try {
-      const server = (typeof MSTREAMAPI !== 'undefined') ? MSTREAMAPI.currentServer : null;
-      if (!server || !server.host || !server.token) { return; }
+      const server = authedServer();
+      if (!server) { return; }
+      if (tickCount++ % STATUS_EVERY_N_TICKS === 0) {
+        await fetchEnrichStatus(server).catch(() => {});
+      }
       const res = await fetch(server.host + 'api/v1/scan/progress', {
         headers: { 'x-access-token': server.token },
       });
       if (!res.ok) { return; }
-      render(await res.json());
+      render(await res.json(), enrichRunning);
     } catch { /* ignore transient network errors */ }
   }
 

--- a/webapp/alpha/spa.css
+++ b/webapp/alpha/spa.css
@@ -1463,6 +1463,18 @@ select {
   white-space: nowrap;
   flex-shrink: 0;
 }
+/* Enrichment-pass variant: blue accent (vs the scan cards' green) so a
+   background pass reads as "working, not scanning". Same blue as the
+   indeterminate shimmer above. */
+.spc-enrich {
+  border-left-color: #657ee4;
+}
+.spc-enrich .spc-dot {
+  background: #657ee4;
+}
+.spc-enrich .spc-fill {
+  background: #657ee4;
+}
 
 /* ── Auto-DJ panel ─────────────────────────────────────────────────
    PR-E2: replaces the legacy folder-checkbox layout with a velvet-


### PR DESCRIPTION
## What

Phase 2 of the enrichment status work (stacked on #748 — GitHub will retarget this to master when that merges). Two UI surfaces over the new `GET /api/v1/scan/status` endpoint:

**Admin › Database — "Enrichment Status" card**
- Queue line: what's running / queued (task kinds only), total indexed tracks when idle.
- One row per pass: state badge (`Running` green / `Queued` blue / `Idle` / `Off` — environment reasons spelled out, e.g. "Off — waiting for ffmpeg", while plain config-off stays terse), live progress bar, last-run summary in each worker's own vocabulary ("Completed just now — 9 fetched", "FAILED", "nothing to do", "· more queued" on hitCap), and durable coverage ("9 / 9 tracks · 9 found") with a fill bar.
- Polls every 4s while the view is mounted (cheap — the endpoint memoises coverage server-side); transient poll failures keep showing the last snapshot instead of blanking or toasting.

**Main UI top bar — enrichment chip**
- One quiet blue chip while a pass runs: pass label + progress, indeterminate shimmer when the worker hasn't reported totals. Reuses the existing `spc-*` scan-card styles with a blue accent so background enrichment reads as "working, not scanning".
- `/scan/status` is fetched every other scan-progress tick (6s). The strictly-serial task queue means at most one chip, and never next to a scan card.

## Bug fix that fell out

The existing top-bar scan-progress widget **never worked on locally-served sessions**: it required a truthy `MSTREAMAPI.currentServer.host`, but host is `''` whenever the webapp is served by the same instance it talks to — the normal setup — since m.js builds relative URLs off it everywhere. Only the token check is load-bearing; the host check is dropped. (Found because the new chip inherited the same guard and refused to appear.)

## Verification (live, real server + real passes)

No JS test harness exists for these vanilla-JS webapp files (eslint ignores `webapp/**` too), so this was verified end-to-end in a browser against a booted server, driving real lyrics-backfill runs via a slow local LRCLib mock (`MSTREAM_LRCLIB_BASE`):

- Admin card observed through the full cycle: `Off`/`Idle` defaults → **"Now running: Lyrics"** with green `Running` badge → coverage ticking live mid-run (5/9 → 9/9 tracks · found counts from the outcomes ledger) → "Completed just now — 9 fetched". Waveforms row shows the zero-work branch ("nothing to do") and real coverage (9/9 tracks).
- Top-bar chip: DOM sampling across a staged 20s run shows the chip appearing within one poll of the pass starting, persisting for the run, and clearing after; screenshot confirmed the visual (blue dot + label + shimmer).
- Discovery row correctly shows "—" coverage while no discovery.db exists; BPM/AcoustID show 0/0 backlogs because 1-second fixtures sit below the workers' duration floors — i.e. the UI faithfully renders the eligibility semantics from #748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)