### PR TITLE
perf(scanner): stream sampled files; old-DB guard; parity coverage (hash review batch 4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,12 +101,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Build rust-parser FROM THIS PR'S SOURCE. The committed bin/ binaries
+      # are rebuilt by CI only AFTER a merge to master, so on a PR that
+      # changes the Rust scanner they are one generation stale — and the
+      # capability-probed suites (sampled hashes, hash-generation migration)
+      # would silently SKIP their Rust halves, leaving the JS↔Rust hash
+      # parity contract unverified at the exact moment it's being changed.
+      # The test helper prefers rust-parser/target/release over bin/, so
+      # this build puts the PR's own scanner under test on every OS.
+      # rust-cache keys off Cargo.lock; warm runs restore in seconds.
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust-parser
+
+      - name: Build rust-parser from source
+        working-directory: rust-parser
+        run: cargo build --release
+
       # Build the fixture library once (normally npm's `pretest`), then run this
-      # shard. The committed rust-parser binary drives the scanner-parity tests
-      # on every OS — including macOS/arm64: the prebuilt binaries are now
-      # self-tested at build time (see build-rust-parser.yml), so the old
-      # macOS-only from-source rebuild is gone. If the binary were absent the
-      # parity tests would skip / fall back to the JS scanner.
+      # shard. The freshly built rust-parser above drives the scanner-parity
+      # tests on every OS; the committed bin/ binaries remain the fallback for
+      # local runs without a toolchain.
       - name: Build fixtures
         run: npm run pretest
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -346,7 +346,9 @@ components:
               description: |
                 V14 audio-payload hash — the preferred stable track identity
                 (survives tag edits, album-art changes, ReplayGain rewrites),
-                unlike `hash` (whole-file MD5). DB column `audio_hash`.
+                unlike `hash` (whole-file coverage). Both are full MD5s for
+                files under 25MB and sampled digests above (V60) — content
+                identities, not byte-exact checksums. DB column `audio_hash`.
             created-at:
               type: string
               nullable: true

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -161,7 +161,10 @@ struct ScanConfig {
 
 impl ScanConfig {
     fn sample_threshold(&self) -> u64 {
-        self.hash_sample_threshold.unwrap_or(SAMPLE_THRESHOLD_DEFAULT)
+        // .max(1): a zero threshold would sample EVERY file (u64 >= 0 is
+        // always true) — the JS scanner's Joi schema rejects 0 outright,
+        // and the engines must never diverge on the same config.
+        self.hash_sample_threshold.unwrap_or(SAMPLE_THRESHOLD_DEFAULT).max(1)
     }
 }
 
@@ -600,15 +603,16 @@ fn main() {
 
     // Hidden developer/test subcommand that uses the buffered scan path
     // (whole file into RAM → md5 from slice). Exercises the same
-    // `compute_hashes_from_bytes` the scanner uses, so a side-by-side
-    // diff vs. `--audio-hash` below proves the streaming and buffered
+    // `compute_hashes_from_bytes` the scanner uses for sub-threshold
+    // files (its only mode — full hashes), so a side-by-side diff vs.
+    // `--audio-hash` below proves the streaming and buffered full
     // paths are byte-identical.
     if args.len() == 3 && args[1] == "--audio-hash-buffered" {
         let p = Path::new(&args[2]);
         let ext = file_ext(p).to_lowercase();
         match fs::read(p) {
             Ok(bytes) => {
-                let (fh, ah) = compute_hashes_from_bytes(&bytes, &ext, SAMPLE_THRESHOLD_DEFAULT);
+                let (fh, ah) = compute_hashes_from_bytes(&bytes, &ext);
                 let ah_json = match ah {
                     Some(s) => format!("\"{}\"", s),
                     None => "null".to_string(),
@@ -1756,6 +1760,24 @@ fn run_scan(config: &ScanConfig) -> Result<(), Box<dyn std::error::Error>> {
             ).into());
         }
     }
+    // BINARY-vs-DB guard, independent of the config check above (which
+    // only compares the SERVER's expectation — an older server driving
+    // this newer binary passes it and would then die mid-scan on a raw
+    // 'no such column: hash_v' with no fallback). This binary reads AND
+    // writes tracks.hash_v (V60), so refuse a pre-V60 database with a
+    // clear versioned message through the same exit-3 mapping.
+    let has_hash_v: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('tracks') WHERE name = 'hash_v'",
+        [], |row| row.get(0))?;
+    if has_hash_v == 0 {
+        return Err(format!(
+            "{}this scanner stamps hashing generation {} and needs tracks.hash_v \
+             (schema V60+), but this database is at V{} — run the matching mStream \
+             server so its migrations bring the DB current, or use the scanner that \
+             shipped with this server version.",
+            SCHEMA_GUARD_ERROR_PREFIX, HASH_GENERATION, schema_version_at_open,
+        ).into());
+    }
 
     // Per-directory folder-image listing cache. Each entry is a OnceLock so
     // the first worker to hit a directory does the read_dir exactly once and
@@ -2829,8 +2851,19 @@ fn extract_track(
     // of ms per new/modified file; on CIFS or spinning disk they're
     // dominant. A size threshold keeps memory bounded so a pathological
     // 2 GB WAV doesn't blow out the process.
+    //
+    // Files at/above the SAMPLING threshold are deliberately NOT
+    // buffered: sampled hashing reads ~1MB of windows, and lofty's
+    // streaming Probe::open reads only tag/header regions — so the
+    // streaming arm costs a couple of MB of I/O where a buffered read
+    // would still pull the whole file over the wire and erase the
+    // entire point of sampling for the 25MB–256MB band. (This is also
+    // why every sampled hash goes through ONE implementation — the
+    // seek-based file path — instead of a buffered twin that must stay
+    // byte-identical with it.)
     const MAX_BUFFERED_FILE: u64 = 256 * 1024 * 1024;
-    let buf: Option<Vec<u8>> = if file_size <= MAX_BUFFERED_FILE {
+    let buf: Option<Vec<u8>> = if file_size <= MAX_BUFFERED_FILE
+        && file_size < config.sample_threshold() {
         match fs::read(filepath) {
             Ok(b) => Some(b),
             Err(e) => {
@@ -3129,7 +3162,9 @@ fn extract_track(
     }
 
     let (file_hash, audio_hash) = match buf.as_deref() {
-        Some(bytes) => compute_hashes_from_bytes(bytes, ext, config.sample_threshold()),
+        // Buffered = below the sampling threshold by the gate above, so
+        // the bytes path only ever computes FULL hashes.
+        Some(bytes) => compute_hashes_from_bytes(bytes, ext),
         None => compute_hashes(filepath, ext, config.sample_threshold())?,
     };
 
@@ -3141,23 +3176,19 @@ fn extract_track(
     // epoch only, also compute what the OLD scheme would have called
     // this file; commit_track ledgers fullCanon→sampledCanon and the
     // stale sweep consults the ledger before orphaning an unmatched
-    // candidate. On the buffered arm this reuses the bytes already in
-    // RAM (pure CPU); the streaming arm pays one extra full read — the
-    // deliberate one-time epoch cost for >256MB files. A genuinely new
-    // (not moved) file leaves an inert ledger row the drain applier
-    // no-ops. Mirrors scanner.mjs.
+    // candidate. Costs one full streaming read per NEW-PATH big file
+    // (>=threshold files are never buffered) — the deliberate one-time
+    // epoch cost. A genuinely new (not moved) file leaves an inert
+    // ledger row the drain applier no-ops. Mirrors scanner.mjs.
     let epoch_old_canon: Option<String> =
         if config.hash_epoch && existing.is_none() && file_size >= config.sample_threshold() {
-            let (full_file, full_audio) = match buf.as_deref() {
-                Some(bytes) => compute_hashes_from_bytes(bytes, ext, u64::MAX),
-                None => match compute_hashes(filepath, ext, u64::MAX) {
-                    Ok(pair) => pair,
-                    Err(e) => {
-                        eprintln!("Warning: epoch move-bridge hash failed for {}: {}",
-                            filepath.display(), e);
-                        (String::new(), None)
-                    }
-                },
+            let (full_file, full_audio) = match compute_hashes(filepath, ext, u64::MAX) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    eprintln!("Warning: epoch move-bridge hash failed for {}: {}",
+                        filepath.display(), e);
+                    (String::new(), None)
+                }
             };
             let full_canon = full_audio.unwrap_or(full_file);
             let sampled_canon = audio_hash.as_deref().unwrap_or(file_hash.as_str());
@@ -5450,6 +5481,13 @@ fn fingerprint_from_file(path: &Path, ext: &str) -> Option<FingerprintOutput> {
 // never flip audio_hash across it. Below the threshold nothing changes:
 // the existing full-hash code runs untouched, byte-identical with every
 // existing row. MUST stay byte-identical with src/db/audio-hash.js.
+//
+// THE CONSTANTS BELOW ARE ONE UNIT, pinned to HASH_GENERATION = 2 —
+// threshold included (it selects which scheme a given content gets, so
+// a tune silently splits identities inside a generation with no
+// convergence signal). Changing any of them means a generation bump +
+// migration with rescanEpochId + replacement partial index, mirrored in
+// audio-hash.js. Never tune in place.
 const SAMPLE_THRESHOLD_DEFAULT: u64 = 25 * 1024 * 1024;
 // Hashing generation stamped into tracks.hash_v: rows written by this
 // scanner carry 2 (threshold-hybrid); pre-V60 rows carry 1 (full-only).
@@ -5495,16 +5533,17 @@ fn read_logical_span_file(
         let rlen = end.saturating_sub(start);
         if rlen == 0 { continue; }
         if skip >= rlen { skip -= rlen; continue; }
-        let mut file_off = start + skip;
+        let file_off = start + skip;
         let mut avail = end - file_off;
         skip = 0;
+        // Sequential reads advance the cursor on their own — one seek
+        // positions the whole span.
         file.seek(SeekFrom::Start(file_off))?;
         while avail > 0 && remaining > 0 {
             let want = (buf.len() as u64).min(avail).min(remaining) as usize;
             let n = file.read(&mut buf[..want])?;
             if n == 0 { return Ok(()); }
             md5.update(&buf[..n]);
-            file_off += n as u64;
             avail -= n as u64;
             remaining -= n as u64;
         }
@@ -5523,44 +5562,9 @@ fn sampled_hash_file(
     Ok(hex_lower(md5.finalize()))
 }
 
-// Buffer twin for the RAM fast-path: same windows over in-memory ranges.
-fn sampled_hash_slices(buf: &[u8], ranges: &[(u64, u64)], total_len: u64) -> String {
-    let mut md5 = Md5::new();
-    md5.update(format!("{}{}:", SAMPLE_DOMAIN, total_len).as_bytes());
-    for (off, len) in sample_windows(total_len) {
-        let mut skip = off;
-        let mut remaining = len;
-        for &(start, end) in ranges {
-            if remaining == 0 { break; }
-            let rlen = end.saturating_sub(start);
-            if rlen == 0 { continue; }
-            if skip >= rlen { skip -= rlen; continue; }
-            let s = (start + skip) as usize;
-            let take = (end - start - skip).min(remaining) as usize;
-            let e = (s + take).min(buf.len());
-            if e > s { md5.update(&buf[s..e]); }
-            remaining -= take as u64;
-            skip = 0;
-        }
-    }
-    hex_lower(md5.finalize())
-}
-
-// Full-content helpers for the mixed combo (file above threshold, audio
-// below — a huge-tag file): single-purpose reads whose byte order is
-// identical to the JS full paths.
-fn full_file_hash(file: &mut fs::File) -> Result<String, std::io::Error> {
-    file.seek(SeekFrom::Start(0))?;
-    let mut md5 = Md5::new();
-    let mut buf = [0u8; 65536];
-    loop {
-        let n = file.read(&mut buf)?;
-        if n == 0 { break; }
-        md5.update(&buf[..n]);
-    }
-    Ok(hex_lower(md5.finalize()))
-}
-
+// Full-content helper for the mixed combo (file above threshold, audio
+// below — a huge-tag file): a single-purpose read whose byte order is
+// identical to the JS full path.
 fn full_ranges_hash(file: &mut fs::File, ranges: &[(u64, u64)]) -> Result<String, std::io::Error> {
     let mut md5 = Md5::new();
     let mut buf = [0u8; 65536];
@@ -5579,40 +5583,17 @@ fn full_ranges_hash(file: &mut fs::File, ranges: &[(u64, u64)]) -> Result<String
     Ok(hex_lower(md5.finalize()))
 }
 
-fn compute_hashes_from_bytes(buf: &[u8], ext: &str, sample_threshold: u64) -> (String, Option<String>) {
+// FULL hashes only, by construction: the scan's buffered arm is gated
+// on file_size < sample_threshold (and the audio payload can never
+// exceed the file), so sampled hashing has exactly ONE implementation —
+// the seek-based path in compute_hashes — with no buffered twin to
+// drift from it.
+fn compute_hashes_from_bytes(buf: &[u8], ext: &str) -> (String, Option<String>) {
     // audio_ranges_for_ext still needs a Read + Seek to walk headers;
     // a Cursor over the slice satisfies that without copying.
     let mut cursor = Cursor::new(buf);
     let ranges = audio_ranges_for_ext(&mut cursor, ext, buf.len() as u64)
         .unwrap_or_default();
-
-    // Sampled pre-branch (see the threshold-hybrid comment above): the
-    // full-hash code below runs untouched when both hashes stay full.
-    let file_size = buf.len() as u64;
-    let audio_len: u64 = ranges.iter().map(|(s, e)| e.saturating_sub(*s)).sum();
-    let file_sampled = file_size >= sample_threshold;
-    let audio_sampled = !ranges.is_empty() && audio_len >= sample_threshold;
-    if file_sampled || audio_sampled {
-        let file_hash = if file_sampled {
-            sampled_hash_slices(buf, &[(0, file_size)], file_size)
-        } else {
-            let mut ctx = Md5::new();
-            ctx.update(buf);
-            hex_lower(ctx.finalize())
-        };
-        let audio_hash = if ranges.is_empty() {
-            None
-        } else if audio_sampled {
-            Some(sampled_hash_slices(buf, &ranges, audio_len))
-        } else {
-            let mut ctx = Md5::new();
-            for &(s, e) in &ranges {
-                if e > s { ctx.update(&buf[s as usize..e as usize]); }
-            }
-            Some(hex_lower(ctx.finalize()))
-        };
-        return (file_hash, audio_hash);
-    }
 
     let mut file_ctx = Md5::new();
 
@@ -5674,15 +5655,15 @@ fn compute_hashes(
     // Sampled pre-branch (see the threshold-hybrid comment above): the
     // single-pass full-hash code below runs untouched when both hashes
     // stay full, preserving byte parity with every existing row.
+    // Gated on file_sampled ALONE: extractor ranges are in-file and
+    // disjoint, so audio_len <= file_size always — the audio hash can
+    // never cross the threshold without the file hash crossing it too
+    // (the reverse — huge-tag files — is the real mixed combo below).
     let audio_len: u64 = ranges.iter().map(|(s, e)| e.saturating_sub(*s)).sum();
     let file_sampled = file_size >= sample_threshold;
     let audio_sampled = has_ranges && audio_len >= sample_threshold;
-    if file_sampled || audio_sampled {
-        let file_hash = if file_sampled {
-            sampled_hash_file(&mut file, &[(0, file_size)], file_size)?
-        } else {
-            full_file_hash(&mut file)?
-        };
+    if file_sampled {
+        let file_hash = sampled_hash_file(&mut file, &[(0, file_size)], file_size)?;
         let audio_hash = if !has_ranges {
             None
         } else if audio_sampled {

--- a/src/api/db.js
+++ b/src/api/db.js
@@ -88,8 +88,11 @@ export function renderMetadataObj(row) {
       // maps (trackQuery already SELECTs t.*, so no extra query). ────────
       // `audio-hash` is the V14 audio-payload hash: the PREFERRED stable
       // identity (survives tag edits, album-art changes, ReplayGain
-      // rewrites), unlike `hash` above which is the whole-file MD5. Added
-      // as a new field; `hash` is left untouched for back-compat.
+      // rewrites), unlike `hash` above which covers the whole file.
+      // Both are full MD5s below the 25MB sampling threshold and
+      // sampled digests above it (V60 — see src/db/audio-hash.js), so
+      // neither is a byte-exact checksum for big files. Added as a new
+      // field; `hash` is left untouched for back-compat.
       'audio-hash': row.audio_hash || null,
       // When the track row was first scanned ≈ "date added to library".
       'created-at': row.created_at || null,

--- a/src/db/audio-hash.js
+++ b/src/db/audio-hash.js
@@ -1,9 +1,15 @@
 /**
  * Dual-hash computation for the scanner.
  *
- *   file_hash  — MD5 of the whole file. Changes on any byte change.
- *   audio_hash — MD5 of just the audio payload region (tag regions
- *                stripped). Stable across tag edits.
+ *   file_hash  — content hash of the whole file. Below the 25MB
+ *                sampling threshold: MD5 of every byte (changes on any
+ *                byte change). At/above it: a domain-prefixed sampled
+ *                MD5 (three windows + length — see the threshold-hybrid
+ *                comment below), so mid-file byte flips OUTSIDE the
+ *                windows do not change it. NOT a whole-file integrity
+ *                checksum for big files.
+ *   audio_hash — same scheme over just the audio payload region (tag
+ *                regions stripped). Stable across tag edits.
  *
  * audio_hash is the preferred identity key for user-facing state
  * (stars, play counts, bookmarks, play queue). It is NULL for formats
@@ -103,6 +109,14 @@ export function fileHashOf(filepath) {
 // MUST stay byte-identical with rust-parser/src/main.rs (same windows,
 // same domain string, same decimal length encoding) — enforced by
 // test/scanner/sampled-hash-vectors.test.mjs and the parity suite.
+//
+// THE FIVE CONSTANTS BELOW ARE ONE UNIT, pinned to HASH_GENERATION = 2.
+// Changing ANY of them (threshold included — it selects which scheme a
+// given content gets, so a tune silently splits identities inside a
+// generation with no convergence signal) means: bump HASH_GENERATION,
+// ship a migration with a rescanEpochId, add a replacement partial
+// index (WHERE hash_v < N), and mirror it all in main.rs. Never tune in
+// place.
 export const SAMPLE_THRESHOLD_DEFAULT = 25 * 1024 * 1024;
 export const HASH_GENERATION = 2;
 const W_START = 256 * 1024;
@@ -129,11 +143,11 @@ function sampleWindows(totalLen) {
 
 // Feed md5 with `len` bytes starting at `logicalOff` of the
 // concatenated ranges' content. Short reads (file truncated mid-scan)
-// end the span early — the next scan recomputes and heals.
-async function readLogicalSpan(fd, ranges, logicalOff, len, md5) {
+// end the span early — the next scan recomputes and heals. `buf` is
+// the caller's scratch buffer, shared across a hash's windows.
+async function readLogicalSpan(fd, ranges, logicalOff, len, md5, buf) {
   let skip = logicalOff;
   let remaining = len;
-  const buf = Buffer.alloc(64 * 1024);
   for (const [start, end] of ranges) {
     if (remaining <= 0) { break; }
     const rlen = end - start;
@@ -154,16 +168,15 @@ async function readLogicalSpan(fd, ranges, logicalOff, len, md5) {
   }
 }
 
-async function sampledHashOverRanges(filepath, ranges, totalLen) {
+// `fd` is opened (and closed) by computeHashes so both sampled hashes
+// share one descriptor — a second open/close is a full round-trip on
+// the network mounts big libraries usually live on.
+async function sampledHashOverRanges(fd, ranges, totalLen) {
   const md5 = crypto.createHash('md5');
   md5.update(`${SAMPLE_DOMAIN}${totalLen}:`);
-  const fd = await fsp.open(filepath, 'r');
-  try {
-    for (const [off, len] of sampleWindows(totalLen)) {
-      await readLogicalSpan(fd, ranges, off, len, md5);
-    }
-  } finally {
-    await fd.close();
+  const scratch = Buffer.alloc(64 * 1024);
+  for (const [off, len] of sampleWindows(totalLen)) {
+    await readLogicalSpan(fd, ranges, off, len, md5, scratch);
   }
   return md5.digest('hex');
 }
@@ -422,6 +435,11 @@ const EXTRACTORS = {
  * @returns {Promise<{fileHash: string, audioHash: string|null, format: string|null}>}
  */
 export async function computeHashes(filepath, { sampleThreshold = SAMPLE_THRESHOLD_DEFAULT } = {}) {
+  // Clamp to >= 1: a zero threshold would sample EVERY file. The scan
+  // payload's Joi schema rejects 0 outright, and the Rust engine clamps
+  // identically (ScanConfig::sample_threshold) — the engines must never
+  // diverge on the same config.
+  const threshold = Math.max(1, sampleThreshold);
   const stat = await fsp.stat(filepath);
   const fileSize = stat.size;
 
@@ -440,19 +458,30 @@ export async function computeHashes(filepath, { sampleThreshold = SAMPLE_THRESHO
   // Per-hash independent thresholds: file_hash by file size, audio_hash
   // by audio-payload length (see the sampled-hashing comment above). A
   // huge-tag file can therefore sample one and not the other — each
-  // hash's choice is deterministic for its own content.
-  const fileHash = fileSize >= sampleThreshold
-    ? await sampledHashOverRanges(filepath, [[0, fileSize]], fileSize)
-    : await hashStream(filepath, 0, null);
+  // hash's choice is deterministic for its own content. When either
+  // hash samples, ONE descriptor is opened here and shared by both
+  // sampled reads (each open is a round-trip on network mounts).
+  const audioLen = ranges
+    ? ranges.reduce((sum, [start, end]) => sum + Math.max(0, end - start), 0)
+    : 0;
+  const fileSampled = fileSize >= threshold;
+  const audioSampled = audioLen >= threshold;
+  const fd = (fileSampled || audioSampled) ? await fsp.open(filepath, 'r') : null;
+  try {
+    const fileHash = fileSampled
+      ? await sampledHashOverRanges(fd, [[0, fileSize]], fileSize)
+      : await hashStream(filepath, 0, null);
 
-  if (!extractor) { return { fileHash, audioHash: null, format: null }; }
-  if (extractorFailed || !ranges) { return { fileHash, audioHash: null, format: ext }; }
+    if (!extractor) { return { fileHash, audioHash: null, format: null }; }
+    if (extractorFailed || !ranges) { return { fileHash, audioHash: null, format: ext }; }
 
-  const audioLen = ranges.reduce((sum, [start, end]) => sum + Math.max(0, end - start), 0);
-  const audioHash = audioLen >= sampleThreshold
-    ? await sampledHashOverRanges(filepath, ranges, audioLen)
-    : await hashRanges(filepath, ranges);
-  return { fileHash, audioHash, format: ext };
+    const audioHash = audioSampled
+      ? await sampledHashOverRanges(fd, ranges, audioLen)
+      : await hashRanges(filepath, ranges);
+    return { fileHash, audioHash, format: ext };
+  } finally {
+    if (fd) { await fd.close(); }
+  }
 }
 
 /**

--- a/src/db/scanner.mjs
+++ b/src/db/scanner.mjs
@@ -1010,8 +1010,9 @@ async function parseMyFile(absolutePath, modified) {
   songInfo.modified = modified;
   songInfo.filePath = path.relative(loadJson.directory, absolutePath).replace(/\\/g, '/');
   songInfo.format = getFileType(absolutePath);
-  // Compute both hashes in one pass. file_hash is whole-file MD5 (stable
-  // identity for a specific byte sequence); audio_hash strips tag regions
+  // Compute both hashes in one pass. file_hash covers the whole file
+  // (full MD5 below the 25MB sampling threshold, sampled scheme above —
+  // see audio-hash.js); audio_hash strips tag regions
   // so stars / bookmarks / play-queue entries survive tag-only edits. For
   // formats the extractor doesn't cover (ogg, opus, m4a, wav, aac)
   // audioHash is null and user_* callers fall back to file_hash.

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -137,9 +137,13 @@ export const SCHEMA_V1 = `
     bitrate INTEGER,
     format TEXT,
     file_size INTEGER,
-    -- file_hash is a content MD5 of the raw file bytes (hex, lowercase).
-    -- Changes on ANY byte change, including tag edits. Used for whole-file
-    -- integrity (e.g. waveform cache — bytes change → re-render).
+    -- file_hash is a content hash of the raw file bytes (hex, lowercase).
+    -- Below the 25MB sampling threshold: MD5 of every byte, changing on
+    -- ANY byte change including tag edits. At/above it (since V60 /
+    -- hash_v generation 2): a domain-prefixed sampled MD5 over three
+    -- windows + the length — see src/db/audio-hash.js — so it is NOT a
+    -- whole-file integrity checksum for big files. tracks.hash_v records
+    -- which scheme generation a row's hashes were computed under.
     --
     -- Companion column audio_hash (added in migration V14) hashes just the
     -- audio payload region, skipping tag metadata. It is the PREFERRED

--- a/test/helpers/scanner-runner.mjs
+++ b/test/helpers/scanner-runner.mjs
@@ -58,6 +58,25 @@ export function findRustParser() {
   return null;
 }
 
+// The hashing generation a binary stamps (its `--hash-generation`
+// answer), or null for pre-probe builds — the shared capability check
+// for suites that need sampled-hash support. One cheap spawnSync
+// replaces the per-suite scan-based feature probes (which cost two full
+// scans each and could disagree between files). Production's gate lives
+// in task-queue.js probeHashGeneration; this mirrors it for tests.
+export function rustParserHashGeneration(bin) {
+  if (!bin) { return null; }
+  try {
+    const r = spawnSync(bin, ['--hash-generation'],
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000 });
+    if (r.status !== 0) { return null; }
+    const gen = parseInt((r.stdout || '').toString().trim(), 10);
+    return Number.isInteger(gen) ? gen : null;
+  } catch (_) {
+    return null;
+  }
+}
+
 export const FFMPEG = process.platform === 'win32'
   ? path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg.exe')
   : path.join(REPO_ROOT, 'bin', 'ffmpeg', 'ffmpeg');

--- a/test/scanner/hash-generation-migration.test.mjs
+++ b/test/scanner/hash-generation-migration.test.mjs
@@ -31,9 +31,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
-  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
+  findRustParser, rustParserHashGeneration, FFMPEG,
+  initEmptyDb, buildScanConfig, runScan, runJsScan,
 } from '../helpers/scanner-runner.mjs';
 import { makeAudio } from '../helpers/scanner-fixture.mjs';
+import { canonicalHash, HASH_GENERATION } from '../../src/db/audio-hash.js';
 
 const MP3 = ['-c:a', 'libmp3lame', '-b:a', '128k', '-id3v2_version', '3'];
 const TEST_THRESHOLD = 96 * 1024;
@@ -46,16 +48,9 @@ let rustHasSampling = null;
 before(async () => {
   rustBin = findRustParser();
   scratch = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-hashmig-'));
-  if (rustBin && fs.existsSync(FFMPEG)) {
-    // Same feature probe as sampled-hash-vectors: stale binaries ignore
-    // the threshold override and keep full hashes.
-    const sb = await makeSandbox('probe', 'rust');
-    await makeAudio(path.join(sb.libRoot, 'p.mp3'), MP3, { title: 'P' }, 30);
-    await sb.scan();
-    const v1 = sb.rows()[0].file_hash;
-    await sb.scan({ forceRescan: true, hashSampleThreshold: HUGE });
-    rustHasSampling = sb.rows()[0].file_hash !== v1;
-  }
+  // Same capability probe as sampled-hash-vectors: one spawnSync
+  // instead of the old two-full-scans feature detection.
+  rustHasSampling = rustParserHashGeneration(rustBin) === HASH_GENERATION;
 });
 
 after(async () => {
@@ -92,7 +87,7 @@ async function makeSandbox(label, engine) {
   return { root, libRoot, waveDir, dbPath, libraryId, vpath, scan, withDb, rows };
 }
 
-const canonOf = (r) => r.audio_hash || r.file_hash;
+const canonOf = canonicalHash;  // the production key-preference rule, not a re-derivation
 
 for (const engine of ['rust', 'js']) {
   const available = () =>
@@ -269,6 +264,46 @@ for (const engine of ['rust', 'js']) {
       { readOnly: true });
       assert.deepEqual(ledger, [{ old_hash: h1, new_hash: h2 }],
         'the move-bridge ledger entry remains for the drain applier');
+    });
+
+    test('rust: refuses a pre-V60 database with a versioned schema-guard message', async (t) => {
+      // Rust-only: the binary reads AND writes tracks.hash_v, so
+      // against a pre-V60 DB it must refuse up front (exit 3, the
+      // schema-guard code) with a message naming the needed version —
+      // not die mid-scan on a raw 'no such column'. The config's
+      // expectedSchemaVersion is pinned to the DB's own version to
+      // simulate the dangerous combo: an OLDER server (whose
+      // expectation matches its own DB) driving this newer binary.
+      if (engine !== 'rust') { t.skip('rust-binary guard'); return; }
+      if (!available()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
+      const { spawnSync } = await import('node:child_process');
+      const { DatabaseSync } = await import('node:sqlite');
+      const { applyAllMigrations } = await import('../helpers/apply-migrations.mjs');
+
+      const root = path.join(scratch, `oldguard-${seq++}`);
+      await fsp.mkdir(path.join(root, 'lib'), { recursive: true });
+      await fsp.mkdir(path.join(root, 'art'), { recursive: true });
+      const dbPath = path.join(root, 'old.db');
+      const db = new DatabaseSync(dbPath);
+      db.exec('PRAGMA foreign_keys = ON');
+      db.exec('PRAGMA recursive_triggers = ON');
+      applyAllMigrations(db, { upToVersion: 59 });
+      db.prepare("INSERT INTO libraries (name, root_path) VALUES ('m', ?)").run(
+        path.join(root, 'lib'));
+      db.close();
+
+      const config = buildScanConfig({
+        dbPath, libraryId: 1, vpath: 'm', directory: path.join(root, 'lib'),
+        albumArtDirectory: path.join(root, 'art'),
+        waveformCacheDir: path.join(root, 'wave'),
+        scanId: 'oldguard',
+        overrides: { expectedSchemaVersion: 59 },
+      });
+      const r = spawnSync(rustBin, [JSON.stringify(config)],
+        { stdio: ['ignore', 'pipe', 'pipe'], timeout: 30000 });
+      assert.equal(r.status, 3, `schema-guard exit code, stderr: ${r.stderr}`);
+      assert.match((r.stderr || '').toString(), /tracks\.hash_v.*V60/s,
+        'the refusal names the missing column and the needed version');
     });
 
     test('content replacement: derived cooldowns stay behind, no transition recorded', async (t) => {

--- a/test/scanner/sampled-hash-vectors.test.mjs
+++ b/test/scanner/sampled-hash-vectors.test.mjs
@@ -31,11 +31,14 @@ import os from 'node:os';
 import path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
-  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
+  findRustParser, rustParserHashGeneration, FFMPEG,
+  initEmptyDb, buildScanConfig, runScan, runJsScan,
 } from '../helpers/scanner-runner.mjs';
 import { makeAudio } from '../helpers/scanner-fixture.mjs';
 import { appendId3v23TextFrames } from '../helpers/id3.mjs';
-import { computeHashes, SAMPLE_THRESHOLD_DEFAULT } from '../../src/db/audio-hash.js';
+import {
+  computeHashes, SAMPLE_THRESHOLD_DEFAULT, HASH_GENERATION,
+} from '../../src/db/audio-hash.js';
 
 const MP3 = ['-c:a', 'libmp3lame', '-b:a', '128k', '-id3v2_version', '3'];
 // Small enough for fast fixtures, large enough that a ~3-minute 128kbps
@@ -49,17 +52,10 @@ let rustHasSampling = null;
 before(async () => {
   rustBin = findRustParser();
   scratch = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-samphash-'));
-
-  // Feature-detect: a pre-sampling binary ignores hashSampleThreshold
-  // and produces the full-scheme hash for an above-threshold file.
-  if (rustBin && fs.existsSync(FFMPEG)) {
-    const probe = await scanBoth('probe', async (lib) => {
-      await makeAudio(path.join(lib, 'p.mp3'), MP3, { title: 'P' }, 30);
-    }, { engines: ['rust'] });
-    const rel = 'p.mp3';
-    const full = await fullSchemeHashes(path.join(probe.libRoot, rel));
-    rustHasSampling = probe.rust.get(rel).file_hash !== full.fileHash;
-  }
+  // Capability probe: a binary that can't answer --hash-generation with
+  // the current generation predates sampled hashing (or stamps a
+  // different scheme) — skip its half of the suite.
+  rustHasSampling = rustParserHashGeneration(rustBin) === HASH_GENERATION;
 });
 
 after(async () => {
@@ -171,6 +167,27 @@ describe('sampled-hash vectors', () => {
       { sampleThreshold: Number.MAX_SAFE_INTEGER });
     assert.equal(js.audioHash, full.audioHash, 'audio stayed on the full scheme');
     assert.notEqual(js.fileHash, full.fileHash, 'file went sampled');
+  });
+
+  test('three-window branch parity: a stream ABOVE the 1MB window sum', async (t) => {
+    // Every other fixture here sits under W_START+W_MID+W_END = 1MB, so
+    // it exercises the whole-stream clamp. Production >=25MB files take
+    // the THREE-WINDOW branch — the mid-window centering and
+    // disjointness arithmetic — which therefore needs its own
+    // above-the-sum fixture (~70s at 128kbps ≈ 1.12MB) pinned across
+    // engines. Also proves the streaming sampled path (files at/above
+    // the threshold are never buffered — the I/O-gate arm).
+    if (!engineAvailable('rust')) { t.skip('rust binary unavailable or pre-sampling'); return; }
+    const r = await scanBoth('threewin', async (lib) => {
+      await makeAudio(path.join(lib, 'long.mp3'), MP3, { artist: 'W', title: 'Windows' }, 70);
+    });
+    const { size } = await fsp.stat(path.join(r.libRoot, 'long.mp3'));
+    assert.ok(size > 1024 * 1024, `fixture must exceed the window sum (got ${size})`);
+    assert.deepEqual(r.rust.get('long.mp3'), r.js.get('long.mp3'),
+      'both engines must place and hash the three windows identically');
+    const { fileHash: fullLong } = await fullSchemeHashes(path.join(r.libRoot, 'long.mp3'));
+    assert.notEqual(r.rust.get('long.mp3').file_hash, fullLong,
+      'the sampled scheme ran (not the full path)');
   });
 
   test('production default threshold is 25MB', () => {


### PR DESCRIPTION
Final batch of the PR #761 adversarial-review findings (batches 1–3 shipped inside #761).

## The I/O gate — the one that makes sampling worth it

The Rust buffered fast-path read **whole files into RAM up to 256MB** regardless of the sampling threshold, so for the 25MB–256MB band — the exact population sampled hashing targets — the scheme saved only MD5 CPU and **zero disk/NAS I/O**. The buffered arm is now gated on `file_size < sample_threshold`: sampled files stream (lofty reads tag/header regions; the hasher seeks three ~KB..512KB windows), cutting per-file I/O from the full payload to ~1–2MB on the mounts big libraries actually live on.

Structural bonus: with the buffered arm sub-threshold-only, `compute_hashes_from_bytes` is full-only again — the `sampled_hash_slices` buffered twin (a standing byte-parity liability, review finding F3), the impossible audio-sampled-but-file-full arm, and `full_file_hash` (F4) are **deleted**. Every sampled hash now has exactly one implementation.

## Binary-vs-DB guard (F1)

The schema guard compares the SERVER's expectation to the DB — an older server driving this newer binary passed it (both said V59) and then died mid-scan on a raw `no such column: hash_v` with no fallback. The binary now refuses a pre-V60 database up front, through the existing schema-guard exit-3 path, naming the needed version. Pinned by a test that runs the real binary against a real V59 database.

## Parity coverage (G1 + S4)

- A ~1.12MB fixture finally exercises the **three-window branch** — every prior fixture sat under the 1MB window sum, so the offset arithmetic every production ≥25MB file uses had zero cross-engine coverage.
- The labeled CI matrix now **builds rust-parser from the PR's own source** (Swatinem/rust-cache + `cargo build --release`). Previously the committed `bin/` binaries were one generation stale on any PR that changed the scanner, so the capability-probed suites silently skipped their Rust halves and the JS↔Rust hash contract was never machine-checked until AFTER merge.
- Both suites' expensive scan-based feature probes collapse into one shared `--hash-generation` spawnSync helper; `canonOf` now aliases the production `canonicalHash`.

## Smaller confirmed findings

- JS sampled path: one shared fd for both hashes (an open per hash is a full round-trip on network mounts) and one scratch buffer per hash instead of per window (G4); `sampleThreshold` clamps to ≥1 exactly like the Rust accessor, so a 0 can never make the engines diverge on one config (F5).
- Docs (G5): the 'whole-file MD5 / changes on any byte change' promise survived in five places — audio-hash.js header, schema.js column comment, scanner.mjs, api/db.js, openapi.yaml — all now state the ≥25MB sampled semantics.
- The five scheme constants (windows, domain, threshold, generation) carry an explicit pin (H4): changing any of them is a new generation with its own migration + `rescanEpochId` + replacement partial index — never an in-place tune.

## Verification

Scanner battery + audio-hash parity: 167/0 (three-window parity test included). DB battery + transition-applier integration: 194/0. Rust builds warning-free. Lint delta vs master: zero. With this PR's own CI change, the matrix now proves the cross-engine contract on the PR itself.

Source-only; `bin/rust-parser` binaries rebuild via CI on master push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)