### PR TITLE
perf(db): batch genre enrichment on the last whole-table tg_agg callers (PR-D)

### DIFF
--- a/src/api/db.js
+++ b/src/api/db.js
@@ -183,26 +183,20 @@ export function libraryFilter(user, ignoreVPaths) {
 // user_metadata, and (when `includeGenres` is set) a track_genres
 // aggregation.
 //
-// `includeGenres` controls whether the `tg_agg` LEFT JOIN runs:
-//
-//   • true (default) — adds a GROUP_CONCAT subquery over track_genres
-//     so `renderMetadataObj` can emit `metadata.genres: string[]`
-//     without per-row follow-ups. Use this for response-shaped queries
-//     (velvet-stubs list endpoints, smart-playlists, pullMetaData).
-//
-//   • false — skip the join. Use for candidate-set queries where only
-//     ONE row will actually be rendered (the random-songs picker
-//     loads the candidate pool, picks one index, then enriches just
-//     that row via fetchGenresForTrack below). SQLite has to
-//     MATERIALIZE tg_agg before applying the WHERE clause, so the
-//     cost scales with the full tracks table, not the filtered
-//     candidate set — skipping it cuts the picker's SQL time by ~80%
-//     on a smoke-sized DB and avoids ~460ms of overhead extrapolated
-//     to a 100k-track library.
+// `includeGenres` controls whether the `tg_agg` LEFT JOIN runs — and it
+// DEFAULTS TO FALSE. The join materialises a GROUP_CONCAT over the ENTIRE
+// track_genres table before the WHERE applies, so its cost scales with the
+// library, not the query (~460ms extrapolated at 100k tracks, paid per
+// request). Every caller in the tree was converted off it (2026-07 audit):
+// render your rows first, then attach genres to JUST those rows via
+// enrichRowsWithGenres (lists) or fetchGenresForTrack (single row) below.
+// includeGenres:true survives only for a hypothetical caller that truly
+// wants the whole-table aggregation inline — as of the conversion there are
+// none, and new code should not become the first without measuring.
 //
 // char(31) (ASCII unit separator) is the join delimiter so no legal
 // genre name can collide with it.
-export function trackQuery(userId, { includeGenres = true } = {}) {
+export function trackQuery(userId, { includeGenres = false } = {}) {
   const aggJoin = includeGenres ? `
     LEFT JOIN (
       SELECT tg.track_id, GROUP_CONCAT(g.name, char(31)) AS genres_concat
@@ -257,6 +251,32 @@ function fetchGenresForTracks(d, ids) {
   `).all(...ids);
   for (const r of rows) { out.set(r.track_id, r.genres_concat); }
   return out;
+}
+
+// Enrich trackQuery({ includeGenres: false }) rows with their genre
+// aggregation in ONE indexed batch, in place — the companion every
+// response-shaped list endpoint uses instead of the default tg_agg join
+// (which materialises over the ENTIRE track_genres table, so a list
+// endpoint's cost scaled with the library, not the response — see
+// trackQuery's note). Returns `rows` with genres_concat set,
+// renderMetadataObj-ready. Exported for the trackQuery callers that live
+// outside this file (smart-playlists, velvet-stubs).
+export function enrichRowsWithGenres(d, rows) {
+  // Chunked like renderMetadataByIds/pullMetaDataBatch above: one IN() per
+  // 500 ids keeps huge responses (whole-genre / whole-decade listings) under
+  // SQLite's bound-variable limit — an unchunked list threw 'too many SQL
+  // variables' past ~32k rows. Ids are de-duped first: join-shaped callers
+  // (the smart-playlist genre filter) can hand the same track twice.
+  const uniq = [...new Set(rows.map((r) => r.id))];
+  const genres = new Map();
+  const CHUNK = 500;
+  for (let i = 0; i < uniq.length; i += CHUNK) {
+    for (const [id, gc] of fetchGenresForTracks(d, uniq.slice(i, i + CHUNK))) {
+      genres.set(id, gc);
+    }
+  }
+  for (const row of rows) { row.genres_concat = genres.get(row.id) || null; }
+  return rows;
 }
 
 // Batched metadata render keyed on track id. Returns Map<id, { filepath, metadata }>
@@ -319,12 +339,18 @@ export function pullMetaData(filepath, user) {
   const lib = db.getLibraryByName(pathInfo.vpath);
   if (!lib) { return { filepath: filepath, metadata: null }; }
 
+  // includeGenres:false + point enrichment: the default tg_agg join
+  // materialises the whole track_genres table to fetch ONE row (~69 ms at
+  // 25k tracks) — and the no-login shared-playlist page fires this once per
+  // track. Same conversion pullMetaDataBatch made long ago; this was the
+  // single-row straggler.
   const row = d.prepare(`
-    ${trackQuery(user?.id)}
+    ${trackQuery(user?.id, { includeGenres: false })}
     WHERE t.filepath = ? AND t.library_id = ?
   `).get(...(user?.id ? [user.id] : []), pathInfo.relativePath, lib.id);
 
   if (!row) { return { filepath: filepath, metadata: null }; }
+  row.genres_concat = fetchGenresForTrack(d, row.id).genres_concat ?? null;
   return renderMetadataObj(row);
 }
 
@@ -552,23 +578,34 @@ export function setup(mstream) {
 
   mstream.post('/api/v1/db/genre-songs', (req, res) => {
     const filter = libraryFilter(req.user, req.body?.ignoreVPaths);
-    const allParams = req.user?.id
-      ? [req.user.id, String(req.body.genre), ...filter.params]
-      : [String(req.body.genre), ...filter.params];
 
     // V34: case-insensitive name match — uniform with the post-V34
     // case-folded vocabulary getGenres now returns. Pre-V34 this
     // would silently miss "Jazz" vs "jazz" if the M2M had both rows
     // (the "1247 jazz tracks shown but only 800 returned" bug).
+    //
+    // Name → id(s) resolved FIRST so the M2M probe drives
+    // idx_track_genres_genre instead of walking every track_genres row
+    // (the name-join form scanned the whole M2M regardless of how small
+    // the genre was). NOCASE can hit multiple vocabulary rows on
+    // pre-V34-shaped data; joining every matched id reproduces the old
+    // name-join's row multiplicity exactly.
+    const genreIds = d().prepare('SELECT id FROM genres WHERE name COLLATE NOCASE = ?')
+      .all(String(req.body.genre)).map((r) => r.id);
+    if (genreIds.length === 0) { return res.json([]); }
+    const idPh = genreIds.map(() => '?').join(',');
+    const allParams = req.user?.id
+      ? [req.user.id, ...genreIds, ...filter.params]
+      : [...genreIds, ...filter.params];
+
     const rows = d().prepare(`
-      ${trackQuery(req.user?.id)}
-      JOIN track_genres tg ON tg.track_id = t.id
-      JOIN genres g ON g.id = tg.genre_id
-      WHERE g.name COLLATE NOCASE = ? AND ${filter.clause}
+      ${trackQuery(req.user?.id, { includeGenres: false })}
+      JOIN track_genres tg ON tg.track_id = t.id AND tg.genre_id IN (${idPh})
+      WHERE ${filter.clause}
       ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, t.disc_number, t.track_number
     `).all(...allParams);
 
-    res.json(rows.map(renderMetadataObj));
+    res.json(enrichRowsWithGenres(d(), rows).map(renderMetadataObj));
   });
 
   // ── Album Songs ─────────────────────────────────────────────────────────
@@ -599,12 +636,12 @@ export function setup(mstream) {
     const allParams = req.user?.id ? [req.user.id, ...params] : params;
 
     const rows = d().prepare(`
-      ${trackQuery(req.user?.id)}
+      ${trackQuery(req.user?.id, { includeGenres: false })}
       WHERE ${conditions.join(' AND ')}
       ORDER BY t.disc_number, t.track_number, t.filepath
     `).all(...allParams);
 
-    res.json(rows.map(renderMetadataObj));
+    res.json(enrichRowsWithGenres(d(), rows).map(renderMetadataObj));
   });
 
   // ── Search ──────────────────────────────────────────────────────────────
@@ -716,13 +753,13 @@ export function setup(mstream) {
     const allParams = req.user?.id ? [req.user.id, ...filter.params] : filter.params;
 
     const rows = d().prepare(`
-      ${trackQuery(req.user?.id)}
+      ${trackQuery(req.user?.id, { includeGenres: false })}
       WHERE ${filter.clause}
       ORDER BY t.created_at DESC, t.id DESC
       LIMIT ?
     `).all(...allParams, req.body.limit);
 
-    res.json(rows.map(renderMetadataObj));
+    res.json(enrichRowsWithGenres(d(), rows).map(renderMetadataObj));
   });
 
   // ── Recently Played ─────────────────────────────────────────────────────

