### PR TITLE
perf(audio-analysis): windowed mid-track decode + selectable BPM method

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -372,6 +372,35 @@ export function setup(mstream) {
     res.json({});
   });
 
+  // BPM estimation method for the essentia pass. 'multifeature' = accurate +
+  // confidence-gated; 'degara' = ~6× faster, no confidence output (every
+  // in-range estimate is written). Takes effect on the next pass.
+  mstream.post("/api/v1/admin/db/params/analyze-bpm-method", async (req, res) => {
+    const schema = Joi.object({
+      analyzeBpmMethod: Joi.string().valid('multifeature', 'degara').required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editAnalyzeBpmMethod(req.body.analyzeBpmMethod);
+    res.json({});
+  });
+
+  // Mid-track analysis window (seconds) for the essentia pass: 0 = whole
+  // file, otherwise 30–600. Mirrors the config-side rule; takes effect on
+  // the next pass.
+  mstream.post("/api/v1/admin/db/params/analyze-bpm-window-sec", async (req, res) => {
+    const schema = Joi.object({
+      analyzeBpmWindowSec: Joi.alternatives().try(
+        Joi.number().integer().min(30).max(600),
+        Joi.number().valid(0)
+      ).required()
+    });
+    joiValidate(schema, req.body);
+
+    await admin.editAnalyzeBpmWindowSec(req.body.analyzeBpmWindowSec);
+    res.json({});
+  });
+
   // Toggle the AcoustID identification pass (chromaprint fingerprint →
   // MusicBrainz recording MBID for tracks whose tags carry none). Default
   // OFF — it sends acoustic fingerprints to an external service. Flipping

--- a/src/db/audio-analysis-backfill.mjs
+++ b/src/db/audio-analysis-backfill.mjs
@@ -29,13 +29,14 @@
 // CLI input — single argv entry, JSON-encoded (built in task-queue.js):
 //   { dbPath, ffmpegPath, maxPerRun, expectedSchemaVersion,
 //     minDurationSec, maxDurationSec, maxAnalyzeSeconds,
+//     bpmMethod, windowSec,
 //     minBpmConfidence, minKeyStrength,
 //     analyzedCooldownSec, lowconfCooldownSec, errorCooldownSec,
 //     runBudgetSec, skipGenres }
 //
 // stdout protocol — line-buffered single-line JSON events:
 //   { event: 'audioAnalysisProgress', attempted, total }
-//   { event: 'audioAnalysisComplete', attempted, analyzed, lowconf, errors, hitCap }
+//   { event: 'audioAnalysisComplete', attempted, analyzed, lowconf, errors, hitCap, avgMsPerTrack }
 //   { event: 'error', message }     ← always followed by exit 1
 //
 // Exit codes: 0 completed (per-track failures recorded, not fatal);
@@ -44,9 +45,13 @@
 import path from 'node:path';
 import { DatabaseSync } from './sqlite-driver.js';
 import Joi from 'joi';
-import { decodePcmF32, analyzeSignal, getEssentia } from './audio-analysis-lib.js';
+import { decodePcmF32, analyzeSignal, getEssentia, ANALYSIS_SAMPLE_RATE } from './audio-analysis-lib.js';
 
 const SCHEMA_GUARD_EXIT = 3;
+
+// A seeked window that decodes to less than this is treated as "duration was
+// stale, -ss landed in the tail" and re-decoded from the top (see run loop).
+const MIN_WINDOW_SAMPLES = 5 * ANALYSIS_SAMPLE_RATE;
 
 // ── Parse + validate CLI input ───────────────────────────────────────────────
 
@@ -71,9 +76,22 @@ const schema = Joi.object({
   // is meaningless and the decode is enormous.
   minDurationSec: Joi.number().min(0).default(30),
   maxDurationSec: Joi.number().min(1).default(30 * 60),
-  // Hard cap on the decoded span fed to essentia (memory/time guard) — BPM/key
-  // are stable enough across a track that the head is representative.
+  // Hard cap on the decoded span fed to essentia (memory/time guard). With
+  // windowSec=0 this is the whole-file (head) span; with a window it caps the
+  // window length defensively.
   maxAnalyzeSeconds: Joi.number().integer().min(10).default(600),
+  // RhythmExtractor2013 method. 'multifeature' (default): committee estimator,
+  // most accurate, emits the ~0–5.32 confidence minBpmConfidence gates on.
+  // 'degara': ~6× faster, but its confidence output is always 0 (documented
+  // essentia behaviour) — the confidence floor is skipped for it and the
+  // in-range check is the whole gate.
+  bpmMethod: Joi.string().valid('multifeature', 'degara').default('multifeature'),
+  // Analysis window (seconds) decoded from the MIDDLE of the track; BPM and
+  // key both run on it (one seeked decode replaces the whole-file decode).
+  // Tempo/key benchmarks run on 30 s excerpts, so a 60 s mid-track window is
+  // the evaluated regime — and it skips intros/outros. 0 = legacy whole-file
+  // mode (head up to maxAnalyzeSeconds).
+  windowSec: Joi.number().integer().min(0).default(60),
   // Confidence floors. RhythmExtractor2013 confidence is ~0–5.32; KeyExtractor
   // strength is 0–1. Below the floor the estimate is recorded as 'lowconf'
   // (long cooldown) instead of being written.
@@ -159,6 +177,7 @@ function selectEligibleTracks(nowSec) {
     SELECT MIN(t.id) AS track_id,
            COALESCE(t.audio_hash, t.file_hash) AS canon_hash,
            t.filepath AS filepath,
+           t.duration AS duration,
            lib.root_path AS root
       FROM tracks t
       JOIN libraries lib ON lib.id = t.library_id
@@ -228,7 +247,7 @@ async function run() {
   const tracks = selectEligibleTracks(nowSec);
 
   if (tracks.length === 0) {
-    emit({ event: 'audioAnalysisComplete', attempted: 0, analyzed: 0, lowconf: 0, errors: 0, hitCap: false });
+    emit({ event: 'audioAnalysisComplete', attempted: 0, analyzed: 0, lowconf: 0, errors: 0, hitCap: false, avgMsPerTrack: 0 });
     return;
   }
 
@@ -248,7 +267,7 @@ async function run() {
     // tracks stay eligible; the hitCap re-enqueue resumes them next pass.
     if (Date.now() - startMs > cfg.runBudgetSec * 1000) { hitBudget = true; break; }
 
-    const { canon_hash: canonHash, filepath, root } = tracks[i];
+    const { canon_hash: canonHash, filepath, root, duration } = tracks[i];
     attempted++;
     const attemptSec = Math.floor(Date.now() / 1000);
     let outcome = 'error';
@@ -256,10 +275,38 @@ async function run() {
 
     try {
       const absPath = path.join(root, filepath);
-      const signal = await decodePcmF32(absPath, cfg.ffmpegPath, { maxSeconds: cfg.maxAnalyzeSeconds });
-      const r = analyzeSignal(signal, essentia);
+      // Windowed decode: seek to the middle of the track and analyse windowSec
+      // seconds. Fast container-level -ss seek, so long files cost the same as
+      // short ones; mid-track skips intros/outros. duration comes from the
+      // scanner and can overstate a truncated file — handled below.
+      let decodeOpts = { maxSeconds: cfg.maxAnalyzeSeconds };
+      if (cfg.windowSec > 0) {
+        const win = Math.min(cfg.windowSec, cfg.maxAnalyzeSeconds);
+        const seekSec = duration > win ? Math.floor((duration - win) / 2) : 0;
+        decodeOpts = seekSec > 0 ? { maxSeconds: win, seekSec } : { maxSeconds: win };
+      }
+      let signal;
+      try {
+        signal = await decodePcmF32(absPath, cfg.ffmpegPath, decodeOpts);
+      } catch (e) {
+        if (!decodeOpts.seekSec || e.transient) { throw e; }
+        signal = null;   // fall through to the un-seeked retry below
+      }
+      // A seeked decode that failed outright — or came back with almost no
+      // samples — means the stored duration overstates the real file
+      // (stale/estimated header) and -ss landed at/near EOF. Retry once from
+      // the top before recording an error. Transient failures (spawn error,
+      // timeout) skip the retry — the short 'error' cooldown covers those.
+      if (decodeOpts.seekSec && (signal == null || signal.length < MIN_WINDOW_SAMPLES)) {
+        signal = await decodePcmF32(absPath, cfg.ffmpegPath, { maxSeconds: decodeOpts.maxSeconds });
+      }
+      const r = analyzeSignal(signal, essentia, { bpmMethod: cfg.bpmMethod });
 
-      const bpmUsable = r.bpm != null && r.bpmConfidence >= cfg.minBpmConfidence;
+      // minBpmConfidence gates multifeature's ~0–5.32 confidence. degara's
+      // confidence output is always 0 (documented essentia behaviour, not a
+      // quality signal), so for it the in-range check is the whole gate.
+      const bpmUsable = r.bpm != null
+        && (cfg.bpmMethod === 'degara' || r.bpmConfidence >= cfg.minBpmConfidence);
       const keyUsable = r.musicalKey != null && r.keyStrength >= cfg.minKeyStrength;
 
       if (bpmUsable || keyUsable) {
@@ -298,6 +345,9 @@ async function run() {
     // More work probably remains (full batch or budget cut). persisted>0 breaks
     // the would-be infinite re-enqueue when NOTHING could be recorded.
     hitCap: (tracks.length === cfg.maxPerRun || hitBudget) && persisted > 0,
+    // Decode+analysis wall-clock per attempted track — the number the window /
+    // method tuning knobs exist to move; surfaced in the task-queue log line.
+    avgMsPerTrack: attempted > 0 ? Math.round((Date.now() - startMs) / attempted) : 0,
   });
 }
 

--- a/src/db/audio-analysis-lib.js
+++ b/src/db/audio-analysis-lib.js
@@ -172,6 +172,12 @@ export function decodePcmF32(audioPath, ffmpegBin, opts = {}) {
  *
  * @param {Float32Array} signal  mono PCM at ANALYSIS_SAMPLE_RATE
  * @param {object} essentia      a getEssentia() instance (caller awaits it first)
+ * @param {object} [opts]
+ * @param {string} [opts.bpmMethod='multifeature']  RhythmExtractor2013 method:
+ *   'multifeature' (committee estimator — most accurate, emits the ~0–5.32
+ *   confidence) or 'degara' (~6× faster, same beat-tracker family, but its
+ *   confidence output is always 0 by documented essentia behaviour — callers
+ *   must not confidence-gate degara results).
  * @returns {{
  *   bpm: number|null, bpmConfidence: number,
  *   key: string, scale: string, musicalKey: string|null, keyStrength: number
@@ -183,11 +189,14 @@ export function decodePcmF32(audioPath, ffmpegBin, opts = {}) {
  * Caller inspects bpmConfidence / keyStrength to decide whether to trust /
  * persist the result.
  */
-export function analyzeSignal(signal, essentia) {
+export function analyzeSignal(signal, essentia, opts = {}) {
+  const bpmMethod = opts.bpmMethod || 'multifeature';
   const vec = essentia.arrayToVector(signal);
   let rhythm = null;
   try {
-    rhythm = essentia.RhythmExtractor2013(vec);
+    // Explicit maxTempo/minTempo (208/40) are the algorithm defaults — spelled
+    // out because the method parameter sits between them positionally.
+    rhythm = essentia.RhythmExtractor2013(vec, 208, bpmMethod, 40);
     const k = essentia.KeyExtractor(vec);
     const rawBpm = Math.round(rhythm.bpm);
     const bpm = (rawBpm >= MIN_BPM && rawBpm <= MAX_BPM) ? rawBpm : null;
@@ -213,9 +222,10 @@ export function analyzeSignal(signal, essentia) {
 }
 
 /**
- * Convenience: decode + analyse one file end to end.
+ * Convenience: decode + analyse one file end to end. Decode options and
+ * opts.bpmMethod both ride in the same opts bag.
  */
 export async function analyzeFile(audioPath, ffmpegBin, opts = {}) {
   const signal = await decodePcmF32(audioPath, ffmpegBin, opts);
-  return analyzeSignal(signal, await getEssentia());
+  return analyzeSignal(signal, await getEssentia(), { bpmMethod: opts.bpmMethod });
 }

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1500,6 +1500,11 @@ function runAudioAnalysisTask(taskObj) {
     dbPath: path.join(config.program.storage.dbDirectory, 'mstream.db'),
     ffmpegPath: ffPath,
     maxPerRun: config.program.scanOptions.analyzeBpmPerRun || 200,
+    // Speed knobs (admin-editable, applied on the next pass): BPM method and
+    // the mid-track analysis window. undefined falls through to the worker
+    // defaults (JSON.stringify drops the key).
+    bpmMethod: config.program.scanOptions.analyzeBpmMethod,
+    windowSec: config.program.scanOptions.analyzeBpmWindowSec,
     expectedSchemaVersion: SCHEMA_VERSION,
     // Duration window / confidence floors / cooldowns use the worker defaults.
   };
@@ -1532,8 +1537,9 @@ function runAudioAnalysisTask(taskObj) {
           observers.hitCap = !!evt.hitCap;
           observers.completeEvt = evt;
           if (evt.attempted > 0) {
+            const pace = evt.avgMsPerTrack > 0 ? `, ~${evt.avgMsPerTrack} ms/track` : '';
             winston.info(`Audio-analysis pass complete: ${evt.analyzed} analysed, `
-              + `${evt.lowconf} low-confidence, ${evt.errors} error(s) (${evt.attempted} attempted)`);
+              + `${evt.lowconf} low-confidence, ${evt.errors} error(s) (${evt.attempted} attempted${pace})`);
           }
           return;
         }

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -139,6 +139,21 @@ const scanOptions = Joi.object({
   // runBudget and re-enqueues while a backlog remains — this just bounds one
   // batch. Mirrors autoAlbumArtPerRun.
   analyzeBpmPerRun: Joi.number().integer().min(1).max(10000).default(200),
+  // BPM estimation method (RhythmExtractor2013). 'multifeature' (default) is
+  // the committee estimator: most accurate and the only method that emits the
+  // confidence the pass gates on — but ~6× the CPU of 'degara'. 'degara' is
+  // the fast mode for large libraries / weak hardware; it has no confidence
+  // output, so every in-range estimate is written.
+  analyzeBpmMethod: Joi.string().valid('multifeature', 'degara').default('multifeature'),
+  // Seconds of audio analysed per track, decoded from the MIDDLE of the file
+  // (BPM and key both run on this window). Published tempo/key benchmarks use
+  // 30 s excerpts, so the 60 s default is a 2× margin — and a mid-track window
+  // skips intros/outros. 0 = whole-file mode (the head, up to the worker's
+  // 600 s cap): the pre-window behaviour, several times slower.
+  analyzeBpmWindowSec: Joi.alternatives().try(
+    Joi.number().integer().min(30).max(600),
+    Joi.number().valid(0),
+  ).default(60),
   // AcoustID identification: fingerprint tracks with no MusicBrainz
   // recording MBID (rust-parser --fingerprint, chromaprint) and resolve
   // them via api.acoustid.org into tracks.mbz_recording_id / acoustid_id

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -507,6 +507,27 @@ export async function editAnalyzeBpmPerRun(val) {
   config.program.scanOptions.analyzeBpmPerRun = val;
 }
 
+// BPM estimation method ('multifeature' | 'degara') for the analysis pass.
+// Same live-update pattern as editAnalyzeBpmPerRun — task-queue reads it when
+// it builds the pass's jsonLoad, so it applies on the next pass, no reboot.
+export async function editAnalyzeBpmMethod(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.analyzeBpmMethod = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.analyzeBpmMethod = val;
+}
+
+// Mid-track analysis window in seconds (0 = whole file) for the analysis
+// pass. Same live-update pattern as editAnalyzeBpmPerRun.
+export async function editAnalyzeBpmWindowSec(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.scanOptions) { loadConfig.scanOptions = {}; }
+  loadConfig.scanOptions.analyzeBpmWindowSec = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.scanOptions.analyzeBpmWindowSec = val;
+}
+
 // Toggle the AcoustID identification pass (fingerprint → MusicBrainz
 // recording MBID for tag-less tracks). Same live-update pattern as
 // editAnalyzeBpm; the api route enqueues an immediate pass when this

--- a/test/integration/admin-scan-params.test.mjs
+++ b/test/integration/admin-scan-params.test.mjs
@@ -163,6 +163,60 @@ describe('POST /api/v1/admin/db/params/analyze-bpm-per-run', () => {
   });
 });
 
+// ── POST /db/params/analyze-bpm-method ────────────────────────────────────
+
+describe('POST /api/v1/admin/db/params/analyze-bpm-method', () => {
+  test('sets method + reflects; rejects junk; 405 non-admin', async () => {
+    const r1 = await adminPost('/api/v1/admin/db/params/analyze-bpm-method',
+      { analyzeBpmMethod: 'degara' });
+    assert.equal(r1.status, 200);
+    assert.deepEqual(await r1.json(), {}, 'happy-path response is the empty object {}');
+    assert.equal((await (await adminGet('/api/v1/admin/db/params')).json()).analyzeBpmMethod, 'degara');
+
+    // Restore the default so later tests start in a known state.
+    await adminPost('/api/v1/admin/db/params/analyze-bpm-method',
+      { analyzeBpmMethod: 'multifeature' });
+    assert.equal((await (await adminGet('/api/v1/admin/db/params')).json()).analyzeBpmMethod, 'multifeature');
+
+    for (const bad of [{ analyzeBpmMethod: 'percival' }, { analyzeBpmMethod: 1 },
+      { analyzeBpmMethod: true }, {}]) {
+      const r = await adminPost('/api/v1/admin/db/params/analyze-bpm-method', bad);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
+    }
+    assert.equal((await adminPost('/api/v1/admin/db/params/analyze-bpm-method',
+      { analyzeBpmMethod: 'degara' }, userJwt)).status, 405);
+  });
+});
+
+// ── POST /db/params/analyze-bpm-window-sec ────────────────────────────────
+
+describe('POST /api/v1/admin/db/params/analyze-bpm-window-sec', () => {
+  test('sets window (incl. 0) + reflects; rejects 1–29 / out-of-range; 405 non-admin', async () => {
+    const r1 = await adminPost('/api/v1/admin/db/params/analyze-bpm-window-sec',
+      { analyzeBpmWindowSec: 120 });
+    assert.equal(r1.status, 200);
+    assert.deepEqual(await r1.json(), {}, 'happy-path response is the empty object {}');
+    assert.equal((await (await adminGet('/api/v1/admin/db/params')).json()).analyzeBpmWindowSec, 120);
+
+    // 0 = whole-file mode is explicitly allowed (the alternatives() branch).
+    assert.equal((await adminPost('/api/v1/admin/db/params/analyze-bpm-window-sec',
+      { analyzeBpmWindowSec: 0 })).status, 200);
+    assert.equal((await (await adminGet('/api/v1/admin/db/params')).json()).analyzeBpmWindowSec, 0);
+
+    // Restore the default so later tests start in a known state.
+    await adminPost('/api/v1/admin/db/params/analyze-bpm-window-sec', { analyzeBpmWindowSec: 60 });
+
+    for (const bad of [{ analyzeBpmWindowSec: 15 }, { analyzeBpmWindowSec: 601 },
+      { analyzeBpmWindowSec: -1 }, { analyzeBpmWindowSec: 45.5 },
+      { analyzeBpmWindowSec: 'abc' }, {}]) {
+      const r = await adminPost('/api/v1/admin/db/params/analyze-bpm-window-sec', bad);
+      assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
+    }
+    assert.equal((await adminPost('/api/v1/admin/db/params/analyze-bpm-window-sec',
+      { analyzeBpmWindowSec: 60 }, userJwt)).status, 405);
+  });
+});
+
 // ── POST /db/params/ignore-dot-* (dot-entry ignore toggles) ───────────────
 //
 // Same four-part pattern as analyze-bpm: GET defaults, happy-path flip +

--- a/test/integration/audio-analysis-backfill.test.mjs
+++ b/test/integration/audio-analysis-backfill.test.mjs
@@ -364,3 +364,82 @@ describe('analysis worker (real ffmpeg + essentia)', () => {
     } finally { db.close(); }
   });
 });
+
+// ── Windowed decode + BPM method selection ────────────────────────────────────
+
+describe('windowed decode + bpm method', () => {
+  test('mid-track window: accurate duration → seeked window analyses fine', async () => {
+    // 40s fixture with an ACCURATE DB duration → the seek lands inside the
+    // file: windowSec 30 → seek (40−30)/2 = 5 s, decode 30 s. Exercises the
+    // real windowed path (no fallback — the window is well over 5 s).
+    const env = makeDb([{ file: 'long.flac', dur: 40 }]);
+    const longFx = path.join(scratch, 'cmaj-128-40s.flac');
+    await makeAudio({ notes: ['C', 'E', 'G'], bpm: 128, duration: 40, outPath: longFx });
+    fs.copyFileSync(longFx, path.join(env.musicDir, 'long.flac'));
+
+    const r = await runWorker(baseConfig(env, { windowSec: 30 }));
+    assert.equal(r.code, 0, r.stderr);
+    assert.equal(r.complete.analyzed, 1, r.stderr);
+    assert.ok(Number.isFinite(r.complete.avgMsPerTrack) && r.complete.avgMsPerTrack >= 0,
+      'complete event carries avgMsPerTrack');
+  });
+
+  test('stale duration: seek at/past EOF falls back to whole-file decode', async () => {
+    // The DB duration (200 s) wildly overstates the 9 s fixture, so the seeked
+    // decode yields nothing (or a sub-5 s tail) — the worker must retry from
+    // the top and analyse instead of recording an error.
+    const env = makeDb([{ file: 'stale.flac', dur: 200 }]);
+    placeFixture(env, fxCmajor, 'stale.flac');
+    const r = await runWorker(baseConfig(env, { windowSec: 60 }));
+    assert.equal(r.code, 0, r.stderr);
+    assert.deepEqual(
+      { analyzed: r.complete.analyzed, errors: r.complete.errors },
+      { analyzed: 1, errors: 0 }, r.stderr);
+  });
+
+  test('windowSec 0: legacy whole-file mode still analyses', async () => {
+    const env = makeDb([{ file: 'whole.flac' }]);
+    placeFixture(env, fxCmajor, 'whole.flac');
+    const r = await runWorker(baseConfig(env, { windowSec: 0 }));
+    assert.equal(r.code, 0, r.stderr);
+    assert.equal(r.complete.analyzed, 1, r.stderr);
+  });
+
+  test('degara: bpm written despite an impossible confidence floor; key floor still gates', async () => {
+    const env = makeDb([{ file: 'fast.flac' }]);
+    placeFixture(env, fxCmajor, 'fast.flac');
+    // minBpmConfidence 999 rejects EVERY multifeature estimate (see the
+    // lowconf test above). degara's confidence output is always 0, so the
+    // worker must skip the floor for it — the in-range check is the gate.
+    const r = await runWorker(baseConfig(env,
+      { bpmMethod: 'degara', minBpmConfidence: 999, minKeyStrength: 0.999 }));
+    assert.equal(r.code, 0, r.stderr);
+    assert.equal(r.complete.analyzed, 1, 'degara bpm written without a confidence gate');
+    const db = new DatabaseSync(env.dbPath);
+    try {
+      const row = db.prepare('SELECT bpm, bpm_source, musical_key FROM tracks WHERE filepath = ?').get('fast.flac');
+      assert.ok(row.bpm != null && row.bpm >= 20 && row.bpm <= 300, `bpm filled, got ${row.bpm}`);
+      assert.equal(row.bpm_source, 'essentia');
+      assert.equal(row.musical_key, null, 'impossible key floor still gates the key');
+    } finally { db.close(); }
+  });
+
+  test('bad bpmMethod is rejected by the worker input schema', async () => {
+    const env = makeDb([{}]);
+    const r = await runWorker(baseConfig(env, { bpmMethod: 'percival' }));
+    assert.equal(r.code, 1, 'invalid method must fail Joi validation');
+  });
+
+  test('lib passthrough: degara reaches essentia (confidence 0 vs multifeature > 0)', async () => {
+    const { decodePcmF32, analyzeSignal, getEssentia } = await import('../../src/db/audio-analysis-lib.js');
+    const essentia = await getEssentia();
+    const signal = await decodePcmF32(fxCmajor, FFMPEG, {});
+    const multi = analyzeSignal(signal, essentia, { bpmMethod: 'multifeature' });
+    const degara = analyzeSignal(signal, essentia, { bpmMethod: 'degara' });
+    assert.ok(multi.bpmConfidence > 0, 'multifeature emits a real confidence');
+    assert.equal(degara.bpmConfidence, 0,
+      'degara confidence is always 0 — proves the method string reached essentia');
+    assert.ok(degara.bpm != null && Math.abs(degara.bpm - multi.bpm) <= Math.max(3, multi.bpm * 0.1),
+      `methods roughly agree (multifeature=${multi.bpm}, degara=${degara.bpm})`);
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -2000,6 +2000,18 @@ const dbView = Vue.component('db-view', {
                       </td>
                     </tr>
                     <tr>
+                      <td><b>BPM estimation method:</b> {{dbParams.analyzeBpmMethod}}</td>
+                      <td>
+                        [<a v-on:click="openModal('edit-analyze-bpm-method-modal')">{{ t('admin.settings.edit') }}</a>]
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><b>BPM/key analysis window (seconds, 0 = whole file):</b> {{dbParams.analyzeBpmWindowSec}}</td>
+                      <td>
+                        [<a v-on:click="openModal('edit-analyze-bpm-window-sec-modal')">{{ t('admin.settings.edit') }}</a>]
+                      </td>
+                    </tr>
+                    <tr>
                       <td><b>Ignore dot-hidden files (.name.mp3) when scanning:</b> {{dbParams.ignoreDotFiles}}</td>
                       <td>
                         [<a v-on:click="toggleIgnoreDotFiles()">{{ t('admin.settings.edit') }}</a>]
@@ -8661,6 +8673,136 @@ const editAutoAlbumArtPerRunView = Vue.component('edit-auto-album-art-per-run-mo
           timeout: 3500
         });
       }finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+const editAnalyzeBpmMethodView = Vue.component('edit-analyze-bpm-method-modal', {
+  data() {
+    return {
+      params: ADMINDATA.dbParams,
+      submitPending: false,
+      editValue: ADMINDATA.dbParams.analyzeBpmMethod
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>BPM estimation method</h4>
+        <div class="input-field">
+          <select v-model="editValue" id="edit-analyze-bpm-method" class="browser-default">
+            <option value="multifeature">multifeature — most accurate, confidence-gated (slow)</option>
+            <option value="degara">degara — ~6× faster, no confidence gate</option>
+          </select>
+          <span class="helper-text">multifeature can skip uncertain tracks (low-confidence estimates are not written); degara writes every plausible estimate and suits large libraries or weak hardware. Applies from the next analysis pass.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/db/params/analyze-bpm-method`,
+          data: { analyzeBpmMethod: this.editValue }
+        });
+
+        Vue.set(ADMINDATA.dbParams, 'analyzeBpmMethod', this.editValue);
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+const editAnalyzeBpmWindowSecView = Vue.component('edit-analyze-bpm-window-sec-modal', {
+  data() {
+    return {
+      params: ADMINDATA.dbParams,
+      submitPending: false,
+      editValue: ADMINDATA.dbParams.analyzeBpmWindowSec
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>BPM/key analysis window</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-analyze-bpm-window-sec" required type="number" min="0" max="600">
+          <label for="edit-analyze-bpm-window-sec">Seconds (0 = whole file, otherwise 30–600)</label>
+          <span class="helper-text">Seconds of audio analysed per track, taken from the middle of the file. The 60 s default matches how BPM/key detectors are benchmarked and is several times faster than whole-file analysis. Applies from the next analysis pass.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      const val = Number(this.editValue);
+      if (val !== 0 && (val < 30 || val > 600)) {
+        iziToast.error({
+          title: 'Window must be 0 (whole file) or 30–600 seconds',
+          position: 'topCenter',
+          timeout: 3500
+        });
+        return;
+      }
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/db/params/analyze-bpm-window-sec`,
+          data: { analyzeBpmWindowSec: val }
+        });
+
+        Vue.set(ADMINDATA.dbParams, 'analyzeBpmWindowSec', val);
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
         this.submitPending = false;
       }
     }


### PR DESCRIPTION
## What

Speed tuning for the essentia BPM/key enrichment pass — no engine swap, no new dependencies. Two admin-editable knobs (Database section; live, applied on the next pass):

- **`scanOptions.analyzeBpmWindowSec`** (default **60**; `0` = old whole-file mode, else 30–600): the worker seeks to the **middle** of the track and runs both BPM and key on one small windowed decode, instead of decoding/analysing up to 600 s from the head. A stale-duration guard retries from the top when the seek lands at/near EOF (non-transient decode failure, or <5 s of samples back).
- **`scanOptions.analyzeBpmMethod`** (`multifeature` default | `degara`): degara is ~6× faster in the same beat-tracker family, but its confidence output is always 0 (documented essentia behaviour) — so the `minBpmConfidence` floor is skipped for it and the 20–300 range check is the whole gate. multifeature gating is unchanged.

The completion event now carries `avgMsPerTrack` (printed in the task-queue log line), so the effect is visible on real libraries.

## Why

`RhythmExtractor2013` multifeature on full-length 44.1 kHz audio through single-threaded WASM was ~95 % of a ~9.6 s cost per 4-minute track (KeyExtractor is only ~0.5 s) — and `analyzeBpm` now defaults ON, so every install pays it. Published tempo/key benchmarks score on 30 s excerpts, so a 60 s mid-track window is the evaluated regime, not a shortcut — and it skips intros/outros.

Measured on the shipped code path (240 s fixture, i7-8650U laptop):

| Path | Per 4-min track | Speedup |
|---|---|---|
| Old: whole-file multifeature | 9.6 s | — |
| **New default: 60 s window, multifeature** | **2.2 s** | **4.3×** |
| Opt-in: 60 s window, degara | 0.61 s | 15.7× |

Identical estimates in all three (128 BPM, C major); windowed multifeature confidence 3.57 vs 3.56 whole-file.

## Reviewer notes

- Worker payload schema gains `bpmMethod` + `windowSec` with defaults that preserve old behaviour for old payloads; the eligibility SELECT now also returns `duration` (used for the seek; it was already in the WHERE).
- Old whole-file behaviour is fully recoverable with `analyzeBpmWindowSec: 0`.
- degara results are deliberately un-gated (in-range check only) — that's the documented semantics of its confidence output, surfaced in the admin modal copy.
- Tests: 6 new worker cases (windowed seek, stale-duration fallback, windowSec 0, degara gate rule, bad-method rejection, lib method passthrough proven via the confidence-0 fingerprint) + route coverage in admin-scan-params. 17/17 + 25/25 green; zero new lint on changed files (compared per-file against master).
- Full-suite note: `test/subsonic/subsonic-polish.test.mjs` "updateShare with past expires returns error 10" fails under full-suite context **on clean master too** (passes in isolation) — pre-existing, unrelated, tracked separately.
- Admin UI verified live: rows render Joi defaults, both modals POST/persist, server rejects window 15 and method `percival` (400), accepts window 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
