### PR TITLE
feat(discovery): befriend-a-server ticket box in the admin UI

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -732,17 +732,22 @@ export function setup(mstream) {
 
   // Join the catalog topic at runtime with an extra bootstrap peer (an
   // endpoint ticket or bare endpoint id — e.g. pasted from a friend's
-  // status route). Non-persistent: add it to config discoveryP2p.bootstrapPeers
-  // to survive restarts.
+  // Discovery page). Session-only by default; persist=true (what the UI's
+  // befriend box sends) also appends it to config discoveryP2p.bootstrapPeers
+  // — only after the sidecar accepted it, so a malformed ticket is never
+  // saved.
   mstream.post("/api/v1/admin/discovery/p2p/join", async (req, res) => {
     requireP2pEnabled();
     const schema = Joi.object({
       peer: Joi.string().min(16).max(4096).required(),
+      persist: Joi.boolean().default(false),
     });
     joiValidate(schema, req.body);
     try {
       discoveryCatalog.subscribe();
-      res.json(await discoveryP2p.join([req.body.peer]));
+      const result = await discoveryP2p.join([req.body.peer]);
+      if (req.body.persist === true) { await admin.editAddBootstrapPeer(req.body.peer); }
+      res.json(result);
     } catch (err) {
       winston.warn(`discovery P2P join failed for admin '${req.user?.username}' (peer ${req.body.peer.slice(0, 32)}…): ${err.message}`);
       throw new WebError(`join failed: ${err.message}`, 500);

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -566,6 +566,18 @@ export async function editMaxPeerDbStorageMb(val) {
   config.program.discoveryP2p.maxPeerDbStorageMb = val;
 }
 
+// Append a bootstrap peer (deduplicated) so a friend joined through the
+// UI survives restarts — the join RPC itself is session-only.
+export async function editAddBootstrapPeer(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  const list = loadConfig.discoveryP2p.bootstrapPeers || [];
+  if (!list.includes(val)) { list.push(val); }
+  loadConfig.discoveryP2p.bootstrapPeers = list;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.bootstrapPeers = list;
+}
+
 // Days a silent catalog peer is kept before the hourly prune pass forgets
 // it (0 = keep forever). Live: pruneStalePeers reads the config fresh on
 // every pass, so the next pass honors the new value — no restart.

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -6955,7 +6955,9 @@ const discoveryView = Vue.component('discovery-view', {
       discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false },
       p2pIdentity: P2PIDENTITY,
       p2pToggling: false,
-      peerFilter: ''
+      peerFilter: '',
+      friendTicket: '',
+      joinPending: false
     };
   },
   template: `
@@ -7009,10 +7011,19 @@ const discoveryView = Vue.component('discovery-view', {
                     <div class="progress" style="margin: 4px 0 6px 0;"><div class="indeterminate"></div></div>
                     <span style="color: #757575; font-size: 0.85em;">searching for peers — this page updates itself every few seconds</span>
                   </div>
-                  <p v-if="discoveryP2p.status.ticket"><b>Your ticket</b> — a friend pastes this into their
-                  <code>discoveryP2p.bootstrapPeers</code> to befriend this server:<br>
+                  <p v-if="discoveryP2p.status.ticket" style="margin-bottom: 4px;"><b>Your ticket</b> — a friend pastes this
+                  into the box below on <i>their</i> Discovery page to befriend this server:<br>
                     <textarea readonly rows="2" style="width:100%; font-size: 0.8em;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>
                   </p>
+                  <p style="margin: 8px 0 2px 0;"><b>Befriend a server</b> — paste the ticket from a friend's Discovery page
+                  (saved to your config, so the friendship survives restarts):</p>
+                  <div style="display: flex; gap: 8px; max-width: 640px; align-items: center; margin-bottom: 8px;">
+                    <input v-model="friendTicket" id="p2p-friend-ticket" type="text" placeholder="endpoint…"
+                      style="flex: 1; margin: 0;" v-on:keyup.enter="discoveryJoinPeer()">
+                    <a v-on:click="discoveryJoinPeer()" :class="{disabled: joinPending || !friendTicket.trim()}"
+                      class="waves-effect waves-light btn green" style="flex-shrink: 0;">
+                      {{ joinPending ? 'Joining…' : 'Join' }}</a>
+                  </div>
                   <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
                     {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
                     [<a v-on:click="openModal('edit-p2p-max-storage-modal')">{{ t('admin.settings.edit') }}</a>]
@@ -7054,8 +7065,7 @@ const discoveryView = Vue.component('discovery-view', {
                   </table>
                   <p v-else-if="discoveryP2p.peers.length > 0">No servers match
                     &ldquo;{{ peerFilter }}&rdquo; — [<a v-on:click="peerFilter = ''">clear</a>]</p>
-                  <p v-else>No peers heard yet — add a friend's ticket to <code>discoveryP2p.bootstrapPeers</code>
-                  (or POST it to the join endpoint) and give gossip a minute.</p>
+                  <p v-else>No servers heard yet — paste a friend's ticket above and give gossip a minute.</p>
                   <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]
                   [<a v-on:click="disableP2p()" style="color: #b71c1c;">Disable</a>]</p>
                 </div>
@@ -7257,6 +7267,33 @@ const discoveryView = Vue.component('discovery-view', {
         iziToast.error({ title: 'Remove failed', position: 'topCenter', timeout: 3000 });
       }
       this.loadDiscoveryP2p();
+    },
+    // The befriend box: join the mesh through the pasted ticket AND persist
+    // it to bootstrapPeers (persist: true) so the friendship survives a
+    // restart. Gossip does the rest — their server shows up in the catalog
+    // within a minute or so of both being online.
+    discoveryJoinPeer: async function() {
+      const peer = this.friendTicket.trim();
+      if (!peer || this.joinPending) { return; }
+      try {
+        this.joinPending = true;
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/join`,
+          data: { peer, persist: true }
+        });
+        this.friendTicket = '';
+        iziToast.success({ title: 'Joined — their server appears in the list within a minute or so', position: 'topCenter', timeout: 4000 });
+      } catch (err) {
+        iziToast.error({
+          title: 'Join failed',
+          message: err.response?.data?.error || '',
+          position: 'topCenter', timeout: 4000
+        });
+      } finally {
+        this.joinPending = false;
+      }
+      this.loadDiscoveryP2p(true);
     },
     // Drop a dead server from the list right now instead of waiting out
     // the retention window. Harmless by construction: it reappears on its


### PR DESCRIPTION
**Stacked on #751** — merge that first; GitHub will retarget this to master when its base branch is deleted at merge.

## The problem

The Discovery page shows *your* ticket to hand to a friend, but there's no way to paste *theirs* back. The empty state literally told a browser user to edit `discoveryP2p.bootstrapPeers` in the config file — despite a live `POST /api/v1/admin/discovery/p2p/join` route existing since the N-series PRs. The friend-to-friend story was half-built in the UI.

## The fix

- **"Befriend a server" box** under the ticket textarea: paste a friend's ticket, hit Join (or Enter). Success toast, input clears, catalog refreshes.
- The join route gains an optional **`persist` flag** (default `false` — existing API callers unchanged). When true (what the UI sends), the peer is appended (deduplicated) to `bootstrapPeers` **after** the sidecar accepted it, so a malformed ticket is never written to config and the friendship survives restarts.
- Empty-state copy updated to point at the box instead of the config file.

## Testing

- Live two-server verification: pasted server B's ticket into A's box → toast, `bootstrapPeers` gained the ticket in A's config file, and A's mesh went 0 → 1 neighbors from the UI click alone.
- Full discovery-p2p integration suite (which exercises the join route with the old call shape) run on the stack tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)