### PR TITLE
perf(dj): bound the simple-mode pool; ignoreList becomes track ids

### DIFF
--- a/src/api/random.js
+++ b/src/api/random.js
@@ -354,7 +354,7 @@ export function applyTierFilter(rows, opts) {
 // runs when bpmRangesWide is set; step 5b only runs when ignoreArtists
 // is non-empty; step 10 always runs as a final guarantee that SOMETHING
 // comes back if any rows exist in scope.
-function runWaterfallQuery(d, baseSql, baseParams, filterOpts) {
+function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
   const bpm = buildBpmKeyFilter(filterOpts);
   const art = buildArtistFilter(filterOpts);
   const clauses = [...bpm.clauses, ...art.clauses];
@@ -362,7 +362,27 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts) {
   const sql = clauses.length > 0
     ? `${baseSql} AND ${clauses.join(' AND ')}`
     : baseSql;
-  return d.prepare(sql).all(...baseParams, ...params);
+  if (!bounded) { return d.prepare(sql).all(...baseParams, ...params); }
+
+  // Bounded step (request has no BPM/key constraints, no sonic pool —
+  // see runRandomSongs): sample a small random pool instead of
+  // materialising every match. The id cooldown is excluded in SQL
+  // first; when that alone empties the step, retry the SAME step
+  // without it, so cooldown exhaustion falls back to repeats WITHIN
+  // this step's constraints (matching finalisePick's fallback) instead
+  // of advancing the waterfall and silently relaxing an artist
+  // constraint the pool could still satisfy.
+  const { ignoreIds } = bounded;
+  const attempt = (excludeIgnored) => {
+    const exclude = excludeIgnored && ignoreIds.length > 0
+      ? ` AND t.id NOT IN (${ignoreIds.map(() => '?').join(',')})`
+      : '';
+    return d.prepare(`${sql}${exclude} ORDER BY RANDOM() LIMIT ${SIMPLE_POOL_LIMIT}`)
+      .all(...baseParams, ...params, ...(exclude ? ignoreIds : []));
+  };
+  const rows = attempt(true);
+  if (rows.length > 0 || ignoreIds.length === 0) { return rows; }
+  return attempt(false);
 }
 
 // ── Sonic similarity pool (discovery embeddings) ────────────────────────────
@@ -665,6 +685,17 @@ export function runRandomSongs(req, body) {
     });
   }
 
