### PR TITLE
feat(scanner): scope the stale sweep to the subtree in subtree scans

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -111,12 +111,14 @@ struct ScanConfig {
     //
     // When set, the scan:
     //   - Walks {directory}/{subtree} instead of {directory}
-    //   - SKIPS the "remove tracks not seen in this scan" cleanup pass
-    //     because tracks outside the subtree were never walked (so they
-    //     are absent from the seen-set) but are still on disk — wiping
-    //     them would be a data-loss bug
-    //   - SKIPS the orphan artists/albums/genres cleanup for the same
-    //     reason (no tracks were deleted, so nothing newly orphaned)
+    //   - Runs the stale sweep SCOPED to the subtree prefix: candidate
+    //     rows come only from under the subtree, so "unseen" really
+    //     means "was in the walked area and its file wasn't found" —
+    //     rows outside the subtree can never be candidates
+    //   - Runs the orphan artists/albums/genres cleanup only when the
+    //     scoped sweep deleted rows (the probes are global NOT EXISTS
+    //     queries, correct at any scope); art passes stay
+    //     whole-library-only
     //
     // Relative path is joined onto `directory`; no validation here
     // beyond what walkdir does — the caller (task-queue.js) is
@@ -2233,18 +2235,19 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         ).into());
     }
 
-    // Remove tracks not seen in this scan (deleted files). SKIPPED in
-    // subtree mode: tracks OUTSIDE the subtree were never walked (absent
-    // from the seen-set) but are still on disk; the cleanup would wipe
-    // them. A subtree scan can ONLY add/update tracks under its root,
-    // never delete anything outside it. Stale-track cleanup for the rest
-    // of the library will run on the next whole-library scan.
+    // Remove tracks not seen in this scan (deleted files). In subtree
+    // mode the candidate snapshot is scoped to the subtree prefix
+    // below, so "unseen" regains its real meaning — the row was inside
+    // the walked area and its file wasn't found. Rows OUTSIDE the
+    // subtree share the library_id but can never be candidates;
+    // stale-track cleanup for the rest of the library still runs on the
+    // next whole-library scan.
     // Walk errors no longer veto the whole destructive phase: the sweep
     // shields candidates under the failed-walk prefixes individually and
     // its listing-based presence check fails closed for everything else,
     // so a permanently unreadable #recycle dir can't freeze cleanup for
     // the rest of the library forever.
