### PR TITLE
perf(discovery): un-quadratic resolveVisible + bound the ranked-candidate walks (PR-A)

### DIFF
--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -29,10 +29,36 @@ import * as db from '../db/manager.js';
 import * as sim from '../db/discovery-similarity.js';
 import { joiValidate } from '../util/validation.js';
 import WebError from '../util/web-error.js';
-import { renderMetadataObj, toLiteMetadata, trackQuery, libraryFilter } from './db.js';
+import { renderMetadataObj, toLiteMetadata, trackQuery, libraryFilter, fetchGenresForTrack } from './db.js';
 import { getVPathInfo } from '../util/vpath.js';
 
 const d = () => db.getDB();
+
+// Prepared-statement memo: per DB handle (the handle is replaced on e.g. a
+// backup restore, and a WeakMap lets the old handle's statements be
+// collected with it), then per SQL text. The text varies only with uid
+// presence and the caller's library-filter shape (grant-count IN-list
+// length) — a handful of variants per process, so the inner Map stays
+// small. Re-preparing per candidate was measured at ~75–80% of the probe
+// cost: a full 25k-index visibility walk is ~6 s re-preparing vs ~0.3 s
+// prepared once.
+const stmtCache = new WeakMap();
+function prep(sql) {
+  const handle = d();
+  let bySql = stmtCache.get(handle);
+  if (!bySql) { bySql = new Map(); stmtCache.set(handle, bySql); }
+  let stmt = bySql.get(sql);
+  if (!stmt) { stmt = handle.prepare(sql); bySql.set(sql, stmt); }
+  return stmt;
+}
+
+// Bounded candidate consideration for the ranked loops below. Rankings are
+// similarity-ordered, so entries thousands deep are dissimilar noise —
+// walking them buys latency, not relevance. Results may legitimately come
+// up short for users who can see few of the ranked tracks; responses carry
+// `capped: true` when that happened so clients can tell "short because the
+// pool ran out" from "short because we stopped looking".
+const considerBudget = (limit) => Math.max(limit * 50, 2000);
 
 // Feature gate + index. 403 when the feature is off; 403 (generic) when the
 // store is unavailable despite the flag (boot init failed) — same status so
