### PR TITLE
fix(dj): escape artistless-row pinning; exclude m3u from DJ candidates

### DIFF
--- a/src/api/random.js
+++ b/src/api/random.js
@@ -372,10 +372,15 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
   // materialising every match. The id cooldown is excluded in SQL
   // first; when that alone empties the step, retry the SAME step
   // without it, so cooldown exhaustion falls back to repeats WITHIN
-  // this step's constraints (matching finalisePick's fallback) instead
-  // of advancing the waterfall and silently relaxing an artist
-  // constraint the pool could still satisfy.
-  const { ignoreIds } = bounded;
+  // this step's constraints (matching finalisePick's fallback).
+  //
+  // The retry is skipped for artist-cooldown-ENFORCING steps
+  // (allowRepeatRetry false): their all-cooled rows would be rejected
+  // by the step loop's id-fresh rule anyway (see runRandomSongs), so
+  // returning empty lets the waterfall advance toward the
+  // drop-cooldown step without paying for a query whose result is
+  // discarded.
+  const { ignoreIds, allowRepeatRetry } = bounded;
   const attempt = (excludeIgnored) => {
     const exclude = excludeIgnored && ignoreIds.length > 0
       ? ` AND t.id NOT IN (${ignoreIds.map(() => '?').join(',')})`
@@ -384,7 +389,7 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
       .all(...baseParams, ...params, ...(exclude ? ignoreIds : []));
   };
   const rows = attempt(true);
-  if (rows.length > 0 || ignoreIds.length === 0) { return rows; }
+  if (rows.length > 0 || ignoreIds.length === 0 || !allowRepeatRetry) { return rows; }
   return attempt(false);
 }
 
@@ -486,6 +491,14 @@ export function runRandomSongs(req, body) {
     baseConditions.push(...genre.clauses);
     baseParams.push(...genre.params);
   }
+
+  // Playlist files indexed as tracks (supportedAudioFiles m3u) are never
+  // DJ candidates — the player can't stream an .m3u, so serving one spins
+  // the client's queue-ahead loop on an unplayable pick. Being artist-less,
+  // such rows also survive any ignoreArtists cooldown, which made one the
+  // pinned pick of an entire session (see the artistless-rows rule in the
+  // step loop below). COALESCE keeps legacy NULL-format rows as candidates.
+  baseConditions.push("COALESCE(t.format, '') <> 'm3u'");
 
   // Skip the trackQuery `tg_agg` aggregation for the candidate-set
   // query — only the picked row's genres survive to the response, and
