### PR TITLE
feat(discovery): rotate the peer-DB shelf so suggestions stay fresh

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -536,6 +536,7 @@ export function setup(mstream) {
       serverDescription: config.program.discoveryP2p.serverDescription,
       maxPeerDbStorageMb: config.program.discoveryP2p.maxPeerDbStorageMb,
       autoFetchCount: config.program.discoveryP2p.autoFetchCount,
+      rotationDays: config.program.discoveryP2p.rotationDays,
       peerRetentionDays: config.program.discoveryP2p.peerRetentionDays,
       blockedPeers: config.program.discoveryP2p.blockedPeers,
     });
@@ -565,6 +566,8 @@ export function setup(mstream) {
           stale: (entry.payload.snapshotSeq || 0) > (held.snapshotSeq || 0),
           sizeBytes: held.sizeBytes,
           fetchedAt: held.fetchedAt,
+          firstFetchedAt: held.firstFetchedAt,
+          pinned: held.pinned === true,
         } : null,
         // null = unknown (no local model established yet), not "incompatible"
         compatible: localModel ? entry.payload.modelId === localModel : null,
@@ -584,17 +587,34 @@ export function setup(mstream) {
   });
 
   // Manual shelf management: fetch a specific catalog peer's snapshot now
-  // (still subject to the blocklist + storage cap), or drop one.
+  // (still subject to the blocklist + storage cap), or drop one. A manual
+  // download PINS the entry — an admin's explicit choice must not be
+  // silently rotated away later; the pin route below undoes it.
   mstream.post("/api/v1/admin/discovery/p2p/peer-dbs/fetch", async (req, res) => {
     requireP2pEnabled();
     const schema = Joi.object({ endpointId: Joi.string().hex().length(64).required() });
     joiValidate(schema, req.body);
     try {
-      res.json(await discoveryPeerDbs.fetchPeer(req.body.endpointId));
+      res.json(await discoveryPeerDbs.fetchPeer(req.body.endpointId, { pinned: true }));
     } catch (err) {
       winston.warn(`discovery peer-db fetch failed for admin '${req.user?.username}' (peer ${req.body.endpointId.slice(0, 12)}…): ${err.message}`);
       throw new WebError(`fetch failed: ${err.message}`, 500);
     }
+  });
+
+  // Rotation immunity for one downloaded snapshot. 404 when there's nothing
+  // downloaded to pin — pinning is a shelf property, not a catalog one.
+  mstream.post("/api/v1/admin/discovery/p2p/peer-dbs/pin", (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      endpointId: Joi.string().hex().length(64).required(),
+      pinned: Joi.boolean().required(),
+    });
+    joiValidate(schema, req.body);
+    if (!discoveryPeerDbs.setPinned(req.body.endpointId, req.body.pinned)) {
+      throw new WebError('no fetched snapshot for that peer', 404);
+    }
+    res.json({});
   });
 
   mstream.post("/api/v1/admin/discovery/p2p/peer-dbs/remove", (req, res) => {
@@ -746,6 +766,22 @@ export function setup(mstream) {
     });
     joiValidate(schema, req.body);
     await admin.editAutoFetchCount(req.body.autoFetchCount);
+    res.json({});
+  });
+
+  // How many days a downloaded snapshot may sit on a full shelf before the
+  // hourly rotation pass may swap it for a peer we don't hold (0 = never
+  // rotate). Live: the pass reads the config fresh each run, so no restart
+  // and no stack bounce. Bounds mirror the config Joi
+  // (discoveryP2pOptions.rotationDays). Rotation only ever SWAPS — it never
+  // shrinks the shelf — and pinned entries are exempt regardless.
+  mstream.post("/api/v1/admin/discovery/p2p/rotation", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      rotationDays: Joi.number().integer().min(0).max(3650).required(),
+    });
+    joiValidate(schema, req.body);
+    await admin.editRotationDays(req.body.rotationDays);
     res.json({});
   });
 