@@ -64,12 +90,16 @@ export function resolveSeedTrack(req, filePath, routeTag) {
   if (!lib) { throw new WebError('Track not found', 404); }
   const uid = req.user?.id;
   const seedParams = uid ? [uid, info.relativePath, lib.id] : [info.relativePath, lib.id];
-  const seedRow = d().prepare(`
-    ${trackQuery(uid)}
+  // includeGenres:false + single-track enrichment: the default tg_agg join
+  // materialises a GROUP_CONCAT over the whole track_genres table to fetch
+  // ONE row (~70 ms at 25k tracks, per request). Same trap as resolveVisible.
+  const seedRow = prep(`
+    ${trackQuery(uid, { includeGenres: false })}
     WHERE t.filepath = ? AND t.library_id = ?
     LIMIT 1
   `).get(...seedParams);
   if (!seedRow) { throw new WebError('Track not found', 404); }
+  Object.assign(seedRow, fetchGenresForTrack(d(), seedRow.id));
   return seedRow;
 }
 
@@ -77,13 +107,41 @@ export function resolveSeedTrack(req, filePath, routeTag) {
 // when every copy of that audio lives outside the user's libraries.
 // Exported for the federation vector-seed route (api/federation-discovery.js),
 // which scopes a peer's results the same way.
-export function resolveVisible(uid, filter, canonHash) {
-  const params = uid ? [uid, canonHash, ...filter.params] : [canonHash, ...filter.params];
-  return d().prepare(`
-    ${trackQuery(uid)}
-    WHERE COALESCE(t.audio_hash, t.file_hash) = ? AND ${filter.clause}
+//
+// This runs once per RANKED CANDIDATE inside the routes' loops, so its cost
+// is the whole feature's cost. Two traps, both measured on a 25k-track DB
+// (2026-07 audit — the same planner failure class as the scan/status
+// incident):
+//   • The probe must NOT be phrased `COALESCE(t.audio_hash, t.file_hash) = ?`
+//     — an expression, so neither hash index applies and SQLite (no ANALYZE
+//     stats) falls back to idx_tracks_library = a full library scan per
+//     candidate (~74 ms; minutes per request under filter starvation). The
+//     flat OR rewrite (`t.audio_hash = ? OR ...`) does NOT fix the plan
+//     either; the UNION ALL id-subquery below does (~0.07 ms, ~1000×).
+//   • trackQuery's default includeGenres:true materialises a GROUP_CONCAT
+//     over the ENTIRE track_genres table per call. Resolved rows instead get
+//     the indexed single-track lookup, preserving metadata.genres for every
+//     caller (renderMetadataObj reads genres_concat).
+export function resolveVisible(uid, filter, canonHash, { withGenres = true } = {}) {
+  const params = uid
+    ? [uid, canonHash, canonHash, ...filter.params]
+    : [canonHash, canonHash, ...filter.params];
+  const row = prep(`
+    ${trackQuery(uid, { includeGenres: false })}
+    WHERE t.id IN (
+            SELECT id FROM tracks WHERE audio_hash = ?
+            UNION ALL
+            SELECT id FROM tracks WHERE file_hash = ? AND audio_hash IS NULL
+          )
+      AND ${filter.clause}
     LIMIT 1
   `).get(...params);
+  // withGenres:false for callers that post-filter or never render genres
+  // (similar/tracks rejects on bpm/artist AFTER resolving; federation's
+  // response carries no track genres) — they enrich accepted rows
+  // themselves, so rejected candidates never pay the lookup.
+  if (row && withGenres) { Object.assign(row, fetchGenresForTrack(d(), row.id)); }
+  return row;
 }
 
 function modelBlock(index) {
@@ -124,15 +182,22 @@ export function setup(mstream) {
     const filter = libraryFilter(req.user);
     const ranked = sim.rankTracks(index, seedEntry.vec, canonHash);
     const results = [];
+    const maxConsidered = considerBudget(body.limit);
+    let considered = 0;
+    let capped = false;
     for (const { entry, similarity } of ranked) {
       if (results.length >= body.limit) { break; }
-      const row = resolveVisible(uid, filter, entry.hash);
+      if (++considered > maxConsidered) { capped = true; break; }
+      const row = resolveVisible(uid, filter, entry.hash, { withGenres: false });
       if (!row) { continue; }   // no copy visible to this user
       if (body.excludeSameArtist && row.artist_name && row.artist_name === seedRow.artist_name) { continue; }
       if (body.excludeSameAlbum && row.album_name && row.album_name === seedRow.album_name
         && row.artist_name === seedRow.artist_name) { continue; }
       if (body.bpmRange && !(row.bpm >= body.bpmRange[0] && row.bpm <= body.bpmRange[1])) { continue; }
 
+      // Enrich only rows that survived the filters — rejected candidates
+      // never pay the genre lookup.
+      Object.assign(row, fetchGenresForTrack(d(), row.id));
       const rendered = renderMetadataObj(row);
       results.push({
         filepath: rendered.filepath,
@@ -142,7 +207,7 @@ export function setup(mstream) {
       });
     }
 
-    res.json({ seed, model: modelBlock(index), notAnalyzed: false, results });
+    res.json({ seed, model: modelBlock(index), notAnalyzed: false, capped, results });
   });
 
   // A smooth "journey" between two tracks: `length - 2` waypoints evenly
@@ -275,15 +340,25 @@ export function setup(mstream) {
 
     const ranked = sim.rankArtists(index, body.artist);
     const results = [];
+    // Same bounded-consideration rule as similar/tracks: a user who can see
+    // none of the ranked artists must not walk the whole ranking.
+    const maxConsidered = considerBudget(body.limit);
+    let considered = 0;
+    let capped = false;
     for (const cand of ranked) {
       if (results.length >= body.limit) { break; }
+      if (++considered > maxConsidered) { capped = true; break; }
       if (!artistVisible.get(cand.artist, ...filter.params)) { continue; }
 
       // Entry points: the candidate's tracks closest to the SEED's sound —
       // playable doorways that continue the vibe the user came from.
+      // Bounded too: an artist with a large embedded-but-invisible catalog
+      // shouldn't cost hundreds of probes for two doorways. 200 cached-
+      // statement probes ≈ single-digit ms; real artists exhaust well first.
       const entryPoints = [];
+      let epConsidered = 0;
       for (const { entry } of sim.rankArtistTracks(index, cand.artist, seedCentroid.vec)) {
-        if (entryPoints.length >= 2) { break; }
+        if (entryPoints.length >= 2 || ++epConsidered > 200) { break; }
         const row = resolveVisible(uid, filter, entry.hash);
         if (!row) { continue; }
         const rendered = renderMetadataObj(row);
@@ -299,6 +374,6 @@ export function setup(mstream) {
       });
     }
 
-    res.json({ seed, model: modelBlock(index), notAnalyzed: false, results });
+    res.json({ seed, model: modelBlock(index), notAnalyzed: false, capped, results });
   });
 }

--- a/src/api/federation-discovery.js
+++ b/src/api/federation-discovery.js
@@ -85,9 +85,18 @@ export function setup(mstream) {
     const mbidStmt = ddb ? ddb.prepare('SELECT recording_mbid FROM discovery_tracks WHERE audio_hash = ?') : null;
 
     const results = [];
+    // Bounded like the local similarity routes (2026-07 review): a starved
+    // grant (key scoped to a library with few embedded tracks) would
+    // otherwise walk the ENTIRE ranking — a full-index visibility sweep of
+    // synchronous main-thread SQL per request, on a machine-facing route.
+    // withGenres:false — this response never renders track genres.
+    const maxConsidered = Math.max(body.limit * 50, 2000);
+    let considered = 0;
+    let capped = false;
     for (const { entry, similarity } of sim.rankTracks(index, q, null)) {
       if (results.length >= body.limit) { break; }
-      const row = resolveVisible(uid, filter, entry.hash);
+      if (++considered > maxConsidered) { capped = true; break; }
+      const row = resolveVisible(uid, filter, entry.hash, { withGenres: false });
       if (!row) { continue; }   // no copy inside the caller's granted libraries
       results.push({
         filepath: renderMetadataObj(row).filepath,
@@ -100,6 +109,6 @@ export function setup(mstream) {
       });
     }
 
-    res.json({ model, results });
+    res.json({ model, capped, results });
   });
 }

