### PR TITLE
ci: rebase-and-retry the binary commit pushes (sibling race)

### DIFF
--- a/.github/workflows/build-p2p-sidecar-musl.yml
+++ b/.github/workflows/build-p2p-sidecar-musl.yml
@@ -139,6 +139,14 @@ jobs:
             echo "No binary changes to commit"
           else
             git commit -m "ci: update pre-built p2p-sidecar musl binaries"
-            git pull --rebase origin ${{ github.ref_name }}
-            git push
+            # Rebase-and-retry: sibling binary workflows race this push —
+            # see build-rust-parser.yml's commit step for the rationale.
+            for attempt in 1 2 3 4 5; do
+              git pull --rebase origin ${{ github.ref_name }}
+              if git push; then exit 0; fi
+              echo "push rejected (attempt $attempt) — a sibling workflow pushed; retrying"
+              sleep $(( (RANDOM % 5) + 2 ))
+            done
+            echo "::error::binary push failed after 5 attempts"
+            exit 1
           fi

--- a/.github/workflows/build-p2p-sidecar.yml
+++ b/.github/workflows/build-p2p-sidecar.yml
@@ -174,6 +174,14 @@ jobs:
             echo "No binary changes to commit"
           else
             git commit -m "ci: update pre-built p2p-sidecar binaries"
-            git pull --rebase origin ${{ github.ref_name }}
-            git push
+            # Rebase-and-retry: sibling binary workflows race this push —
+            # see build-rust-parser.yml's commit step for the rationale.
+            for attempt in 1 2 3 4 5; do
+              git pull --rebase origin ${{ github.ref_name }}
+              if git push; then exit 0; fi
+              echo "push rejected (attempt $attempt) — a sibling workflow pushed; retrying"
+              sleep $(( (RANDOM % 5) + 2 ))
+            done
+            echo "::error::binary push failed after 5 attempts"
+            exit 1
           fi

--- a/.github/workflows/build-rust-parser-musl.yml
+++ b/.github/workflows/build-rust-parser-musl.yml
@@ -137,6 +137,14 @@ jobs:
             echo "No binary changes to commit"
           else
             git commit -m "ci: update pre-built rust-parser musl binaries"
-            git pull --rebase origin ${{ github.ref_name }}
-            git push
+            # Rebase-and-retry: sibling binary workflows race this push —
+            # see build-rust-parser.yml's commit step for the rationale.
+            for attempt in 1 2 3 4 5; do
+              git pull --rebase origin ${{ github.ref_name }}
+              if git push; then exit 0; fi
+              echo "push rejected (attempt $attempt) — a sibling workflow pushed; retrying"
+              sleep $(( (RANDOM % 5) + 2 ))
+            done
+            echo "::error::binary push failed after 5 attempts"
+            exit 1
           fi

--- a/.github/workflows/build-rust-parser.yml
+++ b/.github/workflows/build-rust-parser.yml
@@ -167,6 +167,23 @@ jobs:
             echo "No binary changes to commit"
           else
             git commit -m "ci: update pre-built rust-parser binaries"
-            git pull --rebase origin ${{ github.ref_name }}
-            git push
+            # Sibling binary workflows can land on the same push (the
+            # glibc + musl pairs share path triggers, and one commit can
+            # match several families) and their commit jobs race: a
+            # sibling pushing between our rebase and our push gets this
+            # push rejected — run 29967087650's glibc leg lost exactly
+            # that race and needed a manual rerun. Rebase-and-retry until
+            # it lands: each workflow writes a disjoint file set, so the
+            # rebase is always clean and a few attempts always converge.
+            # (A shared concurrency group would be WRONG here — GitHub
+            # keeps only one pending run per group and cancels the rest,
+            # silently dropping a sibling's binary update.)
+            for attempt in 1 2 3 4 5; do
+              git pull --rebase origin ${{ github.ref_name }}
+              if git push; then exit 0; fi
+              echo "push rejected (attempt $attempt) — a sibling workflow pushed; retrying"
+              sleep $(( (RANDOM % 5) + 2 ))
+            done
+            echo "::error::binary push failed after 5 attempts"
+            exit 1
           fi

--- a/.github/workflows/build-rust-server-audio.yml
+++ b/.github/workflows/build-rust-server-audio.yml
@@ -128,6 +128,14 @@ jobs:
             echo "No binary changes to commit"
           else
             git commit -m "ci: update pre-built rust-server-audio binaries"
-            git pull --rebase origin ${{ github.ref_name }}
-            git push
+            # Rebase-and-retry: sibling binary workflows race this push —
+            # see build-rust-parser.yml's commit step for the rationale.
+            for attempt in 1 2 3 4 5; do
+              git pull --rebase origin ${{ github.ref_name }}
+              if git push; then exit 0; fi
+              echo "push rejected (attempt $attempt) — a sibling workflow pushed; retrying"
+              sleep $(( (RANDOM % 5) + 2 ))
+            done
+            echo "::error::binary push failed after 5 attempts"
+            exit 1
           fi


### PR DESCRIPTION
After #767 merged, the two rust-parser binary workflows raced their final pushes: musl landed first, and the glibc workflow's push was rejected in the window between its `git pull --rebase` and `git push` ([run 29967087650](https://github.com/IrosTheBeggar/mStream/actions/runs/29967087650)) — binaries built and self-tested fine, but shipping them took a manual rerun. Every rust-parser-touching merge can reproduce this, and the same pattern exists in all **five** binary-committing workflows (rust-parser ×2, p2p-sidecar ×2, rust-server-audio), any of which can race when one commit matches multiple path filters.

The commit step's push is now a **rebase-and-retry loop** (5 attempts, jittered sleep) in all five. Each workflow writes a disjoint file set, so the rebase is always clean and contenders converge within a couple of attempts; exhaustion fails the step loudly instead of silently.

**Why not the shared concurrency group** (the other candidate fix): GitHub holds at most one *pending* run per group and cancels the rest — a single push triggering both siblings would silently cancel one of the two binary updates. The retry keeps every run alive and parallel, and only serialises the few milliseconds that actually conflict.

Verified: all five YAMLs parse; the retry fragment simulated under the runner's `bash -e -o pipefail` semantics (two simulated rejections → lands on attempt 3). The live proof arrives with the next merge that touches a binary source tree.

No `full-ci` label — this changes no product or test code; the workflows themselves only run on master pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)