### PR TITLE
test(discovery): baked-seeds env guard — suites can never join the real network

### DIFF
--- a/src/state/discovery-seeds.js
+++ b/src/state/discovery-seeds.js
@@ -58,6 +58,30 @@ export const DEFAULT_SEEDS = [
   },
 ];
 
+// Test-only override for the baked list above (same precedent as
+// MSTREAM_TEST_SEEDS_PUBKEY in discovery-seeds-verify.js): a JSON array of
+// {name, endpointId, ticket} entries that REPLACES DEFAULT_SEEDS. The test
+// helper sets '[]' for every spawned server so no suite can bootstrap into
+// the real network through the shipped tickets — resolveBootstrap() UNIONS
+// baked + fetched, so a seed-mechanics suite that re-enables
+// useCommunitySeeds for its stub list would otherwise still join the real
+// seeds and gossip its fake announcements into real users' catalogs (the
+// 2026-07-27 "Stranger" ghost peers). Set-but-unusable fails CLOSED to an
+// empty list, never open to DEFAULT_SEEDS: a typo'd override must not mean
+// "join production". Production installs never set this.
+function bakedSeeds() {
+  const raw = process.env.MSTREAM_TEST_BAKED_SEEDS;
+  if (raw === undefined) { return DEFAULT_SEEDS; }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) { throw new Error('not an array'); }
+    return parsed;
+  } catch (err) {
+    winston.warn(`MSTREAM_TEST_BAKED_SEEDS is set but unusable (${err.message}) — treating it as an empty list`);
+    return [];
+  }
+}
+
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10 * 1000;
 const MAX_SEEDS = 20;            // sanity cap on a fetched list
