### PR TITLE
fix(server-audio): seekable FLACs, volume persistence, and crash paths

### DIFF
--- a/rust-server-audio/Cargo.lock
+++ b/rust-server-audio/Cargo.lock
@@ -3,19 +3,10 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -25,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -52,24 +43,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +53,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -94,28 +76,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cc"
-version = "1.2.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
-dependencies = [
- "find-msvc-tools",
- "jobserver",
- "libc",
- "shlex",
-]
 
 [[package]]
 name = "cesu8"
@@ -124,42 +88,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "claxon"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "combine"
@@ -172,39 +121,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
-dependencies = [
- "bindgen",
+ "bitflags 2.11.0",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
@@ -213,11 +149,28 @@ dependencies = [
  "mach2",
  "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "windows",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -227,10 +180,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -254,10 +211,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
+name = "fastrand"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "futures-core"
@@ -285,33 +242,21 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
+ "rand_core",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "httpdate"
@@ -327,15 +272,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -355,7 +291,7 @@ dependencies = [
  "combine",
  "jni-sys 0.3.1",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -385,17 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom",
- "libc",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -417,31 +343,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lewton"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
-dependencies = [
- "byteorder",
- "ogg",
- "tinyvec",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
@@ -451,9 +362,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -465,23 +376,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -492,21 +397,21 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
+name = "num-bigint"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
- "memchr",
- "minimal-lexical",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -517,7 +422,27 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -527,6 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -548,39 +474,96 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "oboe"
-version = "0.6.1"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "jni",
- "ndk",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "oboe-sys"
-version = "0.6.1"
+name = "objc2-audio-toolbox"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
- "cc",
+ "bitflags 2.11.0",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
-name = "ogg"
-version = "0.8.0"
+name = "objc2-avf-audio"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
- "byteorder",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -630,68 +613,70 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "regex"
-version = "1.12.3"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+ "chacha20",
+ "getrandom",
+ "rand_core",
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.4.14"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "regex-syntax"
-version = "0.8.10"
+name = "rand_distr"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand",
+]
 
 [[package]]
 name = "rodio"
-version = "0.20.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
 dependencies = [
- "claxon",
  "cpal",
- "hound",
- "lewton",
+ "dasp_sample",
+ "num-rational",
+ "rand",
+ "rand_distr",
+ "rtrb",
  "symphonia",
+ "thiserror 2.0.19",
 ]
+
+[[package]]
+name = "rtrb"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
 name = "rust-server-audio"
 version = "0.1.0"
 dependencies = [
+ "fastrand",
  "rodio",
  "serde",
  "serde_json",
  "symphonia",
  "tiny_http",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustversion"
@@ -735,7 +720,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -750,12 +735,6 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -970,12 +949,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -986,7 +985,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1000,21 +1010,6 @@ dependencies = [
  "httpdate",
  "log",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
@@ -1063,15 +1058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,7 +1099,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1147,22 +1133,69 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1172,12 +1205,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1186,7 +1238,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1204,29 +1256,22 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1236,22 +1281,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1260,28 +1293,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1290,34 +1305,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1327,12 +1324,6 @@ checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zmij"

--- a/rust-server-audio/Cargo.toml
+++ b/rust-server-audio/Cargo.toml
@@ -8,11 +8,14 @@ name = "rust-server-audio"
 path = "src/main.rs"
 
 [dependencies]
-rodio = { version = "0.20", features = ["symphonia-all"] }
+# 0.22 for DecoderBuilder: 0.20's decoder hardcoded byte_len to None, which
+# left FLACs without a SEEKTABLE block unseekable (see play_current).
+rodio = { version = "0.22", features = ["symphonia-all"] }
 tiny_http = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 symphonia = { version = "0.5", features = ["all"] }
+fastrand = "2"
 
 [profile.release]
 strip = true

--- a/rust-server-audio/src/main.rs
+++ b/rust-server-audio/src/main.rs
@@ -4,7 +4,10 @@ use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink};
+// rodio 0.22 renamed Sink to Player; aliased back so the rest of this file
+// reads the same, and so it doesn't collide with the local Player struct.
+use rodio::mixer::Mixer;
+use rodio::{Decoder, DeviceSinkBuilder, MixerDeviceSink, Player as Sink};
 use serde::{Deserialize, Serialize};
 use symphonia::core::formats::FormatOptions;
 use symphonia::core::io::MediaSourceStream;
@@ -111,20 +114,25 @@ struct SharedState {
     stopped: bool,
     shuffle: bool,
     loop_mode: LoopMode,
+    /// Desired volume, kept here because a new sink is built for every track
+    /// and starts at full volume otherwise.
+    volume: f32,
 }
 
 struct Player {
-    _stream: OutputStream,
-    stream_handle: OutputStreamHandle,
+    // Field order matters for drop: the sinks inside `shared` must go before
+    // the device that owns the output stream.
     shared: Arc<Mutex<SharedState>>,
+    device: MixerDeviceSink,
 }
 
 impl Player {
-    fn new() -> Self {
-        let (stream, stream_handle) = OutputStream::try_default()
-            .expect("Failed to open audio output device");
-        let sink = Sink::try_new(&stream_handle)
-            .expect("Failed to create audio sink");
+    fn new() -> Result<Self, String> {
+        let mut device = DeviceSinkBuilder::open_default_sink()
+            .map_err(|e| format!("Failed to open audio output device: {}", e))?;
+        // We manage the lifetime; the default drop warning is just noise.
+        device.log_on_drop(false);
+        let sink = Sink::connect_new(device.mixer());
 
         let shared = Arc::new(Mutex::new(SharedState {
             sink,
@@ -135,13 +143,14 @@ impl Player {
             stopped: true,
             shuffle: false,
             loop_mode: LoopMode::None,
+            volume: 1.0,
         }));
 
-        Player { _stream: stream, stream_handle, shared }
+        Ok(Player { shared, device })
     }
 }
 
-fn play_current(state: &mut SharedState, stream_handle: &OutputStreamHandle) -> bool {
+fn play_current(state: &mut SharedState, mixer: &Mixer) -> bool {
     if state.queue_index >= state.queue.len() {
         return false;
     }
@@ -151,8 +160,16 @@ fn play_current(state: &mut SharedState, stream_handle: &OutputStreamHandle) -> 
         Ok(f) => f,
         Err(_) => return false,
     };
-    let reader = BufReader::new(file);
-    let source = match Decoder::new(reader) {
+    // Hand the decoder the file length. Symphonia needs it to binary-search
+    // for a seek point in files without a seek table — notably FLACs written
+    // without a SEEKTABLE block, which were previously unseekable because
+    // rodio's decoder reported byte_len as None.
+    let byte_len = file.metadata().ok().map(|m| m.len());
+    let mut builder = Decoder::builder().with_data(BufReader::new(file)).with_seekable(true);
+    if let Some(len) = byte_len {
+        builder = builder.with_byte_len(len);
+    }
+    let source = match builder.build() {
         Ok(s) => s,
         Err(_) => return false,
     };
@@ -160,7 +177,8 @@ fn play_current(state: &mut SharedState, stream_handle: &OutputStreamHandle) -> 
     let duration = get_file_duration(&path);
 
     state.sink.stop();
-    state.sink = Sink::try_new(stream_handle).expect("Failed to create audio sink");
+    state.sink = Sink::connect_new(mixer);
+    state.sink.set_volume(state.volume);
     state.sink.append(source);
     state.current_file = path;
     state.duration = duration;
@@ -168,30 +186,26 @@ fn play_current(state: &mut SharedState, stream_handle: &OutputStreamHandle) -> 
     true
 }
 
-/// Pick the next index based on shuffle/loop settings
-fn pick_next_index(state: &SharedState) -> Option<usize> {
+/// Pick the next index based on shuffle/loop settings.
+///
+/// `manual` marks a user-pressed skip. Those honour shuffle and loop-all, but
+/// are never held on the same track by loop-one — otherwise pressing next
+/// during loop-one replays the current track forever with no way out.
+fn pick_next_index(state: &SharedState, manual: bool) -> Option<usize> {
     if state.queue.is_empty() {
         return None;
     }
 
-    if state.loop_mode == LoopMode::One {
+    if !manual && state.loop_mode == LoopMode::One {
         return Some(state.queue_index);
     }
 
     if state.shuffle {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-        use std::time::SystemTime;
-        // Simple pseudo-random: hash the current time
-        let mut hasher = DefaultHasher::new();
-        SystemTime::now().hash(&mut hasher);
-        state.queue_index.hash(&mut hasher);
-        let rand = hasher.finish() as usize;
         if state.queue.len() <= 1 {
             return Some(0);
         }
         // Pick a different index than current
-        let offset = (rand % (state.queue.len() - 1)) + 1;
+        let offset = fastrand::usize(1..state.queue.len());
         return Some((state.queue_index + offset) % state.queue.len());
     }
 
@@ -272,7 +286,7 @@ fn ok_resp() -> Response<std::io::Cursor<Vec<u8>>> {
 type State = Arc<Mutex<SharedState>>;
 type Resp = Response<std::io::Cursor<Vec<u8>>>;
 
-fn handle_play(state: &State, sh: &OutputStreamHandle, body: &str) -> Resp {
+fn handle_play(state: &State, sh: &Mixer, body: &str) -> Resp {
     let req: PlayRequest = match serde_json::from_str(body) {
         Ok(r) => r,
         Err(e) => return error_response(&format!("Invalid JSON: {}", e)),
@@ -308,6 +322,12 @@ fn handle_seek(state: &State, body: &str) -> Resp {
         Ok(r) => r,
         Err(e) => return error_response(&format!("Invalid JSON: {}", e)),
     };
+    // Duration::from_secs_f64 panics on negative or non-finite input, and a
+    // panic while holding this mutex poisons it — every later request would
+    // then fail. Validate before converting.
+    if !req.position.is_finite() || req.position < 0.0 {
+        return error_response("Seek failed: position must be a non-negative number");
+    }
     let s = state.lock().unwrap();
     match s.sink.try_seek(Duration::from_secs_f64(req.position)) {
         Ok(_) => ok_resp(),
@@ -320,7 +340,10 @@ fn handle_volume(state: &State, body: &str) -> Resp {
         Ok(r) => r,
         Err(e) => return error_response(&format!("Invalid JSON: {}", e)),
     };
-    state.lock().unwrap().sink.set_volume(req.volume.clamp(0.0, 1.0));
+    let mut s = state.lock().unwrap();
+    let volume = req.volume.clamp(0.0, 1.0);
+    s.volume = volume;
+    s.sink.set_volume(volume);
     ok_resp()
 }
 
@@ -330,7 +353,10 @@ fn handle_status(state: &State) -> Resp {
     let is_paused = s.sink.is_paused();
 
     json_response(&StatusResponse {
-        playing: !is_empty && !is_paused,
+        // `stopped` is set synchronously by /stop, while sink.empty() only
+        // flips on the next audio callback — without it, /status reports
+        // playing:true for a few ms after a stop.
+        playing: !is_empty && !is_paused && !s.stopped,
         paused: is_paused,
         position: s.sink.get_pos().as_secs_f64(),
         duration: s.duration,
@@ -343,9 +369,9 @@ fn handle_status(state: &State) -> Resp {
     })
 }
 
-fn handle_next(state: &State, sh: &OutputStreamHandle) -> Resp {
+fn handle_next(state: &State, sh: &Mixer) -> Resp {
     let mut s = state.lock().unwrap();
-    match pick_next_index(&s) {
+    match pick_next_index(&s, true) {
         Some(idx) => {
             s.queue_index = idx;
             if play_current(&mut s, sh) { ok_resp() } else { error_response("Failed to play next track") }
@@ -354,7 +380,7 @@ fn handle_next(state: &State, sh: &OutputStreamHandle) -> Resp {
     }
 }
 
-fn handle_previous(state: &State, sh: &OutputStreamHandle) -> Resp {
+fn handle_previous(state: &State, sh: &Mixer) -> Resp {
     let mut s = state.lock().unwrap();
     if s.queue_index == 0 {
         if s.loop_mode == LoopMode::All && !s.queue.is_empty() {
@@ -387,7 +413,7 @@ fn handle_loop(state: &State) -> Resp {
 
 // ── Queue handlers ──────────────────────────────────────────────────────────
 
-fn handle_queue_add(state: &State, sh: &OutputStreamHandle, body: &str) -> Resp {
+fn handle_queue_add(state: &State, sh: &Mixer, body: &str) -> Resp {
     let req: PlayRequest = match serde_json::from_str(body) {
         Ok(r) => r,
         Err(e) => return error_response(&format!("Invalid JSON: {}", e)),
@@ -402,7 +428,7 @@ fn handle_queue_add(state: &State, sh: &OutputStreamHandle, body: &str) -> Resp 
     ok_resp()
 }
 
-fn handle_queue_add_many(state: &State, sh: &OutputStreamHandle, body: &str) -> Resp {
+fn handle_queue_add_many(state: &State, sh: &Mixer, body: &str) -> Resp {
     let req: AddManyRequest = match serde_json::from_str(body) {
         Ok(r) => r,
         Err(e) => return error_response(&format!("Invalid JSON: {}", e)),
@@ -417,7 +443,7 @@ fn handle_queue_add_many(state: &State, sh: &OutputStreamHandle, body: &str) -> 
     ok_resp()
 }
 
-fn handle_queue_play_index(state: &State, sh: &OutputStreamHandle, body: &str) -> Resp {
+fn handle_queue_play_index(state: &State, sh: &Mixer, body: &str) -> Resp {
     let req: IndexRequest = match serde_json::from_str(body) {
         Ok(r) => r,
         Err(e) => return error_response(&format!("Invalid JSON: {}", e)),
@@ -428,7 +454,7 @@ fn handle_queue_play_index(state: &State, sh: &OutputStreamHandle, body: &str) -
     if play_current(&mut s, sh) { ok_resp() } else { error_response("Failed to play track at index") }
 }
 
-fn handle_queue_remove(state: &State, sh: &OutputStreamHandle, body: &str) -> Resp {
+fn handle_queue_remove(state: &State, sh: &Mixer, body: &str) -> Resp {
     let req: IndexRequest = match serde_json::from_str(body) {
         Ok(r) => r,
         Err(e) => return error_response(&format!("Invalid JSON: {}", e)),
@@ -447,7 +473,11 @@ fn handle_queue_remove(state: &State, sh: &OutputStreamHandle, body: &str) -> Re
         s.queue_index -= 1;
     } else if req.index == s.queue_index {
         if s.queue_index >= s.queue.len() { s.queue_index = s.queue.len() - 1; }
-        play_current(&mut s, sh);
+        // Only resume if something was actually playing; removing a queue
+        // entry while stopped shouldn't start audio as a side effect.
+        if !s.stopped {
+            play_current(&mut s, sh);
+        }
     }
     ok_resp()
 }
@@ -473,28 +503,44 @@ fn handle_queue_get(state: &State) -> Resp {
 fn main() {
     let args: Vec<String> = env::args().collect();
     let mut port: u16 = 3333;
+    // Loopback by default: this API has no authentication, and it can play
+    // any local file path and report whether it exists. mStream only ever
+    // connects over 127.0.0.1. Pass --host 0.0.0.0 to restore the old
+    // listen-on-everything behaviour.
+    let mut host = String::from("127.0.0.1");
 
     let mut i = 1;
     while i < args.len() {
         if args[i] == "--port" && i + 1 < args.len() {
             port = args[i + 1].parse().unwrap_or(3333);
             i += 2;
+        } else if args[i] == "--host" && i + 1 < args.len() {
+            host = args[i + 1].clone();
+            i += 2;
         } else {
             i += 1;
         }
     }
 
-    let player = Player::new();
+    // A missing or busy audio device is a normal condition on a headless box;
+    // report it and exit instead of panicking with a backtrace.
+    let player = match Player::new() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    };
     let state = Arc::clone(&player.shared);
-    let stream_handle = player.stream_handle;
+    let mixer = player.device.mixer();
 
-    let addr = format!("0.0.0.0:{}", port);
+    let addr = format!("{}:{}", host, port);
     let server = Server::http(&addr).unwrap_or_else(|e| {
         eprintln!("Failed to start server on {}: {}", addr, e);
         std::process::exit(1);
     });
 
-    println!("rust-server-audio listening on http://0.0.0.0:{}", port);
+    println!("rust-server-audio listening on http://{}", addr);
 
     loop {
         // Auto-advance: check if sink emptied and advance to next track
@@ -503,10 +549,10 @@ fn main() {
             if s.sink.empty() && !s.stopped && !s.queue.is_empty() {
                 let mut attempts = 0;
                 loop {
-                    match pick_next_index(&s) {
+                    match pick_next_index(&s, false) {
                         Some(idx) => {
                             s.queue_index = idx;
-                            if play_current(&mut s, &stream_handle) {
+                            if play_current(&mut s, mixer) {
                                 break; // successfully started playing
                             }
                             // Failed to decode — try next track
@@ -542,22 +588,22 @@ fn main() {
         let body = read_body(&mut request);
 
         let response = match (method, path.as_str()) {
-            (Method::Post, "/play") => match body { Some(b) => handle_play(&state, &stream_handle, &b), None => error_response("Missing request body") },
+            (Method::Post, "/play") => match body { Some(b) => handle_play(&state, mixer, &b), None => error_response("Missing request body") },
             (Method::Post, "/pause")    => handle_pause(&state),
             (Method::Post, "/resume")   => handle_resume(&state),
             (Method::Post, "/stop")     => handle_stop(&state),
-            (Method::Post, "/next")     => handle_next(&state, &stream_handle),
-            (Method::Post, "/previous") => handle_previous(&state, &stream_handle),
+            (Method::Post, "/next")     => handle_next(&state, mixer),
+            (Method::Post, "/previous") => handle_previous(&state, mixer),
             (Method::Post, "/seek")     => match body { Some(b) => handle_seek(&state, &b), None => error_response("Missing request body") },
             (Method::Post, "/volume")   => match body { Some(b) => handle_volume(&state, &b), None => error_response("Missing request body") },
             (Method::Post, "/shuffle")  => match body { Some(b) => handle_shuffle(&state, &b), None => error_response("Missing request body") },
             (Method::Post, "/loop")     => handle_loop(&state),
             (Method::Get, "/status")    => handle_status(&state),
 
-            (Method::Post, "/queue/add")        => match body { Some(b) => handle_queue_add(&state, &stream_handle, &b), None => error_response("Missing request body") },
-            (Method::Post, "/queue/add-many")   => match body { Some(b) => handle_queue_add_many(&state, &stream_handle, &b), None => error_response("Missing request body") },
-            (Method::Post, "/queue/play-index") => match body { Some(b) => handle_queue_play_index(&state, &stream_handle, &b), None => error_response("Missing request body") },
-            (Method::Post, "/queue/remove")     => match body { Some(b) => handle_queue_remove(&state, &stream_handle, &b), None => error_response("Missing request body") },
+            (Method::Post, "/queue/add")        => match body { Some(b) => handle_queue_add(&state, mixer, &b), None => error_response("Missing request body") },
+            (Method::Post, "/queue/add-many")   => match body { Some(b) => handle_queue_add_many(&state, mixer, &b), None => error_response("Missing request body") },
+            (Method::Post, "/queue/play-index") => match body { Some(b) => handle_queue_play_index(&state, mixer, &b), None => error_response("Missing request body") },
+            (Method::Post, "/queue/remove")     => match body { Some(b) => handle_queue_remove(&state, mixer, &b), None => error_response("Missing request body") },
             (Method::Post, "/queue/clear")      => handle_queue_clear(&state),
             (Method::Get, "/queue")             => handle_queue_get(&state),
 

--- a/src/api/server-playback.js
+++ b/src/api/server-playback.js
@@ -236,13 +236,22 @@ export function resolveFilePath(filePath, user) {
   return info.fullPath;
 }
 
+// Is `child` the same path as `root`, or inside it? A plain startsWith isn't
+// enough: "C:\Music" is a prefix of "C:\MusicVideos\song.mp3" without
+// containing it, which produced vpaths like "music/../MusicVideos/song.mp3".
+export function isWithin(child, root) {
+  if (child === root) { return true; }
+  const withSep = root.endsWith(path.sep) ? root : root + path.sep;
+  return child.startsWith(withSep);
+}
+
 // Reverse: convert an absolute path back to a virtual path (e.g. "55/song.mp3")
 export function absoluteToVpath(absolutePath) {
   const normalized = path.normalize(absolutePath);
   const libraries = db.getAllLibraries();
   for (const lib of libraries) {
     const root = path.normalize(lib.root_path);
-    if (normalized.startsWith(root)) {
+    if (isWithin(normalized, root)) {
       const relative = path.relative(root, normalized);
       return lib.name + '/' + relative.replace(/\\/g, '/');
     }

--- a/test/unit/server-playback-vpath.test.mjs
+++ b/test/unit/server-playback-vpath.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * Tests for the containment check behind absoluteToVpath()
+ * (src/api/server-playback.js).
+ *
+ * absoluteToVpath maps an absolute path reported by the audio engine back to
+ * a library-relative vpath for the frontend. It used to decide "is this file
+ * in that library?" with a plain startsWith, which is true for sibling
+ * directories that merely share a prefix — a library at "/music" claimed
+ * "/music-videos/clip.mp3" and produced a vpath containing "..".
+ *
+ * isWithin is exported purely so this boundary can be tested without
+ * standing up a database.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+
+import { isWithin } from '../../src/api/server-playback.js';
+
+describe('isWithin', () => {
+  const join = (...parts) => parts.join(path.sep);
+
+  test('accepts a file inside the library', () => {
+    assert.equal(isWithin(join('C:', 'Music', 'song.mp3'), join('C:', 'Music')), true);
+    assert.equal(
+      isWithin(join('C:', 'Music', 'Artist', 'Album', 'song.mp3'), join('C:', 'Music')),
+      true,
+    );
+  });
+
+  test('accepts the library root itself', () => {
+    assert.equal(isWithin(join('C:', 'Music'), join('C:', 'Music')), true);
+  });
+
+  test('rejects a sibling directory that shares a prefix', () => {
+    // The regression: "C:\Music" is a string prefix of "C:\MusicVideos".
+    assert.equal(isWithin(join('C:', 'MusicVideos', 'clip.mp3'), join('C:', 'Music')), false);
+    assert.equal(isWithin(join('C:', 'Music2', 'song.mp3'), join('C:', 'Music')), false);
+  });
+
+  test('rejects an unrelated path', () => {
+    assert.equal(isWithin(join('D:', 'Other', 'song.mp3'), join('C:', 'Music')), false);
+  });
+
+  test('tolerates a library root stored with a trailing separator', () => {
+    assert.equal(isWithin(join('C:', 'Music', 'song.mp3'), join('C:', 'Music') + path.sep), true);
+    assert.equal(isWithin(join('C:', 'MusicVideos', 'clip.mp3'), join('C:', 'Music') + path.sep), false);
+  });
+});


### PR DESCRIPTION
Eight fixes to `rust-server-audio` and one on the Node side, found while writing a terminal client against the server-audio control API. Every one was reproduced against the running binary before and after.

## The headline: FLACs weren't seekable

Seeking inside a FLAC that has no `SEEKTABLE` block failed with `SeekError(Unseekable)`. rodio 0.20's decoder reports `byte_len` as `None`, and symphonia needs the file length to binary-search for a seek point when there's no seek table — which is exactly what ffmpeg produces by default. Plenty of real libraries are full of these.

The fix is rodio 0.22 plus building the decoder through `DecoderBuilder` with the length from file metadata. That upgrade is why the diff is larger than the bug: 0.22 renames `Sink` to `Player` and replaces `OutputStream`/`OutputStreamHandle` with `DeviceSinkBuilder`/`Mixer`. I aliased `Player as Sink` on import so the body of the file still reads the way it did.

## Also fixed

| | |
|---|---|
| **Volume reset to 100% on every track change** | `play_current` builds a fresh sink per track and never re-applied the level. The desired volume now lives in `SharedState`. |
| **`POST /next` during loop-one was inescapable** | It replayed the same track forever. Manual skips now bypass loop-one; automatic advance still honours it. |
| **Missing audio device panicked at startup** | A normal condition on a headless box. It now prints the reason and exits 1. |
| **`POST /queue/remove` started playback while stopped** | Removing the current index resumed audio as a side effect. |
| **`POST /seek` with a negative position panicked** | `Duration::from_secs_f64` panics on negative/non-finite input, and panicking while holding the state mutex **poisoned it — every later request failed too**. Positions are validated first. |
| **`GET /status` was briefly wrong after `/stop`** | `sink.empty()` only flips on the next audio callback, so `playing` stayed true for a few ms. |
| **Shuffle hashed the system clock** | Biased and predictable; now `fastrand`. |
| **Bound `0.0.0.0` with no auth** | Any host on the network could drive playback and probe for local files by path (`/play` takes an absolute path and reports whether it opened). Now binds `127.0.0.1` — where mStream has always connected — with `--host 0.0.0.0` to restore the old behaviour. |

## Node side

`absoluteToVpath` decided library membership with a plain `startsWith`, so a library rooted at `C:\Music` claimed `C:\MusicVideos\clip.mp3` and returned a vpath containing `..`. Containment is now checked on a path-separator boundary, with a unit test covering the sibling-prefix case.

## Verification

- `cargo build --release` clean.
- Ran the built binary and exercised each fix over the control API: FLAC seek now lands at 40.0s (previously `Unseekable`); volume survives `/next`; a negative seek is rejected and the server stays responsive; `/status` reports stopped immediately; remove-while-stopped stays silent.
- `node --test "test/unit/*.test.mjs"` → 378 pass, 0 fail.

## Notes

- The bind-address change is the one behaviour change here. Anything connecting to this port from another machine would need `--host 0.0.0.0`; nothing in this repo does.
- Adding a shared-secret header to the control API would close the remaining gap for people who do expose it. Left out to keep this to fixes.
- `src/api/server-playback.js` has a pre-existing lint error (`no-empty`, the chmod `catch`) on master. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
