### PR TITLE
feat(boot): self-terminate on lost supervision (console loss + --supervised stdin watch)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,13 @@ jobs:
           node-version: 24
           cache: npm
 
+      # Bun runtime, for the supervision suite's bun legs — the shipped
+      # standalone binaries are Bun builds, so the lost-supervision behavior
+      # (test/integration/supervision-shutdown.test.mjs) is asserted on that
+      # runtime too. Those legs skip wherever bun is absent.
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       # ffmpeg sources differ per OS: version-pinned, checksum-verified static
       # builds fetched from GitHub-CDN mirrors on Linux (BtbN) and Windows
       # (gyan.dev); Homebrew on macOS (arm64 runner — handled separately

--- a/cli-boot-wrapper.js
+++ b/cli-boot-wrapper.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Must stay the first import: arms the console-loss watcher (see
+// src/util/supervision.js) before any other module can write.
+import { watchSupervisorStdin } from './src/util/supervision.js';
 import { join } from 'path';
 import { maybeRunWorker } from './src/util/worker-process.js';
 import { appRoot } from './src/util/esm-helpers.js';
@@ -18,7 +21,10 @@ if (await maybeRunWorker()) {
   // binary's own directory under a Bun standalone build (appRoot resolves both).
   // MSTREAM_CONFIG overrides the default; an explicit -j/--json overrides that.
   const defaultJson = process.env.MSTREAM_CONFIG || join(appRoot, 'save/conf/default.json');
-  const { json } = parseArgs(process.argv.slice(2), defaultJson);
+  const { json, supervised } = parseArgs(process.argv.slice(2), defaultJson);
+
+  // Armed before the banner so a supervisor that died mid-boot still stops us.
+  if (supervised) { watchSupervisorStdin(); }
 
   console.clear();
   console.log(`
@@ -40,6 +46,7 @@ if (await maybeRunWorker()) {
 
 function parseArgs(args, defaultJson) {
   let json = defaultJson;
+  let supervised = false;
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === '-V' || arg === '--version') {
@@ -52,8 +59,15 @@ function parseArgs(args, defaultJson) {
 Options:
   -V, --version        output the version number
   -j, --json <json>    Specify JSON Boot File (default: ${defaultJson})
+  --supervised         exit when the launching process closes stdin (for
+                       supervisors that run mStream as a managed child and
+                       hold its stdin pipe open)
   -h, --help           display help for command`);
       process.exit(0);
+    }
+    if (arg === '--supervised') {
+      supervised = true;
+      continue;
     }
     if (arg === '-j' || arg === '--json') {
       json = args[++i];
@@ -70,5 +84,5 @@ Options:
     console.error(`error: unknown option '${arg}'`);
     process.exit(1);
   }
-  return { json };
+  return { json, supervised };
 }

