### PR TITLE
feat(scanner): link new folder art beside fast-pathed tracks

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -1749,6 +1749,13 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
     // verify-absence check finds the file on disk and keeps them — same
     // outcome as the old unstamped-row path, warning included.
     let mut seen_ids: HashSet<i64> = HashSet::with_capacity(existing_tracks.len());
+    // Rel directories (fwd slash, '' = library root) whose tracks rode the
+    // mtime fast-path this scan. Folder-art discovery only runs while a
+    // track is (re)parsed, so a NEW cover.jpg dropped beside unchanged
+    // audio was invisible to normal scans forever — link_folder_art_drift
+    // reconciles exactly these directories after the walk. (Re)parsed
+    // tracks already link art inline in commit_track.
+    let mut fastpath_dirs: HashSet<String> = HashSet::new();
     // Commit cadence: doubles as progress-update cadence and write-lock release.
     // Lower = more responsive API writes during scans but more COMMIT/BEGIN overhead.
     // Admin-configurable via scanCommitInterval; default (25) is a balanced starting point.
@@ -1804,6 +1811,13 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                     // A no-op rescan on this path never takes the writer
                     // lock except for the periodic progress updates below.
                     seen_ids.insert(existing_id);
+                    if let Ok(rel) = entry.path().strip_prefix(&config.directory) {
+                        let rel = rel.to_string_lossy().replace('\\', "/");
+                        fastpath_dirs.insert(match rel.rfind('/') {
+                            Some(i) => rel[..i].to_string(),
+                            None => String::new(),
+                        });
+                    }
                 }
                 ExtractResult::Extracted(et) => {
                     // Tight per-song transaction around just the DB write.
@@ -2017,6 +2031,10 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
                             // rescan, one row rewrite + index maintenance
                             // per unchanged file through the WAL writer.)
                             seen_ids.insert(existing_id);
+                            fastpath_dirs.insert(match rel.rfind('/') {
+                                Some(i) => rel[..i].to_string(),
+                                None => String::new(),
+                            });
                         }
                         Ok(ExtractResult::Extracted(et)) => {
                             // First write of this batch opens its
@@ -2215,7 +2233,7 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             config.directory, existing_tracks.len(),
         );
         println!(
-            "{{\"event\":\"scanComplete\",\"filesProcessed\":0,\"filesUnchanged\":0,\"filesScanned\":0,\"staleEntriesRemoved\":0,\"movedTracksRehomed\":0,\"movedRefsRehomed\":0}}"
+            "{{\"event\":\"scanComplete\",\"filesProcessed\":0,\"filesUnchanged\":0,\"filesScanned\":0,\"staleEntriesRemoved\":0,\"movedTracksRehomed\":0,\"movedRefsRehomed\":0,\"folderArtLinked\":0}}"
         );
         return Ok(());
     }
@@ -2234,6 +2252,16 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             SCHEMA_GUARD_ERROR_PREFIX, schema_version_at_open, schema_version_now,
         ).into());
     }
+
+    // Folder-art drift: NEW images beside fast-pathed tracks (a dropped
+    // cover.jpg) get their reference rows / junctions / NULL-default
+    // fills now — parse-time capture never sees these directories.
+    // Behind the schema guard like every other post-walk write; runs in
+    // subtree mode too (the dir set is scoped by the walk).
+    let folder_art_linked = link_folder_art_drift(
+        &conn, config, &dir_art_cache, &known_ref_hashes,
+        &existing_tracks, &fastpath_dirs,
+    )?;
 
     // Remove tracks not seen in this scan (deleted files). In subtree
     // mode the candidate snapshot is scoped to the subtree prefix
@@ -2436,9 +2464,9 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
         .saturating_sub(file_count)
         .saturating_sub(error_count);
     println!(
-        "{{\"event\":\"scanComplete\",\"filesProcessed\":{},\"filesUnchanged\":{},\"filesScanned\":{},\"staleEntriesRemoved\":{},\"movedTracksRehomed\":{},\"movedRefsRehomed\":{},\"walkErrors\":{}}}",
+        "{{\"event\":\"scanComplete\",\"filesProcessed\":{},\"filesUnchanged\":{},\"filesScanned\":{},\"staleEntriesRemoved\":{},\"movedTracksRehomed\":{},\"movedRefsRehomed\":{},\"folderArtLinked\":{},\"walkErrors\":{}}}",
         file_count, unchanged, total_processed, sweep.deleted, sweep.moved_tracks,
-        sweep.moved_refs, walk_errors
+        sweep.moved_refs, folder_art_linked, walk_errors
     );
     Ok(())
 }
@@ -5196,6 +5224,176 @@ fn normalize_pic_type(pt: PictureType) -> Option<&'static str> {
 // art). Same per-directory single-init concurrency story as the old
 // directory-art cache: the map lock is held only for the entry lookup, never
 // across I/O.
