### PR TITLE
fix(federation): escape peer strings in admin toasts; gate peer content in public mode

### DIFF
--- a/src/api/db.js
+++ b/src/api/db.js
@@ -426,9 +426,16 @@ export function setup(mstream) {
   });
 
   mstream.post('/api/v1/db/metadata/batch', (req, res) => {
-    const batch = pullMetaDataBatch(req.body, req.user);
+    // The body is a BARE array of filepaths. Validate the shape: both the
+    // loop below and pullMetaDataBatch iterate it directly, so a non-array
+    // body (or non-string entries) threw a TypeError -> generic 500 where a
+    // malformed request should be a 400.
+    const schema = Joi.array().items(Joi.string()).required();
+    const { value: filepaths } = joiValidate(schema, req.body);
+
+    const batch = pullMetaDataBatch(filepaths, req.user);
     const returnThis = {};
-    req.body.forEach(f => {
+    filepaths.forEach(f => {
       returnThis[f] = batch.get(f);
     });
     res.json(returnThis);

--- a/src/api/discovery-federation.js
+++ b/src/api/discovery-federation.js
@@ -25,6 +25,7 @@ import * as config from '../state/config.js';
 import * as discoveryDb from '../db/discovery-db.js';
 import * as fedDb from '../db/federation.js';
 import { localIdentitySets, isNovel, norm } from '../db/discovery-novelty.js';
+import { assertPeerContentAllowed } from './federation-auth.js';
 import { resolveSeedTrack } from './discovery.js';
 import { joiValidate } from '../util/validation.js';
 import WebError from '../util/web-error.js';
@@ -69,6 +70,7 @@ export function setup(mstream) {
     if (config.program.federation.enabled !== true) {
       throw new WebError('federation is disabled (config: federation.enabled)', 403);
     }
+    assertPeerContentAllowed(req);
     const schema = Joi.object({
       filePath: Joi.string().required(),
       limit: Joi.number().integer().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -26,6 +26,7 @@
 import winston from 'winston';
 import WebError from '../util/web-error.js';
 import * as config from '../state/config.js';
+import * as db from '../db/manager.js';
 import * as fedDb from '../db/federation.js';
 
 // Read routes a federation key may call. Exact "METHOD path" matches plus
@@ -62,6 +63,33 @@ export function isFederationPathAllowed(req) {
   if (ALLOWED_EXACT.has(`${req.method} ${req.path}`)) { return true; }
   if (req.method === 'GET' && ALLOWED_GET_PREFIXES.some((p) => req.path.startsWith(p))) { return true; }
   return false;
+}
+
+// The OUTBOUND counterpart to the inbound policy above: guards the two routes
+// that serve a PEER's content to a local requester (the Discover panel's
+// federated rows in api/discovery-federation.js and the stream proxy in
+// api/federation-stream.js).
+//
+// A peer grants its libraries to this server's OPERATOR. isPublicMode is true
+// both on a no-users server (every request gets the anonymous sentinel, with
+// every library attached) and for the federation key's synthetic user (id
+// null) — and neither may consume peer content by default:
+//   - a public-mode server would otherwise re-publish a peer's music to anyone
+//     who can reach the port, a grant its admin never made and can't observe;
+//   - a federation key must never chain through us to a THIRD server. The
+//     allowlist already omits both routes, so that half is defense in depth.
+// The public-mode half is escapable per-server (federation.allowPublicMode)
+// for operators who really do want an open relay; the chaining half is not.
+export function assertPeerContentAllowed(req) {
+  if (!db.isPublicMode(req.user)) { return; }
+  if (req.user?.federation === true) {
+    winston.warn(`[federation] blocked peer-content request from federation key '${req.user.username}' on ${req.path} (no proxy chaining)`);
+    throw new WebError('Forbidden', 403);
+  }
+  if (config.program.federation.allowPublicMode !== true) {
+    winston.warn(`[federation] blocked peer-content request from ${req.ip} on ${req.path}: this server has no user accounts`);
+    throw new WebError('Federated peer content is not served on a server with no user accounts — a peer granted its libraries to this server, not to the public. Set federation.allowPublicMode to override.', 403);
+  }
 }
 
 // Validate a presented key and build the synthetic read-only req.user.

--- a/src/api/federation-stream.js
+++ b/src/api/federation-stream.js
@@ -19,10 +19,13 @@
 // against the LOCAL library.
 
 import { Readable } from 'node:stream';
+import Joi from 'joi';
 import winston from 'winston';
+import { joiValidate } from '../util/validation.js';
 import * as config from '../state/config.js';
 import * as fedDb from '../db/federation.js';
 import { fedFetchWithDeadline } from './discovery-federation.js';
+import { assertPeerContentAllowed } from './federation-auth.js';
 import WebError from '../util/web-error.js';
 
 // Request headers forwarded verbatim — seeking needs range/if-range, and
@@ -40,6 +43,11 @@ export function setup(mstream) {
     if (config.program.federation.enabled !== true) {
       throw new WebError('federation is disabled (config: federation.enabled)', 403);
     }
+    assertPeerContentAllowed(req);
+    // Same :id validation every admin federation route already does. Without
+    // it a non-numeric id reaches the lookup as NaN and comes back "Peer not
+    // found" — true but misleading, since a malformed id is a 400, not a 404.
+    joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), { id: req.params.id });
     const peer = fedDb.getFederationPeerById(Number(req.params.id));
     if (!peer) { throw new WebError('Peer not found', 404); }
 

--- a/src/api/file-explorer.js
+++ b/src/api/file-explorer.js
@@ -146,6 +146,11 @@ export function setup(mstream) {
   });
 
   mstream.post("/api/v1/file-explorer/m3u", async (req, res) => {
+    // Without this, a missing `path` reached getVPathInfo as undefined and
+    // died on `.charAt` — a 500 for what is a malformed request.
+    const schema = Joi.object({ path: Joi.string().required() });
+    joiValidate(schema, req.body);
+
     const pathInfo = vpath.getVPathInfo(req.body.path, req.user);
 
     const playlistParentDir = path.dirname(req.body.path);

--- a/src/server.js
+++ b/src/server.js
@@ -431,6 +431,16 @@ export async function serveIt(configFile) {
       return res.status(error.status).json({ error: error.message });
     }
 
+    // The body-parsing stack (express.json/urlencoded) rejects malformed,
+    // oversized or wrongly-encoded payloads BEFORE any handler runs, tagging
+    // the error with a `type` and a 4xx status. Those are client errors, but
+    // being neither a Joi nor a WebError they fell through to a generic 500 —
+    // so every route answered bad JSON with "Server Error".
+    const bodyStatus = error?.status ?? error?.statusCode;
+    if (error?.type && Number.isInteger(bodyStatus) && bodyStatus >= 400 && bodyStatus < 500) {
+      return res.status(bodyStatus).json({ error: 'Malformed request body' });
+    }
+
     res.status(500).json({ error: 'Server Error' });
   });
 

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -365,10 +365,20 @@ const irohOptions = Joi.object({
 //   serverName — display name embedded in minted tickets so the friend's
 //                add-peer UI can label this server; '' falls back to
 //                os.hostname() at mint time.
+//   allowPublicMode — let a server with NO user accounts consume peer content
+//                (the Discover panel's federated rows and the stream proxy).
+//                A peer grants its libraries to THIS SERVER's operator; in
+//                public mode the auth wall hands every request the anonymous
+//                sentinel, so leaving this on would re-publish a peer's music
+//                to anyone who can reach the port — a grant its admin never
+//                made and cannot see being used. Off by default; the 403 that
+//                results names this flag. Same shape as `shareCodePublic`
+//                above: the feature keeps working for servers WITH users.
 const federationOptions = Joi.object({
   enabled: Joi.boolean().default(false),
   secretKey: Joi.string().optional(),
   serverName: Joi.string().max(64).allow('').default(''),
+  allowPublicMode: Joi.boolean().default(false),
 });
 
 // The music-discovery P2P layer (p2p-sidecar: iroh-blobs snapshot sharing

--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -49,7 +49,15 @@ const CONNECT_TIMEOUT_MS = 25000;
 // (scripted retry loops, not offline attacks on a 256-bit key).
 const BACKOFF_THRESHOLD = 5;
 const BACKOFF_MS = 60 * 1000;
-const failedHandshakes = new Map(); // remoteId -> { fails, blockedUntil }
+// The map is keyed by remote EndpointId, and minting a fresh identity is free
+// — so a flood of one-shot failures from throwaway endpoints would otherwise
+// accrete entries that nothing ever revisits (only the SAME remote returning
+// clears its own). Entries idle past the TTL are swept, with a hard cap as
+// the backstop against a flood outrunning the sweep. Dropping an entry only
+// forgives backoff, which the reboot-forgives note above already accepts.
+const HANDSHAKE_ENTRY_TTL_MS = 10 * 60 * 1000;
+const FAILED_HANDSHAKE_MAX = 4096;
+const failedHandshakes = new Map(); // remoteId -> { fails, blockedUntil, touched }
 
 // Server state
 let irohMod = null;
@@ -115,11 +123,28 @@ function isBackedOff(remote) {
   return false;
 }
 
+// Drop entries nobody has touched for a while, skipping any remote still
+// serving a live backoff. If a flood is still outrunning that, evict oldest-
+// first (Map iterates in insertion order) until we're back under the cap.
+function sweepFailedHandshakes(now) {
+  for (const [remote, entry] of failedHandshakes) {
+    if (entry.blockedUntil > now) { continue; }
+    if (now - entry.touched > HANDSHAKE_ENTRY_TTL_MS) { failedHandshakes.delete(remote); }
+  }
+  for (const remote of failedHandshakes.keys()) {
+    if (failedHandshakes.size <= FAILED_HANDSHAKE_MAX) { break; }
+    failedHandshakes.delete(remote);
+  }
+}
+
 function recordHandshakeFailure(remote) {
-  const entry = failedHandshakes.get(remote) || { fails: 0, blockedUntil: 0 };
+  const now = Date.now();
+  if (failedHandshakes.size >= FAILED_HANDSHAKE_MAX) { sweepFailedHandshakes(now); }
+  const entry = failedHandshakes.get(remote) || { fails: 0, blockedUntil: 0, touched: now };
   entry.fails += 1;
+  entry.touched = now;
   if (entry.fails >= BACKOFF_THRESHOLD) {
-    entry.blockedUntil = Date.now() + BACKOFF_MS;
+    entry.blockedUntil = now + BACKOFF_MS;
     winston.warn(`[federation] backing off ${remote} for ${BACKOFF_MS / 1000}s after ${entry.fails} failed handshakes`);
   }
   failedHandshakes.set(remote, entry);

--- a/test/integration/federation-discovery-aggregate.test.mjs
+++ b/test/integration/federation-discovery-aggregate.test.mjs
@@ -139,7 +139,11 @@ describe('discovery federation aggregate (B queries A over iroh)', { skip: avail
       startServer({
         dlnaMode: 'disabled',
         extraConfig: {
-          federation: { enabled: true },
+          // B is the CONSUMER here, and this harness runs no-users servers —
+          // which the peer-content gate refuses by default (a peer granted
+          // its libraries to the operator, not to anonymous callers). Opt in
+          // explicitly; the gate itself is covered in test/unit.
+          federation: { enabled: true, allowPublicMode: true },
           scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' },
         },
       }),

--- a/test/unit/federation-auth.test.mjs
+++ b/test/unit/federation-auth.test.mjs
@@ -20,7 +20,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { isFederationPathAllowed, authenticateFederationKey } from '../../src/api/federation-auth.js';
+import { isFederationPathAllowed, authenticateFederationKey, assertPeerContentAllowed } from '../../src/api/federation-auth.js';
 import { getUserLibraryIds } from '../../src/db/manager.js';
 import * as config from '../../src/state/config.js';
 
@@ -88,6 +88,58 @@ describe('federation disabled gate', () => {
       () => authenticateFederationKey('fedk_anything', req('GET', '/api/v1/federation/health')),
       (err) => err.status === 401 && /Authentication/.test(err.message),
     );
+  });
+});
+
+// The OUTBOUND half: who may read a PEER's library through us. isPublicMode
+// is true for both the no-users sentinel and the federation synthetic user
+// (id null), and neither gets peer content by default. No DB is initialized
+// in this process, so _anonymousUserId is null and a real id reads as
+// not-public — exactly the distinction under test.
+describe('peer-content gate', () => {
+  let tmpDir;
+  const peerReq = (user) => ({ ...req('POST', '/api/v1/discovery/federation/similar'), user });
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-fed-peer-'));
+    await config.setup(path.join(tmpDir, 'config.json'));
+  });
+  after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+  // FIRST — asserts the shipped default before any test mutates it.
+  test('allowPublicMode defaults to off', () => {
+    assert.equal(config.program.federation.allowPublicMode, false);
+  });
+
+  test('a real logged-in user may consume peer content', () => {
+    assert.doesNotThrow(() => assertPeerContentAllowed(peerReq({ id: 5, username: 'someone' })));
+  });
+
+  test('a no-users server is refused, and the 403 names the override', () => {
+    config.program.federation.allowPublicMode = false;
+    assert.throws(
+      () => assertPeerContentAllowed(peerReq({ id: null, username: 'mstream-user' })),
+      (err) => err.status === 403 && /allowPublicMode/.test(err.message),
+    );
+  });
+
+  test('allowPublicMode opts a no-users server back in', () => {
+    config.program.federation.allowPublicMode = true;
+    try {
+      assert.doesNotThrow(() => assertPeerContentAllowed(peerReq({ id: null, username: 'mstream-user' })));
+    } finally { config.program.federation.allowPublicMode = false; }
+  });
+
+  // The chaining guard is NOT escapable by the flag: a peer reading us must
+  // never be able to hop onward into a third server we paired with.
+  test('a federation key can never chain through us, even with allowPublicMode on', () => {
+    config.program.federation.allowPublicMode = true;
+    try {
+      assert.throws(
+        () => assertPeerContentAllowed(peerReq({ id: null, federation: true, username: 'federation:friend' })),
+        (err) => err.status === 403 && /Forbidden/.test(err.message),
+      );
+    } finally { config.program.federation.allowPublicMode = false; }
   });
 });
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -740,6 +740,20 @@ const P2PIDENTITY = { serverName: '', serverDescription: '' };
 // route, the max-storage modal edits it.
 const P2PSETTINGS = { maxPeerDbStorageMb: 500 };
 
+// iziToast renders `title` and `message` as HTML (it appends them through an
+// innerHTML-parsed fragment), and several toasts rely on that for <br>/<b>.
+// So ANY value that didn't originate in this file must be escaped before it
+// is interpolated into a toast — Vue's auto-escaping does not reach here.
+//
+// That matters most for federation: a peer's name, its /federation/health
+// response and its error text are all controlled by a REMOTE server we
+// deliberately treat as untrusted, so an unescaped toast handed a hostile
+// peer script execution in the admin's authenticated session. Declared with
+// the shared objects above so every view component can reach it.
+const escapeHtml = (s) => String(s).replace(/[&<>"']/g, (c) => ({
+  '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+}[c]));
+
 const foldersView = Vue.component('folders-view', {
   data() {
     return {
@@ -3334,7 +3348,7 @@ const federationView = Vue.component('federation-view', {
       try {
         await API.axios({ method: 'DELETE', url: `${API.url()}/api/v1/admin/federation/keys/${key.id}` });
         await ADMINDATA.getFederationKeys();
-        iziToast.success({ title: 'Revoked', message: `'${key.name}' can no longer read this server.`, position: 'topCenter', timeout: 3500 });
+        iziToast.success({ title: 'Revoked', message: `'${escapeHtml(key.name)}' can no longer read this server.`, position: 'topCenter', timeout: 3500 });
       } catch (e) {
         iziToast.error({ title: 'Error', message: 'Failed to revoke the key.' });
       }
@@ -3364,7 +3378,9 @@ const federationView = Vue.component('federation-view', {
         // The async first health check lands a moment later; refresh the dots.
         setTimeout(() => ADMINDATA.getFederationPeers(), 4000);
       } catch (e) {
-        iziToast.error({ title: 'Error', message: (e.response && e.response.data && e.response.data.error) || 'Failed to add the peer.' });
+        // The server echoes the ticket-parse error, which quotes bytes the
+        // pasted ticket controls.
+        iziToast.error({ title: 'Error', message: escapeHtml((e.response && e.response.data && e.response.data.error) || 'Failed to add the peer.') });
       }
       this.addPeerPending = false;
     },
@@ -3374,9 +3390,13 @@ const federationView = Vue.component('federation-view', {
         const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/federation/peers/${peer.id}/test` });
         await ADMINDATA.getFederationPeers();
         if (res.data.ok) {
-          iziToast.success({ title: 'Connected', message: `'${peer.name}' shares: ${res.data.health.libraries.join(', ') || '(nothing)'}`, position: 'topCenter', timeout: 3500 });
+          // Everything interpolated here crosses the trust boundary: the name
+          // came from the peer's ticket, the library list straight out of its
+          // /federation/health body.
+          const shares = (res.data.health.libraries || []).map(escapeHtml).join(', ') || '(nothing)';
+          iziToast.success({ title: 'Connected', message: `'${escapeHtml(peer.name)}' shares: ${shares}`, position: 'topCenter', timeout: 3500 });
         } else {
-          iziToast.warning({ title: 'Unreachable', message: res.data.error, position: 'topCenter', timeout: 3500 });
+          iziToast.warning({ title: 'Unreachable', message: escapeHtml(res.data.error), position: 'topCenter', timeout: 3500 });
         }
       } catch (e) {
         iziToast.error({ title: 'Error', message: 'Test failed.' });
@@ -3388,7 +3408,7 @@ const federationView = Vue.component('federation-view', {
       try {
         await API.axios({ method: 'DELETE', url: `${API.url()}/api/v1/admin/federation/peers/${peer.id}` });
         await ADMINDATA.getFederationPeers();
-        iziToast.success({ title: 'Removed', message: `'${peer.name}' forgotten.`, position: 'topCenter', timeout: 3500 });
+        iziToast.success({ title: 'Removed', message: `'${escapeHtml(peer.name)}' forgotten.`, position: 'topCenter', timeout: 3500 });
       } catch (e) {
         iziToast.error({ title: 'Error', message: 'Failed to remove the peer.' });
       }
@@ -7016,15 +7036,12 @@ const backupView = Vue.component('backup-view', {
       modVM.currentViewModal = 'backup-history-modal';
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
     },
-    // iziToast renders message as HTML (the <br> tags below rely on it),
-    // so anything user-controlled must be escaped before interpolation —
-    // dest_path is admin-entered and round-trips verbatim through the API.
-    // Stored self-XSS only (admins set these values), but this is the one
-    // spot in the backup UI where API data bypasses Vue's auto-escaping.
-    escapeHtml(s) {
-      return String(s).replace(/[&<>"']/g,
-        (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-    },
+    // Exposed as a method so the template/toasts below can reach the shared
+    // helper: dest_path is admin-entered and round-trips verbatim through
+    // the API, and the <br> tags in removeDestination's message mean that
+    // toast is HTML-parsed. Stored self-XSS only (admins set these values),
+    // but it's the one spot in the backup UI that bypasses Vue's escaping.
+    escapeHtml,
     removeDestination(dest) {
       iziToast.question({
         timeout: 20000,


### PR DESCRIPTION
Fixes the security findings from an audit of the v7 federation feature. The auth model itself held up — wall ordering, TOFU binding, the read-route allowlist and grant scoping all behaved as designed under test. These are the gaps around it.

## 🔴 Stored XSS in the admin panel via a malicious peer

iziToast renders `title`/`message` as **HTML** — it appends them through an `innerHTML`-parsed fragment, which several toasts rely on for `<br>`/`<b>`. The federation toasts interpolated strings a **remote peer controls**:

```js
message: `'${peer.name}' shares: ${res.data.health.libraries.join(', ')}`
```

`health.libraries` is the peer's `/api/v1/federation/health` body, passed through verbatim by `federation-client.js` → `admin-federation.js`. A hostile peer answers with `libraries: ["<img src=x onerror=…>"]` and gets script execution in the admin's authenticated session — inheriting full admin-API access. Clicking **Test** right after adding a peer is enough to fire it; `peer.name` (ticket `n` field) and the peer's error text are the same sink.

This is squarely in-model: the feature treats peers as untrusted everywhere else (TOFU binding, leaked-ticket defense, per-key revocation). The frontend was the one place that didn't. **Escaped at all five sinks.** The Vue tables and the Discover panel were already safe — there is no `v-html` anywhere in the webapp — so the toasts were the only unsafe path.

## 🟠 Public-mode servers re-published peer content

Neither the discovery aggregate nor the stream proxy had a gate beyond `federation.enabled`. On a no-users server the auth wall hands every request the anonymous sentinel, so **anyone who could reach the port could stream a peer's shared libraries through us** — re-publishing a grant the peer's admin made to this server's *operator*, which they can neither observe nor revoke short of pulling the key.

Now refused by default via `assertPeerContentAllowed()`, with **`federation.allowPublicMode`** (default `false`) as the opt-in for operators who genuinely want an open relay — same shape as the existing `shareCodePublic` flag. The 403 names the flag so it's discoverable.

The same guard refuses a federation key outright, so a peer can't **chain through us** to a third server. That half is deliberately *not* escapable by the flag.

> ⚠️ **Behavior change:** no-users servers no longer consume peer content until `federation.allowPublicMode` is set. Servers with user accounts are unaffected.

## Also

- **Bounded the `failedHandshakes` backoff map.** Keyed by remote EndpointId against a publicly dialable endpoint where minting identities is free, and only the *same* remote returning ever cleared its own entry — so one-shot failures accreted without limit. TTL sweep plus a hard cap; forgetting an entry only forgives backoff, which the existing reboot-forgives note already accepts.
- **Validation** on `/db/metadata/batch` (bare array) and `/file-explorer/m3u` (`path`), which iterated/dereferenced the body directly and turned a malformed request into a 500. Plus `:id` on the stream proxy, matching the admin routes.
- **Malformed JSON returned 500 on every route.** body-parser rejects the payload before any handler runs, and the central error handler had no branch for it, so it fell through to `"Server Error"`. Found while verifying the above against a live server — untouched `/api/v1/db/search` behaved identically. Now a 400.

## Verification

- Full suite: **1858 pass / 0 fail** (4 pre-existing skips).
- **5 new unit tests** covering the gate: the default-off flag, a real user allowed, public mode refused with the flag named, the opt-in working, and a federation key refused *even with the flag on*.
- Live-server pass over every validation path and both gated routes (9/9), which is what surfaced the global malformed-JSON 500.
- The aggregate integration suite runs no-users servers, so it now opts into `allowPublicMode` explicitly.

## Not fixed here

`/album-art/:file` serves any content-hash filename with no library check, so a federation key can fetch art for a hash outside its grants. Traversal is blocked by a strict filename regex and this is pre-existing behavior shared by every authenticated user, so it's noted rather than changed — happy to take it in a follow-up if you want art scoped per library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)