### PR TITLE
test: surface boot-crash stderr in startServer failures

### DIFF
--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -31,6 +31,11 @@ function findFreePort() {
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
+// How much of the child's stderr to keep when logs aren't captured. Big
+// enough for a full ERR_MODULE_NOT_FOUND / Joi stack, small enough that a
+// chatty server can't grow test-process memory.
+const STDERR_TAIL_BYTES = 4096;
+
 // The timeout is a ceiling, not a wait: healthy boots return as soon as the
 // API answers, and a crashed boot bails immediately via getExitError. 90s
 // because heavy discovery suites (onnxruntime + iroh sidecar init) have blown
@@ -225,11 +230,39 @@ export async function startServer(opts = {}) {
     },
   );
 
-  // Drain output so the buffer doesn't back up even when not captured.
+  // Drain output so the buffer doesn't back up even when not captured — but
+  // keep a rolling tail of stderr. A boot crash used to surface as a bare
+  // "server exited with code 1" with the real cause (e.g. a missing package
+  // taking every integration suite down) discarded here.
+  const stderrChunks = [];
+  let stderrTailLen = 0;
   if (!captureLogs) {
     proc.stdout.on('data', () => {});
-    proc.stderr.on('data', () => {});
+    proc.stderr.on('data', chunk => {
+      stderrChunks.push(chunk);
+      stderrTailLen += chunk.length;
+      while (stderrTailLen > STDERR_TAIL_BYTES) {
+        const excess = stderrTailLen - STDERR_TAIL_BYTES;
+        if (stderrChunks[0].length <= excess) {
+          stderrTailLen -= stderrChunks.shift().length;
+        } else {
+          stderrChunks[0] = stderrChunks[0].subarray(excess);
+          stderrTailLen -= excess;
+        }
+      }
+    });
   }
+  // Empty when captureLogs is true (stdio inherited — the crash already
+  // printed to the test's own console) or when the child wrote nothing.
+  const stderrTail = () => {
+    const text = Buffer.concat(stderrChunks).toString('utf8').trim();
+    return text ? `\n--- server stderr (tail) ---\n${text}` : '';
+  };
+  // 'exit' can fire while stderr data is still in the pipe; before building
+  // an error message from the tail, wait (capped — a surviving scanner
+  // grandchild can hold the pipe open) for the child's stdio to close.
+  const procClosed = new Promise(r => proc.once('close', r));
+  const flushStderr = () => Promise.race([procClosed, sleep(250)]);
 
   const baseUrl = `http://127.0.0.1:${port}`;
   let exitedEarly = null;
@@ -241,8 +274,9 @@ export async function startServer(opts = {}) {
     await waitForReady(baseUrl, { getExitError: () => exitedEarly });
   } catch (err) {
     try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    if (exitedEarly) { await flushStderr(); }
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-    throw exitedEarly ? new Error(exitedEarly) : err;
+    throw exitedEarly ? new Error(exitedEarly + stderrTail()) : err;
   }
 
   if (waitForScan) {
@@ -283,8 +317,9 @@ export async function startServer(opts = {}) {
     if (!r.ok) {
       const msg = await r.text();
       try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+      await flushStderr();
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-      throw new Error(`failed to create user "${u.username}": ${r.status} ${msg}`);
+      throw new Error(`failed to create user "${u.username}": ${r.status} ${msg}${stderrTail()}`);
     }
   }
 


### PR DESCRIPTION
## What

When the spawned mStream server crashes at boot, `startServer` in `test/helpers/server.mjs` now appends a `--- server stderr (tail) ---` block naming the real cause to the thrown error, instead of the bare `server exited with code 1`. The tail is also appended to the "failed to create user" error path.

## Why

With `captureLogs: false` (the default), the helper drained the child's stdout/stderr into no-ops, so a boot crash discarded its own diagnostics. Today that turned a missing `chokidar` package (ERR_MODULE_NOT_FOUND after a stale `node_modules`) into hundreds of identical `server exited with code 1` failures across every integration suite, with zero output pointing at the cause.

## How

- The stderr drain handler keeps a rolling tail bounded to 4KB: chunks append, and the front is trimmed (including partial-chunk trims via zero-copy `subarray`), so memory stays strictly bounded no matter how chatty the server is. stdout is still drained no-op — neither pipe can back up and block the child.
- The child's `exit` event can fire while the last stderr chunks are still in the pipe, so before building either error message the helper waits for the child's `close` event (all stdio flushed), capped at 250ms in case a surviving scanner grandchild holds the pipe open.
- `captureLogs: true` is unchanged: stdio is inherited, no handlers attach, the tail is empty, and the thrown messages are byte-identical to before.

## Verification

- Healthy tree: boots, creates a user, stops cleanly through the helper.
- With a bogus import injected into `src/server.js` (same ERR_MODULE_NOT_FOUND shape as the chokidar failure): the thrown error now includes the full `Cannot find package ... imported from ...src/server.js` stack. Injection reverted afterwards.
- Same broken tree with `captureLogs: true`: crash prints straight to the console and the thrown message stays the bare old one.
- `npx eslint test/helpers/server.mjs` clean; `test/integration/feature-disabled-403.test.mjs` passes through the modified helper.

No test asserts on the old error strings (grepped), so appending the tail is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
