### PR TITLE
fix(torrent): make seed-existing work on real-world torrents + close webapp XSS holes

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -941,7 +941,13 @@ export function setup(mstream) {
   mstream.put("/api/v1/admin/directory", async (req, res) => {
     const schema = Joi.object({
       directory: Joi.string().required(),
-      vpath: Joi.string().pattern(/[a-zA-Z0-9-]+/).required(),
+      // Anchored: the pattern was `/[a-zA-Z0-9-]+/` (unanchored), which
+      // only requires the name to CONTAIN one slug char — a vpath like
+      // `x"><img src=y onerror=...>` passed and later reached an
+      // unescaped innerHTML/toast sink in the webapp. The admin UI's
+      // input already enforces the anchored form; this closes the
+      // direct-API bypass. vpaths are URL path segments, so slug-only.
+      vpath: Joi.string().pattern(/^[a-zA-Z0-9-]+$/).required(),
       autoAccess: Joi.boolean().default(false),
       isAudioBooks: Joi.boolean().default(false)
     });

--- a/src/api/torrent.js
+++ b/src/api/torrent.js
@@ -976,6 +976,13 @@ function _sanitizeSeedExistingForUser(body) {
       delete out.vpathRoot;
       delete out.matchedRoot;
       break;
+    case 'pad_files_missing':
+      // Absolute paths stripped like the others; vpath, clientType and
+      // the pad counts stay so the UI can explain the hybrid-torrent
+      // pad-file requirement.
+      delete out.vpathRoot;
+      delete out.matchedRoot;
+      break;
     case 'partial_match':
       delete out.vpathRoot;
       delete out.partialRoot;

--- a/src/api/torrent.js
+++ b/src/api/torrent.js
@@ -968,6 +968,14 @@ function _sanitizeSeedExistingForUser(body) {
       delete out.matchedRoot;
       delete out.addedAt;
       break;
+    case 'match_unmapped':
+      // Same absolute-path concern as `seeded`. vpath and
+      // mappingConfidence stay — the player UI uses them to tell the
+      // user which library matched and that an admin needs to confirm
+      // the path mapping before seeding can proceed.
+      delete out.vpathRoot;
+      delete out.matchedRoot;
+      break;
     case 'partial_match':
       delete out.vpathRoot;
       delete out.partialRoot;

--- a/src/torrent/constants.js
+++ b/src/torrent/constants.js
@@ -106,3 +106,24 @@ export function isUsable(confidence) {
 export function isClientActive(clientType) {
   return clientType != null && clientType !== CLIENT_TYPE.DISABLED;
 }
+
+/**
+ * Does this client need BEP 47 padding files materialised on disk to
+ * seed a hybrid (v1+v2) torrent from existing data?
+ *
+ * Verified against real daemons (2026-07): libtorrent-backed clients
+ * (qBittorrent, Deluge) synthesize the pad zeros and reach 100% +
+ * seeding with only the real files present. Transmission 4.1.3 cannot
+ * reconstruct the piece that straddles a real-file/pad boundary — it
+ * stalls (e.g. 73.9%) until the `.pad/NNN` bytes exist on disk. So the
+ * seed-existing flow must NOT report a hybrid torrent as `seeded` on
+ * Transmission unless the pad files are actually there.
+ *
+ * Keyed off the client rather than a version probe: this is a stable
+ * architectural difference, and being conservative (requiring pads) on
+ * a hypothetical future Transmission that gains synthesis only costs a
+ * `pad_files_missing` instead of a `seeded` — never a false success.
+ */
+export function clientNeedsPadFilesOnDisk(clientType) {
+  return clientType === CLIENT_TYPE.TRANSMISSION;
+}

--- a/src/torrent/seed-existing-flow.js
+++ b/src/torrent/seed-existing-flow.js
@@ -18,7 +18,7 @@ import * as vpathAccessCache from './vpath-access-cache.js';
 import * as infoHashLib from './info-hash.js';
 import * as seedExisting from './seed-existing.js';
 import { _normalizeDaemonPath, _joinDaemonPath } from './path-probe.js';
-import { isUsable } from './constants.js';
+import { isUsable, clientNeedsPadFilesOnDisk } from './constants.js';
 
 export const SEED_OUTCOMES = Object.freeze({
   SEEDED:            'seeded',
@@ -27,6 +27,13 @@ export const SEED_OUTCOMES = Object.freeze({
   // daemon. Distinct from NO_MATCH — the operator's fix is "run
   // auto-detect / set the mapping", not "find the files".
   MATCH_UNMAPPED:    'match_unmapped',
+  // All real files are on disk and the mapping is usable, but this is a
+  // hybrid torrent with BEP 47 pad files that aren't on disk, and the
+  // active client (Transmission) can't seed without them. Handing off
+  // would leave the daemon stalled mid-recheck, so we report this
+  // instead of a false `seeded`. libtorrent clients never hit this —
+  // they synthesize the pad bytes. See clientNeedsPadFilesOnDisk.
+  PAD_FILES_MISSING: 'pad_files_missing',
   PARTIAL_MATCH:     'partial_match',
   NO_MATCH:          'no_match',
   ALREADY_IN_DAEMON: 'already_in_daemon',
@@ -115,6 +122,8 @@ export async function processSeedExistingFlow(opts) {
   // library. The vpath order is preserved.
   const partials = [];
   let unmapped = null;
+  let padBlocked = null;
+  const needsPads = clientNeedsPadFilesOnDisk(clientType);
   for (const vp of vpathNames) {
     const lib = db.getLibraryByName(vp);
     if (!lib) { continue; }
@@ -134,6 +143,23 @@ export async function processSeedExistingFlow(opts) {
             // null = never probed; 'unconfirmed'/'pending' = probed
             // but not usable. The UI phrases the fix differently.
             mappingConfidence: access ? access.confidence : null,
+          };
+        }
+        continue;
+      }
+      // Hybrid torrent whose real files are all here, mapping is usable,
+      // but the pad files aren't on disk and this client can't seed
+      // without them (Transmission). Remember it and keep scanning — a
+      // different vpath might have the pads too — but don't hand off:
+      // the daemon would stall mid-recheck and we'd have lied `seeded`.
+      if (needsPads && result.padFilesTotal > result.padFilesPresent) {
+        if (!padBlocked) {
+          padBlocked = {
+            vpath:       vp,
+            vpathRoot:   lib.root_path,
+            matchedRoot: result.matchedRoot,
+            padFilesTotal:   result.padFilesTotal,
+            padFilesPresent: result.padFilesPresent,
           };
         }
         continue;
@@ -204,6 +230,26 @@ export async function processSeedExistingFlow(opts) {
         missing:     result.missing,
       });
     }
+  }
+
+  if (padBlocked) {
+    // Real files all present, mapping usable — the furthest we get
+    // without seeding. Only the client's pad-file requirement blocks
+    // it, so this is the most precise diagnosis; it outranks unmapped
+    // (which still needs a path mapping) and partials.
+    return {
+      ok:              true,
+      outcome:         SEED_OUTCOMES.PAD_FILES_MISSING,
+      infoHash,
+      name:            displayName,
+      vpath:           padBlocked.vpath,
+      vpathRoot:       padBlocked.vpathRoot,
+      matchedRoot:     padBlocked.matchedRoot,
+      padFilesTotal:   padBlocked.padFilesTotal,
+      padFilesPresent: padBlocked.padFilesPresent,
+      clientType,
+      checkedVpaths:   vpathNames,
+    };
   }
 
   if (unmapped) {

--- a/src/torrent/seed-existing-flow.js
+++ b/src/torrent/seed-existing-flow.js
@@ -22,6 +22,11 @@ import { isUsable } from './constants.js';
 
 export const SEED_OUTCOMES = Object.freeze({
   SEEDED:            'seeded',
+  // Every file is on disk under a vpath, but that (client, vpath)
+  // has no usable path mapping so we can't hand the torrent to the
+  // daemon. Distinct from NO_MATCH — the operator's fix is "run
+  // auto-detect / set the mapping", not "find the files".
+  MATCH_UNMAPPED:    'match_unmapped',
   PARTIAL_MATCH:     'partial_match',
   NO_MATCH:          'no_match',
   ALREADY_IN_DAEMON: 'already_in_daemon',
@@ -53,6 +58,9 @@ export const SEED_OUTCOMES = Object.freeze({
  *                                    managed_torrents row.
  * @returns {Promise<object>} Response body (JSON-serialisable).
  *   Always includes `ok: true` and one of the `SEED_OUTCOMES` values.
+ *   `match_unmapped` means every file matched on disk but the vpath
+ *   has no usable daemon path mapping — the operator should run
+ *   auto-detect (or set the mapping manually) and retry.
  *   `partial_match` returns a `matches[]` array with one entry per
  *   vpath that had >0 matched files; top-level keys mirror matches[0]
  *   for backward compatibility with older admin consumers.
@@ -93,22 +101,43 @@ export async function processSeedExistingFlow(opts) {
     }
   } catch { /* fall through */ }
 
-  // Step 3 — probe vpaths. First all-match wins and triggers the
-  // daemon add; otherwise we collect EVERY partial hit (matched > 0)
-  // and return them as `matches[]` so the UI can render one row
-  // per library. The vpath order is preserved.
+  // Step 3 — probe vpaths. The filesystem check runs UNGATED: it
+  // only reads lib.root_path (mStream's own view), so it needs no
+  // daemon path mapping. The mapping gate applies solely to the
+  // daemon hand-off below — previously it sat in front of the disk
+  // check, so an unprobed/unconfirmed vpath was silently skipped
+  // and the caller saw a flat `no_match` even with every file on
+  // disk. First all-match on a USABLE mapping wins and triggers the
+  // daemon add; an all-match on an unmapped vpath is remembered (we
+  // keep scanning in case a later vpath is both matched AND mapped)
+  // and reported as `match_unmapped`. Partial hits (matched > 0)
+  // are collected as `matches[]` so the UI can render one row per
+  // library. The vpath order is preserved.
   const partials = [];
+  let unmapped = null;
   for (const vp of vpathNames) {
     const lib = db.getLibraryByName(vp);
     if (!lib) { continue; }
-    const access = vpathAccessCache.getOne(clientType, vp);
-    if (!access || !isUsable(access.confidence)) { continue; }
 
     let result;
     try { result = await seedExisting.checkFilesExist(fileBuffer, lib.root_path); }
     catch { continue; }
 
     if (result.allMatch) {
+      const access = vpathAccessCache.getOne(clientType, vp);
+      if (!access || !isUsable(access.confidence)) {
+        if (!unmapped) {
+          unmapped = {
+            vpath:       vp,
+            vpathRoot:   lib.root_path,
+            matchedRoot: result.matchedRoot,
+            // null = never probed; 'unconfirmed'/'pending' = probed
+            // but not usable. The UI phrases the fix differently.
+            mappingConfidence: access ? access.confidence : null,
+          };
+        }
+        continue;
+      }
       // Normalise the cached daemonPath BEFORE handing it to the
       // daemon. Native-Windows clients (qBit/Transmission installed
       // directly on Windows) accept either separator, but mStream's
@@ -175,6 +204,24 @@ export async function processSeedExistingFlow(opts) {
         missing:     result.missing,
       });
     }
+  }
+
+  if (unmapped) {
+    // Full match on disk, no usable daemon mapping anywhere. Takes
+    // precedence over partials: "the files are all here, confirm the
+    // path mapping" is strictly more actionable than "some files
+    // matched somewhere else."
+    return {
+      ok:                true,
+      outcome:           SEED_OUTCOMES.MATCH_UNMAPPED,
+      infoHash,
+      name:              displayName,
+      vpath:             unmapped.vpath,
+      vpathRoot:         unmapped.vpathRoot,
+      matchedRoot:       unmapped.matchedRoot,
+      mappingConfidence: unmapped.mappingConfidence,
+      checkedVpaths:     vpathNames,
+    };
   }
 
   if (partials.length > 0) {

--- a/src/torrent/seed-existing.js
+++ b/src/torrent/seed-existing.js
@@ -10,6 +10,12 @@
 //   - Every file the torrent declares in info.files (or the single
 //     info.length file) is present on disk under <vpathRoot>/
 //     <info.name>/<f.path>, AND its byte size matches f.length.
+//   - BEP 47 padding files are excluded from the tally entirely.
+//     Hybrid v1+v2 torrents (libtorrent 2.x / qBittorrent 4.4+
+//     creators) interleave `.pad/NNN` entries flagged attr='p'
+//     between the real files to align piece boundaries — clients
+//     never write them to disk, so counting them as "missing"
+//     made every hybrid torrent structurally unmatchable.
 //   - We deliberately do NOT hash the contents. The daemon does
 //     SHA-1 verification when it starts a seed; double-hashing
 //     here would burn a lot of CPU for no behavioural gain. The
@@ -38,9 +44,36 @@ import { findField } from './bencode.js';
 // rest are noise.
 const _MISSING_REPORT_CAP = 20;
 
+// BEP 47: a file entry's `attr` is a byte string of single-character
+// flags; 'p' marks a padding file the client never writes to disk.
+// The name-prefix check catches the pre-BEP-47 BitComet convention
+// (`_____padding_file_N_...`), which carries no attr flag but is
+// treated as padding by libtorrent-based clients all the same.
+function _isPadFile(relPath, attr) {
+  if (attr.includes('p')) { return true; }
+  const leaf = relPath[relPath.length - 1] || '';
+  return leaf.startsWith('_____padding_file');
+}
+
+// A path segment we're willing to join under the candidate root.
+// f.path comes straight out of attacker-controlled metainfo; a '..'
+// (or separator-bearing) segment would walk the stat probe outside
+// the library and turn this check into an exists-with-size oracle
+// for arbitrary server paths.
+function _isSafeSegment(seg) {
+  return seg.length > 0 && seg !== '.' && seg !== '..'
+    && !seg.includes('/') && !seg.includes('\\') && !seg.includes('\0');
+}
+
 /**
  * Pull the file list out of an info dict, normalised into
- *   [{ relPath: ['dir', 'file'], length: 12345 }, ...]
+ *   [{ relPath: ['dir', 'file'], length: 12345, unsafe: false }, ...]
+ *
+ * BEP 47 padding entries are dropped here, so `filesInTorrent.length`
+ * is the count of REAL files — the denominator the caller reports.
+ * `unsafe` marks entries whose path segments must never be joined
+ * onto the candidate root (traversal shapes); the caller counts them
+ * as missing without statting.
  *
  * For single-file torrents (info.length present, no info.files),
  * the list has one entry whose relPath is just [info.name]. The
@@ -52,10 +85,19 @@ function _enumerateFiles(infoDict) {
     ? Buffer.from(infoDict.name).toString('utf8')
     : '';
   if (Array.isArray(infoDict.files)) {
-    const files = infoDict.files.map(f => ({
-      relPath: (f.path || []).map(b => Buffer.isBuffer(b) ? b.toString('utf8') : String(b)),
-      length:  typeof f.length === 'number' ? f.length : 0,
-    }));
+    const files = [];
+    for (const f of infoDict.files) {
+      const relPath = (f.path || []).map(b => Buffer.isBuffer(b) ? b.toString('utf8') : String(b));
+      const attr = f.attr
+        ? (Buffer.isBuffer(f.attr) ? f.attr.toString('utf8') : String(f.attr))
+        : '';
+      if (_isPadFile(relPath, attr)) { continue; }
+      files.push({
+        relPath,
+        length: typeof f.length === 'number' ? f.length : 0,
+        unsafe: relPath.length === 0 || !relPath.every(_isSafeSegment),
+      });
+    }
     return { filesInTorrent: files, topName, isMulti: true };
   }
   // Single-file: filename IS info.name; the "rel path" is the
@@ -64,7 +106,10 @@ function _enumerateFiles(infoDict) {
   // [info.name] which would double up — handle by emitting an
   // empty relPath. checkFilesExist below documents this.
   return {
-    filesInTorrent: [{ relPath: [], length: typeof infoDict.length === 'number' ? infoDict.length : 0 }],
+    // unsafe: false — the empty relPath is the documented single-file
+    // shape (candidateRoot IS the file); topName safety is checked by
+    // checkFilesExist before the root is ever joined.
+    filesInTorrent: [{ relPath: [], length: typeof infoDict.length === 'number' ? infoDict.length : 0, unsafe: false }],
     topName,
     isMulti: false,
   };
@@ -120,13 +165,25 @@ export async function checkFilesExist(metainfo, vpathRoot) {
   // relPath=[] so the join below resolves to just candidateRoot.
   // For multi-file, info.name is the top directory and the file
   // entries hold the within-torrent rel paths.
-  const candidateRoot = topName
+  //
+  // info.name is attacker-controlled too (BEP-3 says it SHOULD be a
+  // single segment, but nothing enforces that) — a separator- or
+  // '..'-bearing name would relocate the whole probe outside the
+  // library, so an unsafe topName makes every file unmatchable.
+  const topNameSafe = !topName || _isSafeSegment(topName);
+  const candidateRoot = topName && topNameSafe
     ? path.join(vpathRoot, topName)
     : vpathRoot;
 
   let matchedCount = 0;
   const missing = [];
   for (const f of filesInTorrent) {
+    if (!topNameSafe || f.unsafe) {
+      if (missing.length < _MISSING_REPORT_CAP) {
+        missing.push(f.relPath.length > 0 ? f.relPath.join('/') : topName);
+      }
+      continue;
+    }
     const absPath = f.relPath.length > 0
       ? path.join(candidateRoot, ...f.relPath)
       : candidateRoot;

--- a/src/torrent/seed-existing.js
+++ b/src/torrent/seed-existing.js
@@ -69,16 +69,24 @@ function _isSafeSegment(seg) {
  * Pull the file list out of an info dict, normalised into
  *   [{ relPath: ['dir', 'file'], length: 12345, unsafe: false }, ...]
  *
- * BEP 47 padding entries are dropped here, so `filesInTorrent.length`
- * is the count of REAL files — the denominator the caller reports.
- * `unsafe` marks entries whose path segments must never be joined
- * onto the candidate root (traversal shapes); the caller counts them
- * as missing without statting.
+ * BEP 47 padding entries are split into a SEPARATE `padFiles` list, so
+ * `filesInTorrent.length` is the count of REAL files — the denominator
+ * the caller reports to the user. `unsafe` marks entries whose path
+ * segments must never be joined onto the candidate root (traversal
+ * shapes); the caller counts them as missing without statting.
+ *
+ * Pad files are kept (not discarded) because whether they must exist on
+ * disk is a per-client question the caller answers: libtorrent clients
+ * (qBittorrent, Deluge) synthesize the pad zeros and seed without them,
+ * but Transmission (4.1.3, verified) can't reconstruct the piece that
+ * straddles a real-file/pad boundary and stalls until the pad bytes are
+ * materialised. Keeping the list lets the caller check pad presence
+ * only when the target client needs it.
  *
  * For single-file torrents (info.length present, no info.files),
  * the list has one entry whose relPath is just [info.name]. The
  * caller can treat both cases uniformly when joining onto a
- * candidate root.
+ * candidate root. Single-file torrents never carry pad files.
  */
 function _enumerateFiles(infoDict) {
   const topName = infoDict.name
@@ -86,19 +94,21 @@ function _enumerateFiles(infoDict) {
     : '';
   if (Array.isArray(infoDict.files)) {
     const files = [];
+    const padFiles = [];
     for (const f of infoDict.files) {
       const relPath = (f.path || []).map(b => Buffer.isBuffer(b) ? b.toString('utf8') : String(b));
       const attr = f.attr
         ? (Buffer.isBuffer(f.attr) ? f.attr.toString('utf8') : String(f.attr))
         : '';
-      if (_isPadFile(relPath, attr)) { continue; }
-      files.push({
+      const entry = {
         relPath,
         length: typeof f.length === 'number' ? f.length : 0,
         unsafe: relPath.length === 0 || !relPath.every(_isSafeSegment),
-      });
+      };
+      if (_isPadFile(relPath, attr)) { padFiles.push(entry); }
+      else                          { files.push(entry); }
     }
-    return { filesInTorrent: files, topName, isMulti: true };
+    return { filesInTorrent: files, padFiles, topName, isMulti: true };
   }
   // Single-file: filename IS info.name; the "rel path" is the
   // filename itself. The caller's candidateRoot already includes
@@ -110,6 +120,7 @@ function _enumerateFiles(infoDict) {
     // shape (candidateRoot IS the file); topName safety is checked by
     // checkFilesExist before the root is ever joined.
     filesInTorrent: [{ relPath: [], length: typeof infoDict.length === 'number' ? infoDict.length : 0, unsafe: false }],
+    padFiles: [],
     topName,
     isMulti: false,
   };
@@ -144,9 +155,24 @@ async function _checkOne(absPath, expectedLength) {
  *                              // pre-filled directoryName to let the
  *                              // daemon hash the existing files and
  *                              // download only what's missing.
+ *   padFilesTotal:   number,  // BEP 47 pad entries in the torrent (0 for
+ *                              // single-file / non-hybrid torrents).
+ *   padFilesPresent: number,  // pad entries found on disk at the right
+ *                              // size. matched/total/missing above are
+ *                              // REAL files only; pad presence is
+ *                              // reported separately because whether it
+ *                              // matters is the CALLER's per-client call
+ *                              // (Transmission needs them on disk;
+ *                              // libtorrent clients synthesize them).
  *   topName:     string,
  *   isMulti:     boolean,
  * }>}
+ *
+ * `allMatch` reflects the REAL files only — a torrent whose real files
+ * are all present reports allMatch:true even if pad files are absent.
+ * The seed-existing flow layers the Transmission-needs-pads policy on
+ * top using padFilesTotal/padFilesPresent, so this primitive stays
+ * client-agnostic.
  *
  * Throws when the .torrent bytes don't have a usable info dict —
  * callers map this to outcome:'invalid_torrent'. Every other path
@@ -158,7 +184,7 @@ export async function checkFilesExist(metainfo, vpathRoot) {
   if (!info.found || !info.raw) {
     throw new Error('no info dict in torrent file');
   }
-  const { filesInTorrent, topName, isMulti } = _enumerateFiles(info.value);
+  const { filesInTorrent, padFiles, topName, isMulti } = _enumerateFiles(info.value);
 
   // Candidate root: <vpathRoot>/<info.name>. For single-file
   // torrents info.name IS the filename, and _enumerateFiles emits
@@ -204,6 +230,24 @@ export async function checkFilesExist(metainfo, vpathRoot) {
   // do NOT set matchedRoot for partials — existing admin-route consumers
   // rely on `matchedRoot != null ⇒ all files matched ⇒ daemon-add succeeded`.
   const partialRoot = !allMatch && matchedCount > 0 ? candidateRoot : null;
+
+  // Pad-file presence. Reported regardless of the real-file result so
+  // the caller can apply its per-client policy. A pad entry is "present"
+  // by the same size-match rule as a real file. Unsafe pad paths (a
+  // hostile torrent naming a pad `../x`) never match. Only meaningful
+  // when topName is safe — an unsafe topName already zeroes allMatch.
+  let padFilesPresent = 0;
+  if (topNameSafe) {
+    for (const p of padFiles) {
+      if (p.unsafe) { continue; }
+      const absPath = p.relPath.length > 0
+        ? path.join(candidateRoot, ...p.relPath)
+        : candidateRoot;
+      const r = await _checkOne(absPath, p.length);
+      if (r.exists && r.sizeMatch) { padFilesPresent++; }
+    }
+  }
+
   return {
     allMatch,
     matched:     matchedCount,
@@ -211,6 +255,8 @@ export async function checkFilesExist(metainfo, vpathRoot) {
     missing,
     matchedRoot: allMatch ? candidateRoot : null,
     partialRoot,
+    padFilesTotal:   padFiles.length,
+    padFilesPresent,
     topName,
     isMulti,
   };

--- a/test/torrent/torrent-routes.test.mjs
+++ b/test/torrent/torrent-routes.test.mjs
@@ -508,6 +508,34 @@ describe('POST /api/v1/torrent/add — input validation', () => {
 });
 
 // ────────────────────────────────────────────────────────────────────
+// PUT /api/v1/admin/directory — vpath name validation (anchored)
+//
+// A library (vpath) name is a URL path segment AND flows into the
+// webapp's torrent surfaces. The webapp escapes it at every sink, but
+// the server-side Joi pattern is the source-of-truth gate: it must be
+// anchored so a name bearing HTML metacharacters can't be stored in
+// the first place. The pattern was unanchored (`/[a-zA-Z0-9-]+/`),
+// which merely required the name to CONTAIN a slug char — so
+// `x"><img ...>` slipped through. These pin the anchored form. A
+// rejected name never reaches addDirectory, so there are no
+// filesystem side effects to clean up.
+// ────────────────────────────────────────────────────────────────────
+describe('PUT /api/v1/admin/directory — vpath must be a slug', () => {
+  for (const badVpath of [
+    'x"><img src=y onerror=alert(1)>',   // HTML/attribute break-out
+    'lib">',                              // minimal attribute break-out
+    'my lib',                             // space (would need URL-encoding)
+    '../evil',                            // path separators
+  ]) {
+    test(`rejects vpath ${JSON.stringify(badVpath)} with 400`, async () => {
+      const r = await jput('/api/v1/admin/directory',
+        { directory: '/tmp/does-not-matter', vpath: badVpath }, adminJwt);
+      assert.equal(r.status, 400, 'anchored pattern must reject non-slug vpath');
+    });
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────
 // /torrent/add — magnet code-path gates
 //
 // The magnet-PARSING path (infoHashFromMagnet) is unit-tested in

--- a/test/torrent/torrent-seed-existing-flow.test.mjs
+++ b/test/torrent/torrent-seed-existing-flow.test.mjs
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for src/torrent/seed-existing-flow.js — the orchestrator
+ * that wraps checkFilesExist + the daemon add + the managed_torrents
+ * write. Boots a real config + DB (same pattern as
+ * torrent-completion-watcher.test.mjs) and stubs the RPC module, so
+ * the tests pin the outcome contract without a live daemon.
+ *
+ * The headline regressions covered here:
+ *   - the filesystem check runs even when the vpath has no usable
+ *     path mapping (it used to be silently skipped, reporting a flat
+ *     `no_match` with every file on disk), surfacing `match_unmapped`
+ *   - a BEP 47 hybrid torrent (pad files) seeds end-to-end when all
+ *     real files are on disk
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const B = (s) => Buffer.from(s);
+
+// Multi-file torrent builder — same encoding as torrent-seed-existing.test.mjs.
+function makeMultiFile(topName, files) {
+  let inner = `d4:name${topName.length}:${topName}5:files` + 'l';
+  for (const f of files) {
+    let pathList = 'l';
+    for (const seg of f.path) { pathList += `${seg.length}:${seg}`; }
+    pathList += 'e';
+    const attr = f.attr ? `4:attr${f.attr.length}:${f.attr}` : '';
+    inner += `d${attr}6:lengthi${f.length}e4:path${pathList}e`;
+  }
+  inner += 'ee';
+  return B(`d4:info${inner}e`);
+}
+
+let tmpDir, dbManager, cache, flow, SEED_OUTCOMES, userId;
+let mappedRoot, unmappedRoot, unconfirmedRoot;
+
+// Stub RPC module. `addCalls` records every addTorrent invocation so
+// tests can assert the daemon was (or was not) touched.
+const addCalls = [];
+const stubModule = {
+  listTorrents: () => Promise.resolve([]),
+  addTorrent:   (creds, args) => {
+    addCalls.push(args);
+    return Promise.resolve({ infoHash: null, name: '', isDuplicate: false });
+  },
+};
+
+async function layOut(root, files) {
+  for (const f of files) {
+    const full = path.join(root, f.relPath);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, Buffer.alloc(f.size, 0));
+  }
+}
+
+before(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-seedflow-'));
+  fsSync.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+  fsSync.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory:       path.join(tmpDir, 'db'),
+      albumArtDirectory: path.join(tmpDir, 'art'),
+      logsDirectory:     path.join(tmpDir, 'logs'),
+    },
+    port: 0,
+  }, null, 2));
+  const config = await import('../../src/state/config.js');
+  await config.setup(path.join(tmpDir, 'config.json'));
+  dbManager = await import('../../src/db/manager.js');
+  dbManager.initDB();
+
+  // managed_torrents.user_id has an FK to users — seed one row.
+  dbManager.getDB().prepare(
+    `INSERT INTO users (username, password, salt) VALUES ('seeder', 'x', 'x')`
+  ).run();
+  userId = dbManager.getDB().prepare(
+    `SELECT id FROM users WHERE username = 'seeder'`
+  ).get().id;
+
+  // Three libraries: one with a usable mapping, one never probed,
+  // one probed-but-unconfirmed.
+  mappedRoot      = path.join(tmpDir, 'lib-mapped');
+  unmappedRoot    = path.join(tmpDir, 'lib-unmapped');
+  unconfirmedRoot = path.join(tmpDir, 'lib-unconfirmed');
+  for (const [name, root] of [
+    ['mapped', mappedRoot], ['unmapped', unmappedRoot], ['unconfirmed', unconfirmedRoot],
+  ]) {
+    await fs.mkdir(root, { recursive: true });
+    dbManager.getDB().prepare(
+      `INSERT INTO libraries (name, root_path, type, follow_symlinks)
+       VALUES (?, ?, 'music', 0)`
+    ).run(name, root);
+  }
+  // The manager memoises library rows on first read; anything that
+  // touched them before these raw INSERTs would leave the flow's
+  // getLibraryByName() blind to the new rows.
+  dbManager.invalidateCache();
+
+  cache = await import('../../src/torrent/vpath-access-cache.js');
+  cache.upsert({
+    clientType: 'transmission', vpathName: 'mapped',
+    result: {
+      confidence: 'verified', method: 'test', verified: true,
+      daemonPath: '/downloads/mapped', mstreamWritable: true,
+    },
+    source: 'auto',
+  });
+  cache.upsert({
+    clientType: 'transmission', vpathName: 'unconfirmed',
+    result: {
+      confidence: 'unconfirmed', method: 'test', verified: false,
+      daemonPath: null, reason: 'probe failed',
+    },
+    source: 'auto',
+  });
+  // 'unmapped' deliberately gets no row at all.
+
+  ({ processSeedExistingFlow: flow, SEED_OUTCOMES } =
+    await import('../../src/torrent/seed-existing-flow.js'));
+});
+
+after(async () => {
+  // Same teardown as torrent-completion-watcher.test.mjs: the SQLite
+  // handle keeps the event loop alive, so exit explicitly once the
+  // temp dir is gone.
+  try { await fs.rm(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); }
+  catch { /* leave the temp dir */ }
+  setImmediate(() => process.exit(0));
+});
+
+function runFlow(fileBuffer, vpathNames) {
+  return flow({
+    fileBuffer,
+    vpathNames,
+    clientType: 'transmission',
+    active:     { creds: { host: 'stub' }, module: stubModule },
+    userId,
+  });
+}
+
+describe('seed-existing flow outcomes', () => {
+  test('hybrid torrent (pad files) on a mapped vpath → seeded, daemon add fires', async () => {
+    await layOut(mappedRoot, [
+      { relPath: 'Hybrid/01.flac', size: 100 },
+      { relPath: 'Hybrid/02.flac', size: 200 },
+    ]);
+    const meta = makeMultiFile('Hybrid', [
+      { path: ['01.flac'], length: 100 },
+      { path: ['.pad', '412'], length: 412, attr: 'p' },
+      { path: ['02.flac'], length: 200 },
+    ]);
+    addCalls.length = 0;
+    const r = await runFlow(meta, ['mapped']);
+    assert.equal(r.outcome, SEED_OUTCOMES.SEEDED);
+    assert.equal(r.vpath, 'mapped');
+    assert.equal(addCalls.length, 1);
+    assert.equal(addCalls[0].downloadDir, '/downloads/mapped');
+    assert.equal(addCalls[0].paused, false);
+    // managed_torrents row lands with the daemon-side content path.
+    const row = dbManager.getDB().prepare(
+      `SELECT download_path FROM managed_torrents WHERE info_hash = ?`
+    ).get(r.infoHash);
+    assert.equal(row.download_path, '/downloads/mapped/Hybrid');
+  });
+
+  test('all files on disk, vpath never probed → match_unmapped, daemon untouched', async () => {
+    await layOut(unmappedRoot, [
+      { relPath: 'Solo/01.flac', size: 100 },
+    ]);
+    const meta = makeMultiFile('Solo', [
+      { path: ['01.flac'], length: 100 },
+    ]);
+    addCalls.length = 0;
+    const r = await runFlow(meta, ['unmapped']);
+    assert.equal(r.outcome, SEED_OUTCOMES.MATCH_UNMAPPED);
+    assert.equal(r.vpath, 'unmapped');
+    assert.equal(r.matchedRoot, path.join(unmappedRoot, 'Solo'));
+    assert.equal(r.mappingConfidence, null, 'null = never probed');
+    assert.equal(addCalls.length, 0, 'must not hand the torrent to the daemon');
+  });
+
+  test('all files on disk, mapping unconfirmed → match_unmapped with the probed confidence', async () => {
+    await layOut(unconfirmedRoot, [
+      { relPath: 'Duo/01.flac', size: 50 },
+    ]);
+    const meta = makeMultiFile('Duo', [
+      { path: ['01.flac'], length: 50 },
+    ]);
+    addCalls.length = 0;
+    const r = await runFlow(meta, ['unconfirmed']);
+    assert.equal(r.outcome, SEED_OUTCOMES.MATCH_UNMAPPED);
+    assert.equal(r.mappingConfidence, 'unconfirmed');
+    assert.equal(addCalls.length, 0);
+  });
+
+  test('match on an unmapped vpath does not shadow a seedable match later in the list', async () => {
+    await layOut(unmappedRoot, [
+      { relPath: 'Both/01.flac', size: 70 },
+    ]);
+    await layOut(mappedRoot, [
+      { relPath: 'Both/01.flac', size: 70 },
+    ]);
+    const meta = makeMultiFile('Both', [
+      { path: ['01.flac'], length: 70 },
+    ]);
+    addCalls.length = 0;
+    const r = await runFlow(meta, ['unmapped', 'mapped']);
+    assert.equal(r.outcome, SEED_OUTCOMES.SEEDED, 'prefer the vpath that can actually seed');
+    assert.equal(r.vpath, 'mapped');
+    assert.equal(addCalls.length, 1);
+  });
+
+  test('partial match on an unmapped vpath is reported (the disk check is ungated)', async () => {
+    await layOut(unmappedRoot, [
+      { relPath: 'Half/01.flac', size: 10 },
+      // 02.flac missing
+    ]);
+    const meta = makeMultiFile('Half', [
+      { path: ['01.flac'], length: 10 },
+      { path: ['02.flac'], length: 20 },
+    ]);
+    const r = await runFlow(meta, ['unmapped']);
+    assert.equal(r.outcome, SEED_OUTCOMES.PARTIAL_MATCH);
+    assert.equal(r.matched, 1);
+    assert.equal(r.total, 2);
+  });
+
+  test('nothing on disk anywhere → no_match with the full checked list', async () => {
+    const meta = makeMultiFile('Ghost', [
+      { path: ['01.flac'], length: 999 },
+    ]);
+    const r = await runFlow(meta, ['mapped', 'unmapped', 'unconfirmed']);
+    assert.equal(r.outcome, SEED_OUTCOMES.NO_MATCH);
+    assert.deepEqual(r.checkedVpaths, ['mapped', 'unmapped', 'unconfirmed']);
+  });
+});

--- a/test/torrent/torrent-seed-existing-flow.test.mjs
+++ b/test/torrent/torrent-seed-existing-flow.test.mjs
@@ -102,14 +102,19 @@ before(async () => {
   dbManager.invalidateCache();
 
   cache = await import('../../src/torrent/vpath-access-cache.js');
-  cache.upsert({
-    clientType: 'transmission', vpathName: 'mapped',
-    result: {
-      confidence: 'verified', method: 'test', verified: true,
-      daemonPath: '/downloads/mapped', mstreamWritable: true,
-    },
-    source: 'auto',
-  });
+  // Mirror a usable 'mapped' row for both clients we exercise, so the
+  // pad-policy split (Transmission requires pads, qBittorrent doesn't)
+  // can be tested with the same library layout.
+  for (const clientType of ['transmission', 'qbittorrent']) {
+    cache.upsert({
+      clientType, vpathName: 'mapped',
+      result: {
+        confidence: 'verified', method: 'test', verified: true,
+        daemonPath: '/downloads/mapped', mstreamWritable: true,
+      },
+      source: 'auto',
+    });
+  }
   cache.upsert({
     clientType: 'transmission', vpathName: 'unconfirmed',
     result: {
@@ -133,39 +138,72 @@ after(async () => {
   setImmediate(() => process.exit(0));
 });
 
-function runFlow(fileBuffer, vpathNames) {
+function runFlow(fileBuffer, vpathNames, clientType = 'transmission') {
   return flow({
     fileBuffer,
     vpathNames,
-    clientType: 'transmission',
+    clientType,
     active:     { creds: { host: 'stub' }, module: stubModule },
     userId,
   });
 }
 
 describe('seed-existing flow outcomes', () => {
-  test('hybrid torrent (pad files) on a mapped vpath → seeded, daemon add fires', async () => {
+  // Hybrid torrent with a pad file; the pad is NOT on disk (realistic —
+  // a user's library holds only their real files). Verified against
+  // real daemons: qBittorrent/Deluge synthesize the pad and seed;
+  // Transmission stalls without it.
+  const hybridMeta = makeMultiFile('Hybrid', [
+    { path: ['01.flac'], length: 100 },
+    { path: ['.pad', '412'], length: 412, attr: 'p' },
+    { path: ['02.flac'], length: 200 },
+  ]);
+
+  test('hybrid torrent on qBittorrent (pads synthesized) → seeded, daemon add fires', async () => {
     await layOut(mappedRoot, [
       { relPath: 'Hybrid/01.flac', size: 100 },
       { relPath: 'Hybrid/02.flac', size: 200 },
     ]);
-    const meta = makeMultiFile('Hybrid', [
-      { path: ['01.flac'], length: 100 },
-      { path: ['.pad', '412'], length: 412, attr: 'p' },
-      { path: ['02.flac'], length: 200 },
-    ]);
     addCalls.length = 0;
-    const r = await runFlow(meta, ['mapped']);
+    const r = await runFlow(hybridMeta, ['mapped'], 'qbittorrent');
     assert.equal(r.outcome, SEED_OUTCOMES.SEEDED);
     assert.equal(r.vpath, 'mapped');
     assert.equal(addCalls.length, 1);
     assert.equal(addCalls[0].downloadDir, '/downloads/mapped');
     assert.equal(addCalls[0].paused, false);
-    // managed_torrents row lands with the daemon-side content path.
     const row = dbManager.getDB().prepare(
       `SELECT download_path FROM managed_torrents WHERE info_hash = ?`
     ).get(r.infoHash);
     assert.equal(row.download_path, '/downloads/mapped/Hybrid');
+  });
+
+  test('hybrid torrent on Transmission with NO pad on disk → pad_files_missing, daemon untouched', async () => {
+    // Regression for the smoke-test finding: Transmission 4.1.3 can't
+    // reconstruct the boundary piece, so we must NOT claim seeded.
+    await layOut(mappedRoot, [
+      { relPath: 'Hybrid/01.flac', size: 100 },
+      { relPath: 'Hybrid/02.flac', size: 200 },
+    ]);
+    addCalls.length = 0;
+    const r = await runFlow(hybridMeta, ['mapped'], 'transmission');
+    assert.equal(r.outcome, SEED_OUTCOMES.PAD_FILES_MISSING);
+    assert.equal(r.vpath, 'mapped');
+    assert.equal(r.padFilesTotal, 1);
+    assert.equal(r.padFilesPresent, 0);
+    assert.equal(r.clientType, 'transmission');
+    assert.equal(addCalls.length, 0, 'must not hand a stall-prone torrent to Transmission');
+  });
+
+  test('hybrid torrent on Transmission WITH pad on disk → seeded', async () => {
+    await layOut(mappedRoot, [
+      { relPath: 'Hybrid/01.flac', size: 100 },
+      { relPath: 'Hybrid/02.flac', size: 200 },
+      { relPath: 'Hybrid/.pad/412', size: 412 },   // pad materialised
+    ]);
+    addCalls.length = 0;
+    const r = await runFlow(hybridMeta, ['mapped'], 'transmission');
+    assert.equal(r.outcome, SEED_OUTCOMES.SEEDED);
+    assert.equal(addCalls.length, 1);
   });
 
   test('all files on disk, vpath never probed → match_unmapped, daemon untouched', async () => {

--- a/test/torrent/torrent-seed-existing.test.mjs
+++ b/test/torrent/torrent-seed-existing.test.mjs
@@ -207,11 +207,13 @@ describe('multi-file torrents', () => {
 });
 
 describe('BEP 47 padding files', () => {
-  test('attr=p entries are excluded — hybrid torrent all-matches on real files alone', async () => {
+  test('attr=p entries are excluded from the real-file tally; pad presence reported separately', async () => {
     // The shape a libtorrent-2.x / qBittorrent-4.4+ creator emits:
     // real files interleaved with .pad/NNN entries flagged attr='p'.
-    // Clients never write the pad files to disk, so they must not
-    // count toward total or missing.
+    // The pad files are NOT on disk here (the realistic case — a user's
+    // library has only their real files). allMatch is about real files,
+    // so it's true; pad stats report the absence for the caller's
+    // per-client policy.
     const root = await layOut('p1', [
       { relPath: 'Album/01.flac', size: 100 },
       { relPath: 'Album/02.flac', size: 200 },
@@ -228,6 +230,39 @@ describe('BEP 47 padding files', () => {
     assert.equal(r.total, 2, 'pad entries must not count toward total');
     assert.deepEqual(r.missing, []);
     assert.equal(r.matchedRoot, path.join(root, 'Album'));
+    assert.equal(r.padFilesTotal, 2);
+    assert.equal(r.padFilesPresent, 0, 'no .pad files on disk');
+  });
+
+  test('pad files present on disk are counted in padFilesPresent', async () => {
+    const root = await layOut('p1b', [
+      { relPath: 'Album/01.flac', size: 100 },
+      { relPath: 'Album/02.flac', size: 200 },
+      { relPath: 'Album/.pad/412', size: 412 },     // pad materialised (Transmission case)
+    ]);
+    const meta = makeMultiFile('Album', [
+      { path: ['01.flac'], length: 100 },
+      { path: ['.pad', '412'], length: 412, attr: 'p' },
+      { path: ['02.flac'], length: 200 },
+    ]);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.allMatch, true);
+    assert.equal(r.padFilesTotal, 1);
+    assert.equal(r.padFilesPresent, 1, 'the on-disk pad is detected');
+  });
+
+  test('pad present but wrong size does not count', async () => {
+    const root = await layOut('p1c', [
+      { relPath: 'Album/01.flac', size: 100 },
+      { relPath: 'Album/.pad/412', size: 999 },     // wrong size
+    ]);
+    const meta = makeMultiFile('Album', [
+      { path: ['01.flac'], length: 100 },
+      { path: ['.pad', '412'], length: 412, attr: 'p' },
+    ]);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.padFilesTotal, 1);
+    assert.equal(r.padFilesPresent, 0, 'size mismatch → pad not present');
   });
 
   test('BitComet-style _____padding_file names are excluded without an attr flag', async () => {

--- a/test/torrent/torrent-seed-existing.test.mjs
+++ b/test/torrent/torrent-seed-existing.test.mjs
@@ -23,14 +23,17 @@ function makeSingleFile(name, length) {
   return B(`d4:info${inner}e`);
 }
 
-// Build a multi-file torrent. files = [{path: [seg], length: N}, ...]
+// Build a multi-file torrent. files = [{path: [seg], length: N, attr?}, ...]
+// `attr` (e.g. 'p' for a BEP 47 padding file) is emitted first — bencode
+// dict keys must be sorted, and 'attr' < 'length' < 'path'.
 function makeMultiFile(topName, files) {
   let inner = `d4:name${topName.length}:${topName}5:files` + 'l';
   for (const f of files) {
     let pathList = 'l';
     for (const seg of f.path) { pathList += `${seg.length}:${seg}`; }
     pathList += 'e';
-    inner += `d6:lengthi${f.length}e4:path${pathList}e`;
+    const attr = f.attr ? `4:attr${f.attr.length}:${f.attr}` : '';
+    inner += `d${attr}6:lengthi${f.length}e4:path${pathList}e`;
   }
   inner += 'ee';
   return B(`d4:info${inner}e`);
@@ -200,6 +203,100 @@ describe('multi-file torrents', () => {
     assert.equal(r.matched, 0);
     assert.equal(r.total, 50);
     assert.equal(r.missing.length, 20, 'missing array should be capped at 20');
+  });
+});
+
+describe('BEP 47 padding files', () => {
+  test('attr=p entries are excluded — hybrid torrent all-matches on real files alone', async () => {
+    // The shape a libtorrent-2.x / qBittorrent-4.4+ creator emits:
+    // real files interleaved with .pad/NNN entries flagged attr='p'.
+    // Clients never write the pad files to disk, so they must not
+    // count toward total or missing.
+    const root = await layOut('p1', [
+      { relPath: 'Album/01.flac', size: 100 },
+      { relPath: 'Album/02.flac', size: 200 },
+    ]);
+    const meta = makeMultiFile('Album', [
+      { path: ['01.flac'], length: 100 },
+      { path: ['.pad', '412'], length: 412, attr: 'p' },
+      { path: ['02.flac'], length: 200 },
+      { path: ['.pad', '824'], length: 824, attr: 'p' },
+    ]);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.allMatch, true);
+    assert.equal(r.matched, 2);
+    assert.equal(r.total, 2, 'pad entries must not count toward total');
+    assert.deepEqual(r.missing, []);
+    assert.equal(r.matchedRoot, path.join(root, 'Album'));
+  });
+
+  test('BitComet-style _____padding_file names are excluded without an attr flag', async () => {
+    const root = await layOut('p2', [
+      { relPath: 'Album/01.flac', size: 100 },
+    ]);
+    const meta = makeMultiFile('Album', [
+      { path: ['01.flac'], length: 100 },
+      { path: ['_____padding_file_0_if you see this file, please update to BitComet'], length: 512 },
+    ]);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.allMatch, true);
+    assert.equal(r.total, 1);
+  });
+
+  test('torrent with ONLY pad files → total 0, no match', async () => {
+    const root = await layOut('p3', []);
+    const meta = makeMultiFile('Album', [
+      { path: ['.pad', '512'], length: 512, attr: 'p' },
+    ]);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.allMatch, false, 'allMatch requires total > 0');
+    assert.equal(r.total, 0);
+    assert.equal(r.matchedRoot, null);
+  });
+});
+
+describe('hostile path shapes', () => {
+  test('.. segments never match and never stat outside the root', async () => {
+    // A file OUTSIDE the checked root whose size matches the torrent
+    // entry exactly. If the probe joined the '..' segments it would
+    // reach this file and report a match — turning the endpoint into
+    // an exists-with-size oracle for arbitrary server paths.
+    const outside = path.join(tmpDir, 'outside.bin');
+    await fs.writeFile(outside, Buffer.alloc(100, 0));
+    const root = await layOut('h1', []);
+    const meta = makeMultiFile('Album', [
+      { path: ['..', '..', 'outside.bin'], length: 100 },
+    ]);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.allMatch, false);
+    assert.equal(r.matched, 0, 'traversal-shaped entries must count as missing, not matched');
+  });
+
+  test('separator-bearing info.name → no match, no escape', async () => {
+    const outside = path.join(tmpDir, 'esc.bin');
+    await fs.writeFile(outside, Buffer.alloc(50, 0));
+    const root = await layOut('h2', []);
+    // Single-file torrent whose name walks out of the root.
+    const name = '../esc.bin';
+    const meta = B(`d4:infod4:name${name.length}:${name}6:lengthi50eee`);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.allMatch, false);
+    assert.equal(r.matched, 0);
+    assert.equal(r.matchedRoot, null);
+  });
+
+  test('empty path list in a file entry counts as missing without statting', async () => {
+    const root = await layOut('h3', [
+      { relPath: 'Album/01.flac', size: 100 },
+    ]);
+    const meta = makeMultiFile('Album', [
+      { path: ['01.flac'], length: 100 },
+      { path: [], length: 5 },
+    ]);
+    const r = await checkFilesExist(meta, root);
+    assert.equal(r.allMatch, false);
+    assert.equal(r.matched, 1);
+    assert.equal(r.total, 2);
   });
 });
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -5689,6 +5689,18 @@ const torrentView = Vue.component('torrent-view', {
       </div>
     </div>`,
   methods: {
+    // iziToast renders `title`/`message` as HTML (its internal helper
+    // does div.innerHTML = value), so any interpolated server data —
+    // torrent names (attacker-controlled info.name), vpath/library
+    // names, usernames, daemon-reported version strings — must be
+    // HTML-escaped before it reaches a toast. Vue's own {{ }} template
+    // interpolation escapes automatically, but these programmatic toast
+    // calls bypass it.
+    _esc: function(s) {
+      return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+      }[c]));
+    },
     applyClient: async function() {
       const client = this.selectedClient;
       try {
@@ -5746,7 +5758,7 @@ const torrentView = Vue.component('torrent-view', {
         });
         Vue.set(ADMINDATA.users[username], 'allowTorrent', allowTorrent);
         iziToast.success({
-          title: `${username}: torrent ${allowTorrent ? 'granted' : 'revoked'}`,
+          title: `${this._esc(username)}: torrent ${allowTorrent ? 'granted' : 'revoked'}`,
           position: 'topCenter',
           timeout: 2500
         });
@@ -5778,7 +5790,7 @@ const torrentView = Vue.component('torrent-view', {
         });
         if (res.data.ok) {
           iziToast.success({
-            title: `Reachable${res.data.version ? ' (Transmission ' + res.data.version + ')' : ''}`,
+            title: `Reachable${res.data.version ? ' (Transmission ' + this._esc(res.data.version) + ')' : ''}`,
             position: 'topCenter', timeout: 3000
           });
         } else {
@@ -5810,7 +5822,7 @@ const torrentView = Vue.component('torrent-view', {
           // Same applies to qBittorrent + Deluge below.
           await ADMINDATA.getTorrentVpathAccess();
           iziToast.success({
-            title: `Connected${res.data.version ? ' to Transmission ' + res.data.version : ''}`,
+            title: `Connected${res.data.version ? ' to Transmission ' + this._esc(res.data.version) : ''}`,
             position: 'topCenter', timeout: 3500
           });
           // Wipe the password field once it's been accepted — the
@@ -5908,7 +5920,7 @@ const torrentView = Vue.component('torrent-view', {
         Vue.set(this.accessEditPath, name, null);
         Vue.set(this.accessEditMode, name, 'view');
         iziToast.success({
-          title: `${name}: mapped → ${res.data.daemonPath} (${res.data.confidence})`,
+          title: `${this._esc(name)}: mapped → ${this._esc(res.data.daemonPath)} (${this._esc(res.data.confidence)})`,
           position: 'topCenter', timeout: 3000
         });
       } catch (err) {
@@ -5919,7 +5931,7 @@ const torrentView = Vue.component('torrent-view', {
         // is persisted — just the final state.
         await ADMINDATA.getTorrentVpathAccess();
         iziToast.error({
-          title: errorData.message || errorData.error || err.message || 'Could not verify path',
+          title: this._esc(errorData.message || errorData.error || err.message || 'Could not verify path'),
           position: 'topCenter', timeout: 5000
         });
       } finally {
@@ -5944,7 +5956,7 @@ const torrentView = Vue.component('torrent-view', {
       } catch (err) {
         const errorData = err.response?.data || {};
         iziToast.error({
-          title: errorData.message || errorData.error || err.message || 'Auto-detect failed',
+          title: this._esc(errorData.message || errorData.error || err.message || 'Auto-detect failed'),
           position: 'topCenter', timeout: 3500
         });
       } finally {
@@ -6019,7 +6031,7 @@ const torrentView = Vue.component('torrent-view', {
           Vue.delete(this.tmplDraft, name);
           await ADMINDATA.getTorrentPathTemplates();
           iziToast.success({
-            title: raw ? `${name}: template saved` : `${name}: template cleared`,
+            title: raw ? `${this._esc(name)}: template saved` : `${this._esc(name)}: template cleared`,
             position: 'topCenter', timeout: 2500
           });
         } else {
@@ -6191,13 +6203,13 @@ const torrentView = Vue.component('torrent-view', {
           // Surface as a warning rather than success so the operator
           // knows the daemon may still have the torrent in its session.
           iziToast.warning({
-            title:    `${t.name}: mStream record removed, daemon-side delete failed`,
-            message:  body.daemonRemoveError || 'See server logs',
+            title:    `${this._esc(t.name)}: mStream record removed, daemon-side delete failed`,
+            message:  this._esc(body.daemonRemoveError || 'See server logs'),
             position: 'topCenter', timeout: 5500,
           });
         } else {
           iziToast.success({
-            title:    `Removed ${t.name}`,
+            title:    `Removed ${this._esc(t.name)}`,
             message:  'Files on disk kept',
             position: 'topCenter', timeout: 3000,
           });
@@ -6206,7 +6218,7 @@ const torrentView = Vue.component('torrent-view', {
       } catch (err) {
         const body = err.response?.data || {};
         iziToast.error({
-          title:    body.message || body.error || err.message || 'Remove failed',
+          title:    this._esc(body.message || body.error || err.message || 'Remove failed'),
           position: 'topCenter', timeout: 4000,
         });
       } finally {
@@ -6249,7 +6261,7 @@ const torrentView = Vue.component('torrent-view', {
         await ADMINDATA.getTorrentStatus();
         if (this.status.connected) {
           iziToast.success({
-            title: `Reachable${this.status.version ? ` (${label} ${this.status.version})` : ''}`,
+            title: `Reachable${this.status.version ? ` (${this._esc(label)} ${this._esc(this.status.version)})` : ''}`,
             position: 'topCenter', timeout: 3000
           });
         } else {
@@ -6283,7 +6295,7 @@ const torrentView = Vue.component('torrent-view', {
         });
         if (res.data.ok) {
           iziToast.success({
-            title: `Reachable${res.data.version ? ' (qBittorrent ' + res.data.version + ')' : ''}`,
+            title: `Reachable${res.data.version ? ' (qBittorrent ' + this._esc(res.data.version) + ')' : ''}`,
             position: 'topCenter', timeout: 3000
           });
         } else {
@@ -6310,7 +6322,7 @@ const torrentView = Vue.component('torrent-view', {
           await ADMINDATA.getTorrentVpathAccess();
           await ADMINDATA.getTorrentList();
           iziToast.success({
-            title: `Connected${res.data.version ? ' to qBittorrent ' + res.data.version : ''}`,
+            title: `Connected${res.data.version ? ' to qBittorrent ' + this._esc(res.data.version) : ''}`,
             position: 'topCenter', timeout: 3500
           });
           this.qForm.password = '';
@@ -6360,7 +6372,7 @@ const torrentView = Vue.component('torrent-view', {
         });
         if (res.data.ok) {
           iziToast.success({
-            title: `Reachable${res.data.version ? ' (Deluge ' + res.data.version + ')' : ''}`,
+            title: `Reachable${res.data.version ? ' (Deluge ' + this._esc(res.data.version) + ')' : ''}`,
             position: 'topCenter', timeout: 3000
           });
         } else {
@@ -6387,7 +6399,7 @@ const torrentView = Vue.component('torrent-view', {
           await ADMINDATA.getTorrentVpathAccess();
           await ADMINDATA.getTorrentList();
           iziToast.success({
-            title: `Connected${res.data.version ? ' to Deluge ' + res.data.version : ''}`,
+            title: `Connected${res.data.version ? ' to Deluge ' + this._esc(res.data.version) : ''}`,
             position: 'topCenter', timeout: 3500
           });
           this.dForm.password = '';

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -5410,6 +5410,14 @@ const torrentView = Vue.component('torrent-view', {
                           {{r.mappingConfidence ? 'not confirmed' : 'not probed yet'}} —
                           run auto-detect in "Library Access" above, then retry.
                         </span>
+                        <span v-else-if="r.outcome === 'pad_files_missing'">
+                          All files found in <b>{{r.vpath}}</b>, but this is a hybrid torrent
+                          whose alignment (padding) files aren't on disk
+                          ({{r.padFilesPresent}}/{{r.padFilesTotal}} present).
+                          {{r.clientType}} can't seed without them — it would re-download the
+                          boundary pieces. Use qBittorrent/Deluge (which synthesize padding),
+                          or fetch this torrent's padding files first.
+                        </span>
                         <span v-else-if="r.outcome === 'partial_match'">
                           {{r.matched}}/{{r.total}} files matched in <b>{{r.vpath}}</b>; missing:
                           <span v-for="(m, i) in r.missing.slice(0, 3)" :key="i" style="font-family:monospace">
@@ -6044,6 +6052,7 @@ const torrentView = Vue.component('torrent-view', {
       switch (outcome) {
         case 'seeded':            return 'status-verified';
         case 'match_unmapped':    return 'status-inferred';
+        case 'pad_files_missing': return 'status-inferred';
         case 'partial_match':     return 'status-inferred';
         case 'already_in_daemon': return 'status-inferred';
         case 'no_match':          return 'status-unconfirmed';
@@ -6056,6 +6065,7 @@ const torrentView = Vue.component('torrent-view', {
       switch (outcome) {
         case 'seeded':            return '✓ Seeding';
         case 'match_unmapped':    return '! Unmapped';
+        case 'pad_files_missing': return '! Needs padding';
         case 'partial_match':     return '~ Partial';
         case 'already_in_daemon': return '⊝ Already there';
         case 'no_match':          return '✗ Not found';

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -838,6 +838,18 @@ const foldersView = Vue.component('folders-view', {
       }
     },
     methods: {
+      // iziToast renders title/message as HTML (its internal helper does
+      // div.innerHTML = value), and the i18n t() helper interpolates
+      // params into translation strings WITHOUT escaping (some strings
+      // are intentionally HTML, e.g. removeTitle's <b>{{folder}}</b>). So
+      // any library/vpath name or root path — admin-set, and arbitrary
+      // when created via config.json or loki migration — must be escaped
+      // before it reaches a toast title or a t() param.
+      _esc: function(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({
+          '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+        }[c]));
+      },
       // V21: per-library followSymlinks flag. Default false —
       // operators opt in per library when they want the scanner to
       // traverse symlinks inside that vpath.
@@ -854,12 +866,12 @@ const foldersView = Vue.component('folders-view', {
             Vue.set(ADMINDATA.folders[vpath], 'followSymlinks', value);
           }
           iziToast.success({
-            title: `Symlink policy updated for ${vpath}`,
+            title: `Symlink policy updated for ${this._esc(vpath)}`,
             position: 'topCenter', timeout: 2500,
           });
         } catch (err) {
           iziToast.error({
-            title: `Failed: ${err.message || '?'}`,
+            title: `Failed: ${this._esc(err.message || '?')}`,
             position: 'topCenter', timeout: 3000,
           });
         }
@@ -940,7 +952,11 @@ const foldersView = Vue.component('folders-view', {
           zindex: 99999,
           layout: 2,
           maxWidth: 600,
-          title: t('admin.folders.removeTitle', { folder: folder }),
+          // Escape the folder (a library root path — admin-set, possibly
+          // HTML-bearing) BEFORE interpolation: t() does not escape params
+          // and removeTitle is intentionally HTML (<b>{{folder}}</b>), so
+          // escaping the whole result would show a literal <b> instead.
+          title: t('admin.folders.removeTitle', { folder: this._esc(folder) }),
           message: t('admin.folders.removeMessage'),
           position: 'center',
           buttons: [

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -6173,7 +6173,9 @@ const torrentView = Vue.component('torrent-view', {
       try {
         await ADMINDATA.getTorrentList();
         if (this.list.error) {
-          iziToast.error({ title: this.list.error, position: 'topCenter', timeout: 3500 });
+          // Daemon-derived (listTorrents err.message) → HTML-escape before
+          // the iziToast title sink, like every other error path here.
+          iziToast.error({ title: this._esc(this.list.error), position: 'topCenter', timeout: 3500 });
         }
       } finally {
         this.listRefreshPending = false;
@@ -6266,7 +6268,9 @@ const torrentView = Vue.component('torrent-view', {
           });
         } else {
           iziToast.error({
-            title: this.status.reason || 'Not reachable',
+            // Daemon-derived (testConnection err.message) → escape, mirroring
+            // the escaped version string in the reachable branch above.
+            title: this._esc(this.status.reason || 'Not reachable'),
             position: 'topCenter', timeout: 4000
           });
         }

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -5404,6 +5404,12 @@ const torrentView = Vue.component('torrent-view', {
                         <span v-if="r.outcome === 'seeded'">
                           ✓ {{r.vpath}} → <code>{{r.addedAt}}</code>
                         </span>
+                        <span v-else-if="r.outcome === 'match_unmapped'">
+                          All files found in <b>{{r.vpath}}</b> at <code>{{r.matchedRoot}}</code>,
+                          but the path mapping for that library is
+                          {{r.mappingConfidence ? 'not confirmed' : 'not probed yet'}} —
+                          run auto-detect in "Library Access" above, then retry.
+                        </span>
                         <span v-else-if="r.outcome === 'partial_match'">
                           {{r.matched}}/{{r.total}} files matched in <b>{{r.vpath}}</b>; missing:
                           <span v-for="(m, i) in r.missing.slice(0, 3)" :key="i" style="font-family:monospace">
@@ -6037,6 +6043,7 @@ const torrentView = Vue.component('torrent-view', {
     seedChipClass(outcome) {
       switch (outcome) {
         case 'seeded':            return 'status-verified';
+        case 'match_unmapped':    return 'status-inferred';
         case 'partial_match':     return 'status-inferred';
         case 'already_in_daemon': return 'status-inferred';
         case 'no_match':          return 'status-unconfirmed';
@@ -6048,6 +6055,7 @@ const torrentView = Vue.component('torrent-view', {
     seedChipLabel(outcome) {
       switch (outcome) {
         case 'seeded':            return '✓ Seeding';
+        case 'match_unmapped':    return '! Unmapped';
         case 'partial_match':     return '~ Partial';
         case 'already_in_daemon': return '⊝ Already there';
         case 'no_match':          return '✗ Not found';

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -1873,6 +1873,21 @@ async function submitAddTorrentPanel() {
           submitBtn.disabled = false;
           return;
 
+        case 'pad_files_missing':
+          // All real files present, but this hybrid torrent's padding
+          // files aren't on disk and the active client can't seed
+          // without them. Handing off would stall the daemon, so stop
+          // here rather than fall through to /add.
+          _clearSeedStatus('at_seed_status');
+          iziToast.info({
+            title:   'Found, but needs padding files',
+            message: `All files are in your "${seedRes.vpath}" library, but this torrent needs its alignment (padding) files, which ${seedRes.clientType} can't recreate. It would re-download the boundary pieces. A qBittorrent/Deluge backend handles these automatically.`,
+            position: 'topCenter',
+            timeout: 9000,
+          });
+          submitBtn.disabled = false;
+          return;
+
         case 'partial_match':
           // Render the suggestion list — clicking [Use this path] in
           // a row populates the vpath + path inputs; the user then

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -1190,8 +1190,11 @@ async function submitTorrent() {
     const res  = await MSTREAMAPI.addTorrent(fd);
     const body = res.data || res;
     iziToast.success({
-      title:   `${body.isDuplicate ? 'Already added: ' : 'Added: '}${body.name}`,
-      message: body.downloadPath,
+      // iziToast renders title/message as HTML — escape the torrent
+      // name (attacker-controlled info.name / magnet dn=) and the
+      // download path (carries the user-supplied directoryName).
+      title:   `${body.isDuplicate ? 'Already added: ' : 'Added: '}${escapeHtml(body.name)}`,
+      message: escapeHtml(body.downloadPath || ''),
       position: 'topCenter',
       timeout: 4000,
     });
@@ -1202,7 +1205,7 @@ async function submitTorrent() {
     if (body.renameWarning) {
       iziToast.warning({
         title:   'Rename failed',
-        message: body.renameWarning,
+        message: escapeHtml(body.renameWarning || ''),
         position: 'topCenter',
         timeout: 6000,
       });
@@ -1216,7 +1219,7 @@ async function submitTorrent() {
   } catch (err) {
     const body = err.response?.data || {};
     iziToast.error({
-      title:   body.message || body.error || err.message || 'Add failed',
+      title:   escapeHtml(body.message || body.error || err.message || 'Add failed'),
       position: 'topCenter',
       timeout: 5000,
     });
@@ -1616,7 +1619,7 @@ async function onAutoDetectMetadata() {
     if (res.confidence === 'high') {
       iziToast.success({
         title: 'Metadata detected',
-        message: `Method: ${res.method}`,
+        message: `Method: ${escapeHtml(res.method)}`,
         position: 'topCenter', timeout: 2500
       });
       document.getElementById('at_meta_warning').classList.add('super-hide');
@@ -1632,7 +1635,7 @@ async function onAutoDetectMetadata() {
     const body = err.response?.data || {};
     iziToast.error({
       title: 'Auto-detect failed',
-      message: body.message || body.error || err.message || 'Server error',
+      message: escapeHtml(body.message || body.error || err.message || 'Server error'),
       position: 'topCenter', timeout: 4000
     });
   } finally {
@@ -1818,7 +1821,7 @@ async function submitAddTorrentPanel() {
         case 'seeded':
           _clearSeedStatus('at_seed_status');
           iziToast.success({
-            title:   `Already in your library: ${seedRes.name}`,
+            title:   `Already in your library: ${escapeHtml(seedRes.name)}`,
             message: 'No download needed — the files were already here, and your torrent client is now sharing them.',
             position: 'topCenter',
             timeout: 5000,
@@ -1829,7 +1832,7 @@ async function submitAddTorrentPanel() {
         case 'already_in_daemon':
           _clearSeedStatus('at_seed_status');
           iziToast.info({
-            title:   `Already added: ${seedRes.name || ''}`,
+            title:   `Already added: ${escapeHtml(seedRes.name || '')}`,
             message: 'This torrent is already in your torrent client. Nothing to do.',
             position: 'topCenter',
             timeout: 4500,
@@ -1841,7 +1844,7 @@ async function submitAddTorrentPanel() {
           _clearSeedStatus('at_seed_status');
           iziToast.error({
             title:   'Invalid torrent file',
-            message: seedRes.error || 'The file is malformed.',
+            message: escapeHtml(seedRes.error || 'The file is malformed.'),
             position: 'topCenter',
             timeout: 5000,
           });
@@ -1852,7 +1855,7 @@ async function submitAddTorrentPanel() {
           _clearSeedStatus('at_seed_status');
           iziToast.error({
             title:   'Torrent client error',
-            message: seedRes.error || 'Could not reach the torrent client.',
+            message: escapeHtml(seedRes.error || 'Could not reach the torrent client.'),
             position: 'topCenter',
             timeout: 5000,
           });
@@ -1866,7 +1869,7 @@ async function submitAddTorrentPanel() {
           _clearSeedStatus('at_seed_status');
           iziToast.info({
             title:   'Found, but not seedable yet',
-            message: `All files are already in your "${seedRes.vpath}" library, but the torrent client's path mapping for it isn't set up. Ask your admin to run auto-detect on the Torrent admin page, then retry.`,
+            message: `All files are already in your "${escapeHtml(seedRes.vpath)}" library, but the torrent client's path mapping for it isn't set up. Ask your admin to run auto-detect on the Torrent admin page, then retry.`,
             position: 'topCenter',
             timeout: 8000,
           });
@@ -1881,7 +1884,7 @@ async function submitAddTorrentPanel() {
           _clearSeedStatus('at_seed_status');
           iziToast.info({
             title:   'Found, but needs padding files',
-            message: `All files are in your "${seedRes.vpath}" library, but this torrent needs its alignment (padding) files, which ${seedRes.clientType} can't recreate. It would re-download the boundary pieces. A qBittorrent/Deluge backend handles these automatically.`,
+            message: `All files are in your "${escapeHtml(seedRes.vpath)}" library, but this torrent needs its alignment (padding) files, which ${escapeHtml(seedRes.clientType)} can't recreate. It would re-download the boundary pieces. A qBittorrent/Deluge backend handles these automatically.`,
             position: 'topCenter',
             timeout: 9000,
           });
@@ -1925,7 +1928,7 @@ async function submitAddTorrentPanel() {
     // self-XSS scenarios matter — e.g. an admin pastes a hostile magnet).
     statusEl.innerHTML = `✓ Added: <b>${escapeHtml(body.name)}</b><br>Files will land at: <code>${escapeHtml(body.downloadPath)}</code>`;
     iziToast.success({
-      title: `${body.isDuplicate ? 'Already added: ' : 'Added: '}${body.name}`,
+      title: `${body.isDuplicate ? 'Already added: ' : 'Added: '}${escapeHtml(body.name)}`,
       position: 'topCenter', timeout: 3500,
     });
     // Non-fatal rename-root warning — separate toast so the success
@@ -1933,7 +1936,7 @@ async function submitAddTorrentPanel() {
     if (body.renameWarning) {
       iziToast.warning({
         title:   'Rename failed',
-        message: body.renameWarning,
+        message: escapeHtml(body.renameWarning || ''),
         position: 'topCenter',
         timeout: 6000,
       });
@@ -1945,7 +1948,7 @@ async function submitAddTorrentPanel() {
     statusEl.textContent = `Add failed: ${errBody.message || errBody.error || err.message || 'unknown error'}`;
     submitBtn.disabled = false;
     iziToast.error({
-      title: errBody.message || errBody.error || err.message || 'Add failed',
+      title: escapeHtml(errBody.message || errBody.error || err.message || 'Add failed'),
       position: 'topCenter', timeout: 5000,
     });
   }

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -1859,6 +1859,20 @@ async function submitAddTorrentPanel() {
           submitBtn.disabled = false;
           return;
 
+        case 'match_unmapped':
+          // Every file is on disk in seedRes.vpath, but that library's
+          // daemon path mapping isn't usable — /add would bounce off
+          // the same gate (412/409), so don't fall through to it.
+          _clearSeedStatus('at_seed_status');
+          iziToast.info({
+            title:   'Found, but not seedable yet',
+            message: `All files are already in your "${seedRes.vpath}" library, but the torrent client's path mapping for it isn't set up. Ask your admin to run auto-detect on the Torrent admin page, then retry.`,
+            position: 'topCenter',
+            timeout: 8000,
+          });
+          submitBtn.disabled = false;
+          return;
+
         case 'partial_match':
           // Render the suggestion list — clicking [Use this path] in
           // a row populates the vpath + path inputs; the user then

--- a/webapp/torrent/index.js
+++ b/webapp/torrent/index.js
@@ -395,6 +395,17 @@
           submitBtn.disabled = false;
           return;
         }
+        if (seedRes.outcome === 'pad_files_missing') {
+          // All real files present, but this hybrid torrent's padding
+          // files aren't on disk and the active client can't seed
+          // without them. Don't fall through to /add — the daemon would
+          // stall mid-recheck.
+          setStatus('info', `All files for this torrent are already in your "${seedRes.vpath}" library, ` +
+                            `but it needs its alignment (padding) files, which ${seedRes.clientType} can't recreate. ` +
+                            'It would re-download the boundary pieces. A qBittorrent or Deluge backend handles these automatically.');
+          submitBtn.disabled = false;
+          return;
+        }
         if (seedRes.outcome === 'partial_match') {
           // The desktop panel has a "Use this path" picker for the best
           // candidate. The mobile flow degrades: tell the user we

--- a/webapp/torrent/index.js
+++ b/webapp/torrent/index.js
@@ -384,6 +384,17 @@
           submitBtn.disabled = false;
           return;
         }
+        if (seedRes.outcome === 'match_unmapped') {
+          // Every file is already on disk, but the library's daemon
+          // path mapping isn't confirmed — /add would be refused by
+          // the same gate (412/409), so falling through just produces
+          // a more confusing error. Surface the actionable fix instead.
+          setStatus('info', `All files for this torrent are already in your "${seedRes.vpath}" library, ` +
+                            'but the torrent client\'s path mapping for it is not set up. ' +
+                            'Ask your admin to run auto-detect on the Torrent admin page, then retry.');
+          submitBtn.disabled = false;
+          return;
+        }
         if (seedRes.outcome === 'partial_match') {
           // The desktop panel has a "Use this path" picker for the best
           // candidate. The mobile flow degrades: tell the user we

--- a/webapp/torrent/index.js
+++ b/webapp/torrent/index.js
@@ -31,6 +31,16 @@
   function show(el) { el.classList.remove('hidden'); }
   function hide(el) { el.classList.add('hidden'); }
 
+  // HTML-escape untrusted values before they reach an innerHTML sink or
+  // an iziToast title/message (iziToast renders both as HTML). Torrent
+  // names come from an attacker-controlled info.name; vpath names are
+  // admin-set but reach the <option> markup below unescaped otherwise.
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c]));
+  }
+
   function setStatus(kind, msg) {
     const el = $('status');
     el.className = 'status show ' + kind;
@@ -258,7 +268,7 @@
       show(banner);
       return;
     }
-    select.innerHTML = vpaths.map(v => `<option value="${v}">${v}</option>`).join('');
+    select.innerHTML = vpaths.map(v => `<option value="${esc(v)}">${esc(v)}</option>`).join('');
 
     hide($('loading'));
     show($('add-torrent-form'));
@@ -361,7 +371,7 @@
             `Already in your library — your client is now seeding "${seedRes.name}".`);
           iziToast.success({
             title:   'Seeding existing files',
-            message: seedRes.name,
+            message: esc(seedRes.name),
             position: 'topCenter',
             timeout: 4500,
           });
@@ -372,7 +382,7 @@
           setStatus('info', `Already added to your torrent client: ${seedRes.name || ''}`);
           iziToast.info({
             title:   'Already added',
-            message: seedRes.name || '',
+            message: esc(seedRes.name || ''),
             position: 'topCenter',
             timeout: 4500,
           });
@@ -434,14 +444,14 @@
       const prefix = res.isDuplicate ? 'Already added: ' : 'Added: ';
       setStatus('success', `${prefix}${res.name}\nFiles will land at: ${res.downloadPath}`);
       iziToast.success({
-        title:    `${prefix}${res.name}`,
+        title:    `${prefix}${esc(res.name)}`,
         position: 'topCenter',
         timeout:  3500,
       });
       if (res.renameWarning) {
         iziToast.warning({
           title:    'Rename failed',
-          message:  res.renameWarning,
+          message:  esc(res.renameWarning),
           position: 'topCenter',
           timeout:  6000,
         });
@@ -451,7 +461,7 @@
       const body = err.response?.data || {};
       const msg = body.message || body.error || err.message || 'Add failed';
       setStatus('error', msg);
-      iziToast.error({ title: msg, position: 'topCenter', timeout: 5000 });
+      iziToast.error({ title: esc(msg), position: 'topCenter', timeout: 5000 });
       submitBtn.disabled = false;
     }
   }


### PR DESCRIPTION
Two related threads in the torrent feature: making the **seed-existing** (\"data already on disk\") check actually work, and closing the **DOM XSS** holes found while auditing the webapp surfaces that render torrent-derived data.

## Part 1 — Seed-existing now works on real-world torrents

The \"already have these files, just seed them\" check never succeeded in practice. Two root causes:

- **BEP 47 padding files.** Real-world (hybrid v1+v2) torrents carry `.pad/NNN` alignment files the client never writes to disk. The old check counted them as missing → the match never completed. It now splits pad files out of the real-file denominator and reports pad presence separately.
- **The disk check was gated behind the daemon path-mapping probe**, so an unmapped/unconfirmed library was silently skipped and reported a flat `no_match` even with every file present. The disk check is now ungated; the mapping gate applies only to the daemon hand-off. A new `match_unmapped` outcome tells the operator to run auto-detect rather than \"find the files\".

**Client-aware pad policy (found via Docker smoke testing against real daemons).** libtorrent clients (qBittorrent, Deluge) synthesize the pad zeros and seed with only the real files present; **Transmission cannot** — it stalls mid-recheck (observed 73.9%) until the `.pad` bytes exist. So a \"skip pads entirely\" fix would report a false `seeded` on Transmission. `checkFilesExist` stays client-agnostic (reports `padFilesTotal`/`padFilesPresent`); the flow applies `clientNeedsPadFilesOnDisk()` and returns a new `pad_files_missing` outcome (real files present, daemon deliberately untouched) instead of lying. Verified end-to-end against all three daemons: Transmission → `pad_files_missing` (and `seeded` once pads are on disk), qBittorrent/Deluge → `seeded`, daemons confirm 100% + 0 bytes downloaded.

Also hardened path-traversal handling: unsafe path segments (`..`, separators, an unsafe `info.name`) are counted missing without statting, so the probe can't be turned into an exists-with-size oracle for arbitrary server paths.

## Part 2 — Webapp DOM XSS (iziToast HTML sink)

While auditing the webapp, found that **iziToast renders `title`/`message` as HTML** (its internal helper does `div.innerHTML = value`), and the player + admin surfaces passed server-supplied strings into toasts unescaped.

**Primary vector:** a torrent's `info.name` (or a magnet `dn=`) is attacker-controlled — `info-hash.js` decodes and length-caps it but does no HTML sanitising — and flows verbatim into the `name` field of every `/torrent/add` and `/seed-existing` response. A `.torrent` named `<img src=x onerror=...>` runs script in the victim's authenticated session the moment they add it; for an admin that's session compromise. **Verified live** against the vendored `izi-toast.js`: raw payload creates a live `<img>` and its `onerror` fires; the escaped payload renders as inert text.

Sinks fixed across the three surfaces, plus secondary sources of the same class:
- **`webapp/alpha/m.js`** and **`webapp/torrent/index.js`** — torrent name, download path, vpath, client type, rename warning, error strings, auto-detect method; the mobile page's `<option>` list built via `innerHTML`. (torrent/index.js gets a local `esc()`; m.js already had a top-level `escapeHtml`.)
- **`webapp/admin/index.js`** (torrent-view) — daemon-reported torrent name, vpath/daemon-path, **username** (no server-side character validation), daemon version strings, and two bare-expression error toasts (`this.list.error`, `this.status.reason`) an initial `${...}`-only sweep missed. New `_esc()` method on the component.
- **`webapp/admin/index.js`** (folders-view) — library name + **root path** in the follow-symlinks/remove toasts. The remove title routes through the i18n `t()` helper, which interpolates params without escaping into an intentionally-HTML string (`Remove access to <b>{{folder}}</b>?`), so the param is escaped **before** interpolation to keep the `<b>` while neutralising the value.

**Server-side defense-in-depth:** anchored the `PUT /admin/directory` vpath validator (`/[a-zA-Z0-9-]+/` → `/^[a-zA-Z0-9-]+$/`). The old pattern only required the name to *contain* a slug char, so a metacharacter-bearing vpath passed. This matches the admin UI input's own `pattern` and the original slug-only intent. Note it's strict-on-create / lenient-on-manage by design — the delete/symlink routes stay lenient so pre-existing config/migration libraries with non-slug names remain removable.

## Reviewer notes

- The XSS class is closed on the **torrent** surface; the folders-view fix also covered the library-management toasts. One sibling of the same class remains in the **Subsonic key-mint** flow (`username` → toast) — out of scope here, tracked separately.
- Fixed-option dropdown values (`client`, `enabledFor`) are intentionally left unescaped — closed enums, can't carry HTML.
- All escaping was **verified in a real browser** against the actual vendored iziToast with positive controls (raw payload fires; escaped payload inert; `<b>` preserved in the i18n case).

## Testing

- Full torrent suite green (unit + `torrent-routes` integration, incl. 4 new vpath-rejection cases and the seed-existing flow tests booting a real DB + stubbed RPC).
- Seed-existing flow validated end-to-end against real Transmission 4.1.3 / qBittorrent / Deluge daemons in Docker.
- XSS fixes verified live in a browser against the real iziToast build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)