### PR TITLE
fix(boot): a broken console pipe must not kill an orphaned server

### DIFF
--- a/cli-boot-wrapper.js
+++ b/cli-boot-wrapper.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Must stay the first import: installs the stdout/stderr error guards before
+// any other module can write to the console (see src/util/stdio-guard.js).
+import './src/util/stdio-guard.js';
 import { join } from 'path';
 import { maybeRunWorker } from './src/util/worker-process.js';
 import { appRoot } from './src/util/esm-helpers.js';

--- a/cli-boot-wrapper.js
+++ b/cli-boot-wrapper.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-// Must stay the first import: installs the stdout/stderr error guards before
-// any other module can write to the console (see src/util/stdio-guard.js).
+// Must stay the first import: installs the stdout/stderr error guards (Bun
+// runtime only — see src/util/stdio-guard.js) before any other module can
+// write to the console.
 import './src/util/stdio-guard.js';
 import { join } from 'path';
 import { maybeRunWorker } from './src/util/worker-process.js';

--- a/src/logger.js
+++ b/src/logger.js
@@ -219,6 +219,18 @@ export function setBufferCapacity(n) {
   }
 }
 
+// Out-of-band breadcrumb from the stdio guard (src/util/stdio-guard.js): a
+// console write just failed, so this one event CANNOT be logged through
+// winston — the Console transport would write to the very stream that broke.
+// Push straight into the ring so the admin live-log viewer still records why
+// console output stopped. (The on-disk file transport is deliberately not
+// invoked: this path stays free of anything that could itself fail.)
+export function noteStreamFailure(streamName, code) {
+  pushEntry('warn',
+    `[stdio] ${streamName} write failed (${code || 'unknown error'}) — ` +
+    'console output is no longer being delivered; live/file logging continues');
+}
+
 // Read recent log entries for the admin live-log viewer. `sinceSeq` is the
 // highest seq the client has already seen; entries newer than it are returned
 // (oldest→newest) along with the current `lastSeq` cursor and the buffer

--- a/src/util/stdio-guard.js
+++ b/src/util/stdio-guard.js
@@ -1,0 +1,29 @@
+// Keep console breakage from killing the server.
+//
+// stdout/stderr are pipes whenever a supervisor spawned us — the desktop app,
+// Docker, npm, a service manager. If that parent dies without reaping us
+// (crash, force-kill, double-launch cleanup), the pipes lose their reader and
+// the next console write raises EPIPE. winston's Console transport writes to
+// process.stdout with no 'error' listener, so the runtime escalates that to an
+// uncaught exception: an orphaned-but-healthy server drops dead the moment it
+// logs anything — often mid-request, and observed in the field when a mere
+// ping or an admin call made an orphan log itself to death. Its crash report
+// goes down the same dead pipe, so nothing is ever captured. (logger.js's
+// `exitOnError: false` doesn't cover this: the error fires on the raw stream,
+// outside winston.)
+//
+// mStream is a daemon, not a shell filter — losing the console must never
+// take the server down. Swallow write errors on the two std streams; the
+// file and in-memory ring transports keep logging either way. Imported for
+// its side effect as the FIRST import of cli-boot-wrapper.js, so the guard is
+// installed before any other module can write (covers Bun self-dispatched
+// workers too, which re-enter the wrapper).
+
+function guard(stream) {
+  if (stream && typeof stream.on === 'function') {
+    stream.on('error', () => { /* see above — console loss is never fatal */ });
+  }
+}
+
+guard(process.stdout);
+guard(process.stderr);

--- a/src/util/stdio-guard.js
+++ b/src/util/stdio-guard.js
@@ -16,14 +16,39 @@
 // take the server down. Swallow write errors on the two std streams; the
 // file and in-memory ring transports keep logging either way. Imported for
 // its side effect as the FIRST import of cli-boot-wrapper.js, so the guard is
-// installed before any other module can write (covers Bun self-dispatched
-// workers too, which re-enter the wrapper).
+// installed before any other module can write.
 
