### PR TITLE
fix(status): un-quadratic the hash-ledger coverage query (22 s → 20 ms)

### DIFF
--- a/src/db/enrichment-status-lib.js
+++ b/src/db/enrichment-status-lib.js
@@ -40,7 +40,11 @@ const ANALYSIS_MAX_DURATION_SEC = 30 * 60;
 const ACOUSTID_MIN_DURATION_SEC = 10;
 const ACOUSTID_MAX_DURATION_SEC = 2 * 60 * 60;
 
-const CACHE_TTL_MS = 5_000;
+// Above the admin page's 4 s poll on purpose: with a 5 s TTL every poll
+// recomputed the whole snapshot. Freshness at pass/scan boundaries comes
+// from invalidateCoverageCache(), not the TTL — this only bounds staleness
+// of mid-pass counts.
+const CACHE_TTL_MS = 15_000;
 const WAVEFORM_FS_TTL_MS = 60_000;
 
 // key = sorted libIds signature → { at, data }. Bounded: a burst of
@@ -77,14 +81,28 @@ function libClause(column, libIds) {
 // (idx_tracks_audio_hash / idx_tracks_hash).
 function outcomesForHashLedger(d, table, outcomeCol, libIds) {
   const lib = libClause('t.library_id', libIds);
+  // Ledger rows are keyed by the CANONICAL hash — COALESCE(audio_hash,
+  // file_hash), exactly how every enrichment worker keys them — so
+  // visibility is "the hash belongs to some visible track". Phrased as
+  // IN (materialised subquery): one pass over tracks builds the hash set,
+  // then each ledger row is a single probe.
+  //
+  // ⚠ Do NOT rewrite this as a correlated EXISTS with the coalesce spelled
+  // out as an OR (t.audio_hash = l.audio_hash OR (t.audio_hash IS NULL AND
+  // t.file_hash = l.audio_hash)): without ANALYZE stats SQLite plans that
+  // probe via idx_tracks_library instead of the hash indexes — effectively
+  // ledger-rows × library-rows. On a 19k-track library with an 18.5k-row
+  // audio_analysis ledger that was ~22 SECONDS of synchronous main-thread
+  // CPU per status poll (measured on prod, 2026-07-30, admin page pinned
+  // the server at 100%); this form is ~20 ms on the same data.
   const rows = d.prepare(`
     SELECT l.${outcomeCol} AS outcome, COUNT(*) AS n
       FROM ${table} l
-     WHERE EXISTS (
-             SELECT 1 FROM tracks t
-              WHERE (t.audio_hash = l.audio_hash
-                     OR (t.audio_hash IS NULL AND t.file_hash = l.audio_hash))
-                AND ${lib.clause}
+     WHERE l.audio_hash IN (
+             SELECT COALESCE(t.audio_hash, t.file_hash)
+               FROM tracks t
+              WHERE ${lib.clause}
+                AND COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
            )
      GROUP BY l.${outcomeCol}
   `).all(...lib.params);

--- a/test/integration/enrichment-status.test.mjs
+++ b/test/integration/enrichment-status.test.mjs
@@ -240,3 +240,61 @@ describe('enrichment status: lifecycle through the real queue', () => {
     assert.equal(b.lastRun.counts.generated, 0, 'nested counts must be insulated');
   });
 });
