### PR TITLE
fix(search): query length cap + webapp search hardening (audit follow-ups)

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -465,7 +465,12 @@ export function runFtsSearch(req, search, opts = {}, { strict = false } = {}) {
 export function setup(mstream) {
   mstream.post('/api/v1/db/search', (req, res) => {
     const schema = Joi.object({
-      search: Joi.string().required(),
+      // 512 is far beyond any real query (a remembered lyric line runs
+      // ~100 chars) but keeps a 1MB request body (the express default
+      // limit) from turning into a giant AND-of-prefixes MATCH
+      // expression or a megabyte LIKE pattern scanned against every
+      // lyrics blob. Joi violation → 400 via the error middleware.
+      search: Joi.string().max(512).required(),
       noArtists: Joi.boolean().optional(),
       noAlbums: Joi.boolean().optional(),
       noTitles: Joi.boolean().optional(),

--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -1073,7 +1073,12 @@ function normalizeQueryFragment(q) {
   // tokenizes case-insensitively. We DO NOT strip * or " here any more
   // — buildFtsExpression handles them safely via escapeFts, and the FTS
   // parser's syntax doesn't expose them to user input directly.
-  return String(q || '').trim().replace(/[%_]/g, '').toLowerCase();
+  //
+  // The 512 cap mirrors the /api/v1/db/search Joi cap. Subsonic queries
+  // ride the URL (node's ~16KB header ceiling bounds them anyway), and
+  // Subsonic clients expect lenient handling, so over-length input is
+  // truncated rather than rejected.
+  return String(q || '').trim().slice(0, 512).replace(/[%_]/g, '').toLowerCase();
 }
 
 // Latch + log so a misconfigured server (FTS5 not compiled in) doesn't

--- a/test/integration/search-route.test.mjs
+++ b/test/integration/search-route.test.mjs
@@ -242,6 +242,25 @@ describe('/api/v1/db/search algorithm dispatch', () => {
     assert.equal(r.status, 400);
   });
 
+  // ── Search length cap (hardening audit follow-up) ────────────────
+
+  test('search longer than 512 chars → 400 from the Joi cap', async () => {
+    // Without the cap, a request-body-sized search (1MB express default)
+    // becomes a giant AND-of-prefixes MATCH expression or a megabyte
+    // LIKE pattern scanned against every lyrics blob.
+    const r = await searchReq(server.baseUrl, { search: 'a'.repeat(513) });
+    assert.equal(r.status, 400);
+  });
+
+  test('search at exactly 512 chars is accepted (cap is inclusive)', async () => {
+    for (const algorithm of ['basic', 'fts5', 'combo']) {
+      const r = await searchReq(server.baseUrl, { search: 'a'.repeat(512), algorithm });
+      assert.equal(r.status, 200, `algorithm=${algorithm} must accept a boundary-length search`);
+      assert.deepEqual(Object.keys(r.body).sort(), ['albums', 'artists', 'files', 'lyrics', 'title'],
+        'boundary-length search returns the normal envelope');
+    }
+  });
+
   // ── Default-is-combo + combo vs fts5 divergence on parse failure ──
 
   test("no-alnum query '&' — combo falls back to LIKE per category and returns rows", async () => {
@@ -429,7 +448,7 @@ describe('/api/v1/db/search algorithm dispatch', () => {
       assert.ok(hit, `algorithm=${algorithm} must find the synced-LRC track by a lyric word`);
       assert.equal(typeof hit.snippet, 'string', `algorithm=${algorithm} FTS path must yield a snippet`);
       assert.match(hit.snippet, /crazyseventy/, 'snippet shows the matching line');
-      assert.doesNotMatch(hit.snippet, /[\[\]]/, 'snippet carries no LRC stamp brackets');
+      assert.doesNotMatch(hit.snippet, /[[\]]/, 'snippet carries no LRC stamp brackets');
       assert.doesNotMatch(hit.snippet, /\d/, 'snippet carries no stamp digits');
       // Scoped: a lyric-only word must not leak into the other categories.
       assert.equal(r.body.title.length, 0);

--- a/test/subsonic/subsonic-search.test.mjs
+++ b/test/subsonic/subsonic-search.test.mjs
@@ -398,6 +398,20 @@ describe('Subsonic search3/search2 with FTS5 (PR3)', () => {
 
   // ── musicFolderId scope ───────────────────────────────────────────
 
+  test('search3 truncates an over-length query instead of erroring', async () => {
+    // normalizeQueryFragment caps at 512 chars (mirror of the
+    // /api/v1/db/search Joi cap). Subsonic clients expect lenient
+    // handling, so a huge query degrades to its first 512 chars and the
+    // request still succeeds. The pad is the SAME token repeated ~1200
+    // times: every token surviving the cut (including a clipped 'pi' /
+    // 'pin' tail) still prefix-matches Pink Floyd, so the all-words AND
+    // stays satisfiable and the truncation itself is what's under test.
+    const env = await call(server.baseUrl, 'search3', { query: 'pink '.repeat(1200) });
+    assert.equal(env.status, 'ok', 'over-length query must not error');
+    assert.ok(env.searchResult3.artist?.some(a => a.name === 'Pink Floyd'),
+      'the in-cap prefix still searches');
+  });
+
   test('search3 with unknown musicFolderId returns empty envelope (no crash)', async () => {
     // Encoded folder id that doesn't match any library the user can see.
     const env = await call(server.baseUrl, 'search3', { query: 'pink', musicFolderId: 'mf-99999' });

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -4394,7 +4394,10 @@ function setupSearchPanel(searchTerm) {
   programState = [{ state: 'searchPanel' }];
 
   let valString = '';
-  if (searchTerm) { valString = `value="${searchTerm}"`; }
+  // escapeHtml matters: searchTerm is the user's PREVIOUS query replayed
+  // on back-navigation — a quote in it would otherwise break out of the
+  // value attribute (broken input at best, self-XSS at worst).
+  if (searchTerm) { valString = `value="${escapeHtml(searchTerm)}"`; }
 
   document.getElementById('filelist').innerHTML = 
     `<div>
@@ -4488,7 +4491,7 @@ async function submitSearchForm() {
         // perform some operation on a value;
         searchList += `<li class="collection-item">
           <div onclick="${searchMap[key].func}(this);" data-${searchMap[key].data}="${escapeHtml(value.filepath ? value.filepath : value.name)}" class="${searchMap[key].class} left">
-            <b>${searchMap[key].name}:</b> ${escapeHtml(value.name)}${key === 'lyrics' && value.snippet ? `<br><small class="grey-text">…${escapeHtml(value.snippet)}…</small>` : ''}
+            <b>${searchMap[key].name}:</b> ${escapeHtml(value.name)}${key === 'lyrics' && value.snippet ? `<br><small class="grey-text">${escapeHtml(value.snippet)}</small>` : ''}
           </div>
           ${
             key === 'files' || key === 'title' || key === 'lyrics' ? `<div class="song-button-box">

--- a/webapp/velvet/alpha/m.js
+++ b/webapp/velvet/alpha/m.js
@@ -1637,7 +1637,10 @@ function setupSearchPanel(searchTerm) {
   programState = [{ state: 'searchPanel' }];
 
   let valString = '';
-  if (searchTerm) { valString = `value="${searchTerm}"`; }
+  // escapeHtml matters: searchTerm is the user's PREVIOUS query replayed
+  // on back-navigation — a quote in it would otherwise break out of the
+  // value attribute (broken input at best, self-XSS at worst).
+  if (searchTerm) { valString = `value="${escapeHtml(searchTerm)}"`; }
 
   document.getElementById('filelist').innerHTML = 
     `<div>


### PR DESCRIPTION
Follow-ups from the lyrics-search audit. #765 fixed the timestamp-indexing bug; this lands the three remaining findings, all small and search-adjacent.

## What changed

1. **Query length cap on `POST /api/v1/db/search`** (`src/api/search.js`). The `search` field had no `.max()` while the body limit defaults to 1MB — a huge query became a giant AND-of-prefix-terms MATCH expression or a megabyte LIKE pattern scanned against every lyrics blob. That's a cheap DoS lever, and the route is also reachable by read-only federation peers. Now capped at 512 chars (far beyond any real query; a remembered lyric line runs ~100) → over-cap gets the standard Joi 400.

2. **Same cap on the Subsonic side** (`normalizeQueryFragment` in `src/api/subsonic/handlers.js`). Subsonic queries ride the URL, so node's ~16KB header ceiling already bounds them; the 512 truncation makes the two search stacks symmetric. Truncate-not-reject because Subsonic clients expect lenient handling.

3. **Escape the replayed search term** (`webapp/alpha/m.js` + `webapp/velvet/alpha/m.js`). `setupSearchPanel` re-rendered the user's previous query into `value="${searchTerm}"` unescaped on back-navigation — a query containing `"` broke out of the attribute (broken input at best, self-XSS at worst; confined to the user's own in-memory session, so low severity). Now wrapped in the file's existing `escapeHtml`.

4. **Drop doubled ellipses on lyric excerpts** (`webapp/alpha/m.js`). FTS5 `snippet()` already embeds `…` exactly where context was trimmed; the UI wrapped the excerpt in another unconditional pair, rendering "……text…". The wrapper is gone — the server's markers are the source of truth. (Velvet has no lyrics-search UI, so only the escaping fix applies there.)

Plus a one-character `no-useless-escape` lint cleanup in the V59 snippet test that just landed via #765.

## Verification

- New tests: over-cap → 400 and boundary-length (512) → 200 across all three algorithms on the route; Subsonic over-length query truncates and still matches via the kept prefix. Both touched suites green: **35/35**.
- The webapp has no test harness, so both UI fixes were verified live in the browser against a seeded server: searching `harbor "`, drilling into a result, and navigating back replays the input intact (`harbor "` preserved, single well-formed input element); the lyric excerpt renders with exactly one server-provided `…` instead of the doubled pair.
- Changed files introduce no new eslint errors.

## Reviewer notes

- 512 is the one number to bikeshed — it mirrors nothing pre-existing (there was no cap anywhere). Happy to adjust.
- The Subsonic truncation changes behaviour only for >512-char queries, which previously just burned CPU; result contents for any sane query are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)