-function guard(stream) {
-  if (stream && typeof stream.on === 'function') {
-    stream.on('error', () => { /* see above — console loss is never fatal */ });
-  }
+// One breadcrumb per process: the first failed write drops a note into the
+// live-log ring so the admin viewer records that console output stopped.
+let noted = false;
+
+function guard(stream, name) {
+  if (!stream || typeof stream.on !== 'function') { return; }
+  stream.on('error', err => {
+    // Console loss is never fatal (see header). The note is routed straight
+    // into the ring — NOT through winston, whose Console transport would
+    // write to the very stream that just broke. Lazy import keeps this
+    // module dependency-free at load time; by the time a write can fail,
+    // logger.js is long since cached.
+    if (noted) { return; }
+    noted = true;
+    import('../logger.js')
+      .then(l => l.noteStreamFailure(name, err && err.code))
+      .catch(() => { /* logging must never throw */ });
+  });
 }
 
-guard(process.stdout);
-guard(process.stderr);
+// Workers keep fail-fast stdio. A worker's stdout is not a console — it's the
+// line-protocol IPC channel to the server that spawned it, and that pipe's
+// read end can only die with the server itself. EPIPE there means "your
+// consumer is gone", and dying on it is the correct teardown (it also matches
+// Node-mode workers, which fork loose scripts and never load this module —
+// only Bun self-dispatched workers re-enter the wrapper). The flag literal
+// mirrors WORKER_FLAG_PREFIX in worker-process.js; kept inline because this
+// module must import nothing.
+const isWorker = process.argv.some(a => a.startsWith('--mstream-worker='));
+
+if (!isWorker) {
+  guard(process.stdout, 'stdout');
+  guard(process.stderr, 'stderr');
+}

--- a/src/util/stdio-guard.js
+++ b/src/util/stdio-guard.js
@@ -1,4 +1,4 @@
-// Keep console breakage from killing the server.
+// Keep console breakage from killing the server — Bun runtime only.
 //
 // stdout/stderr are pipes whenever a supervisor spawned us — the desktop app,
 // Docker, npm, a service manager. If that parent dies without reaping us
@@ -17,6 +17,19 @@
 // file and in-memory ring transports keep logging either way. Imported for
 // its side effect as the FIRST import of cli-boot-wrapper.js, so the guard is
 // installed before any other module can write.
+//
+// SCOPE — Bun only, by decision rather than necessity. The underlying bug is
+// runtime-agnostic (Node dies the exact same way; the regression test pins
+// that), but the shipped standalone binaries are Bun builds, and they are
+// what supervisors spawn and orphan — so the guard covers the packaged
+// distribution and leaves node/npm installs with Node's stock fail-fast
+// stdio semantics, unchanged from every released version. If the crash class
+// ever matters for Node deployments (e.g. systemd units whose journald
+// restarts), widening this gate is the one-line change. Detection is
+// process.versions.bun (any Bun, never Node) rather than esm-helpers'
+// isBunStandalone: this module must import nothing, and a runtime gate —
+// unlike a compiled-binary gate — is exercisable by tests without building
+// a binary first.
 
 // One breadcrumb per process: the first failed write drops a note into the
 // live-log ring so the admin viewer records that console output stopped.
@@ -38,17 +51,19 @@ function guard(stream, name) {
   });
 }
 
-// Workers keep fail-fast stdio. A worker's stdout is not a console — it's the
-// line-protocol IPC channel to the server that spawned it, and that pipe's
-// read end can only die with the server itself. EPIPE there means "your
-// consumer is gone", and dying on it is the correct teardown (it also matches
-// Node-mode workers, which fork loose scripts and never load this module —
-// only Bun self-dispatched workers re-enter the wrapper). The flag literal
-// mirrors WORKER_FLAG_PREFIX in worker-process.js; kept inline because this
-// module must import nothing.
+const isBunRuntime = typeof process.versions.bun === 'string';
+
+// Workers keep fail-fast stdio even under Bun. A worker's stdout is not a
+// console — it's the line-protocol IPC channel to the server that spawned it,
+// and that pipe's read end can only die with the server itself. EPIPE there
+// means "your consumer is gone", and dying on it is the correct teardown (it
+// also matches Node-mode workers, which fork loose scripts and never load
+// this module — only Bun self-dispatched workers re-enter the wrapper). The
+// flag literal mirrors WORKER_FLAG_PREFIX in worker-process.js; kept inline
+// because this module must import nothing.
 const isWorker = process.argv.some(a => a.startsWith('--mstream-worker='));
 