--- a/src/api/discovery-p2p.js
+++ b/src/api/discovery-p2p.js
@@ -138,6 +138,11 @@ export function setup(mstream) {
         modelId: e.modelId,
         sizeBytes: e.sizeBytes,
         fetchedAt: e.fetchedAt,
+        // Shelf-membership provenance: how long this snapshot has been the
+        // library we search (rotation's aging clock) and whether it's
+        // rotation-immune.
+        firstFetchedAt: e.firstFetchedAt,
+        pinned: e.pinned === true,
       })),
     });
   });

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -410,6 +410,13 @@ const discoveryP2pOptions = Joi.object({
   autoFetch: Joi.boolean().default(true),
   autoFetchCount: Joi.number().integer().min(0).max(50).default(6),
   maxPeerDbStorageMb: Joi.number().integer().min(10).max(100000).default(500),
+  // Rotation: once a full shelf's snapshot has been held this many days,
+  // the hourly pass may SWAP it (never just drop it) for a catalog peer we
+  // don't hold yet, so network suggestions cycle instead of freezing on
+  // the first peers ever heard. 0 = off. Pinned entries (admin manual
+  // downloads, or the per-peer Pin action) are never rotated. Live-editable
+  // (POST /api/v1/admin/discovery/p2p/rotation).
+  rotationDays: Joi.number().integer().min(0).max(3650).default(7),
   // Auto-forget: drop a catalog entry once the peer hasn't been heard from in
   // this many days (0 = keep forever). Peers whose snapshot is on the local
   // shelf are exempt — forgetting them would orphan the downloaded file

--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -14,6 +14,12 @@
 // target, total-storage cap, a free-disk floor, and the blockedPeers config
 // list.
 //
+// Rotation (rotatePeerDbs, hourly) keeps the shelf's MEMBERSHIP fresh once
+// it's full: swap the least-useful long-held snapshot (rotationDays age,
+// offline-longest first) for the most-novel catalog peer we don't hold.
+// Swap-only, one per pass, `pinned` entries immune (manual admin downloads
+// pin themselves). Decision logic is pure — discovery-peer-rotation.js.
+//
 // Every snapshot is validated before it's accepted onto the shelf — a peer
 // hands us an arbitrary SQLite file, so we check the snapshot format marker
 // and schema shape before ever querying it, and open it with a fresh
@@ -27,6 +33,7 @@ import * as config from './config.js';
 import * as discoveryDb from '../db/discovery-db.js';
 import * as discoveryP2p from './discovery-p2p.js';
 import * as discoveryCatalog from './discovery-catalog.js';
+import { candidateOrder, planRotation } from './discovery-peer-rotation.js';
 
 const REGISTRY_FILE = 'peer-dbs.json';
 const SNAPSHOT_FORMAT_VERSION = 1; // must match discovery-export.js
@@ -36,9 +43,14 @@ const SNAPSHOT_FORMAT_VERSION = 1; // must match discovery-export.js
 const RECONCILE_DEBOUNCE_MS =
   Number(process.env.MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS) || 30 * 1000;
 const RECONCILE_INTERVAL_MS = 10 * 60 * 1000;
-// A peer is "online" when we heard a re-announcement recently. Announcers
-// re-broadcast every ~15s; 90s tolerates a few missed rounds.
-const ONLINE_WINDOW_MS = 90 * 1000;
+// Rotation cadence: hourly is plenty — the shelf only changes as
+// announcements arrive, and churn is capped at one swap per pass anyway.
+// Env override for the integration tests, like the debounce above.
+const ROTATE_INTERVAL_MS =
+  Number(process.env.MSTREAM_TEST_DISCOVERY_ROTATE_MS) || 60 * 60 * 1000;
+// Rotated-out ledger cap — enough history to prefer never-held candidates
+// on any realistic catalog without the file growing forever.
+const ROTATION_LEDGER_MAX = 200;
 // Real-disk guard: however generous maxPeerDbStorageMb is, a snapshot
 // download must never run the volume itself near zero — after the download
 // at least this much must remain free. The env override exists for the
@@ -61,9 +73,15 @@ const connections = new Map();
 const matrixCache = new Map();
 
 let reconcileTimer = null;
+let rotateTimer = null;
 let debounceTimer = null;
 let reconcileInFlight = false;
+let rotateInFlight = false;
 let wired = false;
+
+// endpointId -> evictedAt ISO: who rotation dropped and when, so candidate
+// selection can prefer never-held peers. Lazily loaded; null = not yet.
+let rotationLedger = null;
 
 export function peerDbDir() {
   return path.join(config.program.storage.dbDirectory, 'discovery-peers');
@@ -79,7 +97,14 @@ function ensureLoaded() {
   try {
     for (const e of JSON.parse(fs.readFileSync(registryPath(), 'utf8'))) {
       // Drop registry entries whose file has vanished (manual cleanup etc.).
-      if (e && e.endpointId && e.path && fs.existsSync(e.path)) { registry.set(e.endpointId, e); }
+      if (e && e.endpointId && e.path && fs.existsSync(e.path)) {
+        // Backfill pre-rotation registries: the membership clock starts at
+        // whatever fetch we knew about, and nothing is pinned until an
+        // admin says so.
+        if (!e.firstFetchedAt) { e.firstFetchedAt = e.fetchedAt || new Date().toISOString(); }
+        if (typeof e.pinned !== 'boolean') { e.pinned = false; }
+        registry.set(e.endpointId, e);
+      }
     }
   } catch (err) {
     if (err.code !== 'ENOENT') {
@@ -172,9 +197,13 @@ function dropConnection(endpointId) {
 }
 
 // Download one peer's current snapshot (per its catalog announcement) and
-// put it on the shelf. Manual (admin route) and automatic (reconcile) fetches
-// both come through here — blocklist and storage cap always apply.
-export async function fetchPeer(endpointId) {
+// put it on the shelf. Manual (admin route) and automatic (reconcile/
+// rotation) fetches both come through here — blocklist, storage cap, and
+// disk floor always apply. `pinned: true` (the manual route) marks the
+// entry rotation-immune: an admin's explicit download must not silently
+// vanish a week later. Pinning is sticky — a refresh or re-download never
+// UNpins; only the pin route does.
+export async function fetchPeer(endpointId, { pinned = false } = {}) {
   ensureLoaded();
   const entry = discoveryCatalog.get(endpointId);
   if (!entry) { throw new Error('peer is not in the catalog (no announcement heard)'); }
@@ -247,6 +276,11 @@ export async function fetchPeer(endpointId) {
     sizeBytes: fetched.size,
     name: entry.payload.name || '',
     fetchedAt: new Date().toISOString(),
+    // The MEMBERSHIP clock (rotation's aging signal) — carried over on a
+    // refresh, because a refresh replaces the bytes, not the membership.
+    // Resetting it here would make an actively-publishing peer immortal.
+    firstFetchedAt: existing?.firstFetchedAt || new Date().toISOString(),
+    pinned: existing?.pinned === true || pinned === true,
   };
   registry.set(endpointId, record);
   save();
@@ -275,6 +309,17 @@ export function removePeerDb(endpointId) {
       .catch((err) => winston.debug(`[discovery-peer-dbs] forget removed blob: ${err.message}`));
   }
   pushHolds();
+  return true;
+}
+
+// Rotation immunity, admin-controlled. Returns false for a peer with no
+// fetched snapshot (nothing to pin).
+export function setPinned(endpointId, pinned) {
+  ensureLoaded();
+  const entry = registry.get(endpointId);
+  if (!entry) { return false; }
+  entry.pinned = pinned === true;
+  save();
   return true;
 }
 
@@ -358,25 +403,8 @@ export function readEmbeddings(endpointId, modelId) {
 
 // ── Auto-fetch ───────────────────────────────────────────────────────────────
 
-// Sort candidates by usefulness: peers whose announced embedding model
-// matches ours first (an incompatible snapshot is dead weight for the
-// similar search until a migration lands — still fetchable, just last in
-// line), then peers we can hear right now, then by library size. No local
-// model established yet = no compatibility signal; everyone ties.
-function candidateOrder(localModel) {
-  const now = Date.now();
-  return (a, b) => {
-    if (localModel) {
-      const aCompat = a.payload.modelId === localModel ? 1 : 0;
-      const bCompat = b.payload.modelId === localModel ? 1 : 0;
-      if (aCompat !== bCompat) { return bCompat - aCompat; }
-    }
-    const aOnline = now - Date.parse(a.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
-    const bOnline = now - Date.parse(b.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
-    if (aOnline !== bOnline) { return bOnline - aOnline; }
-    return (b.payload.rowCount || 0) - (a.payload.rowCount || 0);
-  };
-}
+// Candidate/eviction ordering and the rotation decision itself live in
+// discovery-peer-rotation.js — pure functions, unit-tested without a server.
 
 // Failure backoff: a peer whose fetch keeps failing (unreachable, invalid
 // snapshot, disk trouble) must not be retried on every 30s reconcile
@@ -409,7 +437,7 @@ function inFetchBackoff(endpointId) {
 // autoFetchCount from the best-looking catalog peers. Serialized; failures
 // log and move on (an unreachable peer must not wedge the loop).
 export async function reconcile() {
-  if (!config.program.discoveryP2p.autoFetch || reconcileInFlight) { return; }
+  if (!config.program.discoveryP2p.autoFetch || reconcileInFlight || rotateInFlight) { return; }
   reconcileInFlight = true;
   try {
     ensureLoaded();
@@ -468,6 +496,122 @@ export async function reconcile() {
   }
 }
 
+// ── Rotation ─────────────────────────────────────────────────────────────────
+//
+// The anti-calcification pass: hourly, swap the least-useful long-held
+// snapshot for the most-novel catalog peer we don't hold, so the shelf's
+// MEMBERSHIP cycles instead of freezing on the first N peers ever heard.
+// Policy (who/whether) is pure and lives in discovery-peer-rotation.js;
+// this half only executes the swap. Also the only path that ever breaks a
+// dead peer's grip: a silent peer on the shelf is exempt from catalog
+// retention (the #751 pin-set), so without rotation it would be listed —
+// and searched — forever.
+
+function rotationLedgerPath() {
+  return path.join(config.program.storage.dbDirectory, 'discovery-p2p', 'rotation.json');
+}
+
+function ensureRotationLedger() {
+  if (rotationLedger) { return rotationLedger; }
+  rotationLedger = {};
+  try {
+    const raw = JSON.parse(fs.readFileSync(rotationLedgerPath(), 'utf8'));
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      for (const [id, at] of Object.entries(raw)) {
+        if (typeof at === 'string') { rotationLedger[id] = at; }
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      winston.warn(`discovery rotation ledger unreadable (${err.message}) — starting empty`);
+    }
+  }
+  return rotationLedger;
+}
+
+function recordEviction(endpointId) {
+  const ledger = ensureRotationLedger();
+  ledger[endpointId] = new Date().toISOString();
+  // Cap by dropping the oldest evictions — recent history is what prevents
+  // ping-pong; ancient history only grows the file.
+  const entries = Object.entries(ledger);
+  if (entries.length > ROTATION_LEDGER_MAX) {
+    entries.sort((a, b) => Date.parse(a[1]) - Date.parse(b[1]));
+    rotationLedger = Object.fromEntries(entries.slice(entries.length - ROTATION_LEDGER_MAX));
+  }
+  try {
+    fs.mkdirSync(path.dirname(rotationLedgerPath()), { recursive: true });
+    fs.writeFileSync(rotationLedgerPath(), JSON.stringify(rotationLedger, null, 2));
+  } catch (err) {
+    winston.warn(`discovery rotation ledger save failed: ${err.message}`);
+  }
+}
+
+// One rotation pass: at most one swap, and only a swap — never an eviction
+// without a replacement in hand. Returns the executed plan (or null).
+// Serialized against itself AND against reconcile: both mutate the shelf,
+// and interleaved awaits would double-count storage headroom.
+export async function rotatePeerDbs() {
+  if (rotateInFlight || reconcileInFlight) { return null; }
+  rotateInFlight = true;
+  try {
+    ensureLoaded();
+    const cfg = config.program.discoveryP2p;
+    const localModel = discoveryDb.openDiscoveryDbIfExists()
+      ? discoveryDb.getMeta('embedding_model_id') : null;
+    const plan = planRotation({
+      shelf: [...registry.values()],
+      catalog: discoveryCatalog.list(),
+      ledger: ensureRotationLedger(),
+      localModel,
+      now: Date.now(),
+      rotationDays: cfg.rotationDays,
+      autoFetch: cfg.autoFetch,
+      autoFetchCount: cfg.autoFetchCount,
+      capBytes: storageCapBytes(),
+      isBlocked,
+      inBackoff: inFetchBackoff,
+      seederCountOf: (hash) => discoveryCatalog.seederCount(hash),
+    });
+    if (!plan) { return null; }
+
+    const evictee = registry.get(plan.evictId);
+    const heldSince = evictee?.firstFetchedAt || evictee?.fetchedAt || 'unknown';
+    if (plan.evictFirst) {
+      // The incoming snapshot needs the evictee's bytes gone first. If the
+      // fetch then fails, the shelf runs one short until the next
+      // reconcile/rotation pass — logged, bounded, accepted.
+      removePeerDb(plan.evictId);
+      recordEviction(plan.evictId);
+      try {
+        await fetchPeer(plan.fetchId);
+      } catch (err) {
+        recordFetchFailure(plan.fetchId);
+        winston.warn(`[discovery-peer-dbs] rotation fetch of ${plan.fetchId.slice(0, 12)}… failed `
+          + `after evicting ${plan.evictId.slice(0, 12)}… — shelf runs one short until the next pass: ${err.message}`);
+        return plan;
+      }
+    } else {
+      // Fetch-first: a failed download costs nothing — keep the evictee.
+      try {
+        await fetchPeer(plan.fetchId);
+      } catch (err) {
+        recordFetchFailure(plan.fetchId);
+        winston.warn(`[discovery-peer-dbs] rotation fetch of ${plan.fetchId.slice(0, 12)}… failed `
+          + `— keeping ${plan.evictId.slice(0, 12)}… on the shelf: ${err.message}`);
+        return null;
+      }
+      removePeerDb(plan.evictId);
+      recordEviction(plan.evictId);
+    }
+    winston.info(`[discovery-peer-dbs] rotated ${plan.evictId.slice(0, 12)}… `
+      + `(held since ${heldSince}) out for ${plan.fetchId.slice(0, 12)}…`);
+    return plan;
+  } finally {
+    rotateInFlight = false;
+  }
+}
+
 // Wire auto-fetch into the world: run soon after boot (give the catalog a
 // moment to fill from gossip), re-run debounced as announcements arrive, and
 // sweep periodically as a catch-all. Idempotent across server reboot()s.
@@ -490,6 +634,13 @@ export function startAutoFetch() {
     reconcile().catch((err) => winston.warn(`[discovery-peer-dbs] reconcile failed: ${err.message}`));
   }, RECONCILE_INTERVAL_MS);
   if (reconcileTimer.unref) { reconcileTimer.unref(); }
+  // Rotation: interval-only by design — the first pass runs one full
+  // interval after boot, never during startup (boot already reconciles;
+  // rotating before the catalog has re-filled would evict on stale info).
+  rotateTimer = setInterval(() => {
+    rotatePeerDbs().catch((err) => winston.warn(`[discovery-peer-dbs] rotation failed: ${err.message}`));
+  }, ROTATE_INTERVAL_MS);
+  if (rotateTimer.unref) { rotateTimer.unref(); }
 }
 
 // The disable half: detach the listener and kill both timers so nothing
@@ -502,4 +653,5 @@ export function stopAutoFetch() {
   discoveryP2p.events.removeListener('announcement', onAnnouncement);
   if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
   if (reconcileTimer) { clearInterval(reconcileTimer); reconcileTimer = null; }
+  if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
 }

--- a/src/state/discovery-peer-rotation.js
+++ b/src/state/discovery-peer-rotation.js
@@ -1,0 +1,145 @@
+// Shelf policy for fetched peer snapshots — the PURE half of
+// discovery-peer-dbs.js, split out so the selection/rotation rules are unit
+// testable without a server, a sidecar, or a config singleton. Everything a
+// decision needs arrives as an argument; nothing here touches disk, network,
+// or clocks.
+//
+// Two policies live here:
+//
+//   candidateOrder      which unheld catalog peer is most worth downloading
+//                       (used by the reconcile top-up AND by rotation)
+//   planRotation        which held snapshot to swap for which candidate so
+//                       shelf MEMBERSHIP cycles over time ("suggestions stay
+//                       fresh") — the anti-calcification pass
+//
+// Rotation philosophy: the shelf only ever SWAPS (never shrinks — evicting
+// with no replacement serves nobody), churns at most one pair per pass
+// (gentle, self-limiting on small catalogs), never touches pinned entries,
+// and prefers to evict what's least useful (long-offline, longest-held) in
+// favor of what's most novel (never held before, model-compatible, online).
+
+// A peer is "online" when we heard a re-announcement recently. Announcers
+// re-broadcast every ~15s; 90s tolerates a few missed rounds.
+export const ONLINE_WINDOW_MS = 90 * 1000;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Missing/garbage timestamps parse to 0 = "the beginning of time". For
+// membership ages that makes a record with no clock ELIGIBLE to rotate
+// (conservative: unknown age is treated as old, and rotation is harmless —
+// snapshots are re-fetchable cache); for last-heard it sorts an unknown
+// peer as longest-silent, the first to evict.
+function ts(value) {
+  const parsed = Date.parse(value || '');
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+// Sort candidates by usefulness: peers whose announced embedding model
+// matches ours first (an incompatible snapshot is dead weight for the
+// similar search until a migration lands — still fetchable, just last in
+// line), then peers we can hear right now, then by library size. No local
+// model established yet = no compatibility signal; everyone ties.
+export function candidateOrder(localModel, now = Date.now()) {
+  return (a, b) => {
+    if (localModel) {
+      const aCompat = a.payload.modelId === localModel ? 1 : 0;
+      const bCompat = b.payload.modelId === localModel ? 1 : 0;
+      if (aCompat !== bCompat) { return bCompat - aCompat; }
+    }
+    const aOnline = now - ts(a.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+    const bOnline = now - ts(b.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+    if (aOnline !== bOnline) { return bOnline - aOnline; }
+    return (b.payload.rowCount || 0) - (a.payload.rowCount || 0);
+  };
+}
+
+// Rotation's candidate order: novelty first — a peer we've NEVER shelved
+// beats every past evictee, and among past evictees the longest-gone comes
+// back first (no A↔B ping-pong while unheld peers wait). Ties fall through
+// to the regular usefulness order.
+export function rotationCandidateOrder(ledger, localModel, now = Date.now()) {
+  const base = candidateOrder(localModel, now);
+  return (a, b) => {
+    const aEvicted = ts(ledger[a.from]); // 0 = never held here
+    const bEvicted = ts(ledger[b.from]);
+    if (aEvicted !== bEvicted) { return aEvicted - bEvicted; }
+    return base(a, b);
+  };
+}
+
+// Which held snapshot is least worth keeping: peers we can't hear at all
+// go first (longest-silent first among them — their data only ages, no
+// refresh is coming), then the longest-standing membership. Tie-break
+// prefers evicting a snapshot OTHER live peers still hold (seeders ≥ 2),
+// so rotation avoids deleting the swarm's last copy when it has a choice.
+function evictionOrder(catalogByFrom, seederCountOf, now) {
+  return (a, b) => {
+    const aCat = catalogByFrom.get(a.endpointId);
+    const bCat = catalogByFrom.get(b.endpointId);
+    const aOnline = aCat && now - ts(aCat.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+    const bOnline = bCat && now - ts(bCat.updatedAt) < ONLINE_WINDOW_MS ? 1 : 0;
+    if (aOnline !== bOnline) { return aOnline - bOnline; }
+    if (!aOnline) {
+      const aHeard = aCat ? ts(aCat.updatedAt) : 0;
+      const bHeard = bCat ? ts(bCat.updatedAt) : 0;
+      if (aHeard !== bHeard) { return aHeard - bHeard; }
+    }
+    const aStart = ts(a.firstFetchedAt);
+    const bStart = ts(b.firstFetchedAt);
+    if (aStart !== bStart) { return aStart - bStart; }
+    return seederCountOf(b.hash) - seederCountOf(a.hash);
+  };
+}
+
+// One rotation decision: `{ evictId, fetchId, evictFirst } | null`.
+//
+//   shelf          registry entries ({ endpointId, hash, sizeBytes, pinned,
+//                  firstFetchedAt, ... })
+//   catalog        discovery-catalog list() entries ({ from, updatedAt,
+//                  payload: { size, rowCount, modelId, ... } })
+//   ledger         { endpointId -> evictedAt ISO } — past rotation evictions
+//   localModel     active embedding model id, or null when none established
+//   rotationDays   0 disables rotation entirely
+//   autoFetch/autoFetchCount   rotation is an auto-fetch behavior: a paused
+//                  shelf (feature off, or count 0) must not keep swapping
+//   capBytes       the storage cap; a candidate must fit AFTER the eviction
+//   isBlocked / inBackoff / seederCountOf   injected lookups (pure-testable)
+//
+// evictFirst is true when the incoming snapshot only fits once the evictee's
+// bytes are gone — the caller must then evict before fetching and accept the
+// small window where the fetch fails and the shelf runs one short. When it
+// fits in current headroom the caller fetches FIRST, so a failed download
+// costs nothing.
+export function planRotation({
+  shelf, catalog, ledger, localModel, now,
+  rotationDays, autoFetch, autoFetchCount, capBytes,
+  isBlocked = () => false,
+  inBackoff = () => false,
+  seederCountOf = () => 0,
+}) {
+  if (!autoFetch || !(autoFetchCount > 0) || !(rotationDays > 0)) { return null; }
+
+  const eligible = shelf.filter((e) => e.pinned !== true
+    && now - ts(e.firstFetchedAt || e.fetchedAt) >= rotationDays * DAY_MS);
+  if (eligible.length === 0) { return null; }
+
+  const held = new Set(shelf.map((e) => e.endpointId));
+  const candidates = catalog
+    .filter((c) => !held.has(c.from) && !isBlocked(c.from) && !inBackoff(c.from))
+    .sort(rotationCandidateOrder(ledger, localModel, now));
+  if (candidates.length === 0) { return null; }
+
+  const catalogByFrom = new Map(catalog.map((c) => [c.from, c]));
+  const evict = [...eligible].sort(evictionOrder(catalogByFrom, seederCountOf, now))[0];
+
+  const totalBytes = shelf.reduce((sum, e) => sum + (e.sizeBytes || 0), 0);
+  const headroomAfterEvict = capBytes - (totalBytes - (evict.sizeBytes || 0));
+  const incoming = candidates.find((c) => (c.payload.size || 0) <= headroomAfterEvict);
+  if (!incoming) { return null; }
+
+  return {
+    evictId: evict.endpointId,
+    fetchId: incoming.from,
+    evictFirst: (incoming.payload.size || 0) > capBytes - totalBytes,
+  };
+}

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -607,6 +607,14 @@ export async function editAutoFetchCount(val) {
   config.program.discoveryP2p.autoFetchCount = val;
 }
 
+export async function editRotationDays(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.rotationDays = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.rotationDays = val;
+}
+
 // Append a bootstrap peer (deduplicated) so a friend joined through the
 // UI survives restarts — the join RPC itself is session-only.
 export async function editAddBootstrapPeer(val) {

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -792,6 +792,150 @@ describe('discovery p2p — similarity search + novelty filter', () => {
   });
 });
 
+// ── Shelf rotation: membership cycles instead of freezing ───────────────────
+// A FULL shelf (registry pre-crafted with two long-held snapshots, count=2)
+// must SWAP its oldest unpinned entry for a newly announced peer — the
+// count-capped top-up alone can never do this (room is 0). The registry is
+// crafted BEFORE the server boots by pointing extraConfig.storage at a
+// pre-seeded state dir, so ensureLoaded's first read sees the aged shelf —
+// no load-order races. Rotation policy details are unit-tested
+// (test/unit/discovery-peer-rotation.test.mjs); this proves the wiring:
+// timer → plan → fetch → evict → ledger, live over real gossip.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — shelf rotation', () => {
+  let server;
+  let peer;
+  let dir;
+  let dbDir;
+  const AGED_ID = 'a'.repeat(64);
+  const PINNED_ID = 'b'.repeat(64);
+
+  const shelfIds = async () => {
+    const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+    return s.peerDbs.map((p) => p.endpointId);
+  };
+
+  before(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-rot-'));
+    const stateDir = path.join(dir, 'state');
+    dbDir = path.join(stateDir, 'db');
+
+    // Craft the shelf: two valid snapshot files + a registry that says both
+    // have been held for 10 days. One is pinned — rotation must not touch it.
+    const agedDb = makeSnapshotFile(path.join(dbDir, 'discovery-peers', 'aged.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Aged Artist', title: 'Old Song', vec: [1, 0, 0, 0] }],
+    });
+    const pinnedDb = makeSnapshotFile(path.join(dbDir, 'discovery-peers', 'pinned.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Pinned Artist', title: 'Kept Song', vec: [0, 1, 0, 0] }],
+    });
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const entry = (endpointId, hash, filePath, name, pinned) => ({
+      endpointId, hash, path: filePath, snapshotSeq: 1,
+      modelId: 'test-model', modelVersion: '1', rowCount: 1,
+      sizeBytes: fs.statSync(filePath).size, name,
+      fetchedAt: tenDaysAgo, firstFetchedAt: tenDaysAgo, pinned,
+    });
+    fs.mkdirSync(path.join(dbDir, 'discovery-p2p'), { recursive: true });
+    fs.writeFileSync(path.join(dbDir, 'discovery-p2p', 'peer-dbs.json'), JSON.stringify([
+      entry(AGED_ID, 'd'.repeat(64), agedDb, 'Aged Peer', false),
+      entry(PINNED_ID, 'e'.repeat(64), pinnedDb, 'Pinned Peer', true),
+    ], null, 2));
+
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      env: {
+        MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS: '750',
+        MSTREAM_TEST_DISCOVERY_ROTATE_MS: '2000',
+      },
+      extraConfig: {
+        // Wholesale storage override (the helper's spread replaces the
+        // object) — every key must be present or state leaks to defaults.
+        storage: {
+          albumArtDirectory: path.join(stateDir, 'image-cache'),
+          dbDirectory: dbDir,
+          logsDirectory: path.join(stateDir, 'logs'),
+          syncConfigDirectory: path.join(stateDir, 'sync'),
+          waveformCacheDirectory: path.join(stateDir, 'waveform-cache'),
+        },
+        // count=2 with 2 held: the top-up has NO room — only rotation can
+        // bring the new peer in. rotationDays=1 << the crafted 10-day age.
+        discoveryP2p: { enabled: true, autoFetchCount: 2, rotationDays: 1 },
+      },
+    });
+    peer = new RawSidecar(SIDECAR_BIN, path.join(dir, 'sidecar'));
+    await peer.ready;
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('a full shelf swaps its oldest unpinned snapshot for a new peer; pinned survives', async () => {
+    // The crafted registry is live: both pre-seeded snapshots on the shelf.
+    assert.deepEqual((await shelfIds()).sort(), [AGED_ID, PINNED_ID]);
+
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    const snap = makeSnapshotFile(path.join(dir, 'fresh.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Fresh Artist', title: 'New Song', vec: [0, 0, 1, 0] }],
+    });
+    const pub = await peer.rpc('publish', { path: snap });
+    await peer.rpc('announce', {
+      payload: { hash: pub.hash, size: pub.size, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Fresh Peer' },
+    });
+
+    // The hourly pass runs every 2s here: swap in the fresh peer, evict the
+    // aged unpinned one, keep the shelf at exactly autoFetchCount.
+    await pollUntil(async () => {
+      const ids = await shelfIds();
+      return ids.includes(peer.endpointId) && !ids.includes(AGED_ID) ? ids : null;
+    }, { timeoutMs: 30000, what: 'rotation to swap the aged snapshot for the fresh peer' });
+
+    const ids = await shelfIds();
+    assert.equal(ids.length, 2, 'rotation must swap, never grow or shrink the shelf');
+    assert.ok(ids.includes(PINNED_ID), 'the pinned snapshot must survive rotation');
+
+    // The eviction is remembered (novelty preference for future passes)…
+    const ledger = JSON.parse(fs.readFileSync(
+      path.join(dbDir, 'discovery-p2p', 'rotation.json'), 'utf8'));
+    assert.ok(ledger[AGED_ID], 'rotation must record the eviction in the ledger');
+    // …and the evicted snapshot file is actually gone.
+    assert.ok(!fs.existsSync(path.join(dbDir, 'discovery-peers', 'aged.db')));
+  });
+
+  test('pin route flips rotation immunity live; unknown peer is 404', async () => {
+    const pinUrl = `${server.baseUrl}/api/v1/admin/discovery/p2p/peer-dbs/pin`;
+    const post = (body) => fetch(pinUrl, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const fetchedRow = async () => {
+      const cat = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`)).json();
+      return cat.peers.find((p) => p.from === peer.endpointId)?.fetched;
+    };
+
+    // The rotation-fetched peer arrives unpinned (automatic download).
+    assert.equal((await fetchedRow())?.pinned, false);
+
+    assert.equal((await post({ endpointId: peer.endpointId, pinned: true })).status, 200);
+    assert.equal((await fetchedRow())?.pinned, true);
+    assert.equal((await post({ endpointId: peer.endpointId, pinned: false })).status, 200);
+    assert.equal((await fetchedRow())?.pinned, false);
+
+    assert.equal((await post({ endpointId: 'f'.repeat(64), pinned: true })).status, 404,
+      'pinning needs a downloaded snapshot');
+  });
+});
+
 // ── Community seeds: merge logic (pure, no server) ──────────────────────────
 describe('discovery seeds — mergeSeedLists', () => {
   const T = (n) => `endpointticket${'x'.repeat(16)}${n}`;
@@ -1394,6 +1538,26 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
       assert.equal(rej.status, 400, `${JSON.stringify(bad)} should be 400`);
     }
     assert.equal((await (await fetch(api('status'))).json()).autoFetchCount, 0,
+      'rejections must not clobber the saved value');
+  });
+
+  test('rotation saves live, persists, and validates (0 = off is legal)', async () => {
+    const r = await post('rotation', { rotationDays: 21 });
+    assert.equal(r.status, 200);
+
+    const status = await (await fetch(api('status'))).json();
+    assert.equal(status.rotationDays, 21);
+    assert.equal(readConfig().discoveryP2p.rotationDays, 21);
+
+    // 0 turns rotation off — a real setting, not a rejection.
+    assert.equal((await post('rotation', { rotationDays: 0 })).status, 200);
+    assert.equal((await (await fetch(api('status'))).json()).rotationDays, 0);
+
+    for (const bad of [-1, 3651, 1.5, 'week', null]) {
+      const rej = await post('rotation', { rotationDays: bad });
+      assert.equal(rej.status, 400, `${JSON.stringify(bad)} should be 400`);
+    }
+    assert.equal((await (await fetch(api('status'))).json()).rotationDays, 0,
       'rejections must not clobber the saved value');
   });
 

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -627,6 +627,14 @@ describe('discovery p2p — similarity search + novelty filter', () => {
     assert.equal(shelf1.rowCount, 1);
     assert.equal(shelf1.modelId, 'test-model');
 
+    // Membership metadata at first fetch, straight from the persisted
+    // registry (an automatic download must arrive unpinned).
+    const registryPath = path.join(server.tmpDir, 'db', 'discovery-p2p', 'peer-dbs.json');
+    const reg1 = JSON.parse(fs.readFileSync(registryPath, 'utf8'))
+      .find((e) => e.endpointId === peer.endpointId);
+    assert.equal(reg1.pinned, false);
+    assert.ok(reg1.firstFetchedAt, 'first fetch must stamp the membership clock');
+
     // Bump: new snapshot content + higher monotonic seq -> auto-refresh.
     const v2 = makeSnapshotFile(path.join(peerDir, 'snap-v2.db'), {
       modelId: 'test-model',
@@ -646,6 +654,17 @@ describe('discovery p2p — similarity search + novelty filter', () => {
       const entry = s.peerDbs.find((p) => p.endpointId === peer.endpointId);
       return entry && entry.rowCount === 2 ? entry : null;
     }, { timeoutMs: 30000, what: 'auto-fetch to refresh the stale snapshot' });
+
+    // A refresh replaces the bytes, NOT the membership: the record is
+    // rewritten (fetchedAt advances) but the membership clock and the pin
+    // state carry over — reset either here and an actively-publishing peer
+    // could never rotate (or would silently lose its pin).
+    const reg2 = JSON.parse(fs.readFileSync(registryPath, 'utf8'))
+      .find((e) => e.endpointId === peer.endpointId);
+    assert.notEqual(reg2.fetchedAt, reg1.fetchedAt, 'the refresh must rewrite the record');
+    assert.equal(reg2.firstFetchedAt, reg1.firstFetchedAt,
+      'the membership clock must survive a seq-refresh');
+    assert.equal(reg2.pinned, false, 'a refresh must not invent a pin');
   });
 });
 
@@ -806,6 +825,7 @@ describe('discovery p2p — similarity search + novelty filter', () => {
   let peer;
   let dir;
   let dbDir;
+  let tenDaysAgo;
   const AGED_ID = 'a'.repeat(64);
   const PINNED_ID = 'b'.repeat(64);
 
@@ -821,6 +841,10 @@ describe('discovery p2p — similarity search + novelty filter', () => {
 
     // Craft the shelf: two valid snapshot files + a registry that says both
     // have been held for 10 days. One is pinned — rotation must not touch it.
+    // The aged entry is deliberately OLD-FORMAT (no firstFetchedAt, no
+    // pinned — what every pre-rotation install has on disk): loading must
+    // backfill the membership clock from fetchedAt, which is exactly what
+    // makes this entry rotation-eligible.
     const agedDb = makeSnapshotFile(path.join(dbDir, 'discovery-peers', 'aged.db'), {
       modelId: 'test-model',
       tracks: [{ artist: 'Aged Artist', title: 'Old Song', vec: [1, 0, 0, 0] }],
@@ -829,17 +853,21 @@ describe('discovery p2p — similarity search + novelty filter', () => {
       modelId: 'test-model',
       tracks: [{ artist: 'Pinned Artist', title: 'Kept Song', vec: [0, 1, 0, 0] }],
     });
-    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
-    const entry = (endpointId, hash, filePath, name, pinned) => ({
-      endpointId, hash, path: filePath, snapshotSeq: 1,
-      modelId: 'test-model', modelVersion: '1', rowCount: 1,
-      sizeBytes: fs.statSync(filePath).size, name,
-      fetchedAt: tenDaysAgo, firstFetchedAt: tenDaysAgo, pinned,
-    });
+    tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
     fs.mkdirSync(path.join(dbDir, 'discovery-p2p'), { recursive: true });
     fs.writeFileSync(path.join(dbDir, 'discovery-p2p', 'peer-dbs.json'), JSON.stringify([
-      entry(AGED_ID, 'd'.repeat(64), agedDb, 'Aged Peer', false),
-      entry(PINNED_ID, 'e'.repeat(64), pinnedDb, 'Pinned Peer', true),
+      { // old-format: pre-rotation registries carry neither new field
+        endpointId: AGED_ID, hash: 'd'.repeat(64), path: agedDb, snapshotSeq: 1,
+        modelId: 'test-model', modelVersion: '1', rowCount: 1,
+        sizeBytes: fs.statSync(agedDb).size, name: 'Aged Peer',
+        fetchedAt: tenDaysAgo,
+      },
+      {
+        endpointId: PINNED_ID, hash: 'e'.repeat(64), path: pinnedDb, snapshotSeq: 1,
+        modelId: 'test-model', modelVersion: '1', rowCount: 1,
+        sizeBytes: fs.statSync(pinnedDb).size, name: 'Pinned Peer',
+        fetchedAt: tenDaysAgo, firstFetchedAt: tenDaysAgo, pinned: true,
+      },
     ], null, 2));
 
     server = await startServer({
@@ -875,6 +903,15 @@ describe('discovery p2p — similarity search + novelty filter', () => {
   test('a full shelf swaps its oldest unpinned snapshot for a new peer; pinned survives', async () => {
     // The crafted registry is live: both pre-seeded snapshots on the shelf.
     assert.deepEqual((await shelfIds()).sort(), [AGED_ID, PINNED_ID]);
+
+    // The old-format entry was backfilled on load: membership clock from
+    // fetchedAt, unpinned by default — the upgrade path every pre-rotation
+    // install takes on its first boot with this code.
+    const shelf0 = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+    const agedRow = shelf0.peerDbs.find((p) => p.endpointId === AGED_ID);
+    assert.equal(agedRow.firstFetchedAt, tenDaysAgo,
+      'backfill must derive the membership clock from the old fetchedAt');
+    assert.equal(agedRow.pinned, false, 'backfill must default pinned to false');
 
     const status = await pollUntil(async () => {
       const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
@@ -933,6 +970,194 @@ describe('discovery p2p — similarity search + novelty filter', () => {
 
     assert.equal((await post({ endpointId: 'f'.repeat(64), pinned: true })).status, 404,
       'pinning needs a downloaded snapshot');
+  });
+});
+
+// ── Rotation, evict-first: the incoming snapshot fits only after the
+// eviction ──────────────────────────────────────────────────────────────────
+// Registry claims the held snapshot is 6MB under a 10MB cap; the candidate
+// announces 5MB. Fetch-first would blow the cap (6+5 > 10 → fetchPeer
+// throws → backoff → no swap, ever), so a completed swap is itself proof
+// the executor took the evict-then-fetch branch. Announced sizes are what
+// the planner trusts; the actual blob is tiny.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — rotation evict-first', () => {
+  let server;
+  let peer;
+  let dir;
+  let dbDir;
+  const AGED_ID = 'a'.repeat(64);
+
+  before(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-rotef-'));
+    const stateDir = path.join(dir, 'state');
+    dbDir = path.join(stateDir, 'db');
+    const agedDb = makeSnapshotFile(path.join(dbDir, 'discovery-peers', 'aged.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Bulky Artist', title: 'Big Old Song', vec: [1, 0, 0, 0] }],
+    });
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    fs.mkdirSync(path.join(dbDir, 'discovery-p2p'), { recursive: true });
+    fs.writeFileSync(path.join(dbDir, 'discovery-p2p', 'peer-dbs.json'), JSON.stringify([{
+      endpointId: AGED_ID, hash: 'd'.repeat(64), path: agedDb, snapshotSeq: 1,
+      modelId: 'test-model', modelVersion: '1', rowCount: 1,
+      // The lie that shapes the plan: 6MB held under a 10MB cap.
+      sizeBytes: 6 * 1024 * 1024, name: 'Bulky Aged Peer',
+      fetchedAt: tenDaysAgo, firstFetchedAt: tenDaysAgo, pinned: false,
+    }], null, 2));
+
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      env: {
+        MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS: '750',
+        MSTREAM_TEST_DISCOVERY_ROTATE_MS: '1500',
+      },
+      extraConfig: {
+        storage: {
+          albumArtDirectory: path.join(stateDir, 'image-cache'),
+          dbDirectory: dbDir,
+          logsDirectory: path.join(stateDir, 'logs'),
+          syncConfigDirectory: path.join(stateDir, 'sync'),
+          waveformCacheDirectory: path.join(stateDir, 'waveform-cache'),
+        },
+        discoveryP2p: {
+          enabled: true, autoFetchCount: 1, rotationDays: 1, maxPeerDbStorageMb: 10,
+        },
+      },
+    });
+    peer = new RawSidecar(SIDECAR_BIN, path.join(dir, 'sidecar'));
+    await peer.ready;
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('the swap completes by evicting first when the incoming needs the headroom', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    const snap = makeSnapshotFile(path.join(dir, 'incoming.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Incoming Artist', title: 'New Song', vec: [0, 1, 0, 0] }],
+    });
+    const pub = await peer.rpc('publish', { path: snap });
+    await peer.rpc('announce', {
+      // Announced 5MB: over the 4MB current headroom, under the cap once
+      // the 6MB evictee is gone.
+      payload: { hash: pub.hash, size: 5 * 1024 * 1024, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Oversized Claim' },
+    });
+
+    const shelf = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+      const ids = s.peerDbs.map((p) => p.endpointId);
+      return ids.includes(peer.endpointId) && !ids.includes(AGED_ID) ? s.peerDbs : null;
+    }, { timeoutMs: 30000, what: 'the evict-first rotation swap' });
+
+    assert.equal(shelf.length, 1);
+    // The record stores what was actually downloaded, not the announced claim.
+    assert.ok(shelf[0].sizeBytes < 1024 * 1024, 'real blob size, not the announced 5MB');
+    const ledger = JSON.parse(fs.readFileSync(
+      path.join(dbDir, 'discovery-p2p', 'rotation.json'), 'utf8'));
+    assert.ok(ledger[AGED_ID], 'the eviction must be in the ledger');
+  });
+});
+
+// ── Rotation, failed fetch: the evictee is never spent on a download that
+// didn't happen ─────────────────────────────────────────────────────────────
+// The sky-high free-disk floor makes every fetch refuse instantly, so each
+// rotation pass plans the swap, tries the fetch FIRST, fails, and must keep
+// the evictee — shelf unchanged, no ledger entry, across several passes.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — rotation keeps the evictee on fetch failure', () => {
+  let server;
+  let peer;
+  let dir;
+  let dbDir;
+  const AGED_ID = 'a'.repeat(64);
+
+  before(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-rotff-'));
+    const stateDir = path.join(dir, 'state');
+    dbDir = path.join(stateDir, 'db');
+    const agedDb = makeSnapshotFile(path.join(dbDir, 'discovery-peers', 'aged.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Sturdy Artist', title: 'Kept Song', vec: [1, 0, 0, 0] }],
+    });
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    fs.mkdirSync(path.join(dbDir, 'discovery-p2p'), { recursive: true });
+    fs.writeFileSync(path.join(dbDir, 'discovery-p2p', 'peer-dbs.json'), JSON.stringify([{
+      endpointId: AGED_ID, hash: 'd'.repeat(64), path: agedDb, snapshotSeq: 1,
+      modelId: 'test-model', modelVersion: '1', rowCount: 1,
+      sizeBytes: fs.statSync(agedDb).size, name: 'Sturdy Aged Peer',
+      fetchedAt: tenDaysAgo, firstFetchedAt: tenDaysAgo, pinned: false,
+    }], null, 2));
+
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      env: {
+        MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS: '750',
+        MSTREAM_TEST_DISCOVERY_ROTATE_MS: '1500',
+        // ~8 exabytes of required headroom: every download refuses up front.
+        MSTREAM_TEST_DISCOVERY_DISK_FLOOR_BYTES: '9007199254740992',
+      },
+      extraConfig: {
+        storage: {
+          albumArtDirectory: path.join(stateDir, 'image-cache'),
+          dbDirectory: dbDir,
+          logsDirectory: path.join(stateDir, 'logs'),
+          syncConfigDirectory: path.join(stateDir, 'sync'),
+          waveformCacheDirectory: path.join(stateDir, 'waveform-cache'),
+        },
+        discoveryP2p: { enabled: true, autoFetchCount: 1, rotationDays: 1 },
+      },
+    });
+    peer = new RawSidecar(SIDECAR_BIN, path.join(dir, 'sidecar'));
+    await peer.ready;
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('a failed rotation fetch keeps the shelf intact and writes no ledger entry', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    const snap = makeSnapshotFile(path.join(dir, 'unreachable.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Blocked Artist', title: 'Never Arrives', vec: [0, 1, 0, 0] }],
+    });
+    const pub = await peer.rpc('publish', { path: snap });
+    await peer.rpc('announce', {
+      payload: { hash: pub.hash, size: pub.size, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Unfetchable Peer' },
+    });
+    // Candidate is definitely on the table before we watch for (non-)swaps.
+    await pollUntil(async () => {
+      const c = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`)).json();
+      return c.peers.find((p) => p.from === peer.endpointId) || null;
+    }, { what: 'the candidate announcement to reach the catalog' });
+
+    // ≥4 rotation passes at 1.5s: the first one attempts the fetch and
+    // fails on the floor; failure backoff quiets the rest. Through all of
+    // it the evictee must stay put.
+    await new Promise((resolve) => setTimeout(resolve, 7000));
+
+    const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+    assert.deepEqual(s.peerDbs.map((p) => p.endpointId), [AGED_ID],
+      'the evictee must never be spent on a download that did not happen');
+    assert.ok(!fs.existsSync(path.join(dbDir, 'discovery-p2p', 'rotation.json')),
+      'no eviction happened, so no ledger entry may exist');
   });
 });
 

--- a/test/unit/discovery-peer-rotation.test.mjs
+++ b/test/unit/discovery-peer-rotation.test.mjs
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for the pure shelf-rotation policy
+ * (src/state/discovery-peer-rotation.js). No server, no sidecar, no config
+ * singleton — every decision input is handcrafted, so each rule is pinned
+ * down in isolation:
+ *
+ *   - gates: rotation is an auto-fetch behavior (feature off / count 0 /
+ *     rotationDays 0 all disable it)
+ *   - eligibility: membership age via firstFetchedAt; pinned = immune
+ *   - swap-only: no candidate -> no eviction, ever
+ *   - eviction order: offline (longest-silent) -> oldest membership ->
+ *     prefer entries other seeders still hold
+ *   - candidate order: never-held first (ledger), then the shared
+ *     usefulness order (model-compatible -> online -> biggest)
+ *   - capacity: the incoming snapshot must fit AFTER the eviction;
+ *     evictFirst signals when it only fits because of it
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  planRotation,
+  candidateOrder,
+  rotationCandidateOrder,
+  ONLINE_WINDOW_MS,
+} from '../../src/state/discovery-peer-rotation.js';
+
+const NOW = Date.parse('2026-07-28T12:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+const iso = (msAgo) => new Date(NOW - msAgo).toISOString();
+const id = (ch) => ch.repeat(64);
+
+// A held shelf entry, aged `heldDays` and heard-from per `updatedAt` on the
+// catalog side (see cat()).
+function held(ch, { heldDays = 10, pinned = false, sizeBytes = 1000 } = {}) {
+  return {
+    endpointId: id(ch),
+    hash: id(ch === 'a' ? 'f' : ch), // hash distinct from endpointId is fine
+    sizeBytes,
+    pinned,
+    firstFetchedAt: iso(heldDays * DAY),
+    fetchedAt: iso(1 * DAY),
+  };
+}
+
+// A catalog entry. `silentMs` controls online-ness (ONLINE_WINDOW_MS = 90s).
+function cat(ch, { silentMs = 0, size = 1000, rowCount = 10, modelId = 'model-x' } = {}) {
+  return {
+    from: id(ch),
+    updatedAt: iso(silentMs),
+    payload: { size, rowCount, modelId, hash: id(ch) },
+  };
+}
+
+// Baseline inputs: one aged unpinned entry, one fresh candidate, ample cap.
+function inputs(overrides = {}) {
+  return {
+    shelf: [held('a')],
+    catalog: [cat('c')],
+    ledger: {},
+    localModel: null,
+    now: NOW,
+    rotationDays: 7,
+    autoFetch: true,
+    autoFetchCount: 3,
+    capBytes: 100000,
+    ...overrides,
+  };
+}
+
+describe('planRotation — gates', () => {
+  test('happy path: aged entry + candidate -> swap plan', () => {
+    const plan = planRotation(inputs());
+    assert.deepEqual(plan, { evictId: id('a'), fetchId: id('c'), evictFirst: false });
+  });
+
+  test('rotationDays 0 disables rotation', () => {
+    assert.equal(planRotation(inputs({ rotationDays: 0 })), null);
+  });
+
+  test('autoFetch off disables rotation', () => {
+    assert.equal(planRotation(inputs({ autoFetch: false })), null);
+  });
+
+  test('autoFetchCount 0 (paused shelf) disables rotation', () => {
+    assert.equal(planRotation(inputs({ autoFetchCount: 0 })), null);
+  });
+});
+
+describe('planRotation — eligibility', () => {
+  test('an entry younger than rotationDays is not eligible', () => {
+    assert.equal(planRotation(inputs({ shelf: [held('a', { heldDays: 3 })] })), null);
+  });
+
+  test('a refresh must not reset the clock: age comes from firstFetchedAt, not fetchedAt', () => {
+    // fetchedAt is 1 day ago (a recent refresh) but membership is 10 days old.
+    const plan = planRotation(inputs());
+    assert.ok(plan, 'the recently-refreshed but long-held entry must still rotate');
+  });
+
+  test('pinned entries are immune however old', () => {
+    assert.equal(planRotation(inputs({ shelf: [held('a', { heldDays: 400, pinned: true })] })), null);
+  });
+
+  test('a missing membership timestamp is treated as ancient (eligible)', () => {
+    const e = held('a');
+    delete e.firstFetchedAt;
+    delete e.fetchedAt;
+    assert.ok(planRotation(inputs({ shelf: [e] })));
+  });
+});
+
+describe('planRotation — swap-only', () => {
+  test('no candidates at all -> no eviction', () => {
+    assert.equal(planRotation(inputs({ catalog: [] })), null);
+  });
+
+  test('candidates already held, blocked, or in backoff do not count', () => {
+    const base = inputs({
+      shelf: [held('a'), held('b', { heldDays: 1 })],
+      catalog: [cat('a'), cat('x'), cat('y')],
+      isBlocked: (p) => p === id('x'),
+      inBackoff: (p) => p === id('y'),
+    });
+    assert.equal(planRotation(base), null);
+  });
+});
+
+describe('planRotation — eviction order', () => {
+  test('an offline peer is evicted before an online one', () => {
+    const plan = planRotation(inputs({
+      shelf: [held('a'), held('b')],
+      // a is online (heard 5s ago), b has been silent for a day.
+      catalog: [cat('a', { silentMs: 5000 }), cat('b', { silentMs: DAY }), cat('c')],
+    }));
+    assert.equal(plan.evictId, id('b'));
+  });
+
+  test('among offline peers, the longest-silent goes first', () => {
+    const plan = planRotation(inputs({
+      shelf: [held('a'), held('b')],
+      catalog: [cat('a', { silentMs: 2 * DAY }), cat('b', { silentMs: 1 * DAY }), cat('c')],
+    }));
+    assert.equal(plan.evictId, id('a'));
+  });
+
+  test('a held peer with NO catalog entry sorts as silent-forever (first out)', () => {
+    const plan = planRotation(inputs({
+      shelf: [held('a'), held('b')],
+      catalog: [cat('b', { silentMs: 30 * DAY }), cat('c')], // nothing for a
+    }));
+    assert.equal(plan.evictId, id('a'));
+  });
+
+  test('equal silence: oldest membership goes first', () => {
+    const plan = planRotation(inputs({
+      shelf: [held('a', { heldDays: 8 }), held('b', { heldDays: 30 })],
+      catalog: [cat('c')],
+    }));
+    assert.equal(plan.evictId, id('b'));
+  });
+
+  test('full tie: prefer evicting the snapshot other seeders still hold', () => {
+    const a = held('a');
+    const b = held('b');
+    const plan = planRotation(inputs({
+      shelf: [a, b],
+      catalog: [cat('c')],
+      seederCountOf: (hash) => (hash === b.hash ? 3 : 1),
+    }));
+    assert.equal(plan.evictId, id('b'), 'the swarm keeps a copy of b; ours was the last copy of a');
+  });
+
+  test('pinned entries never win eviction even when they sort worst', () => {
+    const plan = planRotation(inputs({
+      shelf: [held('a', { heldDays: 400, pinned: true }), held('b', { heldDays: 8 })],
+      catalog: [cat('c')],
+    }));
+    assert.equal(plan.evictId, id('b'));
+  });
+});
+
+describe('planRotation — candidate choice', () => {
+  test('a never-held candidate beats a past evictee', () => {
+    const plan = planRotation(inputs({
+      catalog: [cat('d'), cat('e')],
+      ledger: { [id('d')]: iso(2 * DAY) }, // d was rotated out recently
+    }));
+    assert.equal(plan.fetchId, id('e'));
+  });
+
+  test('among past evictees, the longest-gone returns first', () => {
+    const plan = planRotation(inputs({
+      catalog: [cat('d'), cat('e')],
+      ledger: { [id('d')]: iso(1 * DAY), [id('e')]: iso(30 * DAY) },
+    }));
+    assert.equal(plan.fetchId, id('e'));
+  });
+
+  test('novelty ties fall through to the usefulness order (model-compatible first)', () => {
+    const plan = planRotation(inputs({
+      localModel: 'model-x',
+      catalog: [
+        cat('d', { modelId: 'other-model', rowCount: 99999 }),
+        cat('e', { modelId: 'model-x', rowCount: 1 }),
+      ],
+    }));
+    assert.equal(plan.fetchId, id('e'));
+  });
+});
+
+describe('planRotation — capacity', () => {
+  test('the incoming snapshot must fit after the eviction; too big -> next candidate', () => {
+    const plan = planRotation(inputs({
+      shelf: [held('a', { sizeBytes: 500 })],
+      capBytes: 1000,
+      catalog: [
+        cat('d', { size: 2000, rowCount: 99999 }), // never fits, even post-evict
+        cat('e', { size: 800, rowCount: 1 }),      // fits only after the evict
+      ],
+    }));
+    assert.deepEqual(plan, { evictId: id('a'), fetchId: id('e'), evictFirst: true });
+  });
+
+  test('no candidate fits even after eviction -> no swap', () => {
+    assert.equal(planRotation(inputs({
+      shelf: [held('a', { sizeBytes: 100 })],
+      capBytes: 1000,
+      catalog: [cat('d', { size: 5000 })],
+    })), null);
+  });
+
+  test('evictFirst is false when the candidate fits in current headroom', () => {
+    const plan = planRotation(inputs({
+      shelf: [held('a', { sizeBytes: 100 })],
+      capBytes: 10000,
+      catalog: [cat('d', { size: 500 })],
+    }));
+    assert.equal(plan.evictFirst, false);
+  });
+});
+
+describe('order helpers', () => {
+  test('candidateOrder: compatible > online > rowCount', () => {
+    const list = [
+      cat('a', { modelId: 'other', rowCount: 500, silentMs: 0 }),
+      cat('b', { modelId: 'model-x', rowCount: 10, silentMs: 10 * DAY }),
+      cat('c', { modelId: 'model-x', rowCount: 5, silentMs: 0 }),
+      cat('d', { modelId: 'model-x', rowCount: 50, silentMs: 0 }),
+    ].sort(candidateOrder('model-x', NOW));
+    assert.deepEqual(list.map((c) => c.from[0]), ['d', 'c', 'b', 'a']);
+  });
+
+  test('candidateOrder without a local model ignores compatibility', () => {
+    const list = [
+      cat('a', { modelId: 'other', rowCount: 500 }),
+      cat('b', { modelId: 'model-x', rowCount: 10 }),
+    ].sort(candidateOrder(null, NOW));
+    assert.equal(list[0].from, id('a'));
+  });
+
+  test('rotationCandidateOrder: never-held first, then oldest-evicted', () => {
+    const ledger = { [id('a')]: iso(1 * DAY), [id('b')]: iso(9 * DAY) };
+    const list = [cat('a', { rowCount: 999 }), cat('b'), cat('c', { rowCount: 1 })]
+      .sort(rotationCandidateOrder(ledger, null, NOW));
+    assert.deepEqual(list.map((c) => c.from[0]), ['c', 'b', 'a']);
+  });
+
+  test('the online window matches the announce cadence', () => {
+    assert.equal(ONLINE_WINDOW_MS, 90 * 1000);
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -738,7 +738,7 @@ const P2PIDENTITY = { serverName: '', serverDescription: '' };
 // Same shared-object pattern (and the same must-be-hoisted TDZ rule) for
 // the editable p2p settings: the Discovery card fills it from the status
 // route, the max-storage modal edits it.
-const P2PSETTINGS = { maxPeerDbStorageMb: 500, autoFetchCount: 6, peerRetentionDays: 30 };
+const P2PSETTINGS = { maxPeerDbStorageMb: 500, autoFetchCount: 6, rotationDays: 7, peerRetentionDays: 30 };
 
 const foldersView = Vue.component('folders-view', {
   data() {
@@ -7315,6 +7315,12 @@ const discoveryView = Vue.component('discovery-view', {
                       : 'never (offline servers stay listed forever)' }}
                     [<a v-on:click="openModal('edit-p2p-peer-retention-modal')">{{ t('admin.settings.edit') }}</a>]
                   </p>
+                  <p><b>Rotate downloads:</b>
+                    {{ discoveryP2p.status.rotationDays > 0
+                      ? 'swap the oldest unpinned download for a new server after ' + discoveryP2p.status.rotationDays + ' days'
+                      : 'never (downloads stay until removed by hand)' }}
+                    [<a v-on:click="openModal('edit-p2p-rotation-modal')">{{ t('admin.settings.edit') }}</a>]
+                  </p>
                   <div v-if="discoveryP2p.peers.length > 5" class="input-field" style="max-width: 360px; margin: 4px 0 0 0;">
                     <input v-model="peerFilter" id="p2p-peer-filter" type="text" placeholder="Search servers — name or description">
                   </div>
@@ -7333,10 +7339,14 @@ const discoveryView = Vue.component('discovery-view', {
                         <td>{{ peer.seeders }}</td>
                         <td :title="peer.updatedAt">{{ peer.online ? 'online' : 'offline' + discoveryAge(peer.updatedAt) }}</td>
                         <td>{{ peer.compatible === null ? 'unknown' : (peer.compatible ? 'compatible' : 'incompatible') }}</td>
-                        <td>{{ peer.fetched ? (peer.fetched.stale ? 'update available' : 'yes') : 'no' }}</td>
+                        <td :title="peer.fetched && peer.fetched.firstFetchedAt ? 'held since ' + peer.fetched.firstFetchedAt : ''">
+                          {{ peer.fetched ? (peer.fetched.stale ? 'update available' : 'yes') : 'no' }}<span
+                            v-if="peer.fetched && peer.fetched.pinned"> · pinned</span>
+                        </td>
                         <td>
                           [<a v-on:click="discoveryFetchPeer(peer.from)">{{ peer.fetched ? 'Update' : 'Download' }}</a>]
                           <span v-if="peer.fetched">[<a v-on:click="discoveryRemovePeer(peer.from)">Remove</a>]</span>
+                          <span v-if="peer.fetched">[<a v-on:click="discoveryPinPeer(peer.from, !peer.fetched.pinned)">{{ peer.fetched.pinned ? 'Unpin' : 'Pin' }}</a>]</span>
                           <span v-if="!peer.online && !peer.fetched">[<a v-on:click="discoveryForgetPeer(peer.from)">Forget</a>]</span>
                           [<a v-on:click="discoveryBlockPeer(peer.from)" style="color: #b71c1c;">Block</a>]
                         </td>
@@ -7508,10 +7518,11 @@ const discoveryView = Vue.component('discovery-view', {
         P2PIDENTITY.serverName = status.serverName || '';
         P2PIDENTITY.serverDescription = status.serverDescription || '';
         if (status.maxPeerDbStorageMb) { P2PSETTINGS.maxPeerDbStorageMb = status.maxPeerDbStorageMb; }
-        // 0 (= never forget / no auto-downloads) is a valid value for both
-        // of these — don't truthiness-check it away.
+        // 0 (= never forget / no auto-downloads / no rotation) is a valid
+        // value for all of these — don't truthiness-check it away.
         if (typeof status.peerRetentionDays === 'number') { P2PSETTINGS.peerRetentionDays = status.peerRetentionDays; }
         if (typeof status.autoFetchCount === 'number') { P2PSETTINGS.autoFetchCount = status.autoFetchCount; }
+        if (typeof status.rotationDays === 'number') { P2PSETTINGS.rotationDays = status.rotationDays; }
         if (status.enabled === true) {
           const cat = (await API.axios({
             method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
@@ -7554,6 +7565,25 @@ const discoveryView = Vue.component('discovery-view', {
         });
       } catch (err) {
         iziToast.error({ title: 'Remove failed', position: 'topCenter', timeout: 3000 });
+      }
+      this.loadDiscoveryP2p();
+    },
+    // Pin = rotation immunity for a downloaded snapshot (manual downloads
+    // arrive pinned already; this is the lever for auto-fetched ones — and
+    // the undo for manual ones).
+    discoveryPinPeer: async function(endpointId, pinned) {
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/peer-dbs/pin`,
+          data: { endpointId, pinned }
+        });
+      } catch (err) {
+        iziToast.error({
+          title: pinned ? 'Pin failed' : 'Unpin failed',
+          message: err.response?.data?.error || '',
+          position: 'topCenter', timeout: 3000
+        });
       }
       this.loadDiscoveryP2p();
     },
@@ -8864,6 +8894,71 @@ const editP2pAutoFetchCountView = Vue.component('edit-p2p-auto-fetch-count-modal
         });
 
         P2PSETTINGS.autoFetchCount = Number(this.editValue);
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          message: err.response?.data?.error || '',
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+// How many days a downloaded snapshot may sit on a full shelf before the
+// hourly rotation pass swaps it for a server we don't hold yet. Applies
+// from the very next pass — no restart. Swap-only by design: rotation
+// never shrinks the shelf, and pinned downloads are never touched.
+const editP2pRotationView = Vue.component('edit-p2p-rotation-modal', {
+  data() {
+    return {
+      submitPending: false,
+      editValue: P2PSETTINGS.rotationDays
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Rotate downloads</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-p2p-rotation" required type="number" min="0" max="3650">
+          <label for="edit-p2p-rotation">Days before a download may be swapped</label>
+          <span class="helper-text">Once the shelf is full, a snapshot held longer than this may be swapped — one per hour at most — for a server you don't have yet, so network suggestions stay fresh. Only ever a swap: nothing is dropped without a replacement, and pinned downloads are never touched. 0 turns rotation off.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/rotation`,
+          data: { rotationDays: Number(this.editValue) }
+        });
+
+        P2PSETTINGS.rotationDays = Number(this.editValue);
 
         M.Modal.getInstance(document.getElementById('admin-modal')).close();
 


### PR DESCRIPTION
Part B of the shelf-freshness work — #777 (space-aware acquisition) was Part A.

## Problem

Once the shelf reaches `autoFetchCount`, membership freezes on the first peers ever heard: the top-up has no room, so "From the network" suggestions calcify. Worse, a **dead peer on the shelf is immortal** — it's exempt from catalog retention (the shelf is #751's prune pin-set) *and* never evicted, so it stays listed and searched forever.

## What this adds

**Hourly rotation** — swap the least-useful long-held snapshot for the most-novel catalog peer we don't hold, so shelf membership cycles.

- **Pure policy** in new `src/state/discovery-peer-rotation.js` (`planRotation`): swap-only (never evict without a replacement in hand — the shelf can only churn, never shrink), one swap per pass, pinned entries immune. Eviction order: offline-longest first, then oldest membership, tie-break prefers snapshots other seeders still hold (don't delete the swarm's last copy when there's a choice). Candidate order: never-held first via a persisted rotated-out ledger (`discovery-p2p/rotation.json`, capped 200 — prevents A↔B ping-pong), then the shared usefulness order (model-compatible → online → biggest); the incoming snapshot must fit the storage cap **after** the eviction. `candidateOrder` moved here from `discovery-peer-dbs.js` so the reconcile top-up and rotation share one ordering.
- **Registry additions** (backfilled on load, no format migration): `firstFetchedAt` — the membership clock, deliberately **carried over on seq-refresh re-fetches** (a refresh replaces the bytes, not the membership; resetting it would make an actively-publishing peer immortal) — and `pinned`. Manual admin downloads auto-pin (an explicit choice must not silently vanish a week later); pinning is sticky until the pin route flips it.
- **Execution** (`rotatePeerDbs`): fetch-first — a failed download keeps the evictee; the evict-first path (needed only when the incoming snapshot requires the evictee's headroom) logs the one-pass gap. Cleanup rides the existing `removePeerDb` (connection close, file removal, blob `forget` → sidecar GC, holds re-push) — no new cleanup paths. Hourly timer in `start`/`stopAutoFetch`, serialized against reconcile, `MSTREAM_TEST_DISCOVERY_ROTATE_MS` test override.
- **Config/API/UI**: `discoveryP2p.rotationDays` (0–3650, **default 7**, 0 = off), live `POST /api/v1/admin/discovery/p2p/rotation` + `POST /peer-dbs/pin` routes, `rotationDays` in status, `pinned`/`firstFetchedAt` in the admin catalog's fetched block; Discovery page gets a "Rotate downloads" line + modal, per-row [Pin]/[Unpin], a "yes · pinned" marker, and a held-since tooltip.

Rotation gates on the whole auto-fetch feature (`autoFetch && autoFetchCount > 0 && rotationDays > 0`) — a paused shelf must not keep swapping. A rotated-out silent peer then ages out of the catalog via normal retention, and re-enters as a candidate if it ever announces again.

## Tests

- **26 unit tests** for the pure policy (`test/unit/discovery-peer-rotation.test.mjs`): gates, membership-age eligibility (refresh must not reset the clock), pinned immunity, swap-only, eviction/candidate ordering incl. the seeder tie-break and ledger novelty preference, capacity/`evictFirst`.
- **Integration** (`discovery-p2p.test.mjs`, now 42/42): a new suite pre-seeds an aged two-snapshot shelf **before boot** by pointing `extraConfig.storage` at a crafted state dir (the helper replaces `storage` wholesale, so `ensureLoaded`'s first read sees the aged registry — no load-order races), then proves the live wiring over real gossip: timer → swap, pinned twin survives, ledger written, evicted file deleted; plus pin-route flips (404 on unknown) and rotation-route CRUD (0 = off is legal).
- No sidecar/protocol changes → no capability-gating needed; lint clean.

## Verification beyond the suite

- Browser-verified on a seeded preview: rotation line + modal save (status + config file), Pin → "yes · pinned" → Unpin round-trip persisted to the registry.
- Live 3-server smoke: a consumer booted with a 10-day-old crafted shelf entry (`rotationDays: 1`, 5s test interval) and two genuinely-announcing test-fake publishers — one pass swapped the aged entry for a real publisher (exactly one `rotated a1a1… out for 4ffefb…` log line, fetch-first ordering visible), shelf stayed at exactly `autoFetchCount` across further passes, ledger recorded the eviction, the evicted file was deleted, zero discovery warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)