--- a/test/integration/discovery-similarity.test.mjs
+++ b/test/integration/discovery-similarity.test.mjs
@@ -454,3 +454,57 @@ describe('POST /api/v1/discovery/local/path', () => {
       { startFilePath: 'testlib/nope/missing.mp3', endFilePath: neonPath })).status, 404);
   });
 });
+
+// ── resolveVisible probe semantics (2026-07 perf rewrite regression pins) ────
+//
+// The COALESCE-expression probe was rewritten as a UNION ALL id-subquery
+// (planner trap: expression probes fall back to idx_tracks_library — see
+// resolveVisible's comment). These pin the two semantics the rewrite must
+// preserve: file_hash-keyed tracks (audio_hash NULL) stay resolvable, and
+// metadata.genres survives the includeGenres:false + point-lookup split.
+// Deliberately LAST in the file: the hash flip below mutates live rows.
+describe('resolveVisible probe semantics', () => {
+  const seedPath = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
+
+  test('genres reach results via the single-track enrichment path', async () => {
+    const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'));
+    try {
+      mdb.exec('PRAGMA busy_timeout = 5000');
+      mdb.prepare("INSERT OR IGNORE INTO genres (name) VALUES ('Probe Genre')").run();
+      const gid = mdb.prepare("SELECT id FROM genres WHERE name = 'Probe Genre'").get().id;
+      const rise = mdb.prepare("SELECT id FROM tracks WHERE title = 'Rise'").get();
+      mdb.prepare('INSERT OR IGNORE INTO track_genres (track_id, genre_id) VALUES (?, ?)').run(rise.id, gid);
+    } finally { mdb.close(); }
+
+    const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath });
+    const riseRes = body.results.find((r) => r.metadata.title === 'Rise');
+    assert.ok(riseRes, 'Rise must rank');
+    assert.ok(Array.isArray(riseRes.metadata.genres) && riseRes.metadata.genres.includes('Probe Genre'),
+      `metadata.genres must carry the live genre row, got ${JSON.stringify(riseRes.metadata.genres)}`);
+  });
+
+  test('a file_hash-keyed track (audio_hash NULL) still resolves', async () => {
+    // Move Neon's canonical hash from audio_hash to file_hash — the canonical
+    // value is unchanged, so its discovery row still matches; only the probe's
+    // second UNION arm can find it now. Scanned rows carry BOTH hashes
+    // (audio-hash.js always writes file_hash), so stash the originals and
+    // restore them explicitly — deriving the restore from the mutated row
+    // would permanently NULL the scanner's whole-file hash.
+    const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'));
+    try {
+      mdb.exec('PRAGMA busy_timeout = 5000');
+      const orig = mdb.prepare("SELECT id, audio_hash, file_hash FROM tracks WHERE title = 'Neon'").get();
+      assert.ok(orig?.audio_hash, 'fixture must have a Neon row with an audio_hash');
+      try {
+        mdb.prepare('UPDATE tracks SET file_hash = audio_hash, audio_hash = NULL WHERE id = ?').run(orig.id);
+
+        const { body } = await api('/api/v1/discovery/local/similar/tracks', { filePath: seedPath });
+        const neon = body.results.find((r) => r.metadata.title === 'Neon');
+        assert.ok(neon, `file_hash-keyed Neon must still resolve; got ${JSON.stringify(body.results.map((r) => r.metadata.title))}`);
+      } finally {
+        mdb.prepare('UPDATE tracks SET audio_hash = ?, file_hash = ? WHERE id = ?')
+          .run(orig.audio_hash, orig.file_hash, orig.id);
+      }
+    } finally { mdb.close(); }
+  });
+});