-if (!isWorker) {
+if (isBunRuntime && !isWorker) {
   guard(process.stdout, 'stdout');
   guard(process.stderr, 'stderr');
 }

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -337,5 +337,7 @@ export async function startServer(opts = {}) {
     ? `http://127.0.0.1:${sPort}`
     : baseUrl;
 
-  return { baseUrl, port, tmpDir, musicDir, subsonicBaseUrl, subsonicPort: sPort, stop };
+  // `proc` is the raw child handle, for tests that exercise process-level
+  // behavior (e.g. stdio-epipe-orphan.test.mjs destroys its pipe read ends).
+  return { baseUrl, port, tmpDir, musicDir, subsonicBaseUrl, subsonicPort: sPort, proc, stop };
 }

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -86,6 +86,9 @@ async function waitForScanComplete(baseUrl, timeoutMs = 90_000) {
  * @param {number} [opts.subsonicPort]             Port for Subsonic separate-port mode
  * @param {boolean} [opts.waitForScan=true]        Block until the initial scan finishes
  * @param {boolean} [opts.captureLogs=false]       Pipe stdout/stderr to the test process
+ * @param {string}  [opts.execPath]                Runtime to spawn the server with
+ *                                                 (default: this Node). The stdio-guard
+ *                                                 suite boots under `bun` with it.
  * @param {number}  [opts.rustPlayerPort]          Override config.rustPlayerPort so tests
  *                                                 can point the server-playback proxy
  *                                                 (and Subsonic jukeboxControl) at a stub.
@@ -103,6 +106,7 @@ export async function startServer(opts = {}) {
     rustPlayerPort,
     waitForScan   = true,
     captureLogs   = false,
+    execPath      = process.execPath,
     users         = [],
     // Additional library mounts beyond the default `testlib` fixtures.
     // Shape: { vpathName: '/absolute/dir', ... }. Each entry is added
@@ -221,7 +225,7 @@ export async function startServer(opts = {}) {
   }
 
   const proc = spawn(
-    process.execPath,
+    execPath,
     ['cli-boot-wrapper.js', '-j', configPath],
     {
       cwd: REPO_ROOT,

--- a/test/integration/stdio-epipe-orphan.test.mjs
+++ b/test/integration/stdio-epipe-orphan.test.mjs
@@ -1,14 +1,24 @@
 /**
- * An orphaned server must survive losing its console.
+ * stdio behavior when the console pipes lose their reader (dead parent).
  *
  * When the process that spawned mStream (desktop app, Docker, npm, a service
  * manager) dies without reaping it, the server's stdout/stderr pipes lose
- * their reader. The next console write then raises EPIPE — and winston's
+ * their reader and the next console write raises EPIPE — and winston's
  * Console transport writes to process.stdout with no 'error' listener, so an
- * unguarded server escalates that to an uncaught exception and drops dead the
- * moment it logs anything (observed in the field: a ping or admin call made a
- * healthy orphan log itself to death, with the crash report lost down the
- * same dead pipe). src/util/stdio-guard.js swallows those stream errors.
+ * unguarded server escalates that to an uncaught exception and drops dead
+ * (observed in the field: a ping or admin call made a healthy orphan log
+ * itself to death, with the crash report lost down the same dead pipe).
+ *
+ * The guard (src/util/stdio-guard.js) is deliberately Bun-only: the shipped
+ * standalone binaries are Bun builds, and they are what supervisors spawn
+ * and orphan; node/npm installs keep Node's stock fail-fast semantics. Both
+ * halves of that decision are pinned here:
+ *
+ *   - under Node, the server still DIES on its first post-breakage write —
+ *     the guard must not install (widen the gate deliberately, not by
+ *     accident, if that ever changes);
+ *   - under Bun, it survives and drops the [stdio] breadcrumb into the
+ *     live-log ring (skipped when bun isn't installed on this machine).
  *
  * The dead parent is simulated from this side of the pipes: destroying OUR
  * read ends is, from the child's perspective, exactly what a crashed
@@ -17,52 +27,82 @@
  * library needed.
  */
 
-import { describe, test, before, after } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { startServer } from '../helpers/server.mjs';
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
-describe('stdio EPIPE survival (orphaned server)', () => {
-  let server;
+const bunProbe = spawnSync('bun', ['--version'], { encoding: 'utf8' });
+const bunAvailable = !bunProbe.error && bunProbe.status === 0;
 
-  before(async () => {
-    server = await startServer({ dlnaMode: 'disabled', waitForScan: false });
-  });
+// Fire-and-forget a request that makes the server log (failed logins warn
+// unconditionally, even with zero users). The response is throttled ~800ms
+// and the server may die mid-request — only the write attempt matters.
+function triggerLogWrite(baseUrl) {
+  fetch(`${baseUrl}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'ghost', password: 'nope' }),
+  }).catch(() => { /* expected when the server dies underneath it */ });
+}
 
-  after(async () => { if (server) { await server.stop(); } });
-
-  test('keeps serving after its stdio pipes lose their reader', async () => {
+test('Node keeps stock fail-fast stdio (guard is Bun-only)', async () => {
+  const server = await startServer({ dlnaMode: 'disabled', waitForScan: false });
+  try {
     const { proc, baseUrl } = server;
-
     assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
 
-    // The dead parent: close the read ends of the child's stdio pipes.
+    const exited = new Promise(resolve => proc.once('exit', resolve));
     proc.stdout.destroy();
     proc.stderr.destroy();
+    triggerLogWrite(baseUrl);
 
-    // Trigger console writes. The 401 response is delayed ~800ms by the
-    // login throttle, so fire-and-forget; the winston.warn fires immediately
-    // on receipt. A few rounds with settle time give the async stream
-    // 'error' event every chance to surface (and kill an unguarded server).
-    for (let i = 0; i < 4; i++) {
-      fetch(`${baseUrl}/api/v1/auth/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: 'ghost', password: 'nope' }),
-      }).catch(() => { /* only the server's survival matters */ });
-      await sleep(250);
-    }
-
-    assert.equal(proc.exitCode, null,
-      'server process died after its stdio pipes broke');
-    assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
-
-    // The guard leaves one breadcrumb in the live-log ring so the admin
-    // viewer records why console output stopped (public mode → no token).
-    const logs = await (await fetch(`${baseUrl}/api/v1/admin/logs/recent?since=0`)).json();
-    assert.ok(
-      logs.entries.some(e => e.message.startsWith('[stdio] ') && e.message.includes('write failed')),
-      'expected a [stdio] breadcrumb in the live-log ring');
-  });
+    // Any post-breakage write (our trigger, or a background scan line) must
+    // take the unguarded server down promptly. The timer is cleared so a
+    // fast pass doesn't hold the test process open for the full window.
+    let timer;
+    const timeout = new Promise(r => { timer = setTimeout(() => r('timeout'), 8000); });
+    const code = await Promise.race([exited, timeout]);
+    clearTimeout(timer);
+    assert.notEqual(code, 'timeout',
+      'expected the Node server to die on EPIPE — stock semantics; is the guard installing under Node?');
+  } finally {
+    await server.stop();
+  }
 });
