### PR TITLE
feat(scanner): re-home path-keyed refs when the stale sweep detects a move

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -901,6 +901,194 @@ fn chunk_yield() {
     std::thread::sleep(Duration::from_millis(WRITER_YIELD_MIN_MS + jitter));
 }
 
+// A stale-sweep candidate: a scan-start snapshot row the walk did not
+// account for. Hashes ride along so the sweep can pair a verified-gone
+// row with its moved/renamed twin (see rewrite_moved_refs).
+struct StaleCandidate {
+    id: i64,
+    rel: String,
+    audio_hash: Option<String>,
+    file_hash: Option<String>,
+}
+
+// Counters chunked_delete_stale_tracks returns for the scanComplete
+// event. Mirrors deleteStaleTracks's return shape in
+// src/db/orphan-cleanup.js.
+struct SweepOutcome {
+    deleted: usize,
+    moved_tracks: usize,
+    moved_refs: usize,
+}
+
+// A live row a doomed candidate can re-home its path-keyed references
+// to. `rel` is the vpath-relative forward-slash path, like
+// tracks.filepath.
+struct MoveTarget {
+    id: i64,
+    library_id: i64,
+    rel: String,
+}
+
+// Lazy per-sweep state for move re-homing: every live row whose content
+// hash a candidate carries (indexed under BOTH its hashes), plus the
+// libraries.name map needed to compose playlist_tracks'
+// "<vpath>/<rel>" paths. Targets are rows NOT themselves candidates —
+// i.e. rows the walk accounted for, rows inserted mid-scan, and rows of
+// OTHER libraries (a cross-library move heals when the destination
+// library was scanned first). Mirrors buildTargets in
+// src/db/orphan-cleanup.js.
+struct RehomeState {
+    targets: HashMap<String, Vec<MoveTarget>>,
+    vpath_by_id: HashMap<i64, String>,
+}
+
+fn build_rehome_state(
+    conn: &Connection, candidates: &[StaleCandidate],
+) -> Result<RehomeState, rusqlite::Error> {
+    let candidate_ids: std::collections::HashSet<i64> =
+        candidates.iter().map(|c| c.id).collect();
+    let mut candidate_hashes: std::collections::HashSet<&str> =
+        std::collections::HashSet::new();
+    for c in candidates {
+        if let Some(h) = c.audio_hash.as_deref() { candidate_hashes.insert(h); }
+        if let Some(h) = c.file_hash.as_deref() { candidate_hashes.insert(h); }
+    }
+    let mut vpath_by_id = HashMap::new();
+    {
+        let mut stmt = conn.prepare("SELECT id, name FROM libraries")?;
+        let rows = stmt.query_map([], |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+        })?;
+        for row in rows {
+            let (id, name) = row?;
+            vpath_by_id.insert(id, name);
+        }
+    }
+    // One pass over tracks, kept only for hashes a candidate actually
+    // carries — a mass deletion with no surviving twins stays cheap.
+    let mut targets: HashMap<String, Vec<MoveTarget>> = HashMap::new();
+    if !candidate_hashes.is_empty() {
+        let mut stmt = conn.prepare(
+            "SELECT id, filepath, library_id, audio_hash, file_hash FROM tracks")?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, i64>(2)?,
+                r.get::<_, Option<String>>(3)?,
+                r.get::<_, Option<String>>(4)?,
+            ))
+        })?;
+        for row in rows {
+            let (id, rel, library_id, audio_hash, file_hash) = row?;
+            if candidate_ids.contains(&id) { continue; }
+            for h in [audio_hash.as_deref(), file_hash.as_deref()].into_iter().flatten() {
+                if candidate_hashes.contains(h) {
+                    targets.entry(h.to_string()).or_default()
+                        .push(MoveTarget { id, library_id, rel: rel.clone() });
+                }
+            }
+        }
+    }
+    Ok(RehomeState { targets, vpath_by_id })
+}
+
+// Lookup tries audio_hash first (survives tag edits), then file_hash
+// (covers pre-audio_hash rows). Ties resolve deterministically — same
+// library, then same basename, then lowest (library_id, filepath) — so
+// both scanners converge on one answer; for byte-identical duplicates
+// any winner plays the same audio. (String order here is UTF-8 bytes vs
+// the JS scanner's UTF-16 code units — they diverge only beyond the BMP,
+// and only among same-hash ties with such names.)
+fn pick_target<'a>(
+    state: &'a RehomeState, c: &StaleCandidate, scanned_library_id: i64,
+) -> Option<&'a MoveTarget> {
+    let list = c.audio_hash.as_deref().and_then(|h| state.targets.get(h))
+        .or_else(|| c.file_hash.as_deref().and_then(|h| state.targets.get(h)))?;
+    let old_base = c.rel.rsplit('/').next().unwrap_or("");
+    let key = |t: &MoveTarget| (
+        (t.library_id != scanned_library_id) as u8,
+        (t.rel.rsplit('/').next().unwrap_or("") != old_base) as u8,
+        t.library_id,
+    );
+    list.iter().min_by(|a, b| key(a).cmp(&key(b)).then_with(|| a.rel.cmp(&b.rel)))
+}
+
+// Rewrite the path-keyed user references of doomed candidates that
+// paired with a live twin, BEFORE the chunk's DELETE. That ordering is
+// the crash safety: dying between rewrite and delete leaves references
+// pointing at the live file and the old row still sweepable next scan
+// (the rewrites then no-op). Batched CASE per table so each is scanned
+// once per chunk, not once per pair (play_events has no filepath index
+// and can be large). Every SET expression sees the PRE-update row, so
+// both CASEs key off the original filepath value. Returns rows
+// rewritten. Mirrors rewriteMovedRefs in src/db/orphan-cleanup.js.
+fn rewrite_moved_refs(
+    conn: &Connection, state: &RehomeState, scanned_library_id: i64,
+    pairs: &[(&StaleCandidate, &MoveTarget)],
+) -> Result<usize, rusqlite::Error> {
+    let mut refs = 0usize;
+    // Earliest created_at wins so a moved file doesn't re-enter the V43
+    // "recently added" sort. The dying row is still present (pre-DELETE)
+    // for the correlated read; MIN over the TEXT 'YYYY-MM-DD HH:MM:SS'
+    // format is chronological, and COALESCE keeps the target's own
+    // value when either side is NULL.
+    {
+        let mut keep_created = conn.prepare_cached(
+            "UPDATE tracks SET created_at = COALESCE(
+               MIN(created_at, (SELECT created_at FROM tracks WHERE id = ?1)),
+               created_at) WHERE id = ?2")?;
+        for (c, t) in pairs {
+            keep_created.execute(rusqlite::params![c.id, t.id])?;
+        }
+    }
+    // playlist_tracks needs a libraries.name prefix on both sides; a
+    // pair whose library row vanished mid-scan is skipped, not guessed.
+    let mut pl_pairs: Vec<(String, String)> = Vec::new();
+    if let Some(scanned_vpath) = state.vpath_by_id.get(&scanned_library_id) {
+        for (c, t) in pairs {
+            if let Some(tv) = state.vpath_by_id.get(&t.library_id) {
+                pl_pairs.push((
+                    format!("{}/{}", scanned_vpath, c.rel),
+                    format!("{}/{}", tv, t.rel),
+                ));
+            }
+        }
+    }
+    if !pl_pairs.is_empty() {
+        let arms = vec!["WHEN ? THEN ?"; pl_pairs.len()].join(" ");
+        let in_ph = vec!["?"; pl_pairs.len()].join(",");
+        let sql = format!(
+            "UPDATE playlist_tracks SET filepath = CASE filepath {} ELSE filepath END \
+             WHERE filepath IN ({})",
+            arms, in_ph,
+        );
+        let mut params: Vec<&dyn rusqlite::ToSql> =
+            Vec::with_capacity(pl_pairs.len() * 3);
+        for (old, new) in &pl_pairs { params.push(old); params.push(new); }
+        for (old, _) in &pl_pairs { params.push(old); }
+        refs += conn.prepare(&sql)?.execute(params.as_slice())?;
+    }
+    for table in ["cue_points", "play_events"] {
+        let arms = vec!["WHEN ? THEN ?"; pairs.len()].join(" ");
+        let in_ph = vec!["?"; pairs.len()].join(",");
+        let sql = format!(
+            "UPDATE {t} SET filepath = CASE filepath {a} ELSE filepath END, \
+             library_id = CASE filepath {a} ELSE library_id END \
+             WHERE library_id = ? AND filepath IN ({i})",
+            t = table, a = arms, i = in_ph,
+        );
+        let mut params: Vec<&dyn rusqlite::ToSql> =
+            Vec::with_capacity(pairs.len() * 5 + 1);
+        for (c, t) in pairs { params.push(&c.rel); params.push(&t.rel); }
+        for (c, t) in pairs { params.push(&c.rel); params.push(&t.library_id); }
+        params.push(&scanned_library_id);
+        for (c, _) in pairs { params.push(&c.rel); }
+        refs += conn.prepare(&sql)?.execute(params.as_slice())?;
+    }
+    Ok(refs)
+}
+
 // Per-chunk row cap for the end-of-scan stale-track sweep. Same value as
 // ORPHAN_CHUNK_SIZE: each deleted tracks row is heavier than an orphan
 // (it fires the FTS5 AFTER DELETE trigger and cascades to track_genres /