@@ -695,19 +708,40 @@ export function runRandomSongs(req, body) {
   // take: the client sends ignoreArtists from pick #2 onward (artist
   // cooldown has no off switch), which routes them through the waterfall
   // even when BPM/key/similar features are all disabled.
-  const bounded = (!hasBpm && !hasBpmWide && !hasKey && !sonic)
-    ? { ignoreIds: ignoreIdsFrom(body) }
-    : null;
+  const boundedMode = !hasBpm && !hasBpmWide && !hasKey && !sonic;
+  const ignoreIds = ignoreIdsFrom(body);
+  const ignoreSet = new Set(ignoreIds);
 
   let rows = [];
   for (const step of steps) {
     if (!step.gate()) { continue; }
+    const opts = step.opts();
+    // Artistless-rows rule: a step that ENFORCES the artist cooldown
+    // must yield at least one id-fresh row to win. Tracks with no
+    // artist credits trivially survive the ignoreArtists exclusion, so
+    // when the cooldown covers every artist in scope they become a
+    // step's only survivors — and because the step is then never
+    // empty, the drop-cooldown fallback would never fire, pinning the
+    // session to those few rows forever. If every survivor is in the
+    // id cooldown the pick would be a repeat anyway; taking it from
+    // the drop-cooldown pool below instead restores real variety
+    // (id-fresh tracks by cooled artists). The drop-cooldown step
+    // always exists when ignoreArtists is set, and it accepts
+    // all-cooled rows (finalisePick then repeats), so the session
+    // still never stalls.
+    const enforcesCooldown = Array.isArray(opts.ignoreArtists) && opts.ignoreArtists.length > 0;
     // The sonic pool intersects EVERY step's result before the emptiness
     // check that drives relaxation — the waterfall relaxes BPM/key/artist
     // constraints WITHIN the pool and never relaxes the pool itself
     // (including the final unrestricted step).
-    rows = sonicFilter(runWaterfallQuery(d, baseSql, baseParams, step.opts(), bounded));
-    if (rows.length > 0) { break; }
+    const candidate = sonicFilter(runWaterfallQuery(
+      d, baseSql, baseParams, opts,
+      boundedMode ? { ignoreIds, allowRepeatRetry: !enforcesCooldown } : null,
+    ));
+    if (candidate.length === 0) { continue; }
+    if (enforcesCooldown && candidate.every((r) => ignoreSet.has(r.id))) { continue; }
+    rows = candidate;
+    break;
   }
 
   if (rows.length === 0) {

--- a/test/integration/random-route.test.mjs
+++ b/test/integration/random-route.test.mjs
@@ -1313,3 +1313,181 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
     assert.deepEqual(r.body.songs[0].metadata.genres, []);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// Artist cooldown vs artistless rows — dedicated fixture.
+//
+// Tracks with no artist credits trivially survive the ignoreArtists
+// exclusion. Before the artistless-rows rule (see runRandomSongs), a
+// cooldown covering every artist in scope left artistless rows as the
+// only survivors of the 'unrestricted' step — which, being non-empty,
+// blocked the drop-cooldown fallback and pinned the session to those
+// rows forever. Reproduced live with an .m3u indexed as a track
+// (artist-less AND unplayable). Own server + seed: two real artists,
+// two artistless audio tracks, a NULL-format track, and an m3u row.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('random-songs — artist cooldown vs artistless rows', () => {
+  let tmpDir;
+  let server;
+
+  function seedCooldownDB(dbPath) {
+    const db = new DatabaseSync(dbPath);
+    db.exec('PRAGMA foreign_keys = ON');
+    const lib = db.prepare("SELECT id FROM libraries WHERE name = 'testlib'").get().id;
+    const a1 = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist Uno')").run().lastInsertRowid);
+    const a2 = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist Dos')").run().lastInsertRowid);
+    const insT = db.prepare(`
+      INSERT INTO tracks (filepath, library_id, title, artist_id, format,
+                          file_hash, audio_hash, modified, scan_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'cd-seed')
+    `);
+    let ts = 1700000000000;
+    // [filepath, title, artist_id, format]
+    const rows = [
+      ['uno.flac',       'Uno Song',        a1,   'flac'],
+      ['dos.flac',       'Dos Song',        a2,   'flac'],
+      ['untagged1.flac', 'Untagged One',    null, 'flac'],
+      ['untagged2.flac', 'Untagged Two',    null, 'flac'],
+      ['formatless',     'Formatless Song', null, null],   // legacy NULL format — still a candidate
+      ['mix.m3u',        'Mixtape',         null, 'm3u'],  // playlist-as-track — never a candidate
+    ];
+    for (let i = 0; i < rows.length; i++) {
+      const [fp, title, aid, format] = rows[i];
+      insT.run(fp, lib, title, aid, format, `cfh${i}`, `cah${i}`, ts++);
+    }
+    db.close();
+  }
+
+  function idsByTitle() {
+    const sdb = new DatabaseSync(path.join(tmpDir, 'db', 'mstream.db'), { readOnly: true });
+    const map = {};
+    for (const r of sdb.prepare("SELECT id, title FROM tracks WHERE scan_id = 'cd-seed'").all()) {
+      map[r.title] = r.id;
+    }
+    sdb.close();
+    return map;
+  }
+
+  const ARTISTLESS = ['Untagged One', 'Untagged Two', 'Formatless Song'];
+  const REAL_ARTIST_TRACKS = ['Uno Song', 'Dos Song'];
+  const BOTH_ARTISTS = ['Artist Uno', 'Artist Dos'];
+
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-random-cd-'));
+    const musicDir = path.join(tmpDir, 'music');
+    await fs.mkdir(musicDir, { recursive: true });
+    server = await bootMstream(tmpDir, musicDir);
+    await killProc(server.proc);
+    await sleep(200);
+    seedCooldownDB(path.join(tmpDir, 'db', 'mstream.db'));
+    server = await bootMstream(tmpDir, musicDir);
+  });
+
+  after(async () => {
+    if (server?.proc) await killProc(server.proc);
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('m3u rows are never DJ candidates (simple mode)', async () => {
+    const seen = new Set();
+    for (let i = 0; i < 40; i++) {
+      const r = await randomReq(server.baseUrl, {});
+      assert.equal(r.status, 200);
+      seen.add(pickedTitle(r));
+    }
+    assert.ok(!seen.has('Mixtape'), 'unplayable .m3u row surfaced as a DJ pick');
+    // The other five (incl. the NULL-format legacy row) all remain
+    // candidates. 40 draws over a 5-pool misses a given row with
+    // P ~ 2e-4; assert >=4 distinct so one unlucky miss cannot flake CI,
+    // and require the NULL-format row unless it was the single miss.
+    assert.ok(seen.size >= 4, `expected >=4 distinct picks, saw ${[...seen].join(',')}`);
+    assert.ok(seen.has('Formatless Song') || seen.size === 5,
+      'NULL-format row should stay a candidate');
+  });
+
+  test('m3u rows are excluded from the drop-cooldown step too', async () => {
+    // Cool down both artists AND id-cool every artistless row: the
+    // enforcing step is rejected (all survivors id-cooled), and the
+    // drop-cooldown pool must still exclude the m3u.
+    const ids = idsByTitle();
+    for (let i = 0; i < 15; i++) {
+      const r = await randomReq(server.baseUrl, {
+        ignoreArtists: BOTH_ARTISTS,
+        ignoreList: ARTISTLESS.map((t) => ids[t]),
+      });
+      assert.equal(r.status, 200);
+      assert.notEqual(pickedTitle(r), 'Mixtape', `pick ${i} served the .m3u`);
+    }
+  });
+
+  test('cooldown covering every artist: session escapes artistless pinning', async () => {
+    // The live-repro walk. Feed the returned ignoreList back each pick
+    // with both artists cooled. Picks drain the id-fresh artistless
+    // rows first (they legitimately satisfy the cooldown); once those
+    // are id-cooled the enforcing step is rejected and the
+    // drop-cooldown step must surface REAL-artist tracks. Previously
+    // impossible: the session pinned to the artistless rows forever.
+    let ignoreList = [];
+    const picks = [];
+    for (let i = 0; i < 6; i++) {
+      const r = await randomReq(server.baseUrl, {
+        ignoreArtists: BOTH_ARTISTS, ignoreList,
+      });
+      assert.equal(r.status, 200);
+      picks.push(pickedTitle(r));
+      ignoreList = r.body.ignoreList;
+    }
+    // First three picks: the artistless rows, no repeats among them.
+    assert.deepEqual([...picks.slice(0, 3)].sort(), [...ARTISTLESS].sort(),
+      `expected the three artistless rows first, got ${picks.join(' | ')}`);
+    // Picks 4-5: the real-artist tracks — the escape. (They are id-fresh
+    // in the drop-cooldown pool, so no repeats until they too are cooled.)
+    assert.deepEqual([...picks.slice(3, 5)].sort(), [...REAL_ARTIST_TRACKS].sort(),
+      `expected the real-artist tracks after the escape, got ${picks.join(' | ')}`);
+  });
+
+  test('same escape through the requireBpm (unbounded) path', async () => {
+    // The live repro ran with bpmContinuity on and no anchor, i.e.
+    // requireBpm: true. Every row here has NULL bpm, so the BPM steps
+    // are empty and the cooldown-enforcing 'unrestricted' step decides
+    // — same pinning, different (unbounded) code path.
+    const ids = idsByTitle();
+    const r = await randomReq(server.baseUrl, {
+      requireBpm: true,
+      ignoreArtists: BOTH_ARTISTS,
+      ignoreList: ARTISTLESS.map((t) => ids[t]),
+    });
+    assert.equal(r.status, 200);
+    assert.ok(REAL_ARTIST_TRACKS.includes(pickedTitle(r)),
+      `expected a real-artist track, got ${pickedTitle(r)}`);
+  });
+
+  test('partial cooldown is unaffected while id-fresh survivors exist', async () => {
+    // Only Artist Uno cooled: the enforcing step keeps id-fresh
+    // survivors (Dos Song + the artistless rows), so it still wins and
+    // Uno Song never surfaces.
+    const seen = new Set();
+    for (let i = 0; i < 30; i++) {
+      const r = await randomReq(server.baseUrl, { ignoreArtists: ['Artist Uno'] });
+      assert.equal(r.status, 200);
+      seen.add(pickedTitle(r));
+    }
+    assert.ok(!seen.has('Uno Song'), 'artist cooldown leaked a cooled artist');
+    assert.ok(!seen.has('Mixtape'));
+    assert.ok(seen.size >= 3, `expected >=3 distinct picks, saw ${[...seen].join(',')}`);
+  });
+
+  test('tiny library fully id-cooled still never stalls (repeats from drop-cooldown pool)', async () => {
+    const ids = idsByTitle();
+    const all = Object.entries(ids)
+      .filter(([t]) => t !== 'Mixtape')
+      .map(([, id]) => id);
+    const r = await randomReq(server.baseUrl, {
+      ignoreArtists: BOTH_ARTISTS, ignoreList: all,
+    });
+    assert.equal(r.status, 200);
+    assert.notEqual(pickedTitle(r), 'Mixtape');
+    assert.equal(r.body.ignoreList.length, all.length, 'move-to-end keeps the list from growing');
+  });
+});