--- a/src/api/smart-playlists.js
+++ b/src/api/smart-playlists.js
@@ -3,7 +3,7 @@
 // as SQL queries against the tracks/artists/albums/genres tables.
 
 import * as db from '../db/manager.js';
-import { renderMetadataObj, libraryFilter, trackQuery } from './db.js';
+import { renderMetadataObj, libraryFilter, trackQuery, enrichRowsWithGenres } from './db.js';
 
 const d = () => db.getDB();
 
@@ -98,8 +98,12 @@ function runSmartQuery(filters, sort, limit, userId, user) {
     ? 'JOIN track_genres tg ON tg.track_id = t.id JOIN genres g ON g.id = tg.genre_id'
     : '';
 
+  // includeGenres:false: the default tg_agg join materialises the WHOLE
+  // track_genres table per query (cost scales with the library, not this
+  // playlist) — genres are batch-enriched onto just the returned rows
+  // below. `genreJoin` is unrelated: it joins the M2M for FILTERING.
   const sql = `
-    ${trackQuery(userId)}
+    ${trackQuery(userId, { includeGenres: false })}
     ${genreJoin}
     WHERE ${conditions.join(' AND ')}
     ORDER BY ${buildSortClause(sort)}
@@ -107,7 +111,7 @@ function runSmartQuery(filters, sort, limit, userId, user) {
   `;
 
   const allParams = [...userIdParams, ...params, Math.min(limit || 50, 1000)];
-  return d().prepare(sql).all(...allParams);
+  return enrichRowsWithGenres(d(), d().prepare(sql).all(...allParams));
 }
 
 function countSmartQuery(filters, userId, user) {

--- a/src/api/velvet-stubs.js
+++ b/src/api/velvet-stubs.js
@@ -3,7 +3,7 @@
 // stubs for features that aren't implemented yet.
 
 import * as db from '../db/manager.js';
-import { renderMetadataObj, libraryFilter, trackQuery } from './db.js';
+import { renderMetadataObj, libraryFilter, trackQuery, enrichRowsWithGenres } from './db.js';
 import { warmScrobbleUser } from './scrobbler.js';
 import { getVPathInfo } from '../util/vpath.js';
 
@@ -51,11 +51,11 @@ export function setup(mstream) {
     if (isNaN(decade)) return res.json([]);
     const f = libraryFilter(req.user);
     const rows = d().prepare(`
-      ${trackQuery(req.user?.id)}
+      ${trackQuery(req.user?.id, { includeGenres: false })}
       WHERE t.year >= ? AND t.year < ? AND ${f.clause}
       ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, t.track_number
     `).all(...(req.user?.id ? [req.user.id] : []), decade, decade + 10, ...f.params);
-    res.json(rows.map(renderMetadataObj));
+    res.json(enrichRowsWithGenres(d(), rows).map(renderMetadataObj));
   });
 
   // ── Genre groups ─────────────────────────────────────────────
