### PR TITLE
feat(scanner): ignore NAS/system dirs and dot entries in walk + sweep

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -87,13 +87,14 @@ struct ScanConfig {
     // Dot-entry ignore flags (scanOptions.ignoreDotFiles/ignoreDotFolders):
     // skip dot-hidden files / directories during the walk, and treat
     // matching rows as stale in the sweep so a flag flip converges the
-    // index on the next scan. Default TRUE when absent — config JSONs
-    // from older servers predate the fields. The hardcoded directory
+    // index on the next scan. Default FALSE when absent (bool default) —
+    // the rules are opt-in via the admin toggles, and config JSONs from
+    // older servers predate the fields. The hardcoded directory
     // blocklist (IGNORED_DIR_NAMES below) is always on, independent of
     // these. Mirror fields exist in src/db/scanner.mjs.
-    #[serde(rename = "ignoreDotFiles", default = "default_true")]
+    #[serde(rename = "ignoreDotFiles", default)]
     ignore_dot_files: bool,
-    #[serde(rename = "ignoreDotFolders", default = "default_true")]
+    #[serde(rename = "ignoreDotFolders", default)]
     ignore_dot_folders: bool,
     // Accepted-but-ignored: BPM/key ANALYSIS left the scanner with the
     // waveform/stratum decode pass (it returns as the future essentia

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -84,6 +84,17 @@ struct ScanConfig {
     // changed to match in this release.
     #[serde(rename = "followSymlinks", default)]
     follow_symlinks: bool,
+    // Dot-entry ignore flags (scanOptions.ignoreDotFiles/ignoreDotFolders):
+    // skip dot-hidden files / directories during the walk, and treat
+    // matching rows as stale in the sweep so a flag flip converges the
+    // index on the next scan. Default TRUE when absent — config JSONs
+    // from older servers predate the fields. The hardcoded directory
+    // blocklist (IGNORED_DIR_NAMES below) is always on, independent of
+    // these. Mirror fields exist in src/db/scanner.mjs.
+    #[serde(rename = "ignoreDotFiles", default = "default_true")]
+    ignore_dot_files: bool,
+    #[serde(rename = "ignoreDotFolders", default = "default_true")]
+    ignore_dot_folders: bool,
     // Accepted-but-ignored: BPM/key ANALYSIS left the scanner with the
     // waveform/stratum decode pass (it returns as the future essentia
     // enrichment scanner). Tag-sourced BPM/key still land during the
@@ -134,6 +145,80 @@ struct ScanConfig {
 fn default_commit_interval() -> u64 { 25 }
 fn default_true() -> bool { true }
 fn default_art_priority() -> String { "metadata".to_string() }
+
+// ── Walk/sweep ignore rules ─────────────────────────────────────────────────
+// MUST stay in lockstep with src/db/scan-ignore.js: the JS scanner walks
+// and sweeps with the identical rules, and the sweep applies the same
+// predicate as the walk so rows indexed before a rule existed converge
+// OUT of the index instead of surviving as "still on disk" candidates.
+
+// Hardcoded directory blocklist — always on, no config, matched
+// case-insensitively against each directory NAME. NAS recycle bins
+// ($RECYCLE.BIN, #recycle, @Recycle), NAS snapshot dirs
+// (@Recently-Snapshot, #snapshot), VCS/sync metadata (.git, .stfolder,
+// .stversions) and OS artifacts (lost+found, System Volume Information)
+// hold deleted/duplicate/system files, never library music.
+const IGNORED_DIR_NAMES: [&str; 10] = [
+    "$recycle.bin",
+    "#recycle",
+    "@recycle",
+    "@recently-snapshot",
+    "#snapshot",
+    ".git",
+    "lost+found",
+    ".stfolder",
+    ".stversions",
+    "system volume information",
+];
+
+fn is_ignored_dir_name(name: &str) -> bool {
+    IGNORED_DIR_NAMES.iter().any(|d| name.eq_ignore_ascii_case(d))
+}
+
+// A "dot entry" is hidden-by-convention: a SINGLE leading dot. Names
+// starting with ".." ("..WeirdAlbum", "...Trilogy") are ordinary names —
+// albums really do start with ellipses. Mirrors Navidrome's isDotEntry.
+fn is_dot_entry(name: &str) -> bool {
+    name.starts_with('.') && !name.starts_with("..")
+}
+
+// filter_entry predicate for the walk: prune blocklisted / dot-hidden
+// directories (never descend), skip dot-hidden files. The blocklist is a
+// directory rule only — a FILE named "#recycle" is walked like any other
+// (its extension decides). Under follow_links, file_type() is the link
+// TARGET's type, so a symlink to a directory prunes by its link name.
+// Callers must exempt depth 0: the scan root itself is never pruned — a
+// library (or subtree scan) deliberately rooted at a dot-folder still
+// scans; rules apply to entries BELOW the root.
+fn is_ignored_walk_entry(
+    entry: &walkdir::DirEntry, ignore_dot_files: bool, ignore_dot_folders: bool,
+) -> bool {
+    let name = entry.file_name().to_string_lossy();
+    if entry.file_type().is_dir() {
+        is_ignored_dir_name(&name) || (ignore_dot_folders && is_dot_entry(&name))
+    } else {
+        ignore_dot_files && is_dot_entry(&name)
+    }
+}
+
+// Sweep-side arm of the same rules, applied to a DB row's library-relative
+// path (forward slashes, as normalized at insert): ignored when ANY
+// directory segment is blocklisted or (flag-dependent) dot-hidden, or the
+// filename is dot-hidden — every segment counts, because the walk prunes
+// whole subtrees. Rel paths never contain the scan root itself, so the
+// never-prune-the-root rule holds here by construction.
+fn is_ignored_rel_path(rel: &str, ignore_dot_files: bool, ignore_dot_folders: bool) -> bool {
+    let mut segs = rel.split('/').filter(|s| !s.is_empty()).peekable();
+    while let Some(seg) = segs.next() {
+        if segs.peek().is_none() {
+            return ignore_dot_files && is_dot_entry(seg);
+        }
+        if is_ignored_dir_name(seg) || (ignore_dot_folders && is_dot_entry(seg)) {
+            return true;
+        }
+    }
+    false
+}
 
 // Snapshot of a row in the `tracks` table, pre-fetched in bulk at scan
 // start so the per-file fast-path check doesn't hit SQLite. For a
@@ -975,6 +1060,7 @@ fn chunked_delete_stale_tracks(
     conn: &Connection, candidates: &[(i64, String)], expected_schema_version: i64,
     library_root: &str, follow_symlinks: bool, failed_walk_prefixes: &[String],
     supported_files: &HashMap<String, bool>,
+    ignore_dot_files: bool, ignore_dot_folders: bool,
 ) -> Result<usize, Box<dyn std::error::Error>> {
     let root = Path::new(library_root);
 
@@ -1097,6 +1183,13 @@ fn chunked_delete_stale_tracks(
             match listing {
                 None => { skipped += 1; }
                 Some(_) if !ext_supported => doomed.push((*id, rel.as_str())),
+                // Walk-faithful presence also applies the walk's IGNORE
+                // rules: a row under a pruned directory (blocklist, always)
+                // or with a dot-hidden segment/filename (flag-dependent)
+                // would never be indexed by the walk again — it converges
+                // out of the index exactly like an unsupported extension.
+                Some(_) if is_ignored_rel_path(rel, ignore_dot_files, ignore_dot_folders) =>
+                    doomed.push((*id, rel.as_str())),
                 Some(names) => match names.get(name) {
                     Some(Kind::RegularFile) => survivors += 1,
                     Some(Kind::Unknown) => { skipped += 1; } // DT_UNKNOWN — unverifiable
@@ -1362,6 +1455,18 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     let entries: Vec<(walkdir::DirEntry, String)> = WalkDir::new(&scan_root)
         .follow_links(config.follow_symlinks)
         .into_iter()
+        // Prune ignored entries during the walk: blocklisted NAS-recycle/
+        // system dirs always, dot-hidden entries per the ignore flags (see
+        // is_ignored_walk_entry). A pruned directory is never descended
+        // into or read, so it can produce neither entries nor walk errors.
+        // filter_entry sees the scan root itself at depth 0 — exempt it,
+        // so a library deliberately rooted at a dot-folder still scans.
+        // Errors pass through the predicate untouched; the error handling
+        // and failed_walk_prefixes logic below are unaffected.
+        .filter_entry(|e| {
+            e.depth() == 0
+                || !is_ignored_walk_entry(e, config.ignore_dot_files, config.ignore_dot_folders)
+        })
         .filter_map(|e| match e {
             Ok(entry) => Some(entry),
             Err(err) => {
@@ -1962,6 +2067,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             &conn, &candidates, schema_version_at_open,
             &config.directory, config.follow_symlinks, &failed_walk_prefixes,
             &config.supported_files,
+            config.ignore_dot_files, config.ignore_dot_folders,
         )?
     };
 

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -318,6 +318,31 @@ export function setup(mstream) {
     res.json({});
   });
 
+  // Dot-entry ignore toggles (default OFF). Live: the next scan of any
+  // vpath picks the flags up from config.program, skips matching entries
+  // in the walk, and converges already-indexed matching rows out via the
+  // sweep (flipping OFF brings them back on the next scan). No immediate
+  // scan is enqueued — the change is about what future scans index.
+  mstream.post("/api/v1/admin/db/params/ignore-dot-files", async (req, res) => {
+    const schema = Joi.object({
+      ignoreDotFiles: Joi.boolean().required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editIgnoreDotFiles(req.body.ignoreDotFiles);
+    res.json({});
+  });
+
+  mstream.post("/api/v1/admin/db/params/ignore-dot-folders", async (req, res) => {
+    const schema = Joi.object({
+      ignoreDotFolders: Joi.boolean().required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editIgnoreDotFolders(req.body.ignoreDotFolders);
+    res.json({});
+  });
+
   // Tracks analysed per essentia pass (bounds how long one batch holds the
   // serial task slot; the worker also caps wall-clock and re-enqueues a
   // backlog). Mirrors auto-album-art-per-run; takes effect on the next pass.

--- a/src/db/orphan-cleanup.js
+++ b/src/db/orphan-cleanup.js
@@ -28,6 +28,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { isIgnoredRelPath } from './scan-ignore.js';
 
 // Per-chunk row cap. Balances per-chunk lock duration (well under
 // SQLite's 5s busy_timeout) against per-iteration overhead — each
@@ -212,7 +213,7 @@ const ORPHAN_GENRES_SQL = 'SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM
 // today) the sweep degrades to deleting every candidate unverified.
 export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
   { libraryRoot = null, followSymlinks = false, failedWalkPrefixes = [],
-    supportedFiles = null } = {}) {
+    supportedFiles = null, ignoreDotFiles = true, ignoreDotFolders = true } = {}) {
   const versionStmt = db.prepare('PRAGMA user_version');
   const KIND_FILE = 1; const KIND_SYMLINK = 2; const KIND_OTHER = 3;
   const listings = new Map(); // relDir -> Map(name -> kind) | null (unreadable)
@@ -300,6 +301,15 @@ export function deleteStaleTracks(db, candidates, expectedSchemaVersion = null,
       // immortal candidate warned about on every scan.
       if (supportedFiles !== null
           && !supportedFiles[name.split('.').pop().toLowerCase()]) {
+        doomed.push(c);
+        continue;
+      }
+      // Walk-faithful presence also applies the walk's IGNORE rules
+      // (src/db/scan-ignore.js): a row under a pruned directory (NAS
+      // recycle/system names, always) or a dot-hidden segment/filename
+      // (flag-dependent) would never be indexed by the walk again — it
+      // converges out of the index exactly like an unsupported extension.
+      if (isIgnoredRelPath(c.filepath, { ignoreDotFiles, ignoreDotFolders })) {
         doomed.push(c);
         continue;
       }

--- a/src/db/scan-ignore.js
+++ b/src/db/scan-ignore.js
@@ -1,0 +1,64 @@
+// Walk/sweep ignore rules, shared by the JS scanner's directory walk
+// (src/db/scanner.mjs) and the stale-track sweep (src/db/orphan-cleanup.js).
+// The Rust scanner carries the same rules (is_ignored_dir_name /
+// is_dot_entry / is_ignored_rel_path in rust-parser/src/main.rs); the two
+// implementations MUST stay in lockstep — the sweep applies the same
+// predicate as the walk so that rows indexed before a rule existed (or
+// under a different flag setting) converge OUT of the index on the next
+// scan instead of surviving forever as "file still exists on disk" rows.
+
+// Hardcoded directory blocklist — always on, no config, matched
+// case-insensitively against each directory NAME. NAS recycle bins
+// ($RECYCLE.BIN, #recycle, @Recycle), NAS snapshot dirs
+// (@Recently-Snapshot, #snapshot), VCS/sync metadata (.git, .stfolder,
+// .stversions) and OS artifacts (lost+found, System Volume Information)
+// hold deleted/duplicate/system files, never library music — indexing a
+// recycle bin resurrects every deleted track in the browse UI. Entries
+// are stored lowercase; look up with a lowercased name.
+export const IGNORED_DIR_NAMES = new Set([
+  '$recycle.bin',
+  '#recycle',
+  '@recycle',
+  '@recently-snapshot',
+  '#snapshot',
+  '.git',
+  'lost+found',
+  '.stfolder',
+  '.stversions',
+  'system volume information',
+]);
+
+export function isIgnoredDirName(name) {
+  return IGNORED_DIR_NAMES.has(name.toLowerCase());
+}
+
+// A "dot entry" is hidden-by-convention: a SINGLE leading dot. Names
+// starting with '..' ('..WeirdAlbum', '...Trilogy') are ordinary names —
+// albums really do start with ellipses. Mirrors Navidrome's isDotEntry.
+export function isDotEntry(name) {
+  return name.startsWith('.') && !name.startsWith('..');
+}
+
+// Sweep-side arm of the walk's ignore rules, applied to a DB row's
+// library-relative path (forward slashes, as normalized at insert). A row
+// is ignored when ANY directory segment is blocklisted or (flag-dependent)
+// dot-hidden, or when the filename itself is dot-hidden — every segment is
+// considered, not just the basename, because the walk prunes whole
+// subtrees. The blocklist deliberately does NOT apply to the filename
+// segment: it is a directory rule, and a FILE named '#recycle' is walked
+// like any other (its extension decides). Rel paths never contain the
+// library root itself, so the never-prune-the-scan-root rule holds here by
+// construction.
+export function isIgnoredRelPath(relPath, { ignoreDotFiles = true, ignoreDotFolders = true } = {}) {
+  const segs = relPath.split('/');
+  for (let i = 0; i < segs.length; i++) {
+    const seg = segs[i];
+    if (seg === '') { continue; }
+    if (i === segs.length - 1) {
+      if (ignoreDotFiles && isDotEntry(seg)) { return true; }
+    } else if (isIgnoredDirName(seg) || (ignoreDotFolders && isDotEntry(seg))) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -61,12 +61,13 @@ const schema = Joi.object({
   // behaviour). Resolved in task-queue.js from `library.follow_symlinks`.
   followSymlinks: Joi.boolean().default(false),
   // Dot-entry ignore flags (scanOptions.ignoreDotFiles/ignoreDotFolders).
-  // Default true — and the use sites treat an ABSENT field as true too
-  // (`!== false`), because this validate() call only checks, it doesn't
-  // apply Joi defaults back onto loadJson. The hardcoded directory
-  // blocklist (src/db/scan-ignore.js) is always on, no field for it.
-  ignoreDotFiles: Joi.boolean().default(true),
-  ignoreDotFolders: Joi.boolean().default(true),
+  // Default FALSE (opt-in via the admin toggles) — and the use sites
+  // treat an ABSENT field as false too (`=== true`), because this
+  // validate() call only checks, it doesn't apply Joi defaults back
+  // onto loadJson. The hardcoded directory blocklist
+  // (src/db/scan-ignore.js) is always on, no field for it.
+  ignoreDotFiles: Joi.boolean().default(false),
+  ignoreDotFolders: Joi.boolean().default(false),
   // Accepted but ignored by the JS fallback scanner — stratum-dsp
   // is a Rust crate, only the Rust scanner runs the BPM/key
   // analysis. Listed here so task-queue.js can pass the same
@@ -1104,11 +1105,11 @@ const statForWalk = loadJson.followSymlinks
   ? fs.statSync
   : fs.lstatSync;
 
-// Dot-entry ignore flags: absent fields mean TRUE (older task-queue
-// payloads predate them), matching serde's default_true in rust-parser.
-// Only an explicit false disables the rule.
-const ignoreDotFiles = loadJson.ignoreDotFiles !== false;
-const ignoreDotFolders = loadJson.ignoreDotFolders !== false;
+// Dot-entry ignore flags: absent fields mean FALSE (the rules are
+// opt-in; older task-queue payloads predate them), matching serde's
+// bool default in rust-parser. Only an explicit true enables the rule.
+const ignoreDotFiles = loadJson.ignoreDotFiles === true;
+const ignoreDotFolders = loadJson.ignoreDotFolders === true;
 
 // Real directory paths already visited — used ONLY when following
 // symlinks, to break cycles (dir A → symlink → dir B → symlink → dir A).

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -15,6 +15,7 @@ import { computeHashes } from './audio-hash.js';
 import { extractArtists, chooseAlbumArtistId } from './artist-extraction.js';
 import { migrateAlbumStars, migrateArtistStars, migrateAlbumArtState } from './album-migration.js';
 import { cleanupOrphans, cleanupStaleArt, reconcileAlbumArt, deleteStaleTracks, VARIOUS_ARTISTS_MBZ_ID } from './orphan-cleanup.js';
+import { isIgnoredDirName, isDotEntry } from './scan-ignore.js';
 import { detectSource } from './source-detect.js';
 
 // ── Parse CLI input ─────────────────────────────────────────────────────────
@@ -59,6 +60,13 @@ const schema = Joi.object({
   // (follows symlinks to their target, matching pre-v6.5 JS-scanner
   // behaviour). Resolved in task-queue.js from `library.follow_symlinks`.
   followSymlinks: Joi.boolean().default(false),
+  // Dot-entry ignore flags (scanOptions.ignoreDotFiles/ignoreDotFolders).
+  // Default true — and the use sites treat an ABSENT field as true too
+  // (`!== false`), because this validate() call only checks, it doesn't
+  // apply Joi defaults back onto loadJson. The hardcoded directory
+  // blocklist (src/db/scan-ignore.js) is always on, no field for it.
+  ignoreDotFiles: Joi.boolean().default(true),
+  ignoreDotFolders: Joi.boolean().default(true),
   // Accepted but ignored by the JS fallback scanner — stratum-dsp
   // is a Rust crate, only the Rust scanner runs the BPM/key
   // analysis. Listed here so task-queue.js can pass the same
@@ -1096,6 +1104,12 @@ const statForWalk = loadJson.followSymlinks
   ? fs.statSync
   : fs.lstatSync;
 
+// Dot-entry ignore flags: absent fields mean TRUE (older task-queue
+// payloads predate them), matching serde's default_true in rust-parser.
+// Only an explicit false disables the rule.
+const ignoreDotFiles = loadJson.ignoreDotFiles !== false;
+const ignoreDotFolders = loadJson.ignoreDotFolders !== false;
+
 // Real directory paths already visited — used ONLY when following
 // symlinks, to break cycles (dir A → symlink → dir B → symlink → dir A).
 // Without it, statSync follows the loop forever and the walk recurses
@@ -1156,8 +1170,17 @@ function collectFiles(dir, out) {
     // silently skipped — no-follow by default.
     try { stat = statForWalk(filepath); } catch (_e) { continue; }
     if (stat.isDirectory()) {
+      // Prune ignored directories: the hardcoded NAS-recycle/system
+      // blocklist always, dot-named dirs per flag (src/db/scan-ignore.js).
+      // Only entries BELOW the walk root pass through here — the root
+      // itself is the initial collectFiles argument, so a library (or
+      // subtree scan) deliberately rooted at a dot-folder still scans.
+      // The stale sweep applies the same rules (isIgnoredRelPath), so
+      // rows indexed before a rule applied converge out of the index.
+      if (isIgnoredDirName(file) || (ignoreDotFolders && isDotEntry(file))) { continue; }
       collectFiles(filepath, out);
     } else if (stat.isFile() && loadJson.supportedFiles[getFileType(file).toLowerCase()]) {
+      if (ignoreDotFiles && isDotEntry(file)) { continue; }
       // Math.trunc(mtimeMs), NOT stat.mtime.getTime(): Node builds the
       // Date by ROUNDING the fractional ms (dateFromMs adds 0.5) while
       // the Rust scanner's as_millis() TRUNCATES — so getTime() disagrees
@@ -1493,7 +1516,8 @@ async function run() {
       : { changes: deleteStaleTracks(db,
           preScanRows.filter((r) => !seenPaths.has(r.filepath)), schemaVersionAtOpen,
           { libraryRoot: loadJson.directory, followSymlinks: !!loadJson.followSymlinks,
-            failedWalkPrefixes, supportedFiles: loadJson.supportedFiles }) };
+            failedWalkPrefixes, supportedFiles: loadJson.supportedFiles,
+            ignoreDotFiles, ignoreDotFolders }) };
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
     // to run the waveform post-processor and to print a human-readable summary.
     // Field shapes mirror the rust-parser's emitter:

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1758,14 +1758,15 @@ function runScan(scanObj) {
     // effect on the next scan of this vpath without the scanner
     // needing to know anything about the admin UI.
     followSymlinks: library.follow_symlinks === 1,
-    // Dot-entry ignore flags (scanOptions, default true) — both scanners
-    // skip dot-hidden files/folders during the walk AND treat matching
-    // rows as stale in the sweep, so a flag flip converges the index on
-    // the next scan. The hardcoded NAS-recycle/system-dir blocklist
-    // (src/db/scan-ignore.js) is always on and needs no field here. Old
-    // scanner builds ignore both fields.
-    ignoreDotFiles: config.program.scanOptions.ignoreDotFiles !== false,
-    ignoreDotFolders: config.program.scanOptions.ignoreDotFolders !== false,
+    // Dot-entry ignore flags (scanOptions, default FALSE — opt-in via
+    // the admin toggles) — both scanners skip dot-hidden files/folders
+    // during the walk AND treat matching rows as stale in the sweep, so
+    // a flag flip converges the index on the next scan. The hardcoded
+    // NAS-recycle/system-dir blocklist (src/db/scan-ignore.js) is
+    // always on and needs no field here. Old scanner builds ignore
+    // both fields.
+    ignoreDotFiles: config.program.scanOptions.ignoreDotFiles === true,
+    ignoreDotFolders: config.program.scanOptions.ignoreDotFolders === true,
     // TRANSITION-ONLY fields: current scanners ignore both — waveform
     // generation moved to the post-scan waveform task (runWaveformTask)
     // and BPM analysis left the scanner entirely (it returns as the

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1758,6 +1758,14 @@ function runScan(scanObj) {
     // effect on the next scan of this vpath without the scanner
     // needing to know anything about the admin UI.
     followSymlinks: library.follow_symlinks === 1,
+    // Dot-entry ignore flags (scanOptions, default true) — both scanners
+    // skip dot-hidden files/folders during the walk AND treat matching
+    // rows as stale in the sweep, so a flag flip converges the index on
+    // the next scan. The hardcoded NAS-recycle/system-dir blocklist
+    // (src/db/scan-ignore.js) is always on and needs no field here. Old
+    // scanner builds ignore both fields.
+    ignoreDotFiles: config.program.scanOptions.ignoreDotFiles !== false,
+    ignoreDotFolders: config.program.scanOptions.ignoreDotFolders !== false,
     // TRANSITION-ONLY fields: current scanners ignore both — waveform
     // generation moved to the post-scan waveform task (runWaveformTask)
     // and BPM analysis left the scanner entirely (it returns as the

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -48,6 +48,18 @@ const scanOptions = Joi.object({
   skipImg: Joi.boolean().default(false),
   scanInterval: Joi.number().min(0).default(24),
   bootScanDelay: Joi.number().default(3),
+  // Skip dot-hidden entries during the scan walk: ignoreDotFiles covers
+  // files (.hidden.mp3), ignoreDotFolders covers directories
+  // (.hiddenalbum/). "Dot-hidden" means a SINGLE leading dot — names
+  // starting with '..' ('..WeirdAlbum') are ordinary names that stay
+  // indexed. Separate from these flags, both scanners ALWAYS prune a
+  // hardcoded NAS-recycle/system-dir blocklist ($RECYCLE.BIN, #recycle,
+  // @Recycle, #snapshot, .git, System Volume Information, ...) — see
+  // src/db/scan-ignore.js. The stale sweep applies the same predicate,
+  // so flipping a flag converges already-indexed rows out of (or a
+  // rescan brings them back into) the index on the next scan.
+  ignoreDotFiles: Joi.boolean().default(true),
+  ignoreDotFolders: Joi.boolean().default(true),
   compressImage: Joi.boolean().default(true),
   // Tracks scanned per SQLite COMMIT — also gates how often the scanner
   // emits progress updates. Lower = more responsive UI + shorter

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -58,8 +58,11 @@ const scanOptions = Joi.object({
   // src/db/scan-ignore.js. The stale sweep applies the same predicate,
   // so flipping a flag converges already-indexed rows out of (or a
   // rescan brings them back into) the index on the next scan.
-  ignoreDotFiles: Joi.boolean().default(true),
-  ignoreDotFolders: Joi.boolean().default(true),
+  // Default OFF: an upgrade must not silently delete dot-named tracks
+  // users already have indexed — opting in is an admin toggle
+  // (/api/v1/admin/db/params/ignore-dot-*).
+  ignoreDotFiles: Joi.boolean().default(false),
+  ignoreDotFolders: Joi.boolean().default(false),
   compressImage: Joi.boolean().default(true),
   // Tracks scanned per SQLite COMMIT — also gates how often the scanner
   // emits progress updates. Lower = more responsive UI + shorter

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -463,6 +463,27 @@ export async function editAnalyzeBpm(val) {
   config.program.scanOptions.analyzeBpm = val;
 }
 
+// Dot-entry ignore toggles (scanOptions.ignoreDotFiles/ignoreDotFolders,
+// default false). Same live pattern: task-queue reads config.program
+// when it builds each scan's jsonLoad, so a flip takes effect on the
+// next scan with no reboot — and the sweep's convergence rule then
+// removes (or a rescan re-adds) the affected rows.
+export async function editIgnoreDotFiles(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.ignoreDotFiles = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.ignoreDotFiles = val;
+}
+
+export async function editIgnoreDotFolders(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.ignoreDotFolders = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.ignoreDotFolders = val;
+}
+
 // Tracks analysed per essentia pass. Same live-update pattern as
 // editAutoAlbumArtPerRun — the worker reads it fresh when task-queue builds
 // the pass's jsonLoad, so a change takes effect on the next pass with no reboot.

--- a/test/integration/admin-scan-params.test.mjs
+++ b/test/integration/admin-scan-params.test.mjs
@@ -160,6 +160,43 @@ describe('POST /api/v1/admin/db/params/analyze-bpm-per-run', () => {
   });
 });
 
+// ── POST /db/params/ignore-dot-* (dot-entry ignore toggles) ───────────────
+//
+// Same four-part pattern as analyze-bpm: GET defaults, happy-path flip +
+// reflect, Joi boundary rejections (400), non-admin 405. No side effects:
+// the toggles only change what FUTURE scans index (no enqueue on flip).
+
+describe('dot-entry ignore params', () => {
+  test('GET includes both defaults (false — opt-in)', async () => {
+    const body = await (await adminGet('/api/v1/admin/db/params')).json();
+    assert.equal(body.ignoreDotFiles, false, 'ignoreDotFiles default is false');
+    assert.equal(body.ignoreDotFolders, false, 'ignoreDotFolders default is false');
+  });
+
+  for (const [route, field] of [
+    ['ignore-dot-files', 'ignoreDotFiles'],
+    ['ignore-dot-folders', 'ignoreDotFolders'],
+  ]) {
+    test(`${route}: flips + reflects; rejects junk; 405 non-admin`, async () => {
+      const r1 = await adminPost(`/api/v1/admin/db/params/${route}`, { [field]: true });
+      assert.equal(r1.status, 200);
+      assert.deepEqual(await r1.json(), {}, 'happy-path response is the empty object {}');
+      assert.equal((await (await adminGet('/api/v1/admin/db/params')).json())[field], true);
+
+      // Restore the default so later tests start in a known state.
+      await adminPost(`/api/v1/admin/db/params/${route}`, { [field]: false });
+      assert.equal((await (await adminGet('/api/v1/admin/db/params')).json())[field], false);
+
+      for (const bad of [{ [field]: 'yes' }, { [field]: 1 }, { [field]: null }, {}]) {
+        const r = await adminPost(`/api/v1/admin/db/params/${route}`, bad);
+        assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
+      }
+      assert.equal((await adminPost(`/api/v1/admin/db/params/${route}`,
+        { [field]: true }, userJwt)).status, 405);
+    });
+  }
+});
+
 // ── POST /db/params/auto-album-art-* (the downloader's config family) ──────
 //
 // Same four-part pattern as analyze-bpm above: GET defaults, happy-path

--- a/test/scanner-ignore-rules.test.mjs
+++ b/test/scanner-ignore-rules.test.mjs
@@ -4,9 +4,10 @@
  * Both scanners must (a) prune the hardcoded NAS-recycle/system directory
  * blocklist ($RECYCLE.BIN, #recycle, @Recycle, System Volume Information,
  * ...) unconditionally and case-insensitively, (b) skip dot-hidden files/
- * folders behind the default-true ignoreDotFiles/ignoreDotFolders flags —
- * where "dot-hidden" is a SINGLE leading dot, so '..WeirdAlbum' is an
- * ordinary album name that stays indexed — and (c) apply the SAME predicate
+ * folders behind the default-FALSE (admin-toggleable)
+ * ignoreDotFiles/ignoreDotFolders flags — where "dot-hidden" is a SINGLE
+ * leading dot, so '..WeirdAlbum' is an ordinary album name that stays
+ * indexed — and (c) apply the SAME predicate
  * in the stale sweep, so rows indexed before the rules existed (or under
  * different flag settings) converge OUT of the index on the next scan even
  * though their files still exist on disk. Without (c), such rows would
@@ -40,7 +41,7 @@ const NORMAL_FILES = [
   'Solo Artist/Echoes/01 One.mp3',
   'Solo Artist/Echoes/02 Two.mp3',
 ];
-// Indexed only when the matching ignoreDot* flag is false.
+// Indexed unless the matching ignoreDot* flag is explicitly true.
 const DOT_FILES = [
   '.hiddenalbum/01 Hid.mp3',              // dot FOLDER
   'Solo Artist/Echoes/.hidden.mp3',       // dot FILE beside normal files
@@ -149,34 +150,37 @@ async function rescanTracks(env, scanId, overrides, runner) {
 
 describe('scanner ignore rules', () => {
 
-  test('default flags: blocklist + dot entries pruned, ..-prefixed names indexed [rust+js]', async (t) => {
+  test('default flags: only the hardcoded blocklist prunes; dot entries index [rust+js]', async (t) => {
     if (!fs.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
     for (const [engine, runner] of Object.entries(engines())) {
       const reason = skipReason(engine);
       if (reason) { t.diagnostic(`skipping ${engine}: ${reason}`); continue; }
 
       // No ignore fields in the config at all — the absent-field default
-      // must be TRUE in both engines (serde default_true / `!== false`).
+      // must be FALSE in both engines (serde bool default / `=== true`):
+      // dot entries index; only the hardcoded blocklist prunes.
       const { filepaths, event } = await scanTracks(`default-${engine}`, {}, runner);
-      assert.deepEqual(filepaths, NORMAL_FILES,
-        `[${engine}] only normal files (incl. '..WeirdAlbum') may be indexed`);
+      assert.deepEqual(filepaths, [...NORMAL_FILES, ...DOT_FILES].sort(),
+        `[${engine}] defaults index dot entries but NEVER the blocklist dirs`);
       // Pruned at WALK time, not indexed-then-swept: the walk never even
-      // counts the ignored files.
-      assert.equal(event.filesScanned, NORMAL_FILES.length,
-        `[${engine}] walk must not visit pruned entries`);
+      // counts the blocklist files.
+      assert.equal(event.filesScanned, NORMAL_FILES.length + DOT_FILES.length,
+        `[${engine}] walk must not visit pruned blocklist entries`);
     }
   });
 
-  test('ignoreDot* false: dot entries indexed, hardcoded blocklist still pruned [rust+js]', async (t) => {
+  test('ignoreDot* true: dot entries pruned, ..-prefixed names still indexed [rust+js]', async (t) => {
     if (!fs.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
     for (const [engine, runner] of Object.entries(engines())) {
       const reason = skipReason(engine);
       if (reason) { t.diagnostic(`skipping ${engine}: ${reason}`); continue; }
 
-      const { filepaths } = await scanTracks(`flagsoff-${engine}`,
-        { ignoreDotFiles: false, ignoreDotFolders: false }, runner);
-      assert.deepEqual(filepaths, [...NORMAL_FILES, ...DOT_FILES].sort(),
-        `[${engine}] flags off indexes dot entries but NEVER the blocklist dirs`);
+      const { filepaths, event } = await scanTracks(`flagson-${engine}`,
+        { ignoreDotFiles: true, ignoreDotFolders: true }, runner);
+      assert.deepEqual(filepaths, NORMAL_FILES,
+        `[${engine}] flags on index only normal files (incl. '..WeirdAlbum')`);
+      assert.equal(event.filesScanned, NORMAL_FILES.length,
+        `[${engine}] walk must not visit any pruned entries`);
     }
   });
 
@@ -186,13 +190,12 @@ describe('scanner ignore rules', () => {
       const reason = skipReason(engine);
       if (reason) { t.diagnostic(`skipping ${engine}: ${reason}`); continue; }
 
-      // Scan 1 with both flags off gets the dot entries into the DB for
-      // real; blocklist rows (which no walk ever indexes) are seeded by
-      // direct INSERT, modelling rows indexed before the rules existed.
+      // Scan 1 with the (false) defaults gets the dot entries into the DB
+      // for real; blocklist rows (which no walk ever indexes) are seeded
+      // by direct INSERT, modelling rows indexed before the rules existed.
       // Every seeded path has a live file on disk — that's the point: the
       // sweep must doom them off the ignore predicate, not off absence.
-      const env = await scanTracks(`converge-${engine}`,
-        { ignoreDotFiles: false, ignoreDotFolders: false }, runner);
+      const env = await scanTracks(`converge-${engine}`, {}, runner);
       assert.deepEqual(env.filepaths, [...NORMAL_FILES, ...DOT_FILES].sort());
 
       const db = new DatabaseSync(env.dbPath);
@@ -204,10 +207,11 @@ describe('scanner ignore rules', () => {
         .filter(r => NORMAL_FILES.includes(r.filepath))
         .map(r => r.id);
 
-      // Rescan with defaults: dot + blocklist rows are stale-swept even
-      // though every file still exists; normal rows are untouched (same
-      // ids — not deleted and re-created).
-      const second = await rescanTracks(env, `converge-${engine}-2`, {}, runner);
+      // Rescan with the flags ON (the admin toggle): dot + blocklist rows
+      // are stale-swept even though every file still exists; normal rows
+      // are untouched (same ids — not deleted and re-created).
+      const second = await rescanTracks(env, `converge-${engine}-2`,
+        { ignoreDotFiles: true, ignoreDotFolders: true }, runner);
       assert.deepEqual(second.filepaths, NORMAL_FILES,
         `[${engine}] previously-indexed ignored rows must converge out of the index`);
       assert.equal(second.event.staleEntriesRemoved,
@@ -218,6 +222,13 @@ describe('scanner ignore rules', () => {
         .map(r => r.id);
       assert.deepEqual(normalIdsAfter, normalIdsBefore,
         `[${engine}] normal rows must survive the sweep with their ids intact`);
+
+      // Flipping the flags back OFF re-indexes the dot entries on the
+      // next scan — the admin-toggle round trip is lossless for files
+      // still on disk.
+      const third = await rescanTracks(env, `converge-${engine}-3`, {}, runner);
+      assert.deepEqual(third.filepaths, [...NORMAL_FILES, ...DOT_FILES].sort(),
+        `[${engine}] flags back off must re-index the dot entries`);
     }
   });
 });

--- a/test/scanner-ignore-rules.test.mjs
+++ b/test/scanner-ignore-rules.test.mjs
@@ -1,0 +1,223 @@
+/**
+ * Scanner ignore rules — walk pruning + sweep convergence, both engines.
+ *
+ * Both scanners must (a) prune the hardcoded NAS-recycle/system directory
+ * blocklist ($RECYCLE.BIN, #recycle, @Recycle, System Volume Information,
+ * ...) unconditionally and case-insensitively, (b) skip dot-hidden files/
+ * folders behind the default-true ignoreDotFiles/ignoreDotFolders flags —
+ * where "dot-hidden" is a SINGLE leading dot, so '..WeirdAlbum' is an
+ * ordinary album name that stays indexed — and (c) apply the SAME predicate
+ * in the stale sweep, so rows indexed before the rules existed (or under
+ * different flag settings) converge OUT of the index on the next scan even
+ * though their files still exist on disk. Without (c), such rows would
+ * survive forever as "still exists on disk" candidates.
+ *
+ * Skipped when the bundled ffmpeg is missing (fixture generation) or, for
+ * the rust engine, when no rust-parser binary is available. A prebuilt
+ * binary that predates the ignore rules is feature-detected and skipped
+ * (same convention as the resume test in scanner-parity.test.mjs); the JS
+ * scanner always runs from source.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
+} from './helpers/scanner-runner.mjs';
+import { makeAudio } from './helpers/scanner-fixture.mjs';
+
+const MP3 = ['-c:a', 'libmp3lame', '-b:a', '64k', '-id3v2_version', '3'];
+
+// Always indexed. '..WeirdAlbum' is the load-bearing one: a leading '..'
+// is NOT a dot entry (albums really do start with ellipses).
+const NORMAL_FILES = [
+  '..WeirdAlbum/01 Weird.mp3',
+  'Solo Artist/Echoes/01 One.mp3',
+  'Solo Artist/Echoes/02 Two.mp3',
+];
+// Indexed only when the matching ignoreDot* flag is false.
+const DOT_FILES = [
+  '.hiddenalbum/01 Hid.mp3',              // dot FOLDER
+  'Solo Artist/Echoes/.hidden.mp3',       // dot FILE beside normal files
+];
+// Never indexed: hardcoded blocklist, including a deeper-nested dir and a
+// case variant (each under its own parent — Windows filesystems are
+// case-insensitive, so '#recycle' and '#RECYCLE' as siblings would be ONE
+// directory and the case check would test nothing).
+const BLOCKLIST_FILES = [
+  '#recycle/junk1.mp3',
+  'CaseTest/#RECYCLE/case.mp3',
+  'Nested Artist/@Recycle/junk2.mp3',
+  'System Volume Information/svi.mp3',
+];
+
+let rustBin;
+let workDir;
+let libRoot;
+let dbDir;
+let artDir;
+// null = probe not run; false = binary predates ignore rules (skip rust).
+let rustHasIgnoreRules = null;
+
+before(async () => {
+  rustBin = findRustParser();
+  if (!fs.existsSync(FFMPEG)) { return; } // every test skips
+
+  workDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-ignore-'));
+  libRoot = path.join(workDir, 'library');
+  dbDir   = path.join(workDir, 'db');
+  artDir  = path.join(workDir, 'art');
+  await fsp.mkdir(dbDir,  { recursive: true });
+  await fsp.mkdir(artDir, { recursive: true });
+
+  let n = 0;
+  for (const rel of [...NORMAL_FILES, ...DOT_FILES, ...BLOCKLIST_FILES]) {
+    await makeAudio(path.join(libRoot, rel), MP3, {
+      title:  `Ignore Fixture ${++n}`,
+      artist: 'Ignore Artist',
+      album:  'Ignore Album',
+    });
+  }
+
+  // Feature-detect a stale prebuilt binary: a pre-ignore-rules build walks
+  // straight into the blocklist dirs. Rust tests skip on it (CI machines
+  // whose bin/rust-parser predates the rebuild); a locally built
+  // target/release binary exercises the rules for real.
+  if (rustBin) {
+    const probe = await scanTracks('probe-rust', {}, cfg => runScan(rustBin, cfg));
+    rustHasIgnoreRules = !probe.filepaths.includes('#recycle/junk1.mp3');
+  }
+});
+
+after(async () => {
+  if (workDir) {
+    await fsp.rm(workDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+// Both engines behind one interface; tests loop over the pair so every
+// scenario runs against the Rust binary AND the JS fallback.
+function engines() {
+  return {
+    rust: cfg => runScan(rustBin, cfg),
+    js:   cfg => runJsScan(cfg),
+  };
+}
+
+function skipReason(engine) {
+  if (!fs.existsSync(FFMPEG)) { return 'no bundled ffmpeg'; }
+  if (engine === 'rust' && !rustBin) { return 'no rust-parser binary'; }
+  if (engine === 'rust' && rustHasIgnoreRules === false) {
+    return 'rust-parser binary predates ignore rules — rebuild with `npm run build-rust`';
+  }
+  return null;
+}
+
+function trackRows(dbPath) {
+  const db = new DatabaseSync(dbPath);
+  const rows = db.prepare('SELECT id, filepath FROM tracks ORDER BY filepath').all();
+  db.close();
+  return rows;
+}
+
+// Fresh DB + one scan; returns the indexed filepaths (sorted, fwd slashes)
+// plus everything needed for a follow-up rescan of the SAME DB.
+async function scanTracks(label, overrides, runner) {
+  const dbPath = path.join(dbDir, `mstream-${label}.db`);
+  const { libraryId, vpath } = initEmptyDb(dbPath, libRoot, 'testlib');
+  const result = await rescanTracks({ dbPath, libraryId, vpath }, `${label}-1`, overrides, runner);
+  return { dbPath, libraryId, vpath, ...result };
+}
+
+async function rescanTracks(env, scanId, overrides, runner) {
+  const cfg = buildScanConfig({
+    dbPath: env.dbPath, libraryId: env.libraryId, vpath: env.vpath,
+    directory: libRoot,
+    albumArtDirectory: artDir,
+    scanId,
+    overrides,
+  });
+  const { event } = await runner(cfg);
+  const rows = trackRows(env.dbPath);
+  return { event, rows, filepaths: rows.map(r => r.filepath) };
+}
+
+describe('scanner ignore rules', () => {
+
+  test('default flags: blocklist + dot entries pruned, ..-prefixed names indexed [rust+js]', async (t) => {
+    if (!fs.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+    for (const [engine, runner] of Object.entries(engines())) {
+      const reason = skipReason(engine);
+      if (reason) { t.diagnostic(`skipping ${engine}: ${reason}`); continue; }
+
+      // No ignore fields in the config at all — the absent-field default
+      // must be TRUE in both engines (serde default_true / `!== false`).
+      const { filepaths, event } = await scanTracks(`default-${engine}`, {}, runner);
+      assert.deepEqual(filepaths, NORMAL_FILES,
+        `[${engine}] only normal files (incl. '..WeirdAlbum') may be indexed`);
+      // Pruned at WALK time, not indexed-then-swept: the walk never even
+      // counts the ignored files.
+      assert.equal(event.filesScanned, NORMAL_FILES.length,
+        `[${engine}] walk must not visit pruned entries`);
+    }
+  });
+
+  test('ignoreDot* false: dot entries indexed, hardcoded blocklist still pruned [rust+js]', async (t) => {
+    if (!fs.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+    for (const [engine, runner] of Object.entries(engines())) {
+      const reason = skipReason(engine);
+      if (reason) { t.diagnostic(`skipping ${engine}: ${reason}`); continue; }
+
+      const { filepaths } = await scanTracks(`flagsoff-${engine}`,
+        { ignoreDotFiles: false, ignoreDotFolders: false }, runner);
+      assert.deepEqual(filepaths, [...NORMAL_FILES, ...DOT_FILES].sort(),
+        `[${engine}] flags off indexes dot entries but NEVER the blocklist dirs`);
+    }
+  });
+
+  test('convergence: rows under ignored paths sweep out on rescan despite files existing [rust+js]', async (t) => {
+    if (!fs.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+    for (const [engine, runner] of Object.entries(engines())) {
+      const reason = skipReason(engine);
+      if (reason) { t.diagnostic(`skipping ${engine}: ${reason}`); continue; }
+
+      // Scan 1 with both flags off gets the dot entries into the DB for
+      // real; blocklist rows (which no walk ever indexes) are seeded by
+      // direct INSERT, modelling rows indexed before the rules existed.
+      // Every seeded path has a live file on disk — that's the point: the
+      // sweep must doom them off the ignore predicate, not off absence.
+      const env = await scanTracks(`converge-${engine}`,
+        { ignoreDotFiles: false, ignoreDotFolders: false }, runner);
+      assert.deepEqual(env.filepaths, [...NORMAL_FILES, ...DOT_FILES].sort());
+
+      const db = new DatabaseSync(env.dbPath);
+      const ins = db.prepare('INSERT INTO tracks (filepath, library_id, title) VALUES (?, ?, ?)');
+      for (const rel of BLOCKLIST_FILES) { ins.run(rel, env.libraryId, 'seeded'); }
+      db.close();
+
+      const normalIdsBefore = env.rows
+        .filter(r => NORMAL_FILES.includes(r.filepath))
+        .map(r => r.id);
+
+      // Rescan with defaults: dot + blocklist rows are stale-swept even
+      // though every file still exists; normal rows are untouched (same
+      // ids — not deleted and re-created).
+      const second = await rescanTracks(env, `converge-${engine}-2`, {}, runner);
+      assert.deepEqual(second.filepaths, NORMAL_FILES,
+        `[${engine}] previously-indexed ignored rows must converge out of the index`);
+      assert.equal(second.event.staleEntriesRemoved,
+        DOT_FILES.length + BLOCKLIST_FILES.length,
+        `[${engine}] the sweep (not some other path) must remove the ignored rows`);
+      const normalIdsAfter = second.rows
+        .filter(r => NORMAL_FILES.includes(r.filepath))
+        .map(r => r.id);
+      assert.deepEqual(normalIdsAfter, normalIdsBefore,
+        `[${engine}] normal rows must survive the sweep with their ids intact`);
+    }
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1974,6 +1974,18 @@ const dbView = Vue.component('db-view', {
                       </td>
                     </tr>
                     <tr>
+                      <td><b>Ignore dot-hidden files (.name.mp3) when scanning:</b> {{dbParams.ignoreDotFiles}}</td>
+                      <td>
+                        [<a v-on:click="toggleIgnoreDotFiles()">{{ t('admin.settings.edit') }}</a>]
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><b>Ignore dot-hidden folders (.name/) when scanning:</b> {{dbParams.ignoreDotFolders}}</td>
+                      <td>
+                        [<a v-on:click="toggleIgnoreDotFolders()">{{ t('admin.settings.edit') }}</a>]
+                      </td>
+                    </tr>
+                    <tr>
                       <td><b>Tracks identified per AcoustID pass:</b> {{dbParams.acoustidPerRun}}</td>
                       <td>
                         [<a v-on:click="openModal('edit-acoustid-per-run-modal')">{{ t('admin.settings.edit') }}</a>]
@@ -2438,6 +2450,58 @@ const dbView = Vue.component('db-view', {
           }],
         ]
       });
+    },
+    // Dot-entry ignore toggles. Applied on the NEXT scan: enabling
+    // removes already-indexed dot-hidden entries (the sweep converges
+    // them out); disabling brings them back on the next scan. Names
+    // starting with '..' are never treated as hidden.
+    toggleIgnoreDot: function(field, route, noun) {
+      iziToast.question({
+        timeout: 20000,
+        close: false,
+        overlayClose: true,
+        overlay: true,
+        displayMode: 'once',
+        id: 'question',
+        zindex: 99999,
+        layout: 2,
+        maxWidth: 600,
+        title: `<b>${this.dbParams[field] === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')} ignoring dot-hidden ${noun}?</b>`,
+        message: 'Takes effect on the next scan; already-indexed matching entries are removed (or re-added) then.',
+        position: 'center',
+        buttons: [
+          [`<button><b>${this.dbParams[field] === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')}</b></button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+            API.axios({
+              method: 'POST',
+              url: `${API.url()}/api/v1/admin/db/params/${route}`,
+              data: { [field]: !this.dbParams[field] }
+            }).then(() => {
+              Vue.set(ADMINDATA.dbParams, field, !this.dbParams[field]);
+              iziToast.success({
+                title: t('admin.settings.updated'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            }).catch(() => {
+              iziToast.error({
+                title: t('admin.settings.failed'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            });
+          }, true],
+          [`<button>${t('admin.folders.goBack')}</button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+          }],
+        ]
+      });
+    },
+    toggleIgnoreDotFiles: function() {
+      this.toggleIgnoreDot('ignoreDotFiles', 'ignore-dot-files', 'files');
+    },
+    toggleIgnoreDotFolders: function() {
+      this.toggleIgnoreDot('ignoreDotFolders', 'ignore-dot-folders', 'folders');
     },
     toggleAnalyzeAcoustid: function() {
       iziToast.question({


### PR DESCRIPTION
## What

Both scanners indexed everything with a supported extension — including NAS recycle bins, snapshot dirs, and dot-hidden files. This adds:

- **Hardcoded, case-insensitive directory blocklist** — always on, pruned at walk time (never descended): `$RECYCLE.BIN`, `#recycle`, `@Recycle`, `@Recently-Snapshot`, `#snapshot`, `.git`, `lost+found`, `.stfolder`, `.stversions`, `System Volume Information`.
- **Dot-entry skipping** behind `scanOptions.ignoreDotFiles` / `ignoreDotFolders` — **default OFF (opt-in)**, so an upgrade never silently deletes dot-named tracks users already have indexed. Single-leading-dot semantics: `.hidden.mp3` is skippable, `..WeirdAlbum` is always indexed (album names really do start with ellipses). Scan roots are never pruned.
- **Admin API + UI toggles (live, no reboot)**: `POST /api/v1/admin/db/params/ignore-dot-files` and `.../ignore-dot-folders` (generate-waveforms pattern — Joi boolean, persists to config.json + mutates `config.program` in-memory), two rows with confirm-toast toggles in the admin panel's DB Scan Settings, values surfaced through the existing `GET /db/params`.
- **Sweep convergence**: the stale sweep applies the SAME predicate (shared `src/db/scan-ignore.js` + a Rust mirror), so flipping a flag ON converges already-indexed matching rows out on the next scan, and flipping it back OFF re-indexes them — a lossless round trip for files still on disk.

## Why

On Synology/QNAP, deleted music reappears in the library via `#recycle` / `@Recycle`; Windows shares contribute `$RECYCLE.BIN` and `System Volume Information`. Ignore policy modeled on Navidrome's (their blocklist + isDotEntry nuance).

## Tests

`test/scanner-ignore-rules.test.mjs` — 3 scenarios × both engines: defaults (only the blocklist prunes; dot entries index; `filesScanned` proves walk-time pruning; `..WeirdAlbum` + case-variant `#RECYCLE` covered), flags-on (dot entries pruned), and convergence (previously-indexed rows swept on a flags-on rescan with ids of normal rows stable, then re-indexed when flags flip back off). `test/integration/admin-scan-params.test.mjs` gains four-part coverage (GET defaults, flip+reflect, Joi 400s, non-admin 405) for both new routes. Scanner parity suite green.

Smoke-tested against a live server: boot scan under defaults indexed a `.hidden.mp3` while pruning `#recycle`; clicking the admin-panel toggle flipped `ignoreDotFiles` in `GET /db/params` AND in `config.json` on disk; a force-rescan then converged the dot-file out of the index.

## ⚠ Behavior change

Rows under blocklisted paths are **deleted on the next scan** (always-on). Dot-entry removal only happens after an admin opts in. Hash-keyed user state survives either way; playlist rows pointing into recycle bins dangle (arguably correct — they pointed at deleted files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)