### PR DESCRIPTION
## Summary

Built on #774 (now merged); the branch is synced with master and the diff is this fix alone.

Fixes the pre-existing Auto-DJ edge documented in #774's description: tracks with no artist credits trivially survive `buildArtistFilter`'s `ignoreArtists` exclusion. Once the client's artist cooldown (capped at 15) covers every distinct artist in the DJ's scope, artistless rows become the **only survivors** of the `unrestricted` waterfall step — and because that step is never empty, the `unrestricted-drop-cooldown` fallback never fires. The session pins to those rows forever. Reproduced live with an `.m3u` indexed as a track (`supportedAudioFiles.m3u: true`): artist-less **and** unplayable, so the queue-ahead loop spun on it — 19 copies queued in seconds.

## Two fixes

### 1. `.m3u` rows are never DJ candidates

A base condition (`COALESCE(t.format, '') <> 'm3u'`) applied to every path — simple, waterfall, sonic. The player cannot stream a playlist file, so serving one is always wrong regardless of the cooldown story. NULL-format legacy rows remain candidates. (Whether the scanner should index `.m3u` into `tracks` at all is a bigger question — it touches search/stats/counts and needs rust-parser + JS scanner parity — deliberately left out of this fix.)

### 2. The artistless-rows rule

A waterfall step that **enforces** the artist cooldown must yield at least one id-fresh row to win; otherwise the loop continues toward its drop-cooldown sibling (which always exists when `ignoreArtists` is set). Rationale: if every survivor is id-cooled, the pick would be a repeat anyway — taking it from the drop-cooldown pool instead restores real variety, because that pool contains id-fresh tracks by cooled artists. Priorities become: fresh song by any artist > repeat.

