### PR TITLE
fix(federation): register connections before the handshake OK is sent

### DIFF
--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -127,7 +127,12 @@ function recordHandshakeFailure(remote) {
 
 // First bi-stream carries the raw key. Look it up, enforce/establish the TOFU
 // binding, reply OK/NO. Returns the key row on success, null otherwise.
-async function authenticateConnection(conn, remote) {
+// `onAuthorized` runs BEFORE the OK byte is flushed: the caller registers
+// the connection in the live-conns map there, so a peer that has been told
+// OK is already severable by closeConnectionsForKey — with registration
+// after the reply, an admin revoking the key (or anything else acting on
+// the client-visible OK) races the registry update and severs nothing.
+async function authenticateConnection(conn, remote, onAuthorized) {
   const authBi = await conn.acceptBi();
   const sent = Buffer.from(await authBi.recv.readToEnd(HANDSHAKE_LIMIT)).toString('utf8');
 
@@ -153,6 +158,11 @@ async function authenticateConnection(conn, remote) {
       winston.warn(`[federation] rejected key '${keyRow.name}' from ${remote}: bound to ${keyRow.bound_endpoint_id} (possible leaked ticket)`);
     }
   }
+
+  // Registry first, reply second (see the contract above). The write
+  // failure below is swallowed, so ok ⇒ keyRow is returned ⇒ the caller's
+  // untrack pairing in its finally still holds on every path.
+  if (ok && onAuthorized) { onAuthorized(keyRow); }
 
   try {
     await authBi.send.writeAll(Array.from(Buffer.from(ok ? 'OK' : 'NO')));
@@ -220,14 +230,17 @@ async function runAcceptLoop(targetHost, targetPort) {
           try { conn.close(1n, Array.from(Buffer.from('backoff'))); } catch (_err) { /* noop */ }
           return;
         }
-        const keyRow = await authenticateConnection(conn, remote);
+        // Tracking happens inside the handshake, before the peer hears OK
+        // (see authenticateConnection's contract); a null return means the
+        // callback never ran, so the failure path has nothing to untrack.
+        const keyRow = await authenticateConnection(conn, remote,
+          (row) => trackConn(row.id, conn));
         if (!keyRow) {
           recordHandshakeFailure(remote);
           try { conn.close(1n, Array.from(Buffer.from('unauthorized'))); } catch (_err) { /* noop */ }
           return;
         }
         failedHandshakes.delete(remote);
-        trackConn(keyRow.id, conn);
         winston.info(`[federation] peer connection authorized: key '${keyRow.name}' from ${remote}`);
         try {
           await acceptConnection(conn, targetHost, targetPort);


### PR DESCRIPTION
## What

`authenticateConnection` wrote the `OK` byte to the dialer and only **then** did the accept loop add the connection to the live-conns registry — several event-loop hops later. Anything acting on the client-visible OK could race that window:

- a real admin revoking a key mid-handshake severed nothing (`closeConnectionsForKey` returned 0 and the revoked peer's tunnel kept coasting);
- the handshake test failed intermittently on slow CI runners for exactly this reason (macos leg on #757, ubuntu leg on #758 — `AssertionError 0 !== 1`).

Registration now happens via an `onAuthorized` callback invoked **before** the reply is flushed, so "peer heard OK" strictly happens-after "severable". Path analysis is in the code comments: the reply-write failure stays swallowed, so `ok` ⇒ the row is returned ⇒ the caller's finally-untrack pairing holds on every path, and the null-return failure path never ran the callback, so it has nothing to untrack.

**No test changes** — the existing assertion is now legitimately deterministic rather than lucky.

## Verification

- `federation-handshake` integration suite: **20/20 repeat runs** locally (previously intermittent), plus a clean single run of all 5 tests including the severed-pipe follow-up assertion.
- Full federation family green: federation-auth / federation-config / federation-ticket / iroh-config / iroh-envelope / iroh-ticket / db-v57-federation (35/35).
- Lint identical to master.

## Note

The unpushed federation-v2 stack (worktree `eager-euclid-419603`) reworks this area; this fix is deliberately surgical (one callback parameter, 16 lines) so it rebases or re-applies trivially there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)