### PR TITLE
fix(subsonic): validate share expires at stored-seconds granularity

### DIFF
--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -2785,15 +2785,18 @@ export function createShare(req, res) {
   const filepaths = songIds.map(id => fpById.get(id)).filter(Boolean);
   if (!filepaths.length) { return SubErr.NOT_FOUND(req, res, 'Song'); }
 
-  // Subsonic sends `expires` as ms-since-epoch. Reject past timestamps —
-  // an already-expired share is a client bug we'd rather surface than
-  // silently store. Null/missing/zero = no expiry.
+  // Subsonic sends `expires` as ms-since-epoch, but the column stores whole
+  // seconds — so validate at storage granularity: the stored second must be
+  // strictly after the current one, else the share is born expired (the
+  // share-viewer's jwt.verify and the cleanup DELETEs both treat the
+  // current second as dead). An already-expired share is a client bug we'd
+  // rather surface than silently store. Null/missing/zero = no expiry.
   const expiresMs = parseInt(req.query.expires, 10);
-  if (Number.isFinite(expiresMs) && expiresMs > 0 && expiresMs <= Date.now()) {
+  const expires = Number.isFinite(expiresMs) && expiresMs > 0 ? Math.floor(expiresMs / 1000) : null;
+  if (expires !== null && expires <= Math.floor(Date.now() / 1000)) {
     return SubErr.GENERIC_CODE(req, res, 10, '`expires` must be in the future');
   }
-  const hasExpiry = Number.isFinite(expiresMs) && expiresMs > Date.now();
-  const expires = hasExpiry ? Math.floor(expiresMs / 1000) : null;
+  const hasExpiry = expires !== null;
   const description = req.query.description ? String(req.query.description) : null;
   const shareId = nanoid(10);
 
@@ -2807,7 +2810,7 @@ export function createShare(req, res) {
     username:   req.user.username,
   };
   const jwtOptions = hasExpiry
-    ? { expiresIn: Math.max(1, Math.floor((expiresMs - Date.now()) / 1000)) }
+    ? { expiresIn: Math.max(1, expires - Math.floor(Date.now() / 1000)) }
     : {};
   const token = jwt.sign(tokenData, config.program.secret, jwtOptions);
 
@@ -2836,11 +2839,13 @@ export function updateShare(req, res) {
   if (row.user_id !== req.user.id && !req.user.admin) { return SubErr.NOT_AUTHORIZED(req, res); }
 
   if ('expires' in req.query) {
+    // Same storage-granularity rule as createShare: the stored second must
+    // be strictly in the future. Zero/invalid clears the expiry.
     const ms = parseInt(req.query.expires, 10);
-    if (Number.isFinite(ms) && ms > 0 && ms <= Date.now()) {
+    const expires = Number.isFinite(ms) && ms > 0 ? Math.floor(ms / 1000) : null;
+    if (expires !== null && expires <= Math.floor(Date.now() / 1000)) {
       return SubErr.GENERIC_CODE(req, res, 10, '`expires` must be in the future');
     }
-    const expires = Number.isFinite(ms) && ms > 0 ? Math.floor(ms / 1000) : null;
     db.getDB().prepare('UPDATE shared_playlists SET expires = ? WHERE share_id = ?').run(expires, shareId);
   }
   // V15 added the `description` column — persist what the client sent.

--- a/test/subsonic/subsonic-polish.test.mjs
+++ b/test/subsonic/subsonic-polish.test.mjs
@@ -216,9 +216,39 @@ describe('createShare + updateShare description and expiry', () => {
     const songIds = await randomSongIds(1);
     const created = await call('createShare', { id: songIds });
     const id = created.shares.share[0].id;
-    const u = await call('updateShare', { id, expires: Date.now() - 1 });
+    // A wide margin, not -1ms: Date.now() in the spawned server process can
+    // read a few ms behind this process's (per-process clock interpolation
+    // on Windows), so a barely-past timestamp lands in the server's future
+    // and gets accepted. Mirrors the createShare test above.
+    const u = await call('updateShare', { id, expires: Date.now() - 60000 });
     assert.equal(u.status, 'failed');
     assert.equal(u.error.code, 10);
+    await call('deleteShare', { id });
+  });
+
+  test('expires within the current server second returns error 10', async () => {
+    const songIds = await randomSongIds(1);
+    const created = await call('createShare', { id: songIds });
+    const id = created.shares.share[0].id;
+
+    // The column stores whole seconds, so a timestamp inside the current
+    // second is born expired and must be rejected. Derive the probe from
+    // the SERVER's clock (HTTP Date header, whole seconds) rather than
+    // ours: the end of a server-reported second can never be in a later
+    // second than the server's clock at processing time, so this stays
+    // deterministic under cross-process clock skew (see the test above).
+    const ping = await fetch(url('ping'));
+    const serverSec = Math.floor(new Date(ping.headers.get('date')).getTime() / 1000);
+    const endOfServerSecond = serverSec * 1000 + 999;
+
+    const u = await call('updateShare', { id, expires: endOfServerSecond });
+    assert.equal(u.status, 'failed');
+    assert.equal(u.error.code, 10);
+
+    const c = await call('createShare', { id: songIds, expires: endOfServerSecond });
+    assert.equal(c.status, 'failed');
+    assert.equal(c.error.code, 10);
+
     await call('deleteShare', { id });
   });
 });


### PR DESCRIPTION
## What

`createShare` / `updateShare` validated the Subsonic `expires` parameter in milliseconds (`ms <= Date.now()`) but store `floor(ms/1000)` seconds. A timestamp accepted as "future" by less than a second truncates into a second that is already past — the server stores a share that is born expired, which is exactly what this validation exists to surface. Both handlers now reject when the stored second is not strictly after the current one, and createShare anchors the share JWT's `expiresIn` to the stored second so the token and the DB row expire together. Zero/missing/invalid input still means no expiry (create) / clear expiry (update).

Readers already treat the current second as dead (share-viewer `jwt.verify`, both cleanup `DELETE`s compare in whole seconds), so the only newly rejected inputs are positive timestamps inside the current-or-earlier second.

## Test changes

- The `updateShare` past-expires probe sent `Date.now() - 1`, which asserts a 1ms boundary across two processes' clocks. On Windows the spawned server's `Date.now()` can read a few ms behind the test runner's (measured 2ms server-behind while debugging this; varies per process pair and worsens under load), so the "past" value landed in the server's future and the test failed `'ok' !== 'failed'` on loaded full-suite runs. It now uses a 60s margin, mirroring the createShare test above it.
- New test `expires within the current server second returns error 10` covers the tightened boundary for both handlers. To stay deterministic under that same skew it derives the probe from the server's own clock via the HTTP `Date` response header: the end of a server-reported second can never be in a later second than the server's clock at processing time.

## Verification

- Polish suite standalone: 19/19.
- The new test fails against the old handler code (verified via stash round-trip) and passes with the fix — it genuinely discriminates.
- Full `npm test` before and after the handler change: byte-identical failing-test sets (48 pre-existing local-environment failures on this box — stale rust-parser binary suites plus an untracked WIP admin-mdns test — unrelated to this change); the share and phase3 suites green in both runs.
- `npx eslint` clean on both changed files.

Sibling of #787 — both fell out of the same debugging session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)