### PR TITLE
feat(discovery): auto-forget catalog peers after a retention window

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -494,6 +494,7 @@ export function setup(mstream) {
       serverName: config.program.discoveryP2p.serverName,
       serverDescription: config.program.discoveryP2p.serverDescription,
       maxPeerDbStorageMb: config.program.discoveryP2p.maxPeerDbStorageMb,
+      peerRetentionDays: config.program.discoveryP2p.peerRetentionDays,
     });
   });
 
@@ -638,6 +639,21 @@ export function setup(mstream) {
     });
     joiValidate(schema, req.body);
     await admin.editMaxPeerDbStorageMb(req.body.maxPeerDbStorageMb);
+    res.json({});
+  });
+
+  // How long a silent peer stays in the catalog before the hourly prune
+  // pass forgets it (0 = forever). Live: the pass reads the config fresh, so
+  // no restart and no stack bounce. Bounds mirror the config Joi
+  // (discoveryP2pOptions.peerRetentionDays). Peers whose snapshot is on the
+  // local shelf are never pruned regardless of this value.
+  mstream.post("/api/v1/admin/discovery/p2p/peer-retention", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      peerRetentionDays: Joi.number().integer().min(0).max(3650).required(),
+    });
+    joiValidate(schema, req.body);
+    await admin.editPeerRetentionDays(req.body.peerRetentionDays);
     res.json({});
   });
 

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -564,6 +564,24 @@ export function setup(mstream) {
     res.json({});
   });
 