### PR DESCRIPTION
## What

The top finding of the 2026-07-30 perf audit (all three CRITICALs traced to one function). `resolveVisible` — the per-user visibility probe every discovery route runs **once per ranked candidate** — had three stacked costs, now fixed:

1. **Planner trap** (same class as #791): `WHERE COALESCE(t.audio_hash, t.file_hash) = ?` is an expression → neither hash index applies → `idx_tracks_library` full-scan per candidate (~74 ms @25k). Rewritten as a `UNION ALL` id-subquery that probes both hash indexes. ⚠ The *flat OR* rewrite does **not** fix the plan (measured) — a warning comment guards the shape.
2. **Whole-table genre materialization per call** (`trackQuery` default): resolved rows now use the indexed single-track lookup — deferred until *after* the rejection filters on `similar/tracks`, skipped entirely on federation (its response has no track genres). `resolveSeedTrack` had the same trap (~70 ms per request to fetch one seed row — also paid by sonic Auto-DJ) — same fix.
3. **Per-candidate statement re-preparation** (~75–80% of the residual cost): `resolveVisible`/`resolveSeedTrack` now use a prepared-statement memo (WeakMap per DB handle → per SQL text; a handful of variants per process).

The ranked loops get a consideration budget of `max(limit*50, 2000)` — on `similar/tracks`, `similar/artists`, **and the federation similar route, which previously had no bound at all** and could walk the whole index per request under a starved grant. When the budget trips before `limit` fills, responses carry an additive **`capped: true`** so clients can distinguish "pool ran out" from "stopped looking". `/discovery/local/path`'s gate is deliberately uncapped: the statement memo bounds its worst case at ~0.4 s, and capping inside `pathBetween` would change path semantics (its JS-side costs are PR-B).

## Measured (25k-track fixture, production SQL text)

| Workload | Before | After |
|---|---|---|
| 200-candidate resolve loop | 6,606 ms | **22 ms** (0 resolution mismatches) |
| Default `/similar/tracks` request | ~1.46 s (audited) | single-digit ms |
| Full starved visibility walk (worst case) | **~31 min** | 399 ms |
| Budgeted route walk, worst case | — | 112 ms |

## Review

An adversarial multi-agent review of the first cut confirmed **10 findings, 0 refuted** — uncapped federation/path walks (major), genre lookups paid by rejected candidates, re-preparation dominance, silent truncation with no wire signal, over-tight caps starving sparse-visibility users, and a lossy test restore. All are addressed in this diff (caps ×4 looser + `capped` field; enrichment reordered; statement memo; federation bounded; test stashes and restores both hash columns).

## Reviewer notes

- `resolveVisible` is a **visibility boundary**; the rewrite was verified row-identical against the old form over mixed audio_hash/file_hash candidates, and two new tests pin the semantics (file_hash-keyed tracks resolve via the second UNION arm; `metadata.genres` survives the enrichment split).
- `capped` is additive; existing clients ignore it.
- 60/60 across the four affected suites (discovery-similarity incl. 2 new pins, federation ×2, random-similar-artists); zero new lint.
- Fixes audit findings C1, C2, C3 (SQL half), plus the seed-row half of H8. Full audit: `.claude/perf-audit-2026-07-30.md` on the audit branch / session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