+
+test('Bun survives losing its console and leaves a breadcrumb',
+  { skip: bunAvailable ? false : 'bun is not installed on this machine' },
+  async () => {
+    const server = await startServer(
+      { dlnaMode: 'disabled', waitForScan: false, execPath: 'bun' });
+    try {
+      const { proc, baseUrl } = server;
+      assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
+
+      proc.stdout.destroy();
+      proc.stderr.destroy();
+
+      // A few rounds with settle time give the async stream 'error' event
+      // every chance to surface (and kill an unguarded server).
+      for (let i = 0; i < 4; i++) {
+        triggerLogWrite(baseUrl);
+        await sleep(250);
+      }
+
+      assert.equal(proc.exitCode, null,
+        'guarded Bun server died after its stdio pipes broke');
+      assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
+
+      // The guard leaves one breadcrumb in the live-log ring so the admin
+      // viewer records why console output stopped (public mode → no token).
+      const logs = await (await fetch(`${baseUrl}/api/v1/admin/logs/recent?since=0`)).json();
+      assert.ok(
+        logs.entries.some(e => e.message.startsWith('[stdio] ') && e.message.includes('write failed')),
+        'expected a [stdio] breadcrumb in the live-log ring');
+    } finally {
+      await server.stop();
+    }
+  });