@@ -98,14 +98,19 @@ export function setup(mstream) {
     const genre = req.body.genre;
     if (!genre) return res.json([]);
     const f = libraryFilter(req.user);
+    // Name -> id(s) first so the M2M probe drives idx_track_genres_genre
+    // instead of walking the whole table; mirrors /api/v1/db/genre-songs.
+    const genreIds = d().prepare('SELECT id FROM genres WHERE name COLLATE NOCASE = ?')
+      .all(String(genre)).map((r) => r.id);
+    if (genreIds.length === 0) return res.json([]);
+    const idPh = genreIds.map(() => '?').join(',');
     const rows = d().prepare(`
-      ${trackQuery(req.user?.id)}
-      JOIN track_genres tg ON tg.track_id = t.id
-      JOIN genres g ON g.id = tg.genre_id
-      WHERE g.name COLLATE NOCASE = ? AND ${f.clause}
+      ${trackQuery(req.user?.id, { includeGenres: false })}
+      JOIN track_genres tg ON tg.track_id = t.id AND tg.genre_id IN (${idPh})
+      WHERE ${f.clause}
       ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, t.track_number
-    `).all(...(req.user?.id ? [req.user.id] : []), genre, ...f.params);
-    res.json(rows.map(renderMetadataObj));
+    `).all(...(req.user?.id ? [req.user.id] : []), ...genreIds, ...f.params);
+    res.json(enrichRowsWithGenres(d(), rows).map(renderMetadataObj));
   });
 
   // ── Album library browse ─────────────────────────────────────
@@ -161,12 +166,12 @@ export function setup(mstream) {
     const f = libraryFilter(req.user);
     const placeholders = artists.map(() => '?').join(',');
     const rows = d().prepare(`
-      ${trackQuery(req.user?.id)}
+      ${trackQuery(req.user?.id, { includeGenres: false })}
       WHERE a.name COLLATE NOCASE IN (${placeholders}) AND ${f.clause}
       ORDER BY RANDOM()
       LIMIT ?
     `).all(...(req.user?.id ? [req.user.id] : []), ...artists, ...f.params, limit);
-    res.json(rows.map(renderMetadataObj));
+    res.json(enrichRowsWithGenres(d(), rows).map(renderMetadataObj));
   });
 
   // ── Play logging ─────────────────────────────────────────────

--- a/test/integration/genre-agg-endpoints.test.mjs
+++ b/test/integration/genre-agg-endpoints.test.mjs
@@ -1,0 +1,217 @@
+/**
+ * Genre-enrichment parity tests for the endpoints converted off trackQuery's
+ * default whole-table tg_agg join (2026-07 perf audit, PR-D): the join
+ * materialised a GROUP_CONCAT over the ENTIRE track_genres table per request,
+ * so list/metadata endpoints scaled with the library instead of the response.
+ * They now run trackQuery({ includeGenres: false }) and batch-enrich just the
+ * returned rows (enrichRowsWithGenres / fetchGenresForTrack).
+ *
+ * These tests lock the BEHAVIOUR the conversion must preserve: every
+ * converted endpoint still emits identical metadata.genres content.
+ * Covered: /db/metadata (single pullMetaData), /db/genre-songs (incl. the
+ * name→id-first probe + NOCASE), /db/album-songs, /db/recent/added,
+ * /smart-playlists/run (genre FILTER join vs genre SELECT enrichment stay
+ * independent), and the velvet stubs /db/genre/songs + /db/decade/songs.
+ *
+ * Pattern mirrors test/integration/playlist-load.test.mjs: boot a real
+ * mStream in public/no-users mode, seed the DB directly, hit the HTTP API.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForReady(baseUrl, timeoutMs = 30_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(`${baseUrl}/api/`);
+      if (r.status < 500) return;
+    } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+
+async function bootMstream(tmpDir, musicDir) {
+  const port = await findFreePort();
+  const config = {
+    // ui:'velvet' so the velvet-gated modules (smart-playlists, velvet-stubs)
+    // mount too — the core /db routes are identical under either UI.
+    port, address: '127.0.0.1', ui: 'velvet',
+    dlna:     { mode: 'disabled' },
+    subsonic: { mode: 'disabled' },
+    folders:  { testlib: { root: musicDir } },
+    storage: {
+      albumArtDirectory:   path.join(tmpDir, 'image-cache'),
+      dbDirectory:         path.join(tmpDir, 'db'),
+      logsDirectory:       path.join(tmpDir, 'logs'),
+    },
+    scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+  };
+  for (const dir of Object.values(config.storage)) {
+    await fs.mkdir(dir, { recursive: true });
+  }
+  const configPath = path.join(tmpDir, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2));
+  const proc = spawn(
+    process.execPath,
+    ['cli-boot-wrapper.js', '-j', configPath],
+    { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } },
+  );
+  proc.stdout.on('data', () => {});
+  proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForReady(baseUrl);
+  return { proc, baseUrl, port };
+}
+
+async function killProc(proc) {
+  if (proc.exitCode != null || proc.signalCode != null) return;
+  proc.kill('SIGKILL');
+  await new Promise(r => proc.once('exit', r));
+}
+
+// Two tracks with distinct artist/album/year/genres — Song A carries TWO
+// genres so single- vs multi-genre aggregation is distinguishable.
+function seedDB(dbPath) {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA foreign_keys = ON');
+
+  const lib = db.prepare("SELECT id FROM libraries WHERE name = 'testlib'").get().id;
+  const aA = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist A')").run().lastInsertRowid);
+  const aB = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist B')").run().lastInsertRowid);
+  const alA = Number(db.prepare("INSERT INTO albums (name, artist_id, year) VALUES ('Album A', ?, 2001)").run(aA).lastInsertRowid);
+  const alB = Number(db.prepare("INSERT INTO albums (name, artist_id, year) VALUES ('Album B', ?, 2002)").run(aB).lastInsertRowid);
+
+  const insT = db.prepare(`
+    INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, year, format,
+                        duration, file_hash, audio_hash, modified, scan_id)
+    VALUES (?, ?, ?, ?, ?, ?, 'flac', ?, ?, ?, ?, 'seed')
+  `);
+  const tA = Number(insT.run('a.flac', lib, 'Song A', aA, alA, 2001, 180, 'hA', 'aA', 1700000000001).lastInsertRowid);
+  const tB = Number(insT.run('b.flac', lib, 'Song B', aB, alB, 2002, 240, 'hB', 'aB', 1700000000002).lastInsertRowid);
+
+  const insG = db.prepare('INSERT INTO genres (name) VALUES (?)');
+  const gJazz = Number(insG.run('Jazz').lastInsertRowid);
+  const gFunk = Number(insG.run('Funk').lastInsertRowid);
+  const gRock = Number(insG.run('Rock').lastInsertRowid);
+  const insTG = db.prepare('INSERT INTO track_genres (track_id, genre_id) VALUES (?, ?)');
+  insTG.run(tA, gJazz); insTG.run(tA, gFunk);   // Song A: Jazz + Funk
+  insTG.run(tB, gRock);                          // Song B: Rock
+
+  db.close();
+}
+
+async function api(baseUrl, route, body) {
+  const r = await fetch(`${baseUrl}${route}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: r.status, body: r.status === 200 ? await r.json() : await r.text() };
+}
+
+const genresOf = (item) => [...(item.metadata?.genres ?? [])].sort();
+
+describe('genre aggregation parity across converted endpoints', () => {
+  let tmpDir;
+  let server;
+
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-genreagg-'));
+    const musicDir = path.join(tmpDir, 'music');
+    await fs.mkdir(musicDir, { recursive: true });
+    server = await bootMstream(tmpDir, musicDir);
+    await killProc(server.proc);
+    await sleep(200);
+    seedDB(path.join(tmpDir, 'db', 'mstream.db'));
+    server = await bootMstream(tmpDir, musicDir);
+  });
+
+  after(async () => {
+    if (server?.proc) await killProc(server.proc);
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('/db/metadata (single pullMetaData) carries full genres', async () => {
+    const r = await api(server.baseUrl, '/api/v1/db/metadata', { filepath: 'testlib/a.flac' });
+    assert.equal(r.status, 200);
+    assert.deepEqual(genresOf(r.body), ['Funk', 'Jazz']);
+  });
+
+  test('/db/genre-songs matches NOCASE via the id-first probe and returns only that genre', async () => {
+    const r = await api(server.baseUrl, '/api/v1/db/genre-songs', { genre: 'jazz' });   // lowercase on purpose
+    assert.equal(r.status, 200);
+    assert.equal(r.body.length, 1, 'only Song A is Jazz');
+    assert.equal(r.body[0].metadata.title, 'Song A');
+    assert.deepEqual(genresOf(r.body[0]), ['Funk', 'Jazz'], 'full genre list, not just the matched one');
+  });
+
+  test('/db/genre-songs with an unknown genre returns []', async () => {
+    const r = await api(server.baseUrl, '/api/v1/db/genre-songs', { genre: 'Polka' });
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.body, []);
+  });
+
+  test('/db/album-songs carries genres', async () => {
+    const r = await api(server.baseUrl, '/api/v1/db/album-songs', { album: 'Album B' });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.length, 1);
+    assert.deepEqual(genresOf(r.body[0]), ['Rock']);
+  });
+
+  test('/db/recent/added carries genres for every row', async () => {
+    const r = await api(server.baseUrl, '/api/v1/db/recent/added', { limit: 10 });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.length, 2);
+    const byTitle = Object.fromEntries(r.body.map((x) => [x.metadata.title, genresOf(x)]));
+    assert.deepEqual(byTitle, { 'Song A': ['Funk', 'Jazz'], 'Song B': ['Rock'] });
+  });
+
+  test('smart-playlists/run: genre FILTER join and genre SELECT enrichment stay independent', async () => {
+    // Filter on Jazz — the response row must still carry BOTH of Song A's
+    // genres (the filter join must not become the source of the genre list).
+    const r = await api(server.baseUrl, '/api/v1/smart-playlists/run',
+      { filters: { genres: ['Jazz'] }, sort: 'artist', limit: 10 });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.songs.length, 1);
+    assert.equal(r.body.songs[0].metadata.title, 'Song A');
+    assert.deepEqual(genresOf(r.body.songs[0]), ['Funk', 'Jazz']);
+  });
+
+  test('velvet stubs /db/genre/songs + /db/decade/songs carry genres', async () => {
+    const g = await api(server.baseUrl, '/api/v1/db/genre/songs', { genre: 'ROCK' });
+    assert.equal(g.status, 200);
+    assert.equal(g.body.length, 1);
+    assert.deepEqual(genresOf(g.body[0]), ['Rock']);
+
+    const d = await api(server.baseUrl, '/api/v1/db/decade/songs', { decade: 2000 });
+    assert.equal(d.status, 200);
+    assert.equal(d.body.length, 2);
+    for (const item of d.body) { assert.ok(genresOf(item).length > 0, 'decade rows keep genres'); }
+  });
+});