+  // Forget a catalog peer right now instead of waiting out the retention
+  // window. Same pin rule as the automatic prune: a peer whose snapshot is
+  // on the local shelf stays — forgetting it would orphan the downloaded
+  // file invisibly (remove the snapshot first, then forget). Reversible by
+  // nature: the peer re-enters the catalog on its next announcement.
+  mstream.post("/api/v1/admin/discovery/p2p/forget", (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({ endpointId: Joi.string().hex().length(64).required() });
+    joiValidate(schema, req.body);
+    if (discoveryPeerDbs.get(req.body.endpointId)) {
+      throw new WebError('peer has a downloaded snapshot — remove the snapshot first', 409);
+    }
+    if (!discoveryCatalog.forget(req.body.endpointId)) {
+      throw new WebError('unknown peer — not in the catalog', 404);
+    }
+    res.json({});
+  });
+
   // Publish the current export snapshot and broadcast its signed
   // announcement to the catalog topic. 404 until an export exists.
   mstream.post("/api/v1/admin/discovery/p2p/announce", async (req, res) => {

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -375,6 +375,11 @@ const discoveryP2pOptions = Joi.object({
   autoFetch: Joi.boolean().default(true),
   autoFetchCount: Joi.number().integer().min(0).max(50).default(3),
   maxPeerDbStorageMb: Joi.number().integer().min(10).max(100000).default(500),
+  // Auto-forget: drop a catalog entry once the peer hasn't been heard from in
+  // this many days (0 = keep forever). Peers whose snapshot is on the local
+  // shelf are exempt — forgetting them would orphan the downloaded file
+  // invisibly. See discovery-catalog.pruneStalePeers for the guardrails.
+  peerRetentionDays: Joi.number().integer().min(0).max(3650).default(30),
   // Endpoint ids whose announcements are ignored and whose snapshots are
   // never fetched — the v1 spam/abuse lever.
   blockedPeers: Joi.array().items(Joi.string().hex().length(64)).default([]),

--- a/src/state/discovery-catalog.js
+++ b/src/state/discovery-catalog.js
@@ -29,7 +29,10 @@ import * as discoveryP2p from './discovery-p2p.js';
 const { events } = discoveryP2p;
 
 const SAVE_DEBOUNCE_MS = 2000;
-const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+// The env override exists for integration/smoke tests (waiting an hour per
+// assertion is unkind); production installs should never set it.
+const PRUNE_INTERVAL_MS =
+  Number(process.env.MSTREAM_TEST_DISCOVERY_PRUNE_MS) || 60 * 60 * 1000;
 
 // endpointId -> { from, payload, firstSeenAt, updatedAt }
 const catalog = new Map();

--- a/src/state/discovery-catalog.js
+++ b/src/state/discovery-catalog.js
@@ -126,6 +126,17 @@ export function size() {
   return catalog.size;
 }
 
+// Manual forget: the operator's "drop this dead server now" button, the
+// immediate sibling of the retention pruning below. Deleting is never
+// permanent — one announcement from the peer re-creates the entry.
+export function forget(endpointId) {
+  ensureLoaded();
+  if (!catalog.delete(endpointId)) { return false; }
+  scheduleSave();
+  winston.info(`[discovery-catalog] operator forgot peer ${endpointId.slice(0, 12)}…`);
+  return true;
+}
+
 // ── Auto-forget (retention pruning) ──────────────────────────────────────────
 // A peer that stops announcing stays in the catalog as "offline" — useful for
 // a weekend outage, noise after a month. Drop entries not heard from in

--- a/src/state/discovery-catalog.js
+++ b/src/state/discovery-catalog.js
@@ -12,7 +12,9 @@
 //   - persisted to {dbDirectory}/discovery-p2p/catalog.json (debounced) so
 //     the catalog survives restarts — peers announce every ~15s while
 //     online, but a rebooted server shouldn't forget everyone who is
-//     currently offline.
+//     currently offline;
+//   - offline isn't forever: entries not heard from in
+//     discoveryP2p.peerRetentionDays age out (see pruneStalePeers below).
 //
 // This is deliberately NOT a table in discovery.db: that file is the
 // exportable share-safe unit, and what other servers exist is internal
@@ -22,9 +24,12 @@ import fs from 'fs';
 import path from 'path';
 import winston from 'winston';
 import * as config from './config.js';
-import { events } from './discovery-p2p.js';
+import * as discoveryP2p from './discovery-p2p.js';
+
+const { events } = discoveryP2p;
 
 const SAVE_DEBOUNCE_MS = 2000;
+const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
 // endpointId -> { from, payload, firstSeenAt, updatedAt }
 const catalog = new Map();
@@ -116,6 +121,83 @@ export function get(endpointId) {
 export function size() {
   ensureLoaded();
   return catalog.size;
+}
+
+// ── Auto-forget (retention pruning) ──────────────────────────────────────────
+// A peer that stops announcing stays in the catalog as "offline" — useful for
+// a weekend outage, noise after a month. Drop entries not heard from in
+// discoveryP2p.peerRetentionDays (0 = keep forever). Two exemptions:
+//   - `keep` (peers whose snapshot is on the local shelf): forgetting them
+//     would hide the shelf row from the UI and orphan the file on disk —
+//     snapshot removal stays an explicit operator action;
+//   - nothing else. Blocked peers are dropped REGARDLESS of age (unless
+//     kept): record() refuses their announcements, so a pre-existing entry
+//     could never refresh and would otherwise sit visible until it aged out.
+// `now` is injectable for tests. Returns the dropped endpoint ids.
+export function pruneStalePeers({ keep = new Set(), now = Date.now() } = {}) {
+  ensureLoaded();
+  const days = config.program.discoveryP2p.peerRetentionDays;
+  const cutoff = days > 0 ? now - (days * 24 * 60 * 60 * 1000) : null;
+  const dropped = [];
+  for (const [from, entry] of catalog) {
+    if (keep.has(from)) { continue; }
+    const blocked = config.program.discoveryP2p.blockedPeers.includes(from);
+    // An unparseable updatedAt can never refresh (record() rewrites it on
+    // every announcement), so it counts as stale rather than immortal.
+    const heardAt = Date.parse(entry.updatedAt);
+    const stale = cutoff !== null && !(heardAt >= cutoff);
+    if (!blocked && !stale) { continue; }
+    catalog.delete(from);
+    dropped.push(from);
+  }
+  if (dropped.length > 0) {
+    scheduleSave();
+    winston.info(`[discovery-catalog] forgot ${dropped.length} peer(s) `
+      + `(${days > 0 ? `not heard in ${days}d` : 'blocked'}): `
+      + dropped.map((id) => id.slice(0, 12) + '…').join(', '));
+  }
+  return dropped;
+}
+
+// The hourly prune pass. Only runs while the sidecar reports at least one
+// live gossip neighbor: with zero neighbors we can't hear ANYONE, so silence
+// is evidence of our own isolation, not of peers being gone — an offline
+// server must never wake up and forget its whole catalog. (Live peers
+// re-announce every ~15s, so by the first pass — an hour after start —
+// everyone reachable has refreshed their in-memory updatedAt.)
+async function prunePass(getPinned) {
+  try {
+    if (!discoveryP2p.isRunning()) { return; }
+    const s = await discoveryP2p.status();
+    if (!(Number(s.neighbors) > 0)) { return; }
+  } catch (err) {
+    winston.debug(`[discovery-catalog] prune skipped (status unavailable): ${err.message}`);
+    return;
+  }
+  pruneStalePeers({ keep: getPinned() });
+  // Persist current heartbeat timestamps while we're here: record() only
+  // saves on real changes, so without this the on-disk updatedAt of a
+  // stable live peer could lag reality by months. One write an hour keeps
+  // the persisted catalog honest across restarts.
+  scheduleSave();
+}
+
+let pruneTimer = null;
+
+// getPinned: () => Set of endpoint ids that must never be pruned (the
+// caller knows what's on the shelf; this module deliberately doesn't import
+// discovery-peer-dbs — it imports us). Idempotent, like subscribe().
+export function startPruning(getPinned) {
+  if (pruneTimer) { return; }
+  pruneTimer = setInterval(() => {
+    prunePass(getPinned).catch((err) =>
+      winston.warn(`[discovery-catalog] prune pass failed: ${err.message}`));
+  }, PRUNE_INTERVAL_MS);
+  if (pruneTimer.unref) { pruneTimer.unref(); }
+}
+
+export function stopPruning() {
+  if (pruneTimer) { clearInterval(pruneTimer); pruneTimer = null; }
 }
 
 // ── Holder tracking (N3) ─────────────────────────────────────────────────────

--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -54,6 +54,10 @@ export async function startDiscoveryP2pStack() {
     // logged, never fatal.
     const peerDbs = await import('./discovery-peer-dbs.js');
     peerDbs.startAutoFetch();
+    // Retention pruning: forget catalog peers not heard from in
+    // discoveryP2p.peerRetentionDays. The shelf is the pin-set — a peer
+    // whose snapshot we hold stays listed however long it's been silent.
+    catalog.startPruning(() => new Set(peerDbs.list().map((e) => e.endpointId)));
     running = true;
   })();
   try { await starting; } finally { starting = null; }
@@ -65,8 +69,10 @@ export async function startDiscoveryP2pStack() {
 export async function stopDiscoveryP2pStack() {
   const seeds = await import('./discovery-seeds.js');
   const peerDbs = await import('./discovery-peer-dbs.js');
+  const catalog = await import('./discovery-catalog.js');
   seeds.stopMeshHealthWatch();
   peerDbs.stopAutoFetch();
+  catalog.stopPruning();
   const p2p = await import('./discovery-p2p.js');
   await p2p.stop();
   running = false;

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -566,6 +566,17 @@ export async function editMaxPeerDbStorageMb(val) {
   config.program.discoveryP2p.maxPeerDbStorageMb = val;
 }
 
+// Days a silent catalog peer is kept before the hourly prune pass forgets
+// it (0 = keep forever). Live: pruneStalePeers reads the config fresh on
+// every pass, so the next pass honors the new value — no restart.
+export async function editPeerRetentionDays(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.peerRetentionDays = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.peerRetentionDays = val;
+}
+
 // The p2p master switch. Persisting the flag is all this does — the api
 // route owns starting/stopping the runtime stack (and rolls this back if
 // the stack fails to come up), so the config file never claims a state the

--- a/test/unit/discovery-catalog-prune.test.mjs
+++ b/test/unit/discovery-catalog-prune.test.mjs
@@ -112,3 +112,14 @@ describe('discovery-catalog retention pruning', () => {
     assert.equal(catalog.get(HELD).payload.snapshotSeq, 2);
   });
 });
+
+describe('discovery-catalog manual forget', () => {
+  test('forget drops a known peer, reports an unknown one, and record() undoes it', () => {
+    assert.equal(catalog.forget(HELD), true);
+    assert.equal(catalog.size(), 0);
+    assert.equal(catalog.forget(HELD), false, 'already forgotten');
+    // Forgetting is never permanent: the next announcement re-creates it.
+    assert.equal(catalog.record(HELD, { snapshotSeq: 3, hash: 'h3', name: 'back-again', rowCount: 5, modelId: 'test-model' }), true);
+    assert.equal(catalog.get(HELD).payload.snapshotSeq, 3);
+  });
+});

--- a/test/unit/discovery-catalog-prune.test.mjs
+++ b/test/unit/discovery-catalog-prune.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Catalog retention pruning (discovery-catalog.pruneStalePeers) — the
+ * "forget offline servers" rules, no sidecar or server needed:
+ *
+ *  - entries not heard from in discoveryP2p.peerRetentionDays are dropped;
+ *  - the keep-set (peers whose snapshot is on the local shelf) always wins —
+ *    over staleness AND over the blocklist;
+ *  - blocked peers are dropped regardless of age (record() refuses their
+ *    announcements, so a leftover entry could never refresh itself);
+ *  - peerRetentionDays = 0 disables age-based pruning but not blocked-drop;
+ *  - an unparseable updatedAt counts as stale, not immortal;
+ *  - a pruned peer re-enters the catalog on its next announcement.
+ *
+ * The catalog file is crafted on disk BEFORE the module's lazy first load so
+ * entry ages are controlled without reaching into module state. The hourly
+ * timer + neighbor gate (startPruning/prunePass) need a live sidecar and are
+ * exercised by the integration suite's stack lifecycle.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import * as config from '../../src/state/config.js';
+import * as catalog from '../../src/state/discovery-catalog.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.now();
+
+// Distinct 64-hex endpoint ids, à la real iroh endpoint ids.
+const id = (seed) => seed.repeat(64).slice(0, 64);
+const FRESH = id('a');
+const STALE = id('b');
+const HELD = id('c');
+const BLOCKED = id('d');
+const BAD_DATE = id('e');
+
+function entry(from, updatedAt, seq = 1) {
+  return {
+    from,
+    payload: { snapshotSeq: seq, hash: `hash-${from.slice(0, 4)}`, name: from.slice(0, 4), rowCount: 10, modelId: 'test-model' },
+    firstSeenAt: new Date(NOW - 200 * DAY_MS).toISOString(),
+    updatedAt,
+  };
+}
+
+let tmpDir;
+
+before(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-catalog-prune-'));
+  await config.setup(path.join(tmpDir, 'config.json'));
+  config.program.storage.dbDirectory = tmpDir;
+  // Written before the module's first ensureLoaded so ages are ours to pick.
+  const dir = path.join(tmpDir, 'discovery-p2p');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'catalog.json'), JSON.stringify([
+    entry(FRESH, new Date(NOW).toISOString()),
+    entry(STALE, new Date(NOW - 100 * DAY_MS).toISOString()),
+    entry(HELD, new Date(NOW - 100 * DAY_MS).toISOString()),
+    entry(BLOCKED, new Date(NOW).toISOString()),
+    entry(BAD_DATE, 'not-a-timestamp'),
+  ]));
+});
+
+after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+describe('discovery-catalog retention pruning', () => {
+  test('loads the crafted catalog', () => {
+    assert.equal(catalog.size(), 5);
+  });
+
+  test('drops stale + blocked + unparseable; keeps fresh and shelf-pinned', () => {
+    config.program.discoveryP2p.peerRetentionDays = 30;
+    config.program.discoveryP2p.blockedPeers = [BLOCKED];
+    const dropped = catalog.pruneStalePeers({ keep: new Set([HELD]), now: NOW });
+    assert.deepEqual(dropped.sort(), [STALE, BLOCKED, BAD_DATE].sort());
+    assert.deepEqual(catalog.list().map((e) => e.from).sort(), [FRESH, HELD].sort());
+  });
+
+  test('nothing to drop → returns empty, catalog untouched', () => {
+    const dropped = catalog.pruneStalePeers({ keep: new Set([HELD]), now: NOW });
+    assert.deepEqual(dropped, []);
+    assert.equal(catalog.size(), 2);
+  });
+
+  test('retention 0 keeps silent peers forever (but still drops blocked)', () => {
+    config.program.discoveryP2p.peerRetentionDays = 0;
+    config.program.discoveryP2p.blockedPeers = [FRESH];
+    // A century of silence: age-pruning is off, so only the blocked id goes.
+    const dropped = catalog.pruneStalePeers({ now: NOW + 36500 * DAY_MS });
+    assert.deepEqual(dropped, [FRESH]);
+    assert.deepEqual(catalog.list().map((e) => e.from), [HELD]);
+  });
+
+  test('keep-set shields a blocked peer too', () => {
+    config.program.discoveryP2p.blockedPeers = [HELD];
+    assert.deepEqual(catalog.pruneStalePeers({ keep: new Set([HELD]), now: NOW }), []);
+    assert.equal(catalog.size(), 1);
+    config.program.discoveryP2p.blockedPeers = [];
+  });
+
+  test('a pruned peer re-enters the catalog on its next announcement', () => {
+    config.program.discoveryP2p.peerRetentionDays = 30;
+    // Everything left (HELD, silent 100 days) goes once its pin is gone…
+    assert.deepEqual(catalog.pruneStalePeers({ now: NOW }), [HELD]);
+    assert.equal(catalog.size(), 0);
+    // …and one announcement brings it straight back.
+    assert.equal(catalog.record(HELD, { snapshotSeq: 2, hash: 'h2', name: 'back', rowCount: 5, modelId: 'test-model' }), true);
+    assert.equal(catalog.size(), 1);
+    assert.equal(catalog.get(HELD).payload.snapshotSeq, 2);
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -738,7 +738,7 @@ const P2PIDENTITY = { serverName: '', serverDescription: '' };
 // Same shared-object pattern (and the same must-be-hoisted TDZ rule) for
 // the editable p2p settings: the Discovery card fills it from the status
 // route, the max-storage modal edits it.
-const P2PSETTINGS = { maxPeerDbStorageMb: 500 };
+const P2PSETTINGS = { maxPeerDbStorageMb: 500, peerRetentionDays: 30 };
 
 const foldersView = Vue.component('folders-view', {
   data() {
@@ -7019,6 +7019,12 @@ const discoveryView = Vue.component('discovery-view', {
                     — auto-fetch {{ discoveryP2p.autoFetch ? 'on' : 'off' }}
                     — community seeds {{ discoveryP2p.status.communitySeeds ? 'on (public network)' : 'off (friends only)' }}
                   </p>
+                  <p><b>Forget offline servers:</b>
+                    {{ discoveryP2p.status.peerRetentionDays > 0
+                      ? 'after ' + discoveryP2p.status.peerRetentionDays + ' days of silence'
+                      : 'never (offline servers stay listed forever)' }}
+                    [<a v-on:click="openModal('edit-p2p-peer-retention-modal')">{{ t('admin.settings.edit') }}</a>]
+                  </p>
                   <div v-if="discoveryP2p.peers.length > 5" class="input-field" style="max-width: 360px; margin: 4px 0 0 0;">
                     <input v-model="peerFilter" id="p2p-peer-filter" type="text" placeholder="Search servers — name or description">
                   </div>
@@ -7035,7 +7041,7 @@ const discoveryView = Vue.component('discovery-view', {
                         </td>
                         <td>{{ peer.payload.rowCount }}</td>
                         <td>{{ peer.seeders }}</td>
-                        <td>{{ peer.online ? 'online' : 'offline' }}</td>
+                        <td :title="peer.updatedAt">{{ peer.online ? 'online' : 'offline' + discoveryAge(peer.updatedAt) }}</td>
                         <td>{{ peer.compatible === null ? 'unknown' : (peer.compatible ? 'compatible' : 'incompatible') }}</td>
                         <td>{{ peer.fetched ? (peer.fetched.stale ? 'update available' : 'yes') : 'no' }}</td>
                         <td>
@@ -7204,6 +7210,8 @@ const discoveryView = Vue.component('discovery-view', {
         P2PIDENTITY.serverName = status.serverName || '';
         P2PIDENTITY.serverDescription = status.serverDescription || '';
         if (status.maxPeerDbStorageMb) { P2PSETTINGS.maxPeerDbStorageMb = status.maxPeerDbStorageMb; }
+        // 0 (= never forget) is a valid value — don't truthiness-check it away.
+        if (typeof status.peerRetentionDays === 'number') { P2PSETTINGS.peerRetentionDays = status.peerRetentionDays; }
         if (status.enabled === true) {
           const cat = (await API.axios({
             method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
@@ -7254,6 +7262,17 @@ const discoveryView = Vue.component('discovery-view', {
       if (n >= 1073741824) { return (n / 1073741824).toFixed(1) + ' GB'; }
       if (n >= 1048576) { return (n / 1048576).toFixed(1) + ' MB'; }
       return Math.ceil(n / 1024) + ' KB';
+    },
+    // How long ago a peer was last heard, as a table-cell suffix
+    // (' · 3d'). An offline row that's been silent for weeks should read
+    // differently from one that dropped off five minutes ago.
+    discoveryAge: function(iso) {
+      const ms = Date.now() - Date.parse(iso);
+      if (!isFinite(ms) || ms < 0) { return ''; }
+      const mins = Math.floor(ms / 60000);
+      if (mins < 60) { return ' · ' + Math.max(mins, 1) + 'm'; }
+      if (mins < 48 * 60) { return ' · ' + Math.floor(mins / 60) + 'h'; }
+      return ' · ' + Math.floor(mins / (24 * 60)) + 'd';
     }
   }
 });
@@ -8331,6 +8350,71 @@ const editP2pMaxStorageView = Vue.component('edit-p2p-max-storage-modal', {
         });
 
         P2PSETTINGS.maxPeerDbStorageMb = Number(this.editValue);
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          message: err.response?.data?.error || '',
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+// Retention for the peer catalog: how many days a server may stay silent
+// before it's forgotten (0 = never). Applies from the very next hourly
+// prune pass — no restart. Downloaded snapshots pin their peer in the list
+// regardless, so this can't invisibly orphan storage.
+const editP2pPeerRetentionView = Vue.component('edit-p2p-peer-retention-modal', {
+  data() {
+    return {
+      submitPending: false,
+      editValue: P2PSETTINGS.peerRetentionDays
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Forget offline servers</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-p2p-peer-retention" required type="number" min="0" max="3650">
+          <label for="edit-p2p-peer-retention">Days of silence before a server is forgotten</label>
+          <span class="helper-text">A server that hasn't announced itself in this many days is dropped from the list automatically — it reappears the moment it comes back online. Servers whose snapshot you've downloaded are never forgotten; remove the snapshot first. 0 keeps every server forever.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-retention`,
+          data: { peerRetentionDays: Number(this.editValue) }
+        });
+
+        P2PSETTINGS.peerRetentionDays = Number(this.editValue);
 
         M.Modal.getInstance(document.getElementById('admin-modal')).close();
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -7047,6 +7047,7 @@ const discoveryView = Vue.component('discovery-view', {
                         <td>
                           [<a v-on:click="discoveryFetchPeer(peer.from)">{{ peer.fetched ? 'Update' : 'Download' }}</a>]
                           <span v-if="peer.fetched">[<a v-on:click="discoveryRemovePeer(peer.from)">Remove</a>]</span>
+                          <span v-if="!peer.online && !peer.fetched">[<a v-on:click="discoveryForgetPeer(peer.from)">Forget</a>]</span>
                         </td>
                       </tr>
                     </tbody>
@@ -7254,6 +7255,26 @@ const discoveryView = Vue.component('discovery-view', {
         });
       } catch (err) {
         iziToast.error({ title: 'Remove failed', position: 'topCenter', timeout: 3000 });
+      }
+      this.loadDiscoveryP2p();
+    },
+    // Drop a dead server from the list right now instead of waiting out
+    // the retention window. Harmless by construction: it reappears on its
+    // next announcement if it ever comes back.
+    discoveryForgetPeer: async function(endpointId) {
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/forget`,
+          data: { endpointId }
+        });
+        iziToast.success({ title: 'Server forgotten — it reappears if it comes back online', position: 'topCenter', timeout: 3500 });
+      } catch (err) {
+        iziToast.error({
+          title: 'Forget failed',
+          message: err.response?.data?.error || '',
+          position: 'topCenter', timeout: 4000
+        });
       }
       this.loadDiscoveryP2p();
     },


### PR DESCRIPTION
## The problem

Once a peer's signed announcement is heard, its catalog entry lives forever. A server that died months ago still shows in every operator's Discovery page as a bare "offline" — indistinguishable from one that dropped off five minutes ago. (Spotted via a long-dead test lab box that never left the list.)

Related gap fixed along the way: adding a peer to `discoveryP2p.blockedPeers` stopped *new* announcements from being recorded, but never removed or hid the already-recorded entry.

## The fix

New `discoveryP2p.peerRetentionDays` (default **30**, `0` = keep forever). An hourly pass in `discovery-catalog.js` (`pruneStalePeers`) drops:

- entries not heard from within the retention window, and
- blocked peers of any age.

A pruned peer re-enters the catalog the moment it announces again — forgetting is never permanent.

### Guardrails

- **Neighbor gate**: the pass only runs while the sidecar reports ≥1 gossip neighbor. With zero neighbors, silence is evidence of our own isolation, not of peers being gone — a server that boots after months offline must never wipe its whole catalog. (Live peers re-announce every ~15s, so everyone reachable has refreshed `updatedAt` long before the first pass at +1h.)
- **Shelf pin**: peers whose snapshot is on the local shelf are never pruned — the catalog row is what makes the downloaded snapshot visible/manageable in the UI, so forgetting it would orphan disk usage invisibly. Snapshot removal stays an explicit operator action; after that the row ages out normally. The pin-set is injected as a callback from `discovery-p2p-stack` (the catalog keeps not importing `discovery-peer-dbs`; the dependency already points the other way).
- **Timestamp honesty**: same-seq heartbeats refresh `updatedAt` only in memory (`record()` deliberately doesn't save them). Each hourly pass now schedules a save, so persisted timestamps stay ≤1h stale across restarts.

## Admin surface (max-storage pattern)

- `POST /api/v1/admin/discovery/p2p/peer-retention` — live, no restart; the next pass reads the config fresh. Joi mirrors the config bounds (0–3650).
- Value exposed in the p2p status payload.
- Discovery page: "Forget offline servers: after N days of silence [edit]" line + modal (0 renders as "never").
- The catalog table's Online column now shows how long a silent peer has been gone — `offline · 45d` — with the full timestamp as a hover title.

## Testing

- New `test/unit/discovery-catalog-prune.test.mjs` (6 tests): stale/blocked/unparseable-timestamp dropped; fresh + shelf-pinned kept; keep-set shields blocked peers; retention 0 disables age pruning but not blocked-drop; pruned peer re-enters on next announcement. Crafts `catalog.json` before the module's lazy first load to control entry ages.
- Full `discovery-p2p` integration suite (covers the stack start/stop paths the prune timer is wired into): 36/36.
- Full unit run: 309 pass / 0 fail.
- Browser click-through on a live instance with a seeded catalog: panel line + modal save (200, persisted, re-rendered), 400 on out-of-range, offline ages in the table.

## Behavior-change note

Retention defaults to **on at 30 days** for existing servers. Operators who want the old keep-forever behavior set the value to 0 in the new modal (or config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)