### PR TITLE
fix(admin): stop sending a null auth header that shadows a valid session cookie

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -36,9 +36,9 @@ info:
     |------|---------|
     | 400  | Bad request (invalid input) |
     | 401  | Unauthenticated |
-    | 403  | Forbidden (Joi validation error, missing permission) |
+    | 403  | Forbidden (Joi validation error, missing permission, non-admin caller on an admin route, or admin request from outside the allowed network) |
     | 404  | Resource not found |
-    | 405  | Admin API locked |
+    | 405  | Admin API locked by configuration (adminAccess.mode = 'none') |
     | 500  | Server error |
     | 503  | External dependency unavailable (ffmpeg, rust audio server) |
 
@@ -893,7 +893,11 @@ components:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
     AdminLocked:
-      description: Admin API disabled (either by configuration or because the user is not an admin).
+      description: >-
+        Admin API disabled by configuration (adminAccess.mode = 'none', formerly
+        lockAdmin). A caller who is authenticated but simply lacks the admin role
+        gets 403 `Admin access required` instead — that case used to share this
+        405 and is no longer reported here.
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -40,10 +40,14 @@ import { getTransCodecs, getTransBitrates } from '../api/transcode.js';
 export function setup(mstream) {
   mstream.all('/api/v1/admin/{*path}', (req, res, next) => {
     if (config.program.lockAdmin === true) { return res.status(405).json({ error: 'Admin API Disabled' }); }
-    if (req.user.admin !== true) { return res.status(405).json({ error: 'Admin API Disabled' }); }
+    // A non-admin caller is authenticated fine — they just lack the role. That
+    // is 403, not 405, and it is NOT "Admin API Disabled": the API is up, this
+    // user simply isn't allowed. The old 405 + shared message made a role
+    // failure indistinguishable from the whole API being switched off.
+    if (req.user.admin !== true) { return res.status(403).json({ error: 'Admin access required' }); }
     // Application-level IP gate (adminAccess.mode = all|none|localhost|whitelist).
     // 'none' is already caught by the lockAdmin check above; localhost/whitelist
-    // are enforced here. Ordering: none-check(405) -> admin-role(405) -> network(403).
+    // are enforced here. Ordering: none-check(405) -> admin-role(403) -> network(403).
     if (!isAdminAllowed(req)) { return res.status(403).json({ error: 'Admin access restricted to local network' }); }
     next();
   });

--- a/src/server.js
+++ b/src/server.js
@@ -178,12 +178,26 @@ export async function serveIt(configFile) {
       return next();
     }
 
+    let decoded;
     try {
-      jwt.verify(req.cookies['x-access-token'], config.program.secret);
-      next();
+      decoded = jwt.verify(req.cookies['x-access-token'], config.program.secret);
     } catch (_err) {
       return res.redirect(302, '/login');
     }
+
+    // A valid token is NOT enough — verify the ROLE too. Every /api/v1/admin/*
+    // call the panel makes is gated on req.user.admin, so serving the panel to
+    // a non-admin handed them a shell in which every request fails. Send them
+    // to the player instead; bouncing to /login would be wrong (their session
+    // is fine) and would loop, since logging back in returns the same user.
+    const user = decoded.username ? dbManager.getUserByUsername(decoded.username) : null;
+    if (!user) { return res.redirect(302, '/login'); }
+    if (user.is_admin !== 1) {
+      winston.warn(`Non-admin user '${decoded.username}' from ${req.ip} requested the admin panel`);
+      return res.redirect(302, '/');
+    }
+
+    next();
   });
 
   // Gate the entire admin asset tree (index.html, index.js, index.css, …),