+// Folder-art drift: link NEW folder images that appeared in directories
+// whose tracks all rode the mtime fast-path. Art capture normally runs
+// only while a track is (re)parsed, so a cover.jpg dropped beside
+// unchanged audio was never picked up by ordinary scans (the reap half
+// of that asymmetry — deleted images — is cleanup_stale_art's job).
+//
+// Scope is deliberately ADD-only and NEW-only: an image whose rel_path
+// the scan-start reference snapshot already knows was linked when its
+// tracks last (re)parsed, and re-linking could resurrect state a later
+// user action removed. Per new image, mirror commit_track's linking:
+// a reference art_files row + track_art/album_art junctions (source
+// 'folder') for every direct-child track and its album. When a track
+// has NO default at all and the dir's first sorted image is one of the
+// new ones, mirror the parse-time election too: cache it (defaults are
+// always cache files), thumbnail it, and fill album_art_file/source on
+// tracks and albums under the same fill-NULL-only guards the parse
+// uses. Runs inside one short transaction per scan; every statement is
+// the same idempotent INSERT OR IGNORE / guarded UPDATE shape the
+// parse path uses, so a re-run heals rather than duplicates. Returns
+// the number of newly linked images. Mirrors linkFolderArtDrift in
+// src/db/scanner.mjs.
+fn link_folder_art_drift(
+    conn: &Connection,
+    config: &ScanConfig,
+    dir_art_cache: &Mutex<HashMap<String, Arc<OnceLock<Arc<Vec<FolderImage>>>>>>,
+    known_ref_hashes: &HashMap<String, Option<String>>,
+    existing_tracks: &HashMap<String, ExistingTrack>,
+    fastpath_dirs: &HashSet<String>,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    if config.skip_img || fastpath_dirs.is_empty() { return Ok(0); }
+
+    let mut dirs: Vec<&String> = fastpath_dirs.iter().collect();
+    dirs.sort(); // deterministic processing order across runs/engines
+
+    let mut linked = 0usize;
+    let mut txn_open = false;
+    for rel_dir in dirs {
+        let abs_dir = if rel_dir.is_empty() {
+            PathBuf::from(&config.directory)
+        } else {
+            Path::new(&config.directory).join(rel_dir.as_str())
+        };
+        let imgs = list_folder_images_dir(&abs_dir, config, dir_art_cache, known_ref_hashes);
+        let new_rel: HashSet<&str> = imgs.iter()
+            .filter(|fi| !known_ref_hashes.contains_key(&fi.rel_path))
+            .map(|fi| fi.rel_path.as_str())
+            .collect();
+        if new_rel.is_empty() { continue; }
+
+        // Direct children from the scan-start snapshot: fast-pathed rows
+        // are by definition unmodified, so its album/default columns are
+        // current. Sorted for deterministic junction ordering.
+        let mut tracks: Vec<(&String, &ExistingTrack)> = existing_tracks.iter()
+            .filter(|(path, _)| match path.rfind('/') {
+                Some(i) => &path[..i] == rel_dir.as_str(),
+                None => rel_dir.is_empty(),
+            })
+            .collect();
+        if tracks.is_empty() { continue; }
+        tracks.sort_by(|a, b| a.0.cmp(b.0));
+
+        // Parse-parity default election: only when a track has no default
+        // AND the dir's first sorted image is NEW. (NULL default alongside
+        // pre-existing folder art can't normally happen — parse would have
+        // elected it — so an old imgs[0] simply skips the fill.)
+        let needs_default = tracks.iter().any(|(_, t)| t.album_art_file.is_none());
+        let mut promoted: Option<(String, &FolderImage)> = None; // (cache_file, img)
+        if needs_default {
+            if let Some(fi) = imgs.first() {
+                if new_rel.contains(fi.rel_path.as_str()) {
+                    if let Ok(data) = fs::read(&fi.path) {
+                        if let Some((cf, _hash)) = cache_art_bytes(
+                            &data, &file_ext(&fi.path).to_ascii_lowercase(), config,
+                        ) {
+                            if config.compress_image {
+                                compress_album_art(&data, &cf, &config.album_art_directory);
+                            }
+                            promoted = Some((cf, fi));
+                        }
+                    }
+                }
+            }
+        }
+
+        if !txn_open {
+            conn.execute("BEGIN IMMEDIATE", [])?;
+            txn_open = true;
+        }
+
+        let mut ins_cached = conn.prepare_cached("INSERT OR IGNORE INTO art_files (kind, cache_file, content_hash, byte_size) VALUES ('cached', ?, ?, ?)")?;
+        let mut sel_cached = conn.prepare_cached("SELECT id FROM art_files WHERE kind = 'cached' AND cache_file = ?")?;
+        let mut ins_ref = conn.prepare_cached("INSERT OR IGNORE INTO art_files (kind, library_id, rel_path, content_hash, byte_size) VALUES ('reference', ?, ?, ?, ?)")?;
+        let mut sel_ref = conn.prepare_cached("SELECT id FROM art_files WHERE kind = 'reference' AND library_id = ? AND rel_path = ?")?;
+        let mut ins_ta = conn.prepare_cached("INSERT OR IGNORE INTO track_art (track_id, art_id, source, picture_type, position) VALUES (?, ?, 'folder', ?, ?)")?;
+        let mut ins_aa = conn.prepare_cached("INSERT OR IGNORE INTO album_art (album_id, art_id, source, picture_type, position) VALUES (?, ?, 'folder', ?, ?)")?;
+        let mut fill_track = conn.prepare_cached(
+            "UPDATE tracks SET album_art_file = ?, album_art_source = 'folder'
+              WHERE id = ? AND album_art_file IS NULL")?;
+        let mut fill_album = conn.prepare_cached(
+            "UPDATE albums SET album_art_file = ?, album_art_source = 'folder'
+              WHERE id = ? AND album_art_file IS NULL")?;
+
+        for (i, fi) in imgs.iter().enumerate() {
+            if !new_rel.contains(fi.rel_path.as_str()) { continue; }
+            // Every statement is an idempotent OR-IGNORE / guarded
+            // UPDATE, so `changed` counts REAL mutations only and a
+            // fully-converged dir reports zero.
+            let mut changed = 0usize;
+            // A promoted default lives as a CACHED row keyed by its
+            // content-addressed filename — it never enters the reference
+            // snapshot, so on later scans the same cover would otherwise
+            // be re-classified as new and minted a duplicate reference
+            // row. Election is stateless at parse time; here the cache
+            // probe is the stateless equivalent: bytes we already hold
+            // as a cached row are linked to that row, never re-added.
+            let cache_probe: Option<(String, i64)> = fi.content_hash.as_deref().map(|h| {
+                let cf = format!("{}.{}", h, file_ext(&fi.path).to_ascii_lowercase());
+                let id = sel_cached.query_row(rusqlite::params![cf], |r| r.get(0))
+                    .optional().unwrap_or(None);
+                (cf, id.unwrap_or(-1))
+            }).filter(|(_, id)| *id >= 0);
+            let is_promoted = matches!(&promoted, Some((_, p)) if p.rel_path == fi.rel_path);
+            let art_id: Option<i64> = if let Some((_, id)) = &cache_probe {
+                Some(*id)
+            } else if is_promoted {
+                let (cf, _) = promoted.as_ref().unwrap();
+                changed += ins_cached.execute(rusqlite::params![cf, fi.content_hash, fi.byte_size])?;
+                sel_cached.query_row(rusqlite::params![cf], |r| r.get(0)).optional()?
+            } else {
+                changed += ins_ref.execute(rusqlite::params![
+                    config.library_id, fi.rel_path, fi.content_hash, fi.byte_size])?;
+                sel_ref.query_row(
+                    rusqlite::params![config.library_id, fi.rel_path], |r| r.get(0)).optional()?
+            };
+            let Some(art_id) = art_id else { continue; };
+            // A cache hit also restores default-fill behaviour for
+            // tracks still missing one (same guarded no-op otherwise).
+            let fill_cf: Option<&str> = if let Some((cf, _)) = &cache_probe {
+                Some(cf.as_str())
+            } else if is_promoted {
+                promoted.as_ref().map(|(cf, _)| cf.as_str())
+            } else {
+                None
+            };
+            for (_, t) in &tracks {
+                changed += ins_ta.execute(rusqlite::params![t.id, art_id, fi.ptype, i as i64])?;
+                if let Some(aid) = t.album_id {
+                    changed += ins_aa.execute(rusqlite::params![aid, art_id, fi.ptype, i as i64])?;
+                }
+            }
+            if let Some(cf) = fill_cf {
+                for (_, t) in &tracks {
+                    changed += fill_track.execute(rusqlite::params![cf, t.id])?;
+                    if let Some(aid) = t.album_id {
+                        changed += fill_album.execute(rusqlite::params![cf, aid])?;
+                    }
+                }
+            }
+            if changed > 0 { linked += 1; }
+        }
+    }
+    if txn_open {
+        conn.execute("COMMIT", [])?;
+    }
+    if linked > 0 {
+        println!("Linked {} new folder image(s) beside unchanged tracks", linked);
+    }
+    Ok(linked)
+}
+
 fn list_folder_images(
     filepath: &Path,
     config: &ScanConfig,
@@ -5203,6 +5401,18 @@ fn list_folder_images(
     known_ref_hashes: &HashMap<String, Option<String>>,
 ) -> Arc<Vec<FolderImage>> {
     let Some(dir) = filepath.parent() else { return Arc::new(Vec::new()); };
+    list_folder_images_dir(dir, config, cache, known_ref_hashes)
+}
+
+// Directory-keyed core of list_folder_images — also used by the
+// folder-art drift pass, which starts from a directory rather than a
+// track path. Same cache, same ordering contract.
+fn list_folder_images_dir(
+    dir: &Path,
+    config: &ScanConfig,
+    cache: &Mutex<HashMap<String, Arc<OnceLock<Arc<Vec<FolderImage>>>>>>,
+    known_ref_hashes: &HashMap<String, Option<String>>,
+) -> Arc<Vec<FolderImage>> {
     let dir_key = dir.to_string_lossy().to_string();
     let cell = {
         let mut guard = cache.lock().unwrap();

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -566,6 +566,139 @@ function listFolderImages(absDir, relDir) {
   return imgs;
 }
 
+// Folder-art drift: link NEW folder images that appeared in directories
+// whose tracks all rode the mtime fast-path. Art capture normally runs
+// only while a track is (re)parsed, so a cover.jpg dropped beside
+// unchanged audio was never picked up by ordinary scans (the reap half
+// of that asymmetry — deleted images — is cleanupStaleArt's job).
+//
+// Scope is deliberately ADD-only and NEW-only: an image whose relPath
+// the scan-start reference snapshot (knownRefHashes) already knows was
+// linked when its tracks last (re)parsed, and re-linking could
+// resurrect state a later user action removed. Per new image, mirror
+// insertTrack's linking: a reference art_files row + track_art /
+// album_art junctions (source 'folder') for every direct-child track
+// and its album. When a track has NO default at all and the dir's
+// first sorted image is one of the new ones, mirror the parse-time
+// election too: cache it (defaults are always cache files), thumbnail
+// it, and fill album_art_file/source on tracks and albums under the
+// same fill-NULL-only guards the parse uses. One short transaction per
+// scan; every statement is the idempotent INSERT OR IGNORE / guarded
+// UPDATE shape the parse path uses, so a re-run heals rather than
+// duplicates. Returns the number of newly linked images. Mirrors
+// link_folder_art_drift in rust-parser/src/main.rs.
+async function linkFolderArtDrift(preScanRows) {
+  if (loadJson.skipImg === true || fastpathDirs.size === 0) { return 0; }
+  const dirs = [...fastpathDirs].sort();
+  const trackMeta = db.prepare('SELECT album_id, album_art_file FROM tracks WHERE id = ?');
+  const fillTrack = db.prepare(
+    "UPDATE tracks SET album_art_file = ?, album_art_source = 'folder' WHERE id = ? AND album_art_file IS NULL");
+
+  let linked = 0;
+  let txnOpen = false;
+  try {
+    for (const relDir of dirs) {
+      const absDir = relDir === '' ? loadJson.directory : path.join(loadJson.directory, relDir);
+      const imgs = listFolderImages(absDir, relDir);
+      if (!imgs.some((f) => !knownRefHashes.has(f.relPath))) { continue; }
+
+      // Direct children from the sweep snapshot (subtree-scoped when the
+      // scan is); album/default columns read fresh per id — fast-pathed
+      // rows are unmodified, so this is one cheap indexed probe each.
+      const tracks = [];
+      for (const r of preScanRows) {
+        const i = r.filepath.lastIndexOf('/');
+        const parent = i === -1 ? '' : r.filepath.slice(0, i);
+        if (parent !== relDir) { continue; }
+        const meta = trackMeta.get(r.id);
+        if (meta) {
+          tracks.push({ id: r.id, filepath: r.filepath, albumId: meta.album_id, aaFile: meta.album_art_file });
+        }
+      }
+      if (tracks.length === 0) { continue; }
+      tracks.sort((a, b) => (a.filepath < b.filepath ? -1 : a.filepath > b.filepath ? 1 : 0));
+
+      // Parse-parity default election: only when a track has no default
+      // AND the dir's first sorted image is NEW. (A NULL default
+      // alongside pre-existing folder art can't normally happen — the
+      // parse would have elected it — so an old imgs[0] skips the fill.)
+      const needsDefault = tracks.some((t) => t.aaFile === null);
+      const first = imgs[0];
+      let promoted = null; // { cacheFile, relPath }
+      if (needsDefault && first && !knownRefHashes.has(first.relPath)) {
+        try {
+          const buf = fs.readFileSync(path.join(absDir, first.fileName));
+          const hash = crypto.createHash('md5').update(buf).digest('hex');
+          const cacheFile = hash + '.' + getFileType(first.fileName).toLowerCase();
+          const p = path.join(loadJson.albumArtDirectory, cacheFile);
+          let ok = fs.existsSync(p);
+          if (!ok) { try { fs.writeFileSync(p, buf); ok = true; } catch (_e) { /* fall through */ } }
+          if (ok) {
+            if (loadJson.compressImage) { await compressAlbumArt(buf, cacheFile); }
+            promoted = { cacheFile, relPath: first.relPath };
+          }
+        } catch (_e) { /* read failure — no promotion; references still link */ }
+      }
+
+      if (!txnOpen) { db.exec('BEGIN IMMEDIATE'); txnOpen = true; }
+      for (let i = 0; i < imgs.length; i++) {
+        const f = imgs[i];
+        if (knownRefHashes.has(f.relPath)) { continue; }
+        // Every statement is an idempotent OR-IGNORE / guarded UPDATE,
+        // so `changed` counts REAL mutations only and a fully-converged
+        // dir reports zero.
+        let changed = 0;
+        // A promoted default lives as a CACHED row keyed by its
+        // content-addressed filename — it never enters the reference
+        // snapshot, so on later scans the same cover would otherwise be
+        // re-classified as new and minted a duplicate reference row.
+        // Election is stateless at parse time; here the cache probe is
+        // the stateless equivalent: bytes we already hold as a cached
+        // row are linked to that row, never re-added.
+        let cacheProbe = null; // { cacheFile, id }
+        if (f.contentHash) {
+          const cf = `${f.contentHash}.${getFileType(f.fileName).toLowerCase()}`;
+          const hit = stmts.findArtCached.get(cf);
+          if (hit) { cacheProbe = { cacheFile: cf, id: hit.id }; }
+        }
+        const isPromoted = promoted !== null && promoted.relPath === f.relPath;
+        let artId = null;
+        if (cacheProbe !== null) {
+          artId = cacheProbe.id;
+        } else if (isPromoted) {
+          changed += stmts.insertArtCached.run(promoted.cacheFile, f.contentHash, f.byteSize).changes;
+          artId = stmts.findArtCached.get(promoted.cacheFile)?.id ?? null;
+        } else {
+          changed += stmts.insertArtRef.run(loadJson.libraryId, f.relPath, f.contentHash, f.byteSize).changes;
+          artId = stmts.findArtRef.get(loadJson.libraryId, f.relPath)?.id ?? null;
+        }
+        if (artId === null) { continue; }
+        for (const t of tracks) {
+          changed += stmts.insertTrackArt.run(t.id, artId, 'folder', f.type, i).changes;
+          if (t.albumId !== null) { changed += stmts.insertAlbumArt.run(t.albumId, artId, 'folder', f.type, i).changes; }
+        }
+        // A cache hit also restores default-fill behaviour for tracks
+        // still missing one (same guarded no-op otherwise).
+        const fillCf = cacheProbe !== null ? cacheProbe.cacheFile
+          : (isPromoted ? promoted.cacheFile : null);
+        if (fillCf !== null) {
+          for (const t of tracks) {
+            changed += fillTrack.run(fillCf, t.id).changes;
+            if (t.albumId !== null) { changed += stmts.updateAlbumArt.run(fillCf, 'folder', t.albumId).changes; }
+          }
+        }
+        if (changed > 0) { linked++; }
+      }
+    }
+    if (txnOpen) { db.exec('COMMIT'); }
+  } catch (e) {
+    if (txnOpen) { try { db.exec('ROLLBACK'); } catch (_) {} }
+    throw e;
+  }
+  if (linked > 0) { console.log(`Linked ${linked} new folder image(s) beside unchanged tracks`); }
+  return linked;
+}
+
 async function getAlbumArt(songInfo) {
   songInfo.artList = [];
   songInfo.aaFile = undefined;
@@ -1057,6 +1190,13 @@ const COMMIT_INTERVAL = loadJson.scanCommitInterval || 25;
 // keeps them — same outcome as the old unstamped-row path, warning
 // included.
 const seenPaths = new Set();
+// Rel directories ('' = library root) whose tracks rode the mtime
+// fast-path this scan. Folder-art discovery only runs while a track is
+// (re)parsed, so a NEW cover.jpg dropped beside unchanged audio was
+// invisible to normal scans forever — linkFolderArtDrift reconciles
+// exactly these directories after the walk. Mirrors fastpath_dirs in
+// rust-parser/src/main.rs.
+const fastpathDirs = new Set();
 
 // Re-home hops recorded during the scan, replayed after the stale-track
 // sweep. The per-file hops run with doomed sibling rows (files deleted
@@ -1242,6 +1382,10 @@ async function processFile(filepath, fileMtime) {
       // sweep consults, so a no-op rescan never takes the writer lock
       // except for the periodic progress updates below.
       seenPaths.add(relativePath);
+      {
+        const di = relativePath.lastIndexOf('/');
+        fastpathDirs.add(di === -1 ? '' : relativePath.slice(0, di));
+      }
     } else {
       // New or modified file. Capture the prior identity before the slow
       // parse below — which runs with no transaction open, so a
@@ -1483,7 +1627,7 @@ async function run() {
         console.log(JSON.stringify({
           event: 'scanComplete',
           filesProcessed: 0, filesUnchanged: 0, filesScanned: 0, staleEntriesRemoved: 0,
-          movedTracksRehomed: 0, movedRefsRehomed: 0,
+          movedTracksRehomed: 0, movedRefsRehomed: 0, folderArtLinked: 0,
         }));
         return;
       }
@@ -1516,6 +1660,13 @@ async function run() {
         `Warning: ${walkErrors} directory enumeration error(s) during the walk — ` +
         'rows under the affected subtrees are shielded from this scan\'s cleanup');
     }
+
+    // Folder-art drift: NEW images beside fast-pathed tracks (a dropped
+    // cover.jpg) get their reference rows / junctions / NULL-default
+    // fills now — parse-time capture never sees these directories.
+    // Behind the schema guard like every other post-walk write; runs in
+    // subtree mode too (the dir set is scoped by the walk).
+    const folderArtLinked = await linkFolderArtDrift(preScanRows);
 
     // Remove tracks that weren't seen in this scan (deleted files).
     // In subtree mode the candidate snapshot was scoped to the subtree
@@ -1563,6 +1714,7 @@ async function run() {
       staleEntriesRemoved: sweep.removed,
       movedTracksRehomed: sweep.movedTracks,
       movedRefsRehomed: sweep.movedRefs,
+      folderArtLinked,
       // Subtrees the scan could not see (their rows were shielded from
       // cleanup) — surfaced so a permanently unreadable directory is
       // operator-visible in the scan summary, not just a stderr line.

--- a/test/scanner/scanner-folder-art-drift.test.mjs
+++ b/test/scanner/scanner-folder-art-drift.test.mjs
@@ -1,0 +1,201 @@
+/**
+ * Folder-art drift — both engines.
+ *
+ * Art capture normally runs only while a track is (re)parsed, and
+ * unchanged tracks ride the mtime fast-path — so a NEW cover.jpg
+ * dropped beside unchanged audio was never picked up by ordinary scans
+ * (only a force-rescan linked it; the watcher made that gap
+ * user-visible). The drift pass reconciles exactly those directories:
+ *
+ *   - a new image beside fully fast-pathed tracks links on the next
+ *     scan with filesProcessed staying 0 (the chip's core assertion):
+ *     art_files row + track_art/album_art junctions, and — when the
+ *     tracks had NO default at all — the parse-parity promotion to a
+ *     CACHED default (defaults are always cache files) with
+ *     album_art_file/source filled under the same NULL-only guards;
+ *   - tracks that already have an embedded default keep it: the new
+ *     image joins the set as a plain 'reference' row, defaults
+ *     untouched;
+ *   - the pass is idempotent (a third scan links nothing new);
+ *   - skipImg suppresses it, exactly like parse-time capture.
+ *
+ * Skipped (like scanner-parity.test.mjs) when ffmpeg or the rust
+ * binary is unavailable; a prebuilt binary predating the drift pass is
+ * feature-detected and skipped for the rust engine.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
+} from '../helpers/scanner-runner.mjs';
+import { makeAudio, makeAudioWithArt } from '../helpers/scanner-fixture.mjs';
+
+const MP3 = ['-c:a', 'libmp3lame', '-b:a', '64k', '-id3v2_version', '3'];
+// Minimal JPEG (SOI + APP0 + EOI): the scanners content-address and copy
+// bytes, they never decode (compressImage is off in the test config).
+const TINY_JPG = Buffer.from('ffd8ffe000104a46494600010100000100010000ffd9', 'hex');
+const TINY_JPG_MD5 = crypto.createHash('md5').update(TINY_JPG).digest('hex');
+// A second, distinct image for the reference-only scenario.
+const TINY_JPG2 = Buffer.concat([TINY_JPG.subarray(0, 4), Buffer.from([0x01]), TINY_JPG.subarray(4)]);
+
+let rustBin;
+let scratch;
+// null = probe not run; false = binary predates the drift pass.
+let rustHasDrift = null;
+
+before(async () => {
+  rustBin = findRustParser();
+  scratch = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-artdrift-'));
+
+  // Feature-detect a stale prebuilt binary: scan, drop an image, rescan —
+  // a pre-drift build reports no folderArtLinked field (or links nothing).
+  if (rustBin && fs.existsSync(FFMPEG)) {
+    const root = path.join(scratch, 'probe');
+    const libRoot = path.join(root, 'lib');
+    await makeAudio(path.join(libRoot, 'A', 'p.mp3'), MP3, { title: 'P' }, 1);
+    const dbPath = path.join(root, 'probe.db');
+    const { libraryId, vpath } = initEmptyDb(dbPath, libRoot);
+    const cfg = (scanId) => buildScanConfig({
+      dbPath, libraryId, vpath, directory: libRoot,
+      albumArtDirectory: path.join(root, 'art'),
+      waveformCacheDir: path.join(root, 'wave'), scanId,
+    });
+    await fsp.mkdir(path.join(root, 'art'), { recursive: true });
+    await runScan(rustBin, cfg('probe-1'));
+    await fsp.writeFile(path.join(libRoot, 'A', 'cover.jpg'), TINY_JPG);
+    const { event } = await runScan(rustBin, cfg('probe-2'));
+    rustHasDrift = event.folderArtLinked === 1;
+  }
+});
+
+after(async () => {
+  if (scratch) { await fsp.rm(scratch, { recursive: true, force: true }); }
+});
+
+let sandboxSeq = 0;
+async function makeSandbox(engine) {
+  const root = path.join(scratch, `sb${sandboxSeq++}-${engine}`);
+  const libRoot = path.join(root, 'lib');
+  const artDir = path.join(root, 'art');
+  await fsp.mkdir(libRoot, { recursive: true });
+  await fsp.mkdir(artDir, { recursive: true });
+  const dbPath = path.join(root, 'test.db');
+  const { libraryId, vpath } = initEmptyDb(dbPath, libRoot);
+  let scanSeq = 0;
+  const scan = (overrides = {}) => {
+    const config = buildScanConfig({
+      dbPath, libraryId, vpath, directory: libRoot,
+      albumArtDirectory: artDir, waveformCacheDir: path.join(root, 'wave'),
+      scanId: `scan-${scanSeq++}`, overrides,
+    });
+    return engine === 'js' ? runJsScan(config) : runScan(rustBin, config);
+  };
+  return { root, libRoot, artDir, dbPath, libraryId, scan };
+}
+
+function withDb(dbPath, fn) {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try { return fn(db); } finally { db.close(); }
+}
+const trackArtState = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT filepath, album_art_file, album_art_source FROM tracks ORDER BY filepath')
+    .all().map(r => ({ ...r })));
+const artRows = (dbPath) => withDb(dbPath, db =>
+  db.prepare('SELECT kind, cache_file, rel_path FROM art_files ORDER BY id').all().map(r => ({ ...r })));
+const junctionCounts = (dbPath) => withDb(dbPath, db => ({
+  trackArt: db.prepare("SELECT COUNT(*) AS n FROM track_art WHERE source = 'folder'").get().n,
+  albumArt: db.prepare("SELECT COUNT(*) AS n FROM album_art WHERE source = 'folder'").get().n,
+}));
+
+for (const engine of ['rust', 'js']) {
+  const engineAvailable = () =>
+    fs.existsSync(FFMPEG) && (engine === 'js' || (!!rustBin && rustHasDrift !== false));
+
+  describe(`folder-art drift (${engine} scanner)`, () => {
+    test('new cover beside fast-pathed tracks links with filesProcessed 0, promotes the NULL default', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'Artist', 'Album', 'one.mp3'), MP3,
+        { artist: 'Artist', album: 'Album', title: 'One' }, 1);
+      await makeAudio(path.join(sb.libRoot, 'Artist', 'Album', 'two.mp3'), MP3,
+        { artist: 'Artist', album: 'Album', title: 'Two' }, 2);
+      await sb.scan();
+      assert.ok(trackArtState(sb.dbPath).every(r => r.album_art_file === null),
+        'baseline: no art anywhere');
+
+      await fsp.writeFile(path.join(sb.libRoot, 'Artist', 'Album', 'cover.jpg'), TINY_JPG);
+      const { event } = await sb.scan();
+
+      assert.strictEqual(event.filesProcessed, 0, 'no audio was re-parsed');
+      assert.strictEqual(event.folderArtLinked, 1);
+      const expectCache = `${TINY_JPG_MD5}.jpg`;
+      assert.deepStrictEqual(trackArtState(sb.dbPath), [
+        { filepath: 'Artist/Album/one.mp3', album_art_file: expectCache, album_art_source: 'folder' },
+        { filepath: 'Artist/Album/two.mp3', album_art_file: expectCache, album_art_source: 'folder' },
+      ], 'both fast-pathed tracks gained the promoted default');
+      assert.deepStrictEqual(artRows(sb.dbPath),
+        [{ kind: 'cached', cache_file: expectCache, rel_path: null }],
+        'the promoted default is a CACHED art row (parse parity)');
+      assert.deepStrictEqual(junctionCounts(sb.dbPath), { trackArt: 2, albumArt: 1 });
+      assert.ok(fs.existsSync(path.join(sb.artDir, expectCache)),
+        'the cache copy exists on disk');
+      const album = withDb(sb.dbPath, db =>
+        db.prepare('SELECT album_art_file, album_art_source FROM albums').get());
+      assert.deepStrictEqual({ ...album },
+        { album_art_file: expectCache, album_art_source: 'folder' },
+        'the album default filled under the NULL-only guard');
+
+      // Idempotency: a third scan links nothing and changes nothing.
+      const { event: idle } = await sb.scan();
+      assert.strictEqual(idle.folderArtLinked, 0);
+      assert.strictEqual(idle.filesProcessed, 0);
+      assert.deepStrictEqual(junctionCounts(sb.dbPath), { trackArt: 2, albumArt: 1 });
+    });
+
+    test('tracks with an embedded default keep it; the new image joins as a reference', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudioWithArt(path.join(sb.libRoot, 'Band', 'Disc', 'song.mp3'), 'red',
+        { artist: 'Band', album: 'Disc', title: 'Song' });
+      await sb.scan();
+      const before = trackArtState(sb.dbPath);
+      assert.strictEqual(before[0].album_art_source, 'embedded', 'baseline: embedded default');
+
+      await fsp.writeFile(path.join(sb.libRoot, 'Band', 'Disc', 'extra.jpg'), TINY_JPG2);
+      const { event } = await sb.scan();
+
+      assert.strictEqual(event.filesProcessed, 0);
+      assert.strictEqual(event.folderArtLinked, 1);
+      assert.deepStrictEqual(trackArtState(sb.dbPath), before,
+        'the embedded default is untouched');
+      const refs = artRows(sb.dbPath).filter(r => r.kind === 'reference');
+      assert.deepStrictEqual(refs.map(r => r.rel_path), ['Band/Disc/extra.jpg'],
+        'the new image joined the set as a plain reference');
+    });
+
+    test('skipImg suppresses the drift pass; the next normal scan heals', async (t) => {
+      if (!engineAvailable()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const sb = await makeSandbox(engine);
+      await makeAudio(path.join(sb.libRoot, 'Q', 'q.mp3'), MP3, { title: 'Q' }, 3);
+      await sb.scan();
+
+      await fsp.writeFile(path.join(sb.libRoot, 'Q', 'cover.jpg'), TINY_JPG);
+      const { event: skipped } = await sb.scan({ skipImg: true });
+      assert.strictEqual(skipped.folderArtLinked, 0);
+      assert.ok(trackArtState(sb.dbPath).every(r => r.album_art_file === null),
+        'skipImg linked nothing');
+
+      const { event: healed } = await sb.scan();
+      assert.strictEqual(healed.folderArtLinked, 1);
+      assert.ok(trackArtState(sb.dbPath).every(r => r.album_art_file !== null),
+        'the next normal scan linked it');
+    });
+  });
+}


### PR DESCRIPTION
## What

Folder-art capture ran only while a track was being (re)parsed, and unchanged tracks ride the mtime fast-path — so a NEW `cover.jpg` dropped beside unchanged audio was **never picked up by ordinary scans** (only a force-rescan linked it). The filesystem watcher (#758) made the gap user-visible: it fires the correct targeted scan, which then reported `2 unchanged` and linked nothing.

Both scanners now run a **folder-art drift pass** after the walk, over exactly the directories whose tracks fast-pathed:

- NEW images (rel_path absent from the scan-start reference snapshot) get an `art_files` row + `track_art`/`album_art` junctions (source `folder`) for every direct-child track and its album;
- when tracks had NO default at all, the parse-parity promotion applies: the first sorted image is CACHED (content-addressed copy + thumbnails — defaults are always cache files, per the multi-art model) and `album_art_file`/`album_art_source` fill under the same NULL-only guards the parse uses;
- a **cache probe by content-addressed filename** keeps the pass stateless like parse-time election: bytes already held as a cached row (e.g. a previously promoted default) link to that row instead of minting a duplicate reference;
- **change-counting** makes the new `folderArtLinked` scanComplete counter report real mutations only — a converged dir reports zero (the dual-engine idempotency test caught both of these during development);
- `skipImg` suppresses the pass exactly like parse-time capture; subtree scans are scoped by their walk; one short transaction per scan, behind the mid-scan schema guard.

Scope is deliberately ADD-only and NEW-only — removed images stay `cleanupStaleArt`'s job, and images the snapshot already knows are never re-linked (that could resurrect deliberately removed state).

## Tests

New `test/scanner/scanner-folder-art-drift.test.mjs`, 3 scenarios × both engines (6/6): the chip's core case (drop cover beside fast-pathed tracks → links with **`filesProcessed` staying 0**, promoted CACHED default, album fill, cache file on disk, idempotent third scan), embedded-default preservation (new image joins as a plain reference), and skipImg suppression + heal. Regression battery green: multi-art, parity, star-survival, move-rehome, ignore-rules, subtree-sweep, schema-guard, orphan-cleanup (87/87). `cargo build --release` clean; no new lint findings.

## Live smoke

The exact scenario that exposed the gap, redeemed: watcher enabled on a live server, `cover.jpg` dropped beside unchanged tracks, **zero manual triggers** → `album_art_file` populated with the content-addressed cache name (`source: folder`) within seconds via watcher → targeted scan → drift pass.

Source-only; `bin/rust-parser` binaries rebuild via CI on master push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)