### PR TITLE
feat(scanner): filesystem watcher for near-instant targeted scans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "archiver": "^8.0.0",
         "busboy": "^1.6.0",
+        "chokidar": "^4.0.3",
         "command-exists": "^1.2.9",
         "cookie-parser": "^1.4.7",
         "essentia.js": "^0.1.3",
@@ -2025,6 +2026,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/color": {
@@ -4095,6 +4111,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/yqnn"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/roarr": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "archiver": "^8.0.0",
     "busboy": "^1.6.0",
+    "chokidar": "^4.0.3",
     "command-exists": "^1.2.9",
     "cookie-parser": "^1.4.7",
     "essentia.js": "^0.1.3",
@@ -69,8 +70,8 @@
     "ws": "^8.21.0"
   },
   "optionalDependencies": {
-    "@number0/iroh": "^1.0.0",
     "@huggingface/transformers": "^4.2.0",
+    "@number0/iroh": "^1.0.0",
     "onnxruntime-node": "^1.24.3"
   },
   "devDependencies": {

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -343,6 +343,22 @@ export function setup(mstream) {
     res.json({});
   });
 
+  // Live toggle for the filesystem watcher: persists, then starts or
+  // stops the watchers in-process — no reboot. Watchers only ever
+  // ENQUEUE scans (through the same task-queue dedup as every other
+  // trigger), so flipping this is always safe.
+  mstream.post("/api/v1/admin/db/params/watcher-enabled", async (req, res) => {
+    const schema = Joi.object({
+      watcherEnabled: Joi.boolean().required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editWatcherEnabled(req.body.watcherEnabled);
+    if (req.body.watcherEnabled === true) { dbQueue.startLibraryWatchers(); }
+    else { dbQueue.stopLibraryWatchers(); }
+    res.json({});
+  });
+
   // Tracks analysed per essentia pass (bounds how long one batch holds the
   // serial task slot; the worker also caps wall-clock and re-enqueues a
   // backlog). Mirrors auto-album-art-per-run; takes effect on the next pass.
@@ -944,6 +960,8 @@ export function setup(mstream) {
     }catch (err) {
       winston.error('/api/v1/admin/directory failed to add ', { stack: err });
     }
+    // Watched set tracks the library list (no-op while disabled).
+    dbQueue.refreshLibraryWatchers();
   });
 
   mstream.delete("/api/v1/admin/directory", async (req, res) => {
@@ -954,6 +972,7 @@ export function setup(mstream) {
 
     await admin.removeDirectory(req.body.vpath);
     res.json({});
+    dbQueue.refreshLibraryWatchers();
   });
 
   // V21: per-library followSymlinks flag. Takes effect on the next

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -13,6 +13,7 @@ import { launchWorker, workerReaperMarker } from '../util/worker-process.js';
 import { ffmpegBin, ensureFfmpeg } from '../util/ffmpeg-bootstrap.js';
 import * as dlnaApi from '../api/dlna.js';
 import * as discoveryDb from './discovery-db.js';
+import * as libraryWatcher from '../util/library-watcher.js';
 
 const __dirname = getDirname(import.meta.url);
 
@@ -2185,6 +2186,33 @@ export function scanVPath(vPath) {
   addScanTask(vPath);
 }
 
+// Filesystem-watcher lifecycle, bound to this queue's enqueue functions
+// and scan-activity signal so the watcher module never has to import
+// task-queue (no cycle). Restart-idempotent — boot, reboot() and the
+// admin toggle all call these blindly; directory add/remove restarts
+// them so the watched set tracks the library list.
+export function startLibraryWatchers() {
+  libraryWatcher.startLibraryWatchers({
+    libraries: db.getAllLibraries(),
+    waitSeconds: config.program.scanOptions.watcherWait,
+    isScanActive: () => activeTask?.kind === 'scan',
+    enqueueFull: (vpath) => addScanTask(vpath),
+    enqueueSubtree: (vpath, subtree) => addSubtreeScanTask(vpath, subtree),
+  });
+}
+
+export function stopLibraryWatchers() {
+  libraryWatcher.stopLibraryWatchers();
+}
+
+// Re-sync the watched set with the current library list; a no-op while
+// the feature is disabled.
+export function refreshLibraryWatchers() {
+  if (config.program.scanOptions.watcherEnabled === true) {
+    startLibraryWatchers();
+  }
+}
+
 // Targeted subtree scan. Walks {vpath}/{subtree} only; the stale sweep
 // runs scoped to that prefix (deleted/renamed files under the subtree
 // converge out, with move re-homing — rows outside it are never
@@ -2306,6 +2334,14 @@ export function runAfterBoot() {
     }
     if (config.program.scanOptions.scanInterval > 0 && scanIntervalTimer === null) {
       scanIntervalTimer = setInterval(() => scanAll(), config.program.scanOptions.scanInterval * 60 * 60 * 1000);
+    }
+    // Filesystem watcher (opt-in). Started/stopped here so reboot()
+    // re-evaluates the flag; start is restart-idempotent. Any events it
+    // catches during the boot scan are absorbed by the queue's dedup.
+    if (config.program.scanOptions.watcherEnabled === true) {
+      startLibraryWatchers();
+    } else {
+      stopLibraryWatchers();
     }
   }, config.program.scanOptions.bootScanDelay * 1000);
 }

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -63,6 +63,17 @@ const scanOptions = Joi.object({
   // (/api/v1/admin/db/params/ignore-dot-*).
   ignoreDotFiles: Joi.boolean().default(false),
   ignoreDotFolders: Joi.boolean().default(false),
+  // Filesystem watcher: near-instant targeted scans when library files
+  // change (src/util/library-watcher.js). Default OFF (opt-in): change
+  // events don't fire on most CIFS/NFS mounts, so the scanInterval loop
+  // stays the delivery mechanism there — the watcher is an accelerator
+  // for local disks, never a replacement. watcherWait is the debounce in
+  // seconds: events coalesce until the library has been quiet that long
+  // (a torrent writing 200 files becomes one subtree scan), tripled
+  // while a scan is already running. Applied when the watcher (re)starts
+  // — boot, reboot, or the admin toggle.
+  watcherEnabled: Joi.boolean().default(false),
+  watcherWait: Joi.number().integer().min(1).max(600).default(10),
   compressImage: Joi.boolean().default(true),
   // Tracks scanned per SQLite COMMIT — also gates how often the scanner
   // emits progress updates. Lower = more responsive UI + shorter

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -484,6 +484,18 @@ export async function editIgnoreDotFolders(val) {
   config.program.scanOptions.ignoreDotFolders = val;
 }
 
+// Filesystem-watcher toggle. Persist + in-memory like the others; the
+// API route starts/stops the watchers through dbQueue so the flip is
+// live (no reboot). watcherWait stays config-file-only for now and is
+// read when the watchers (re)start.
+export async function editWatcherEnabled(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.watcherEnabled = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.watcherEnabled = val;
+}
+
 // Tracks analysed per essentia pass. Same live-update pattern as
 // editAutoAlbumArtPerRun — the worker reads it fresh when task-queue builds
 // the pass's jsonLoad, so a change takes effect on the next pass with no reboot.

--- a/src/util/library-watcher.js
+++ b/src/util/library-watcher.js
@@ -1,0 +1,255 @@
+// Filesystem watcher → near-instant targeted scans.
+//
+// Watches each library root (chokidar) and maps change events to the
+// EXISTING scan machinery — the watcher never touches the index itself,
+// it only enqueues scans through the same task-queue dedup every other
+// trigger uses. A missed or duplicated event can therefore never corrupt
+// anything: worst case is a redundant subtree scan, or a delay until the
+// scanInterval loop covers it. That loop stays untouched as the delivery
+// mechanism for storage that emits no events (most CIFS/NFS mounts —
+// the reason the watcher defaults OFF).
+//
+// Control loop (modeled on Navidrome's watcher):
+//   event → relevance filter (scan-ignore rules + watched extensions)
+//         → directory target (files map to their parent; deletions walk
+//           UP to the nearest still-existing ancestor — you can't scan a
+//           directory that's gone)
+//         → per-vpath pending set, debounced until the library has been
+//           QUIET for watcherWait seconds (a torrent writing 200 files
+//           becomes one subtree scan)
+//         → if a scan is already running, re-arm at 3× the wait instead
+//           of enqueueing into the storm
+//         → flush: nested targets collapse to their shallowest ancestor,
+//           '' (library root) absorbs everything and becomes a full
+//           vpath scan; everything else goes through addSubtreeScanTask,
+//           whose scoped sweep (PR #757) makes deletions land too.
+//
+// The pure mapping/coalescing pieces are exported for unit tests; only
+// startLibraryWatchers/stopLibraryWatchers touch chokidar or timers.
+
+import path from 'path';
+import fs from 'fs';
+import chokidar from 'chokidar';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import { isIgnoredDirName, isIgnoredRelPath } from '../db/scan-ignore.js';
+
+// Non-audio files whose changes still warrant a scan: folder art feeds
+// album-art discovery, .lrc/.txt sidecars feed lyrics. False positives
+// are cheap — a debounced subtree scan that fast-paths every unchanged
+// file.
+const EXTRA_WATCH_EXTS = new Set(['jpg', 'jpeg', 'png', 'lrc', 'txt']);
+
+// Library-relative forward-slash path for an absolute event path, or
+// null when the path escapes the root (defensive: chokidar shouldn't
+// produce one). '' means the root itself.
+export function relFromRoot(libraryRoot, absPath) {
+  const rel = path.relative(libraryRoot, absPath);
+  if (rel === '') { return ''; }
+  if (rel.startsWith('..') || path.isAbsolute(rel)) { return null; }
+  return rel.replace(/\\/g, '/');
+}
+
+// The directory a file event should scan: its parent ('' at root level).
+export function parentRel(rel) {
+  const i = rel.lastIndexOf('/');
+  return i === -1 ? '' : rel.slice(0, i);
+}
+
+// Walk a target up to the nearest ancestor that still exists as a
+// directory ('' = library root, which the caller turns into a full
+// scan). Deletion events point at paths that are already gone; the scan
+// must root somewhere real so its scoped sweep covers the removed rows.
+export function walkUpToExisting(libraryRoot, rel, isDirFn = defaultIsDir) {
+  let cur = rel;
+  while (cur !== '' && !isDirFn(path.join(libraryRoot, cur))) {
+    cur = parentRel(cur);
+  }
+  return cur;
+}
+
+function defaultIsDir(p) {
+  try { return fs.statSync(p).isDirectory(); } catch (_e) { return false; }
+}
+
+// Should this event schedule a scan at all? Reuses the scanners' ignore
+// predicate (hardcoded blocklist + the LIVE dot-entry flags — the admin
+// toggles apply to the very next event) and, for files, the watched
+// extension set: configured audio formats plus art/lyrics sidecars.
+export function eventLooksRelevant(rel, isDirEvent, {
+  supportedFiles = {}, ignoreDotFiles = false, ignoreDotFolders = false,
+} = {}) {
+  if (rel === null) { return false; }
+  if (rel === '') { return true; }
+  // For file events the last segment is a filename and isIgnoredRelPath's
+  // semantics match exactly. For directory events, check the dir path's
+  // segments under the FOLDER rule by probing it as "<rel>/x" so the
+  // final segment is treated as a directory, not a filename.
+  const probe = isDirEvent ? `${rel}/x` : rel;
+  if (isIgnoredRelPath(probe, { ignoreDotFiles, ignoreDotFolders })) { return false; }
+  if (isDirEvent) { return true; }
+  const name = rel.slice(rel.lastIndexOf('/') + 1);
+  const dot = name.lastIndexOf('.');
+  if (dot <= 0) { return false; }
+  const ext = name.slice(dot + 1).toLowerCase();
+  return supportedFiles[ext] === true || EXTRA_WATCH_EXTS.has(ext);
+}
+
+// Minimal covering set of directory targets: '' absorbs everything;
+// otherwise descendants of another member are dropped (segment-boundary
+// safe, so 'sub' never absorbs 'subX'). Order: shallowest first for
+// deterministic enqueueing.
+export function collapseTargets(targets) {
+  const list = [...targets];
+  if (list.includes('')) { return ['']; }
+  list.sort((a, b) => a.length - b.length || (a < b ? -1 : 1));
+  const kept = [];
+  for (const t of list) {
+    if (!kept.some((k) => t === k || t.startsWith(`${k}/`))) { kept.push(t); }
+  }
+  return kept;
+}
+
+// Debounce-until-quiet coalescer. Every add() re-arms the timer, so a
+// long busy burst (rsync, torrent) holds the flush off until the
+// library settles for waitMs; an active scan re-arms at 3× instead of
+// piling more scans behind it. Timers are unref'd — the watcher never
+// keeps the server process alive on its own.
+export class ScanCoalescer {
+  constructor({ waitMs, isScanActive, enqueueFull, enqueueSubtree }) {
+    this.waitMs = waitMs;
+    this.isScanActive = isScanActive;
+    this.enqueueFull = enqueueFull;
+    this.enqueueSubtree = enqueueSubtree;
+    this.pending = new Map(); // vpath -> Set(relDir)
+    this.timer = null;
+  }
+
+  add(vpath, relDir) {
+    let set = this.pending.get(vpath);
+    if (!set) { set = new Set(); this.pending.set(vpath, set); }
+    set.add(relDir);
+    this.arm(this.waitMs);
+  }
+
+  arm(ms) {
+    if (this.timer) { clearTimeout(this.timer); }
+    this.timer = setTimeout(() => this.flush(), ms);
+    if (this.timer.unref) { this.timer.unref(); }
+  }
+
+  flush() {
+    this.timer = null;
+    if (this.pending.size === 0) { return; }
+    if (this.isScanActive()) {
+      this.arm(this.waitMs * 3);
+      return;
+    }
+    for (const [vpath, targets] of this.pending) {
+      for (const target of collapseTargets(targets)) {
+        if (target === '') { this.enqueueFull(vpath); }
+        else { this.enqueueSubtree(vpath, target); }
+      }
+    }
+    this.pending.clear();
+  }
+
+  stop() {
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+    this.pending.clear();
+  }
+}
+
+// ── chokidar lifecycle ─────────────────────────────────────────────────
+// Module-level state, restart-idempotent like backupManager.init():
+// startLibraryWatchers always tears down first, so boot, reboot(), and
+// the admin toggle can all call it blindly.
+
+let watchers = [];
+let coalescer = null;
+
+export function isRunning() {
+  return watchers.length > 0;
+}
+
+// Per-event options come from live config so the admin dot-entry
+// toggles apply to the very next event; injectable for tests that run
+// without a booted config.
+function defaultEventOpts() {
+  return {
+    supportedFiles: config.program.supportedAudioFiles,
+    ignoreDotFiles: config.program.scanOptions.ignoreDotFiles === true,
+    ignoreDotFolders: config.program.scanOptions.ignoreDotFolders === true,
+  };
+}
+
+export function startLibraryWatchers({
+  libraries, waitSeconds, isScanActive, enqueueFull, enqueueSubtree,
+  getEventOpts = defaultEventOpts,
+}) {
+  stopLibraryWatchers();
+  coalescer = new ScanCoalescer({
+    waitMs: Math.max(1, waitSeconds) * 1000,
+    isScanActive, enqueueFull, enqueueSubtree,
+  });
+
+  for (const lib of libraries) {
+    const root = lib.root_path;
+    const name = lib.name;
+    let watcher;
+    try {
+      watcher = chokidar.watch(root, {
+        ignoreInitial: true,
+        followSymlinks: lib.follow_symlinks === 1,
+        // Don't fire while a file is still being written (torrents,
+        // rsync): wait for 2s of size stability first.
+        awaitWriteFinish: { stabilityThreshold: 2000, pollInterval: 200 },
+        // Prune only the HARDCODED blocklist here (static — never
+        // watch #recycle churn at all). The dot-entry rules are
+        // config-live, so they filter per-event instead, where the
+        // current flag values apply.
+        ignored: (p) => {
+          const rel = relFromRoot(root, p);
+          if (rel === null || rel === '') { return false; }
+          return rel.split('/').some((seg) => isIgnoredDirName(seg));
+        },
+      });
+    } catch (err) {
+      winston.warn(`Library watcher failed to start for '${name}': ${err.message}`);
+      continue;
+    }
+
+    const onEvent = (isDirEvent, isDeletion) => (absPath) => {
+      const rel = relFromRoot(root, absPath);
+      if (!eventLooksRelevant(rel, isDirEvent, getEventOpts())) { return; }
+      let target = isDirEvent ? rel : parentRel(rel);
+      if (isDeletion) { target = walkUpToExisting(root, target); }
+      coalescer.add(name, target);
+    };
+
+    watcher.on('add', onEvent(false, false));
+    watcher.on('change', onEvent(false, false));
+    watcher.on('unlink', onEvent(false, true));
+    watcher.on('addDir', onEvent(true, false));
+    watcher.on('unlinkDir', onEvent(true, true));
+    // EMFILE/inotify-limit and permission errors land here; the watcher
+    // degrades to "quiet" and the scanInterval loop still covers the
+    // library. Warn so the operator can raise fs.inotify.max_user_watches
+    // or exclude the library rather than wonder why events stopped.
+    watcher.on('error', (err) => {
+      winston.warn(`Library watcher error for '${name}': ${err.message}`);
+    });
+
+    watchers.push(watcher);
+    winston.info(`Library watcher started for '${name}' (${root})`);
+  }
+}
+
+export function stopLibraryWatchers() {
+  for (const w of watchers) {
+    try { w.close(); } catch (_e) { /* already dead */ }
+  }
+  if (watchers.length > 0) { winston.info('Library watchers stopped'); }
+  watchers = [];
+  if (coalescer) { coalescer.stop(); coalescer = null; }
+}

--- a/src/util/library-watcher.js
+++ b/src/util/library-watcher.js
@@ -194,8 +194,16 @@ export function startLibraryWatchers({
   });
 
   for (const lib of libraries) {
-    const root = lib.root_path;
+    // Long-form real path, not the configured string: on Windows a root
+    // containing an 8.3 short name (RUNNER~1, PROGRA~1) trips a NATIVE
+    // libuv assert in fs-event.c when events come back long-form —
+    // aborting the whole server process, uncatchable from JS. realpath
+    // (native) expands short names and resolves symlinks; fall back to
+    // the raw path when it fails (root momentarily unavailable) and let
+    // the error handler below report whatever chokidar hits.
     const name = lib.name;
+    let root = lib.root_path;
+    try { root = fs.realpathSync.native(root); } catch (_e) { /* keep raw */ }
     let watcher;
     try {
       watcher = chokidar.watch(root, {

--- a/test/integration/admin-scan-params.test.mjs
+++ b/test/integration/admin-scan-params.test.mjs
@@ -197,6 +197,40 @@ describe('dot-entry ignore params', () => {
   }
 });
 
+// ── POST /db/params/watcher-enabled (filesystem watcher toggle) ───────────
+//
+// Same four-part pattern. The happy-path flip exercises the LIVE side
+// effect too: enabling starts real chokidar watchers on the fixture
+// library inside the test server, disabling stops them — both harmless
+// (watchers only enqueue scans, and the fixture stays quiet).
+
+describe('filesystem watcher params', () => {
+  test('GET includes the defaults (disabled, 10s wait)', async () => {
+    const body = await (await adminGet('/api/v1/admin/db/params')).json();
+    assert.equal(body.watcherEnabled, false, 'watcherEnabled default is false (opt-in)');
+    assert.equal(body.watcherWait, 10);
+  });
+
+  test('watcher-enabled: flips + reflects; rejects junk; 405 non-admin', async () => {
+    const r1 = await adminPost('/api/v1/admin/db/params/watcher-enabled',
+      { watcherEnabled: true });
+    assert.equal(r1.status, 200);
+    assert.deepEqual(await r1.json(), {}, 'happy-path response is the empty object {}');
+    assert.equal((await (await adminGet('/api/v1/admin/db/params')).json()).watcherEnabled, true);
+
+    // Restore the default (also stops the watchers the flip started).
+    await adminPost('/api/v1/admin/db/params/watcher-enabled', { watcherEnabled: false });
+    assert.equal((await (await adminGet('/api/v1/admin/db/params')).json()).watcherEnabled, false);
+
+    for (const bad of [{ watcherEnabled: 'yes' }, { watcherEnabled: 1 }, { watcherEnabled: null }, {}]) {
+      const r = await adminPost('/api/v1/admin/db/params/watcher-enabled', bad);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
+    }
+    assert.equal((await adminPost('/api/v1/admin/db/params/watcher-enabled',
+      { watcherEnabled: true }, userJwt)).status, 405);
+  });
+});
+
 // ── POST /db/params/auto-album-art-* (the downloader's config family) ──────
 //
 // Same four-part pattern as analyze-bpm above: GET defaults, happy-path

--- a/test/unit/library-watcher.test.mjs
+++ b/test/unit/library-watcher.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * Library watcher — pure mapping/coalescing logic + one real-chokidar
+ * round trip.
+ *
+ * The watcher only ever ENQUEUES scans, so these tests pin the decision
+ * layer: which events count (scan-ignore rules + watched extensions),
+ * which directory a scan targets (files → parent; deletions walk up to
+ * the nearest surviving ancestor), how bursts coalesce (debounce until
+ * quiet, 3× back-off while a scan runs), and how nested targets collapse
+ * (segment-boundary safe, '' absorbs all). Timer behaviour runs under
+ * node:test mock timers — deterministic on every CI runner.
+ *
+ * The single integration test drives real chokidar over a temp dir with
+ * an injected enqueue, because watch backends differ per OS; it uses a
+ * directory event (not gated by awaitWriteFinish) and a generous
+ * timeout to stay CI-safe.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  relFromRoot, parentRel, walkUpToExisting, eventLooksRelevant,
+  collapseTargets, ScanCoalescer, startLibraryWatchers, stopLibraryWatchers,
+} from '../../src/util/library-watcher.js';
+
+const AUDIO = { mp3: true, flac: true };
+
+describe('event → target mapping', () => {
+  test('relFromRoot normalises separators and rejects escapes', () => {
+    assert.equal(relFromRoot('C:\\lib', 'C:\\lib\\Artist\\a.mp3'), 'Artist/a.mp3');
+    assert.equal(relFromRoot('/lib', '/lib'), '');
+    assert.equal(relFromRoot('/lib', '/outside/a.mp3'), null);
+  });
+
+  test('parentRel maps files to their directory', () => {
+    assert.equal(parentRel('Artist/Album/a.mp3'), 'Artist/Album');
+    assert.equal(parentRel('a.mp3'), '');
+  });
+
+  test('walkUpToExisting climbs to the nearest surviving ancestor', () => {
+    const alive = new Set(['/lib', path.join('/lib', 'Artist')]);
+    const isDir = (p) => alive.has(p);
+    assert.equal(walkUpToExisting('/lib', 'Artist/Album/Disc', isDir), 'Artist');
+    assert.equal(walkUpToExisting('/lib', 'Gone/Deeper', isDir), '');
+    assert.equal(walkUpToExisting('/lib', 'Artist', isDir), 'Artist');
+  });
+
+  test('eventLooksRelevant: extensions, blocklist, and LIVE dot flags', () => {
+    const base = { supportedFiles: AUDIO };
+    assert.equal(eventLooksRelevant('Artist/a.mp3', false, base), true);
+    assert.equal(eventLooksRelevant('Artist/cover.jpg', false, base), true,
+      'folder art counts');
+    assert.equal(eventLooksRelevant('Artist/a.lrc', false, base), true,
+      'lyric sidecars count');
+    assert.equal(eventLooksRelevant('Artist/notes.pdf', false, base), false);
+    assert.equal(eventLooksRelevant('#recycle/junk.mp3', false, base), false,
+      'blocklist always ignored');
+    assert.equal(eventLooksRelevant('.hidden.mp3', false, base), true,
+      'dot files count while the flag is off');
+    assert.equal(eventLooksRelevant('.hidden.mp3', false,
+      { ...base, ignoreDotFiles: true }), false);
+    assert.equal(eventLooksRelevant('.hiddendir', true,
+      { ...base, ignoreDotFolders: true }), false,
+      'dir events use the FOLDER rule for their own name');
+    assert.equal(eventLooksRelevant('.hiddendir', true,
+      { ...base, ignoreDotFiles: true, ignoreDotFolders: false }), true,
+      'a dot DIR is not governed by the file flag');
+    assert.equal(eventLooksRelevant('..WeirdAlbum', true, base), true);
+    assert.equal(eventLooksRelevant('', true, base), true, 'library root');
+  });
+
+  test('collapseTargets: root absorbs, descendants fold, boundaries hold', () => {
+    assert.deepEqual(collapseTargets(new Set(['a/b', '', 'c'])), ['']);
+    assert.deepEqual(collapseTargets(new Set(['a/b/c', 'a/b', 'a/b/d'])), ['a/b']);
+    assert.deepEqual(collapseTargets(new Set(['sub', 'subX'])), ['sub', 'subX'],
+      "'sub' must not absorb 'subX'");
+  });
+});
+
+describe('ScanCoalescer (mock timers)', () => {
+  function makeCoalescer(t, { active = () => false, waitMs = 1000 } = {}) {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const full = [];
+    const sub = [];
+    const c = new ScanCoalescer({
+      waitMs, isScanActive: active,
+      enqueueFull: (v) => full.push(v),
+      enqueueSubtree: (v, s) => sub.push([v, s]),
+    });
+    return { c, full, sub };
+  }
+
+  test('debounce-until-quiet: every add re-arms the timer', (t) => {
+    const { c, sub } = makeCoalescer(t);
+    c.add('music', 'a');
+    t.mock.timers.tick(900);
+    c.add('music', 'b');          // re-arms — old deadline must NOT fire
+    t.mock.timers.tick(900);
+    assert.equal(sub.length, 0, 'still within the re-armed window');
+    t.mock.timers.tick(100);
+    assert.deepEqual(sub, [['music', 'a'], ['music', 'b']]);
+  });
+
+  test('an active scan re-arms at 3× instead of enqueueing', (t) => {
+    let scanning = true;
+    const { c, sub } = makeCoalescer(t, { active: () => scanning });
+    c.add('music', 'a');
+    t.mock.timers.tick(1000);     // fires into the active scan → back-off
+    assert.equal(sub.length, 0);
+    scanning = false;
+    t.mock.timers.tick(2999);
+    assert.equal(sub.length, 0, '3× back-off window still open');
+    t.mock.timers.tick(1);
+    assert.deepEqual(sub, [['music', 'a']]);
+  });
+
+  test('flush collapses targets and routes root to a full scan', (t) => {
+    const { c, full, sub } = makeCoalescer(t);
+    c.add('music', 'a/b');
+    c.add('music', 'a/b/c');
+    c.add('other', '');
+    c.add('other', 'x');
+    t.mock.timers.tick(1000);
+    assert.deepEqual(sub, [['music', 'a/b']]);
+    assert.deepEqual(full, ['other']);
+  });
+
+  test('stop() drops pending work and timers', (t) => {
+    const { c, sub } = makeCoalescer(t);
+    c.add('music', 'a');
+    c.stop();
+    t.mock.timers.tick(10_000);
+    assert.equal(sub.length, 0);
+  });
+});
+
+describe('chokidar round trip', () => {
+  test('a created directory enqueues a subtree scan after the quiet window', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-watch-'));
+    const enqueued = [];
+    try {
+      startLibraryWatchers({
+        libraries: [{ name: 'watched', root_path: root, follow_symlinks: 0 }],
+        waitSeconds: 1,
+        isScanActive: () => false,
+        enqueueFull: (v) => enqueued.push([v, '']),
+        enqueueSubtree: (v, s) => enqueued.push([v, s]),
+        getEventOpts: () => ({ supportedFiles: AUDIO }),
+      });
+      // chokidar needs a beat to install platform watchers before events count.
+      await new Promise((r) => setTimeout(r, 1500));
+      await fsp.mkdir(path.join(root, 'NewAlbum'));
+
+      const deadline = Date.now() + 30_000;
+      while (enqueued.length === 0 && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      assert.deepEqual(enqueued[0], ['watched', 'NewAlbum'],
+        'the new directory becomes a targeted subtree scan');
+    } finally {
+      stopLibraryWatchers();
+      await fsp.rm(root, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+});

--- a/test/unit/library-watcher.test.mjs
+++ b/test/unit/library-watcher.test.mjs
@@ -30,9 +30,17 @@ const AUDIO = { mp3: true, flac: true };
 
 describe('event → target mapping', () => {
   test('relFromRoot normalises separators and rejects escapes', () => {
-    assert.equal(relFromRoot('C:\\lib', 'C:\\lib\\Artist\\a.mp3'), 'Artist/a.mp3');
-    assert.equal(relFromRoot('/lib', '/lib'), '');
-    assert.equal(relFromRoot('/lib', '/outside/a.mp3'), null);
+    // Separator semantics are platform-owned (backslash is a plain name
+    // character on POSIX), so each platform asserts its native form.
+    if (process.platform === 'win32') {
+      assert.equal(relFromRoot('C:\\lib', 'C:\\lib\\Artist\\a.mp3'), 'Artist/a.mp3');
+      assert.equal(relFromRoot('C:\\lib', 'C:\\lib'), '');
+      assert.equal(relFromRoot('C:\\lib', 'C:\\outside\\a.mp3'), null);
+    } else {
+      assert.equal(relFromRoot('/lib', '/lib/Artist/a.mp3'), 'Artist/a.mp3');
+      assert.equal(relFromRoot('/lib', '/lib'), '');
+      assert.equal(relFromRoot('/lib', '/outside/a.mp3'), null);
+    }
   });
 
   test('parentRel maps files to their directory', () => {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -1986,6 +1986,12 @@ const dbView = Vue.component('db-view', {
                       </td>
                     </tr>
                     <tr>
+                      <td><b>Watch libraries for changes (instant scans, local disks):</b> {{dbParams.watcherEnabled}}</td>
+                      <td>
+                        [<a v-on:click="toggleWatcherEnabled()">{{ t('admin.settings.edit') }}</a>]
+                      </td>
+                    </tr>
+                    <tr>
                       <td><b>Tracks identified per AcoustID pass:</b> {{dbParams.acoustidPerRun}}</td>
                       <td>
                         [<a v-on:click="openModal('edit-acoustid-per-run-modal')">{{ t('admin.settings.edit') }}</a>]
@@ -2502,6 +2508,51 @@ const dbView = Vue.component('db-view', {
     },
     toggleIgnoreDotFolders: function() {
       this.toggleIgnoreDot('ignoreDotFolders', 'ignore-dot-folders', 'folders');
+    },
+    // Filesystem-watcher toggle. Live: the server starts/stops the
+    // watchers on POST — no reboot. Same confirm-toast pattern as the
+    // other boolean scan params.
+    toggleWatcherEnabled: function() {
+      iziToast.question({
+        timeout: 20000,
+        close: false,
+        overlayClose: true,
+        overlay: true,
+        displayMode: 'once',
+        id: 'question',
+        zindex: 99999,
+        layout: 2,
+        maxWidth: 600,
+        title: `<b>${this.dbParams.watcherEnabled === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')} watching libraries for changes?</b>`,
+        message: 'Changed files trigger a targeted scan within seconds. Network mounts (NAS shares) usually emit no change events — the scheduled scan interval still covers those.',
+        position: 'center',
+        buttons: [
+          [`<button><b>${this.dbParams.watcherEnabled === true ? t('admin.settings.disableButton') : t('admin.settings.enableButton')}</b></button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+            API.axios({
+              method: 'POST',
+              url: `${API.url()}/api/v1/admin/db/params/watcher-enabled`,
+              data: { watcherEnabled: !this.dbParams.watcherEnabled }
+            }).then(() => {
+              Vue.set(ADMINDATA.dbParams, 'watcherEnabled', !this.dbParams.watcherEnabled);
+              iziToast.success({
+                title: t('admin.settings.updated'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            }).catch(() => {
+              iziToast.error({
+                title: t('admin.settings.failed'),
+                position: 'topCenter',
+                timeout: 3500
+              });
+            });
+          }, true],
+          [`<button>${t('admin.folders.goBack')}</button>`, (instance, toast) => {
+            instance.hide({ transitionOut: 'fadeOut' }, toast, 'button');
+          }],
+        ]
+      });
     },
     toggleAnalyzeAcoustid: function() {
       iziToast.question({


### PR DESCRIPTION
## What

Watches each library root (chokidar) and turns filesystem events into **targeted scans through the existing machinery** — the watcher never touches the index itself, it only enqueues through the same task-queue dedup every other trigger uses, so a missed or duplicated event can never corrupt anything. Worst case is a redundant subtree scan or falling back to the interval scan.

Control loop (modeled on Navidrome's watcher):

- **Relevance filter**: scan-ignore rules (blocklist + LIVE dot-entry flags) plus watched extensions — configured audio formats, folder art (jpg/jpeg/png), lyric sidecars (lrc/txt).
- **Target mapping**: file events → parent directory; deletion events walk UP to the nearest still-existing ancestor; the library root itself degrades to a full vpath scan.
- **Coalescing**: per-vpath pending set, debounced until the library is QUIET for `watcherWait` seconds (default 10 — a torrent writing 200 files becomes one subtree scan), re-armed at 3× while a scan is already running. `awaitWriteFinish` (2s stability) keeps half-written files from triggering.
- **Flush**: nested targets collapse to their shallowest ancestor (segment-boundary safe) → `addSubtreeScanTask`, whose scoped sweep (#757) makes deletions land too.

**Default OFF** (`scanOptions.watcherEnabled`): most CIFS/NFS mounts emit no change events, so the `scanInterval` loop remains the delivery mechanism there — the watcher is an accelerator for local disks, never a replacement. Live admin toggle (persist + start/stop in-process, no reboot) + admin-panel row; directory add/remove re-syncs the watched set; boot/`reboot()` evaluate the flag idempotently. Watcher errors (inotify limits, permissions) degrade to a warn + quiet watcher, never a crash.

## Tests

- `test/unit/library-watcher.test.mjs`: pure mapping/coalescing logic (relevance incl. live flag semantics, walk-up, segment-boundary collapse) + ScanCoalescer under node:test **mock timers** (debounce re-arm, 3× active-scan back-off) + one real-chokidar round trip over a temp dir (10/10).
- `admin-scan-params` gains the four-part coverage for `watcher-enabled` — the happy-path flip exercises the real start/stop side effect inside the booted test server (22/22).
- Torrent completion-watcher suites green (33/33) — the other subtree-scan producer.

## Live smoke (real server)

Enabled the watcher via the admin endpoint on a running instance, then **without any manual scan trigger**: dropped a new file → auto-indexed in **12s**; deleted it → auto-converged in **10s**. The scan log shows `(1 scanned)` / `(0 scanned)` — the watcher-fired scans visited only the affected subtree, and the deletion line composed all three scanner PRs: scoped sweep removed the row, move re-homing paired its byte-identical twin.

## Notes

- New dependency: `chokidar` ^4.0.3 (v4 — no glob engine; recursive watching that works on the 3-OS matrix; Node's bare fs.watch recursive is newer on Linux and leaks watch descriptors on large trees).
- `watcherWait` is config-file-only for now (applied when watchers (re)start); the admin UI gets the boolean toggle.
- No schema changes; scanners untouched (no parity impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)