### PR DESCRIPTION
## What

Converts the final 8 call sites off `trackQuery`'s default genre join, whose `GROUP_CONCAT` materialises over the **entire** `track_genres` table per query — cost scaling with the library, not the response (audit findings H9/M11/M8). Rows are now fetched with `includeGenres:false` and genres are attached to *just the returned rows* via a new `enrichRowsWithGenres` helper (chunked at 500 ids + de-duped, mirroring `renderMetadataByIds`) or `fetchGenresForTrack` for single rows.

Converted: `pullMetaData` (single `/db/metadata`), `/db/genre-songs`, `/db/album-songs`, `/db/recent/added`, smart-playlists `runSmartQuery`, and the velvet stubs `decade/songs` + `genre/songs` + `songs-by-artists`. The two genre endpoints also resolve genre name → id(s) first (`COLLATE NOCASE`, all matching vocabulary rows) so the M2M probe drives `idx_track_genres_genre` instead of walking the whole table.

With zero default-callers left, **`trackQuery`'s `includeGenres` default flips to `false`** and the doc comment now steers new code to the enrichment helpers — the old default was a measured multi-second landmine for the next caller (review finding).

## Measured (25k-track fixture)

| Endpoint | Before | After |
|---|---|---|
| `pullMetaData` (per call) | 15.8 ms | **0.2 ms** |
| …the no-login 100-track shared-playlist page | ~seconds (audited ~7 s) | ~20 ms |
| `/db/genre-songs` (833-track genre) | 66 ms | 17 ms |
| `/db/album-songs` | 52 ms | 23 ms |
| `/db/recent/added` (limit 50) | 142 ms | 77 ms* |