--- a/src/util/supervision.js
+++ b/src/util/supervision.js
@@ -1,0 +1,93 @@
+// The server must not outlive its supervision.
+//
+// When another process spawns mStream as a managed child (the desktop app, a
+// wrapper script), the server's stdout/stderr are pipes into that parent. If
+// the parent dies abruptly — crash, force-kill — nothing on Unix or Windows
+// cleans the child up: the server lives on as an orphan the supervisor no
+// longer knows about, holding the port the supervisor will try to reuse when
+// it relaunches. Today that orphan doesn't even fail cleanly: its first
+// console write after the parent's death raises EPIPE on the raw stream,
+// which no one listens for, so the runtime kills it with an uncaught
+// exception — at some arbitrary later moment, mid-request, with the crash
+// report lost down the same dead pipe. (logger.js's `exitOnError: false`
+// doesn't cover this: the error fires on the stream, outside winston.)
+//
+// An unowned server squatting the supervisor's port is a liability, not a
+// feature — so both mechanisms here resolve lost supervision the same way:
+// log the reason, then shut down cleanly. process.exit() fires the
+// kill-queue 'exit' hook (src/state/kill-list.js), which reaps the scanner /
+// backup / playback children, so this rides the same teardown path as a
+// signal-driven stop.
+//
+//  1. Console loss (always on): an 'error' on stdout/stderr — EPIPE from a
+//     dead reader is the canonical case — triggers shutdown with a distinct
+//     exit code instead of an uncaught crash. Lazy by nature: it only fires
+//     when the server next writes. Installed via this module's import side
+//     effect, which is why it must be the FIRST import of
+//     cli-boot-wrapper.js — armed before any other module can write.
+//  2. `--supervised` (opt-in): the server watches stdin and shuts down the
+//     moment it hits EOF — which is exactly what the spawning parent's death
+//     produces. Event-driven and immediate: no waiting for the next log
+//     line, no PID polling, portable everywhere. Supervisors that pass the
+//     flag MUST hold a live stdin pipe open; it is opt-in because a
+//     standalone daemonized server (`mstream < /dev/null`, nohup) sees EOF
+//     instantly and would self-terminate at boot.
+//
+// Workers are exempt from both: their stdout is the line-protocol IPC
+// channel to the server that spawned them, that pipe can only die with the
+// server itself, and their EPIPE crash-death is the existing, correct
+// teardown (Node-mode workers fork loose scripts and never load this module;
+// the argv check below keeps Bun self-dispatched workers — which re-enter
+// the wrapper — identical). The flag literal mirrors WORKER_FLAG_PREFIX in
+// worker-process.js; kept inline because this module must import nothing.
+
+// sysexits EX_IOERR. Deliberately nonzero: an uncaught EPIPE crash exits 1
+// today, and a supervisor configured to restart on failure (systemd
+// Restart=on-failure after a journald bounce broke the log stream) should
+// keep doing so — a restart is exactly what re-establishes logging.
+const EXIT_CONSOLE_LOST = 74;
+
+let shuttingDown = false;
+
+// Log why, give the file transport a beat to flush, then exit. The
+// winston.warn is safe even when the console is the thing that broke: the
+// stream watcher below is already attached, so the Console transport's
+// failing write surfaces as a guarded 'error' event, while the ring buffer
+// and file transports still record the entry. Dynamic import keeps this
+// module dependency-free at load time (and is a cached no-op by the time
+// anything can fail).
+function shutdown(reason, code) {
+  if (shuttingDown) { return; }
+  shuttingDown = true;
+  import('winston')
+    .then(w => (w.default || w).warn(reason))
+    .catch(() => { /* shutting down regardless */ })
+    .finally(() => {
+      setTimeout(() => process.exit(code), 400);
+    });
+}
+
+function watchStream(stream, name) {
+  if (!stream || typeof stream.on !== 'function') { return; }
+  stream.on('error', err => {
+    const cause = (err && err.code) || 'stream error';
+    shutdown(`[supervision] ${name} write failed (${cause}) — console lost, shutting down`,
+      EXIT_CONSOLE_LOST);
+  });
+}
+
+// `--supervised`: treat stdin EOF as "the supervisor is gone". Exit code 0 —
+// from the server's perspective this is an orderly, expected stop.
+export function watchSupervisorStdin() {
+  const done = () => shutdown('[supervision] supervisor closed stdin — shutting down', 0);
+  process.stdin.on('end', done);
+  process.stdin.on('error', done);
+  process.stdin.resume();
+}
+
+const isWorker = process.argv.some(a => a.startsWith('--mstream-worker='));
+
+if (!isWorker) {
+  watchStream(process.stdout, 'stdout');
+  watchStream(process.stderr, 'stderr');
+}

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -91,6 +91,9 @@ async function waitForScanComplete(baseUrl, timeoutMs = 90_000) {
  * @param {string}  [opts.stdin='ignore']          stdio mode for the child's stdin;
  *                                                 'pipe' lets a test hold it open and
  *                                                 close it (the supervision suite)
+ * @param {string}  [opts.execPath]                Runtime to spawn the server with
+ *                                                 (default: this Node). The supervision
+ *                                                 suite's bun legs pass 'bun'.
  * @param {number}  [opts.rustPlayerPort]          Override config.rustPlayerPort so tests
  *                                                 can point the server-playback proxy
  *                                                 (and Subsonic jukeboxControl) at a stub.
@@ -110,6 +113,7 @@ export async function startServer(opts = {}) {
     captureLogs   = false,
     extraArgs     = [],
     stdin         = 'ignore',
+    execPath      = process.execPath,
     users         = [],
     // Additional library mounts beyond the default `testlib` fixtures.
     // Shape: { vpathName: '/absolute/dir', ... }. Each entry is added
@@ -228,7 +232,7 @@ export async function startServer(opts = {}) {
   }
 
   const proc = spawn(
-    process.execPath,
+    execPath,
     ['cli-boot-wrapper.js', '-j', configPath, ...extraArgs],
     {
       cwd: REPO_ROOT,

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -86,6 +86,11 @@ async function waitForScanComplete(baseUrl, timeoutMs = 90_000) {
  * @param {number} [opts.subsonicPort]             Port for Subsonic separate-port mode
  * @param {boolean} [opts.waitForScan=true]        Block until the initial scan finishes
  * @param {boolean} [opts.captureLogs=false]       Pipe stdout/stderr to the test process
+ * @param {string[]} [opts.extraArgs]              Extra CLI args after `-j <config>`
+ *                                                 (e.g. ['--supervised'])
+ * @param {string}  [opts.stdin='ignore']          stdio mode for the child's stdin;
+ *                                                 'pipe' lets a test hold it open and
+ *                                                 close it (the supervision suite)
  * @param {number}  [opts.rustPlayerPort]          Override config.rustPlayerPort so tests
  *                                                 can point the server-playback proxy
  *                                                 (and Subsonic jukeboxControl) at a stub.
@@ -103,6 +108,8 @@ export async function startServer(opts = {}) {
     rustPlayerPort,
     waitForScan   = true,
     captureLogs   = false,
+    extraArgs     = [],
+    stdin         = 'ignore',
     users         = [],
     // Additional library mounts beyond the default `testlib` fixtures.
     // Shape: { vpathName: '/absolute/dir', ... }. Each entry is added
@@ -222,10 +229,10 @@ export async function startServer(opts = {}) {
 
   const proc = spawn(
     process.execPath,
-    ['cli-boot-wrapper.js', '-j', configPath],
+    ['cli-boot-wrapper.js', '-j', configPath, ...extraArgs],
     {
       cwd: REPO_ROOT,
-      stdio: captureLogs ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+      stdio: captureLogs ? 'inherit' : [stdin, 'pipe', 'pipe'],
       env: { ...process.env, NODE_ENV: 'test', MSTREAM_TEST_BAKED_SEEDS: '[]', ...env },
     },
   );
@@ -337,5 +344,7 @@ export async function startServer(opts = {}) {
     ? `http://127.0.0.1:${sPort}`
     : baseUrl;
 
-  return { baseUrl, port, tmpDir, musicDir, subsonicBaseUrl, subsonicPort: sPort, stop };
+  // `proc` is the raw child handle, for tests that exercise process-level
+  // behavior (the supervision suite destroys its pipes / closes its stdin).
+  return { baseUrl, port, tmpDir, musicDir, subsonicBaseUrl, subsonicPort: sPort, proc, stop };
 }

--- a/test/integration/supervision-shutdown.test.mjs
+++ b/test/integration/supervision-shutdown.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Lost supervision must end in a clean, logged self-termination.
+ *
+ * A supervisor that dies abruptly (desktop-app crash, force-kill) can't
+ * clean up its child — the server it spawned lives on as an orphan holding
+ * the supervisor's port, and its next console write EPIPE-crashes it at some
+ * arbitrary later moment with the crash report lost down the dead pipe.
+ * src/util/supervision.js turns both halves of that into deliberate
+ * shutdowns:
+ *
+ *   - console loss (always on): a stdout/stderr write error → log the
+ *     reason → exit 74 (sysexits EX_IOERR; distinct from the uncaught
+ *     crash's exit 1, and nonzero so restart-on-failure supervisors bring
+ *     the server back with fresh pipes);
+ *   - `--supervised` (opt-in): stdin EOF — what a dead parent's closed
+ *     pipe produces — → log → exit 0, immediately, no log write needed.
+ *
+ * The dead parent is simulated from this side of the pipes: destroying our
+ * read ends (or closing our stdin write end) is, from the child's
+ * perspective, exactly what a crashed supervisor looks like. Log writes are
+ * triggered via a failed login, which winston.warn()s unconditionally
+ * (src/api/auth.js) — no auth or library needed.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { startServer } from '../helpers/server.mjs';
+
+// Waits for the child to exit, capped so a server that wrongly survives
+// fails the test instead of hanging it. The timer is cleared on the fast
+// path so a passing run doesn't hold the test process open.
+function exitWithin(proc, ms) {
+  return new Promise(resolve => {
+    const timer = setTimeout(() => resolve('timeout'), ms);
+    proc.once('exit', code => { clearTimeout(timer); resolve(code); });
+  });
+}
+
+async function readLogFiles(tmpDir) {
+  const dir = path.join(tmpDir, 'logs');
+  let out = '';
+  for (const f of await fs.readdir(dir).catch(() => [])) {
+    out += await fs.readFile(path.join(dir, f), 'utf8').catch(() => '');
+  }
+  return out;
+}
+
+test('console loss → clean exit 74 with the reason on disk', async () => {
+  // stdin stays the default 'ignore' (/dev/null): this doubles as the pin
+  // that WITHOUT --supervised, an immediate stdin EOF must NOT shut the
+  // server down — it boots and serves normally.
+  const server = await startServer({
+    dlnaMode: 'disabled', waitForScan: false, extraConfig: { writeLogs: true },
+  });
+  try {
+    const { proc, baseUrl, tmpDir } = server;
+    assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
+
+    const exited = exitWithin(proc, 10_000);
+
+    // The dead parent: close the read ends of the child's stdio pipes,
+    // then make the server log (the response is throttled ~800ms and the
+    // server exits underneath it, so fire-and-forget).
+    proc.stdout.destroy();
+    proc.stderr.destroy();
+    fetch(`${baseUrl}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'ghost', password: 'nope' }),
+    }).catch(() => { /* expected */ });
+
+    const code = await exited;
+    assert.notEqual(code, 'timeout', 'server kept running after losing its console');
+    assert.equal(code, 74, 'expected the deliberate EX_IOERR exit, not an uncaught crash');
+
+    const logs = await readLogFiles(tmpDir);
+    assert.match(logs, /console lost, shutting down/,
+      'expected the shutdown reason in the on-disk log');
+  } finally {
+    await server.stop();
+  }
+});
+
+test('--supervised: stdin EOF → immediate clean exit 0', async () => {
+  const server = await startServer({
+    dlnaMode: 'disabled', waitForScan: false, extraConfig: { writeLogs: true },
+    extraArgs: ['--supervised'], stdin: 'pipe',
+  });
+  try {
+    const { proc, baseUrl, tmpDir } = server;
+    assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
+
+    const exited = exitWithin(proc, 10_000);
+    proc.stdin.end(); // the supervisor vanishes — no log write required
+
+    const code = await exited;
+    assert.notEqual(code, 'timeout', 'supervised server ignored stdin EOF');
+    assert.equal(code, 0, 'supervised shutdown is an orderly stop');
+
+    const logs = await readLogFiles(tmpDir);
+    assert.match(logs, /supervisor closed stdin/,
+      'expected the shutdown reason in the on-disk log');
+  } finally {
+    await server.stop();
+  }
+});

--- a/test/integration/supervision-shutdown.test.mjs
+++ b/test/integration/supervision-shutdown.test.mjs
@@ -15,6 +15,11 @@
  *   - `--supervised` (opt-in): stdin EOF — what a dead parent's closed
  *     pipe produces — → log → exit 0, immediately, no log write needed.
  *
+ * Both scenarios run twice: under this Node, and under `bun` (skipped where
+ * bun isn't installed) — the shipped standalone binaries are Bun builds, so
+ * the supervision contract must hold on that runtime too, not just the one
+ * the test harness happens to use.
+ *
  * The dead parent is simulated from this side of the pipes: destroying our
  * read ends (or closing our stdin write end) is, from the child's
  * perspective, exactly what a crashed supervisor looks like. Log writes are
@@ -24,9 +29,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { startServer } from '../helpers/server.mjs';
+
+const bunProbe = spawnSync('bun', ['--version'], { encoding: 'utf8' });
+const bunAvailable = !bunProbe.error && bunProbe.status === 0;
+const noBun = bunAvailable ? false : 'bun is not installed on this machine';
 
 // Waits for the child to exit, capped so a server that wrongly survives
 // fails the test instead of hanging it. The timer is cleared on the fast
@@ -47,24 +57,25 @@ async function readLogFiles(tmpDir) {
   return out;
 }
 
-test('console loss → clean exit 74 with the reason on disk', async () => {
+// Scenario 1: break the console pipes, make the server log, expect the
+// deliberate EX_IOERR exit with the reason on disk.
+async function consoleLossScenario(execPath) {
   // stdin stays the default 'ignore' (/dev/null): this doubles as the pin
   // that WITHOUT --supervised, an immediate stdin EOF must NOT shut the
   // server down — it boots and serves normally.
   const server = await startServer({
     dlnaMode: 'disabled', waitForScan: false, extraConfig: { writeLogs: true },
+    execPath,
   });
   try {
     const { proc, baseUrl, tmpDir } = server;
     assert.equal((await fetch(`${baseUrl}/api/v1/ping`)).status, 200);
 
     const exited = exitWithin(proc, 10_000);
-
-    // The dead parent: close the read ends of the child's stdio pipes,
-    // then make the server log (the response is throttled ~800ms and the
-    // server exits underneath it, so fire-and-forget).
     proc.stdout.destroy();
     proc.stderr.destroy();
+    // The 401 is throttled ~800ms and the server exits underneath the
+    // request, so fire-and-forget; only the server-side write matters.
     fetch(`${baseUrl}/api/v1/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -74,19 +85,18 @@ test('console loss → clean exit 74 with the reason on disk', async () => {
     const code = await exited;
     assert.notEqual(code, 'timeout', 'server kept running after losing its console');
     assert.equal(code, 74, 'expected the deliberate EX_IOERR exit, not an uncaught crash');
-
-    const logs = await readLogFiles(tmpDir);
-    assert.match(logs, /console lost, shutting down/,
+    assert.match(await readLogFiles(tmpDir), /console lost, shutting down/,
       'expected the shutdown reason in the on-disk log');
   } finally {
     await server.stop();
   }
-});
+}
 
-test('--supervised: stdin EOF → immediate clean exit 0', async () => {
+// Scenario 2: --supervised + stdin EOF → immediate orderly exit 0.
+async function supervisedScenario(execPath) {
   const server = await startServer({
     dlnaMode: 'disabled', waitForScan: false, extraConfig: { writeLogs: true },
-    extraArgs: ['--supervised'], stdin: 'pipe',
+    extraArgs: ['--supervised'], stdin: 'pipe', execPath,
   });
   try {
     const { proc, baseUrl, tmpDir } = server;
@@ -98,11 +108,21 @@ test('--supervised: stdin EOF → immediate clean exit 0', async () => {
     const code = await exited;
     assert.notEqual(code, 'timeout', 'supervised server ignored stdin EOF');
     assert.equal(code, 0, 'supervised shutdown is an orderly stop');
-
-    const logs = await readLogFiles(tmpDir);
-    assert.match(logs, /supervisor closed stdin/,
+    assert.match(await readLogFiles(tmpDir), /supervisor closed stdin/,
       'expected the shutdown reason in the on-disk log');
   } finally {
     await server.stop();
   }
-});
+}
+
+test('console loss → clean exit 74 with the reason on disk',
+  () => consoleLossScenario(undefined));
+
+test('--supervised: stdin EOF → immediate clean exit 0',
+  () => supervisedScenario(undefined));
+
+test('console loss under the Bun runtime', { skip: noBun },
+  () => consoleLossScenario('bun'));
+
+test('--supervised under the Bun runtime', { skip: noBun },
+  () => supervisedScenario('bun'));


### PR DESCRIPTION
Supersedes #799 with the opposite lifecycle philosophy: **the server must not outlive its supervision.**

## The problem

When a supervisor spawns mStream as a managed child (the desktop app, a wrapper script) and then dies abruptly — crash, force-kill — nothing on any OS cleans the child up. The server lives on as an orphan the supervisor no longer knows about, **holding the port the supervisor will try to reuse when it relaunches**. And today the orphan doesn't even fail cleanly: its first console write after the parent's death raises EPIPE on the raw stream (winston's Console transport attaches no `'error'` listener, and `exitOnError: false` can't reach stream-level errors), so the runtime kills it with an uncaught exception — at some arbitrary later moment, mid-request, exit code 1, with the crash report lost down the same dead pipe. Observed in the field on v6.19.2: an orphan answered pings fine until an admin call made it log, then died with zero forensics.

An unowned server squatting its supervisor's port is a liability, not a feature. Both mechanisms here resolve lost supervision the same way: **log the reason, then shut down cleanly.** `process.exit()` fires the kill-queue `'exit'` hook (`src/state/kill-list.js`), so the scanner/backup/playback children are reaped exactly like a signal-driven stop.

## Behavior

1. **Console loss — always on.** A write error on stdout/stderr (EPIPE from a dead reader is the canonical case) logs `[supervision] <stream> write failed (…) — console lost, shutting down` to the ring buffer and the on-disk log, then exits **74** (sysexits `EX_IOERR`). Deliberately nonzero and distinct from the crash's code 1: a supervisor configured to restart on failure (systemd after a journald bounce broke the log stream) keeps restarting — which is exactly what re-establishes logging. Armed as the **first import** of `cli-boot-wrapper.js`, before any module can write. Inherently lazy: it fires at the next log line, which in practice is quick (an orphan died from its own boot-tail chatter within ~1s in testing) but not instant for a silent idle server — hence:

2. **`--supervised` — opt-in.** The server watches stdin and exits **0** the moment it hits EOF, which is precisely what the spawning parent's death produces. Immediate, event-driven, no PID polling, portable to all three OSes. **Must stay opt-in**: a daemonized `mstream < /dev/null` or nohup'd server sees EOF instantly and would self-terminate at boot. Supervisors that pass the flag must hold a live stdin pipe open (the desktop app's `Process.start` already does).

**Unchanged:** standalone servers without the flag see exactly one difference — a broken console now produces a logged exit-74 instead of an unlogged crash-1; lifecycle outcome is the same on Node and Bun alike, so there's nothing to scope by runtime. Workers are exempt from both mechanisms (argv gate): their stdout is the line-protocol IPC channel to the server, and their existing EPIPE fail-fast death is the correct teardown.

## Follow-up (desktop app repo)

The app should pass `--supervised` when spawning the bundled server — version-gated, since `parseArgs` exits on unknown options for older binaries. With that in place, an app crash kills the server instantly instead of leaving a port-squatter for the recycle logic to clean up at next boot.

## Verification

- `test/integration/supervision-shutdown.test.mjs`:
  - console loss → exit **74** (not a crash's 1) + the shutdown reason present in the on-disk log; doubles as the pin that `/dev/null` stdin **without** the flag does *not* shut the server down.
  - `--supervised` + stdin EOF → immediate exit **0** + on-disk reason. No log write needed.
- End-to-end scenario (the motivating one): spawned a server from a driver that then died → the genuine orphan self-terminated within ~1s (its own boot-tail log line tripped console loss) → port free → **a fresh server booted on the same port and answered ping 200**.
- Regression: `test:unit` 373 pass; integration slice through the modified helper (`notfound-codes`, `admin-access`, `random-route`) 113 pass; ESLint clean; `-V`/help unaffected (help now documents `--supervised`).
- Helper additions are additive: exposes `proc`, `extraArgs`, and a `stdin` stdio mode for process-level suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)