--- a/test/integration/admin-page-gate.test.mjs
+++ b/test/integration/admin-page-gate.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * Integration contract for the GET /admin PAGE gate (src/server.js).
+ *
+ * The gate used to check only that the session cookie carried a VALID jwt —
+ * not that the user held the admin role. Every /api/v1/admin/* call the panel
+ * makes is role-gated, so a logged-in non-admin was served the whole admin
+ * shell and then watched all ~25 of its requests get rejected. Four of the
+ * panel's loaders had no error branch, so their tabs (Directories, Users,
+ * Settings, Transcode) hung on a spinner forever.
+ *
+ * The gate now checks the role and bounces non-admins to the player. It must
+ * NOT bounce them to /login: their session is perfectly valid, and logging
+ * back in returns the same non-admin user — that would loop.
+ *
+ * Companion to the API-side role check, which answers 403 'Admin access
+ * required' (it answered 405 'Admin API Disabled' before, which was
+ * indistinguishable from the whole admin API being switched off).
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startServer } from '../helpers/server.mjs';
+
+const ADMIN = { username: 'admin', password: 'pw-admin' };
+const USER  = { username: 'bob',   password: 'pw-bob'   };
+
+let server;
+const jwts = {};
+const cookies = {};
+
+before(async () => {
+  server = await startServer({
+    dlnaMode: 'disabled',
+    waitForScan: false,
+    users: [
+      { ...ADMIN, admin: true },
+      { ...USER,  admin: false },
+    ],
+  });
+  for (const u of [ADMIN, USER]) {
+    const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(u),
+    });
+    jwts[u.username] = (await r.json()).token;
+    cookies[u.username] = r.headers.getSetCookie()
+      .find(c => c.startsWith('x-access-token='))
+      .split(';')[0];
+  }
+});
+
+after(async () => {
+  if (server) { await server.stop(); }
+});
+
+// The page gate reads the COOKIE (not the x-access-token header) — that is
+// what a browser navigating to /admin actually sends.
+function getAdminPage(cookie) {
+  return fetch(`${server.baseUrl}/admin`, {
+    headers: cookie ? { cookie } : {},
+    redirect: 'manual',
+  });
+}
+
+describe('GET /admin page gate — role', () => {
+  test('admin is served the panel', async () => {
+    // The gate calls next(); express.static then 301s /admin -> /admin/ to
+    // add the directory's trailing slash. Follow it and assert what the
+    // operator actually ends up looking at.
+    const r = await fetch(`${server.baseUrl}/admin`, {
+      headers: { cookie: cookies.admin },
+      redirect: 'follow',
+    });
+    assert.equal(r.status, 200);
+    assert.ok(r.url.endsWith('/admin/'), `expected to land on /admin/, got ${r.url}`);
+    const html = await r.text();
+    assert.ok(html.includes('<title>mStream Admin</title>'), 'expected the admin panel HTML');
+  });
+
+  test('non-admin is redirected to the player, NOT to /login', async () => {
+    const r = await getAdminPage(cookies.bob);
+    assert.equal(r.status, 302);
+    assert.equal(r.headers.get('location'), '/',
+      'a non-admin has a valid session — bouncing to /login would loop');
+  });
+
+  test('no cookie at all still redirects to /login', async () => {
+    const r = await getAdminPage(null);
+    assert.equal(r.status, 302);
+    assert.equal(r.headers.get('location'), '/login');
+  });
+
+  test('a garbage cookie redirects to /login', async () => {
+    const r = await getAdminPage('x-access-token=not-a-jwt');
+    assert.equal(r.status, 302);
+    assert.equal(r.headers.get('location'), '/login');
+  });
+});
+
+describe('admin API role check — status + body', () => {
+  test('non-admin gets 403 "Admin access required"', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/users`, {
+      headers: { 'x-access-token': jwts.bob },
+    });
+    assert.equal(r.status, 403);
+    assert.deepEqual(await r.json(), { error: 'Admin access required' });
+  });
+
+  test('the role rejection is distinguishable from the API being disabled', async () => {
+    // 'Admin API Disabled' is reserved for adminAccess.mode='none'
+    // (lockAdmin), which still answers 405. A role failure must not
+    // masquerade as the whole API being switched off.
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/users`, {
+      headers: { 'x-access-token': jwts.bob },
+    });
+    const body = await r.json();
+    assert.notEqual(r.status, 405);
+    assert.notEqual(body.error, 'Admin API Disabled');
+  });
+
+  test('admin still gets through', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/users`, {
+      headers: { 'x-access-token': jwts.admin },
+    });
+    assert.equal(r.status, 200);
+  });
+});

--- a/test/integration/admin-scan-params.test.mjs
+++ b/test/integration/admin-scan-params.test.mjs
@@ -80,9 +80,9 @@ describe('GET /api/v1/admin/db/params', () => {
     assert.equal(typeof body.skipImg, 'boolean');
   });
 
-  test('rejects non-admin users with 405 (outer admin guard)', async () => {
+  test('rejects non-admin users with 403 (outer admin guard)', async () => {
     const r = await adminGet('/api/v1/admin/db/params', userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });
 
@@ -133,17 +133,17 @@ describe('POST /api/v1/admin/db/params/analyze-bpm', () => {
     assert.equal(r.status, 400);
   });
 
-  test('rejects non-admin users with 405', async () => {
+  test('rejects non-admin users with 403', async () => {
     const r = await adminPost('/api/v1/admin/db/params/analyze-bpm',
       { analyzeBpm: true }, userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });
 
 // ── POST /db/params/analyze-bpm-per-run ───────────────────────────────────
 
 describe('POST /api/v1/admin/db/params/analyze-bpm-per-run', () => {
-  test('sets analyzeBpmPerRun + reflects; rejects out-of-range; 405 non-admin', async () => {
+  test('sets analyzeBpmPerRun + reflects; rejects out-of-range; 403 non-admin', async () => {
     const r1 = await adminPost('/api/v1/admin/db/params/analyze-bpm-per-run',
       { analyzeBpmPerRun: 75 });
     assert.equal(r1.status, 200);
@@ -159,14 +159,14 @@ describe('POST /api/v1/admin/db/params/analyze-bpm-per-run', () => {
       assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/analyze-bpm-per-run',
-      { analyzeBpmPerRun: 50 }, userJwt)).status, 405);
+      { analyzeBpmPerRun: 50 }, userJwt)).status, 403);
   });
 });
 
 // ── POST /db/params/analyze-bpm-method ────────────────────────────────────
 
 describe('POST /api/v1/admin/db/params/analyze-bpm-method', () => {
-  test('sets method + reflects; rejects junk; 405 non-admin', async () => {
+  test('sets method + reflects; rejects junk; 403 non-admin', async () => {
     const r1 = await adminPost('/api/v1/admin/db/params/analyze-bpm-method',
       { analyzeBpmMethod: 'degara' });
     assert.equal(r1.status, 200);
@@ -184,14 +184,14 @@ describe('POST /api/v1/admin/db/params/analyze-bpm-method', () => {
       assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/analyze-bpm-method',
-      { analyzeBpmMethod: 'degara' }, userJwt)).status, 405);
+      { analyzeBpmMethod: 'degara' }, userJwt)).status, 403);
   });
 });
 
 // ── POST /db/params/analyze-bpm-window-sec ────────────────────────────────
 
 describe('POST /api/v1/admin/db/params/analyze-bpm-window-sec', () => {
-  test('sets window (incl. 0) + reflects; rejects 1–29 / out-of-range; 405 non-admin', async () => {
+  test('sets window (incl. 0) + reflects; rejects 1–29 / out-of-range; 403 non-admin', async () => {
     const r1 = await adminPost('/api/v1/admin/db/params/analyze-bpm-window-sec',
       { analyzeBpmWindowSec: 120 });
     assert.equal(r1.status, 200);
@@ -213,14 +213,14 @@ describe('POST /api/v1/admin/db/params/analyze-bpm-window-sec', () => {
       assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/analyze-bpm-window-sec',
-      { analyzeBpmWindowSec: 60 }, userJwt)).status, 405);
+      { analyzeBpmWindowSec: 60 }, userJwt)).status, 403);
   });
 });
 
 // ── POST /db/params/ignore-dot-* (dot-entry ignore toggles) ───────────────
 //
 // Same four-part pattern as analyze-bpm: GET defaults, happy-path flip +
-// reflect, Joi boundary rejections (400), non-admin 405. No side effects:
+// reflect, Joi boundary rejections (400), non-admin 403. No side effects:
 // the toggles only change what FUTURE scans index (no enqueue on flip).
 
 describe('dot-entry ignore params', () => {
@@ -234,7 +234,7 @@ describe('dot-entry ignore params', () => {
     ['ignore-dot-files', 'ignoreDotFiles'],
     ['ignore-dot-folders', 'ignoreDotFolders'],
   ]) {
-    test(`${route}: flips + reflects; rejects junk; 405 non-admin`, async () => {
+    test(`${route}: flips + reflects; rejects junk; 403 non-admin`, async () => {
       const r1 = await adminPost(`/api/v1/admin/db/params/${route}`, { [field]: true });
       assert.equal(r1.status, 200);
       assert.deepEqual(await r1.json(), {}, 'happy-path response is the empty object {}');
@@ -249,7 +249,7 @@ describe('dot-entry ignore params', () => {
         assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
       }
       assert.equal((await adminPost(`/api/v1/admin/db/params/${route}`,
-        { [field]: true }, userJwt)).status, 405);
+        { [field]: true }, userJwt)).status, 403);
     });
   }
 });
@@ -268,7 +268,7 @@ describe('filesystem watcher params', () => {
     assert.equal(body.watcherWait, 10);
   });
 
-  test('watcher-enabled: flips + reflects; rejects junk; 405 non-admin', async () => {
+  test('watcher-enabled: flips + reflects; rejects junk; 403 non-admin', async () => {
     const r1 = await adminPost('/api/v1/admin/db/params/watcher-enabled',
       { watcherEnabled: true });
     assert.equal(r1.status, 200);
@@ -284,14 +284,14 @@ describe('filesystem watcher params', () => {
       assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/watcher-enabled',
-      { watcherEnabled: true }, userJwt)).status, 405);
+      { watcherEnabled: true }, userJwt)).status, 403);
   });
 });
 
 // ── POST /db/params/auto-album-art-* (the downloader's config family) ──────
 //
 // Same four-part pattern as analyze-bpm above: GET defaults, happy-path
-// flip + reflect, Joi boundary rejections (400), non-admin 405. All
+// flip + reflect, Joi boundary rejections (400), non-admin 403. All
 // side-effect-free against the fixtures: the helper boots with
 // autoAlbumArt:false, so no flip here can enqueue a download pass.
 
@@ -303,7 +303,7 @@ describe('downloader config params', () => {
     assert.equal(body.autoAlbumArtPerRun, 100);
   });
 
-  test('auto-album-art-mode: flips + reflects; rejects junk; 405 non-admin', async () => {
+  test('auto-album-art-mode: flips + reflects; rejects junk; 403 non-admin', async () => {
     const r1 = await adminPost('/api/v1/admin/db/params/auto-album-art-mode',
       { autoAlbumArtMode: 'all' });
     assert.equal(r1.status, 200);
@@ -315,10 +315,10 @@ describe('downloader config params', () => {
       assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/auto-album-art-mode',
-      { autoAlbumArtMode: 'all' }, userJwt)).status, 405);
+      { autoAlbumArtMode: 'all' }, userJwt)).status, 403);
   });
 
-  test('auto-album-art-write-to-folder: flips + reflects; rejects junk; 405 non-admin', async () => {
+  test('auto-album-art-write-to-folder: flips + reflects; rejects junk; 403 non-admin', async () => {
     const r1 = await adminPost('/api/v1/admin/db/params/auto-album-art-write-to-folder',
       { autoAlbumArtWriteToFolder: true });
     assert.equal(r1.status, 200);
@@ -331,10 +331,10 @@ describe('downloader config params', () => {
       assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/auto-album-art-write-to-folder',
-      { autoAlbumArtWriteToFolder: true }, userJwt)).status, 405);
+      { autoAlbumArtWriteToFolder: true }, userJwt)).status, 403);
   });
 
-  test('auto-album-art-per-run: sets + reflects; rejects out-of-range; 405 non-admin', async () => {
+  test('auto-album-art-per-run: sets + reflects; rejects out-of-range; 403 non-admin', async () => {
     const r1 = await adminPost('/api/v1/admin/db/params/auto-album-art-per-run',
       { autoAlbumArtPerRun: 250 });
     assert.equal(r1.status, 200);
@@ -347,7 +347,7 @@ describe('downloader config params', () => {
       assert.equal(r.status, 400, `expected rejection for ${JSON.stringify(bad)}`);
     }
     assert.equal((await adminPost('/api/v1/admin/db/params/auto-album-art-per-run',
-      { autoAlbumArtPerRun: 50 }, userJwt)).status, 405);
+      { autoAlbumArtPerRun: 50 }, userJwt)).status, 403);
   });
 
   test('auto-album-art toggle ON routes through the guarded enqueue (no crash, empty 200)', async () => {
@@ -434,8 +434,8 @@ describe('POST /api/v1/admin/config/trust-proxy', () => {
     }
   });
 
-  test('rejects non-admin users with 405', async () => {
+  test('rejects non-admin users with 403', async () => {
     const r = await adminPost('/api/v1/admin/config/trust-proxy', { trustProxy: true }, userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });

--- a/test/integration/admin-users-lastfm.test.mjs
+++ b/test/integration/admin-users-lastfm.test.mjs
@@ -114,11 +114,11 @@ describe('POST /api/v1/admin/users/lastfm', () => {
     }
   });
 
-  test('rejects non-admin callers with 405 (outer admin guard)', async () => {
+  test('rejects non-admin callers with 403 (outer admin guard)', async () => {
     const r = await post('/api/v1/admin/users/lastfm', {
       username: 'bob', lastfmUser: 'bob-fm', lastfmPassword: 'hunter2',
     }, userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 
   test('unknown target user surfaces the helper\'s thrown error (500)', async () => {

--- a/test/subsonic/admin-subsonic-ui.test.mjs
+++ b/test/subsonic/admin-subsonic-ui.test.mjs
@@ -114,7 +114,7 @@ describe('GET /api/v1/admin/subsonic/stats', () => {
 
   test('admin-only', async () => {
     const r = await adminGet('/api/v1/admin/subsonic/stats', userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });
 
@@ -135,7 +135,7 @@ describe('GET /api/v1/admin/subsonic/test', () => {
 
   test('admin-only', async () => {
     const r = await adminGet('/api/v1/admin/subsonic/test', userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });
 
@@ -154,7 +154,7 @@ describe('GET /api/v1/admin/subsonic/jukebox', () => {
 
   test('admin-only', async () => {
     const r = await adminGet('/api/v1/admin/subsonic/jukebox', userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });
 
@@ -196,7 +196,7 @@ describe('token-auth-attempts endpoint', () => {
 
   test('admin-only', async () => {
     const r = await adminGet('/api/v1/admin/subsonic/token-auth-attempts', userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });
 
@@ -232,6 +232,6 @@ describe('POST /api/v1/admin/subsonic/mint-key', () => {
   test('admin-only', async () => {
     const r = await adminPost('/api/v1/admin/subsonic/mint-key',
       { username: ADMIN.username, name: 'x' }, userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });

--- a/test/torrent/torrent-routes.test.mjs
+++ b/test/torrent/torrent-routes.test.mjs
@@ -85,17 +85,17 @@ function jdel(path, jwt) {
 // Admin guard — non-admins must NOT reach /api/v1/admin/* torrent routes
 // ────────────────────────────────────────────────────────────────────
 describe('admin guard on torrent admin routes', () => {
-  test('GET /admin/torrent: bob denied with 405 (Admin API Disabled)', async () => {
+  test('GET /admin/torrent: bob denied with 403 (Admin access required)', async () => {
     const r = await jget('/api/v1/admin/torrent', userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
-  test('PUT /admin/torrent/path-templates/testlib: bob denied with 405', async () => {
+  test('PUT /admin/torrent/path-templates/testlib: bob denied with 403', async () => {
     const r = await jput('/api/v1/admin/torrent/path-templates/testlib', { template: '{{ARTIST}}' }, userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
-  test('DELETE /admin/torrent/{hash}: bob denied with 405', async () => {
+  test('DELETE /admin/torrent/{hash}: bob denied with 403', async () => {
     const r = await jdel('/api/v1/admin/torrent/' + 'a'.repeat(40), userJwt);
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 });
 
@@ -234,7 +234,7 @@ describe('POST /api/v1/admin/torrent/seed-existing', () => {
     return Buffer.from(`d4:infod4:name${name.length}:${name}6:lengthi${length}eee`);
   }
 
-  test('admin-only: non-admin denied with 405', async () => {
+  test('admin-only: non-admin denied with 403', async () => {
     const fd = new FormData();
     fd.append('torrentFile', new Blob([makeTorrentBuf()]), 'x.torrent');
     const r = await fetch(`${server.baseUrl}/api/v1/admin/torrent/seed-existing`, {
@@ -242,7 +242,7 @@ describe('POST /api/v1/admin/torrent/seed-existing', () => {
       headers: { 'x-access-token': userJwt },
       body: fd,
     });
-    assert.equal(r.status, 405);
+    assert.equal(r.status, 403);
   });
 
   test('no active client: 412 no_active_client', async () => {
@@ -404,10 +404,14 @@ describe('POST /api/v1/torrent/seed-existing — user-facing', () => {
 
   test('non-admin gets through the admin guard (route exists for users)', async () => {
     // The big regression we're guarding against: an accidental
-    // /api/v1/admin/* mount that would 405 non-admins. Bob is a
+    // /api/v1/admin/* mount that would reject non-admins. Bob is a
     // non-admin; with no client configured, `_checkUserPermissions`
-    // short-circuits to `feature_disabled` — but the response is from
-    // OUR route, not the admin-guard 405.
+    // short-circuits to `feature_disabled` — but the response must come
+    // from OUR route, not the admin guard.
+    //
+    // The admin guard now answers 403 too (it used to be 405), so status
+    // alone no longer tells the two apart — assert on the BODY, which is
+    // the only thing that still distinguishes them.
     await jpost('/api/v1/admin/torrent/client', { client: 'disabled' }, adminJwt);
     const fd = new FormData();
     fd.append('torrentFile', new Blob([makeTorrentBuf()]), 'x.torrent');
@@ -416,9 +420,10 @@ describe('POST /api/v1/torrent/seed-existing — user-facing', () => {
       headers: { 'x-access-token': userJwt },
       body: fd,
     });
-    assert.notEqual(r.status, 405, 'must not be admin-guarded');
     assert.equal(r.status, 403);
     const body = await r.json();
+    assert.notEqual(body.error, 'Admin access required', 'must not be admin-guarded');
+    assert.notEqual(body.error, 'Admin API Disabled', 'must not be admin-guarded');
     assert.equal(body.ok, false);
     assert.equal(body.error, 'feature_disabled');
   });
@@ -448,6 +453,9 @@ describe('POST /api/v1/torrent/seed-existing — user-facing', () => {
     assert.notEqual(r.status, 404);
     assert.notEqual(r.status, 405);
     const body = await r.json().catch(() => ({}));
+    // Body check, not status: the admin guard answers 403 now, so a
+    // status assertion can no longer prove this wasn't admin-guarded.
+    assert.notEqual(body.error, 'Admin access required', 'must not be admin-guarded');
     assert.equal(body.ok, false);
   });
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -158,29 +158,39 @@ const ADMINDATA = (() => {
     }
   };
 
+  // The `.ts` stamp is what the view's spinner gates on, so it has to land
+  // even when the request fails — otherwise a failed load is indistinguishable
+  // from a slow one and the spinner runs forever. Same idiom as getDlnaParams
+  // and friends below.
   module.getFolders = async () => {
-    const res = await API.axios({
-      method: 'GET',
-      url: `${API.url()}/api/v1/admin/directories`
-    });
+    try {
+      const res = await API.axios({
+        method: 'GET',
+        url: `${API.url()}/api/v1/admin/directories`
+      });
 
-    Object.keys(res.data).forEach(key=>{
-      module.folders[key] = res.data[key];
-    });
-
+      Object.keys(res.data).forEach(key=>{
+        module.folders[key] = res.data[key];
+      });
+    } catch (err) {
+      console.error('failed to load directories', err);
+    }
     module.foldersUpdated.ts = Date.now();
   };
 
   module.getUsers = async () => {
-    const res = await API.axios({
-      method: 'GET',
-      url: `${API.url()}/api/v1/admin/users`
-    });
+    try {
+      const res = await API.axios({
+        method: 'GET',
+        url: `${API.url()}/api/v1/admin/users`
+      });
 
-    Object.keys(res.data).forEach(key=>{
-      module.users[key] = res.data[key];
-    });
-
+      Object.keys(res.data).forEach(key=>{
+        module.users[key] = res.data[key];
+      });
+    } catch (err) {
+      console.error('failed to load users', err);
+    }
     module.usersUpdated.ts = Date.now();
   };
 
@@ -211,15 +221,18 @@ const ADMINDATA = (() => {
   }
 
   module.getServerParams = async () => {
-    const res = await API.axios({
-      method: 'GET',
-      url: `${API.url()}/api/v1/admin/config`
-    });
+    try {
+      const res = await API.axios({
+        method: 'GET',
+        url: `${API.url()}/api/v1/admin/config`
+      });
 
-    Object.keys(res.data).forEach(key=>{
-      module.serverParams[key] = res.data[key];
-    });
-
+      Object.keys(res.data).forEach(key=>{
+        module.serverParams[key] = res.data[key];
+      });
+    } catch (err) {
+      console.error('failed to load server config', err);
+    }
     module.serverParamsUpdated.ts = Date.now();
   }
 
@@ -248,15 +261,18 @@ const ADMINDATA = (() => {
   }
 
   module.getTranscodeParams = async () => {
-    const res = await API.axios({
-      method: 'GET',
-      url: `${API.url()}/api/v1/admin/transcode`
-    });
+    try {
+      const res = await API.axios({
+        method: 'GET',
+        url: `${API.url()}/api/v1/admin/transcode`
+      });
 
-    Object.keys(res.data).forEach(key=>{
-      module.transcodeParams[key] = res.data[key];
-    });
-
+      Object.keys(res.data).forEach(key=>{
+        module.transcodeParams[key] = res.data[key];
+      });
+    } catch (err) {
+      console.error('failed to load transcode params', err);
+    }
     module.transcodeParamsUpdated.ts = Date.now();
   }
 

--- a/webapp/assets/js/api.js
+++ b/webapp/assets/js/api.js
@@ -24,7 +24,10 @@ const API = (() => {
 
   module.logout = () => {
     localStorage.removeItem('token');
-    Cookies.remove('x-access-token');
+    // js-cookie is a `defer` script on the admin page and absent entirely on
+    // the login page, so it can be undefined here. Clearing the cookie is
+    // best-effort — never let it swallow the redirect below.
+    try { Cookies.remove('x-access-token'); } catch (err) { /* no js-cookie on this page */ }
     document.location.assign(window.location.href.replace('/admin', '') + (window.location.href.slice(-1) === '/' ? '' : '/') + 'login');
   }
 