@@ -170,7 +194,7 @@ async function remoteSeeds({ forceRefresh = false, localOnly = false } = {}) {
 export async function resolveBootstrap(opts = {}) {
   const remote = await remoteSeeds(opts);
   return mergeSeedLists(
-    config.program.discoveryP2p.useCommunitySeeds ? DEFAULT_SEEDS : [],
+    config.program.discoveryP2p.useCommunitySeeds ? bakedSeeds() : [],
     remote,
     config.program.discoveryP2p.bootstrapPeers,
     config.program.discoveryP2p.blockedPeers,

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -184,15 +184,22 @@ export async function startServer(opts = {}) {
     // audio-analysis suites drive that worker directly / opt in explicitly.
     ...extraConfig,
     scanOptions: { autoAlbumArt: false, collectDiscoveryData: false, analyzeBpm: false, ...(extraConfig.scanOptions || {}) },
-    // Same guard idea for the discovery network's community seeds — TWO
-    // layers, both load-bearing:
+    // Same guard idea for the discovery network's community seeds — THREE
+    // layers, all load-bearing:
     //  - seedListUrl → dead local port, so no test fetches GitHub;
     //  - useCommunitySeeds → false, so no test falls back to the BAKED
     //    seed list. Without this, every suite that enables discoveryP2p
     //    would join the REAL public network through the shipped seeds and
     //    broadcast its fake test announcements into real users' catalogs.
-    // A test that specifically exercises the seed mechanics overrides both
-    // and brings its own stub list server.
+    //  - MSTREAM_TEST_BAKED_SEEDS='[]' (spawn env below) → empties the
+    //    baked list itself. resolveBootstrap() UNIONS baked + fetched
+    //    rather than picking one, so a seed-mechanics suite that re-enables
+    //    useCommunitySeeds for its stub list still joined the real seeds
+    //    through the first two guards — that union put the suite's fake
+    //    "Stranger" announcements into real users' catalogs (2026-07-27).
+    // A test that specifically exercises the seed mechanics overrides the
+    // two config keys and brings its own stub list server; the env layer
+    // stays, so the stub list is the entire seed universe it can reach.
     discoveryP2p: {
       seedListUrl: 'http://127.0.0.1:9/discovery-seeds.json',
       useCommunitySeeds: false,
@@ -214,7 +221,7 @@ export async function startServer(opts = {}) {
     {
       cwd: REPO_ROOT,
       stdio: captureLogs ? 'inherit' : ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, NODE_ENV: 'test', ...env },
+      env: { ...process.env, NODE_ENV: 'test', MSTREAM_TEST_BAKED_SEEDS: '[]', ...env },
     },
   );
 

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -732,7 +732,12 @@ describe('discovery seeds — mergeSeedLists', () => {
       extraConfig: {
         // useCommunitySeeds must be re-enabled explicitly: the test helper
         // forces it off so ordinary suites can never join the real network
-        // through the baked seed list.
+        // through the baked seed list. Re-enabling it here is safe ONLY
+        // because the helper also spawns every server with
+        // MSTREAM_TEST_BAKED_SEEDS='[]' — resolveBootstrap unions baked +
+        // fetched, so without that env guard this suite would join the real
+        // seeds alongside the stub and bridge its fake announcement into
+        // real users' catalogs (the 2026-07-27 "Stranger" ghost peers).
         discoveryP2p: { enabled: true, serverName: 'Seed Test Server', seedListUrl: listUrl, useCommunitySeeds: true },
         scanOptions: { collectDiscoveryData: true },
       },
@@ -776,6 +781,15 @@ describe('discovery seeds — mergeSeedLists', () => {
     // The status route surfaces the community-seeds mode for the admin UI.
     const status = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
     assert.equal(status.communitySeeds, true);
+
+    // Hermeticity tripwire: this island is seedNode + peerNode and nothing
+    // else, so the server can never have more than 2 mesh neighbors. If the
+    // baked-seeds env guard regresses, resolveBootstrap hands it the real
+    // seed-au-1/seed-eu-1 tickets too and the neighbor set outgrows the
+    // island — the exact path that leaked "Stranger" test announcements
+    // into real catalogs.
+    assert.ok(status.neighbors <= 2,
+      `server meshed beyond the test island (${status.neighbors} neighbors) — baked-seeds guard regressed?`);
   });
 });
 

--- a/test/unit/discovery-seeds.test.mjs
+++ b/test/unit/discovery-seeds.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * Community-seeds bootstrap resolution (discovery-seeds.resolveBootstrap) —
+ * specifically the MSTREAM_TEST_BAKED_SEEDS hermeticity override that keeps
+ * test servers off the real discovery network:
+ *
+ *  - unset → production semantics: the shipped DEFAULT_SEEDS tickets are in
+ *    every useCommunitySeeds bootstrap set;
+ *  - '[]'  → the baked list is empty; no resolved set may contain a real
+ *    seed ticket. resolveBootstrap unions baked + fetched, which is how the
+ *    seed-mechanics suite bridged its fake "Stranger" announcements into
+ *    real users' catalogs (2026-07-27) despite stubbing the fetched list;
+ *  - JSON entries → synthetic baked seeds, for suites exercising the baked
+ *    path against local infrastructure;
+ *  - set-but-garbage → fails CLOSED to empty, never open to DEFAULT_SEEDS;
+ *  - the override must not touch the operator's own bootstrapPeers.
+ *
+ * Every case runs {localOnly:true} so resolution stays network-free.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import * as config from '../../src/state/config.js';
+import { resolveBootstrap, DEFAULT_SEEDS } from '../../src/state/discovery-seeds.js';
+
+const ENV_KEY = 'MSTREAM_TEST_BAKED_SEEDS';
+const REAL_TICKETS = DEFAULT_SEEDS.map((s) => s.ticket);
+
+let tmpDir;
+let savedEnv;
+
+before(async () => {
+  savedEnv = process.env[ENV_KEY];
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-seeds-unit-'));
+  await config.setup(path.join(tmpDir, 'config.json'));
+  // Point the cache path into the empty tmp dir so no developer-machine
+  // seeds-cache.json can leak entries into these assertions.
+  config.program.storage.dbDirectory = tmpDir;
+  config.program.discoveryP2p.useCommunitySeeds = true;
+  config.program.discoveryP2p.bootstrapPeers = [];
+});
+
+after(() => {
+  if (savedEnv === undefined) { delete process.env[ENV_KEY]; } else { process.env[ENV_KEY] = savedEnv; }
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('discovery seeds — baked-list test override', () => {
+  test('unset: production bootstrap includes the shipped seed tickets', async () => {
+    delete process.env[ENV_KEY];
+    const set = await resolveBootstrap({ localOnly: true });
+    for (const ticket of REAL_TICKETS) {
+      assert.ok(set.includes(ticket), `expected baked ticket ${ticket.slice(0, 24)}… in the set`);
+    }
+  });
+
+  test("'[]': the resolved bootstrap set contains no real seed ticket", async () => {
+    process.env[ENV_KEY] = '[]';
+    const set = await resolveBootstrap({ localOnly: true });
+    // Nothing baked, no cache, no user peers — nothing at all.
+    assert.deepEqual(set, []);
+  });
+
+  test('JSON entries: synthetic baked seeds replace the shipped ones', async () => {
+    process.env[ENV_KEY] = JSON.stringify([
+      { name: 'unit-seed', ticket: 'unit-seed-ticket-0000000000000000' },
+    ]);
+    const set = await resolveBootstrap({ localOnly: true });
+    assert.deepEqual(set, ['unit-seed-ticket-0000000000000000']);
+  });
+
+  test('set but unusable: fails closed to empty, never open to the real seeds', async () => {
+    for (const bad of ['not json', '{"seeds":[]}', '"just-a-string"']) {
+      process.env[ENV_KEY] = bad;
+      assert.deepEqual(await resolveBootstrap({ localOnly: true }), [], `for ${JSON.stringify(bad)}`);
+    }
+  });
+
+  test("the override leaves the operator's own bootstrapPeers alone", async () => {
+    process.env[ENV_KEY] = '[]';
+    config.program.discoveryP2p.bootstrapPeers = ['friend-ticket-00000000000000000000'];
+    try {
+      const set = await resolveBootstrap({ localOnly: true });
+      assert.deepEqual(set, ['friend-ticket-00000000000000000000']);
+    } finally {
+      config.program.discoveryP2p.bootstrapPeers = [];
+    }
+  });
+});


### PR DESCRIPTION
## What happened

On 2026-07-27, eight ghost peers named **"Stranger"** (`test-model/v1`, 7 tracks, hash `ccc…c`) appeared in real users' discovery catalogs between 10:28–10:47 UTC — the exact announcement payload of the integration test `discovery seeds — boot joins via fetched seed list`. Each suite run mints a fresh temp identity, so every run added one permanent offline catalog entry to every live server on the network.

## Why the existing guards didn't stop it

The test helper already has two hermeticity layers (#702): a dead `seedListUrl` and `useCommunitySeeds: false`. But the seed-mechanics suite must re-enable `useCommunitySeeds` to exercise the seed-list machinery, trusting its local stub list to isolate it. That trust was misplaced: `resolveBootstrap()` **unions** baked `DEFAULT_SEEDS` with the fetched list rather than picking one, so the server under test joined the real seed-au-1/seed-eu-1 droplets *alongside* the stub — and gossip relayed the test peer's fake announcement into the production mesh. Latent since #702 filled `DEFAULT_SEEDS`.

## The fix — a third layer

- `src/state/discovery-seeds.js`: honor **`MSTREAM_TEST_BAKED_SEEDS`** (precedent: `MSTREAM_TEST_SEEDS_PUBKEY` from #705) — a JSON array that replaces `DEFAULT_SEEDS`. Set-but-unusable fails **closed** to an empty list, never open to the real seeds.
- `test/helpers/server.mjs`: every spawned server gets `MSTREAM_TEST_BAKED_SEEDS='[]'`, so re-enabling `useCommunitySeeds` in a suite can only ever reach that suite's own stub infrastructure.
- Seed-mechanics suite: hermeticity tripwire — the island is two local nodes, so `status.neighbors <= 2`; a regression that re-adds real seeds outgrows the island and fails the test.
- New `test/unit/discovery-seeds.test.mjs`: production semantics unchanged (baked tickets present when env unset), real-ticket exclusion under `'[]'`, synthetic replacement, fail-closed parsing, and operator `bootstrapPeers` passthrough.

## Verification

- Discovery integration suite: **36/36** (includes the formerly-leaky test + tripwire)
- Seeds/catalog unit tests: **21/21**; eslint clean on changed files
- Live canary: a server joined to the **real** mesh while the suite ran recorded zero new peers — the announcement stayed in its island

No sidecar protocol changes, so the prebuilt-binaries CI caveat doesn't apply. The eight existing ghost entries age out via #751's 30-day retention (or per-row Forget in the admin catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)