--- a/test/integration/stdio-epipe-orphan.test.mjs
+++ b/test/integration/stdio-epipe-orphan.test.mjs
@@ -1,0 +1,61 @@
+/**
+ * An orphaned server must survive losing its console.
+ *
+ * When the process that spawned mStream (desktop app, Docker, npm, a service
+ * manager) dies without reaping it, the server's stdout/stderr pipes lose
+ * their reader. The next console write then raises EPIPE — and winston's
+ * Console transport writes to process.stdout with no 'error' listener, so an
+ * unguarded server escalates that to an uncaught exception and drops dead the
+ * moment it logs anything (observed in the field: a ping or admin call made a
+ * healthy orphan log itself to death, with the crash report lost down the
+ * same dead pipe). src/util/stdio-guard.js swallows those stream errors.
+ *
+ * The dead parent is simulated from this side of the pipes: destroying OUR
+ * read ends is, from the child's perspective, exactly what a crashed
+ * supervisor looks like. The log write is then triggered via a failed login,
+ * which winston.warn()s unconditionally (src/api/auth.js) — no auth or
+ * library needed.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { startServer } from '../helpers/server.mjs';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+describe('stdio EPIPE survival (orphaned server)', () => {
+  let server;
+
+  before(async () => {
+    server = await startServer({ dlnaMode: 'disabled', waitForScan: false });
+  });
+
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('keeps serving after its stdio pipes lose their reader', async () => {
+    const { proc, baseUrl } = server;
+
+    assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
+
+    // The dead parent: close the read ends of the child's stdio pipes.
+    proc.stdout.destroy();
+    proc.stderr.destroy();
+
+    // Trigger console writes. The 401 response is delayed ~800ms by the
+    // login throttle, so fire-and-forget; the winston.warn fires immediately
+    // on receipt. A few rounds with settle time give the async stream
+    // 'error' event every chance to surface (and kill an unguarded server).
+    for (let i = 0; i < 4; i++) {
+      fetch(`${baseUrl}/api/v1/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'ghost', password: 'nope' }),
+      }).catch(() => { /* only the server's survival matters */ });
+      await sleep(250);
+    }
+
+    assert.equal(proc.exitCode, null,
+      'server process died after its stdio pipes broke');
+    assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
+  });
+});

--- a/test/integration/stdio-epipe-orphan.test.mjs
+++ b/test/integration/stdio-epipe-orphan.test.mjs
@@ -57,5 +57,12 @@ describe('stdio EPIPE survival (orphaned server)', () => {
     assert.equal(proc.exitCode, null,
       'server process died after its stdio pipes broke');
     assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
+
+    // The guard leaves one breadcrumb in the live-log ring so the admin
+    // viewer records why console output stopped (public mode → no token).
+    const logs = await (await fetch(`${baseUrl}/api/v1/admin/logs/recent?since=0`)).json();
+    assert.ok(
+      logs.entries.some(e => e.message.startsWith('[stdio] ') && e.message.includes('write failed')),
+      'expected a [stdio] breadcrumb in the live-log ring');
   });
 });


### PR DESCRIPTION
## The bug

