### PR TITLE
fix(discovery): default model cache next to dbDirectory; actionable permission errors

### DIFF
--- a/src/db/discovery-backfill.mjs
+++ b/src/db/discovery-backfill.mjs
@@ -53,9 +53,10 @@ import { createEmbedder, analyzeFile, EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL 
 
 const SCHEMA_GUARD_EXIT = 3;
 // Exit contract with task-queue.js: the environment can't load
-// onnxruntime-node at all (missing optional dep, or musl/Alpine where the
-// glibc-only binaries can never load) — the queue latches the pass off
-// until restart instead of retrying an identical failure every batch.
+// onnxruntime-node at all (missing optional dep, or a musl system whose
+// glibc compat layer can't load onnxruntime's glibc-only binaries) — the
+// queue latches the pass off until restart instead of retrying an identical
+// failure every batch.
 const RUNTIME_UNAVAILABLE_EXIT = 4;
 
 // discovery-db.js logs through winston; a forked child has no transports

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -176,6 +176,22 @@ function sha256OfFile(filePath) {
   return hash.digest('hex');
 }
 
+// A permission-class failure on the cache dir means the OPERATOR pointed (or
+// defaulted) storage.modelCacheDirectory somewhere the server can't write —
+// e.g. a Docker image whose config template predates the key, leaving it at
+// the read-only app directory. The raw EACCES names a path but not the
+// config key that controls it; say both, or the error is undebuggable from
+// the log alone.
+function rethrowIfCacheDirUnwritable(err, modelCacheDir) {
+  if (err.code === 'EACCES' || err.code === 'EPERM' || err.code === 'EROFS') {
+    throw new Error(
+      `model cache directory '${modelCacheDir}' is not writable — point storage.modelCacheDirectory `
+      + `at a writable path (on Docker, somewhere under your writable config mount, `
+      + `e.g. '/config/model-cache') and restart (${err.message})`);
+  }
+  throw err;
+}
+
 /**
  * Ensure a pinned model file exists in `modelCacheDir`, downloading it (once)
  * from the project-controlled mirror when absent. The sha256 pin is the
@@ -191,18 +207,28 @@ export async function ensureModelFile({ filename, url, sha256 }, modelCacheDir) 
   if (fs.existsSync(dest)) {
     if (sha256OfFile(dest) === sha256) { return dest; }
     // Corrupt / partial from a previous crash — refetch below.
-    fs.rmSync(dest, { force: true });
+    try { fs.rmSync(dest, { force: true }); }
+    catch (err) { rethrowIfCacheDirUnwritable(err, modelCacheDir); }
   }
 
-  fs.mkdirSync(modelCacheDir, { recursive: true });
   const tmp = `${dest}.downloading`;
-  fs.rmSync(tmp, { force: true });
+  try {
+    fs.mkdirSync(modelCacheDir, { recursive: true });
+    fs.rmSync(tmp, { force: true });
+  } catch (err) { rethrowIfCacheDirUnwritable(err, modelCacheDir); }
 
   const res = await fetch(url, { redirect: 'follow' });
   if (!res.ok || !res.body) {
     throw new Error(`model download failed: HTTP ${res.status} for ${url}`);
   }
-  await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(tmp));
+  try {
+    await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(tmp));
+  } catch (err) {
+    // The dir can exist but be unwritable (created under a different uid —
+    // the Docker PUID-remap case); the open() inside createWriteStream is
+    // where that surfaces.
+    rethrowIfCacheDirUnwritable(err, modelCacheDir);
+  }
 
   const actual = sha256OfFile(tmp);
   if (actual !== sha256) {
@@ -238,11 +264,14 @@ async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
     ort = (await import('onnxruntime-node')).default;
   } catch (err) {
     // Distinguish "the package isn't there" from "it's there but this OS
-    // can't load it" — the latter is the Alpine/musl case (onnxruntime
-    // ships glibc-only binaries; gcompat doesn't cover its fortified
-    // symbols), where the only fix is a glibc-based image.
+    // can't load it". onnxruntime ships glibc-only binaries; on musl they
+    // load through a glibc compat layer, and a modern one genuinely works —
+    // verified 2026-07 on Alpine 3.24 + gcompat (the linuxserver.io image,
+    // x64 and arm64): loads AND runs inference. The dlopen-failure hint
+    // below is for systems that still can't — no compat layer, or one too
+    // old to cover onnxruntime's fortified symbols.
     const muslHint = /ld-linux|Error relocating|ERR_DLOPEN/i.test(`${err.message} ${err.code || ''}`)
-      ? ' — this system cannot load onnxruntime’s glibc binaries (musl/Alpine containers are not supported; use a glibc-based image such as Debian/Ubuntu)'
+      ? ' — this system cannot load onnxruntime’s glibc binaries (on musl/Alpine, install or update the gcompat package; otherwise use a glibc-based image such as Debian/Ubuntu)'
       : '';
     const e = new Error(`onnxruntime-node is not available — the '${spec.weights.filename}' embedding model cannot run${muslHint} (${err.message})`);
     e.dependencyMissing = true;

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1473,14 +1473,18 @@ function runDiscoveryTask(taskObj) {
       // The environment can't load onnxruntime-node at all (worker exit
       // contract: RUNTIME_UNAVAILABLE_EXIT). Retrying every batch would
       // fail identically and spam the log — latch it off until restart.
-      // Seen in the wild on Alpine/musl containers: onnxruntime ships
-      // glibc-only binaries, and gcompat doesn't cover its fortified
-      // symbols, so a glibc-based image is the only fix.
+      // Typical causes: the optional dep never installed, or a musl system
+      // without a working glibc compat layer for onnxruntime's glibc-only
+      // binaries. Modern musl images are NOT categorically broken —
+      // verified 2026-07: Alpine 3.24 + gcompat (the linuxserver.io image)
+      // loads and runs it fine on x64 and arm64; older/leaner musl setups
+      // are what land here.
       discoveryRuntimeUnavailable = true;
       winston.error(
         'Discovery-embedding pass halted: this environment cannot load onnxruntime-node, '
-        + 'so the embedding model cannot run (musl/Alpine containers lack the required glibc). '
-        + 'Recommendations will not build here — use a glibc-based image (e.g. Debian/Ubuntu). '
+        + 'so the embedding model cannot run (optional dependency missing, or a musl/Alpine '
+        + 'system without a working glibc compat layer — install/update gcompat, or use a '
+        + 'glibc-based image such as Debian/Ubuntu). Recommendations will not build here. '
         + 'The pass is disabled until the server restarts.');
     } else if (code !== 0 && code !== null) {
       winston.warn(`Discovery-embedding pass exited with code ${code}`);

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import Joi from 'joi';
@@ -8,16 +9,40 @@ import { getTransCodecs, getTransBitrates } from '../api/transcode.js';
 import { CLIENT_TYPE, ENABLED_FOR } from '../torrent/constants.js';
 import { EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL } from '../db/discovery-features-lib.js';
 
+const DEFAULT_DB_DIRECTORY = path.join(appRoot, 'save/db');
+// The pre-derivation default (see deriveModelCacheDirectory). Installs that
+// ran under it already hold downloaded weights there — honored forever so a
+// version bump doesn't silently re-download them.
+const LEGACY_MODEL_CACHE_DIRECTORY = path.join(appRoot, 'model-cache');
+
+/**
+ * Default for storage.modelCacheDirectory when the config doesn't set it:
+ * a SIBLING of the (resolved or default) dbDirectory. The old default,
+ * appRoot/model-cache, broke every container image whose config template
+ * points storage at a writable mount but predates this key — the app dir is
+ * root-owned there (e.g. linuxserver.io's /app/mstream under PUID), so the
+ * first embed run died with EACCES. dbDirectory is writable by construction
+ * (the server can't boot otherwise), and container templates keep all
+ * storage dirs siblings under one mount (/config/db, /config/album-art,
+ * ...), so its parent is the right home: /config/db → /config/model-cache.
+ * Exported for tests.
+ */
+export function deriveModelCacheDirectory(dbDirectory, legacyDirExists = existsSync(LEGACY_MODEL_CACHE_DIRECTORY)) {
+  if (legacyDirExists) { return LEGACY_MODEL_CACHE_DIRECTORY; }
+  return path.join(path.dirname(dbDirectory || DEFAULT_DB_DIRECTORY), 'model-cache');
+}
+
 const storageJoi = Joi.object({
   albumArtDirectory: Joi.string().default(path.join(appRoot, 'image-cache')),
-  dbDirectory: Joi.string().default(path.join(appRoot, 'save/db')),
+  dbDirectory: Joi.string().default(DEFAULT_DB_DIRECTORY),
   logsDirectory: Joi.string().default(path.join(appRoot, 'save/logs')),
   waveformCacheDirectory: Joi.string().default(path.join(appRoot, 'waveform-cache')),
   // Where ML model weights download/cache (currently: the discovery
-  // embedding model, ~hundreds of MB on first use). Deliberately OUTSIDE
-  // node_modules — transformers.js's default cache lands in there and every
-  // update/reinstall would silently re-download.
-  modelCacheDirectory: Joi.string().default(path.join(appRoot, 'model-cache')),
+  // embedding model, ~18 MB EffNet; CLAP is far larger). Deliberately
+  // OUTSIDE node_modules — transformers.js's default cache lands in there
+  // and every update/reinstall would silently re-download. Defaults next to
+  // dbDirectory (see deriveModelCacheDirectory above).
+  modelCacheDirectory: Joi.string().default((parent) => deriveModelCacheDirectory(parent && parent.dbDirectory)),
 });
 
 const scanOptions = Joi.object({
@@ -115,9 +140,10 @@ const scanOptions = Joi.object({
   // local recommendation features without ever exposing its library. The
   // pass is CPU-heavy but bounded (discoveryPerRun tracks per batch,
   // re-enqueued while a backlog remains) and downloads its model weights
-  // once (~18 MB EffNet). Where the ML runtime is unavailable (e.g. the
-  // glibc-only onnxruntime on musl/Alpine) the worker degrades once,
-  // loudly, and stops. Set false to skip discovery collection entirely.
+  // once (~18 MB EffNet). Where the ML runtime is unavailable (onnxruntime
+  // missing, or a musl system without a working glibc compat layer) the
+  // worker degrades once, loudly, and stops. Set false to skip discovery
+  // collection entirely.
   collectDiscoveryData: Joi.boolean().default(true),
   // Which embedding engine the discovery pass runs — a key into the model
   // registry in src/db/discovery-features-lib.js. Deliberately swappable:
@@ -803,6 +829,23 @@ export async function setup(configFileArg) {
     program.transcode.ffmpegDirectory,
   ]) {
     if (dir) { await fs.mkdir(dir, { recursive: true }); }
+  }
+
+  // The model cache is created best-effort, OUTSIDE the fatal loop above: a
+  // server that can't write model weights must still boot and stream music
+  // (the discovery pass degrades on its own). But surface the problem NOW,
+  // at boot, with the key that fixes it — otherwise the first symptom is a
+  // bare EACCES from the embedding worker, mid-pass, hours later.
+  try {
+    if (program.storage.modelCacheDirectory) {
+      await fs.mkdir(program.storage.modelCacheDirectory, { recursive: true });
+    }
+  } catch (err) {
+    winston.warn(
+      `[config] storage.modelCacheDirectory '${program.storage.modelCacheDirectory}' is not creatable `
+      + `(${err.code || err.message}). The discovery-embedding pass cannot download model weights until `
+      + `it points at a writable path (on Docker, somewhere under your writable config mount, `
+      + `e.g. '/config/model-cache').`);
   }
 
   // Persist a stable mDNS instance id so discovery clients can dedupe the

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import { existsSync } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import Joi from 'joi';
@@ -10,14 +9,10 @@ import { CLIENT_TYPE, ENABLED_FOR } from '../torrent/constants.js';
 import { EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL } from '../db/discovery-features-lib.js';
 
 const DEFAULT_DB_DIRECTORY = path.join(appRoot, 'save/db');
-// The pre-derivation default (see deriveModelCacheDirectory). Installs that
-// ran under it already hold downloaded weights there — honored forever so a
-// version bump doesn't silently re-download them.
-const LEGACY_MODEL_CACHE_DIRECTORY = path.join(appRoot, 'model-cache');
 
 /**
  * Default for storage.modelCacheDirectory when the config doesn't set it:
- * a SIBLING of the (resolved or default) dbDirectory. The old default,
+ * a SIBLING of the (resolved or default) dbDirectory. The previous default,
  * appRoot/model-cache, broke every container image whose config template
  * points storage at a writable mount but predates this key — the app dir is
  * root-owned there (e.g. linuxserver.io's /app/mstream under PUID), so the
@@ -25,10 +20,14 @@ const LEGACY_MODEL_CACHE_DIRECTORY = path.join(appRoot, 'model-cache');
  * (the server can't boot otherwise), and container templates keep all
  * storage dirs siblings under one mount (/config/db, /config/album-art,
  * ...), so its parent is the right home: /config/db → /config/model-cache.
+ * There is deliberately NO migration from the old default: the cache holds
+ * only sha256-pinned re-downloadable weights (~18 MB EffNet) — embeddings
+ * live in discovery.db, keyed by model, so nothing is rebuilt. The next
+ * pass re-fetches into the derived location; a leftover appRoot/model-cache
+ * is unused and safe to delete.
  * Exported for tests.
  */
-export function deriveModelCacheDirectory(dbDirectory, legacyDirExists = existsSync(LEGACY_MODEL_CACHE_DIRECTORY)) {
-  if (legacyDirExists) { return LEGACY_MODEL_CACHE_DIRECTORY; }
+export function deriveModelCacheDirectory(dbDirectory) {
   return path.join(path.dirname(dbDirectory || DEFAULT_DB_DIRECTORY), 'model-cache');
 }
 

--- a/test/db/discovery-model-files.test.mjs
+++ b/test/db/discovery-model-files.test.mjs
@@ -127,3 +127,40 @@ describe('ensureModelFile', () => {
       /HTTP 404/);
   });
 });
+
+// An unwritable cache dir is an OPERATOR problem (storage.modelCacheDirectory
+// pointing at a read-only location — the Docker read-only-app-dir case), so
+// the error must name the config key, not just echo the syscall. chmod-based
+// denial doesn't bind root and Windows ACLs don't map to POSIX modes; the
+// scenario under test is POSIX non-root by construction, so skip elsewhere.
+describe('ensureModelFile: unwritable cache dir', () => {
+  const skip = (process.platform === 'win32' || process.getuid?.() === 0)
+    && 'POSIX non-root only: chmod denial does not bind here';
+
+  test('uncreatable dir (read-only parent) → error names storage.modelCacheDirectory', { skip }, async () => {
+    const parent = path.join(scratch, 'ro-parent');
+    fs.mkdirSync(parent, { recursive: true });
+    fs.chmodSync(parent, 0o555);
+    try {
+      await assert.rejects(
+        ensureModelFile({ filename: 'model.bin', url: `${baseUrl}/model.bin`, sha256: BLOB_SHA },
+          path.join(parent, 'model-cache')),
+        /storage\.modelCacheDirectory/);
+    } finally {
+      fs.chmodSync(parent, 0o755);
+    }
+  });
+
+  test('dir exists but is unwritable (PUID-remap case) → same actionable error', { skip }, async () => {
+    const dir = path.join(scratch, 'ro-cache');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.chmodSync(dir, 0o555);
+    try {
+      await assert.rejects(
+        ensureModelFile({ filename: 'model.bin', url: `${baseUrl}/model.bin`, sha256: BLOB_SHA }, dir),
+        /storage\.modelCacheDirectory/);
+    } finally {
+      fs.chmodSync(dir, 0o755);
+    }
+  });
+});

--- a/test/unit/model-cache-config.test.mjs
+++ b/test/unit/model-cache-config.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * storage.modelCacheDirectory default derivation (src/state/config.js).
+ *
+ * The old default (appRoot/model-cache) broke container images whose config
+ * template points storage at a writable mount but predates the key: the app
+ * dir is root-owned there (linuxserver.io's /app/mstream under PUID), so the
+ * first embed run died with a bare EACCES. The default now derives from
+ * dbDirectory's parent — writable by construction — while a pre-existing
+ * appRoot/model-cache (an old-default install with downloaded weights)
+ * keeps winning so nothing silently re-downloads. Boot creates the dir
+ * best-effort: an unwritable model cache must never stop the music server.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as config from '../../src/state/config.js';
+import { appRoot } from '../../src/util/esm-helpers.js';
+
+const legacyDir = path.join(appRoot, 'model-cache');
+const legacyExists = fs.existsSync(legacyDir);
+
+let tmpDir;
+
+describe('deriveModelCacheDirectory', () => {
+  test('legacy appRoot/model-cache wins when it exists (no re-download)', () => {
+    assert.equal(config.deriveModelCacheDirectory('/config/db', true), legacyDir);
+  });
+
+  test('derives a sibling of the configured dbDirectory', () => {
+    assert.equal(config.deriveModelCacheDirectory('/config/db', false),
+      path.join('/config', 'model-cache'));
+  });
+
+  test('unset dbDirectory derives from the default save/db', () => {
+    assert.equal(config.deriveModelCacheDirectory(undefined, false),
+      path.join(appRoot, 'save', 'model-cache'));
+  });
+});
+
+describe('storage.modelCacheDirectory through config.setup()', () => {
+  before(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-modelcache-cfg-')); });
+  after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+  function writeConfig(name, obj) {
+    const f = path.join(tmpDir, name);
+    fs.writeFileSync(f, JSON.stringify(obj));
+    return f;
+  }
+
+  test('defaults to a sibling of dbDirectory and is created at boot',
+    { skip: legacyExists && 'appRoot/model-cache exists on this machine — legacy default applies' },
+    async () => {
+      const f = writeConfig('a.json', { storage: { dbDirectory: path.join(tmpDir, 'a', 'db') } });
+      await config.setup(f);
+      const expected = path.join(tmpDir, 'a', 'model-cache');
+      assert.equal(config.program.storage.modelCacheDirectory, expected);
+      assert.ok(fs.existsSync(expected), 'setup() creates the model cache best-effort');
+    });
+
+  test('an explicit modelCacheDirectory is used verbatim', async () => {
+    const explicit = path.join(tmpDir, 'b', 'my-models');
+    const f = writeConfig('b.json', {
+      storage: { dbDirectory: path.join(tmpDir, 'b', 'db'), modelCacheDirectory: explicit },
+    });
+    await config.setup(f);
+    assert.equal(config.program.storage.modelCacheDirectory, explicit);
+    assert.ok(fs.existsSync(explicit));
+  });
+
+  // The music server must boot and stream even when model weights have
+  // nowhere to land — the discovery pass degrades on its own, and setup()
+  // warns with the config key instead of throwing.
+  test('an uncreatable model cache dir must not kill boot',
+    { skip: (process.platform === 'win32' || process.getuid?.() === 0)
+      && 'POSIX non-root only: chmod denial does not bind here' },
+    async () => {
+      const roParent = path.join(tmpDir, 'ro');
+      fs.mkdirSync(roParent, { recursive: true });
+      fs.chmodSync(roParent, 0o555);
+      try {
+        const f = writeConfig('c.json', {
+          storage: {
+            dbDirectory: path.join(tmpDir, 'c', 'db'),
+            modelCacheDirectory: path.join(roParent, 'model-cache'),
+          },
+        });
+        await config.setup(f);
+        assert.ok(!fs.existsSync(path.join(roParent, 'model-cache')));
+      } finally {
+        fs.chmodSync(roParent, 0o755);
+      }
+    });
+});

--- a/test/unit/model-cache-config.test.mjs
+++ b/test/unit/model-cache-config.test.mjs
@@ -5,9 +5,9 @@
  * template points storage at a writable mount but predates the key: the app
  * dir is root-owned there (linuxserver.io's /app/mstream under PUID), so the
  * first embed run died with a bare EACCES. The default now derives from
- * dbDirectory's parent — writable by construction — while a pre-existing
- * appRoot/model-cache (an old-default install with downloaded weights)
- * keeps winning so nothing silently re-downloads. Boot creates the dir
+ * dbDirectory's parent — writable by construction. There is no migration
+ * from the old location: the cache holds only re-downloadable pinned
+ * weights, so old installs simply re-fetch once. Boot creates the dir
  * best-effort: an unwritable model cache must never stop the music server.
  */
 
@@ -19,23 +19,16 @@ import path from 'node:path';
 import * as config from '../../src/state/config.js';
 import { appRoot } from '../../src/util/esm-helpers.js';
 
-const legacyDir = path.join(appRoot, 'model-cache');
-const legacyExists = fs.existsSync(legacyDir);
-
 let tmpDir;
 
 describe('deriveModelCacheDirectory', () => {
-  test('legacy appRoot/model-cache wins when it exists (no re-download)', () => {
-    assert.equal(config.deriveModelCacheDirectory('/config/db', true), legacyDir);
-  });
-
   test('derives a sibling of the configured dbDirectory', () => {
-    assert.equal(config.deriveModelCacheDirectory('/config/db', false),
+    assert.equal(config.deriveModelCacheDirectory('/config/db'),
       path.join('/config', 'model-cache'));
   });
 
   test('unset dbDirectory derives from the default save/db', () => {
-    assert.equal(config.deriveModelCacheDirectory(undefined, false),
+    assert.equal(config.deriveModelCacheDirectory(undefined),
       path.join(appRoot, 'save', 'model-cache'));
   });
 });
@@ -50,15 +43,13 @@ describe('storage.modelCacheDirectory through config.setup()', () => {
     return f;
   }
 
-  test('defaults to a sibling of dbDirectory and is created at boot',
-    { skip: legacyExists && 'appRoot/model-cache exists on this machine — legacy default applies' },
-    async () => {
-      const f = writeConfig('a.json', { storage: { dbDirectory: path.join(tmpDir, 'a', 'db') } });
-      await config.setup(f);
-      const expected = path.join(tmpDir, 'a', 'model-cache');
-      assert.equal(config.program.storage.modelCacheDirectory, expected);
-      assert.ok(fs.existsSync(expected), 'setup() creates the model cache best-effort');
-    });
+  test('defaults to a sibling of dbDirectory and is created at boot', async () => {
+    const f = writeConfig('a.json', { storage: { dbDirectory: path.join(tmpDir, 'a', 'db') } });
+    await config.setup(f);
+    const expected = path.join(tmpDir, 'a', 'model-cache');
+    assert.equal(config.program.storage.modelCacheDirectory, expected);
+    assert.ok(fs.existsSync(expected), 'setup() creates the model cache best-effort');
+  });
 
   test('an explicit modelCacheDirectory is used verbatim', async () => {
     const explicit = path.join(tmpDir, 'b', 'my-models');


### PR DESCRIPTION
## What

The discovery-embedding pass fails with a bare `EACCES: permission denied, mkdir '/app/mstream/model-cache'` on the linuxserver.io Docker image (and any container whose config template points `storage.*` at a writable mount but predates the `modelCacheDirectory` key). The image's `/app/mstream` is owned by the build-time uid and the server runs as PUID, so the old default — `appRoot/model-cache` — is never writable there.

Three changes:

1. **Derived default**: `storage.modelCacheDirectory` now defaults to a **sibling of the resolved `dbDirectory`** (`/config/db` → `/config/model-cache`) via `deriveModelCacheDirectory()` in `src/state/config.js`. `dbDirectory` is writable by construction (the server can't boot otherwise), and container templates keep storage dirs as siblings under one mount, so this fixes the lsio image with **no image/template change needed**. Fresh bare-metal installs land at `appRoot/save/model-cache` (already gitignored via the `model-cache/` pattern).

   There is deliberately **no migration** from the old location: the cache holds only sha256-pinned re-downloadable weights (~18 MB EffNet) — embeddings live in `discovery.db` keyed by `(model_id, model_version)`, so nothing is re-embedded. Installs that used the old default re-download once into the derived location on the next pass; a leftover `appRoot/model-cache` is unused and safe to delete (worth a line in the release notes). Containers that happened to work under a writable app dir (default PUID) come out ahead — the cache now persists on `/config` across container recreations instead of living in the container layer.

2. **Actionable errors**: `ensureModelFile()` maps EACCES/EPERM/EROFS on any cache-dir operation to an error naming `storage.modelCacheDirectory` and suggesting a writable path — covering both the uncreatable-dir case and the dir-exists-but-unwritable case (PUID remap, which surfaces at `createWriteStream`, not `mkdir`). `setup()` also creates the dir at boot **best-effort**: a warning with the config key on failure, never a fatal — the music server must boot even when model weights have nowhere to land.

3. **Stale musl/Alpine comments refreshed**: several comments and the exit-4 log message claimed onnxruntime-node can never load on musl/Alpine. Verified 2026-07: onnxruntime-node 1.24.3 loads **and runs inference** on Alpine 3.24 + gcompat (the lsio image), both x64 and arm64. The exit-4 latch stays — it's still right for runtimes that genuinely can't load — but the message now suggests installing/updating gcompat before switching to a glibc image.

## Verification

- `test/unit` 304/304, `test/db` 163/163 with the new tests (unwritable-dir shapes assert the error names the config key, skipped on win32/root; config-level tests cover derivation, explicit-key-wins, and boot-survives-unwritable-dir).
- **End-to-end on the stock lsio image** (PUID=1000, its own unmodified config template — zero `modelCacheDirectory` occurrences) with these four source files bind-mounted over the image's copies, re-run from a fresh `/config` after every revision of this branch: weights downloaded to the derived `/config/model-cache`, and the previously-failing pass logged `Discovery-embedding pass complete: 1 embedded, 0 error(s)`.

## Reviewer notes

- Sibling-of-`dbDirectory` was chosen over inside-it to keep re-downloadable cache out of the directory operators treat as precious data, and to match the lsio `/config` layout convention (`db`, `album-art`, `waveform-cache` are siblings).
- The Joi default is a function receiving the parent storage object; when `dbDirectory` is unset it falls back to the same constant as `dbDirectory`'s own default, so evaluation-order semantics of sibling defaults don't matter. The default is a pure path computation — no filesystem reads during schema validation.
- `task-queue.js` has 6 pre-existing `no-empty` lint errors that exist identically at the merge base; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)