### PR TITLE
refactor(task-queue): run discovery embeddings before the BPM/key pass

### DIFF
--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -367,7 +367,7 @@ function nextTask() {
 // queue makes a decision: they don't count against "drained" (the side
 // effects below are about the SCAN batch), they don't surface as `locked`
 // (isScanning), and they run strictly serial like everything else.
-const ENRICHMENT_KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid'];
+const ENRICHMENT_KINDS = ['waveform', 'albumart', 'lyrics', 'discovery', 'audioanalysis', 'acoustid'];
 
 // ── Enrichment status registry ──────────────────────────────────────────────
 //
@@ -609,23 +609,24 @@ function checkQueueDrainedSideEffectsInner() {
     maybeEnqueueLyrics();
   }
 
-  // Likewise hand off to the essentia BPM/key analysis pass. Separate flag +
-  // enqueue so it runs once per batch alongside (and serialised behind) the
-  // art pass; maybeEnqueueAudioAnalysis re-checks config + eligibility + ffmpeg
+  // Then the discovery-embedding pass (separate discovery.db) — ahead of the
+  // BPM/key pass: its embeddings feed the user-visible Discover panel and
+  // Auto-DJ sonic mode, and since the BPM/key pass went windowed it is no
+  // longer the cheaper of the two. maybeEnqueueDiscovery re-checks config +
+  // ffmpeg + whether anything actually lacks a current-model embedding
+  // before forking.
+  if (discoveryEnqueuePending) {
+    discoveryEnqueuePending = false;
+    maybeEnqueueDiscovery();
+  }
+
+  // Then the essentia BPM/key analysis pass. Separate flag + enqueue so it
+  // runs once per batch, serialised behind the passes above;
+  // maybeEnqueueAudioAnalysis re-checks config + eligibility + ffmpeg
   // before forking.
   if (audioAnalysisEnqueuePending) {
     audioAnalysisEnqueuePending = false;
     maybeEnqueueAudioAnalysis();
-  }
-
-  // And finally the discovery-embedding pass (separate discovery.db) —
-  // last in the chain: it's the most CPU-expensive per track, so every
-  // cheaper pass gets its results in first. maybeEnqueueDiscovery re-checks
-  // config + ffmpeg + whether anything actually lacks a current-model
-  // embedding before forking.
-  if (discoveryEnqueuePending) {
-    discoveryEnqueuePending = false;
-    maybeEnqueueDiscovery();
   }
 
   // AcoustID identification (network-bound, cheap CPU): fingerprints

--- a/test/integration/enrichment-status.test.mjs
+++ b/test/integration/enrichment-status.test.mjs
@@ -35,7 +35,7 @@ let dbManager;
 let taskQueue;
 let libId;
 
-const KINDS = ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid'];
+const KINDS = ['waveform', 'albumart', 'lyrics', 'discovery', 'audioanalysis', 'acoustid'];
 
 function statusOf(kind) {
   const entry = taskQueue.getEnrichmentStatus().find((p) => p.pass === kind);

--- a/test/integration/scan-status.test.mjs
+++ b/test/integration/scan-status.test.mjs
@@ -91,7 +91,7 @@ describe('GET /api/v1/scan/status', () => {
 
     assert.deepEqual(
       body.enrichment.map((p) => p.pass),
-      ['waveform', 'albumart', 'lyrics', 'audioanalysis', 'discovery', 'acoustid']);
+      ['waveform', 'albumart', 'lyrics', 'discovery', 'audioanalysis', 'acoustid']);
     for (const p of body.enrichment) {
       for (const key of ['enabled', 'disabledReason', 'state', 'progress', 'lastRun', 'coverage']) {
         assert.ok(key in p, `'${p.pass}' entry must carry '${key}'`);


### PR DESCRIPTION
## What

Swaps discovery and BPM/key in the post-scan enrichment chain. New order:

**scans → waveforms → album art → lyrics → discovery embeddings → BPM/key → acoustid**

`ENRICHMENT_KINDS` is reordered to match, which also reorders the scan-status API's `enrichment` array — and therefore the admin Enrichment Status table, which renders straight from the API (no webapp change needed).

## Why

Discovery embeddings feed the user-visible features (Discover panel, Auto-DJ sonic mode), so they should get the post-scan idle stretch first. The old "discovery last: it's the most CPU-expensive per track, so every cheaper pass gets its results in first" comment stopped holding once the BPM/key pass went windowed (#786) — the two passes are in the same cost class now — and it predated acoustid trailing it anyway. Comments rewritten to match reality.

## Reviewer notes

- With per-pass `hitCap` re-enqueues, big backlogs round-robin FIFO regardless — this change is about which pass gets the *first* batch after a scan, which is exactly the user-visible one.
- The acoustid↔discovery identity convergence is unaffected: acoustid still runs after discovery, and the two workers converge under either ordering by design (embedding worker stamps identity from `tracks`; acoustid upgrades `anon:` → `mbid:` export IDs after the fact).
- The two tests that assert pass order (`scan-status`, `enrichment-status`) are updated; both files green (12/12). Zero new lint (per-file counts match master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