@@ -916,8 +1104,8 @@ const STALE_TRACK_CHUNK_SIZE: usize = 500;
 // migration force-rescan) that can run past the 5s busy_timeout and
 // stall concurrent API writes from the main server. Chunking is the same
 // cooperate-with-writers pattern chunked_orphan_delete already uses.
-// Returns the total rows deleted (sum across chunks) so the scanComplete
-// count stays accurate.
+// Returns a SweepOutcome (rows deleted + move re-home counters, summed
+// across chunks) so the scanComplete counts stay accurate.
 //
 // `candidates` is computed by the caller as (rows that existed when the
 // scan started) − (rows the walk accounted for), sorted by id — the
@@ -972,10 +1160,10 @@ const STALE_TRACK_CHUNK_SIZE: usize = 500;
 // would happily erase the library — the root check aborts instead
 // (matching the vanished-mount walk guard).
 fn chunked_delete_stale_tracks(
-    conn: &Connection, candidates: &[(i64, String)], expected_schema_version: i64,
+    conn: &Connection, candidates: &[StaleCandidate], expected_schema_version: i64,
     library_root: &str, follow_symlinks: bool, failed_walk_prefixes: &[String],
-    supported_files: &HashMap<String, bool>,
-) -> Result<usize, Box<dyn std::error::Error>> {
+    supported_files: &HashMap<String, bool>, library_id: i64,
+) -> Result<SweepOutcome, Box<dyn std::error::Error>> {
     let root = Path::new(library_root);
 
     // Per-sweep listing cache: rel dir (fwd slashes) → Some(name → kind)
@@ -1040,6 +1228,9 @@ fn chunked_delete_stale_tracks(
 
     let mut total = 0usize;
     let mut skipped = 0usize;
+    let mut rehome: Option<RehomeState> = None;
+    let mut moved_tracks = 0usize;
+    let mut moved_refs = 0usize;
     for chunk in candidates.chunks(STALE_TRACK_CHUNK_SIZE) {
         let v: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         if v != expected_schema_version {
@@ -1059,16 +1250,17 @@ fn chunked_delete_stale_tracks(
         }
         let full_chunk = chunk.len() == STALE_TRACK_CHUNK_SIZE;
 
-        let mut doomed: Vec<(i64, &str)> = Vec::new();
+        let mut doomed: Vec<&StaleCandidate> = Vec::new();
         let mut survivors = 0usize;
-        for (id, rel) in chunk {
+        for cand in chunk {
+            let rel = cand.rel.as_str();
             // A failed prefix shields its exact path and everything below
             // it (slash boundary — "Artist/Bad" must not shield
             // "Artist/Bad2"). The empty prefix (unattributable error)
             // shields everything.
             let shielded = failed_walk_prefixes.iter().any(|p| {
                 p.is_empty()
-                    || rel == p
+                    || rel == p.as_str()
                     || (rel.len() > p.len()
                         && rel.starts_with(p.as_str())
                         && rel.as_bytes()[p.len()] == b'/')
@@ -1079,7 +1271,7 @@ fn chunked_delete_stale_tracks(
             }
             let (dir_rel, name) = match rel.rfind('/') {
                 Some(i) => (&rel[..i], &rel[i + 1..]),
-                None => ("", rel.as_str()),
+                None => ("", rel),
             };
             let listing = listings.entry(dir_rel.to_string()).or_insert_with(|| {
                 build_listing(root, dir_rel, follow_symlinks)
@@ -1096,7 +1288,7 @@ fn chunked_delete_stale_tracks(
                 .unwrap_or(false);
             match listing {
                 None => { skipped += 1; }
-                Some(_) if !ext_supported => doomed.push((*id, rel.as_str())),
+                Some(_) if !ext_supported => doomed.push(cand),
                 Some(names) => match names.get(name) {
                     Some(Kind::RegularFile) => survivors += 1,
                     Some(Kind::Unknown) => { skipped += 1; } // DT_UNKNOWN — unverifiable
@@ -1106,18 +1298,18 @@ fn chunked_delete_stale_tracks(
                         // resolves to a regular file right now.
                         match fs::metadata(root.join(rel)) {
                             Ok(m) if m.is_file() => survivors += 1,
-                            Ok(_) => doomed.push((*id, rel.as_str())),
+                            Ok(_) => doomed.push(cand),
                             Err(e) if matches!(
                                 e.kind(),
                                 std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
-                            ) => doomed.push((*id, rel.as_str())),
+                            ) => doomed.push(cand),
                             Err(_) => { skipped += 1; }
                         }
                     }
                     // Exact-case name missing, a non-file, or a symlink the
                     // no-follow walk would not index — the walk's reality
                     // says this row's file is gone.
-                    _ => doomed.push((*id, rel.as_str())),
+                    _ => doomed.push(cand),
                 },
             }
         }
@@ -1133,6 +1325,23 @@ fn chunked_delete_stale_tracks(
             );
         }
         if !doomed.is_empty() {
+            // Move re-homing: pair verified-gone rows with a live twin by
+            // content hash and rewrite their path-keyed references before
+            // the DELETE below. The target map is built lazily on the
+            // first doomed row (no-op and pure-addition scans never pay
+            // for it) and targets are NOT consumed: several deleted
+            // duplicates re-pointing at one survivor is correct.
+            if rehome.is_none() {
+                rehome = Some(build_rehome_state(conn, candidates)?);
+            }
+            let state = rehome.as_ref().unwrap();
+            let pairs: Vec<(&StaleCandidate, &MoveTarget)> = doomed.iter()
+                .filter_map(|c| pick_target(state, c, library_id).map(|t| (*c, t)))
+                .collect();
+            if !pairs.is_empty() {
+                moved_tracks += pairs.len();
+                moved_refs += rewrite_moved_refs(conn, state, library_id, &pairs)?;
+            }
             // Row-value guard (id AND filepath, both from the scan-start
             // snapshot): the absence check ran against the snapshot path,
             // so a row whose filepath were ever rewritten mid-scan by
@@ -1148,9 +1357,9 @@ fn chunked_delete_stale_tracks(
             );
             let mut params: Vec<&dyn rusqlite::ToSql> =
                 Vec::with_capacity(doomed.len() * 2);
-            for (id, rel) in &doomed {
-                params.push(id);
-                params.push(rel);
+            for c in &doomed {
+                params.push(&c.id);
+                params.push(&c.rel);
             }
             total += conn.prepare(&del_sql)?.execute(params.as_slice())?;
         }
@@ -1163,7 +1372,7 @@ fn chunked_delete_stale_tracks(
             skipped,
         );
     }
-    Ok(total)
+    Ok(SweepOutcome { deleted: total, moved_tracks, moved_refs })
 }
 
 // Parallel-writer batch tuning. The greedy-drain writer holds the single
@@ -1896,7 +2105,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             config.directory, existing_tracks.len(),
         );
         println!(
-            "{{\"event\":\"scanComplete\",\"filesProcessed\":0,\"filesUnchanged\":0,\"filesScanned\":0,\"staleEntriesRemoved\":0}}"
+            "{{\"event\":\"scanComplete\",\"filesProcessed\":0,\"filesUnchanged\":0,\"filesScanned\":0,\"staleEntriesRemoved\":0,\"movedTracksRehomed\":0,\"movedRefsRehomed\":0}}"
         );
         return Ok(());
     }
@@ -1935,8 +2144,8 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    let deleted = if subtree_mode {
-        0
+    let sweep = if subtree_mode {
+        SweepOutcome { deleted: 0, moved_tracks: 0, moved_refs: 0 }
     } else {
         // Sweep candidates = (rows that existed when the scan started) −
         // (rows the walk accounted for), in id order so chunk boundaries
@@ -1946,12 +2155,17 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // fresh scan_id just so a `scan_id != ?` DELETE could find the
         // leftovers. Rows other writers insert mid-scan (ytdl) are not in
         // the scan-start snapshot, so they can never be candidates.
-        let mut candidates: Vec<(i64, String)> = existing_tracks
+        let mut candidates: Vec<StaleCandidate> = existing_tracks
             .iter()
             .filter(|(_, t)| !seen_ids.contains(&t.id))
-            .map(|(path, t)| (t.id, path.clone()))
+            .map(|(path, t)| StaleCandidate {
+                id: t.id,
+                rel: path.clone(),
+                audio_hash: t.audio_hash.clone(),
+                file_hash: t.file_hash.clone(),
+            })
             .collect();
-        candidates.sort_unstable_by_key(|&(id, _)| id);
+        candidates.sort_unstable_by_key(|c| c.id);
         // CHUNKED, not one big DELETE: the stale-track sweep cascades to
         // track_genres / track_artists and fires the per-row FTS5 AFTER
         // DELETE trigger, so on a large-deletion scan a single statement
@@ -1961,7 +2175,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         chunked_delete_stale_tracks(
             &conn, &candidates, schema_version_at_open,
             &config.directory, config.follow_symlinks, &failed_walk_prefixes,
-            &config.supported_files,
+            &config.supported_files, config.library_id,
         )?
     };
 
@@ -2081,8 +2295,9 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         .saturating_sub(file_count)
         .saturating_sub(error_count);
     println!(
-        "{{\"event\":\"scanComplete\",\"filesProcessed\":{},\"filesUnchanged\":{},\"filesScanned\":{},\"staleEntriesRemoved\":{},\"walkErrors\":{}}}",
-        file_count, unchanged, total_processed, deleted, walk_errors
+        "{{\"event\":\"scanComplete\",\"filesProcessed\":{},\"filesUnchanged\":{},\"filesScanned\":{},\"staleEntriesRemoved\":{},\"movedTracksRehomed\":{},\"movedRefsRehomed\":{},\"walkErrors\":{}}}",
+        file_count, unchanged, total_processed, sweep.deleted, sweep.moved_tracks,
+        sweep.moved_refs, walk_errors
     );
     Ok(())
 }

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -234,7 +234,7 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 // several deleted duplicates re-pointing at one survivor is correct.
 export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
   { libraryRoot = null, followSymlinks = false, failedWalkPrefixes = [],
-    supportedFiles = null, ignoreDotFiles = true, ignoreDotFolders = true,
+    supportedFiles = null, ignoreDotFiles = false, ignoreDotFolders = false,
     moveRehome = null } = {}) {
   const versionStmt = db.prepare('PRAGMA user_version');
   const KIND_FILE = 1; const KIND_SYMLINK = 2; const KIND_OTHER = 3;

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -155,11 +155,12 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 // emptied library) that can run past the 5s busy_timeout and stall
 // concurrent API writes from the main server. Same cooperate-with-writers
 // pattern as chunkedDelete above; ORPHAN_CHUNK_SIZE (500) keeps each chunk
-// well under busy_timeout. Returns the total rows deleted so the caller's
-// scanComplete count stays accurate. Mirrors chunked_delete_stale_tracks
-// in rust-parser/src/main.rs.
+// well under busy_timeout. Returns { removed, movedTracks, movedRefs } so
+// the caller's scanComplete counts stay accurate. Mirrors
+// chunked_delete_stale_tracks in rust-parser/src/main.rs.
 //
-// `candidates` is an array of {id, filepath} rows the caller computed as
+// `candidates` is an array of {id, filepath} rows (plus audio_hash /
+// file_hash when the caller wants move re-homing) computed as
 // (rows that existed when the scan started) − (rows the walk accounted
 // for), sorted by id — the scanner's in-memory seen tracking replaced the
 // old per-row `UPDATE tracks SET scan_id = ?` marker (one row rewrite per
@@ -210,9 +211,29 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 // the library. Mirrors chunked_delete_stale_tracks in
 // rust-parser/src/main.rs. With libraryRoot null (no caller does this
 // today) the sweep degrades to deleting every candidate unverified.
+//
+// MOVE RE-HOMING (`moveRehome: { libraryId }`): a doomed candidate whose
+// content hash matches a LIVE row is a moved/renamed file, and the
+// path-keyed user references that would otherwise dangle forever —
+// playlist_tracks ("<vpath>/<rel>", see the Subsonic playlist join),
+// cue_points and play_events (rel + library_id) — are rewritten to the
+// survivor's path BEFORE the chunk's DELETE. That ordering is the crash
+// safety: dying between rewrite and delete leaves references pointing at
+// the live file and the old row still sweepable next scan (the rewrites
+// then no-op). Targets are every tracks row NOT itself a candidate: rows
+// the walk accounted for, rows inserted mid-scan, and rows of OTHER
+// libraries (a cross-library move heals when the destination library was
+// scanned first). Lookup tries audio_hash first (survives tag edits),
+// then file_hash (covers pre-audio_hash rows); ties resolve
+// deterministically — same library, then same basename, then lowest
+// (library_id, filepath) — so both scanners converge on one answer, and
+// for byte-identical duplicates any winner plays the same audio. The
+// target map is built lazily on the first doomed row (no-op and
+// pure-addition scans never pay for it) and targets are NOT consumed:
+// several deleted duplicates re-pointing at one survivor is correct.
 export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
   { libraryRoot = null, followSymlinks = false, failedWalkPrefixes = [],
-    supportedFiles = null } = {}) {
+    supportedFiles = null, moveRehome = null } = {}) {
   const versionStmt = db.prepare('PRAGMA user_version');
   const KIND_FILE = 1; const KIND_SYMLINK = 2; const KIND_OTHER = 3;
   const listings = new Map(); // relDir -> Map(name -> kind) | null (unreadable)
@@ -262,6 +283,114 @@ export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
     || (rel.length > p.length && rel.startsWith(p) && rel[p.length] === '/'));
   const rootAccessible = () => {
     try { return fs.statSync(libraryRoot).isDirectory(); } catch (_err) { return false; }
+  };
+
+  const rehome = moveRehome === null ? null : {
+    libraryId: moveRehome.libraryId,
+    candidateIds: new Set(candidates.map(c => c.id)),
+    candidateHashes: new Set(candidates.flatMap(
+      c => [c.audio_hash, c.file_hash].filter(Boolean))),
+    targets: null,   // content hash -> [{id, filepath, library_id}]
+    vpathById: null, // library_id -> libraries.name (playlist path prefix)
+  };
+  let movedTracks = 0;
+  let movedRefs = 0;
+  const buildTargets = () => {
+    if (rehome.targets !== null) { return; }
+    rehome.targets = new Map();
+    rehome.vpathById = new Map(db.prepare('SELECT id, name FROM libraries')
+      .all().map(r => [r.id, r.name]));
+    if (rehome.candidateHashes.size === 0) { return; }
+    // One pass over tracks, kept only for hashes a candidate actually
+    // carries — a mass deletion with no surviving twins stays cheap.
+    for (const row of db.prepare(
+      'SELECT id, filepath, library_id, audio_hash, file_hash FROM tracks').all()) {
+      if (rehome.candidateIds.has(row.id)) { continue; }
+      for (const h of [row.audio_hash, row.file_hash]) {
+        if (!h || !rehome.candidateHashes.has(h)) { continue; }
+        const list = rehome.targets.get(h);
+        if (list) { list.push(row); } else { rehome.targets.set(h, [row]); }
+      }
+    }
+  };
+  const basename = (p) => p.slice(p.lastIndexOf('/') + 1);
+  const pickTarget = (c) => {
+    const list = (c.audio_hash && rehome.targets.get(c.audio_hash))
+      || (c.file_hash && rehome.targets.get(c.file_hash)) || null;
+    if (!list) { return null; }
+    const oldBase = basename(c.filepath);
+    let best = null;
+    let bestKey = null;
+    for (const t of list) {
+      // Positional tuple compare; number/string positions align between
+      // keys so plain < is safe. (String order is UTF-16 code units vs
+      // the Rust scanner's UTF-8 bytes — they diverge only beyond the
+      // BMP, and only among same-hash ties with such names.)
+      const key = [
+        t.library_id === rehome.libraryId ? 0 : 1,
+        basename(t.filepath) === oldBase ? 0 : 1,
+        t.library_id, t.filepath,
+      ];
+      let less = best === null;
+      for (let i = 0; !less && bestKey && i < key.length; i++) {
+        if (key[i] < bestKey[i]) { less = true; }
+        else if (key[i] > bestKey[i]) { break; }
+      }
+      if (less) { best = t; bestKey = key; }
+    }
+    return best;
+  };
+  const rewriteMovedRefs = (pairs) => {
+    // Earliest created_at wins so a moved file doesn't re-enter the V43
+    // "recently added" sort. The dying row is still present (this runs
+    // pre-DELETE) for the correlated read; MIN over the TEXT
+    // 'YYYY-MM-DD HH:MM:SS' format is chronological, and COALESCE keeps
+    // the target's own value when either side is NULL.
+    const keepCreated = db.prepare(
+      `UPDATE tracks SET created_at = COALESCE(
+         MIN(created_at, (SELECT created_at FROM tracks WHERE id = ?)),
+         created_at) WHERE id = ?`);
+    for (const { c, t } of pairs) { keepCreated.run(c.id, t.id); }
+
+    // playlist_tracks needs a libraries.name prefix on both sides; a
+    // pair whose library row vanished mid-scan is skipped, not guessed.
+    const plPairs = [];
+    const scannedVpath = rehome.vpathById.get(rehome.libraryId);
+    if (scannedVpath !== undefined) {
+      for (const { c, t } of pairs) {
+        const targetVpath = rehome.vpathById.get(t.library_id);
+        if (targetVpath === undefined) { continue; }
+        plPairs.push([`${scannedVpath}/${c.filepath}`, `${targetVpath}/${t.filepath}`]);
+      }
+    }
+    if (plPairs.length > 0) {
+      const r = db.prepare(
+        `UPDATE playlist_tracks SET filepath = CASE filepath ${
+          plPairs.map(() => 'WHEN ? THEN ?').join(' ')} ELSE filepath END
+         WHERE filepath IN (${plPairs.map(() => '?').join(',')})`)
+        .run(...plPairs.flat(), ...plPairs.map(p => p[0]));
+      movedRefs += r.changes;
+    }
+
+    // cue_points / play_events key on (filepath, library_id). Every SET
+    // expression sees the PRE-update row, so both CASEs key off the
+    // original filepath value; batched per chunk so each table is
+    // scanned once, not once per pair (play_events has no filepath
+    // index and can be large).
+    for (const table of ['cue_points', 'play_events']) {
+      const r = db.prepare(
+        `UPDATE ${table} SET filepath = CASE filepath ${
+          pairs.map(() => 'WHEN ? THEN ?').join(' ')} ELSE filepath END,
+           library_id = CASE filepath ${
+          pairs.map(() => 'WHEN ? THEN ?').join(' ')} ELSE library_id END
+         WHERE library_id = ? AND filepath IN (${pairs.map(() => '?').join(',')})`)
+        .run(
+          ...pairs.flatMap(({ c, t }) => [c.filepath, t.filepath]),
+          ...pairs.flatMap(({ c, t }) => [c.filepath, t.library_id]),
+          rehome.libraryId,
+          ...pairs.map(({ c }) => c.filepath));
+      movedRefs += r.changes;
+    }
   };
 
   let total = 0;
@@ -333,6 +462,18 @@ export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
         'disk — keeping them; a swallowed per-file error likely occurred');
     }
     if (doomed.length > 0) {
+      if (rehome !== null) {
+        buildTargets();
+        const pairs = [];
+        for (const c of doomed) {
+          const t = pickTarget(c);
+          if (t) { pairs.push({ c, t }); }
+        }
+        if (pairs.length > 0) {
+          movedTracks += pairs.length;
+          rewriteMovedRefs(pairs);
+        }
+      }
       // Row-value guard (id AND filepath, both from the scan-start
       // snapshot): the absence check ran against the snapshot path, so a
       // row whose filepath were ever rewritten mid-scan by some future
@@ -354,7 +495,7 @@ export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
       `Warning: ${skipped} stale-candidate row(s) left untouched because their ` +
       'subtree could not be verified this scan (walk errors or unreadable directories)');
   }
