### PR TITLE
fix(search): stop indexing LRC timestamps as lyrics (V59 lyrics_search_text)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -591,8 +591,11 @@ components:
           nullable: true
           description: |
             The matching lyric excerpt from FTS5 `snippet()` (the
-            half-remembered line). `null` on the LIKE path (`basic`
-            algorithm), which has no snippet support.
+            half-remembered line). Plain text — LRC `[mm:ss.xx]` stamps
+            and header tags are stripped from the indexed rendition
+            (schema V59), so excerpts contain lyric words only. `null` on
+            the LIKE path (`basic` algorithm), which has no snippet
+            support.
 
     ScanOptions:
       type: object

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -618,11 +618,13 @@ fn main() {
         match extract_lyrics_for_cli(p) {
             Ok((embedded, synced, lang, sidecar_mtime)) => {
                 // Manual JSON serialisation (same reason as --audio-hash:
-                // one-line output, no serde dance). All four fields emit
-                // as `null` when absent so the consumer can JSON.parse
-                // and compare with ===.
+                // one-line output, no serde dance). All fields emit as
+                // `null` when absent so the consumer can JSON.parse and
+                // compare with ===. \t matters: raw tabs are control
+                // chars — invalid inside a JSON string literal — and
+                // real-world .lrc files do contain them.
                 let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"")
-                    .replace('\n', "\\n").replace('\r', "\\r");
+                    .replace('\n', "\\n").replace('\r', "\\r").replace('\t', "\\t");
                 let j = |v: &Option<String>| match v {
                     Some(s) => format!("\"{}\"", esc(s)),
                     None    => "null".to_string(),
@@ -631,8 +633,12 @@ fn main() {
                     Some(n) => format!("{}", n),
                     None    => "null".to_string(),
                 };
-                println!("{{\"lyricsEmbedded\":{},\"lyricsSyncedLrc\":{},\"lyricsLang\":{},\"lyricsSidecarMtime\":{}}}",
-                    j(&embedded), j(&synced), j(&lang), mtime_json);
+                // V59: also emit the derived search text so the parity test
+                // byte-compares lrc_to_search_text against the JS
+                // lrcToSearchText over the same fixture matrix.
+                let search_text = lrc_to_search_text(synced.as_deref());
+                println!("{{\"lyricsEmbedded\":{},\"lyricsSyncedLrc\":{},\"lyricsLang\":{},\"lyricsSidecarMtime\":{},\"lyricsSearchText\":{}}}",
+                    j(&embedded), j(&synced), j(&lang), mtime_json, j(&search_text));
                 return;
             }
             Err(e) => {
@@ -3110,11 +3116,11 @@ fn commit_track(
          disc_number, year, duration, format, file_hash, audio_hash, album_art_file, album_art_source,
          replaygain_track_db, sample_rate, channels, bit_depth, bitrate, file_size,
          track_total, disc_total,
-         lyrics_embedded, lyrics_synced_lrc, lyrics_lang, lyrics_sidecar_mtime, lyrics_source,
+         lyrics_embedded, lyrics_synced_lrc, lyrics_lang, lyrics_sidecar_mtime, lyrics_source, lyrics_search_text,
          bpm, musical_key, bpm_source,
          modified, scan_id, source,
          mbz_recording_id, mbz_release_track_id, isrc, mbz_id_source)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(filepath, library_id) DO UPDATE SET
            title=excluded.title, artist_id=excluded.artist_id, album_id=excluded.album_id,
            track_number=excluded.track_number, disc_number=excluded.disc_number, year=excluded.year,
@@ -3130,6 +3136,7 @@ fn commit_track(
            lyrics_synced_lrc=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_synced_lrc ELSE excluded.lyrics_synced_lrc END,
            lyrics_lang=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_lang ELSE excluded.lyrics_lang END,
            lyrics_source=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_source ELSE excluded.lyrics_source END,
+           lyrics_search_text=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_search_text ELSE excluded.lyrics_search_text END,
            lyrics_sidecar_mtime=excluded.lyrics_sidecar_mtime,
            bpm=excluded.bpm, musical_key=excluded.musical_key, bpm_source=excluded.bpm_source,
            modified=excluded.modified, scan_id=excluded.scan_id, source=excluded.source,
@@ -3147,6 +3154,9 @@ fn commit_track(
         if et.current_sidecar_mtime.is_some() { Some("sidecar") }
         else if et.lyrics_embedded.is_some() || et.lyrics_synced_lrc.is_some() { Some("embedded") }
         else { None::<&str> },
+        // V59: timestamp-stripped search rendition of the synced LRC —
+        // derived at the write site, mirroring scanner.mjs.
+        lrc_to_search_text(et.lyrics_synced_lrc.as_deref()),
         et.bpm, et.musical_key, et.bpm_source,
         et.mod_time, config.scan_id, et.source,
         et.mbz_recording_id, et.mbz_release_track_id, et.isrc, et.mbz_id_source
@@ -3966,6 +3976,115 @@ fn looks_like_lrc(text: &str) -> bool {
         if ss_digits >= 1 { return true; }
     }
     false
+}
+
+// ── V59: lyrics_search_text derivation ──────────────────────────────────────
+//
+// MIRROR of lrcToSearchText in src/api/subsonic/lrc-parser.js. The two
+// scanners must emit byte-identical values for the same input (the parity
+// suite deep-compares full DB snapshots), so any behavioural change must
+// land in both places simultaneously.
+//
+// Per (trimmed) line: drop LRC metadata-tag-only lines ([ar:…],
+// [offset:+500], …), peel every leading `[mm:ss(.xx)]` stamp, blank inline
+// `<mm:ss.xx>` word stamps (enhanced LRC), collapse space/tab runs, and
+// keep whatever survives in original line order. None when nothing does.
+
+// Key list is META_TAG_RE's alternation, verbatim.
+const LRC_META_KEYS: [&str; 11] =
+    ["ar", "ti", "al", "au", "by", "re", "ve", "length", "offset", "lang", "tool"];
+
+// `[key:body-without-]]` spanning the whole line, key case-insensitive —
+// the JS side's /^\[(ar|ti|…):[^\]]*\]$/i.
+fn is_lrc_meta_tag_line(line: &str) -> bool {
+    let after = match line.strip_prefix('[') { Some(a) => a, None => return false };
+    let colon = match after.find(':') { Some(i) => i, None => return false };
+    let key = after[..colon].to_ascii_lowercase();
+    if !LRC_META_KEYS.contains(&key.as_str()) { return false; }
+    let body = &after[colon + 1..];
+    body.ends_with(']') && !body[..body.len() - 1].contains(']')
+}
+
+// Peel one leading `<open>mm:ss(.xx)<close>` stamp; Some(rest after the
+// close delimiter) or None. Digit-run semantics match the JS
+// /^\[(\d{1,3}):(\d{1,2})(?:[.:](\d{1,3}))?\]/ exactly: every boundary
+// (':', '.', close) is a non-digit, so regex backtracking can never
+// shorten a digit run — each run must sit fully within range with the
+// boundary char immediately after. "[1234:56]", "[12:345]" and
+// "[12:34.5678]" are therefore NOT stamps, on both sides.
+fn peel_lrc_stamp(line: &str, open: char, close: char) -> Option<&str> {
+    let after = line.strip_prefix(open)?;
+    let b = after.as_bytes();
+    let close_b = close as u8;
+    let mm = b.iter().take_while(|c| c.is_ascii_digit()).count();
+    if mm == 0 || mm > 3 || b.get(mm) != Some(&b':') { return None; }
+    let ss_start = mm + 1;
+    let ss = b[ss_start..].iter().take_while(|c| c.is_ascii_digit()).count();
+    if ss == 0 || ss > 2 { return None; }
+    let mut idx = ss_start + ss;
+    match b.get(idx) {
+        Some(&c) if c == close_b => { idx += 1; }
+        Some(&c) if c == b'.' || c == b':' => {
+            let frac = b[idx + 1..].iter().take_while(|d| d.is_ascii_digit()).count();
+            if frac == 0 || frac > 3 || b.get(idx + 1 + frac) != Some(&close_b) { return None; }
+            idx += 1 + frac + 1;
+        }
+        _ => return None,
+    }
+    Some(&after[idx..])
+}
+
+// Inline `<mm:ss.xx>` stamps become one space each (JS: replace(RE, ' ')),
+// then space/tab runs of length ≥ 2 collapse to a single space (JS:
+// replace(/[ \t]{2,}/g, ' ') — note a SOLO tab survives as a tab), then
+// trim. Non-stamp '<' passes through verbatim.
+fn strip_inline_stamps(line: &str) -> String {
+    let mut replaced = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(pos) = rest.find('<') {
+        let (head, tail) = rest.split_at(pos);
+        replaced.push_str(head);
+        match peel_lrc_stamp(tail, '<', '>') {
+            Some(after) => { replaced.push(' '); rest = after; }
+            None => { replaced.push('<'); rest = &tail[1..]; }
+        }
+    }
+    replaced.push_str(rest);
+
+    let mut out = String::with_capacity(replaced.len());
+    let mut iter = replaced.chars().peekable();
+    while let Some(ch) = iter.next() {
+        if ch == ' ' || ch == '\t' {
+            let mut run = 1usize;
+            while matches!(iter.peek(), Some(&c) if c == ' ' || c == '\t') {
+                iter.next();
+                run += 1;
+            }
+            out.push(if run >= 2 { ' ' } else { ch });
+        } else {
+            out.push(ch);
+        }
+    }
+    out.trim().to_string()
+}
+
+fn lrc_to_search_text(lrc: Option<&str>) -> Option<String> {
+    let lrc = lrc?;
+    let text = lrc.strip_prefix('\u{FEFF}').unwrap_or(lrc);
+    let mut out: Vec<String> = Vec::new();
+    for raw in text.lines() {
+        let mut line = raw.trim();
+        if line.is_empty() { continue; }
+        if is_lrc_meta_tag_line(line) { continue; }
+        // Peel leading stamp(s); trim between peels so
+        // "[00:01.00] [00:02.00]text" spacing doesn't stop the loop.
+        while let Some(rest) = peel_lrc_stamp(line, '[', ']') {
+            line = rest.trim_start();
+        }
+        let cleaned = strip_inline_stamps(line);
+        if !cleaned.is_empty() { out.push(cleaned); }
+    }
+    if out.is_empty() { None } else { Some(out.join("\n")) }
 }
 
 // Newest mtime across `<base>.lrc`, `<base>.<lang>.lrc`, `<base>.txt`

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -92,13 +92,29 @@ export function shapeFileRow(r, metaMap) {
 // matching lyric excerpt from FTS5 snippet() (null on the LIKE path) — so the
 // UI can show WHY it matched (the half-remembered line).
 //   - shapeLyricsRow: { id, title, album_art_file, artist_name, library_name, filepath, snippet }
+//
+// Since V59 the index stores timestamp-stripped text, so snippets are
+// normally already clean. cleanSnippet is belt-and-braces for the one path
+// stamps can still ride in on: lyrics_embedded that itself contains LRC-ish
+// content (a tagger that stuffed timed text into USLT alongside a real SYLT
+// — extraction keeps it on the plain slot when the synced slot is taken).
+// Fragment-level only: complete `[mm:ss.xx]` / `<mm:ss.xx>` stamps are
+// dropped; a stamp the snippet window clipped mid-way stays (harmless, and
+// only reachable in that same corner case).
+const SNIPPET_STAMP_RE = /\[\d{1,3}:\d{1,2}(?:[.:]\d{1,3})?\]|<\d{1,3}:\d{1,2}(?:[.:]\d{1,3})?>/g;
+function cleanSnippet(snippet) {
+  if (!snippet) { return null; }
+  const cleaned = snippet.replace(SNIPPET_STAMP_RE, ' ').replace(/[ \t]{2,}/g, ' ').trim();
+  return cleaned || null;
+}
+
 export function shapeLyricsRow(r, metaMap) {
   const fp = path.join(r.library_name, r.filepath).replace(/\\/g, '/');
   return {
     name: r.artist_name ? `${r.artist_name} - ${r.title}` : r.title,
     album_art_file: r.album_art_file || null,
     filepath: fp,
-    snippet: r.snippet || null,
+    snippet: cleanSnippet(r.snippet),
     metadata: toLiteMetadata(metaMap?.get(r.id)?.metadata),
   };
 }
@@ -173,8 +189,11 @@ function likeFilesRows(d, filter, search) {
   `).all(`%${search}%`, ...filter.params);
 }
 
-// LIKE over the track's stored lyrics (embedded preferred, else synced LRC).
-// No FTS snippet on this path — `snippet` comes back NULL.
+// LIKE over the track's searchable lyrics: embedded plain text preferred,
+// else the timestamp-stripped rendition of the synced LRC (V59's
+// lyrics_search_text — matching raw lyrics_synced_lrc here would let a
+// numeric query hit `[mm:ss.xx]` stamp digits). Same COALESCE the FTS
+// index stores. No FTS snippet on this path — `snippet` comes back NULL.
 function likeLyricsRows(d, filter, search) {
   return d.prepare(`
     SELECT t.id, t.title, t.album_art_file, a.name AS artist_name, l.name AS library_name, t.filepath,
@@ -182,7 +201,7 @@ function likeLyricsRows(d, filter, search) {
     FROM tracks t
     JOIN libraries l ON t.library_id = l.id
     LEFT JOIN artists a ON t.artist_id = a.id
-    WHERE COALESCE(t.lyrics_embedded, t.lyrics_synced_lrc) LIKE ? AND ${filter.clause}
+    WHERE COALESCE(t.lyrics_embedded, t.lyrics_search_text) LIKE ? AND ${filter.clause}
     LIMIT 30
   `).all(`%${search}%`, ...filter.params);
 }
@@ -329,8 +348,10 @@ function ftsFilesRows(d, filter, parsed) {
   `).all(expr, ...filter.params);
 }
 
-// Lyrics category: scope MATCH to fts_tracks.{lyrics} (the V53 denormalised
-// column). snippet(fts_tracks, 4, …) returns the matching excerpt — column
+// Lyrics category: scope MATCH to fts_tracks.{lyrics} (denormalised in V53;
+// since V59 it indexes COALESCE(lyrics_embedded, lyrics_search_text), the
+// timestamp-stripped rendition — raw LRC stamp digits used to be tokens).
+// snippet(fts_tracks, 4, …) returns the matching excerpt — column
 // index 4 is `lyrics` (title=0, artist_name=1, album_name=2, filepath=3,
 // lyrics=4). fts_tracks is left un-aliased here so snippet()/rank reference it
 // directly. This is the "find a song by a half-remembered line" path.

--- a/src/api/subsonic/lrc-parser.js
+++ b/src/api/subsonic/lrc-parser.js
@@ -37,8 +37,13 @@
  * Consumed by:
  *   - src/api/subsonic/handlers.js      (Subsonic getLyricsBySongId)
  *   - src/api/lyrics.js                 (Velvet-compatible /api/v1/lyrics)
+ *   - src/db/scanner.mjs                (lrcToSearchText at track upsert)
+ *   - src/db/lyrics-backfill.mjs        (lrcToSearchText at commit)
+ *   - src/db/schema.js                  (lrcToSearchText in the V59 backfill)
  *
- * Both endpoints serve identical data under different envelopes.
+ * The two endpoints serve identical data under different envelopes; the
+ * three writers derive tracks.lyrics_search_text (V59) from the same
+ * parsing rules so search matches what the endpoints serve.
  */
 
 // Match an LRC timestamp anchored to the start of a candidate position:
@@ -143,6 +148,61 @@ export function parseLrc(lrc) {
 export function linesToPlainText(lines) {
   if (!Array.isArray(lines)) { return ''; }
   return lines.map(l => l.text || '').filter(Boolean).join('\n');
+}
+
+// Enhanced-LRC ("A2" / Walaoke extension) word-level stamps embedded in a
+// line's BODY: `[00:12.00]<00:12.00>word <00:12.50>word`. parseLrc leaves
+// them in `text` (karaoke clients may want them); the search rendition
+// must drop them or their digits become FTS tokens.
+const INLINE_TIMESTAMP_RE = /<\d{1,3}:\d{1,2}(?:[.:]\d{1,3})?>/g;
+
+/**
+ * Reduce LRC (or LRC-ish) text to its plain lyric words for indexing —
+ * the rendition stored in tracks.lyrics_search_text (V59) and fed to
+ * fts_tracks.lyrics + the search route's LIKE fallback.
+ *
+ * fts5's unicode61 tokenizer treats the DIGITS inside `[mm:ss.xx]`
+ * stamps as real tokens (only the brackets/colons tokenise away), so
+ * indexing raw LRC makes any 2-digit query match nearly every synced
+ * track via its timestamps. This strips, per line:
+ *   - metadata tag lines  ([ar:], [ti:], [offset:+500], …)
+ *   - leading `[mm:ss(.xx)]` stamp(s) (multi-stamp lines included)
+ *   - inline `<mm:ss.xx>` word-level stamps (enhanced LRC)
+ * and keeps everything else VERBATIM in line order — unlike parseLrc it
+ * never duplicates a multi-stamp line per timestamp nor re-sorts by
+ * time, so term frequency and snippet() line order stay faithful to
+ * the text.
+ *
+ * Returns null (not '') when nothing survives, matching the NULL
+ * convention of the other tracks.lyrics_* columns.
+ *
+ * MIRRORED in rust-parser/src/main.rs (lrc_to_search_text). The two
+ * scanners must produce byte-identical values for the same input
+ * (scanner-parity.test.mjs deep-compares full DB snapshots), so any
+ * behavioural change here must land in both places simultaneously.
+ */
+export function lrcToSearchText(lrc) {
+  if (!lrc || typeof lrc !== 'string') { return null; }
+  const text = lrc.charCodeAt(0) === 0xFEFF ? lrc.slice(1) : lrc;
+  const out = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    let line = rawLine.trim();
+    if (!line) { continue; }
+    if (META_TAG_RE.test(line)) { continue; }
+    // Peel leading timestamp(s). trimStart between peels so the odd
+    // "[00:01.00] [00:02.00]text" spacing doesn't stop the loop.
+    for (;;) {
+      const m = line.match(TIMESTAMP_RE);
+      if (!m) { break; }
+      line = line.slice(m[0].length).trimStart();
+    }
+    line = line
+      .replace(INLINE_TIMESTAMP_RE, ' ')
+      .replace(/[ \t]{2,}/g, ' ')
+      .trim();
+    if (line) { out.push(line); }
+  }
+  return out.length ? out.join('\n') : null;
 }
 
 /**

--- a/src/db/lyrics-backfill.mjs
+++ b/src/db/lyrics-backfill.mjs
@@ -30,6 +30,7 @@ import path from 'path';
 import { DatabaseSync } from './sqlite-driver.js';
 import Joi from 'joi';
 import { LYRICS_PROVIDERS } from './lyrics-lookup-lib.js';
+import { lrcToSearchText } from '../api/subsonic/lrc-parser.js';
 
 const SCHEMA_GUARD_EXIT = 3;
 
@@ -151,10 +152,11 @@ function cacheHitFor(canonHash) { return canonHash ? cacheHitStmt.get(canonHash)
 
 const updateTrackLyrics = db.prepare(`
   UPDATE tracks
-     SET lyrics_synced_lrc = COALESCE(?, lyrics_synced_lrc),
-         lyrics_embedded   = COALESCE(?, lyrics_embedded),
-         lyrics_lang       = ?,
-         lyrics_source     = ?
+     SET lyrics_synced_lrc  = COALESCE(?, lyrics_synced_lrc),
+         lyrics_embedded    = COALESCE(?, lyrics_embedded),
+         lyrics_search_text = ?,
+         lyrics_lang        = ?,
+         lyrics_source      = ?
    WHERE id = ? AND lyrics_synced_lrc IS NULL AND lyrics_embedded IS NULL
 `);
 
@@ -162,7 +164,10 @@ const updateTrackLyrics = db.prepare(`
 // The IS NULL re-guard keeps it idempotent (a track that gained lyrics
 // between selection and now is left alone). lyrics_source = the provider so
 // the scanner clobber-guard (Phase 5) preserves it across rescans. The
-// lyrics_* write fires the V53 tracks_au_fts trigger → fts_tracks.lyrics.
+// lyrics_* write fires the V59 tracks_au_fts trigger → fts_tracks.lyrics
+// (indexing COALESCE(embedded, search_text), so the timestamp-stripped
+// lyrics_search_text — NULL on the plain path — must ride along; see the
+// writer contract in schema.js SCHEMA_V59).
 function commitFound(trackId, res, canonHash) {
   const syncedLrc = res.syncedLrc || null;
   const plain = syncedLrc ? null : (res.plain || null);
@@ -170,7 +175,7 @@ function commitFound(trackId, res, canonHash) {
   db.exec('BEGIN IMMEDIATE');
   let changed;
   try {
-    changed = updateTrackLyrics.run(syncedLrc, plain, lang, res.source, trackId).changes > 0;
+    changed = updateTrackLyrics.run(syncedLrc, plain, lrcToSearchText(syncedLrc), lang, res.source, trackId).changes > 0;
     writeCacheRow(canonHash, 'hit', syncedLrc, plain, lang, res.source);
     db.exec('COMMIT');
   } catch (err) {

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -241,6 +241,14 @@ function runMigrations() {
       db.exec('BEGIN IMMEDIATE');
       try {
         db.exec(migration.sql);
+        // Optional per-migration JS hook (first used by V59): computation
+        // SQL can't express, e.g. deriving a column via a JS parser. Runs
+        // INSIDE the same transaction — a hook that throws rolls the whole
+        // version back, exactly like a failing SQL statement. Hooks must
+        // stick to prepare/all/run/exec so both node:sqlite and the Bun
+        // driver shim satisfy them. Mirrored in
+        // test/helpers/apply-migrations.mjs.
+        if (migration.js) { migration.js(db); }
         setSchemaVersion(migration.version);
         db.exec('COMMIT');
       } catch (err) {

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -11,6 +11,7 @@ import Joi from 'joi';
 import { Jimp } from 'jimp';
 import { migrateHashReferences as migrateHashRefsShared } from './hash-migration.js';
 import { extractLyrics, sidecarMtimeCached } from './lyrics-extraction.js';
+import { lrcToSearchText } from '../api/subsonic/lrc-parser.js';
 import { computeHashes } from './audio-hash.js';
 import { extractArtists, chooseAlbumArtistId } from './artist-extraction.js';
 import { migrateAlbumStars, migrateArtistStars, migrateAlbumArtState } from './album-migration.js';
@@ -244,11 +245,11 @@ const stmts = {
      disc_number, year, duration, format, file_hash, audio_hash, album_art_file, album_art_source,
      replaygain_track_db, sample_rate, channels, bit_depth, bitrate, file_size,
      track_total, disc_total,
-     lyrics_embedded, lyrics_synced_lrc, lyrics_lang, lyrics_sidecar_mtime, lyrics_source,
+     lyrics_embedded, lyrics_synced_lrc, lyrics_lang, lyrics_sidecar_mtime, lyrics_source, lyrics_search_text,
      bpm, musical_key, bpm_source,
      modified, scan_id, source,
      mbz_recording_id, mbz_release_track_id, isrc, mbz_id_source)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(filepath, library_id) DO UPDATE SET
        title=excluded.title, artist_id=excluded.artist_id, album_id=excluded.album_id,
        track_number=excluded.track_number, disc_number=excluded.disc_number, year=excluded.year,
@@ -264,6 +265,7 @@ const stmts = {
        lyrics_synced_lrc=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_synced_lrc ELSE excluded.lyrics_synced_lrc END,
        lyrics_lang=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_lang ELSE excluded.lyrics_lang END,
        lyrics_source=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_source ELSE excluded.lyrics_source END,
+       lyrics_search_text=CASE WHEN excluded.lyrics_embedded IS NULL AND excluded.lyrics_synced_lrc IS NULL AND tracks.lyrics_source NOT IN ('embedded', 'sidecar') THEN tracks.lyrics_search_text ELSE excluded.lyrics_search_text END,
        lyrics_sidecar_mtime=excluded.lyrics_sidecar_mtime,
        bpm=excluded.bpm, musical_key=excluded.musical_key, bpm_source=excluded.bpm_source,
        modified=excluded.modified, scan_id=excluded.scan_id, source=excluded.source,
@@ -1090,6 +1092,10 @@ function insertTrack(song) {
     // rescans. Mirrors the Rust scanner.
     (li.lyricsSidecarMtime != null ? 'sidecar'
       : (li.lyricsEmbedded || li.lyricsSyncedLrc) ? 'embedded' : null),
+    // V59: the timestamp-stripped search rendition of the synced LRC —
+    // derived at the write site (not in extractLyrics, keeping the
+    // lyrics-parity CLI/test surface untouched). Mirrors the Rust scanner.
+    lrcToSearchText(li.lyricsSyncedLrc),
     song.bpm ?? null,
     song.musicalKey ?? null,
     song.bpmSource ?? null,

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -1,6 +1,10 @@
 // SQLite schema definitions and migration system for mStream.
 // Uses PRAGMA user_version for tracking which migrations have been applied.
 //
+// This module is SQL-first: the only import is the zero-dependency LRC
+// parser, which the V59 `js` hook uses to derive lyrics_search_text from
+// rows that predate the column (a computation SQL triggers can't express).
+//
 // ── TRIGGER SURVIVAL WARNING ──────────────────────────────────────────────
 // V31 attaches AFTER triggers to `tracks`, `artists`, and `albums` to keep
 // the FTS5 virtual tables (`fts_tracks`, `fts_artists`, `fts_albums`) in
@@ -11,6 +15,8 @@
 // re-create them silently breaks search on every upgrade past that
 // migration. The trigger DDL lives in SCHEMA_V31 — grep there.
 // ──────────────────────────────────────────────────────────────────────────
+
+import { lrcToSearchText } from '../api/subsonic/lrc-parser.js';
 
 // Bumped to 42 after rebasing onto master's V36 (tracks.source). The
 // torrent feature's six migrations land as V37..V42 — see
@@ -58,7 +64,11 @@
 // this server can read (federation_peers). See SCHEMA_V57.
 // V58 adds federation_peers.use_discovery — the per-peer opt-out for
 // outbound discovery-over-federation queries. See SCHEMA_V58.
-export const SCHEMA_VERSION = 58;
+// V59 adds tracks.lyrics_search_text — the timestamp-stripped rendition of
+// synced LRC — and rebuilds fts_tracks to index it instead of raw LRC, so
+// numeric queries stop matching `[mm:ss.xx]` stamp digits. First migration
+// with a `js` hook (in-transaction JS population). See SCHEMA_V59.
+export const SCHEMA_VERSION = 59;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -1995,8 +2005,12 @@ export const SCHEMA_V53 = `
   -- untouched; FTS5 has no external indexes to rebuild). Assumes FTS5 — same
   -- as V31, which creates these tables unguarded; node:sqlite always bundles
   -- it. The indexed value is COALESCE(lyrics_embedded, lyrics_synced_lrc):
-  -- plain wins, else the synced LRC text (its [mm:ss.xx] stamps are non-alnum
-  -- and tokenise away, leaving the words searchable). Mirrors the V31 backfill
+  -- plain wins, else the synced LRC text. (CORRECTION, fixed in V59: this
+  -- migration assumed the [mm:ss.xx] stamps "tokenise away". Only the
+  -- brackets/colons do — unicode61 keeps the DIGITS as tokens, so any
+  -- 2-digit query matched most synced tracks via timestamps. V59 re-points
+  -- the index at the stripped lyrics_search_text; this SQL is immutable
+  -- history and correct only as the V53→V58 state.) Mirrors the V31 backfill
   -- join (LEFT JOIN keeps NULL-FK rows). See the trigger-survival note up top.
   DROP TRIGGER tracks_ai_fts;
   DROP TRIGGER tracks_au_fts;
@@ -2209,6 +2223,131 @@ export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
 
+// ── Lyrics search text (timestamp-stripped index rendition) ────────────────
+//
+// V53 indexed COALESCE(lyrics_embedded, lyrics_synced_lrc) into
+// fts_tracks.lyrics on the assumption that LRC `[mm:ss.xx]` stamps
+// "tokenise away". They don't: unicode61 drops the brackets/colons but
+// keeps the DIGITS as tokens, so for synced-only tracks (sidecar .lrc +
+// most LRCLib backfill hits) any 2-digit lyric query — "22", "45" —
+// matched ~85% of them through timestamps alone, snippet() output came
+// back stamp-cluttered, and LRC header tags ([ar:], [ti:]) were indexed
+// as lyric words.
+//
+// tracks.lyrics_search_text is the fix: the plain-words rendition of
+// lyrics_synced_lrc (stamps, header tags, and enhanced-LRC inline stamps
+// stripped by lrcToSearchText — see src/api/subsonic/lrc-parser.js).
+// NULL when the track has no synced lyrics. The searchable value
+// everywhere becomes COALESCE(lyrics_embedded, lyrics_search_text):
+//   - fts_tracks.lyrics (backfill INSERT + the recreated triggers below)
+//   - the search route's LIKE fallback (src/api/search.js)
+// lyrics_embedded still wins the COALESCE untouched — plain tag text has
+// no stamps to strip (extraction diverts timed-looking payloads to the
+// synced slot), so it needs no companion column.
+//
+// WRITER CONTRACT: every code path that writes lyrics_synced_lrc MUST
+// write lyrics_search_text in the same statement, or the track silently
+// drops out of lyrics search (the triggers can't derive it — stripping
+// needs JS/Rust). Writers today: src/db/scanner.mjs upsert,
+// rust-parser/src/main.rs upsert, src/db/lyrics-backfill.mjs.
+//
+// This is the first migration with a `js` hook: deriving the column for
+// EXISTING rows is regex work SQL can't express, so the runner calls
+// migrateV59LyricsSearchText(db) inside the same per-version
+// transaction, sandwiched between this SQL (drop triggers + old index)
+// and SCHEMA_V59_FTS_REBUILD (new index + triggers) so the rebuild's
+// INSERT…SELECT reads fully-populated rows and no trigger fires during
+// population. NOT rescanRequired: derived from data already in the DB.
+export const SCHEMA_V59 = `
+  ALTER TABLE tracks ADD COLUMN lyrics_search_text TEXT;
+
+  -- Old triggers + index carry raw-LRC lyrics; both are replaced after the
+  -- js hook populates the new column. Dropping FIRST means the hook's
+  -- per-row UPDATEs sync no FTS index (fts_tracks is gone) — the rebuild
+  -- below re-reads everything in one INSERT…SELECT instead.
+  DROP TRIGGER tracks_ai_fts;
+  DROP TRIGGER tracks_au_fts;
+  DROP TRIGGER tracks_ad_fts;
+  DROP TABLE fts_tracks;
+`;
+
+// Second half of V59, exec'd by the js hook AFTER population. Same table
+// shape and trigger names as V53 — only the lyrics value source changes.
+// (Kept in a separate constant, not a second MIGRATIONS entry, so
+// user_version never points between the halves.)
+export const SCHEMA_V59_FTS_REBUILD = `
+  CREATE VIRTUAL TABLE fts_tracks USING fts5(
+    title, artist_name, album_name, filepath, lyrics,
+    tokenize = 'unicode61 remove_diacritics 1'
+  );
+
+  INSERT INTO fts_tracks(rowid, title, artist_name, album_name, filepath, lyrics)
+    SELECT t.id, t.title, a.name, al.name, t.filepath,
+           COALESCE(t.lyrics_embedded, t.lyrics_search_text)
+    FROM tracks t
+    LEFT JOIN artists a  ON a.id  = t.artist_id
+    LEFT JOIN albums  al ON al.id = t.album_id;
+
+  CREATE TRIGGER tracks_ai_fts AFTER INSERT ON tracks BEGIN
+    INSERT INTO fts_tracks(rowid, title, artist_name, album_name, filepath, lyrics)
+    VALUES (
+      NEW.id,
+      NEW.title,
+      (SELECT name FROM artists WHERE id = NEW.artist_id),
+      (SELECT name FROM albums  WHERE id = NEW.album_id),
+      NEW.filepath,
+      COALESCE(NEW.lyrics_embedded, NEW.lyrics_search_text)
+    );
+  END;
+
+  CREATE TRIGGER tracks_ad_fts AFTER DELETE ON tracks BEGIN
+    DELETE FROM fts_tracks WHERE rowid = OLD.id;
+  END;
+
+  -- lyrics_synced_lrc stays in the allowlist even though the indexed value
+  -- no longer reads it: writers change it and lyrics_search_text together,
+  -- so the extra column costs nothing on real writes but keeps the FTS row
+  -- re-COALESCEd if some future path updates synced alone.
+  CREATE TRIGGER tracks_au_fts AFTER UPDATE OF title, artist_id, album_id, filepath, lyrics_embedded, lyrics_synced_lrc, lyrics_search_text ON tracks BEGIN
+    UPDATE fts_tracks
+       SET title       = NEW.title,
+           artist_name = (SELECT name FROM artists WHERE id = NEW.artist_id),
+           album_name  = (SELECT name FROM albums  WHERE id = NEW.album_id),
+           filepath    = NEW.filepath,
+           lyrics      = COALESCE(NEW.lyrics_embedded, NEW.lyrics_search_text)
+     WHERE rowid = NEW.id;
+  END;
+`;
+
+// V59 js hook. Runs inside the migration's BEGIN IMMEDIATE…COMMIT (see
+// runMigrations in src/db/manager.js), between SCHEMA_V59 (triggers +
+// old index dropped) and the rebuild it execs at the end — so a crash
+// anywhere rolls the whole version back atomically.
+//
+// Chunked by id cursor rather than one big SELECT so memory stays flat
+// on synced-heavy libraries (each chunk's rows are fully materialised
+// before the interleaved UPDATEs, avoiding write-during-iterate on the
+// same table). Uses only prepare/all/run/exec — the surface both
+// node:sqlite and the Bun driver shim provide.
+export function migrateV59LyricsSearchText(db) {
+  const sel = db.prepare(`
+    SELECT id, lyrics_synced_lrc FROM tracks
+    WHERE lyrics_synced_lrc IS NOT NULL AND id > ?
+    ORDER BY id LIMIT 1000
+  `);
+  const upd = db.prepare('UPDATE tracks SET lyrics_search_text = ? WHERE id = ?');
+  let lastId = 0;
+  for (;;) {
+    const rows = sel.all(lastId);
+    if (rows.length === 0) { break; }
+    for (const r of rows) {
+      upd.run(lrcToSearchText(r.lyrics_synced_lrc), r.id);
+      lastId = r.id;
+    }
+  }
+  db.exec(SCHEMA_V59_FTS_REBUILD);
+}
+
 // rescanRequired: true — marks migrations that change the tracks table schema
 // and need a force rescan to populate new fields. When applied, a marker file
 // is written so the next boot triggers rescanAll() instead of scanAll().
@@ -2417,4 +2556,10 @@ export const MIGRATIONS = [
   // outbound discovery-over-federation queries. Additive column with a
   // default — no rescan needed. See SCHEMA_V58.
   { version: 58, sql: SCHEMA_V58 },
+  // V59 adds tracks.lyrics_search_text and re-points fts_tracks.lyrics at
+  // it, so LRC timestamp digits stop matching numeric lyric queries. The
+  // js hook populates the column from existing synced rows and execs the
+  // FTS rebuild, all inside the version's transaction. Derived from data
+  // already in the DB — no rescan needed. See SCHEMA_V59.
+  { version: 59, sql: SCHEMA_V59, js: migrateV59LyricsSearchText },
 ];

--- a/test/db/db-fts5-lyrics.test.mjs
+++ b/test/db/db-fts5-lyrics.test.mjs
@@ -21,6 +21,7 @@ import { DatabaseSync } from 'node:sqlite';
 
 import { SCHEMA_VERSION, MIGRATIONS } from '../../src/db/schema.js';
 import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+import { lrcToSearchText } from '../../src/api/subsonic/lrc-parser.js';
 
 function freshDbAllMigrations() {
   const db = new DatabaseSync(':memory:');
@@ -85,7 +86,9 @@ describe('V53 schema shape', () => {
     const sql = db.prepare(
       "SELECT sql FROM sqlite_master WHERE type='trigger' AND name='tracks_au_fts'"
     ).get().sql;
-    assert.match(sql, /UPDATE OF title, artist_id, album_id, filepath, lyrics_embedded, lyrics_synced_lrc/i);
+    // V59 appended lyrics_search_text to the V53 allowlist (see
+    // db-v59-lyrics-search-text.test.mjs for the V59-specific shape).
+    assert.match(sql, /UPDATE OF title, artist_id, album_id, filepath, lyrics_embedded, lyrics_synced_lrc, lyrics_search_text/i);
     db.close();
   });
 });
@@ -153,13 +156,17 @@ describe('V53 lyrics_source backfill (upgrade from v52)', () => {
   });
 });
 
+// NOTE: these run against ALL migrations, so since V59 the synced side of
+// the COALESCE is lyrics_search_text (the stripped rendition), not raw
+// lyrics_synced_lrc. seedTrack mirrors the writer contract and derives it;
+// V59-specific behaviour is covered in db-v59-lyrics-search-text.test.mjs.
 describe('V53 fts_tracks lyrics triggers (steady state)', () => {
   function seedTrack(db, { embedded = null, synced = null } = {}) {
     const libId = Number(db.prepare('INSERT INTO libraries (name, root_path) VALUES (?, ?)').run('Music', '/music').lastInsertRowid);
     return Number(db.prepare(
-      `INSERT INTO tracks (filepath, library_id, title, lyrics_embedded, lyrics_synced_lrc)
-       VALUES (?, ?, ?, ?, ?)`
-    ).run('t.flac', libId, 'Track', embedded, synced).lastInsertRowid);
+      `INSERT INTO tracks (filepath, library_id, title, lyrics_embedded, lyrics_synced_lrc, lyrics_search_text)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run('t.flac', libId, 'Track', embedded, synced, lrcToSearchText(synced)).lastInsertRowid);
   }
 
   test('insert trigger indexes lyrics; track is matchable by a lyric word', () => {

--- a/test/db/db-v59-lyrics-search-text.test.mjs
+++ b/test/db/db-v59-lyrics-search-text.test.mjs
@@ -1,0 +1,199 @@
+/**
+ * V59 tests: tracks.lyrics_search_text + the re-pointed fts_tracks.lyrics.
+ *
+ * V53 indexed COALESCE(lyrics_embedded, lyrics_synced_lrc) — raw LRC —
+ * so `[mm:ss.xx]` stamp DIGITS were tokens and any 2-digit query matched
+ * most synced tracks via timestamps. V59 derives the stripped
+ * lyrics_search_text (via lrcToSearchText) and the index becomes
+ * COALESCE(lyrics_embedded, lyrics_search_text).
+ *
+ * Three angles, mirroring db-fts5-lyrics.test.mjs:
+ *   1. Upgrade from v58: the js hook populates lyrics_search_text for
+ *      existing synced rows inside the migration, the FTS rebuild indexes
+ *      it, and timestamp digits stop matching.
+ *   2. Schema shape: column present, triggers recreated, allowlist grew.
+ *   3. Steady-state: the writer contract — synced writes carry
+ *      lyrics_search_text; the COALESCE precedence; a synced-only write
+ *      without search text is (by design) not lyric-searchable.
+ *
+ * V59 is the first migration with a `js` hook; applying it through
+ * applyAllMigrations exercises the hook the same way the manager.js
+ * runner does.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+
+import { SCHEMA_VERSION, MIGRATIONS } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+import { lrcToSearchText } from '../../src/api/subsonic/lrc-parser.js';
+
+function freshDbAllMigrations() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA recursive_triggers = ON');
+  applyAllMigrations(db);
+  return db;
+}
+
+const TAYLOR_LRC = [
+  '[ar:Header Artist]',
+  '[00:22.10]I do not know about you',
+  '[00:26.45]I am feeling twenty two',
+].join('\n');
+
+describe('V59 registration', () => {
+  test('V59 is registered, carries the js hook, and SCHEMA_VERSION covers it', () => {
+    const v59 = MIGRATIONS.find(m => m.version === 59);
+    assert.ok(v59, 'V59 must be in MIGRATIONS');
+    assert.equal(typeof v59.js, 'function', 'V59 must carry the js population hook');
+    assert.ok(SCHEMA_VERSION >= 59);
+  });
+});
+
+describe('V59 upgrade from v58 (js-hook population + FTS rebuild)', () => {
+  function seedAndUpgrade() {
+    const db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    db.exec('PRAGMA recursive_triggers = ON');
+    applyAllMigrations(db, { upToVersion: 58 });
+
+    const libId = Number(db.prepare(
+      'INSERT INTO libraries (name, root_path) VALUES (?, ?)').run('Music', '/music').lastInsertRowid);
+    const ins = db.prepare(
+      `INSERT INTO tracks (filepath, library_id, title, lyrics_embedded, lyrics_synced_lrc, lyrics_source)
+       VALUES (?, ?, ?, ?, ?, ?)`);
+    // A: synced-only (sidecar-style raw LRC with stamps + a header tag).
+    const syncedId = Number(ins.run('synced.flac', libId, 'TwentyTwo',
+      null, TAYLOR_LRC, 'sidecar').lastInsertRowid);
+    // B: provider-backfilled synced (same population path, different source).
+    const lrclibId = Number(ins.run('lrclib.flac', libId, 'Backfilled',
+      null, '[00:05.00]provider words here', 'lrclib').lastInsertRowid);
+    // C: plain embedded only — no synced, nothing to derive.
+    const plainId = Number(ins.run('plain.flac', libId, 'Plain',
+      'hello darkness my old friend', null, 'embedded').lastInsertRowid);
+    // D: no lyrics at all.
+    const noneId = Number(ins.run('none.flac', libId, 'Instrumental',
+      null, null, null).lastInsertRowid);
+
+    // Pre-upgrade sanity: the V53-era index DOES match stamp digits —
+    // the exact bug under repair.
+    assert.equal(db.prepare(
+      `SELECT count(*) AS c FROM fts_tracks WHERE fts_tracks MATCH '{lyrics} : "22"*'`).get().c, 1,
+      'pre-V59 a stamp-digit query matches (bug present)');
+
+    applyAllMigrations(db, { fromVersion: 58 });
+    return { db, syncedId, lrclibId, plainId, noneId };
+  }
+
+  test('lyrics_search_text is populated for every synced row, stripped', () => {
+    const { db, syncedId, lrclibId, plainId, noneId } = seedAndUpgrade();
+    const st = id => db.prepare('SELECT lyrics_search_text FROM tracks WHERE id = ?').get(id).lyrics_search_text;
+    assert.equal(st(syncedId), 'I do not know about you\nI am feeling twenty two');
+    assert.equal(st(syncedId), lrcToSearchText(TAYLOR_LRC),
+      'population uses the same derivation as the writers');
+    assert.equal(st(lrclibId), 'provider words here');
+    assert.equal(st(plainId), null, 'no synced source → NULL');
+    assert.equal(st(noneId), null);
+    db.close();
+  });
+
+  test('stamp digits and header-tag words stop matching; lyric words still match', () => {
+    const { db, syncedId } = seedAndUpgrade();
+    const count = expr => db.prepare(
+      `SELECT count(*) AS c FROM fts_tracks WHERE fts_tracks MATCH ?`).get(`{lyrics} : ${expr}`).c;
+    assert.equal(count('"22"*'), 0, 'timestamp seconds no longer match');
+    assert.equal(count('"26"*'), 0, 'nor any other stamp field');
+    assert.equal(count('"header"*'), 0, '[ar:] header-tag words are not lyrics');
+    assert.equal(count('"feeling"*'), 1, 'real lyric words still match');
+    assert.equal(db.prepare(
+      `SELECT rowid FROM fts_tracks WHERE fts_tracks MATCH '{lyrics} : "feeling"*'`).get().rowid, syncedId);
+    db.close();
+  });
+
+  test('embedded text still wins the COALESCE and the rebuild preserves other columns', () => {
+    const { db, plainId } = seedAndUpgrade();
+    assert.match(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(plainId).lyrics,
+      /hello darkness/);
+    // Titles survived the rebuild (denormalised columns re-read).
+    assert.equal(db.prepare(
+      `SELECT count(*) AS c FROM fts_tracks WHERE fts_tracks MATCH '{title} : "instrumental"*'`).get().c, 1);
+    assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
+    db.close();
+  });
+});
+
+describe('V59 schema shape', () => {
+  test('tracks gains lyrics_search_text', () => {
+    const db = freshDbAllMigrations();
+    const cols = db.prepare('PRAGMA table_info(tracks)').all().map(c => c.name);
+    assert.ok(cols.includes('lyrics_search_text'));
+    db.close();
+  });
+
+  test('tracks_au_fts allowlist covers lyrics_search_text; index reads it via COALESCE', () => {
+    const db = freshDbAllMigrations();
+    const sql = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='trigger' AND name='tracks_au_fts'").get().sql;
+    assert.match(sql, /UPDATE OF title, artist_id, album_id, filepath, lyrics_embedded, lyrics_synced_lrc, lyrics_search_text/i);
+    assert.match(sql, /COALESCE\(NEW\.lyrics_embedded, NEW\.lyrics_search_text\)/i);
+    db.close();
+  });
+});
+
+describe('V59 steady-state writer contract', () => {
+  function seedTrack(db, { embedded = null, synced = null, searchText } = {}) {
+    const libId = Number(db.prepare(
+      'INSERT INTO libraries (name, root_path) VALUES (?, ?)').run('Music', '/music').lastInsertRowid);
+    // Default mirrors the real writers: search_text derived from synced.
+    const st = searchText !== undefined ? searchText : lrcToSearchText(synced);
+    return Number(db.prepare(
+      `INSERT INTO tracks (filepath, library_id, title, lyrics_embedded, lyrics_synced_lrc, lyrics_search_text)
+       VALUES (?, ?, ?, ?, ?, ?)`).run('t.flac', libId, 'Track', embedded, synced, st).lastInsertRowid);
+  }
+
+  test('a writer-shaped synced insert is searchable by words, not stamps', () => {
+    const db = freshDbAllMigrations();
+    const id = seedTrack(db, { synced: TAYLOR_LRC });
+    const hits = db.prepare(
+      `SELECT rowid FROM fts_tracks WHERE fts_tracks MATCH '{lyrics} : "twenty"*'`).all();
+    assert.deepEqual(hits.map(h => h.rowid), [id]);
+    assert.equal(db.prepare(
+      `SELECT count(*) AS c FROM fts_tracks WHERE fts_tracks MATCH '{lyrics} : "22"*'`).get().c, 0);
+    db.close();
+  });
+
+  test('COALESCE precedence: embedded wins; clearing it surfaces the search text', () => {
+    const db = freshDbAllMigrations();
+    const id = seedTrack(db, { embedded: 'plainword here', synced: '[00:01.00]syncedword here' });
+    assert.match(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics, /plainword/);
+    db.prepare('UPDATE tracks SET lyrics_embedded = NULL WHERE id = ?').run(id);
+    assert.match(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics, /syncedword/);
+    assert.doesNotMatch(db.prepare('SELECT lyrics FROM fts_tracks WHERE rowid = ?').get(id).lyrics, /01/,
+      'the surfaced value is the STRIPPED rendition');
+    db.close();
+  });
+
+  test('synced without search text is not lyric-searchable (the documented contract)', () => {
+    // A writer that sets lyrics_synced_lrc but not lyrics_search_text has
+    // broken the SCHEMA_V59 writer contract; the failure mode is a silent
+    // drop from lyric search — pinned here so it stays a KNOWN mode.
+    const db = freshDbAllMigrations();
+    seedTrack(db, { synced: '[00:01.00]ghostword here', searchText: null });
+    assert.equal(db.prepare(
+      `SELECT count(*) AS c FROM fts_tracks WHERE fts_tracks MATCH '{lyrics} : "ghostword"*'`).get().c, 0);
+    db.close();
+  });
+
+  test('updating lyrics_search_text alone reindexes (allowlist member)', () => {
+    const db = freshDbAllMigrations();
+    const id = seedTrack(db, { synced: '[00:01.00]before text' });
+    db.prepare('UPDATE tracks SET lyrics_search_text = ? WHERE id = ?').run('after text', id);
+    assert.equal(db.prepare(
+      `SELECT count(*) AS c FROM fts_tracks WHERE fts_tracks MATCH '{lyrics} : "before"*'`).get().c, 0);
+    assert.equal(db.prepare(
+      `SELECT count(*) AS c FROM fts_tracks WHERE fts_tracks MATCH '{lyrics} : "after"*'`).get().c, 1);
+    db.close();
+  });
+});

--- a/test/helpers/apply-migrations.mjs
+++ b/test/helpers/apply-migrations.mjs
@@ -16,6 +16,8 @@ export function applyAllMigrations(db, { upToVersion = Infinity, fromVersion = 0
     if (m.version <= fromVersion) { continue; }
     if (m.version > upToVersion) { break; }
     db.exec(m.sql);
+    // Per-migration JS hook (V59+) — matches the runner in manager.js.
+    if (m.js) { m.js(db); }
     db.exec(`PRAGMA user_version = ${m.version}`);
   }
 }

--- a/test/helpers/db-snapshot.mjs
+++ b/test/helpers/db-snapshot.mjs
@@ -62,6 +62,9 @@ function snapTracks(db) {
       t.replaygain_track_db, t.sample_rate, t.channels, t.bit_depth,
       t.lyrics_embedded, t.lyrics_synced_lrc, t.lyrics_lang,
       t.lyrics_sidecar_mtime,
+      -- V59: derived at each scanner's write site (lrcToSearchText /
+      -- lrc_to_search_text) — byte-parity between engines is the contract.
+      t.lyrics_search_text,
       t.bpm, t.musical_key, t.bpm_source,
       -- V55: external-service IDs the scanner sources from tags. acoustid_id
       -- is excluded — the scanner never writes it (Phase 2 fingerprint pass

--- a/test/integration/search-route.test.mjs
+++ b/test/integration/search-route.test.mjs
@@ -24,6 +24,7 @@ import net from 'node:net';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { DatabaseSync } from 'node:sqlite';
+import { lrcToSearchText } from '../../src/api/subsonic/lrc-parser.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -141,6 +142,20 @@ function seedDB(dbPath) {
   // regardless of whether the FTS lyrics index was populated.
   db.prepare("UPDATE tracks SET lyrics_embedded = ? WHERE filepath = 'pf/wall/01.flac'")
     .run('Hello? Is there anybody in there? Just nod if you can hear me.');
+
+  // V59: a synced-only track, seeded the way the real writers write —
+  // raw LRC into lyrics_synced_lrc AND the stripped rendition into
+  // lyrics_search_text (derived with the production helper, so the seed
+  // can't drift from the writer contract). The stamps carry the digit
+  // pairs 22/37/48 that must NOT be matchable; 'crazyseventy' is a token
+  // unique to these lyrics.
+  const KARMA_LRC = [
+    '[ar:Header Person]',
+    '[00:22.10]for a minute there I lost myself',
+    '[00:37.48]crazyseventy phew',
+  ].join('\n');
+  db.prepare("UPDATE tracks SET lyrics_synced_lrc = ?, lyrics_search_text = ? WHERE filepath = 'rh/ok/01.flac'")
+    .run(KARMA_LRC, lrcToSearchText(KARMA_LRC));
 
   db.close();
 }
@@ -397,6 +412,52 @@ describe('/api/v1/db/search algorithm dispatch', () => {
     const r = await searchReq(server.baseUrl, { search: 'anybody', algorithm: 'basic', noLyrics: true });
     assert.equal(r.status, 200);
     assert.equal(r.body.lyrics.length, 0, 'noLyrics returns an empty lyrics array');
+  });
+
+  // ── V59: FTS lyrics path over synced LRC (stripped index) ────────
+
+  const KARMA_FILEPATH = 'testlib/rh/ok/01.flac';
+
+  test('FTS lyrics hit on a synced-LRC track carries a non-null, stamp-free snippet', async () => {
+    // 'crazyseventy' lives only in the seeded synced lyrics of Karma
+    // Police — and only in its WORDS, so this exercises fts_tracks.lyrics
+    // end to end (MATCH + snippet()), not the LIKE fallback.
+    for (const algorithm of ['fts5', 'combo']) {
+      const r = await searchReq(server.baseUrl, { search: 'crazyseventy', algorithm });
+      assert.equal(r.status, 200);
+      const hit = r.body.lyrics.find(t => t.filepath === KARMA_FILEPATH);
+      assert.ok(hit, `algorithm=${algorithm} must find the synced-LRC track by a lyric word`);
+      assert.equal(typeof hit.snippet, 'string', `algorithm=${algorithm} FTS path must yield a snippet`);
+      assert.match(hit.snippet, /crazyseventy/, 'snippet shows the matching line');
+      assert.doesNotMatch(hit.snippet, /[\[\]]/, 'snippet carries no LRC stamp brackets');
+      assert.doesNotMatch(hit.snippet, /\d/, 'snippet carries no stamp digits');
+      // Scoped: a lyric-only word must not leak into the other categories.
+      assert.equal(r.body.title.length, 0);
+      assert.equal(r.body.artists.length, 0);
+    }
+  });
+
+  test('numeric queries do not match LRC timestamps in any algorithm (V59)', async () => {
+    // '22', '37' and '48' appear in the seeded track ONLY inside
+    // [mm:ss.xx] stamps. Pre-V59 these were FTS tokens and this returned
+    // the track; now the index and the LIKE path both read the stripped
+    // lyrics_search_text, so every algorithm must come back empty.
+    for (const digits of ['22', '37', '48']) {
+      for (const algorithm of ['basic', 'fts5', 'combo']) {
+        const r = await searchReq(server.baseUrl, { search: digits, algorithm });
+        assert.equal(r.status, 200);
+        assert.equal(r.body.lyrics.length, 0,
+          `search '${digits}' (${algorithm}) must not match timestamp digits`);
+      }
+    }
+  });
+
+  test('LRC header-tag words are not lyrics (V59)', async () => {
+    // '[ar:Header Person]' is metadata, not a lyric line — lrcToSearchText
+    // drops it before indexing.
+    const r = await searchReq(server.baseUrl, { search: 'header', algorithm: 'fts5' });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.lyrics.length, 0, 'header-tag words must not match as lyrics');
   });
 
   test('filepath sentinel: false on artist/album rows, string on title/file rows', async () => {

--- a/test/scanner/lyrics-parity.test.mjs
+++ b/test/scanner/lyrics-parity.test.mjs
@@ -30,6 +30,7 @@ import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { extractLyrics } from '../../src/db/lyrics-extraction.js';
+import { lrcToSearchText } from '../../src/api/subsonic/lrc-parser.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -154,6 +155,30 @@ before(async () => {
   await makeFlac(path.join(libDir, 'nothing.flac'), {
     artist: 'None A', title: 'None T',
   });
+
+  // V59 stress fixture: every lrcToSearchText / lrc_to_search_text edge in
+  // one sidecar — meta tags, multi-stamp lines, enhanced-LRC inline stamps,
+  // space/tab runs, 1–3-digit minute + colon-frac stamp forms, NON-stamps
+  // that must survive verbatim ([Chorus], [not:a:tag], [1234:56]).
+  await makeFlac(path.join(libDir, 'tricky.flac'), {
+    artist: 'Tricky A', title: 'Tricky T',
+  });
+  await fs.writeFile(path.join(libDir, 'tricky.lrc'), [
+    '[ar:Parity Artist]',
+    '[ti:Tricky]',
+    '[offset:+250]',
+    '[00:10.00][00:50.00]Repeated chorus line',
+    '[00:12.34]<00:12.34>Word <00:12.90>timed line',
+    '[00:15]   spaced   out\t\twords',
+    '[1:2.3]short stamp forms',
+    '[00:20.123]millisecond stamp',
+    'plain fallback line',
+    '[99:59:99]colon frac form',
+    '[123:45.678]big minutes',
+    '[Chorus]',
+    '[not:a:tag]bracketed but kept',
+    '[1234:56]four-digit minutes kept',
+  ].join('\n'), 'utf8');
 });
 
 after(async () => {
@@ -192,6 +217,15 @@ async function assertParity(fixtureName) {
     `lyricsSyncedLrc drift for ${fixtureName}`);
   assert.equal(jsResult.lyricsLang,      rustResult.lyricsLang,
     `lyricsLang drift for ${fixtureName}`);
+
+  // V59: the derived lyrics_search_text must be byte-identical too — this
+  // is the value both scanners write and fts_tracks indexes. The rust CLI
+  // emits it since the V59 change; an older local build failing here just
+  // needs `npm run build-rust`.
+  assert.ok('lyricsSearchText' in rustResult,
+    `rust binary predates the lyricsSearchText field — rebuild with npm run build-rust (${fixtureName})`);
+  assert.equal(lrcToSearchText(jsResult.lyricsSyncedLrc), rustResult.lyricsSearchText,
+    `lyricsSearchText drift for ${fixtureName}`);
 }
 
 describe('JS ↔ Rust lyrics extractor parity', () => {
@@ -217,5 +251,9 @@ describe('JS ↔ Rust lyrics extractor parity', () => {
 
   test('No lyrics anywhere', async () => {
     await assertParity('nothing.flac');
+  });
+
+  test('V59 search-text stress sidecar (stamps/meta/inline/edge forms)', async () => {
+    await assertParity('tricky.flac');
   });
 });

--- a/test/scanner/scanner-lyrics-clobber-guard.test.mjs
+++ b/test/scanner/scanner-lyrics-clobber-guard.test.mjs
@@ -22,15 +22,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const scannerSrc = fs.readFileSync(path.resolve(__dirname, '..', '..', 'src/db/scanner.mjs'), 'utf8');
 const UPSERT_SQL = scannerSrc.match(/INSERT INTO tracks[\s\S]*?RETURNING id/)[0];
 
-// The scanner's column order — lyrics_source is computed in JS and bound at
-// position 27; here we bind it directly to set up the scenarios.
+// The scanner's FULL column order (must stay in lock-step with the extracted
+// SQL — a positional drift here silently binds values one column late).
+// lyrics_source / lyrics_search_text are computed in JS by the scanner; here
+// we bind them directly to set up the scenarios.
 const COLS = [
   'filepath', 'library_id', 'title', 'artist_id', 'album_id', 'track_number',
   'disc_number', 'year', 'duration', 'format', 'file_hash', 'audio_hash',
   'album_art_file', 'album_art_source', 'replaygain_track_db', 'sample_rate',
   'channels', 'bit_depth', 'bitrate', 'file_size', 'track_total', 'disc_total',
   'lyrics_embedded', 'lyrics_synced_lrc', 'lyrics_lang', 'lyrics_sidecar_mtime',
-  'lyrics_source', 'bpm', 'musical_key', 'bpm_source', 'modified', 'scan_id', 'source',
+  'lyrics_source', 'lyrics_search_text', 'bpm', 'musical_key', 'bpm_source',
+  'modified', 'scan_id', 'source',
+  'mbz_recording_id', 'mbz_release_track_id', 'isrc', 'mbz_id_source',
 ];
 
 function freshDb() {
@@ -42,15 +46,19 @@ function freshDb() {
   return db;
 }
 const upsert = (db, over) => db.prepare(UPSERT_SQL).get(...COLS.map((c) => (c === 'library_id' ? 1 : (c in over ? over[c] : null))));
-const trackLyrics = (db, id) => db.prepare('SELECT lyrics_embedded AS emb, lyrics_synced_lrc AS syn, lyrics_source AS src FROM tracks WHERE id = ?').get(id);
+const trackLyrics = (db, id) => db.prepare('SELECT lyrics_embedded AS emb, lyrics_synced_lrc AS syn, lyrics_source AS src, lyrics_search_text AS st FROM tracks WHERE id = ?').get(id);
 
 test('rescan PRESERVES provider-backfilled lyrics (source not embedded/sidecar)', () => {
   const db = freshDb();
   const { id } = upsert(db, { filepath: 'a.flac', title: 'A', file_hash: 'h' }); // scanned, no lyrics
-  db.prepare("UPDATE tracks SET lyrics_synced_lrc = '[00:01.00]hi there', lyrics_source = 'lrclib' WHERE id = ?").run(id);
+  // Simulates the real backfill writer, which since V59 writes the stripped
+  // lyrics_search_text alongside the raw LRC (the FTS index reads only the
+  // stripped copy).
+  db.prepare("UPDATE tracks SET lyrics_synced_lrc = '[00:01.00]hi there', lyrics_search_text = 'hi there', lyrics_source = 'lrclib' WHERE id = ?").run(id);
   upsert(db, { filepath: 'a.flac', title: 'A', file_hash: 'h' }); // rescan: file still lyric-less
   const r = trackLyrics(db, id);
   assert.equal(r.syn, '[00:01.00]hi there'); // PRESERVED
+  assert.equal(r.st, 'hi there');            // the search copy rides the same CASE
   assert.equal(r.src, 'lrclib');
   assert.equal(db.prepare("SELECT COUNT(*) AS n FROM fts_tracks WHERE fts_tracks MATCH 'there'").get().n, 1); // still searchable
   db.close();
@@ -70,11 +78,12 @@ test('rescan CLEARS embedded lyrics that were removed from the file', () => {
 test('rescan that finds NEW local lyrics overwrites a provider backfill', () => {
   const db = freshDb();
   const { id } = upsert(db, { filepath: 'c.flac', title: 'C', file_hash: 'h3' });
-  db.prepare("UPDATE tracks SET lyrics_synced_lrc = '[00:01]provider', lyrics_source = 'lrclib' WHERE id = ?").run(id);
+  db.prepare("UPDATE tracks SET lyrics_synced_lrc = '[00:01]provider', lyrics_search_text = 'provider', lyrics_source = 'lrclib' WHERE id = ?").run(id);
   upsert(db, { filepath: 'c.flac', title: 'C', file_hash: 'h3', lyrics_embedded: 'now embedded', lyrics_source: 'embedded' });
   const r = trackLyrics(db, id);
   assert.equal(r.emb, 'now embedded'); // local wins
   assert.equal(r.syn, null);           // provider synced replaced
+  assert.equal(r.st, null);            // and its search copy with it
   assert.equal(r.src, 'embedded');
   db.close();
 });

--- a/test/unit/lrc-search-text.test.mjs
+++ b/test/unit/lrc-search-text.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for lrcToSearchText (src/api/subsonic/lrc-parser.js) — the
+ * V59 derivation of tracks.lyrics_search_text from synced LRC.
+ *
+ * The contract under test (see the function's doc comment):
+ *   - metadata tag lines ([ar:], [ti:], [offset:+500], …) are dropped
+ *   - leading [mm:ss(.xx)] stamps are peeled, multi-stamp lines included
+ *   - inline <mm:ss.xx> word stamps (enhanced LRC) are blanked
+ *   - everything else survives VERBATIM in line order — no per-stamp
+ *     duplication, no time-sort
+ *   - null (never '') when nothing survives
+ *
+ * The Rust mirror (rust-parser/src/main.rs lrc_to_search_text) is held to
+ * byte-parity by test/scanner/lyrics-parity.test.mjs; these tests pin the
+ * JS reference behaviour the mirror is measured against.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { lrcToSearchText } from '../../src/api/subsonic/lrc-parser.js';
+
+describe('lrcToSearchText basics', () => {
+  test('null / empty / non-string inputs → null', () => {
+    assert.equal(lrcToSearchText(null), null);
+    assert.equal(lrcToSearchText(undefined), null);
+    assert.equal(lrcToSearchText(''), null);
+    assert.equal(lrcToSearchText(42), null);
+  });
+
+  test('plain LRC: stamps peeled, words and line order kept', () => {
+    const lrc = '[00:22.10]I do not know about you\n[00:26.45]I am feeling twenty two';
+    assert.equal(lrcToSearchText(lrc),
+      'I do not know about you\nI am feeling twenty two');
+  });
+
+  test('no timestamp digits survive (the V53 pollution bug)', () => {
+    const lrc = '[00:22.10]hello\n[01:45.99]world';
+    const out = lrcToSearchText(lrc);
+    assert.doesNotMatch(out, /\d/, 'no digit from any stamp may survive');
+  });
+
+  test('lyric words that ARE numbers survive', () => {
+    assert.equal(lrcToSearchText('[00:10.00]I was 22 in 1979'), 'I was 22 in 1979');
+  });
+
+  test('whitespace-only and blank lines are dropped', () => {
+    assert.equal(lrcToSearchText('[00:01.00]one\n\n   \n[00:02.00]two'), 'one\ntwo');
+  });
+
+  test('stamp-only lines (instrumental breaks) are dropped', () => {
+    assert.equal(lrcToSearchText('[00:01.00]words\n[00:17.00]\n[00:20.00]more'), 'words\nmore');
+  });
+
+  test('all-stamps/all-tags input → null, not empty string', () => {
+    assert.equal(lrcToSearchText('[ar:Someone]\n[00:01.00]\n[00:02.00]'), null);
+  });
+});
+
+describe('lrcToSearchText metadata tags', () => {
+  test('header tag lines are dropped, including their words', () => {
+    const lrc = '[ar:Taylor Swift]\n[ti:Twenty Two]\n[al:Red]\n[00:01.00]real line';
+    assert.equal(lrcToSearchText(lrc), 'real line');
+  });
+
+  test('offset / length / lang / tool forms are dropped', () => {
+    const lrc = '[offset:+250]\n[length:03:45]\n[lang:en]\n[tool:foobar]\n[00:01.00]kept';
+    assert.equal(lrcToSearchText(lrc), 'kept');
+  });
+
+  test('tag keys match case-insensitively', () => {
+    assert.equal(lrcToSearchText('[AR:Loud Artist]\n[00:01.00]kept'), 'kept');
+  });
+
+  test('unknown bracket forms are NOT tags and survive verbatim', () => {
+    const lrc = '[Chorus]\n[not:a:tag]still here\n[8]also here';
+    assert.equal(lrcToSearchText(lrc), '[Chorus]\n[not:a:tag]still here\n[8]also here');
+  });
+});
+
+describe('lrcToSearchText stamp forms', () => {
+  test('multi-stamp compaction lines keep ONE copy of the text', () => {
+    assert.equal(lrcToSearchText('[00:15.00][00:45.00]Chorus once'), 'Chorus once');
+  });
+
+  test('multi-stamp with spaces between stamps still peels', () => {
+    assert.equal(lrcToSearchText('[00:15.00] [00:45.00]Chorus once'), 'Chorus once');
+  });
+
+  test('short, colon-frac, millisecond and 3-digit-minute forms all peel', () => {
+    const lrc = '[1:2.3]a\n[99:59:99]b\n[00:20.123]c\n[123:45.678]d\n[00:15]e';
+    assert.equal(lrcToSearchText(lrc), 'a\nb\nc\nd\ne');
+  });
+
+  test('out-of-range forms are not stamps and survive', () => {
+    // 4-digit minutes / 3-digit seconds / 4-digit fraction — the JS
+    // TIMESTAMP_RE rejects all three, so the text is kept as-is.
+    const lrc = '[1234:56]x\n[12:345]y\n[12:34.5678]z';
+    assert.equal(lrcToSearchText(lrc), '[1234:56]x\n[12:345]y\n[12:34.5678]z');
+  });
+
+  test('enhanced-LRC inline word stamps are blanked', () => {
+    assert.equal(
+      lrcToSearchText('[00:12.00]<00:12.00>Never <00:12.50>gonna <00:13.00>give'),
+      'Never gonna give');
+  });
+
+  test('non-stamp angle brackets survive', () => {
+    assert.equal(lrcToSearchText('[00:01.00]a <heart> b'), 'a <heart> b');
+  });
+});
+
+describe('lrcToSearchText whitespace + encoding details', () => {
+  test('space/tab runs collapse to one space; solo tab survives', () => {
+    assert.equal(lrcToSearchText('[00:15]   spaced   out\t\twords'), 'spaced out words');
+    assert.equal(lrcToSearchText('[00:15]a\tb'), 'a\tb', 'a single tab is kept');
+  });
+
+  test('leading BOM is stripped', () => {
+    assert.equal(lrcToSearchText('﻿[00:01.00]first line'), 'first line');
+  });
+
+  test('CRLF input splits cleanly', () => {
+    assert.equal(lrcToSearchText('[00:01.00]one\r\n[00:02.00]two'), 'one\ntwo');
+  });
+
+  test('plain unsynced fallback lines are kept in place', () => {
+    const lrc = '[00:01.00]timed\nplain fallback line\n[00:05.00]more';
+    assert.equal(lrcToSearchText(lrc), 'timed\nplain fallback line\nmore');
+  });
+});


### PR DESCRIPTION
## The bug

V53 wired lyrics into `fts_tracks` as `COALESCE(lyrics_embedded, lyrics_synced_lrc)` on the assumption that LRC `[mm:ss.xx]` stamps "tokenise away". Only the brackets/colons do — unicode61 keeps the **digits** as tokens. Measured impact on realistic synced libraries:

- any 2-digit lyric query ("22", "07", "45") matched **~80–86% of synced-lyric tracks** through timestamps alone, flooding the lyrics category with false positives (sidecar `.lrc` files and most LRCLib backfill hits are synced, so this was the common case, not a corner);
- `snippet()` excerpts came back cluttered (`…[00:22.10]Because a vision…`) with digit tokens eating the 12-token window;
- LRC header tags (`[ar:]`, `[ti:]`) were indexed as lyric words;
- the `basic`/LIKE fallback had the same false positives.

## The fix

New `tracks.lyrics_search_text` — the plain-words rendition of the synced LRC (line stamps, header tags, and enhanced-LRC `<mm:ss.xx>` inline stamps stripped) — and every searchable surface now reads `COALESCE(lyrics_embedded, lyrics_search_text)`. Raw `lyrics_synced_lrc` is untouched, so karaoke/timing display keeps working.

- **Shared derivation**: `lrcToSearchText` lives beside `parseLrc` in `lrc-parser.js`, so search matches exactly what the lyrics endpoints serve. Byte-identical Rust mirror (`lrc_to_search_text`) in the scanner; the `--extract-lyrics` parity CLI now emits it and the parity suite asserts byte-equality across the fixture matrix plus a new stress sidecar (multi-stamp lines, colon-fraction stamps, `[Chorus]`-style non-tags, out-of-range non-stamps).
- **Migration V59** rebuilds `fts_tracks` on the new COALESCE. This is the first migration with a **`js` hook**: `runMigrations` calls it inside the same per-version transaction, sandwiched between dropping the old index/triggers and the rebuild, to derive the column for existing rows — regex work SQL triggers can't express. Chunked by id cursor; only uses the `prepare/all/run/exec` surface both `node:sqlite` and the Bun shim provide. **No rescan required** (derived from data already in the DB).
- **Writer contract**: every path that writes `lyrics_synced_lrc` writes `lyrics_search_text` in the same statement — JS scanner upsert, rust-parser upsert (both with the backfill-preservation CASE extended to the new column), and the LRCLib backfill worker. Documented in `SCHEMA_V59`, pinned by tests.
- **Route**: LIKE fallback matches the stripped column; `shapeLyricsRow` strips residual stamps from snippets for the one remaining corner (taggers that stuff timed text into USLT alongside real SYLT). The incorrect V53 comment is corrected in place (comment-only; migration SQL semantics untouched).

## Also fixed (latent bugs the new tests exposed)

- The rust `--extract-lyrics` CLI's manual JSON serialiser didn't escape tabs — raw `\t` inside a JSON string literal is invalid and broke `JSON.parse` on any tab-bearing lyrics.
- `scanner-lyrics-clobber-guard.test.mjs`'s hardcoded column list had drifted from the real upsert (missing the V55 mbz columns), silently binding every value after `lyrics_source` one position late.

## Reviewer notes

- The `js`-hook mechanism is the one structural change to the migration runner (`manager.js` + the `apply-migrations.mjs` test helper, kept in lock-step). A hook that throws rolls the whole version back, same as failing SQL.
- `bin/rust-parser/*` prebuilts are **not** touched here — CI regenerates them on push, as usual. Until then, local rust-engine scans prefer a fresh `cargo build --release` output (existing `findRustParser` behaviour).
- Multi-stamp chorus lines keep ONE copy of the text in the search rendition (no per-stamp duplication, no time-sort) — line order stays faithful for `snippet()` and bm25 isn't inflated by compaction syntax.

## Verification

- Full suite: **1854 tests, 0 failures** (4 environment-gated skips).
- New coverage: 21 unit tests for the helper; a V59 suite covering the upgrade path (pre-V59 DB reproduces the bug, post-migration it's gone), schema shape, and the writer contract; 3 HTTP-level integration tests (FTS snippet non-null and stamp-free; `22`/`37`/`48` empty across all three algorithms; header words not lyrics); JS↔Rust byte-parity incl. the stress fixture; the engine-parity snapshot now deep-compares the new column.
- Live smokes of **both real paths**: fresh install (real rust-engine scan of a `.lrc` library → HTTP search → clean snippet, zero numeric hits) and in-place upgrade (real V58 DB with the bug live → server boot runs V59 → zero numeric hits, all three lyric sources still searchable, raw LRC byte-intact, `user_version=59`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)