When the process that spawned mStream — the desktop app, Docker, npm, a service manager — dies without reaping it, the server keeps running but its stdout/stderr pipes lose their reader. The next console write raises **EPIPE**, and winston's Console transport writes to `process.stdout` with no `'error'` listener, so the runtime escalates it to an uncaught exception. A healthy orphan drops dead the moment it logs *anything*.

Observed in the field (macOS desktop-app smoke test, v6.19.2 standalone binary): an orphaned server answered pings normally until an admin `POST` made it log the request — it exited mid-probe, and its crash report went down the same dead pipe, so nothing was ever captured. The mstream_music client now recycles orphans instead of adopting them specifically to route around this; the server surviving is the real fix.

`exitOnError: false` in `logger.js` doesn't cover this: the error fires on the raw stream, outside winston. This PR extends that same existing policy — a logging failure must not kill the process — to the one channel outside winston's reach.

## The fix

`src/util/stdio-guard.js` — swallow `'error'` events on `process.stdout`/`process.stderr`, imported as the **first** import of `cli-boot-wrapper.js` so the guard is installed before any module can write (ESM import order guarantees this).

Scoping, refined in review:

- **Bun runtime only.** The shipped standalone binaries are Bun builds, and they are what supervisors spawn and orphan — the guard installs only when `process.versions.bun` is present, so **node/npm installs keep Node's stock fail-fast stdio semantics, unchanged from every released version**. This is a distribution-scoping decision, not a technical boundary: the underlying bug is runtime-agnostic (the regression test proves Node dies identically), and the gate is documented as deliberately widenable if the crash class ever matters for Node deployments (e.g. systemd units whose journald restarts). Detection is `process.versions.bun` rather than `isBunStandalone` because stdio-guard must import nothing, and a runtime gate is testable without compiling a binary.
- **Server only — workers keep fail-fast stdio.** A worker's stdout is not a console, it's the line-protocol IPC channel to the server that spawned it; that pipe's read end can only die with the server itself, so EPIPE there means "your consumer is gone" and dying is the correct teardown. The guard no-ops when argv carries `--mstream-worker=`, matching Node-mode workers (which fork loose scripts and never load it). Without this, an orphaned scanner/embedding worker would grind to completion as a zombie instead of exiting on its next protocol line.
- **One breadcrumb when it fires.** The first failed write pushes `[stdio] <stream> write failed (…) — console output is no longer being delivered` into the in-memory ring, so the admin live-log viewer records why console output stopped. Routed straight into the ring — not through winston, whose Console transport would write to the very stream that just broke.

mStream is a daemon, not a shell filter — losing the console must never take the (packaged) server down. The file and in-memory ring transports keep logging either way; normal console output is unaffected (the listener is inert until a write has already failed at the OS level).

## Verification

- **Regression test** (`test/integration/stdio-epipe-orphan.test.mjs`) pins both halves of the runtime gate, simulating the dead parent by destroying the test's read ends of the child's stdio pipes and triggering log writes via failed logins (`winston.warn` in `api/auth.js` fires unconditionally):
  - **Node leg** (always runs): the server must **die** on its first post-breakage write — stock semantics preserved, guard must not install. Verified: exits within ~0.5s.
  - **Bun leg** (`execPath: 'bun'`, skipped where bun isn't installed): the server must survive, keep answering ping, and the `[stdio]` breadcrumb must appear via `/api/v1/admin/logs/recent`.
- **Pre-gate evidence** the guard itself works (from the earlier revisions of this branch, where it was verified under Node before being scoped to Bun): unguarded server exits code 1 on first write; guarded server survived the same test plus a true-orphan repro (parent process actually dead) through 3 log-triggering requests.
- `npm run test:unit` — 373 pass. Integration slice through the modified helper (`notfound-codes`, `admin-access`, `random-route`) — 113 pass. ESLint clean.

Known limit: with the gate in place, **no automated job currently executes the guarded path** — the dev machine has no bun (Bun leg skips) and CI's build matrix compiles but doesn't run tests. Before a release leans on this, either run the Bun leg once on a machine with bun (`bun --version` present → `node --test test/integration/stdio-epipe-orphan.test.mjs`), or add a small CI test job — the workflow already installs bun for builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)