### PR TITLE
fix(p2p-sidecar): pin noq-udp 1.1.1 — musl binaries abort on first datagram

### DIFF
--- a/.github/workflows/build-p2p-sidecar-musl.yml
+++ b/.github/workflows/build-p2p-sidecar-musl.yml
@@ -96,6 +96,23 @@ jobs:
           out2="$("$bin" --print-id --data-dir selftest-data)"
           [ "$out" = "$out2" ] \
             || { echo "::error::self-test: identity did not persist between runs"; exit 1; }
+          # Real-run smoke: --print-id never opens a socket, so it misses
+          # runtime breakage in the QUIC/UDP layer — noq-udp 1.1.0's musl
+          # cmsg-alignment assert (2026-07, SIGABRT at endpoint bind on the
+          # Alpine Docker image) sailed straight through the identity checks
+          # above. Run the sidecar for real: with stdin at EOF it emits the
+          # 'ready' event (right after the endpoint binds — no relay
+          # round-trip) and then exits cleanly on its own.
+          set +e
+          real_out="$(timeout 30 "$bin" --data-dir smoke-data </dev/null 2>&1)"
+          real_code=$?
+          set -e
+          echo "  real-run exit=$real_code"
+          echo "$real_out" | head -3
+          echo "$real_out" | grep -q '"event":"ready"' \
+            || { echo "::error::real-run smoke: no ready event before exit"; exit 1; }
+          [ "$real_code" -eq 0 ] \
+            || { echo "::error::real-run smoke: sidecar exited $real_code (expected clean EOF shutdown)"; exit 1; }
           echo "self-test passed: ${{ matrix.binary_name }}"
 
       - name: Upload binary

--- a/.github/workflows/build-p2p-sidecar.yml
+++ b/.github/workflows/build-p2p-sidecar.yml
@@ -130,6 +130,29 @@ jobs:
             || { echo "::error::self-test: identity did not persist between runs"; exit 1; }
           echo "self-test passed: ${{ matrix.binary_name }}"
 
+      # Real-run smoke (Linux only — needs GNU timeout): --print-id never
+      # opens a socket, so it misses runtime breakage in the QUIC/UDP layer —
+      # noq-udp 1.1.0's musl cmsg-alignment assert (2026-07) passed the
+      # identity checks and SIGABRTed at endpoint bind in production. With
+      # stdin at EOF the sidecar emits 'ready' (right after the endpoint
+      # binds — no relay round-trip) and exits cleanly on its own.
+      - name: Real-run smoke
+        if: matrix.self_test && runner.os == 'Linux'
+        shell: bash
+        run: |
+          bin="staging/${{ matrix.binary_name }}"
+          set +e
+          real_out="$(timeout 30 "$bin" --data-dir smoke-data </dev/null 2>&1)"
+          real_code=$?
+          set -e
+          echo "  real-run exit=$real_code"
+          echo "$real_out" | head -3
+          echo "$real_out" | grep -q '"event":"ready"' \
+            || { echo "::error::real-run smoke: no ready event before exit"; exit 1; }
+          [ "$real_code" -eq 0 ] \
+            || { echo "::error::real-run smoke: sidecar exited $real_code (expected clean EOF shutdown)"; exit 1; }
+          echo "real-run smoke passed: ${{ matrix.binary_name }}"
+
       - name: Upload binary
         uses: actions/upload-artifact@v7
         with:

--- a/p2p-sidecar/Cargo.lock
+++ b/p2p-sidecar/Cargo.lock
@@ -586,7 +586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -762,7 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9"
+checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3024,7 +3024,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3082,7 +3082,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3174,7 +3174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Pins `noq-udp` to **1.1.1** in `p2p-sidecar/Cargo.lock` (lock-only, 8 lines; `noq`/`noq-proto` stay 1.1.0).
- Adds a **real-run smoke** to both sidecar binary workflows: `timeout 30 <bin> --data-dir smoke-data </dev/null` must print the `"event":"ready"` line and exit 0 (the sidecar self-shuts-down cleanly on stdin EOF). Runs on every musl leg (static binaries already execute under qemu there) and the Linux gnu leg; Windows/macOS keep `--print-id` only.

## Why

The #785 `cargo update -p iroh` swept the noq QUIC crates 1.0.1→1.1.0. noq-udp 1.1.0 enables `SO_TIMESTAMPNS`, whose `timespec` payload (align 8) trips `assert!(align_of::<T>() <= align_of::<C>())` against musl's 4-byte-aligned `cmsghdr` — **every musl build panics on the first received UDP datagram** (a single unauthenticated packet), then aborts via a poisoned-lock destructor panic. On the Alpine-based prod Docker the sidecar died with SIGABRT ~200ms after spawn and the discovery catalog was down for the boot.

Upstream: [n0-computer/noq#774](https://github.com/n0-computer/noq/issues/774) (closed), worked around in noq-udp **1.1.1** (2026-07-29, disables SO_TIMESTAMPNS — we don't use kernel timestamps); real fixes in flight ([noq#775](https://github.com/n0-computer/noq/pull/775), [noq#778](https://github.com/n0-computer/noq/pull/778), porting [quinn#2750](https://github.com/quinn-rs/quinn/pull/2750)'s `read_unaligned`). iroh 1.0.3 requires `^1.1.0`, so rolling back to the known-good 1.0.1 is not resolvable — 1.1.1 is the fix path.

## Why CI missed it

The workflows' self-test runs `--print-id`, which **opens no sockets** — the cmsg path never executes, so the broken binaries passed self-test and reached the commit job. The new real-run smoke exercises the actual endpoint bind + shutdown path; the committed 1.1.0 x64-musl binary fails it (no ready event, exit 134) and the fixed build passes it.

## Verification

- Reproduced the prod crash in an Alpine container with the committed `p2p-sidecar-linux-x64-musl`: `--print-id` passes, real run aborts (`assertion failed: align_of::<T>() <= align_of::<C>()` in `noq-udp-1.1.0/src/cmsg/mod.rs:81`, exit 134) — identical to prod's SIGABRT.
- Built the sidecar with this lock in `rust:alpine` and re-ran in the same container: `ready` event, identity persists across runs, clean exit 0.
- Dry-run dispatches of both workflows (build + self-test + new smoke, no binary commit) triggered on this branch — check the Actions tab for the runs.

After merge, the push triggers both binary workflows (paths include `p2p-sidecar/**`) and CI recommits fresh binaries — this PR stays source-only per the repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