-  return total;
+  return { removed: total, movedTracks, movedRefs };
 }
 
 // Run all three orphan DELETEs in sequence. Order matters: albums first,

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -1387,7 +1387,10 @@ async function run() {
     const preScanRows = subtreeMode
       ? []
       : db.prepare(
-          'SELECT id, filepath FROM tracks WHERE library_id = ? ORDER BY id'
+          // Hashes ride along so the sweep can pair a verified-gone row
+          // with its moved/renamed twin and re-home path-keyed user
+          // references (see deleteStaleTracks's move re-homing).
+          'SELECT id, filepath, audio_hash, file_hash FROM tracks WHERE library_id = ? ORDER BY id'
         ).all(loadJson.libraryId);
 
     // Single walk: collect supported files (with walk-time mtime) so we
@@ -1439,6 +1442,7 @@ async function run() {
         console.log(JSON.stringify({
           event: 'scanComplete',
           filesProcessed: 0, filesUnchanged: 0, filesScanned: 0, staleEntriesRemoved: 0,
+          movedTracksRehomed: 0, movedRefsRehomed: 0,
         }));
         return;
       }
@@ -1488,12 +1492,13 @@ async function run() {
     // failedWalkPrefixes feed the verify-absence check: only rows whose
     // file is provably gone get deleted; unseen-but-alive rows are kept;
     // unverifiable rows are left untouched.
-    const deleted = subtreeMode
-      ? { changes: 0 }
-      : { changes: deleteStaleTracks(db,
+    const sweep = subtreeMode
+      ? { removed: 0, movedTracks: 0, movedRefs: 0 }
+      : deleteStaleTracks(db,
           preScanRows.filter((r) => !seenPaths.has(r.filepath)), schemaVersionAtOpen,
           { libraryRoot: loadJson.directory, followSymlinks: !!loadJson.followSymlinks,
-            failedWalkPrefixes, supportedFiles: loadJson.supportedFiles }) };
+            failedWalkPrefixes, supportedFiles: loadJson.supportedFiles,
+            moveRehome: { libraryId: loadJson.libraryId } });
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
     // to run the waveform post-processor and to print a human-readable summary.
     // Field shapes mirror the rust-parser's emitter:
@@ -1503,6 +1508,10 @@ async function run() {
     //   filesScanned         Total supported files visited (processed +
     //                        unchanged + per-file errors).
     //   staleEntriesRemoved  Tracks deleted because the file disappeared.
+    //   movedTracksRehomed   Deleted rows whose content hash matched a
+    //                        live row (a move/rename); their playlist /
+    //                        cue / play-event references were rewritten.
+    //   movedRefsRehomed     Total reference rows rewritten that way.
     console.log(JSON.stringify({
       event: 'scanComplete',
       filesProcessed: fileCount,
@@ -1511,7 +1520,9 @@ async function run() {
       // as the Rust emitter, whose total_processed increments on the Err
       // arm too.
       filesScanned: totalProcessed + errorCount,
-      staleEntriesRemoved: deleted.changes,
+      staleEntriesRemoved: sweep.removed,
+      movedTracksRehomed: sweep.movedTracks,
+      movedRefsRehomed: sweep.movedRefs,
       // Subtrees the scan could not see (their rows were shielded from
       // cleanup) — surfaced so a permanently unreadable directory is
       // operator-visible in the scan summary, not just a stderr line.

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -534,6 +534,12 @@ function handleScannerLine(scanObj, line) {
           parts.push(`${evt.filesUnchanged} unchanged`);
         }
         parts.push(`${evt.staleEntriesRemoved} stale entries removed`);
+        // Undefined-tolerant like filesUnchanged: a stale prebuilt
+        // rust-parser binary predates the move re-homing fields.
+        if (evt.movedTracksRehomed > 0) {
+          parts.push(`${evt.movedTracksRehomed} moved track(s) re-homed ` +
+            `(${evt.movedRefsRehomed} reference(s) rewritten)`);
+        }
         const tail = evt.filesScanned != null ? ` (${evt.filesScanned} scanned)` : '';
         winston.info(`Scan complete: ${parts.join(', ')}${tail}`);
         if (evt.walkErrors > 0) {

--- a/test/scanner/scanner-move-rehome.test.mjs
+++ b/test/scanner/scanner-move-rehome.test.mjs
@@ -262,6 +262,34 @@ for (const engine of ['rust', 'js']) {
       assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/f.mp3`]);
     });
 
+    test('ignore-doomed rows also re-home: dot-hidden twin converges, refs follow the visible copy', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      // Byte-identical pair: one visible, one dot-hidden. With the
+      // ignoreDotFiles flag OFF (default) both index; flipping it ON
+      // dooms the dot row via the walk-faithful IGNORE predicate — its
+      // file still exists on disk — and the pairing must then treat it
+      // exactly like a move, re-pointing its references at the twin.
+      // This pins the PR-756 × re-home interaction path.
+      await makeAudio(path.join(sb.libRoot, 'visible.mp3'), MP3, { title: 'Twin' }, 8);
+      await fsp.copyFile(path.join(sb.libRoot, 'visible.mp3'),
+        path.join(sb.libRoot, '.hidden.mp3'));
+      await sb.scan();
+      assert.deepStrictEqual(trackPaths(sb.dbPath), ['.hidden.mp3', 'visible.mp3']);
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, '.hidden.mp3');
+
+      const { event } = await sb.scan({ ignoreDotFiles: true });
+
+      assert.strictEqual(event.staleEntriesRemoved, 1);
+      assert.strictEqual(event.movedTracksRehomed, 1);
+      assert.deepStrictEqual(trackPaths(sb.dbPath), ['visible.mp3']);
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/visible.mp3`]);
+      assert.deepStrictEqual(cueRows(sb.dbPath),
+        [{ filepath: 'visible.mp3', library_id: sb.libraryId }]);
+      assert.deepStrictEqual(eventRows(sb.dbPath),
+        [{ filepath: 'visible.mp3', library_id: sb.libraryId }]);
+    });
+
     test('cross-library move heals when the destination was scanned first', async (t) => {
       if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
       const sb = await makeSandbox(engine);

--- a/test/scanner/scanner-move-rehome.test.mjs
+++ b/test/scanner/scanner-move-rehome.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * Move re-homing across the stale sweep.
+ *
+ * playlist_tracks ("<vpath>/<rel>"), cue_points and play_events
+ * (rel + library_id) are path-keyed, and the sweep used to delete a
+ * moved file's old row without touching them — a rename orphaned every
+ * playlist entry pointing at it forever (stars/ratings survive via
+ * audio_hash keying; path-keyed references did not). The sweep now
+ * pairs each verified-gone candidate with a live row by content hash
+ * (audio_hash first — survives tag edits — then file_hash), rewrites
+ * those references BEFORE the DELETE, and preserves the dying row's
+ * created_at so a mass rename doesn't flood "recently added".
+ *
+ * This file pins that behaviour on BOTH scanners:
+ *   - rename / folder-rename re-homes all three tables + created_at;
+ *   - a tag-edit + move in ONE pass still pairs (audio_hash tier —
+ *     the case tag-identity scanners lose);
+ *   - identical-content ties resolve deterministically (same library,
+ *     then same basename, then lowest (library_id, filepath));
+ *   - deleting one of two byte-identical copies re-points references
+ *     at the survivor;
+ *   - a genuine deletion (no twin) leaves references untouched — the
+ *     sweep never guesses;
+ *   - subtree scans never sweep, so they never re-home;
+ *   - a cross-library move heals when the destination library was
+ *     scanned first.
+ *
+ * Fixture gotcha exploited on purpose: makeAudio files with the SAME
+ * duration have byte-identical (silence) audio streams and therefore
+ * share an audio_hash; distinct durations give distinct content.
+ *
+ * Skipped (like scanner-parity.test.mjs) when ffmpeg or the rust binary
+ * is unavailable.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
+} from '../helpers/scanner-runner.mjs';
+import { makeAudio } from '../helpers/scanner-fixture.mjs';
+import { appendId3v23TextFrames } from '../helpers/id3.mjs';
+
+const MP3 = ['-c:a', 'libmp3lame', '-b:a', '64k', '-id3v2_version', '3'];
+
+let rustBin;
+let scratch;
+
+before(async () => {
+  rustBin = findRustParser();
+  scratch = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-moverehome-'));
+});
+
+after(async () => {
+  if (scratch) { await fsp.rm(scratch, { recursive: true, force: true }); }
+});
+
+// Each scenario gets its own sandbox (library root, DB, art dir, and an
+// engine-dispatched scan runner) so JS and Rust runs of the same
+// scenario can't contaminate each other.
+let sandboxSeq = 0;
+async function makeSandbox(engine) {
+  const root = path.join(scratch, `sb${sandboxSeq++}-${engine}`);
+  const libRoot = path.join(root, 'lib');
+  const artDir = path.join(root, 'art');
+  const waveDir = path.join(root, 'wave');
+  await fsp.mkdir(libRoot, { recursive: true });
+  await fsp.mkdir(artDir, { recursive: true });
+  const dbPath = path.join(root, 'test.db');
+  const { libraryId, vpath } = initEmptyDb(dbPath, libRoot);
+  let scanSeq = 0;
+  const scan = (overrides = {}) => {
+    const config = buildScanConfig({
+      dbPath, libraryId, vpath, directory: libRoot,
+      albumArtDirectory: artDir, waveformCacheDir: waveDir,
+      scanId: `scan-${scanSeq++}`, overrides,
+    });
+    return engine === 'js' ? runJsScan(config) : runScan(rustBin, config);
+  };
+  return { root, libRoot, artDir, dbPath, libraryId, vpath, scan };
+}
+
+function withDb(dbPath, fn) {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA foreign_keys = ON');
+  try { return fn(db); } finally { db.close(); }
+}
+
+// Reference rows exactly as the API endpoints write them: playlists via
+// "<vpath>/<rel>", cue_points / play_events via (rel, library_id).
+let eventSeq = 0;
+function seedRefs(dbPath, vpath, libraryId, rel) {
+  withDb(dbPath, db => {
+    db.prepare(`INSERT OR IGNORE INTO users (id, username, password, salt)
+                VALUES (1, 'mover', 'x', 'x')`).run();
+    db.prepare(`INSERT OR IGNORE INTO playlists (id, name, user_id)
+                VALUES (1, 'pl', 1)`).run();
+    const pos = db.prepare(
+      'SELECT COALESCE(MAX(position), -1) + 1 AS p FROM playlist_tracks').get().p;
+    db.prepare(`INSERT INTO playlist_tracks (playlist_id, filepath, position)
+                VALUES (1, ?, ?)`).run(`${vpath}/${rel}`, pos);
+    db.prepare(`INSERT INTO cue_points (filepath, library_id, user_id, position, label)
+                VALUES (?, ?, 1, 12.5, 'drop')`).run(rel, libraryId);
+    db.prepare(`INSERT INTO play_events (event_id, user_id, filepath, library_id)
+                VALUES (?, 1, ?, ?)`).run(`evt-${eventSeq++}`, rel, libraryId);
+  });
+}
+
+const playlistPaths = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT filepath FROM playlist_tracks ORDER BY id').all()
+    .map(r => r.filepath));
+const cueRows = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT filepath, library_id FROM cue_points ORDER BY id').all()
+    .map(r => ({ ...r })));
+const eventRows = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT filepath, library_id FROM play_events ORDER BY id').all()
+    .map(r => ({ ...r })));
+const trackPaths = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT filepath FROM tracks ORDER BY filepath').all()
+    .map(r => r.filepath));
+const backdateTrack = (dbPath, rel, ts) => withDb(dbPath, db =>
+  db.prepare('UPDATE tracks SET created_at = ? WHERE filepath = ?').run(ts, rel));
+const trackCreatedAt = (dbPath, rel) => withDb(dbPath, db =>
+  db.prepare('SELECT created_at FROM tracks WHERE filepath = ?').get(rel)?.created_at);
+
+for (const engine of ['rust', 'js']) {
+  const engineAvailable = () =>
+    fs.existsSync(FFMPEG) && (engine === 'js' || !!rustBin);
+
+  describe(`move re-homing (${engine} scanner)`, () => {
+    test('rename in place re-homes playlist/cue/event refs and keeps created_at', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'a.mp3'), MP3,
+        { artist: 'A', album: 'AL', title: 'T1' }, 1);
+      await sb.scan();
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'a.mp3');
+      backdateTrack(sb.dbPath, 'a.mp3', '2020-01-01 00:00:00');
+
+      await fsp.rename(path.join(sb.libRoot, 'a.mp3'), path.join(sb.libRoot, 'b.mp3'));
+      const { event } = await sb.scan();
+
+      assert.strictEqual(event.staleEntriesRemoved, 1);
+      assert.strictEqual(event.movedTracksRehomed, 1);
+      assert.strictEqual(event.movedRefsRehomed, 3,
+        'one playlist row + one cue + one play event rewritten');
+      assert.deepStrictEqual(trackPaths(sb.dbPath), ['b.mp3']);
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/b.mp3`]);
+      assert.deepStrictEqual(cueRows(sb.dbPath),
+        [{ filepath: 'b.mp3', library_id: sb.libraryId }]);
+      assert.deepStrictEqual(eventRows(sb.dbPath),
+        [{ filepath: 'b.mp3', library_id: sb.libraryId }]);
+      assert.strictEqual(trackCreatedAt(sb.dbPath, 'b.mp3'), '2020-01-01 00:00:00',
+        'moved file must not re-enter "recently added"');
+
+      // A follow-up no-op rescan pays nothing and reports nothing.
+      const { event: idle } = await sb.scan();
+      assert.strictEqual(idle.staleEntriesRemoved, 0);
+      assert.strictEqual(idle.movedTracksRehomed, 0);
+      assert.strictEqual(idle.movedRefsRehomed, 0);
+    });
+
+    test('folder rename pairs every track via the same-basename tiebreak', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      // Same duration on purpose: identical silence ⇒ both files share
+      // one audio_hash, so each old row sees BOTH new rows as targets
+      // and only the basename tiebreak assigns them correctly.
+      await makeAudio(path.join(sb.libRoot, 'X', '1.mp3'), MP3, { title: 'One' }, 1);
+      await makeAudio(path.join(sb.libRoot, 'X', '2.mp3'), MP3, { title: 'Two' }, 1);
+      await sb.scan();
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'X/1.mp3');
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'X/2.mp3');
+
+      await fsp.rename(path.join(sb.libRoot, 'X'), path.join(sb.libRoot, 'Y'));
+      const { event } = await sb.scan();
+
+      assert.strictEqual(event.movedTracksRehomed, 2);
+      assert.deepStrictEqual(playlistPaths(sb.dbPath),
+        [`${sb.vpath}/Y/1.mp3`, `${sb.vpath}/Y/2.mp3`]);
+      assert.deepStrictEqual(cueRows(sb.dbPath), [
+        { filepath: 'Y/1.mp3', library_id: sb.libraryId },
+        { filepath: 'Y/2.mp3', library_id: sb.libraryId },
+      ]);
+    });
+
+    test('tag edit + move in one pass still pairs via audio_hash', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'c.mp3'), MP3,
+        { artist: 'C', title: 'Old' }, 2);
+      await sb.scan();
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'c.mp3');
+
+      await fsp.rename(path.join(sb.libRoot, 'c.mp3'), path.join(sb.libRoot, 'd.mp3'));
+      // Tag surgery changes file bytes (file_hash) but not audio bytes
+      // (audio_hash) — the pairing tier tag-identity scanners lose.
+      await appendId3v23TextFrames(path.join(sb.libRoot, 'd.mp3'), { TCON: 'Retagged' });
+      const { event } = await sb.scan();
+
+      assert.strictEqual(event.movedTracksRehomed, 1);
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/d.mp3`]);
+    });
+
+    test('deleting one of two identical copies re-points refs at the survivor', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'dup1.mp3'), MP3, { title: 'Dup' }, 3);
+      await fsp.copyFile(path.join(sb.libRoot, 'dup1.mp3'),
+        path.join(sb.libRoot, 'dup2.mp3'));
+      await sb.scan();
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'dup1.mp3');
+
+      await fsp.rm(path.join(sb.libRoot, 'dup1.mp3'));
+      const { event } = await sb.scan();
+
+      assert.strictEqual(event.staleEntriesRemoved, 1);
+      assert.strictEqual(event.movedTracksRehomed, 1);
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/dup2.mp3`]);
+      assert.deepStrictEqual(cueRows(sb.dbPath),
+        [{ filepath: 'dup2.mp3', library_id: sb.libraryId }]);
+    });
+
+    test('a genuine deletion never rewrites references', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'e.mp3'), MP3, { title: 'Gone' }, 4);
+      await sb.scan();
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'e.mp3');
+
+      await fsp.rm(path.join(sb.libRoot, 'e.mp3'));
+      const { event } = await sb.scan();
+
+      assert.strictEqual(event.staleEntriesRemoved, 1);
+      assert.strictEqual(event.movedTracksRehomed, 0);
+      assert.strictEqual(event.movedRefsRehomed, 0);
+      // Fail open: the dangling reference is the pre-existing behaviour;
+      // the sweep must not guess a target that doesn't share content.
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/e.mp3`]);
+    });
+
+    test('subtree scans never sweep, so they never re-home', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'f.mp3'), MP3, { title: 'Root' }, 5);
+      await makeAudio(path.join(sb.libRoot, 'sub', 'g.mp3'), MP3, { title: 'Sub' }, 6);
+      await sb.scan();
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'f.mp3');
+
+      await fsp.rm(path.join(sb.libRoot, 'f.mp3'));
+      const { event } = await sb.scan({ subtree: 'sub' });
+
+      assert.strictEqual(event.staleEntriesRemoved, 0);
+      assert.strictEqual(event.movedTracksRehomed, 0);
+      assert.ok(trackPaths(sb.dbPath).includes('f.mp3'),
+        'rows outside the subtree are untouched');
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/f.mp3`]);
+    });
+
+    test('cross-library move heals when the destination was scanned first', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
+      const sb = await makeSandbox(engine);
+      const lib2Root = path.join(sb.root, 'lib2');
+      await fsp.mkdir(lib2Root, { recursive: true });
+      const lib2Id = withDb(sb.dbPath, db => {
+        db.prepare(`INSERT INTO libraries (name, root_path, type)
+                    VALUES ('second', ?, 'music')`).run(lib2Root);
+        return db.prepare(`SELECT id FROM libraries WHERE name = 'second'`).get().id;
+      });
+      const scanLib2 = (scanId) => {
+        const config = buildScanConfig({
+          dbPath: sb.dbPath, libraryId: lib2Id, vpath: 'second',
+          directory: lib2Root, albumArtDirectory: sb.artDir,
+          waveformCacheDir: path.join(sb.root, 'wave'), scanId,
+        });
+        return engine === 'js' ? runJsScan(config) : runScan(rustBin, config);
+      };
+
+      await makeAudio(path.join(sb.libRoot, 'h.mp3'), MP3, { title: 'Wanderer' }, 7);
+      await sb.scan();
+      seedRefs(sb.dbPath, sb.vpath, sb.libraryId, 'h.mp3');
+
+      await fsp.rename(path.join(sb.libRoot, 'h.mp3'), path.join(lib2Root, 'h.mp3'));
+      await scanLib2('xlib-1');                 // destination indexed first
+      const { event } = await sb.scan();        // then the source library sweeps
+
+      assert.strictEqual(event.movedTracksRehomed, 1);
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), ['second/h.mp3']);
+      assert.deepStrictEqual(cueRows(sb.dbPath),
+        [{ filepath: 'h.mp3', library_id: lib2Id }]);
+      assert.deepStrictEqual(eventRows(sb.dbPath),
+        [{ filepath: 'h.mp3', library_id: lib2Id }]);
+    });
+  });
+}

--- a/test/scanner/scanner-schema-guard.test.mjs
+++ b/test/scanner/scanner-schema-guard.test.mjs
@@ -118,7 +118,7 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
 
     const deleted = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false });
-    assert.strictEqual(deleted, 1, 'only the file that is really gone gets deleted');
+    assert.strictEqual(deleted.removed, 1, 'only the file that is really gone gets deleted');
     // Spread into plain objects: node:sqlite rows have a null prototype,
     // which deepStrictEqual treats as a mismatch against object literals.
     const rows = db.prepare('SELECT filepath, scan_id FROM tracks ORDER BY filepath')
@@ -136,7 +136,7 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
     const again = deleteStaleTracks(check, allCandidates(check), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false });
     check.close();
-    assert.strictEqual(again, 0);
+    assert.strictEqual(again.removed, 0);
   });
 
   test('failed-walk prefixes shield rows; unverifiable listings are left untouched', async () => {
@@ -157,7 +157,7 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
 
     const deleted = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false, failedWalkPrefixes: ['broken'] });
-    assert.strictEqual(deleted, 1, 'only the verifiable-and-gone row is deleted');
+    assert.strictEqual(deleted.removed, 1, 'only the verifiable-and-gone row is deleted');
     const rows = db.prepare('SELECT filepath, scan_id FROM tracks ORDER BY filepath')
       .all().map(r => ({ ...r }));
     db.close();
@@ -184,7 +184,7 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
       { libraryRoot: lib, followSymlinks: false });
     const n = db.prepare('SELECT COUNT(*) AS n FROM tracks').get().n;
     db.close();
-    assert.strictEqual(deleted, 1);
+    assert.strictEqual(deleted.removed, 1);
     assert.strictEqual(n, 0);
   });
 
@@ -208,13 +208,13 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
     // sweep must agree it is "absent" and delete the row...
     const deletedNoFollow = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: false });
-    assert.strictEqual(deletedNoFollow, 1);
+    assert.strictEqual(deletedNoFollow.removed, 1);
     // ...while followSymlinks=true treats it as present (kept untouched).
     db.prepare('INSERT INTO tracks (filepath, library_id, scan_id, modified) VALUES (?, 1, ?, 1)')
       .run('linked.mp3', 'ancient');
     const deletedFollow = deleteStaleTracks(db, allCandidates(db), SCHEMA_VERSION,
       { libraryRoot: lib, followSymlinks: true });
-    assert.strictEqual(deletedFollow, 0);
+    assert.strictEqual(deletedFollow.removed, 0);
     const row = db.prepare('SELECT scan_id FROM tracks WHERE filepath = ?').get('linked.mp3');
     db.close();
     assert.strictEqual(row.scan_id, 'ancient');


### PR DESCRIPTION
## What

A renamed or moved file used to permanently orphan every `playlist_tracks` row pointing at its old path (`cue_points` and `play_events` likewise) and reset `created_at`, flooding "recently added" after a library reorganization. Stars/ratings/plays already survived moves via audio_hash keying — path-keyed references did not.

The stale sweep (both scanners) now:

- pairs each verified-gone candidate with a live row by content hash — `audio_hash` first (so a tag edit + move in one pass still pairs), `file_hash` fallback (pre-audio_hash rows);
- rewrites `playlist_tracks` ("<vpath>/<rel>"), `cue_points` and `play_events` (rel + library_id) to the survivor's path **before** the chunk DELETE — crash-safe ordering: dying mid-way leaves references pointing at the live file and the old row sweepable next scan;
- preserves the earliest `created_at` so a mass rename doesn't re-enter "recently added";
- resolves ties deterministically (same library → same basename → lowest (library_id, filepath)) so Rust and JS converge; byte-identical duplicates all play the same audio;
- heals cross-library moves when the destination library was scanned first.

`scanComplete` gains `movedTracksRehomed` / `movedRefsRehomed` (task-queue is undefined-tolerant so stale prebuilt binaries keep clean summaries). `deleteStaleTracks` now returns `{removed, movedTracks, movedRefs}`.

Genuine deletions are unchanged: no content twin → references left untouched (fail open); verify-absence semantics identical.

## Why

Follows the Navidrome scanner study: their move detection preserves row ids so playlists survive renames; our content-hash identity covered stars but left path-keyed tables behind. This closes that gap with a strictly stronger matching key (survives tags+path changing together, which tag-PID matching loses).

## Tests

- New `test/scanner/scanner-move-rehome.test.mjs`: 7 scenarios × both scanners — rename, folder rename via basename tiebreak, tag-edit+move, duplicate-survivor re-point, fail-open deletion, subtree no-op, cross-library heal (14/14).
- Sweep-adjacent suites green: parity, star-survival, follow-symlinks, js-guard, schema-guard, orphan-cleanup (51/51).
- `cargo build --release` clean. Source-only: `bin/rust-parser` binaries rebuild via CI on master push.

## Known limits (documented in code)

- Pairing is within-one-sweep: a cross-scan move (deletion swept before the file reappears) doesn't heal — that's the mark-missing model we deliberately didn't adopt.
- Re-encode + move (content changed, tags same) doesn't pair; a future tier-2 match on `recording_mbid` could close it.
- `shared_playlists` JSON blobs untouched (point-in-time shares).

🤖 Generated with [Claude Code](https://claude.com/claude-code)