\* residual is the unindexed `created_at` sort — separate follow-up, out of this migration-free PR.

## Review

Adversarial multi-agent review: **6 confirmed, 0 refuted** — headlined by a real major *in my own first cut*: the enrichment helper's unchunked `IN()` would have turned >32,766-row responses (≈16.4k with NOCASE genre twins) into `too many SQL variables` 500s where the old slow code returned 200s. All three review lenses found it independently; fixed with the 500-chunk + dedupe and validated clean at 33,001 rows (341 ms). Also confirmed: the velvet `genre/songs` `String()` coercion is a behavior change for non-string JSON bodies (wash-to-improvement — malformed input now gets `200 []` instead of a 500; aligns with `/db/genre-songs`; noted, not reverted). Residual nit for a future pass: velvet `/db/genre/albums` still raw-binds its genre param.

## Reviewer notes

- Response parity is pinned by a new 7-test suite (`genre-agg-endpoints.test.mjs`, boots under `ui:'velvet'` so the velvet-gated modules mount): full genre lists on every converted endpoint, NOCASE id-first probing, unknown-genre `[]`, and the smart-playlist case proving the genre *filter* join and genre *select* enrichment stay independent (filter by Jazz, response still carries Funk+Jazz).
- 141/141 across the 13 affected suites (incl. playlist-load, public-mode-privacy, search-route, random-route — the flipped default's biggest indirect consumer). Zero new lint (the one velvet-stubs error predates this change).
- Fixes audit findings H9, M11, and the probe half of M8 (M8's response-size/pagination half deliberately deferred — it changes the client contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
