### PR TITLE
feat(discovery): runtime blocklist UI — block/unblock peers from the catalog

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -495,6 +495,7 @@ export function setup(mstream) {
       serverDescription: config.program.discoveryP2p.serverDescription,
       maxPeerDbStorageMb: config.program.discoveryP2p.maxPeerDbStorageMb,
       peerRetentionDays: config.program.discoveryP2p.peerRetentionDays,
+      blockedPeers: config.program.discoveryP2p.blockedPeers,
     });
   });
 
@@ -579,6 +580,35 @@ export function setup(mstream) {
     if (!discoveryCatalog.forget(req.body.endpointId)) {
       throw new WebError('unknown peer — not in the catalog', 404);
     }
+    res.json({});
+  });
+
+  // Block a peer — the abuse lever, previously config-file-only. Blocked
+  // means "doesn't exist": future announcements are refused (see
+  // discovery-catalog.record), holds beacons ignored, snapshots never
+  // fetched — and this route makes the present match by dropping any
+  // downloaded snapshot (re-fetchable after an unblock) and the catalog
+  // row in the same action.
+  mstream.post("/api/v1/admin/discovery/p2p/block", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({ endpointId: Joi.string().hex().length(64).required() });
+    joiValidate(schema, req.body);
+    if (req.body.endpointId === discoveryP2p.getEndpointId()) {
+      throw new WebError('cannot block this server itself', 400);
+    }
+    await admin.editAddBlockedPeer(req.body.endpointId);
+    discoveryPeerDbs.removePeerDb(req.body.endpointId);
+    discoveryCatalog.forget(req.body.endpointId);
+    res.json({});
+  });
+
+  // Unblock: the peer re-enters the catalog on its next announcement
+  // (~15s while it's online); nothing to restore proactively.
+  mstream.post("/api/v1/admin/discovery/p2p/unblock", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({ endpointId: Joi.string().hex().length(64).required() });
+    joiValidate(schema, req.body);
+    await admin.editRemoveBlockedPeer(req.body.endpointId);
     res.json({});
   });
 

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -578,6 +578,28 @@ export async function editAddBootstrapPeer(val) {
   config.program.discoveryP2p.bootstrapPeers = list;
 }
 
+// The abuse lever, runtime edition. Live everywhere it matters: record()
+// checks the list per announcement, fetch/holds paths per call, and the
+// hourly prune drops any lingering entry — no restart, no stack bounce.
+export async function editAddBlockedPeer(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  const list = loadConfig.discoveryP2p.blockedPeers || [];
+  if (!list.includes(val)) { list.push(val); }
+  loadConfig.discoveryP2p.blockedPeers = list;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.blockedPeers = list;
+}
+
+export async function editRemoveBlockedPeer(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  const list = (loadConfig.discoveryP2p.blockedPeers || []).filter((p) => p !== val);
+  loadConfig.discoveryP2p.blockedPeers = list;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.blockedPeers = list;
+}
+
 // Days a silent catalog peer is kept before the hourly prune pass forgets
 // it (0 = keep forever). Live: pruneStalePeers reads the config fresh on
 // every pass, so the next pass honors the new value — no restart.

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -7059,6 +7059,7 @@ const discoveryView = Vue.component('discovery-view', {
                           [<a v-on:click="discoveryFetchPeer(peer.from)">{{ peer.fetched ? 'Update' : 'Download' }}</a>]
                           <span v-if="peer.fetched">[<a v-on:click="discoveryRemovePeer(peer.from)">Remove</a>]</span>
                           <span v-if="!peer.online && !peer.fetched">[<a v-on:click="discoveryForgetPeer(peer.from)">Forget</a>]</span>
+                          [<a v-on:click="discoveryBlockPeer(peer.from)" style="color: #b71c1c;">Block</a>]
                         </td>
                       </tr>
                     </tbody>
@@ -7066,6 +7067,13 @@ const discoveryView = Vue.component('discovery-view', {
                   <p v-else-if="discoveryP2p.peers.length > 0">No servers match
                     &ldquo;{{ peerFilter }}&rdquo; — [<a v-on:click="peerFilter = ''">clear</a>]</p>
                   <p v-else>No servers heard yet — paste a friend's ticket above and give gossip a minute.</p>
+                  <p v-if="discoveryP2p.status.blockedPeers && discoveryP2p.status.blockedPeers.length > 0"
+                    style="color: #757575; font-size: 0.9em;">
+                    <b>Blocked servers</b> — announcements ignored, snapshots never fetched:<br>
+                    <span v-for="id in discoveryP2p.status.blockedPeers" :key="id" style="margin-right: 12px; white-space: nowrap;">
+                      <code>{{ id.slice(0, 12) }}…</code> [<a v-on:click="discoveryUnblockPeer(id)">Unblock</a>]
+                    </span>
+                  </p>
                   <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]
                   [<a v-on:click="disableP2p()" style="color: #b71c1c;">Disable</a>]</p>
                 </div>
@@ -7294,6 +7302,43 @@ const discoveryView = Vue.component('discovery-view', {
         this.joinPending = false;
       }
       this.loadDiscoveryP2p(true);
+    },
+    // Block = "make this server not exist": config blocklist + snapshot +
+    // catalog row all in one server-side action. Undo lives in the
+    // blocked-servers list below the table.
+    discoveryBlockPeer: async function(endpointId) {
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/block`,
+          data: { endpointId }
+        });
+        iziToast.success({ title: 'Server blocked — its announcements and snapshots are now ignored', position: 'topCenter', timeout: 3500 });
+      } catch (err) {
+        iziToast.error({
+          title: 'Block failed',
+          message: err.response?.data?.error || '',
+          position: 'topCenter', timeout: 4000
+        });
+      }
+      this.loadDiscoveryP2p();
+    },
+    discoveryUnblockPeer: async function(endpointId) {
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/unblock`,
+          data: { endpointId }
+        });
+        iziToast.success({ title: 'Server unblocked — it reappears on its next announcement', position: 'topCenter', timeout: 3500 });
+      } catch (err) {
+        iziToast.error({
+          title: 'Unblock failed',
+          message: err.response?.data?.error || '',
+          position: 'topCenter', timeout: 4000
+        });
+      }
+      this.loadDiscoveryP2p();
     },
     // Drop a dead server from the list right now instead of waiting out
     // the retention window. Harmless by construction: it reappears on its


### PR DESCRIPTION
**Stacked on the join-box PR** (merge order: #751 → join box → this). 

## The problem

`blockedPeers` is the public discovery network's only abuse lever, and it was config-file-only — on a network where any stranger's server can appear in your catalog with an arbitrary name and description. A runtime blocklist UI has been on the wishlist since the 6.16.0 soft-launch.

## The fix

- **[Block]** action on every catalog row. One server-side action: appends to the config blocklist, drops any downloaded snapshot (unpins the blob, re-fetchable later), and forgets the catalog row — blocked means "doesn't exist", present tense included. Blocking your own endpoint id is refused (400).
- **Blocked servers** list below the table (truncated endpoint ids) with per-id **[Unblock]**. Unblocking restores nothing proactively — the peer re-enters the catalog on its next announcement (~15s while online).
- The status payload now exposes `blockedPeers`.

Everything downstream was already blocklist-aware (`record()` refuses announcements, holds beacons ignored, fetch refuses, the retention prune drops lingering entries) — this PR just gives the lever a handle.

## Testing

- Live click-through: Block → row disappears + blocked section lists the id + config file updated; Unblock → section empties + config cleared. Toasts on both.
- Full discovery-p2p integration suite run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)