+  // With no BPM/key constraints anywhere on the request, the post-chain
+  // tier filter has nothing to classify, and without sonic there is no
+  // JS-side pool intersection — so every step's query can be bounded the
+  // same way simple mode is. This is the shape real alpha DJ sessions
+  // take: the client sends ignoreArtists from pick #2 onward (artist
+  // cooldown has no off switch), which routes them through the waterfall
+  // even when BPM/key/similar features are all disabled.
+  const bounded = (!hasBpm && !hasBpmWide && !hasKey && !sonic)
+    ? { ignoreIds: ignoreIdsFrom(body) }
+    : null;
+
   let rows = [];
   for (const step of steps) {
     if (!step.gate()) { continue; }
@@ -672,7 +703,7 @@ export function runRandomSongs(req, body) {
     // check that drives relaxation — the waterfall relaxes BPM/key/artist
     // constraints WITHIN the pool and never relaxes the pool itself
     // (including the final unrestricted step).
-    rows = sonicFilter(runWaterfallQuery(d, baseSql, baseParams, step.opts()));
+    rows = sonicFilter(runWaterfallQuery(d, baseSql, baseParams, step.opts(), bounded));
     if (rows.length > 0) { break; }
   }
 

--- a/src/api/random.js
+++ b/src/api/random.js
@@ -81,14 +81,17 @@ export const CAMELOT_TO_KEYS = Object.freeze({
 });
 
 // Convert Camelot codes to the flat list of raw-key names the DB
-// might contain. Unknown codes (anything not in the map) are dropped
-// silently — clients sending a typo just get a no-match for that
-// code, not a 400.
+// might contain. Codes are case-folded ('8a' == '8A') — hand-typed
+// or third-party clients shouldn't silently lose a filter to casing.
+// Unknown codes (anything not in the map) are dropped silently —
+// clients sending a typo just get a no-match for that code, not a
+// 400 (unless ALL codes are unrecognised; the route's Joi custom
+// check catches that).
 export function expandCamelotCodes(codes) {
   if (!Array.isArray(codes) || codes.length === 0) { return []; }
   const out = new Set();
   for (const c of codes) {
-    const expansion = CAMELOT_TO_KEYS[String(c).trim()];
+    const expansion = CAMELOT_TO_KEYS[String(c).trim().toUpperCase()];
     if (!expansion) { continue; }
     for (const k of expansion) { out.add(k); }
   }
@@ -774,14 +777,19 @@ function finalisePick(rows, body, sonic) {
 
 export function setup(mstream) {
   mstream.post('/api/v1/db/random-songs', (req, res) => {
-    // bpmRanges items: require min/max numeric AND min <= max. A
-    // backwards range ({min:200, max:50}) is the most common typo and
-    // produces an SQL clause that matches nothing — silently breaks
-    // the user's Auto-DJ for the duration of the session. Better to
-    // 403 it at the boundary than have the route silently fail.
+    // bpmRanges items: require min/max numeric, within [0, 1000], AND
+    // min <= max. A backwards range ({min:200, max:50}) is the most
+    // common typo and produces an SQL clause that matches nothing —
+    // silently breaks the user's Auto-DJ for the duration of the
+    // session. Better to reject it at the boundary than have the
+    // route silently fail. The numeric bounds reject garbage
+    // (negative / absurd BPM) on the same loud-beats-silent
+    // principle; the webapp already clamps its ranges to [20, 300]
+    // (AUTODJ.buildBpmRanges), so 0-1000 is generous headroom for
+    // other clients.
     const bpmRangeItem = Joi.object({
-      min: Joi.number().required(),
-      max: Joi.number().required(),
+      min: Joi.number().min(0).max(1000).required(),
+      max: Joi.number().min(0).max(1000).required(),
     }).custom((v, helpers) => {
       if (v.min > v.max) {
         return helpers.error('any.custom', { message: 'bpm range min must be <= max' });

--- a/src/api/random.js
+++ b/src/api/random.js
@@ -2,15 +2,30 @@
 //
 // Two operating modes selected per-request from the body:
 //
-//   • Simple mode (no BPM/key params, no body) — behaviour identical to
-//     the pre-V32 random-songs route: load all rows that match the
-//     library filter + minRating, pick a random index, return it.
+//   • Simple mode (no BPM/key params, no body) — same observable
+//     behaviour as the pre-V32 random-songs route (uniform pick over
+//     the in-scope set, cooldown against recent picks), but served by
+//     a bounded SQL sample: the cooldown ids are excluded in SQL and
+//     ORDER BY RANDOM() LIMIT keeps only a small pool, so the whole
+//     library is never materialised into JS.
 //
 //   • Continuity mode (any of bpmRanges / bpmRangesWide / musicalKeys /
 //     requireBpm / requireMusicalKey set) — runs a fallback waterfall
 //     that progressively relaxes the BPM/key constraints until at least
 //     one track matches, then applies a tier filter so an in-range pick
-//     wins over an unknown-tag pick wins over a known-wrong pick.
+//     wins over an unknown-tag pick wins over a known-wrong pick. The
+//     waterfall keeps its full candidate sets — the tier filter needs
+//     every row to classify, and the filters already bound the set.
+//
+// The `ignoreList` the client round-trips holds the last-served TRACK
+// IDS (newest last). Pre-rework lists held candidate-set INDICES, which
+// pointed at different tracks on every call as filters and the library
+// changed; ids make the cooldown actually mean "don't repeat these
+// songs". The client treats the list as opaque (persist + send back —
+// see webapp/alpha/auto-dj.js), so the change is wire-compatible, and a
+// session carrying an old index-based list self-heals: stale values
+// match no candidate row and age out of the capped list within a few
+// picks.
 //
 // This is step B of the Auto-DJ velvet port. Similar-artists support
 // (the `artists` / `ignoreArtists` filters) is step D and lands in a
@@ -398,23 +413,23 @@ function buildSonicPool(req, body) {
   return { index, seedVec, allowed };
 }
 
-function pickRandomNonIgnored(rowCount, ignoreList) {
-  // Trim ignoreList when it grows too large — pre-V32 behaviour.
-  const trimmed = [...ignoreList];
-  while (trimmed.length > rowCount * 0.5) { trimmed.shift(); }
-  if (trimmed.length >= rowCount) {
-    // Every slot is ignored — reset, pick freely.
-    trimmed.length = 0;
-  }
-  const ignoreSet = new Set(trimmed);
-  let idx;
-  let attempts = 0;
-  const cap = rowCount * 4;
-  do {
-    idx = Math.floor(Math.random() * rowCount);
-    attempts++;
-  } while (ignoreSet.has(idx) && attempts < cap);
-  return { idx, trimmedIgnore: trimmed };
+// Server-side cooldown ceiling for the round-tripped ignoreList. Deep
+// enough that a real session never hears a repeat it would notice, small
+// enough that the SQL exclusion in simple mode stays a short IN list.
+// (The Joi wire cap of 500 stays as defense-in-depth headroom.)
+const IGNORE_COOLDOWN_MAX = 50;
+
+// Candidate-pool size for the bounded simple-mode query. The pick is one
+// song; 50 keeps the pool comfortably larger than the cooldown so
+// consecutive picks stay varied even right after a fallback.
+const SIMPLE_POOL_LIMIT = 50;
+
+// Sanitize the client's round-tripped ignoreList to track ids we can bind
+// into SQL / compare against rows. Joi already enforces integers >= 0;
+// this guards the internal callers that bypass the route schema.
+function ignoreIdsFrom(body) {
+  const list = Array.isArray(body.ignoreList) ? body.ignoreList : [];
+  return list.filter((n) => Number.isInteger(n) && n >= 0);
 }
 
 export function runRandomSongs(req, body) {
@@ -474,11 +489,38 @@ export function runRandomSongs(req, body) {
   // step-5b "drop cooldown" fallback if the user pruned themselves
   // into an empty pool.)
   if (!hasBpm && !hasBpmWide && !hasKey && !hasArtists && !hasIgnoreArtists) {
+    if (!sonic) {
+      // Bounded pick: exclude the cooldown ids in SQL and let SQLite keep
+      // only a small random pool — the whole in-scope library is never
+      // materialised into JS. (Sonic mode below still needs the full
+      // in-scope set: the allowed-hash intersection happens in JS, and
+      // sampling before intersecting could empty a pool that actually
+      // has matches.)
+      const ignoreIds = ignoreIdsFrom(body);
+      const bounded = (excludeIgnored) => {
+        const exclude = excludeIgnored && ignoreIds.length > 0
+          ? ` AND t.id NOT IN (${ignoreIds.map(() => '?').join(',')})`
+          : '';
+        return d.prepare(
+          `${baseSql}${exclude} ORDER BY RANDOM() LIMIT ${SIMPLE_POOL_LIMIT}`
+        ).all(...baseParams, ...(exclude ? ignoreIds : []));
+      };
+      let rows = bounded(true);
+      if (rows.length === 0 && ignoreIds.length > 0) {
+        // Cooldown covers everything in scope — allow repeats rather
+        // than stalling the session (same contract as the waterfall's
+        // drop-cooldown steps).
+        rows = bounded(false);
+      }
+      if (rows.length === 0) {
+        throw new WebError('No songs that match criteria', 400);
+      }
+      return finalisePick(rows, body, null);
+    }
+
     const rows = sonicFilter(d.prepare(baseSql).all(...baseParams));
     if (rows.length === 0) {
-      throw new WebError(sonic
-        ? 'No songs within the similarity range match criteria'
-        : 'No songs that match criteria', 400);
+      throw new WebError('No songs within the similarity range match criteria', 400);
     }
     return finalisePick(rows, body, sonic);
   }
@@ -651,23 +693,35 @@ export function runRandomSongs(req, body) {
 }
 
 function finalisePick(rows, body, sonic) {
-  const count = rows.length;
-  const ignoreList = Array.isArray(body.ignoreList) ? body.ignoreList : [];
-  const { idx, trimmedIgnore } = pickRandomNonIgnored(count, ignoreList);
-  trimmedIgnore.push(idx);
+  const sent = ignoreIdsFrom(body);
+  const ignoreSet = new Set(sent);
+  // Cooldown: prefer candidates not served recently. When the cooldown
+  // covers the whole candidate set (tiny library / narrow filters / long
+  // session), fall back to the full set — repeats beat stalling the
+  // session. Simple mode already excluded the ids in SQL, so the filter
+  // is a no-op there; waterfall and sonic sets are filtered here.
+  const fresh = rows.filter((r) => !ignoreSet.has(r.id));
+  const pool = fresh.length > 0 ? fresh : rows;
+  const picked = pool[Math.floor(Math.random() * pool.length)];
+
+  // Move-to-end + trim: newest last, bounded, no duplicate of the pick.
+  // Stale entries (deleted tracks, a pre-rework index-based list) age
+  // out through the cap as new picks append.
+  const nextIgnore = sent.filter((id) => id !== picked.id);
+  nextIgnore.push(picked.id);
+  while (nextIgnore.length > IGNORE_COOLDOWN_MAX) { nextIgnore.shift(); }
 
   // Enrich the picked row with `genres_concat` so renderMetadataObj
   // emits a populated `metadata.genres` field. The candidate-set
   // query above skipped the LEFT JOIN aggregation for speed; this
   // single targeted SELECT costs ~10µs and keeps the wire shape
   // contractually identical.
-  const picked = rows[idx];
   const { genres_concat } = fetchGenresForTrack(db.getDB(), picked.id);
   picked.genres_concat = genres_concat;
 
   const out = {
     songs: [renderMetadataObj(picked)],
-    ignoreList: trimmedIgnore,
+    ignoreList: nextIgnore,
   };
 
   // Sonic mode: report the pick's actual cosine vs the seed/centroid (UI
@@ -713,9 +767,9 @@ export function setup(mstream) {
     // history would otherwise pre-eat that budget.
     //
     // The caps are generous relative to expected use:
-    //   • ignoreList:    DJ session never grows beyond ~50 picks before
-    //                    the server-side trim halves it. 500 is 10×
-    //                    that ceiling.
+    //   • ignoreList:    track ids of recent picks; the server caps the
+    //                    returned list at IGNORE_COOLDOWN_MAX (50), so
+    //                    500 is 10× that ceiling.
     //   • ignoreVPaths:  one entry per vpath; users have <20.
     //   • artists/ignoreArtists: Last.fm's `artist.getSimilar` returns
     //                    at most 50 candidates; 100 covers the unioned

--- a/test/integration/random-route.test.mjs
+++ b/test/integration/random-route.test.mjs
@@ -602,6 +602,42 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
     assert.equal(r.body.ignoreList[0], 900001, 'oldest entry shifted out');
   });
 
+  // ── Bounded waterfall (no-BPM/key sessions) ───────────────────────
+  //
+  // Real alpha DJ sessions send ignoreArtists from pick #2 onward, so
+  // they route through the waterfall even with every BPM/key feature
+  // off. With no BPM/key on the request the tier filter is inert and
+  // the steps are bounded like simple mode: id cooldown excluded in
+  // SQL, then a same-step retry without it so exhaustion falls back to
+  // repeats WITHIN the step instead of advancing the waterfall.
+
+  test('artist-cooldown-only session respects the id cooldown (bounded waterfall)', async () => {
+    const ids = trackIdsByTitle();
+    // ignoreArtists forces the waterfall path; the name matches no
+    // seeded artist so it excludes nothing. Cool down all but t4.
+    const ignore = Object.entries(ids).filter(([t]) => t !== 't4').map(([, id]) => id);
+    for (let i = 0; i < 12; i++) {
+      const r = await randomReq(server.baseUrl, {
+        ignoreArtists: ['No Such Artist'], ignoreList: ignore,
+      });
+      assert.equal(r.status, 200);
+      assert.equal(pickedTitle(r), 't4', `pick ${i} ignored the waterfall id cooldown`);
+    }
+  });
+
+  test('artist-cooldown-only session falls back to repeats when the id cooldown covers everything', async () => {
+    const ids = trackIdsByTitle();
+    const all = Object.values(ids);
+    const r = await randomReq(server.baseUrl, {
+      ignoreArtists: ['No Such Artist'], ignoreList: all,
+    });
+    assert.equal(r.status, 200);
+    const picked = ids[pickedTitle(r)];
+    assert.ok(picked, 'picked a real seeded track');
+    assert.equal(r.body.ignoreList.at(-1), picked);
+    assert.equal(r.body.ignoreList.length, all.length, 'move-to-end keeps the list from growing');
+  });
+
   // ── PR-E0: bpm + musical-key fields exposed in metadata response ──
   //
   // Field name is `musical-key` (kebab-case) on the wire to match

--- a/test/integration/random-route.test.mjs
+++ b/test/integration/random-route.test.mjs
@@ -521,6 +521,87 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
     assert.ok(r.body.ignoreList[0] >= 0);
   });
 
+  // ── ignoreList = track ids (bounded-pool rework) ──────────────────
+  //
+  // The round-tripped list holds the last-served TRACK IDS (newest
+  // last, capped at 50). Simple mode excludes them in SQL inside a
+  // bounded ORDER BY RANDOM() pool; the waterfall and sonic paths
+  // filter by id in finalisePick. Stale values (deleted tracks or a
+  // pre-rework index-based list) match nothing and age out via the cap.
+
+  function trackIdsByTitle() {
+    const sdb = new DatabaseSync(path.join(tmpDir, 'db', 'mstream.db'), { readOnly: true });
+    const map = {};
+    for (const r of sdb.prepare("SELECT id, title FROM tracks WHERE scan_id = 'seed'").all()) {
+      map[r.title] = r.id;
+    }
+    sdb.close();
+    return map;
+  }
+
+  test('ignoreList entries are the picked track ids', async () => {
+    const ids = trackIdsByTitle();
+    const r = await randomReq(server.baseUrl, { ignoreList: [] });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.ignoreList.length, 1);
+    assert.equal(r.body.ignoreList[0], ids[pickedTitle(r)],
+      'returned ignoreList entry is the picked track id');
+  });
+
+  test('fed-back ids are excluded from subsequent simple-mode picks', async () => {
+    const ids = trackIdsByTitle();
+    // Cool down everything except t4 — every pick must be t4.
+    const ignore = Object.entries(ids).filter(([t]) => t !== 't4').map(([, id]) => id);
+    for (let i = 0; i < 12; i++) {
+      const r = await randomReq(server.baseUrl, { ignoreList: ignore });
+      assert.equal(r.status, 200);
+      assert.equal(pickedTitle(r), 't4', `pick ${i} ignored the cooldown`);
+    }
+  });
+
+  test('waterfall path also respects the id cooldown', async () => {
+    const ids = trackIdsByTitle();
+    // bpm 124-125 narrows to {t1, t2, t7}; cool down t1+t2 → always t7.
+    const ignore = [ids.t1, ids.t2];
+    for (let i = 0; i < 12; i++) {
+      const r = await randomReq(server.baseUrl, {
+        bpmRanges: [{ min: 124, max: 125 }], ignoreList: ignore,
+      });
+      assert.equal(r.status, 200);
+      assert.equal(pickedTitle(r), 't7', `pick ${i} ignored the waterfall cooldown`);
+    }
+  });
+
+  test('cooldown covering the whole pool falls back to repeats (no 400)', async () => {
+    const ids = trackIdsByTitle();
+    const all = Object.values(ids);
+    const r = await randomReq(server.baseUrl, { ignoreList: all });
+    assert.equal(r.status, 200);
+    // Move-to-end: the picked id appears exactly once, at the end, and
+    // the list does not grow.
+    const picked = ids[pickedTitle(r)];
+    assert.equal(r.body.ignoreList.at(-1), picked);
+    assert.equal(r.body.ignoreList.filter((x) => x === picked).length, 1);
+    assert.equal(r.body.ignoreList.length, all.length);
+  });
+
+  test('stale ids are inert and retained until capped out', async () => {
+    const r = await randomReq(server.baseUrl, { ignoreList: [999991, 999992] });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.ignoreList.length, 3);
+    assert.deepEqual(r.body.ignoreList.slice(0, 2), [999991, 999992]);
+  });
+
+  test('returned list is capped at 50, newest last', async () => {
+    const ids = trackIdsByTitle();
+    const fifty = Array.from({ length: 50 }, (_, i) => 900000 + i);
+    const r = await randomReq(server.baseUrl, { ignoreList: fifty });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.ignoreList.length, 50);
+    assert.equal(r.body.ignoreList.at(-1), ids[pickedTitle(r)], 'picked id lands at the end');
+    assert.equal(r.body.ignoreList[0], 900001, 'oldest entry shifted out');
+  });
+
   // ── PR-E0: bpm + musical-key fields exposed in metadata response ──
   //
   // Field name is `musical-key` (kebab-case) on the wire to match

--- a/test/integration/random-route.test.mjs
+++ b/test/integration/random-route.test.mjs
@@ -171,6 +171,16 @@ describe('buildBpmKeyFilter', () => {
     assert.deepEqual(clauses, []);
   });
 
+  test('Camelot codes are case-insensitive', () => {
+    // '8a' from a hand-typed or third-party client must not silently
+    // drop the filter — it expands identically to '8A'.
+    assert.deepEqual(
+      expandCamelotCodes(['8a', '12b']).sort(),
+      expandCamelotCodes(['8A', '12B']).sort(),
+    );
+    assert.ok(expandCamelotCodes(['8a']).includes('A minor'));
+  });
+
   test('requireMusicalKey adds IS NOT NULL guard', () => {
     const { clauses } = buildBpmKeyFilter({ requireMusicalKey: true });
     assert.deepEqual(clauses, ['t.musical_key IS NOT NULL']);
@@ -710,10 +720,33 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
     assert.equal(meta['musical-key'], null);
   });
 
+  test('lowercase Camelot codes work end-to-end', async () => {
+    // Same narrowing as the round-trip test above, but with '8a' —
+    // case-folding means the filter still pins to t1 (124, "A minor").
+    const r = await randomReq(server.baseUrl, {
+      bpmRanges: [{ min: 124, max: 124 }],
+      musicalKeys: ['8a'],
+    });
+    assert.equal(r.status, 200);
+    const meta = r.body.songs[0].metadata;
+    assert.equal(meta.bpm, 124);
+    assert.equal(meta['musical-key'], 'A minor');
+  });
+
   // ── Joi validation ────────────────────────────────────────────────
 
   test('bpmRanges item missing min → 400', async () => {
     const r = await randomReq(server.baseUrl, { bpmRanges: [{ max: 130 }] });
+    assert.equal(r.status, 400);
+  });
+
+  test('bpmRanges with negative min → 400', async () => {
+    const r = await randomReq(server.baseUrl, { bpmRanges: [{ min: -5, max: 130 }] });
+    assert.equal(r.status, 400);
+  });
+
+  test('bpmRanges with absurd max → 400', async () => {
+    const r = await randomReq(server.baseUrl, { bpmRanges: [{ min: 100, max: 5000 }] });
     assert.equal(r.status, 400);
   });
 

--- a/test/integration/random-sonic.test.mjs
+++ b/test/integration/random-sonic.test.mjs
@@ -93,9 +93,11 @@ async function pick(body, user = 'admin') {
 
 // Repeated picks — the route returns ONE random song per call, so pool
 // membership/coverage is asserted over many draws. Draws are independent:
-// the server trims a fed-back ignoreList to ≤ half the pool size
-// (pickRandomNonIgnored in src/api/random.js), so exclusion can't
-// deterministically drain a pool. Full-coverage draw counts are therefore
+// these helpers never feed the returned ignoreList back, so every call
+// carries the same body and the server-side id cooldown (finalisePick in
+// src/api/random.js — capped list, falls back to repeats when it covers
+// the whole candidate set) can't drain a pool across draws.
+// Full-coverage draw counts are therefore
 // sized so a miss is astronomically unlikely —
 //   P(miss) ≤ poolSize · ((poolSize-1)/poolSize)^draws
 // ≈ 2e-11 for 64 draws over a 3-pool, ≈ 2e-12 for 40 over a 2-pool.


### PR DESCRIPTION
## Summary

The Auto-DJ half of the original #621, reworked for the post-sonic-mode waterfall (the June diff predated #697's rolling/locked anchors and the cooldown-starves-sonic-pool fix, so this is a fresh implementation, not a rebase). Completes the #621 split — the stats half already merged.

Two changes, one file:

### 1. Simple mode is bounded

Simple mode (no BPM/key/artist filters — the default Auto-DJ configuration) loaded **every in-scope track into JS** through the trackQuery joins just to pick one. It now excludes the cooldown ids in SQL and samples a pool with `ORDER BY RANDOM() LIMIT 50` — the library is never materialised into JS.

**156.3ms → 12.6ms (~12×)** per pick on a synthetic 20k-track library with a 50-deep cooldown (best-of-10; the residue is SQLite's in-SQL random scan, which ships 50 rows instead of 20,000).

**Audit follow-up (second commit): the no-BPM/key waterfall steps are bounded too.** Real alpha DJ sessions send `ignoreArtists` from pick #2 onward (the artist cooldown has no off switch), routing them through the waterfall even with every BPM/key feature off — so the bounded simple path alone would only have served a session's *first* pick. When the request has no BPM/key constraints (tier filter inert) and no sonic pool, each step now takes the same treatment, with a same-step retry without the id exclusion so cooldown exhaustion falls back to repeats *within* the step's constraints instead of advancing the waterfall and silently dropping an artist constraint the pool could still satisfy. **221.4ms → 18.3ms (~12×)** for the artist-cooldown-only shape.

Deliberately NOT bounded:
- **Sonic mode** — its allowed-hash intersection happens in JS after the query; sampling before intersecting could empty a pool that actually has matches (the same interaction class as the cooldown-starves-sonic-pool bug).
- **BPM/key requests** — the tier filter needs the full row set to classify in-range vs unknown vs wrong, and those filters already bound the set.

### 2. `ignoreList` becomes track ids

The round-tripped list changes from candidate-set **indices** to **track ids** (newest last, server-capped at 50). Indices pointed at different tracks on every call as filters and the library changed — the cooldown was noise in real sessions. Ids make it mean "don't repeat these songs", and the waterfall/sonic paths now get a working cooldown too (same id filter in `finalisePick`; previously the index dance was meaningless there).

When the cooldown covers the whole candidate set, the pick falls back to the full set — repeats beat stalling the session, mirroring the waterfall's drop-cooldown steps.

**Wire-compatible:** every client treats the list as opaque (persist + resend — `webapp/alpha/auto-dj.js`: "the server is authoritative"), and the Joi shape (ints ≥ 0, max 500) is unchanged. A session carrying a pre-rework index list self-heals: stale values match no candidate row and age out of the capped list within a few picks.

### 3. Audit robustness pair (third commit)

- **Camelot codes are case-folded** — `'8a'` now expands identically to `'8A'` instead of silently dropping the filter (the Joi guard only caught the all-codes-unrecognised case, not partial or all-lowercase lists).
- **`bpmRanges` values bounded to [0, 1000]** at the Joi layer — negative/absurd values produced an SQL clause that matched nothing and silently degraded the session; same loud-beats-silent principle as the existing `min <= max` check. The webapp already clamps its ranges to [20, 300] (`AUTODJ.buildBpmRanges`), so this is pure garbage rejection with headroom for other clients.

Deferred (parked, separate concern): the sonic `poolSize` visibility clamp — the reported pool size counts analyzed tracks regardless of the caller's library access; fixing it needs a per-request scope intersection and touches nothing in this diff.

## Testing

- **8 new integration tests**: ignoreList entries are the picked track's id (verified against the DB); fed-back ids are excluded in simple mode (12/12 picks land on the only non-cooled track); the waterfall path respects the id cooldown (BPM-narrowed pool, 12/12); the bounded artist-cooldown-only shape respects it too (12/12) and falls back to repeats within the step when the cooldown covers everything; cooldown covering the whole pool → 200 with a repeat, move-to-end keeps the list deduped and non-growing; stale ids are inert; the list caps at 50 newest-last.
- **Existing suites green, unchanged**: random-route 77 pre-existing (85 total now), random-sonic + random-similar-artists 31, auto-dj-client 155. Also freshened the sonic suite's draw-independence comment, which cited the removed `pickRandomNonIgnored`.
- **Live smoke on a booted server**: a fed-back API walk over an 8-item library produced 8 distinct picks then graceful repeats with the list stable at 8 ids; the real UI Auto-DJ session (toggle → queue-ahead → track skips) queued 5 distinct tracks with the client persisting server-issued ids `[7,2,5,4,6]`. No console or server errors.
- **4 more tests for the robustness pair**: unit case-fold equivalence; lowercase `['8a']` narrows to the same track as `['8A']` end-to-end; negative min and >1000 max each 400. (120 total across the three random suites.)
- **Second live smoke** for the audit commits: lowercase `['8a']` → 200 (was 400), bogus `['99X']` still 400, negative/absurd ranges 400 with precise Joi messages, sane range 200; real DJ session with BPM continuity on (client-generated ranges through the new bounds) queued 4/4 distinct tracks with id round-trip. One observation from that smoke, pre-existing and unrelated to this diff: with `m3u` in `supportedAudioFiles`, an .m3u indexed as a track is artist-less, so once the artist cooldown covers every real artist it becomes the only surviving candidate of the `unrestricted` step (the drop-cooldown step never fires because the step isn't empty) — and since an .m3u can't play, the queue-ahead loop spins on it. Tiny-library + m3u-config edge; noting for a future artist-cooldown/artistless-rows follow-up.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