- In bounded mode, enforcing steps skip the same-step no-exclusion retry from #774 — their all-cooled rows would be rejected by the new rule anyway, so the step reads as empty and the waterfall advances without paying for a discarded query.
- The drop-cooldown step still accepts all-cooled rows (`finalisePick` then repeats), so a fully-cooled tiny library **repeats rather than stalls** — no new 400s. Sessions without `ignoreArtists` have no enforcing steps and are byte-identical in behavior.

## Testing

- **6 new integration tests** on a dedicated fixture (two real artists, two artistless audio tracks, a NULL-format track, an m3u row): m3u never picked in simple mode nor from the drop-cooldown pool; the **fed-back walk reproducing the live pinning** — 3 artistless picks drain first, then the real-artist tracks surface (previously impossible); the same escape through the `requireBpm` unbounded path (the exact live-repro shape); partial cooldown unaffected; fully-id-cooled tiny library returns 200 repeats with a non-growing list.
- **All suites green**: random-route 95 (89 prior + 6), random-sonic + random-similar-artists + auto-dj-client 186. Lint clean.
- **Live smoke of the original repro**: restored the exact failing state (artist history covering all 5 library artists + BPM continuity on) on a booted server — the session that previously queued 19 unplayable m3u copies now queues **4/4 distinct real tracks, zero m3u picks**, ids tracking, no console or server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