-    if walk_errors > 0 && !subtree_mode {
+    if walk_errors > 0 {
         eprintln!(
             "Warning: {} directory enumeration error(s) during the walk — rows under \
              the affected subtrees are shielded from this scan's cleanup",
@@ -2252,9 +2255,21 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    let sweep = if subtree_mode {
-        SweepOutcome { deleted: 0, moved_tracks: 0, moved_refs: 0 }
+    // DB-side subtree prefix (forward slashes, trailing '/') for scoping
+    // the sweep snapshot. Rebuilt from segments so callers may pass
+    // either separator; tracks.filepath is always a library-relative
+    // forward-slash path.
+    let subtree_prefix: Option<String> = if subtree_mode {
+        let rel: String = config.subtree
+            .split(|c| c == '/' || c == '\\')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("/");
+        Some(format!("{}/", rel))
     } else {
+        None
+    };
+    let sweep = {
         // Sweep candidates = (rows that existed when the scan started) −
         // (rows the walk accounted for), in id order so chunk boundaries
         // are deterministic. On a no-op rescan of a stable library this
@@ -2263,9 +2278,18 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         // fresh scan_id just so a `scan_id != ?` DELETE could find the
         // leftovers. Rows other writers insert mid-scan (ytdl) are not in
         // the scan-start snapshot, so they can never be candidates.
+        // In subtree mode candidates are additionally scoped to the
+        // subtree prefix, so rows outside the walked boundary can never
+        // be candidates — the invariant that used to require skipping
+        // the sweep entirely.
         let mut candidates: Vec<StaleCandidate> = existing_tracks
             .iter()
-            .filter(|(_, t)| !seen_ids.contains(&t.id))
+            .filter(|(path, t)| {
+                !seen_ids.contains(&t.id)
+                    && subtree_prefix
+                        .as_deref()
+                        .map_or(true, |p| path.starts_with(p))
+            })
             .map(|(path, t)| StaleCandidate {
                 id: t.id,
                 rel: path.clone(),
@@ -2306,9 +2330,11 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // SQLITE_BUSY. chunked_orphan_delete releases the writer between
     // batches so other processes can squeeze in.
     //
-    // SKIPPED in subtree mode: we didn't delete any tracks, so nothing
-    // can newly orphan an artist/album/genre. Whole-library scans still
-    // perform this cleanup.
+    // Runs on every whole-library scan, and on subtree scans that
+    // DELETED rows — sweeping the last track of an album must reap the
+    // album now, not at the next full scan. The orphan probes are
+    // global NOT EXISTS queries, correct at any scope; a delete-less
+    // subtree scan still skips them (nothing can be newly orphaned).
     //
     // NOT EXISTS (correlated) rather than NOT IN (… SELECT DISTINCT …): a
     // per-row indexed probe against idx_tracks_artist / idx_albums_artist /
@@ -2316,7 +2342,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // materialising a DISTINCT set — faster, and no IS-NOT-NULL guard needed
     // (a NULL fk just doesn't match). Semantically identical; mirrors
     // src/db/orphan-cleanup.js.
-    if !subtree_mode {
+    if !subtree_mode || sweep.deleted > 0 {
         // Replay recorded re-home hops now that the stale sweep removed
         // the doomed rows that masked their guards mid-scan — BEFORE the
         // orphan sweep decides what's a ghost. Guards make already-done
@@ -2363,7 +2389,13 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         chunked_orphan_delete(&conn, "genres",
             "SELECT id FROM genres WHERE NOT EXISTS (SELECT 1 FROM track_genres WHERE track_genres.genre_id = genres.id)",
             schema_version_at_open)?;
+    }
 
+    // Art passes stay whole-library-only: both walk disk truth for the
+    // entire library (or cache dir), a cost a targeted subtree scan
+    // shouldn't pay — and a swept track's art junction rows already
+    // cascaded with its row.
+    if !subtree_mode {
         // V48 multi-art: reap art_files rows whose image is verifiably gone
         // from disk. Disk is truth, like the track sweep — an UNLINKED image
         // that still exists is KEPT (re-derivable / re-linkable for free),

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -76,9 +76,10 @@ const schema = Joi.object({
   analyzeBpm: Joi.boolean().default(true),
   // Optional vpath-relative subtree to scan instead of the whole library.
   // Default empty string = legacy whole-vpath behaviour. When set, the
-  // scan walks {directory}/{subtree} and SKIPS the stale-cleanup pass
-  // (tracks outside the subtree would otherwise be deleted as "not
-  // seen this scan"). See the matching field in rust-parser/src/main.rs.
+  // scan walks {directory}/{subtree} and the stale sweep runs SCOPED to
+  // that prefix: rows under the subtree whose files are verifiably gone
+  // are deleted (with move re-homing), rows outside it are never
+  // candidates. See the matching field in rust-parser/src/main.rs.
   subtree: Joi.string().allow('').default(''),
   // Rust-only: directory the Rust scanner writes waveform .bin files to.
   // task-queue.js sends this to BOTH scanners (it stopped sending the
@@ -1370,9 +1371,12 @@ async function run() {
   // zero files, and the stale-cleanup DELETE below would then wipe every
   // track for this library — cascading through albums, artists, and
   // user_album_stars. Bail before any destructive write. We check the
-  // library root (not the subtree), exactly like the Rust scanner: a
-  // missing subtree under a healthy root is harmless because subtree
-  // scans never run the cleanup pass.
+  // library root (not the subtree), exactly like the Rust scanner. A
+  // missing subtree under a healthy root needs no guard of its own:
+  // that is exactly what a deleted folder looks like, and the scoped
+  // sweep's verify-absence converges its rows — while an UNREADABLE
+  // subtree (outage, not deletion) records a failed-walk prefix that
+  // shields them.
   if (!isAccessibleDir(loadJson.directory)) {
     console.error(`Scan failed: library directory not accessible: ${loadJson.directory}`);
     try { db.close(); } catch (_) {}
@@ -1394,6 +1398,13 @@ async function run() {
     } else {
       console.log(`Scanning ${loadJson.directory}...`);
     }
+    // DB-side subtree prefix (forward slashes, trailing '/') for scoping
+    // the sweep snapshot. Rebuilt from segments so callers may pass
+    // either separator; tracks.filepath is always a library-relative
+    // forward-slash path.
+    const subtreePrefix = subtreeMode
+      ? `${loadJson.subtree.split(/[/\\]/).filter(Boolean).join('/')}/`
+      : null;
 
     // Scan-start snapshot for the stale sweep: every (id, filepath) this
     // library had BEFORE the walk. Sweep candidates are the snapshot
@@ -1406,16 +1417,18 @@ async function run() {
     // leaked in the DB forever — they now converge out like ordinary
     // rows once verify-absence proves the file gone.) Tens of bytes of
     // RAM per track; the Rust scanner already holds a strictly larger
-    // per-row snapshot for its mtime fast-path. Subtree scans never
-    // sweep, so they skip the snapshot.
-    const preScanRows = subtreeMode
-      ? []
-      : db.prepare(
-          // Hashes ride along so the sweep can pair a verified-gone row
-          // with its moved/renamed twin and re-home path-keyed user
-          // references (see deleteStaleTracks's move re-homing).
-          'SELECT id, filepath, audio_hash, file_hash FROM tracks WHERE library_id = ? ORDER BY id'
-        ).all(loadJson.libraryId);
+    // per-row snapshot for its mtime fast-path. Subtree scans sweep
+    // too, but only within their own boundary: the snapshot is scoped
+    // to the subtree prefix, so rows outside the walked area can never
+    // become candidates — the invariant that used to require skipping
+    // the sweep entirely.
+    // Hashes ride along so the sweep can pair a verified-gone row with
+    // its moved/renamed twin and re-home path-keyed user references
+    // (see deleteStaleTracks's move re-homing).
+    const preScanRows = db.prepare(
+        'SELECT id, filepath, audio_hash, file_hash FROM tracks WHERE library_id = ? ORDER BY id'
+      ).all(loadJson.libraryId)
+      .filter((r) => subtreePrefix === null || r.filepath.startsWith(subtreePrefix));
 
     // Single walk: collect supported files (with walk-time mtime) so we
     // don't stat the whole tree twice. files.length is the progress-bar
@@ -1441,7 +1454,7 @@ async function run() {
     // not 600 coincidentally-corrupt files. Nothing landed in the
     // seen-set, so the stale sweep would treat the entire library as
     // candidates. Skip all cleanup and mark the scan failed.
-    if (!subtreeMode && files.length > 0 && totalProcessed === 0) {
+    if (files.length > 0 && totalProcessed === 0) {
       console.error(
         `Error: walk found ${files.length} files but every one failed to ` +
         'process — skipping stale-track cleanup; scan marked failed.');
@@ -1454,8 +1467,12 @@ async function run() {
     // vanished mid-scan. Re-check: gone → skip cleanup (outage); still
     // accessible → the user genuinely emptied the directory, so fall
     // through and let the stale-cleanup run. Mirrors rust-parser's
-    // run_scan. SKIPPED in subtree mode (it never deletes anything).
-    if (!subtreeMode && totalProcessed === 0) {
+    // run_scan. The LIBRARY-root check stays correct in subtree mode
+    // (an emptied subtree under a healthy root is a real deletion; a
+    // vanished mount kills the root check either way), and priorCount
+    // is deliberately the whole-library count — it is only the "there
+    // was data to lose" signal.
+    if (totalProcessed === 0) {
       const priorCount = stmts.countLibraryTracks.get(loadJson.libraryId)?.n || 0;
       if (priorCount > 0 && !isAccessibleDir(loadJson.directory)) {
         console.error(
@@ -1494,17 +1511,17 @@ async function run() {
     // individually, and its listing-based presence check fails closed
     // for everything else — so one permanently unreadable directory
     // can't freeze cleanup for the rest of the library forever.
-    if (walkErrors > 0 && !subtreeMode) {
+    if (walkErrors > 0) {
       console.error(
         `Warning: ${walkErrors} directory enumeration error(s) during the walk — ` +
         'rows under the affected subtrees are shielded from this scan\'s cleanup');
     }
 
     // Remove tracks that weren't seen in this scan (deleted files).
-    // SKIPPED in subtree mode — tracks outside the subtree share the
-    // library_id but were never walked (absent from the seen-set), and
-    // wiping them would be a data-loss bug. Stale cleanup runs only when
-    // we've actually walked the whole library.
+    // In subtree mode the candidate snapshot was scoped to the subtree
+    // prefix above, so "unseen" regains its real meaning — the row was
+    // inside the walked area and its file wasn't found. Rows outside
+    // the subtree share the library_id but can never be candidates.
     // Candidates = snapshot rows the walk did not account for, already
     // in id order (the snapshot SELECT orders by id) so chunk boundaries
     // are deterministic. On a no-op rescan of a stable library this set
@@ -1516,14 +1533,12 @@ async function run() {
     // failedWalkPrefixes feed the verify-absence check: only rows whose
     // file is provably gone get deleted; unseen-but-alive rows are kept;
     // unverifiable rows are left untouched.
-    const sweep = subtreeMode
-      ? { removed: 0, movedTracks: 0, movedRefs: 0 }
-      : deleteStaleTracks(db,
-          preScanRows.filter((r) => !seenPaths.has(r.filepath)), schemaVersionAtOpen,
-          { libraryRoot: loadJson.directory, followSymlinks: !!loadJson.followSymlinks,
-            failedWalkPrefixes, supportedFiles: loadJson.supportedFiles,
-            ignoreDotFiles, ignoreDotFolders,
-            moveRehome: { libraryId: loadJson.libraryId } });
+    const sweep = deleteStaleTracks(db,
+        preScanRows.filter((r) => !seenPaths.has(r.filepath)), schemaVersionAtOpen,
+        { libraryRoot: loadJson.directory, followSymlinks: !!loadJson.followSymlinks,
+          failedWalkPrefixes, supportedFiles: loadJson.supportedFiles,
+          ignoreDotFiles, ignoreDotFolders,
+          moveRehome: { libraryId: loadJson.libraryId } });
     // Structured end-of-scan event — parsed by task-queue.js to decide whether
     // to run the waveform post-processor and to print a human-readable summary.
     // Field shapes mirror the rust-parser's emitter:
@@ -1554,9 +1569,12 @@ async function run() {
       walkErrors
     }));
 
-    // Clean up orphaned artists, albums, and genres. SKIPPED in
-    // subtree mode (we didn't delete any tracks, so nothing newly
-    // orphaned). Whole-library scans still perform this cleanup.
+    // Clean up orphaned artists, albums, and genres. Runs on every
+    // whole-library scan, and on subtree scans that DELETED rows —
+    // sweeping the last track of an album must reap the album now, not
+    // at the next full scan. The orphan probes are global NOT EXISTS
+    // queries, correct to run at any scope; a delete-less subtree scan
+    // still skips them (nothing can be newly orphaned).
     // yieldBetweenChunks: we are a dedicated scanner process, so the
     // inter-chunk sleep costs nothing and gives concurrent server
     // writes a real window during big cleanups.
@@ -1564,7 +1582,7 @@ async function run() {
     // windows of the whole scan (three chunked DELETEs with 10-20ms
     // yields) — re-verify per chunk for the same reason the stale sweep
     // does.
-    if (!subtreeMode) {
+    if (!subtreeMode || sweep.removed > 0) {
       // Replay recorded re-home hops now that the stale sweep has
       // removed the doomed rows that masked their guards mid-scan —
       // BEFORE the orphan sweep decides what's a ghost.
@@ -1573,6 +1591,12 @@ async function run() {
         yieldBetweenChunks: true,
         expectedSchemaVersion: schemaVersionAtOpen,
       });
+    }
+    // Art passes stay whole-library-only: both walk disk truth for the
+    // entire library (or cache dir), a cost a targeted subtree scan
+    // shouldn't pay — and a swept track's art junction rows already
+    // cascaded with its row.
+    if (!subtreeMode) {
       // V48 multi-art: reap art_files rows whose image is verifiably gone
       // from disk (disk is truth — an unlinked image that still exists is
       // KEPT). Runs regardless of skipImg: reaping is about rows whose

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -2185,10 +2185,12 @@ export function scanVPath(vPath) {
   addScanTask(vPath);
 }
 
-// Targeted subtree scan. Walks {vpath}/{subtree} only and skips the
-// stale-cleanup pass. Used by the torrent completion-watcher so each
-// completed torrent triggers a narrow scan over its own download dir
-// instead of a full library walk.
+// Targeted subtree scan. Walks {vpath}/{subtree} only; the stale sweep
+// runs scoped to that prefix (deleted/renamed files under the subtree
+// converge out, with move re-homing — rows outside it are never
+// touched). Used by the torrent completion-watcher so each completed
+// torrent triggers a narrow scan over its own download dir instead of
+// a full library walk.
 export function scanSubtree(vPath, subtree) {
   addSubtreeScanTask(vPath, subtree);
 }

--- a/test/scanner/scanner-move-rehome.test.mjs
+++ b/test/scanner/scanner-move-rehome.test.mjs
@@ -244,7 +244,11 @@ for (const engine of ['rust', 'js']) {
       assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/e.mp3`]);
     });
 
-    test('subtree scans never sweep, so they never re-home', async (t) => {
+    // Scoped-sweep era: a subtree scan CAN sweep now, but only within
+    // its own prefix — a deletion OUTSIDE the subtree must stay
+    // invisible to it (no sweep, no re-home). The in-scope behaviour is
+    // pinned by scanner-subtree-sweep.test.mjs.
+    test('subtree scans only sweep within their boundary — outside deletions untouched', async (t) => {
       if (!engineAvailable()) { t.skip('ffmpeg or rust binary unavailable'); return; }
       const sb = await makeSandbox(engine);
       await makeAudio(path.join(sb.libRoot, 'f.mp3'), MP3, { title: 'Root' }, 5);

--- a/test/scanner/scanner-subtree-sweep.test.mjs
+++ b/test/scanner/scanner-subtree-sweep.test.mjs
@@ -1,0 +1,220 @@
+/**
+ * Subtree-scoped stale sweep — both engines.
+ *
+ * Subtree scans used to skip the stale sweep entirely (rows outside the
+ * subtree are absent from the seen-set, so an unscoped sweep would have
+ * treated the whole rest of the library as deleted). The sweep now runs
+ * with its candidate snapshot SCOPED to the subtree prefix, restoring
+ * "unseen means the walked area lost this file":
+ *
+ *   - deletions INSIDE the subtree converge out on the subtree scan
+ *     (with move re-homing — the pairing target map is whole-library,
+ *     so a twin elsewhere adopts the references);
+ *   - rows OUTSIDE the subtree are never candidates, even when their
+ *     files are gone (pinned here AND in scanner-move-rehome);
+ *   - the prefix respects path-segment boundaries ('sub' must not
+ *     capture 'subX/…');
+ *   - sweeping the last track of an album reaps the album/artist rows
+ *     right away (orphan cleanup now runs after subtree deletes);
+ *   - a DELETED subtree directory converges its rows (that is what a
+ *     removed folder looks like), while an UNREADABLE one records a
+ *     failed-walk prefix that shields them — outage ≠ deletion.
+ *
+ * Skipped (like scanner-parity.test.mjs) when ffmpeg or the rust binary
+ * is unavailable; a prebuilt binary predating the scoped sweep is
+ * feature-detected and skipped for the rust engine.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
+} from '../helpers/scanner-runner.mjs';
+import { makeAudio } from '../helpers/scanner-fixture.mjs';
+
+const MP3 = ['-c:a', 'libmp3lame', '-b:a', '64k', '-id3v2_version', '3'];
+
+let rustBin;
+let scratch;
+// null = probe not run; false = binary predates the scoped sweep.
+let rustHasScopedSweep = null;
+
+before(async () => {
+  rustBin = findRustParser();
+  scratch = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-subsweep-'));
+
+  // Feature-detect a stale prebuilt binary: scan a subtree after
+  // deleting its only file — a pre-scoped-sweep build reports
+  // staleEntriesRemoved 0 with the row left behind.
+  if (rustBin && fs.existsSync(FFMPEG)) {
+    const root = path.join(scratch, 'probe');
+    const libRoot = path.join(root, 'lib');
+    await makeAudio(path.join(libRoot, 'probe', 'p.mp3'), MP3, { title: 'P' }, 1);
+    const dbPath = path.join(root, 'probe.db');
+    const { libraryId, vpath } = initEmptyDb(dbPath, libRoot);
+    const cfg = (scanId, overrides = {}) => buildScanConfig({
+      dbPath, libraryId, vpath, directory: libRoot,
+      albumArtDirectory: path.join(root, 'art'),
+      waveformCacheDir: path.join(root, 'wave'),
+      scanId, overrides,
+    });
+    await fsp.mkdir(path.join(root, 'art'), { recursive: true });
+    await runScan(rustBin, cfg('probe-1'));
+    await fsp.rm(path.join(libRoot, 'probe', 'p.mp3'));
+    const { event } = await runScan(rustBin, cfg('probe-2', { subtree: 'probe' }));
+    rustHasScopedSweep = event.staleEntriesRemoved === 1;
+  }
+});
+
+after(async () => {
+  if (scratch) { await fsp.rm(scratch, { recursive: true, force: true }); }
+});
+
+let sandboxSeq = 0;
+async function makeSandbox(engine) {
+  const root = path.join(scratch, `sb${sandboxSeq++}-${engine}`);
+  const libRoot = path.join(root, 'lib');
+  const artDir = path.join(root, 'art');
+  await fsp.mkdir(libRoot, { recursive: true });
+  await fsp.mkdir(artDir, { recursive: true });
+  const dbPath = path.join(root, 'test.db');
+  const { libraryId, vpath } = initEmptyDb(dbPath, libRoot);
+  let scanSeq = 0;
+  const scan = (overrides = {}) => {
+    const config = buildScanConfig({
+      dbPath, libraryId, vpath, directory: libRoot,
+      albumArtDirectory: artDir, waveformCacheDir: path.join(root, 'wave'),
+      scanId: `scan-${scanSeq++}`, overrides,
+    });
+    return engine === 'js' ? runJsScan(config) : runScan(rustBin, config);
+  };
+  return { root, libRoot, dbPath, libraryId, vpath, scan };
+}
+
+function withDb(dbPath, fn) {
+  const db = new DatabaseSync(dbPath);
+  try { return fn(db); } finally { db.close(); }
+}
+const trackPaths = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT filepath FROM tracks ORDER BY filepath').all().map(r => r.filepath));
+const albumNames = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT name FROM albums ORDER BY name').all().map(r => r.name));
+const seedPlaylist = (dbPath, vpath, rel) => withDb(dbPath, db => {
+  db.prepare(`INSERT OR IGNORE INTO users (id, username, password, salt)
+              VALUES (1, 'mover', 'x', 'x')`).run();
+  db.prepare(`INSERT OR IGNORE INTO playlists (id, name, user_id) VALUES (1, 'pl', 1)`).run();
+  const pos = db.prepare(
+    'SELECT COALESCE(MAX(position), -1) + 1 AS p FROM playlist_tracks').get().p;
+  db.prepare(`INSERT INTO playlist_tracks (playlist_id, filepath, position)
+              VALUES (1, ?, ?)`).run(`${vpath}/${rel}`, pos);
+});
+const playlistPaths = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT filepath FROM playlist_tracks ORDER BY id').all().map(r => r.filepath));
+
+for (const engine of ['rust', 'js']) {
+  const engineAvailable = () =>
+    fs.existsSync(FFMPEG) && (engine === 'js' || (!!rustBin && rustHasScopedSweep !== false));
+
+  describe(`subtree-scoped sweep (${engine} scanner)`, () => {
+    test('deletion inside the subtree converges on a subtree scan', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'keep.mp3'), MP3, { title: 'Keep' }, 1);
+      await makeAudio(path.join(sb.libRoot, 'tor', 'a.mp3'), MP3, { title: 'A' }, 2);
+      await makeAudio(path.join(sb.libRoot, 'tor', 'b.mp3'), MP3, { title: 'B' }, 3);
+      await sb.scan();
+
+      await fsp.rm(path.join(sb.libRoot, 'tor', 'a.mp3'));
+      const { event } = await sb.scan({ subtree: 'tor' });
+
+      assert.strictEqual(event.staleEntriesRemoved, 1);
+      assert.deepStrictEqual(trackPaths(sb.dbPath), ['keep.mp3', 'tor/b.mp3']);
+    });
+
+    test('prefix respects segment boundaries: subtree "sub" never touches "subX/"', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'sub', 'in.mp3'), MP3, { title: 'In' }, 1);
+      await makeAudio(path.join(sb.libRoot, 'subX', 'near.mp3'), MP3, { title: 'Near' }, 2);
+      await sb.scan();
+
+      // Both files deleted; only the true-subtree row may sweep.
+      await fsp.rm(path.join(sb.libRoot, 'sub', 'in.mp3'));
+      await fsp.rm(path.join(sb.libRoot, 'subX', 'near.mp3'));
+      const { event } = await sb.scan({ subtree: 'sub' });
+
+      assert.strictEqual(event.staleEntriesRemoved, 1);
+      assert.deepStrictEqual(trackPaths(sb.dbPath), ['subX/near.mp3'],
+        'subX/ must survive a scan of subtree "sub"');
+    });
+
+    test('move re-homing works inside a subtree scan (twin outside adopts refs)', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'outside.mp3'), MP3, { title: 'Twin' }, 4);
+      await fsp.mkdir(path.join(sb.libRoot, 'tor'), { recursive: true });
+      await fsp.copyFile(path.join(sb.libRoot, 'outside.mp3'),
+        path.join(sb.libRoot, 'tor', 'inside.mp3'));
+      await sb.scan();
+      seedPlaylist(sb.dbPath, sb.vpath, 'tor/inside.mp3');
+
+      await fsp.rm(path.join(sb.libRoot, 'tor', 'inside.mp3'));
+      const { event } = await sb.scan({ subtree: 'tor' });
+
+      assert.strictEqual(event.staleEntriesRemoved, 1);
+      assert.strictEqual(event.movedTracksRehomed, 1);
+      assert.deepStrictEqual(playlistPaths(sb.dbPath), [`${sb.vpath}/outside.mp3`],
+        'the whole-library pairing map re-points refs across the subtree boundary');
+    });
+
+    test('sweeping the last track of an album reaps the album immediately', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'other', 'stay.mp3'), MP3,
+        { artist: 'Stay', album: 'StayAlbum', title: 'Stay' }, 1);
+      await makeAudio(path.join(sb.libRoot, 'gone', 'last.mp3'), MP3,
+        { artist: 'Gone', album: 'GoneAlbum', title: 'Last' }, 2);
+      await sb.scan();
+      assert.deepStrictEqual(albumNames(sb.dbPath), ['GoneAlbum', 'StayAlbum']);
+
+      await fsp.rm(path.join(sb.libRoot, 'gone', 'last.mp3'));
+      await sb.scan({ subtree: 'gone' });
+
+      assert.deepStrictEqual(albumNames(sb.dbPath), ['StayAlbum'],
+        'the orphaned album must reap on the subtree scan, not the next full scan');
+    });
+
+    test('a deleted subtree directory converges its rows', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'keep.mp3'), MP3, { title: 'Keep' }, 1);
+      await makeAudio(path.join(sb.libRoot, 'doomed', 'x.mp3'), MP3, { title: 'X' }, 2);
+      await makeAudio(path.join(sb.libRoot, 'doomed', 'y.mp3'), MP3, { title: 'Y' }, 3);
+      await sb.scan();
+
+      await fsp.rm(path.join(sb.libRoot, 'doomed'), { recursive: true });
+      const { event } = await sb.scan({ subtree: 'doomed' });
+
+      assert.strictEqual(event.staleEntriesRemoved, 2,
+        'a removed folder is a real deletion — its rows converge');
+      assert.deepStrictEqual(trackPaths(sb.dbPath), ['keep.mp3']);
+    });
+
+    test('a delete-less subtree scan reports zero and touches nothing', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'tor', 'a.mp3'), MP3, { title: 'A' }, 1);
+      await sb.scan();
+
+      const { event } = await sb.scan({ subtree: 'tor' });
+      assert.strictEqual(event.staleEntriesRemoved, 0);
+      assert.strictEqual(event.movedTracksRehomed, 0);
+      assert.deepStrictEqual(trackPaths(sb.dbPath), ['tor/a.mp3']);
+    });
+  });
+}


### PR DESCRIPTION
## What

Subtree scans (`addSubtreeScanTask` — today used by the torrent completion-watcher) skipped the stale sweep entirely: rows outside the subtree are absent from the seen-set, and an unscoped sweep would have treated the rest of the library as deleted. Consequence: a file deleted or renamed away inside the scanned subtree left a ghost row until the next whole-library scan.

The sweep now runs with its **candidate snapshot scoped to the subtree prefix** (segment-boundary safe: `sub` never captures `subX/`), restoring "unseen = the walked area lost this file":

- Deletions inside the subtree converge on the targeted scan — with **move re-homing intact** (the pairing map is whole-library, so a twin elsewhere adopts the playlist/cue/play-event refs across the boundary).
- Rows outside the subtree can never be candidates (pinned in tests from both directions).
- **Orphan cleanup + re-home replay** now run after a subtree sweep that deleted rows — sweeping an album's last track reaps the album immediately instead of at the next full scan (the probes are global `NOT EXISTS` queries, correct at any scope). Art passes stay whole-library-only.
- A **deleted subtree directory** converges its rows (that is what a removed folder looks like); an **unreadable** one records a failed-walk prefix that shields them — outage stays distinct from deletion. The all-files-failed and library-root mount-vanish guards now apply in subtree mode too.

## Why

Immediate: torrent-completion scans finally clean up replaced/renamed files in their download dir. Structural: this is the prerequisite for the filesystem watcher (next roadmap step) — watcher-mapped deletion events land in seconds instead of waiting for the 24h interval scan.

## Tests

New `test/scanner/scanner-subtree-sweep.test.mjs`: 6 scenarios × both scanners — in-subtree convergence, segment-boundary respect, in-subtree move re-homing across the boundary, immediate album reaping, deleted-subtree-dir convergence, delete-less no-op (12/12; stale prebuilt binaries feature-detected and skipped). The out-of-scope direction stays pinned in scanner-move-rehome (title updated). Full regression battery green: move-rehome, ignore-rules, schema-guard, orphan-cleanup, torrent-completion-watcher, parity, star-survival (92 pass / 0 fail). `cargo build --release` clean; source-only (CI rebuilds binaries on master push).

## Notes for review

- The unreadable-subtree (EACCES) shielding path is exercised at the `deleteStaleTracks` level by the existing schema-guard failed-prefix tests; it has no portable Windows fixture at the walk level.
- No schema change, no config change, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)