### PR TITLE
feat(discovery): space-aware peer-DB auto-fetch + admin-editable count

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -535,6 +535,7 @@ export function setup(mstream) {
       serverName: config.program.discoveryP2p.serverName,
       serverDescription: config.program.discoveryP2p.serverDescription,
       maxPeerDbStorageMb: config.program.discoveryP2p.maxPeerDbStorageMb,
+      autoFetchCount: config.program.discoveryP2p.autoFetchCount,
       peerRetentionDays: config.program.discoveryP2p.peerRetentionDays,
       blockedPeers: config.program.discoveryP2p.blockedPeers,
     });
@@ -728,6 +729,23 @@ export function setup(mstream) {
     });
     joiValidate(schema, req.body);
     await admin.editMaxPeerDbStorageMb(req.body.maxPeerDbStorageMb);
+    res.json({});
+  });
+
+  // How many peer snapshots auto-fetch keeps on the shelf. Live: the
+  // reconcile pass reads the config fresh each run, so no restart and no
+  // stack bounce. Bounds mirror the config Joi
+  // (discoveryP2pOptions.autoFetchCount). 0 stops automatic downloads
+  // (manual downloads from the catalog still work); lowering below the
+  // current shelf count evicts nothing — removal stays an explicit
+  // operator action.
+  mstream.post("/api/v1/admin/discovery/p2p/auto-fetch-count", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      autoFetchCount: Joi.number().integer().min(0).max(50).required(),
+    });
+    joiValidate(schema, req.body);
+    await admin.editAutoFetchCount(req.body.autoFetchCount);
     res.json({});
   });
 

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -401,12 +401,14 @@ const discoveryP2pOptions = Joi.object({
   // same rules and would refuse to announce otherwise.
   serverDescription: Joi.string().allow('').max(180).pattern(/^[^|\p{Cc}]*$/u).default(''),
   // Auto-fetch: keep a local shelf of the most useful catalog peers'
-  // snapshots (online-first, then biggest — true popularity ranking needs
-  // the N3 seeder tracking) and refresh a copy when its announced
-  // monotonic snapshotSeq moves ahead. On by default WITHIN the opt-in
-  // feature: downloading metadata-only snapshots is the product working.
+  // snapshots (model-compatible first, then online, then biggest) and
+  // refresh a copy when its announced monotonic snapshotSeq moves ahead.
+  // On by default WITHIN the opt-in feature: downloading metadata-only
+  // snapshots is the product working. The count is admin-editable live
+  // (POST /api/v1/admin/discovery/p2p/auto-fetch-count); the storage cap
+  // below still applies — the shelf stops at whichever limit hits first.
   autoFetch: Joi.boolean().default(true),
-  autoFetchCount: Joi.number().integer().min(0).max(50).default(3),
+  autoFetchCount: Joi.number().integer().min(0).max(50).default(6),
   maxPeerDbStorageMb: Joi.number().integer().min(10).max(100000).default(500),
   // Auto-forget: drop a catalog entry once the peer hasn't been heard from in
   // this many days (0 = keep forever). Peers whose snapshot is on the local

--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -7,11 +7,12 @@
 //
 // Auto-fetch turns the catalog into a working library shelf without admin
 // babysitting: on boot (and as announcements arrive) reconcile() downloads
-// the top-N most useful peers — online-now first, then biggest — and
-// re-fetches a peer whose announced snapshotSeq moved past our copy. The
-// monotonic seq (not wall clocks) is what makes "is our copy stale?" a safe
-// comparison. Guardrails: peer-count target, total-storage cap, and the
-// blockedPeers config list.
+// as many of the most useful peers as fit — model-compatible first, then
+// online-now, then biggest — and re-fetches a peer whose announced
+// snapshotSeq moved past our copy. The monotonic seq (not wall clocks) is
+// what makes "is our copy stale?" a safe comparison. Guardrails: peer-count
+// target, total-storage cap, a free-disk floor, and the blockedPeers config
+// list.
 //
 // Every snapshot is validated before it's accepted onto the shelf — a peer
 // hands us an arbitrary SQLite file, so we check the snapshot format marker
@@ -23,6 +24,7 @@ import path from 'path';
 import winston from 'winston';
 import { DatabaseSync } from '../db/sqlite-driver.js';
 import * as config from './config.js';
+import * as discoveryDb from '../db/discovery-db.js';
 import * as discoveryP2p from './discovery-p2p.js';
 import * as discoveryCatalog from './discovery-catalog.js';
 
@@ -37,6 +39,13 @@ const RECONCILE_INTERVAL_MS = 10 * 60 * 1000;
 // A peer is "online" when we heard a re-announcement recently. Announcers
 // re-broadcast every ~15s; 90s tolerates a few missed rounds.
 const ONLINE_WINDOW_MS = 90 * 1000;
+// Real-disk guard: however generous maxPeerDbStorageMb is, a snapshot
+// download must never run the volume itself near zero — after the download
+// at least this much must remain free. The env override exists for the
+// integration tests (faking a full disk beats filling one); production
+// installs should never set it.
+const DISK_FREE_FLOOR_BYTES =
+  Number(process.env.MSTREAM_TEST_DISCOVERY_DISK_FLOOR_BYTES) || 500 * 1024 * 1024;
 // Cache of parsed embedding matrices (they're a few MB each) — keep the
 // working set small so a Pi isn't holding every peer's vectors forever.
 const MATRIX_CACHE_MAX = 4;
@@ -107,6 +116,20 @@ function storageCapBytes() {
   return config.program.discoveryP2p.maxPeerDbStorageMb * 1024 * 1024;
 }
 
+// Free bytes on the volume snapshots land on, or null when the platform
+// can't say (the caller treats unknown as "don't block"). Statfs'd via the
+// dbDirectory: discovery-peers/ lives under it, and the parent is
+// guaranteed to exist even before the first fetch creates the subdir.
+async function diskFreeBytes() {
+  try {
+    const st = await fs.promises.statfs(config.program.storage.dbDirectory);
+    return Number(st.bavail) * Number(st.bsize);
+  } catch (err) {
+    winston.debug(`[discovery-peer-dbs] free-disk check unavailable (${err.message})`);
+    return null;
+  }
+}
+
 function isBlocked(endpointId) {
   return config.program.discoveryP2p.blockedPeers.includes(endpointId);
 }
@@ -163,6 +186,18 @@ export async function fetchPeer(endpointId) {
   if (projected > storageCapBytes()) {
     throw new Error(`fetch would exceed the peer-DB storage cap `
       + `(${Math.round(projected / 1048576)}MB > ${config.program.discoveryP2p.maxPeerDbStorageMb}MB)`);
+  }
+
+  // The cap budgets what WE may use; this checks what the VOLUME can give.
+  // A replacement downloads before the old file is deleted, so the announced
+  // size is the true transient need either way. Best-effort: statfs support
+  // varies by platform/filesystem, and an unanswerable question must not
+  // block every fetch — only a confident "too little" refuses.
+  const freeBytes = await diskFreeBytes();
+  if (freeBytes !== null && freeBytes < announcedSize + DISK_FREE_FLOOR_BYTES) {
+    throw new Error(`not enough free disk for this snapshot `
+      + `(${Math.round(freeBytes / 1048576)}MB free, need `
+      + `${Math.round((announcedSize + DISK_FREE_FLOOR_BYTES) / 1048576)}MB to keep headroom)`);
   }
 
   // Swarm fetch: any live holder of the hash is a valid source (content
@@ -323,15 +358,24 @@ export function readEmbeddings(endpointId, modelId) {
 
 // ── Auto-fetch ───────────────────────────────────────────────────────────────
 
-// Sort candidates by usefulness: peers we can hear right now first, then by
-// library size. (True popularity — seeder counts — needs the N3 provider
-// tracking; this proxy is honest about what we can actually observe today.)
-function candidateOrder(a, b) {
+// Sort candidates by usefulness: peers whose announced embedding model
+// matches ours first (an incompatible snapshot is dead weight for the
+// similar search until a migration lands — still fetchable, just last in
+// line), then peers we can hear right now, then by library size. No local
+// model established yet = no compatibility signal; everyone ties.
+function candidateOrder(localModel) {
   const now = Date.now();
-  const aOnline = now - Date.parse(a.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
-  const bOnline = now - Date.parse(b.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
-  if (aOnline !== bOnline) { return bOnline - aOnline; }
-  return (b.payload.rowCount || 0) - (a.payload.rowCount || 0);
+  return (a, b) => {
+    if (localModel) {
+      const aCompat = a.payload.modelId === localModel ? 1 : 0;
+      const bCompat = b.payload.modelId === localModel ? 1 : 0;
+      if (aCompat !== bCompat) { return bCompat - aCompat; }
+    }
+    const aOnline = now - Date.parse(a.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+    const bOnline = now - Date.parse(b.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+    if (aOnline !== bOnline) { return bOnline - aOnline; }
+    return (b.payload.rowCount || 0) - (a.payload.rowCount || 0);
+  };
 }
 
 // Failure backoff: a peer whose fetch keeps failing (unreachable, invalid
@@ -379,14 +423,34 @@ export async function reconcile() {
       }
     }
 
-    // Top-up: best candidates we don't hold yet.
+    // Top-up: best candidates we don't hold yet, as many as fit under BOTH
+    // caps. "Announced size doesn't fit" is a sizing fact, not a fetch
+    // failure — skip the candidate without burning its backoff and keep
+    // walking, because a smaller peer further down the list may still fit.
+    // (fetchPeer re-checks the cap at download time; this pre-filter is
+    // what keeps one oversized peer from eating a retry slot forever.)
     const room = config.program.discoveryP2p.autoFetchCount - registry.size;
     if (room > 0) {
-      const candidates = discoveryCatalog.list()
-        .filter((c) => !registry.has(c.from) && !isBlocked(c.from))
-        .sort(candidateOrder)
-        .slice(0, room);
-      targets.push(...candidates.map((c) => c.from));
+      const localModel = discoveryDb.openDiscoveryDbIfExists()
+        ? discoveryDb.getMeta('embedding_model_id') : null;
+      const capBytes = storageCapBytes();
+      let projectedBytes = totalBytes();
+      let picked = 0;
+      let skippedForSpace = 0;
+      for (const c of discoveryCatalog.list()
+        .filter((x) => !registry.has(x.from) && !isBlocked(x.from))
+        .sort(candidateOrder(localModel))) {
+        if (picked >= room) { break; }
+        const announced = c.payload.size || 0;
+        if (projectedBytes + announced > capBytes) { skippedForSpace += 1; continue; }
+        projectedBytes += announced;
+        picked += 1;
+        targets.push(c.from);
+      }
+      if (skippedForSpace > 0) {
+        winston.debug(`[discovery-peer-dbs] skipped ${skippedForSpace} catalog peer(s) whose announced `
+          + `size does not fit under the ${config.program.discoveryP2p.maxPeerDbStorageMb}MB cap`);
+      }
     }
 
     for (const endpointId of targets) {

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -599,6 +599,14 @@ export async function editMaxPeerDbStorageMb(val) {
   config.program.discoveryP2p.maxPeerDbStorageMb = val;
 }
 
+export async function editAutoFetchCount(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.autoFetchCount = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.autoFetchCount = val;
+}
+
 // Append a bootstrap peer (deduplicated) so a friend joined through the
 // UI survives restarts — the join RPC itself is session-only.
 export async function editAddBootstrapPeer(val) {

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -649,6 +649,149 @@ describe('discovery p2p — similarity search + novelty filter', () => {
   });
 });
 
+// ── Space-aware auto-fetch: the storage cap picks WHICH peers, not just how
+// many ───────────────────────────────────────────────────────────────────────
+// A candidate whose announced size can't fit under maxPeerDbStorageMb is a
+// sizing mismatch, not a fetch failure: reconcile must skip it WITHOUT
+// burning its per-peer backoff and keep walking the candidate list so a
+// smaller peer further down still gets downloaded. autoFetchCount=1 makes
+// this a binary discriminator — a count-sliced top-up would pick only the
+// big peer (it outranks on every sort key), fail its fetch forever, and
+// starve the small one.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — space-aware auto-fetch', () => {
+  let server;
+  let bigPeer;
+  let smallPeer;
+  let dir;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      env: { MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS: '750' },
+      extraConfig: {
+        discoveryP2p: { enabled: true, autoFetchCount: 1, maxPeerDbStorageMb: 10 },
+      },
+    });
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-space-'));
+    bigPeer = new RawSidecar(SIDECAR_BIN, path.join(dir, 'big'));
+    smallPeer = new RawSidecar(SIDECAR_BIN, path.join(dir, 'small'));
+    await Promise.all([bigPeer.ready, smallPeer.ready]);
+  });
+  after(async () => {
+    if (bigPeer) { await bigPeer.stop(); }
+    if (smallPeer) { await smallPeer.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('a too-big candidate is skipped and a smaller one is fetched instead', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+
+    await bigPeer.rpc('join', { bootstrap: [status.ticket] });
+    await bigPeer.waitForEvent('neighbor', (e) => e.up === true);
+    await smallPeer.rpc('join', { bootstrap: [status.ticket] });
+    await smallPeer.waitForEvent('neighbor', (e) => e.up === true);
+
+    // The big peer outranks the small one on every sort key (both online,
+    // rowCount 999999) — but its announced 50MB can never fit the 10MB
+    // cap. Fake hash on purpose: the fetch must not even be attempted.
+    await bigPeer.rpc('announce', {
+      payload: { hash: 'c'.repeat(64), size: 50 * 1024 * 1024, rowCount: 999999,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 3, name: 'Too Big' },
+    });
+    // The starvation scenario needs the big peer IN the candidate list
+    // before the small one announces — wait for the catalog to hear it.
+    await pollUntil(async () => {
+      const c = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`)).json();
+      return c.peers.find((p) => p.from === bigPeer.endpointId) || null;
+    }, { what: 'the big announcement to reach the catalog' });
+
+    const snap = makeSnapshotFile(path.join(dir, 'small.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Small Artist', title: 'Small Song', vec: [1, 0, 0, 0] }],
+    });
+    const pub = await smallPeer.rpc('publish', { path: snap });
+    await smallPeer.rpc('announce', {
+      payload: { hash: pub.hash, size: pub.size, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Small Enough' },
+    });
+
+    const shelf = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+      return s.peerDbs.find((p) => p.endpointId === smallPeer.endpointId) || null;
+    }, { timeoutMs: 30000, what: 'auto-fetch to download the smaller candidate' });
+    assert.equal(shelf.rowCount, 1);
+
+    // The oversized peer is known (catalog) but never downloaded (shelf).
+    const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+    assert.equal(s.peerDbs.length, 1);
+    assert.ok(!s.peerDbs.some((p) => p.endpointId === bigPeer.endpointId),
+      'the over-cap candidate must never land on the shelf');
+  });
+});
+
+// ── Free-disk floor: the cap protects the budget, the floor protects the
+// volume ─────────────────────────────────────────────────────────────────────
+// With the floor overridden sky-high (no runner has 8PB free) every
+// download must refuse with a clear error — and refuse BEFORE any bytes
+// move: gossip still records the peer; only fetches are blocked.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — free-disk floor', () => {
+  let server;
+  let peer;
+  let dir;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      env: {
+        MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS: '750',
+        MSTREAM_TEST_DISCOVERY_DISK_FLOOR_BYTES: '9007199254740992',
+      },
+      extraConfig: { discoveryP2p: { enabled: true, autoFetch: false } },
+    });
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-disk-'));
+    peer = new RawSidecar(SIDECAR_BIN, path.join(dir, 'sidecar'));
+    await peer.ready;
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('a fetch is refused when free disk would drop below the floor', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    await peer.rpc('announce', {
+      payload: { hash: 'd'.repeat(64), size: 4096, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Floor Peer' },
+    });
+    await pollUntil(async () => {
+      const c = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`)).json();
+      return c.peers.find((p) => p.from === peer.endpointId) || null;
+    }, { what: 'the announcement to reach the catalog' });
+
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/peer-dbs/fetch`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpointId: peer.endpointId }),
+    });
+    assert.equal(r.status, 500);
+    assert.match((await r.json()).error, /free disk/i);
+
+    // Refused up front: nothing landed on the shelf.
+    const shelf = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+    assert.equal(shelf.peerDbs.length, 0);
+  });
+});
+
 // ── Community seeds: merge logic (pure, no server) ──────────────────────────
 describe('discovery seeds — mergeSeedLists', () => {
   const T = (n) => `endpointticket${'x'.repeat(16)}${n}`;
@@ -1229,6 +1372,29 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
     }
     assert.equal((await (await fetch(api('status'))).json()).maxPeerDbStorageMb, 1234,
       'rejections must not clobber the saved cap');
+  });
+
+  test('auto-fetch-count saves live, persists, and validates (0 = paused is legal)', async () => {
+    const r = await post('auto-fetch-count', { autoFetchCount: 11 });
+    assert.equal(r.status, 200);
+
+    // Status reflects it immediately (reconcile reads the config live, so
+    // this is also the enforcement value from the next pass on) — and it
+    // survives a reboot: persisted to the config file.
+    const status = await (await fetch(api('status'))).json();
+    assert.equal(status.autoFetchCount, 11);
+    assert.equal(readConfig().discoveryP2p.autoFetchCount, 11);
+
+    // 0 is a real setting (pause automatic downloads), not a rejection.
+    assert.equal((await post('auto-fetch-count', { autoFetchCount: 0 })).status, 200);
+    assert.equal((await (await fetch(api('status'))).json()).autoFetchCount, 0);
+
+    for (const bad of [-1, 51, 2.5, 'six', null]) {
+      const rej = await post('auto-fetch-count', { autoFetchCount: bad });
+      assert.equal(rej.status, 400, `${JSON.stringify(bad)} should be 400`);
+    }
+    assert.equal((await (await fetch(api('status'))).json()).autoFetchCount, 0,
+      'rejections must not clobber the saved value');
   });
 
   test('disable: stack stops, gates close, collection deliberately stays on', async () => {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -738,7 +738,7 @@ const P2PIDENTITY = { serverName: '', serverDescription: '' };
 // Same shared-object pattern (and the same must-be-hoisted TDZ rule) for
 // the editable p2p settings: the Discovery card fills it from the status
 // route, the max-storage modal edits it.
-const P2PSETTINGS = { maxPeerDbStorageMb: 500, peerRetentionDays: 30 };
+const P2PSETTINGS = { maxPeerDbStorageMb: 500, autoFetchCount: 6, peerRetentionDays: 30 };
 
 const foldersView = Vue.component('folders-view', {
   data() {
@@ -7303,7 +7303,10 @@ const discoveryView = Vue.component('discovery-view', {
                   <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
                     {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
                     [<a v-on:click="openModal('edit-p2p-max-storage-modal')">{{ t('admin.settings.edit') }}</a>]
-                    — auto-fetch {{ discoveryP2p.autoFetch ? 'on' : 'off' }}
+                    — auto-fetch {{ discoveryP2p.autoFetch === false ? 'off'
+                      : discoveryP2p.status.autoFetchCount === 0 ? 'on (0 servers — automatic downloads paused)'
+                      : 'on (up to ' + discoveryP2p.status.autoFetchCount + ' servers)' }}
+                    [<a v-on:click="openModal('edit-p2p-auto-fetch-count-modal')">{{ t('admin.settings.edit') }}</a>]
                     — community seeds {{ discoveryP2p.status.communitySeeds ? 'on (public network)' : 'off (friends only)' }}
                   </p>
                   <p><b>Forget offline servers:</b>
@@ -7505,8 +7508,10 @@ const discoveryView = Vue.component('discovery-view', {
         P2PIDENTITY.serverName = status.serverName || '';
         P2PIDENTITY.serverDescription = status.serverDescription || '';
         if (status.maxPeerDbStorageMb) { P2PSETTINGS.maxPeerDbStorageMb = status.maxPeerDbStorageMb; }
-        // 0 (= never forget) is a valid value — don't truthiness-check it away.
+        // 0 (= never forget / no auto-downloads) is a valid value for both
+        // of these — don't truthiness-check it away.
         if (typeof status.peerRetentionDays === 'number') { P2PSETTINGS.peerRetentionDays = status.peerRetentionDays; }
+        if (typeof status.autoFetchCount === 'number') { P2PSETTINGS.autoFetchCount = status.autoFetchCount; }
         if (status.enabled === true) {
           const cat = (await API.axios({
             method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
@@ -8794,6 +8799,71 @@ const editP2pPeerRetentionView = Vue.component('edit-p2p-peer-retention-modal', 
         });
 
         P2PSETTINGS.peerRetentionDays = Number(this.editValue);
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          message: err.response?.data?.error || '',
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+// How many peer snapshots the auto-fetch loop keeps on the local shelf.
+// Live: the next reconcile pass (announcement-driven, or the periodic
+// sweep) reads it fresh — no restart. The storage cap above still applies;
+// the shelf stops growing at whichever limit hits first.
+const editP2pAutoFetchCountView = Vue.component('edit-p2p-auto-fetch-count-modal', {
+  data() {
+    return {
+      submitPending: false,
+      editValue: P2PSETTINGS.autoFetchCount
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Auto-download servers</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-p2p-auto-fetch-count" required type="number" min="0" max="50">
+          <label for="edit-p2p-auto-fetch-count">How many servers to keep downloaded automatically</label>
+          <span class="helper-text">Auto-fetch keeps up to this many servers' snapshots downloaded, picking the most useful ones it can hear that fit under the storage cap. Applies from the next check — raising it downloads more; lowering it deletes nothing. 0 pauses automatic downloads; downloading from the server list by hand still works.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/auto-fetch-count`,
+          data: { autoFetchCount: Number(this.editValue) }
+        });
+
+        P2PSETTINGS.autoFetchCount = Number(this.editValue);
 
         M.Modal.getInstance(document.getElementById('admin-modal')).close();
 


### PR DESCRIPTION
Part A of the peer-DB freshness work (plan: space-aware acquisition now, automatic shelf rotation as a follow-up PR).

## What changed

**Space-aware top-up** (`src/state/discovery-peer-dbs.js`): `reconcile()` no longer slices the candidate list to `autoFetchCount − held` — it walks all candidates and skips (without recording a fetch failure) any peer whose announced size can't fit under `maxPeerDbStorageMb`, so a smaller peer further down still gets downloaded. Previously one oversized top candidate would eat a retry slot, go into exponential backoff, and starve everything ranked below it. "Doesn't fit" is a sizing fact, not a failure; the backoff stays reserved for real fetch/validation errors (`fetchPeer` still enforces the cap at download time as the backstop).

**Model-compatible peers first**: `candidateOrder` now prefers peers whose announced model pin matches the local embedding model — an incompatible snapshot can't serve the p2p similar search, so it queues last (still fetchable, never excluded; no local model = no signal, everyone ties).

**Free-disk floor** (`fetchPeer`, auto + manual): announced size + 500MB must be genuinely free on the dbDirectory volume (`fs.promises.statfs`, best-effort — a filesystem that can't answer skips the guard rather than blocking fetches). `MSTREAM_TEST_DISCOVERY_DISK_FLOOR_BYTES` overrides the floor for tests.

**`autoFetchCount`: default 3 → 6, admin-editable live**:
- `POST /api/v1/admin/discovery/p2p/auto-fetch-count` (integer 0–50, Joi mirrors config; 0 = pause automatic downloads, manual downloads still work; lowering evicts nothing)
- exposed in the p2p status route; `editAutoFetchCount` persists config + applies in-memory (reconcile reads it fresh per pass — no restart, no stack bounce)
- Discovery-page settings line — `auto-fetch on (up to 6 servers) [edit]` / `on (0 servers — automatic downloads paused)` — plus an edit modal cloned from the max-storage/peer-retention pattern

## Tests

Discovery p2p integration file: **39/39** (3 new):
- `auto-fetch-count saves live, persists, and validates (0 = paused is legal)`
- `space-aware auto-fetch`: with `autoFetchCount: 1` + a 10MB cap, a fake 50MB peer that outranks everything on every sort key is skipped and a smaller real peer is fetched instead — the old count-sliced top-up fails this hard (it picks only the big peer and starves the small one forever)
- `free-disk floor`: sky-high floor override → manual fetch refused up front with a clear error, nothing lands on the shelf

No sidecar/protocol changes, so no capability gating needed. Lint: no new problems in changed files.

Also browser-verified on an isolated preview (community seeds off): modal save → config persisted → settings line re-renders; both display branches (count / 0-paused) exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)