### PR TITLE
test(scanner): 90s budgets for the per-fork JS-guard tests

### DIFF
--- a/test/scanner/scanner-js-guard.test.mjs
+++ b/test/scanner/scanner-js-guard.test.mjs
@@ -168,7 +168,12 @@ describe('JS fallback scanner — config parity + data-loss guard', () => {
     assert.equal(trackCount(dbPath, libraryId), 2, 'both tracks still present after the rescan');
   });
 
-  test('accessible but empty library: scan runs and sweeps stale tracks', { timeout: 30_000 }, async () => {
+  // 90s, not 30s: each test forks the JS scanner cold, and a slow CI
+  // runner's process spawn + module load once ate a full 30s budget
+  // (35s observed on windows-latest, PR #767 run 29923417061 — passed
+  // on rerun). Labeled full-ci failures block merges, so the budget
+  // needs headroom over the worst runner, not the typical one.
+  test('accessible but empty library: scan runs and sweeps stale tracks', { timeout: 90_000 }, async () => {
     const emptyDir = path.join(workDir, 'empty-lib');
     await fsp.mkdir(emptyDir, { recursive: true });
     const { dbPath, libraryId } = seedDbWithTrack('empty', emptyDir);
@@ -188,7 +193,8 @@ describe('JS fallback scanner — config parity + data-loss guard', () => {
       'stale track should be removed when the library is accessibly empty');
   });
 
-  test('inaccessible library directory: scan aborts without deleting tracks', { timeout: 30_000 }, async () => {
+  // Same 90s budget as above — same per-test scanner fork.
+  test('inaccessible library directory: scan aborts without deleting tracks', { timeout: 90_000 }, async () => {
     const missingDir = path.join(workDir, 'does-not-exist', 'library');
     const { dbPath, libraryId } = seedDbWithTrack('missing', missingDir);
 


### PR DESCRIPTION
The "accessible but empty library" test in `test/scanner/scanner-js-guard.test.mjs` timed out at its 30s budget on a slow windows-latest runner ([PR #767 run](https://github.com/IrosTheBeggar/mStream/actions/runs/29923417061), windows 3/3 — 35s observed) and passed unchanged on rerun: a pure slow-runner flake, but labeled `full-ci` failures block merges, so it can hold real PRs hostage.

Every test in this suite forks the JS scanner as a cold subprocess, and on a congested CI runner the spawn + module load alone can consume most of a 30s budget. Both `30_000` budgets in the file (the empty-library sweep and the inaccessible-directory guard) now carry `90_000` — sized for the worst runner, not the typical one — with a comment recording the observed failure so the number doesn't look arbitrary later.

Test-only change; suite passes locally in 8s (3/3), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)