### PR TITLE
ci(test): pin Windows ffmpeg — drop the flaky latest-release lookup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,16 +44,56 @@ jobs:
           node-version: 24
           cache: npm
 
-      # ffmpeg sources differ per OS: apt on Linux (reliable, full codecs),
-      # setup-ffmpeg's static build on Windows. (setup-ffmpeg is x64-only, and
-      # the macOS runner is arm64 — macOS is handled separately below.)
+      # ffmpeg sources differ per OS: apt on Linux (reliable, full codecs); a
+      # version-pinned, checksum-verified gyan.dev full build on Windows,
+      # fetched from its GitHub mirror; Homebrew on macOS (arm64 runner —
+      # handled separately below).
       - name: Install ffmpeg (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
+      # Deterministic on purpose: the setup-ffmpeg action this replaced
+      # resolved "latest release" through a remote lookup on EVERY run, and
+      # one flake of that lookup ("Cannot get latest release") killed all
+      # three Windows shards before a single test ran (PR #777). A pinned
+      # tag + sha256 has exactly one failure mode — the download itself —
+      # which curl retries and a checksum guards. The full build bundles
+      # libvorbis (the suite encodes .ogg fixtures); asserted below like the
+      # macOS leg. Bump: pick a tag from GyanD/codexffmpeg releases, update
+      # the sha256 (compute locally: sha256sum on the downloaded zip), and
+      # keep the libvorbis assert green.
       - name: Install ffmpeg (Windows)
         if: runner.os == 'Windows'
-        uses: FedericoCarboni/setup-ffmpeg@v3
+        shell: pwsh
+        run: |
+          $tag = '8.1.2'
+          $sha256 = 'b8cdefab5f50590a076c27c2b56b0294a0e6154faded28ba1ba05ebc4f801f57'
+          $zip = "ffmpeg-$tag-full_build.zip"
+          curl.exe -fsSL --retry 3 --retry-delay 5 -o $zip `
+            "https://github.com/GyanD/codexffmpeg/releases/download/$tag/$zip"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::ffmpeg download failed (curl exit $LASTEXITCODE)"
+            exit 1
+          }
+          $actual = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $sha256) {
+            Write-Host "::error::ffmpeg download checksum mismatch (got $actual, want $sha256)"
+            exit 1
+          }
+          tar -xf $zip
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::ffmpeg archive extraction failed"
+            exit 1
+          }
+          New-Item -ItemType Directory -Force bin/ffmpeg | Out-Null
+          Copy-Item "ffmpeg-$tag-full_build/bin/ffmpeg.exe"  bin/ffmpeg/ffmpeg.exe
+          Copy-Item "ffmpeg-$tag-full_build/bin/ffprobe.exe" bin/ffmpeg/ffprobe.exe
+          $enc = & bin/ffmpeg/ffmpeg.exe -hide_banner -encoders
+          if (-not ($enc | Select-String -Quiet libvorbis)) {
+            Write-Host "::error::Windows ffmpeg is missing the libvorbis encoder"
+            exit 1
+          }
+          Remove-Item $zip, "ffmpeg-$tag-full_build" -Recurse -Force
 
       # Homebrew-core ffmpeg (8.x) dropped libvorbis, but the suite encodes
       # .ogg fixtures with it. The homebrew-ffmpeg tap ships a full-codec build
@@ -65,7 +105,8 @@ jobs:
 
       # The fixture generator (and the server's transcoder) look for ffmpeg at
       # bin/ffmpeg/ — the bundled binary is gitignored, so it isn't in the
-      # checkout. Stage the just-installed ffmpeg/ffprobe there.
+      # checkout. Stage the just-installed ffmpeg/ffprobe there. (The Windows
+      # step above already installs straight into bin/ffmpeg/.)
       - name: Stage ffmpeg into bin/ffmpeg/ (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -89,14 +130,6 @@ jobs:
           cp "$ff/ffmpeg"  bin/ffmpeg/ffmpeg
           cp "$ff/ffprobe" bin/ffmpeg/ffprobe
           chmod +x bin/ffmpeg/ffmpeg bin/ffmpeg/ffprobe
-
-      - name: Stage ffmpeg into bin/ffmpeg/ (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force bin/ffmpeg | Out-Null
-          Copy-Item (Get-Command ffmpeg).Source  bin/ffmpeg/ffmpeg.exe
-          Copy-Item (Get-Command ffprobe).Source bin/ffmpeg/ffprobe.exe
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

The Windows test legs installed ffmpeg via `FedericoCarboni/setup-ffmpeg@v3` with no version pin. The action resolves "latest release" through a remote lookup on **every** run, and on [PR #777's run](https://github.com/IrosTheBeggar/mStream/actions/runs/30324553003) that lookup flaked (`AssertionError [ERR_ASSERTION]: Cannot get latest release`) and killed all three `windows-latest` shards ~30s in — before a single test ran. Since the `tests passed` gate blocks merges, one upstream hiccup can block any `full-ci`-labeled PR. (A `gh run rerun --failed` healed that instance, which is what confirmed it as infra flake.)

## Fix

Replace the action with a direct, deterministic install:

- **Pinned artifact**: gyan.dev's `ffmpeg-8.1.2-full_build.zip` fetched from its GitHub mirror ([GyanD/codexffmpeg](https://github.com/GyanD/codexffmpeg/releases/tag/8.1.2)) — stable version tags that persist (unlike BtbN's pruned autobuild tags), served from GitHub's CDN, i.e. the same infra the runner lives on.
- **sha256-verified**: the checksum in the workflow was computed from an artifact downloaded and validated locally — the binary runs, reports `8.1.2-full_build-www.gyan.dev`, and lists the `libvorbis` encoder.
- **curl `--retry 3`** for download transients; explicit exit-code checks at each stage with `::error::` annotations.
- Installs **straight into `bin/ffmpeg/`**, so the separate "Stage ffmpeg into bin/ffmpeg/ (Windows)" `Get-Command` step is gone (every test helper resolves `bin/ffmpeg/` by absolute path; nothing uses PATH).
- Same **fail-loud libvorbis assert** the macOS leg has (the suite encodes `.ogg` fixtures).
- A comment documents the bump procedure (pick a tag, recompute the sha256, keep the assert green).

Linux (apt) and macOS (homebrew-ffmpeg tap) legs unchanged.

## Verification

Dispatched this branch's edited workflow via `gh workflow run test.yml --ref fix/ci-pin-windows-ffmpeg` ([run 30350816828](https://github.com/IrosTheBeggar/mStream/actions/runs/30350816828)): the new install step passed on all three Windows shards, and the **full 9-job matrix + `tests passed` gate is green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)