+
+// ── Coverage: hash-ledger outcome visibility ────────────────────────────────
+//
+// Pins the semantics of outcomesForHashLedger (enrichment-status-lib.js):
+// a ledger row counts iff its hash is some visible track's CANONICAL hash —
+// COALESCE(audio_hash, file_hash), the same key every enrichment worker
+// writes. Guards the 2026-07 rewrite of that query (the correlated-EXISTS
+// form planned via idx_tracks_library and cost ~22 s/poll on a 19k-track
+// prod library, pinning the server at 100% while an admin tab was open).
+describe('coverage outcomes: hash-ledger visibility', () => {
+  test('audio_hash- and file_hash-keyed rows count; orphans and other libraries do not', async () => {
+    const { getEnrichmentCoverage, invalidateCoverageCache } =
+      await import('../../src/db/enrichment-status-lib.js');
+    const d = dbManager.getDB();
+
+    d.prepare(
+      `INSERT INTO libraries (name, root_path, type, follow_symlinks) VALUES ('other-lib', ?, 'music', 0)`
+    ).run(path.join(testRoot, 'other-lib'));
+    dbManager.invalidateCache();
+    const otherId = dbManager.getLibraryByName('other-lib').id;
+
+    const ins = d.prepare(
+      'INSERT INTO tracks (filepath, library_id, title, duration, audio_hash, file_hash) VALUES (?, ?, ?, 200, ?, ?)'
+    );
+    ins.run('cov-a.mp3', libId, 'A', 'cov-hash-audio', null);   // canonical = audio_hash
+    ins.run('cov-b.mp3', libId, 'B', null, 'cov-hash-file');    // canonical = file_hash
+    ins.run('cov-c.mp3', otherId, 'C', 'cov-hash-other', null); // other library only
+
+    const led = d.prepare(
+      'INSERT INTO audio_analysis_lookups (audio_hash, last_attempt_at, outcome, attempts) VALUES (?, ?, ?, 1)'
+    );
+    const now = Math.floor(Date.now() / 1000);
+    led.run('cov-hash-audio', now, 'analyzed');
+    led.run('cov-hash-file', now, 'lowconf');
+    led.run('cov-hash-other', now, 'analyzed');
+    led.run('cov-hash-orphan', now, 'error');   // no matching track anywhere
+
+    try {
+      invalidateCoverageCache();
+      assert.deepEqual(
+        getEnrichmentCoverage([libId]).passes.audioanalysis.outcomes,
+        { analyzed: 1, lowconf: 1 },
+        'one-library view: file_hash-keyed row visible, orphan + other-library rows excluded');
+
+      invalidateCoverageCache();
+      assert.deepEqual(
+        getEnrichmentCoverage([libId, otherId]).passes.audioanalysis.outcomes,
+        { analyzed: 2, lowconf: 1 },
+        'both-libraries view picks up the other-library row; orphan still excluded');
+    } finally {
+      d.prepare("DELETE FROM audio_analysis_lookups WHERE audio_hash LIKE 'cov-hash-%'").run();
+      d.prepare("DELETE FROM tracks WHERE filepath LIKE 'cov-%.mp3'").run();
+      d.prepare('DELETE FROM libraries WHERE id = ?').run(otherId);
+      dbManager.invalidateCache();
+      invalidateCoverageCache();
+    }
+  });
+});


### PR DESCRIPTION
## What

`outcomesForHashLedger` (the per-pass outcome counts in `GET /api/v1/scan/status`) phrased "this ledger hash belongs to a visible track" as a correlated EXISTS with the canonical-hash coalesce expanded into an OR. Without ANALYZE stats, SQLite plans that probe via `idx_tracks_library` — matching essentially the whole library per ledger row — instead of either hash index. Cost is ledger-rows × library-rows.

Rewritten as membership in a materialised canonical-hash set (`l.audio_hash IN (SELECT COALESCE(t.audio_hash, t.file_hash) …)`), which is also the literal definition of how every enrichment worker keys these ledgers. Plus: coverage memo TTL 5 s → 15 s, so it actually outlives the admin page's 4 s poll (event-driven invalidation already handles pass/scan-boundary freshness).

## Impact (measured on prod data: 19k tracks, 18.5k-row audio_analysis ledger)

| | per status call |
|---|---|
| before | **~22,050 ms** (pure main-thread CPU, `SEARCH t USING INDEX idx_tracks_library`) |
| split-EXISTS variant | ~22,500 ms (planner still picks the library index) |
| **after** | **~20 ms** (`SEARCH l USING PK` + one tracks pass) |

This was the root cause of the "server pinned at 100%, UI takes a minute to respond" incident on prod (2026-07-29/30): with an admin tab open, every 4 s poll queued a 22-second synchronous recompute behind the previous one — the event loop never drained. Diagnosed on the live server via the node inspector; the stack pointed at `outcomesForHashLedger ← audioAnalysisCoverage ← getEnrichmentCoverage ← /api/v1/scan/status`. The ledger only grew big enough to hurt once the (new-in-6.19.x, on-by-default) BPM backfill filled it — small libraries and empty ledgers never noticed.

## Reviewer notes

- Results are identical on prod data (`analyzed 18437 / error 16 / lowconf 99` before and after); a new test pins the semantics the rewrite must preserve — `file_hash`-keyed rows (audio_hash NULL) count, orphaned hashes and other-library rows don't.
- A warning comment in the code explains why the correlated-EXISTS form must not come back.
- All three ledger consumers benefit (audio-analysis, lyrics, acoustid) — the others' ledgers are just smaller today.
- 13/13 in the two affected test files; zero lint findings on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