@@ -32,8 +35,47 @@ const API = (() => {
     window.location.assign(window.location.href.replace('/admin', ''));
   }
 
-  module.axios = axios.create({
-    headers: { 'x-access-token': module.token() }
+  module.axios = axios.create();
+
+  // Only attach the header when a token actually exists.
+  //
+  // localStorage is origin-scoped; the session cookie the server sets at
+  // login is host-only and ignores port AND scheme. So a user who logged in
+  // at http://host:3000 and came back through https://host — or whose
+  // script-writable storage was evicted (Safari ITP does this after 7 days) —
+  // still has a perfectly valid cookie but NO localStorage entry.
+  //
+  // Sending the resulting null anyway is strictly worse than sending nothing:
+  // axios 0.19 does not drop it, it serialises it onto the wire as the string
+  // "[object Object]", and src/api/auth.js reads the header BEFORE the cookie.
+  // The garbage then shadows the valid cookie and every admin call 401s with
+  // "jwt malformed" — the whole panel dies while the player, which does guard
+  // this (webapp/alpha/m.js), keeps working.
+  //
+  // Reading inside the interceptor rather than freezing the value at module
+  // init also means a token set after load is picked up.
+  module.axios.interceptors.request.use(config => {
+    const token = module.token();
+    if (token) { config.headers['x-access-token'] = token; }
+    return config;
+  });
+
+  // A 401 means the credentials we hold are dead or absent — the only useful
+  // move is to re-authenticate. Without this the panel just sat there: the
+  // admin panel's boot-time loaders are fire-and-forget, so a 401 became an
+  // unhandled rejection and the spinner spun forever with nothing on screen to
+  // explain it. Guarded so the ~25 parallel boot requests redirect exactly once.
+  //
+  // Deliberately 401-only. A locked admin API answers 405 and an off-network
+  // admin request answers 403 (src/api/admin.js); neither is fixed by logging
+  // in again, so neither should bounce the operator to the login page.
+  let redirecting = false;
+  module.axios.interceptors.response.use(undefined, err => {
+    if (err.response && err.response.status === 401 && !redirecting) {
+      redirecting = true;
+      module.logout();
+    }
+    return Promise.reject(err);
   });
 
   return module;


### PR DESCRIPTION
Fixes the reported "admin panel Directories / Users / Settings spin forever" bug, and the admin-role gating gaps found while verifying it.

**This is not a 6.19 regression.** A reporter's log shows the identical failure while still on schema v52 (v6.13.x), seven minutes *before* they upgraded to v61. `webapp/assets/js/api.js` last changed 2022-01-31 and has shipped this bug since v5.10.0 — it only surfaces once localStorage and the session cookie diverge.

## Commit 1 — the reported bug (client)

**Root cause 1: the panel sends a garbage auth header.** `webapp/assets/js/api.js` seeded its axios instance with `localStorage.getItem('token')`, unguarded. The vendored axios 0.19.2 does not drop a `null` header — measured, it serialises it onto the wire as the literal string `[object Object]`. `src/api/auth.js:106` reads the header *before* the cookie, so the garbage shadows a perfectly valid session cookie → `jwt malformed` → 401 on every admin route. Measured against a live server:

| scenario | code |
|---|---|
| header = real JWT | 200 |
| cookie only, no header | 200 |
| header = `""` + valid cookie | 200 |
| header = `[object Object]` + valid cookie | **401** |

The player is unaffected because `webapp/alpha/m.js:349` guards the same lookup. **How users get there:** localStorage is origin-scoped; the cookie is host-only and ignores port *and* scheme. Logging in at `http://host:3000` and returning via `https://host` (reverse proxy) sends the cookie but reads an empty localStorage; Safari ITP's 7-day eviction does the same. The velvet copy of this file already carried the fix ("so a page refresh after login never sends null") — it was never back-ported.

**Root cause 2: four loaders had no `try/catch`.** `getFolders`, `getUsers`, `getServerParams`, `getTranscodeParams` stamped `*Updated.ts` only on success, and the views gate their spinner on `ts === 0`. They were the *only* loaders without a catch — which is exactly why those tabs, and no others, hung instead of rendering empty.

Changes: attach `x-access-token` from a request interceptor only when a token exists; redirect to `/login` on 401 (guarded, once); stamp `.ts` on failure; make `Cookies.remove` in `logout()` best-effort (js-cookie is `defer`'d on admin, absent on login).

## Commit 2 — the gating gaps this exposed (server)

Verifying commit 1 as a non-admin user showed the same four tabs hanging via a different route: the `/admin` **page** gate only checked that the cookie's jwt was *valid*, not the role — so any logged-in non-admin was served the full panel, and then every one of its ~25 API calls came back 405.

- **`src/server.js`**: the `/admin` page gate now looks up the user and checks `is_admin`. Non-admins are redirected to the player — not `/login`, which would loop (their session is valid; logging back in returns the same user). Deleted-user and garbage cookies still go to `/login`. Public mode (no users) unchanged.
- **`src/api/admin.js`**: the role rejection is now **403 `Admin access required`** (was 405 `Admin API Disabled`). A non-admin is authenticated fine — they lack a permission; that's 403. The old shared 405 made a role failure indistinguishable from the whole API being disabled. `adminAccess.mode='none'` (lockAdmin) keeps its 405, and the network gate keeps its 403.
- **`docs/openapi.yaml`**: `AdminLocked` description and the status-code table updated to match (the old description claimed 405 covered the non-admin case; redocly warning count unchanged at 343).
- **Tests**: role-case `405`→`403` across `admin-scan-params` (24), `admin-users-lastfm` (2), `admin-subsonic-ui` (5), `torrent-routes` (4). Two torrent gate-order tests used `notEqual(status, 405)` to prove a user route wasn't admin-guarded; with the guard now answering 403 like the feature gate, status can't distinguish them — they assert on the response body instead. New `test/integration/admin-page-gate.test.mjs` (7 tests) pins the page-gate redirect matrix and the 403/405 split.

⚠ **Minor API contract change**: clients keying on 405 for "caller isn't admin" will now see 403. Nothing in this repo's webapp branches on the status or message (grepped); the lockAdmin 405 is untouched.

Known residue (pre-existing, unchanged): the `/admin/{*path}` asset gate is deliberately network-gated only, so a non-admin can still fetch the panel's static assets directly — the API-side role guard remains the security boundary, as before. The page-gate redirect is a UX fix, not a new security boundary.

## Verification

Browser-driven against live servers (default UI), plus integration suites:

- **The bug**: valid cookie + empty localStorage → was all-401/stuck spinners; now all 200, panel loads.
- **Healthy / public-mode / POST-with-header-only-auth** (cookie deleted, exercises axios header placement on writes): all 200.
- **Non-admin**: page gate redirects to `/`; API answers 403; no redirect loop; session preserved.
- **lockAdmin**: server replaces the page; panel JS never loads; API 405 intact.
- **Dead session, 2 concurrent 401s**: exactly one redirect to `/login`, token cleared. **Non-401 failure**: spinners resolve to empty state, no redirect.
- Affected suites: **129/129 pass** (`admin-page-gate`, `admin-access`, `admin-scan-params`, `admin-users-lastfm`, `admin-subsonic-ui`, `torrent-routes`).

**Workaround for anyone hitting the spinner bug on a released build:** log out and back in via the login page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
