### PR TITLE
fix(mac): give the .app double-click a visible outcome

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -212,21 +212,36 @@ jobs:
             if curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; then UP=1; break; fi
           done
           if [ "$UP" != "1" ]; then echo "FAIL: detached child never served — the app-launch hand-off is broken"; cat "$RUN/applaunch.log"; exit 1; fi
-          # The detached child must be a DIFFERENT process than the one we ran.
           CHILD=$(pgrep -f "applaunch-config.json" | head -1)
           echo "ok: launcher exited 0, detached child $CHILD serving on 3401"
-          # Relaunching while it runs must exit 0 (redundant, not failed) and
-          # leave exactly one server alive — the nonce probe proving identity.
+
+          # Relaunch, full Finder path: detaches again, and the detached copy is
+          # the one that probes. Its stdio is /dev/null by design, so the only
+          # observable contract here is "exit 0 and don't disturb the running
+          # server" — asserting on its log would test nothing (that mistake is
+          # why this step first shipped red).
           __CFBundleIdentifier=io.mstream.server "$BIN" -j "$RUN/applaunch-config.json" > "$RUN/applaunch2.log" 2>&1
           RC2=$?
-          sleep 2
+          sleep 4
+          COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
+          curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
+          if [ "$RC2" != "0" ]; then echo "FAIL: relaunch exited $RC2, expected 0"; cat "$RUN/applaunch2.log"; pkill -f applaunch-config.json; exit 1; fi
+          if [ "$COUNT" != "1" ] || [ "$STILL" != "0" ]; then echo "FAIL: relaunch disturbed the running server (count=$COUNT alive=$STILL)"; pkill -f applaunch-config.json; exit 1; fi
+          echo "ok: redundant relaunch exited 0 and left the running server alone"
+
+          # Relaunch with the detach already done (MSTREAM_MAC_APP_DETACHED=1 is
+          # what the detached copy itself carries), so the probe runs in THIS
+          # process where its result is observable. This is the assertion that
+          # actually covers the nonce identity check.
+          __CFBundleIdentifier=io.mstream.server MSTREAM_MAC_APP_DETACHED=1 "$BIN" -j "$RUN/applaunch-config.json" > "$RUN/applaunch3.log" 2>&1
+          RC3=$?
           COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
           curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
           pkill -f "applaunch-config.json" 2>/dev/null
-          if [ "$RC2" != "0" ]; then echo "FAIL: relaunch against a running instance exited $RC2, expected 0"; cat "$RUN/applaunch2.log"; exit 1; fi
-          grep -q "already running" "$RUN/applaunch2.log" || { echo "FAIL: relaunch did not recognize the running instance (nonce probe failed)"; cat "$RUN/applaunch2.log"; exit 1; }
+          if [ "$RC3" != "0" ]; then echo "FAIL: in-process relaunch exited $RC3, expected 0 (redundant, not failed)"; cat "$RUN/applaunch3.log"; exit 1; fi
+          grep -q "already running" "$RUN/applaunch3.log" || { echo "FAIL: the nonce probe did not recognize our own running instance"; cat "$RUN/applaunch3.log"; exit 1; }
           if [ "$COUNT" != "1" ] || [ "$STILL" != "0" ]; then echo "FAIL: relaunch disturbed the running server (count=$COUNT alive=$STILL)"; exit 1; fi
-          echo "SMOKE OK: app-launch detach, serve, and redundant-relaunch all behave"
+          echo "SMOKE OK: app-launch detach, serve, redundant relaunch, and nonce probe all behave"
 
       - name: Smoke test iroh native binding
         # Proves the standalone binary can dlopen the bundled @number0/iroh .node

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -122,11 +122,29 @@ jobs:
           CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:3399/api/v1/ping" 2>/dev/null)
           echo "HTTP up=$UP after ~${i}s ; /api/v1/ping -> ${CODE:-000}"
           grep -iE "scan started|scan complete" "$RUN/boot.log"
+
+          # (4) soft reboot must survive under the BUN runtime. Node's test
+          # suite can't catch this class: reboot()'s delayed sweep once hit
+          # the NEW server, and Bun's closeAllConnections (unlike Node's)
+          # stops the listener outright — the binary kept running with no
+          # port. Trigger a reboot-requiring config change, require the
+          # server back up, then require it STILL up after the ~1s sweep.
+          REBOOT_OK=0
+          if [ "$CODE" = "200" ]; then
+            curl -s -X POST -H 'Content-Type: application/json' -d '{"trustProxy":true}' "http://127.0.0.1:3399/api/v1/admin/config/trust-proxy" > /dev/null 2>&1
+            for i in $(seq 1 20); do
+              sleep 1
+              if curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then REBOOT_OK=1; break; fi
+            done
+            sleep 3   # outlive the close-grace sweep, which used to kill the new listener
+            curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || REBOOT_OK=0
+          fi
           kill "$SRV" 2>/dev/null
 
           if [ "$CODE" != "200" ]; then echo "FAIL: server did not serve 200"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; fi
           grep -q "Scan complete" "$RUN/boot.log" || { echo "FAIL: scan did not complete"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; }
-          echo "SMOKE OK: $BIN booted, served 200, and completed a scan"
+          if [ "$REBOOT_OK" != "1" ]; then echo "FAIL: server did not survive a soft reboot (admin config change)"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; fi
+          echo "SMOKE OK: $BIN booted, served 200, completed a scan, and survived a soft reboot"
 
       - name: Smoke test iroh native binding
         # Proves the standalone binary can dlopen the bundled @number0/iroh .node

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -166,9 +166,16 @@ jobs:
             # and most others it has NO unchanged-value short-circuit, so both
             # POSTs really do reboot (with a no-op second POST this test passes
             # against the bug). Bind stays reachable at 127.0.0.1.
-            curl -s -o /dev/null --max-time 5 -X POST -H 'Content-Type: application/json' -d '{"address":"127.0.0.1"}' "http://127.0.0.1:3399/api/v1/admin/config/address" &
+            # Capture each POST's status. Previously these were `curl -s` with
+            # no -f and their exit codes discarded by `wait`, so if the endpoint
+            # ever 400s or moves (a renamed Joi key, a moved route) NO reboot
+            # fired, the untouched server answered every probe, and the step
+            # printed "survived two overlapping reboots" — the rebootInFlight
+            # coalescing could have been deleted outright and this stayed green.
+            CONCURRENT_BOOTS_BEFORE=$(grep -c "Access mStream locally" "$RUN/boot.log")
+            curl -s -o /dev/null -w '%{http_code}' --max-time 5 -X POST -H 'Content-Type: application/json' -d '{"address":"127.0.0.1"}' "http://127.0.0.1:3399/api/v1/admin/config/address" > "$RUN/post1.code" &
             C1=$!
-            curl -s -o /dev/null --max-time 5 -X POST -H 'Content-Type: application/json' -d '{"address":"127.0.0.1"}' "http://127.0.0.1:3399/api/v1/admin/config/address" &
+            curl -s -o /dev/null -w '%{http_code}' --max-time 5 -X POST -H 'Content-Type: application/json' -d '{"address":"127.0.0.1"}' "http://127.0.0.1:3399/api/v1/admin/config/address" > "$RUN/post2.code" &
             C2=$!
             wait $C1 $C2
             CONCURRENT_OK=0
@@ -182,6 +189,27 @@ jobs:
             sleep 10
             curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || CONCURRENT_OK=0
             kill -0 "$SRV" 2>/dev/null || CONCURRENT_OK=0
+            # Fail closed on the TRIGGERS, not just on survival: both requests
+            # must have been accepted, and the server must actually have come
+            # back up again afterwards. Without these, "nothing happened" is
+            # indistinguishable from "handled two overlapping reboots".
+            POST1=$(cat "$RUN/post1.code" 2>/dev/null)
+            POST2=$(cat "$RUN/post2.code" 2>/dev/null)
+            CONCURRENT_BOOTS_AFTER=$(grep -c "Access mStream locally" "$RUN/boot.log")
+            if [ "$POST1" != "200" ] || [ "$POST2" != "200" ]; then
+              echo "FAIL: reboot triggers were not accepted (HTTP $POST1 / $POST2) — this step would otherwise pass having rebooted NOTHING"
+              CONCURRENT_OK=0
+            fi
+            if [ "$CONCURRENT_BOOTS_AFTER" -le "$CONCURRENT_BOOTS_BEFORE" ]; then
+              echo "FAIL: no additional boot after the overlapping reboots (before=$CONCURRENT_BOOTS_BEFORE after=$CONCURRENT_BOOTS_AFTER) — the server never actually restarted"
+              CONCURRENT_OK=0
+            fi
+            # Positive evidence that the SECOND request hit the coalescing guard
+            # rather than being silently lost. Advisory: the interleaving is
+            # timing-dependent, so a miss is reported, not fatal.
+            grep -q "Reboot already in progress" "$RUN/boot.log" \
+              && echo "ok: the duplicate reboot request was coalesced" \
+              || echo "note: no coalescing line — the two reboots did not overlap on this runner"
           fi
           kill "$SRV" 2>/dev/null
 
@@ -281,7 +309,34 @@ jobs:
           if [ "$RC4" = "0" ]; then echo "FAIL: probe ACCEPTED a wrong nonce (exit 0) — identity is a presence test, not a comparison; a local squatter would be handed the real UI origin"; cat "$RUN/applaunch4.log"; exit 1; fi
           if grep -q "already running" "$RUN/applaunch4.log"; then echo "FAIL: probe logged 'already running' for a MISMATCHED nonce"; cat "$RUN/applaunch4.log"; exit 1; fi
           if [ "$BADCOUNT" != "1" ] || [ "$BADSTILL" != "0" ]; then echo "FAIL: mismatch relaunch disturbed the running server (count=$BADCOUNT alive=$BADSTILL)"; exit 1; fi
-          echo "SMOKE OK: app-launch detach, serve, redundant relaunch, nonce MATCH and nonce-MISMATCH rejection all behave"
+
+          # Explicit (non-wildcard) bind. The identity exchange used to be gated
+          # on the caller looking like loopback, but a same-host client reaching
+          # a LAN-bound listener is seen as the LAN address — so the server hid
+          # its identity from its OWN probe and every re-click produced a bogus
+          # "port is in use by another application" alert. Nothing caught that,
+          # because every other case here binds the wildcard. Bind a real
+          # interface address and require the relaunch to still recognize us.
+          LANIP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null)
+          if [ -z "$LANIP" ]; then
+            echo "note: no LAN address on this runner — skipping the explicit-bind probe case"
+          else
+            printf '{"port":3402,"address":"%s"}' "$LANIP" > "$RUN/bindlaunch-config.json"
+            __CFBundleIdentifier=io.mstream.server "$BIN" -j "$RUN/bindlaunch-config.json" > "$RUN/bind1.log" 2>&1
+            BINDUP=0
+            for i in $(seq 1 30); do
+              sleep 1
+              if curl -sf --max-time 5 -o /dev/null "http://$LANIP:3402/api/v1/ping"; then BINDUP=1; break; fi
+            done
+            if [ "$BINDUP" != "1" ]; then echo "FAIL: explicit-bind server never served on $LANIP:3402"; cat "$RUN/bind1.log"; pkill -f bindlaunch-config.json; exit 1; fi
+            __CFBundleIdentifier=io.mstream.server MSTREAM_MAC_APP_DETACHED=1 "$BIN" -j "$RUN/bindlaunch-config.json" > "$RUN/bind2.log" 2>&1
+            RCBIND=$?
+            pkill -f "bindlaunch-config.json" 2>/dev/null
+            if [ "$RCBIND" != "0" ]; then echo "FAIL: explicit-bind relaunch exited $RCBIND — the probe cannot identify a non-wildcard-bound instance"; cat "$RUN/bind2.log"; exit 1; fi
+            grep -q "already running" "$RUN/bind2.log" || { echo "FAIL: explicit-bind relaunch did not recognize our own instance"; cat "$RUN/bind2.log"; exit 1; }
+            echo "ok: explicit-bind ($LANIP) relaunch recognized its own instance"
+          fi
+          echo "SMOKE OK: app-launch detach, serve, redundant relaunch, nonce MATCH, nonce-MISMATCH rejection, and explicit-bind identity all behave"
 
       - name: Smoke test iroh native binding
         # Proves the standalone binary can dlopen the bundled @number0/iroh .node

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -24,6 +24,12 @@ jobs:
   build:
     name: ${{ matrix.key }}
     runs-on: ${{ matrix.os }}
+    # The smoke steps drive a real server: a wedged accept-but-never-respond
+    # process would otherwise sit in a retry loop until the 6-hour default,
+    # burning paid macOS/Windows runners and showing "still running" instead of
+    # a failure. Every smoke curl also carries --max-time. A full build+smoke
+    # is ~2 minutes today.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -116,10 +122,10 @@ jobs:
           UP=0
           for i in $(seq 1 60); do
             sleep 1
-            if curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then UP=1; break; fi
+            if curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then UP=1; break; fi
           done
           sleep 3   # let the boot scan finish
-          CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:3399/api/v1/ping" 2>/dev/null)
+          CODE=$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' "http://127.0.0.1:3399/api/v1/ping" 2>/dev/null)
           echo "HTTP up=$UP after ~${i}s ; /api/v1/ping -> ${CODE:-000}"
           grep -iE "scan started|scan complete" "$RUN/boot.log"
 
@@ -136,17 +142,17 @@ jobs:
           REBOOT_OK=0
           if [ "$CODE" = "200" ]; then
             BOOTS_BEFORE=$(grep -c "Access mStream locally" "$RUN/boot.log")
-            TRIG=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{"trustProxy":true}' "http://127.0.0.1:3399/api/v1/admin/config/trust-proxy")
+            TRIG=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{"trustProxy":true}' "http://127.0.0.1:3399/api/v1/admin/config/trust-proxy")
             if [ "$TRIG" != "200" ]; then
               echo "FAIL: reboot trigger POST returned ${TRIG:-000}, not 200 — the smoke would have passed without rebooting anything"
               cat "$RUN/boot.log"; kill "$SRV" 2>/dev/null; exit 1
             fi
             for i in $(seq 1 20); do
               sleep 1
-              if curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then REBOOT_OK=1; break; fi
+              if curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then REBOOT_OK=1; break; fi
             done
             sleep 3   # outlive the close-grace sweep, which used to kill the new listener
-            curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || REBOOT_OK=0
+            curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || REBOOT_OK=0
             BOOTS_AFTER=$(grep -c "Access mStream locally" "$RUN/boot.log")
             if [ "$BOOTS_AFTER" -le "$BOOTS_BEFORE" ]; then
               echo "FAIL: no re-serve observed (boot lines ${BOOTS_BEFORE} -> ${BOOTS_AFTER}) — the reboot never happened"
@@ -168,13 +174,13 @@ jobs:
             CONCURRENT_OK=0
             for i in $(seq 1 25); do
               sleep 1
-              if curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then CONCURRENT_OK=1; break; fi
+              if curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then CONCURRENT_OK=1; break; fi
             done
             # Must outlive a losing sibling's FULL relisten budget (20 x 250ms):
             # the process.exit lands ~5s in, and a shorter wait passes against
             # the very bug this guards.
             sleep 10
-            curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || CONCURRENT_OK=0
+            curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || CONCURRENT_OK=0
             kill -0 "$SRV" 2>/dev/null || CONCURRENT_OK=0
           fi
           kill "$SRV" 2>/dev/null
@@ -209,7 +215,7 @@ jobs:
           UP=0
           for i in $(seq 1 30); do
             sleep 1
-            if curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; then UP=1; break; fi
+            if curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; then UP=1; break; fi
           done
           if [ "$UP" != "1" ]; then echo "FAIL: detached child never served — the app-launch hand-off is broken"; cat "$RUN/applaunch.log"; exit 1; fi
           CHILD=$(pgrep -f "applaunch-config.json" | head -1)
@@ -224,7 +230,7 @@ jobs:
           RC2=$?
           sleep 4
           COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
-          curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
+          curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
           if [ "$RC2" != "0" ]; then echo "FAIL: relaunch exited $RC2, expected 0"; cat "$RUN/applaunch2.log"; pkill -f applaunch-config.json; exit 1; fi
           if [ "$COUNT" != "1" ] || [ "$STILL" != "0" ]; then echo "FAIL: relaunch disturbed the running server (count=$COUNT alive=$STILL)"; pkill -f applaunch-config.json; exit 1; fi
           echo "ok: redundant relaunch exited 0 and left the running server alone"
@@ -236,7 +242,7 @@ jobs:
           __CFBundleIdentifier=io.mstream.server MSTREAM_MAC_APP_DETACHED=1 "$BIN" -j "$RUN/applaunch-config.json" > "$RUN/applaunch3.log" 2>&1
           RC3=$?
           COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
-          curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
+          curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
           pkill -f "applaunch-config.json" 2>/dev/null
           if [ "$RC3" != "0" ]; then echo "FAIL: in-process relaunch exited $RC3, expected 0 (redundant, not failed)"; cat "$RUN/applaunch3.log"; exit 1; fi
           grep -q "already running" "$RUN/applaunch3.log" || { echo "FAIL: the nonce probe did not recognize our own running instance"; cat "$RUN/applaunch3.log"; exit 1; }

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -129,22 +129,104 @@ jobs:
           # stops the listener outright — the binary kept running with no
           # port. Trigger a reboot-requiring config change, require the
           # server back up, then require it STILL up after the ~1s sweep.
+          # Fail closed: assert the TRIGGER worked (a 400 from a renamed key or
+          # an auth wall would otherwise leave the server up and pass this step
+          # having rebooted nothing), and require a SECOND "Access mStream
+          # locally" line as positive proof a re-serve actually happened.
           REBOOT_OK=0
           if [ "$CODE" = "200" ]; then
-            curl -s -X POST -H 'Content-Type: application/json' -d '{"trustProxy":true}' "http://127.0.0.1:3399/api/v1/admin/config/trust-proxy" > /dev/null 2>&1
+            BOOTS_BEFORE=$(grep -c "Access mStream locally" "$RUN/boot.log")
+            TRIG=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{"trustProxy":true}' "http://127.0.0.1:3399/api/v1/admin/config/trust-proxy")
+            if [ "$TRIG" != "200" ]; then
+              echo "FAIL: reboot trigger POST returned ${TRIG:-000}, not 200 — the smoke would have passed without rebooting anything"
+              cat "$RUN/boot.log"; kill "$SRV" 2>/dev/null; exit 1
+            fi
             for i in $(seq 1 20); do
               sleep 1
               if curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then REBOOT_OK=1; break; fi
             done
             sleep 3   # outlive the close-grace sweep, which used to kill the new listener
             curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || REBOOT_OK=0
+            BOOTS_AFTER=$(grep -c "Access mStream locally" "$RUN/boot.log")
+            if [ "$BOOTS_AFTER" -le "$BOOTS_BEFORE" ]; then
+              echo "FAIL: no re-serve observed (boot lines ${BOOTS_BEFORE} -> ${BOOTS_AFTER}) — the reboot never happened"
+              REBOOT_OK=0
+            fi
+
+            # (5) overlapping reboots must not kill the process. Two rapid admin
+            # saves used to start two serveIt()s racing for the port; the loser
+            # exhausted the relisten budget and process.exit()ed the healthy
+            # winner. /config/address is the right trigger: unlike trust-proxy
+            # and most others it has NO unchanged-value short-circuit, so both
+            # POSTs really do reboot (with a no-op second POST this test passes
+            # against the bug). Bind stays reachable at 127.0.0.1.
+            curl -s -o /dev/null --max-time 5 -X POST -H 'Content-Type: application/json' -d '{"address":"127.0.0.1"}' "http://127.0.0.1:3399/api/v1/admin/config/address" &
+            C1=$!
+            curl -s -o /dev/null --max-time 5 -X POST -H 'Content-Type: application/json' -d '{"address":"127.0.0.1"}' "http://127.0.0.1:3399/api/v1/admin/config/address" &
+            C2=$!
+            wait $C1 $C2
+            CONCURRENT_OK=0
+            for i in $(seq 1 25); do
+              sleep 1
+              if curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then CONCURRENT_OK=1; break; fi
+            done
+            # Must outlive a losing sibling's FULL relisten budget (20 x 250ms):
+            # the process.exit lands ~5s in, and a shorter wait passes against
+            # the very bug this guards.
+            sleep 10
+            curl -sf -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || CONCURRENT_OK=0
+            kill -0 "$SRV" 2>/dev/null || CONCURRENT_OK=0
           fi
           kill "$SRV" 2>/dev/null
 
           if [ "$CODE" != "200" ]; then echo "FAIL: server did not serve 200"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; fi
           grep -q "Scan complete" "$RUN/boot.log" || { echo "FAIL: scan did not complete"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; }
           if [ "$REBOOT_OK" != "1" ]; then echo "FAIL: server did not survive a soft reboot (admin config change)"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; fi
-          echo "SMOKE OK: $BIN booted, served 200, completed a scan, and survived a soft reboot"
+          if [ "$CONCURRENT_OK" != "1" ]; then echo "FAIL: server did not survive two overlapping reboots"; echo "--- boot.log ---"; cat "$RUN/boot.log"; exit 1; fi
+          echo "SMOKE OK: $BIN booted, served 200, completed a scan, and survived both a soft reboot and overlapping reboots"
+
+      - name: Smoke test macOS app-launch flow (detach + serve)
+        # The .app double-click path (src/util/mac-app-launch.js) is gated on
+        # __CFBundleIdentifier, which nothing in CI sets — so the headline flow
+        # of the desktop fix had zero coverage, and LSUIElement means a
+        # regression is INVISIBLE to users (no Dock icon, no window, no console).
+        # Setting the marker by hand reproduces a LaunchServices launch closely
+        # enough to prove the two compiled-binary-only behaviors: the argv slice
+        # in detachForFinderLaunch (whose shape exists only in a Bun standalone)
+        # and the detached hand-off. announceReady's browser spawn is
+        # stdio-ignored and detached, so it's harmless on a runner.
+        if: matrix.key == 'darwin-arm64'
+        shell: bash
+        run: |
+          set +e
+          D=$(ls -d dist/stage/mStream-*-${{ matrix.key }})
+          BIN="$D/mStream.app/Contents/MacOS/mStream"
+          RUN=$(dirname "$BIN")
+          printf '{"port":3401}' > "$RUN/applaunch-config.json"
+          __CFBundleIdentifier=io.mstream.server "$BIN" -j "$RUN/applaunch-config.json" > "$RUN/applaunch.log" 2>&1
+          LAUNCHER_RC=$?
+          if [ "$LAUNCHER_RC" != "0" ]; then echo "FAIL: app-mode launcher exited $LAUNCHER_RC (expected 0 after handing off)"; cat "$RUN/applaunch.log"; exit 1; fi
+          UP=0
+          for i in $(seq 1 30); do
+            sleep 1
+            if curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; then UP=1; break; fi
+          done
+          if [ "$UP" != "1" ]; then echo "FAIL: detached child never served — the app-launch hand-off is broken"; cat "$RUN/applaunch.log"; exit 1; fi
+          # The detached child must be a DIFFERENT process than the one we ran.
+          CHILD=$(pgrep -f "applaunch-config.json" | head -1)
+          echo "ok: launcher exited 0, detached child $CHILD serving on 3401"
+          # Relaunching while it runs must exit 0 (redundant, not failed) and
+          # leave exactly one server alive — the nonce probe proving identity.
+          __CFBundleIdentifier=io.mstream.server "$BIN" -j "$RUN/applaunch-config.json" > "$RUN/applaunch2.log" 2>&1
+          RC2=$?
+          sleep 2
+          COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
+          curl -sf -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
+          pkill -f "applaunch-config.json" 2>/dev/null
+          if [ "$RC2" != "0" ]; then echo "FAIL: relaunch against a running instance exited $RC2, expected 0"; cat "$RUN/applaunch2.log"; exit 1; fi
+          grep -q "already running" "$RUN/applaunch2.log" || { echo "FAIL: relaunch did not recognize the running instance (nonce probe failed)"; cat "$RUN/applaunch2.log"; exit 1; }
+          if [ "$COUNT" != "1" ] || [ "$STILL" != "0" ]; then echo "FAIL: relaunch disturbed the running server (count=$COUNT alive=$STILL)"; exit 1; fi
+          echo "SMOKE OK: app-launch detach, serve, and redundant-relaunch all behave"
 
       - name: Smoke test iroh native binding
         # Proves the standalone binary can dlopen the bundled @number0/iroh .node

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -228,8 +228,17 @@ jobs:
           # why this step first shipped red).
           __CFBundleIdentifier=io.mstream.server "$BIN" -j "$RUN/applaunch-config.json" > "$RUN/applaunch2.log" 2>&1
           RC2=$?
-          sleep 4
-          COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
+          # The detached copy boots FULLY before it hits EADDRINUSE, probes, and
+          # exits — measured 3.6–4.2s across runners, straddling any fixed sleep.
+          # Poll for it to drain back to the single running server rather than
+          # guessing a duration: a fixed `sleep` flakes red when the copy is
+          # merely slow, not broken (30 x 0.5s = 15s ceiling, exits early on drain).
+          COUNT=2
+          for i in $(seq 1 30); do
+            COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
+            [ "$COUNT" = "1" ] && break
+            sleep 0.5
+          done
           curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
           if [ "$RC2" != "0" ]; then echo "FAIL: relaunch exited $RC2, expected 0"; cat "$RUN/applaunch2.log"; pkill -f applaunch-config.json; exit 1; fi
           if [ "$COUNT" != "1" ] || [ "$STILL" != "0" ]; then echo "FAIL: relaunch disturbed the running server (count=$COUNT alive=$STILL)"; pkill -f applaunch-config.json; exit 1; fi
@@ -243,11 +252,36 @@ jobs:
           RC3=$?
           COUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
           curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; STILL=$?
+
+          # Negative control for the nonce identity check. The positive probe
+          # above (RC3 + "already running") stays green even if the probe
+          # regresses from `header === expectedNonce` to a mere presence check —
+          # the two are observationally identical when the nonce genuinely
+          # matches. So overwrite the on-disk nonce the probe reads while the
+          # running server keeps serving its real (in-memory) one: a correct
+          # comparison now MISMATCHES, so the relaunch must refuse to redirect,
+          # exit 1 (never logging "already running"), and leave the server
+          # untouched. A presence-check regression would instead exit 0 here and
+          # hand a local port squatter the real UI's trusted localStorage origin.
+          # The probe's 2s timeout bounds this and its alert is detached — no hang.
+          NONCE_FILE=$(find "$RUN" -name '.instance-nonce' 2>/dev/null | head -1)
+          if [ -z "$NONCE_FILE" ]; then echo "FAIL: running server wrote no .instance-nonce to probe against"; pkill -f "applaunch-config.json"; exit 1; fi
+          cp "$NONCE_FILE" "$RUN/nonce.bak"
+          printf 'not-the-real-nonce' > "$NONCE_FILE"
+          __CFBundleIdentifier=io.mstream.server MSTREAM_MAC_APP_DETACHED=1 "$BIN" -j "$RUN/applaunch-config.json" > "$RUN/applaunch4.log" 2>&1
+          RC4=$?
+          cp "$RUN/nonce.bak" "$NONCE_FILE"
+          BADCOUNT=$(pgrep -f "applaunch-config.json" | wc -l | tr -d ' ')
+          curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3401/api/v1/ping"; BADSTILL=$?
+
           pkill -f "applaunch-config.json" 2>/dev/null
           if [ "$RC3" != "0" ]; then echo "FAIL: in-process relaunch exited $RC3, expected 0 (redundant, not failed)"; cat "$RUN/applaunch3.log"; exit 1; fi
           grep -q "already running" "$RUN/applaunch3.log" || { echo "FAIL: the nonce probe did not recognize our own running instance"; cat "$RUN/applaunch3.log"; exit 1; }
           if [ "$COUNT" != "1" ] || [ "$STILL" != "0" ]; then echo "FAIL: relaunch disturbed the running server (count=$COUNT alive=$STILL)"; exit 1; fi
-          echo "SMOKE OK: app-launch detach, serve, redundant relaunch, and nonce probe all behave"
+          if [ "$RC4" = "0" ]; then echo "FAIL: probe ACCEPTED a wrong nonce (exit 0) — identity is a presence test, not a comparison; a local squatter would be handed the real UI origin"; cat "$RUN/applaunch4.log"; exit 1; fi
+          if grep -q "already running" "$RUN/applaunch4.log"; then echo "FAIL: probe logged 'already running' for a MISMATCHED nonce"; cat "$RUN/applaunch4.log"; exit 1; fi
+          if [ "$BADCOUNT" != "1" ] || [ "$BADSTILL" != "0" ]; then echo "FAIL: mismatch relaunch disturbed the running server (count=$BADCOUNT alive=$BADSTILL)"; exit 1; fi
+          echo "SMOKE OK: app-launch detach, serve, redundant relaunch, nonce MATCH and nonce-MISMATCH rejection all behave"
 
       - name: Smoke test iroh native binding
         # Proves the standalone binary can dlopen the bundled @number0/iroh .node

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ save/waveform-cache-smoke/
 docs/api.html
 model-cache/
 
+# Scratch files left in the repo root by `bun build --compile`; one per build.
+.*.bun-build
+

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ save/*.json
 *.db-wal
 *.db-shm
 .migrated-from-loki
+# Per-boot identity secret for the macOS relaunch probe (src/server.js)
+.instance-nonce
 frp/*.ini
 
 dist/*

--- a/cli-boot-wrapper.js
+++ b/cli-boot-wrapper.js
@@ -3,10 +3,11 @@
 // Must stay the first import: arms the console-loss watcher (see
 // src/util/supervision.js) before any other module can write.
 import { watchSupervisorStdin } from './src/util/supervision.js';
+import { existsSync } from 'fs';
 import { join } from 'path';
 import { maybeRunWorker } from './src/util/worker-process.js';
 import { detachForFinderLaunch } from './src/util/mac-app-launch.js';
-import { appRoot } from './src/util/esm-helpers.js';
+import { appRoot, dataRoot } from './src/util/esm-helpers.js';
 import pkg from './package.json' with { type: 'json' };
 
 const version = pkg.version;
@@ -21,7 +22,14 @@ if (await maybeRunWorker()) {
   // Default config lives next to the app: the repo root under Node, or the
   // binary's own directory under a Bun standalone build (appRoot resolves both).
   // MSTREAM_CONFIG overrides the default; an explicit -j/--json overrides that.
-  const defaultJson = process.env.MSTREAM_CONFIG || join(appRoot, 'save/conf/default.json');
+  //
+  // When the app is read-only (a translocated macOS .app), writable state moves
+  // to dataRoot — but keep honoring a config that ALREADY exists next to the
+  // app first, so a pre-provisioned read-only install keeps booting from the
+  // config it shipped with instead of silently starting empty somewhere else.
+  const bundledJson = join(appRoot, 'save/conf/default.json');
+  const defaultJson = process.env.MSTREAM_CONFIG
+    || (existsSync(bundledJson) ? bundledJson : join(dataRoot, 'save/conf/default.json'));
   const { json, supervised } = parseArgs(process.argv.slice(2), defaultJson);
 
   // Finder double-click (macOS .app only — a no-op everywhere else): hand

--- a/cli-boot-wrapper.js
+++ b/cli-boot-wrapper.js
@@ -5,6 +5,7 @@
 import { watchSupervisorStdin } from './src/util/supervision.js';
 import { join } from 'path';
 import { maybeRunWorker } from './src/util/worker-process.js';
+import { detachForFinderLaunch } from './src/util/mac-app-launch.js';
 import { appRoot } from './src/util/esm-helpers.js';
 import pkg from './package.json' with { type: 'json' };
 
@@ -23,6 +24,14 @@ if (await maybeRunWorker()) {
   const defaultJson = process.env.MSTREAM_CONFIG || join(appRoot, 'save/conf/default.json');
   const { json, supervised } = parseArgs(process.argv.slice(2), defaultJson);
 
+  // Finder double-click (macOS .app only — a no-op everywhere else): hand
+  // the real boot to a detached copy and exit, so LaunchServices doesn't
+  // pin this process as "the app" and swallow later double-clicks. See
+  // src/util/mac-app-launch.js for the whole desktop-launch story.
+  if (detachForFinderLaunch()) {
+    process.exit(0);
+  }
+
   // Armed before the banner so a supervisor that died mid-boot still stops us.
   if (supervised) { watchSupervisorStdin(); }
 
@@ -39,9 +48,20 @@ if (await maybeRunWorker()) {
   console.log('https://discord.gg/AM896Rr');
   console.log();
 
-  // Boot the server
+  // Boot the server. serveIt can reject before the listen handler exists
+  // (bad SSL certs, unexpected setup errors); without this catch that's an
+  // unhandled rejection — a raw stack in a terminal, and total silence when
+  // Finder launched the macOS .app (stdout is /dev/null there). Surface it,
+  // and as a dialog on an app launch (see src/util/mac-app-launch.js).
   const server = await import("./src/server.js");
-  server.serveIt(json);
+  server.serveIt(json).catch(async (err) => {
+    console.error('mStream failed to start:', err);
+    try {
+      const { announceBootFailure } = await import('./src/util/mac-app-launch.js');
+      announceBootFailure(`mStream could not start: ${err.message}`);
+    } catch (_err) { /* feedback is best-effort — still exit nonzero */ }
+    process.exit(1);
+  });
 }
 
 function parseArgs(args, defaultJson) {

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -221,6 +221,13 @@ console.log(`Done: dist/${bundleName}.zip`);
 // src/util/mac-app-launch.js, which keys off CFBundleIdentifier below (the two
 // must stay in sync).
 //
+// KNOWN LIMITATION (deferred, #802): with no Dock presence the running server
+// has no user-facing Quit — re-clicking the app only reopens the browser, so
+// stopping it means Activity Monitor or `kill`. The planned home for a Quit is
+// the macOS menu-bar status item tracked with the tray/autostart work, which
+// will call a graceful-shutdown path; deliberately not added here to keep this
+// PR scoped. See src/util/mac-app-launch.js.
+//
 // The NSLocalNetwork/NSBonjour keys caption macOS 15+'s Local Network consent
 // prompt, which fires on first launch because mDNS advertising
 // (_mstream._tcp, src/discovery/mdns.js) is on by default — without them the

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -211,6 +211,20 @@ console.log(`Done: dist/${bundleName}.zip`);
 
 // macOS .app Info.plist — points CFBundleIconFile at the staged mStream.icns
 // and CFBundleExecutable at the inner binary.
+//
+// LSUIElement is load-bearing (#802): the executable is a faceless CLI server
+// that never connects to the WindowServer, and without this key LaunchServices
+// treats a Finder launch as a regular GUI app — the Dock icon bounces, times
+// out, and the app is branded "Application Not Responding" forever even though
+// the server is up and serving. As a UIElement/agent app it gets no Dock
+// presence at all; the visible launch feedback is the browser open in
+// src/util/mac-app-launch.js, which keys off CFBundleIdentifier below (the two
+// must stay in sync).
+//
+// The NSLocalNetwork/NSBonjour keys caption macOS 15+'s Local Network consent
+// prompt, which fires on first launch because mDNS advertising
+// (_mstream._tcp, src/discovery/mdns.js) is on by default — without them the
+// prompt shows no explanation of why a music server wants LAN access.
 function macInfoPlist(version) {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -225,6 +239,12 @@ function macInfoPlist(version) {
   <key>CFBundleIconFile</key><string>mStream.icns</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>LSMinimumSystemVersion</key><string>11.0</string>
+  <key>LSUIElement</key><true/>
+  <key>NSLocalNetworkUsageDescription</key><string>mStream advertises itself over Bonjour so players on your local network can find your music library.</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_mstream._tcp</string>
+  </array>
 </dict>
 </plist>
 `;

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -240,10 +240,11 @@ function macInfoPlist(version) {
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>LSMinimumSystemVersion</key><string>11.0</string>
   <key>LSUIElement</key><true/>
-  <key>NSLocalNetworkUsageDescription</key><string>mStream advertises itself over Bonjour so players on your local network can find your music library.</string>
+  <key>NSLocalNetworkUsageDescription</key><string>mStream advertises itself on your local network so players and speakers can find your music library, using Bonjour and — if you enable DLNA — SSDP.</string>
   <key>NSBonjourServices</key>
   <array>
     <string>_mstream._tcp</string>
+    <string>_services._dns-sd._udp</string>
   </array>
 </dict>
 </plist>

--- a/src/api/remote.js
+++ b/src/api/remote.js
@@ -78,6 +78,15 @@ export function setupAfterAuth(mstream, server) {
     }
   }});
 
+  // ws forwards the wrapped HTTP server's 'error' events onto the wss (and
+  // adds its own). With no listener here, that re-emit throws mid-dispatch —
+  // killing the process before server.js's own 'error' handler (registered
+  // after this setup runs) ever sees the original event. Log only: fatal
+  // server errors are the HTTP handler's job.
+  wss.on('error', (err) => {
+    winston.error(`WebSocket server error: ${err.message}`);
+  });
+
   wss.on('connection', (connection, req) => {
     const code = nanoid(8);
     winston.info(`Websocket Connection Accepted With Code: ${code}`);

--- a/src/api/remote.js
+++ b/src/api/remote.js
@@ -89,6 +89,15 @@ export function setupAfterAuth(mstream, server) {
 
   wss.on('connection', (connection, req) => {
     const code = nanoid(8);
+    // MUST be attached before anything else can throw: ws raises protocol and
+    // socket failures (a malformed frame, a reset mid-message) on the
+    // individual connection, never on the wss above — and an unhandled
+    // EventEmitter 'error' takes the whole server down. Under Node that made
+    // one 6-byte bad frame from any client that completed the upgrade a remote
+    // process kill; on a fresh install, verifyClient skips auth entirely.
+    connection.on('error', (err) => {
+      winston.warn(`Websocket connection error (${code}): ${err.message}`);
+    });
     winston.info(`Websocket Connection Accepted With Code: ${code}`);
     clients[code] = connection;
 

--- a/src/db/image-compress-manager.js
+++ b/src/db/image-compress-manager.js
@@ -29,6 +29,14 @@ export function run() {
     winston.error(`Image Compress Error: ${data}`);
   });
 
+  // A spawn failure emits 'error' and never 'close'. Without this listener
+  // that's an unhandled EventEmitter error — a dead server — and runningTask
+  // would stay latched, blocking every later compress run.
+  forkedScan.on('error', (err) => {
+    winston.error(`Image compress script failed to start: ${err.message}`);
+    runningTask = undefined;
+  });
+
   forkedScan.on('close', (code) => {
     winston.info(`Image compress script completed with code ${code}`);
     runningTask = undefined;

--- a/src/db/lyrics-lookup-lib.js
+++ b/src/db/lyrics-lookup-lib.js
@@ -173,7 +173,14 @@ function defaultHttpGet(url, { timeoutMs = 8000, headers = {} } = {}) {
         stream.on('error', reject);
       });
       req.on('error', reject);
-      req.setTimeout(Math.min(timeoutMs, remaining), () => req.destroy(new Error('request timeout')));
+      // Explicit rejection alongside destroy: Bun's destroy(err) emits no
+      // 'error', which would leave this promise — and the lyrics backfill
+      // pass awaiting it — pending forever against a stalled endpoint.
+      req.setTimeout(Math.min(timeoutMs, remaining), () => {
+        const timedOut = new Error('request timeout');
+        req.destroy(timedOut);
+        reject(timedOut);
+      });
     };
     follow(url);
   });

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -54,6 +54,14 @@ let _userLibrariesCache = null;   // Map<userId, [libraryId, ...]>
 
 export function initDB() {
   const dbPath = path.join(config.program.storage.dbDirectory, 'mstream.db');
+  // A soft reboot re-runs this. Without closing first, every admin-triggered
+  // reboot leaked the previous connection — its file descriptors and its
+  // native page cache (up to the 64 MB budget below), neither of which the
+  // JS heap knows to reclaim. discovery-db.js already guards the same way.
+  if (db) {
+    try { db.close(); } catch (err) { winston.warn(`Could not close the previous database handle: ${err.message}`); }
+    db = null;
+  }
   db = new DatabaseSync(dbPath);
 
   // Enable WAL mode for better concurrent read/write performance

--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -381,9 +381,16 @@ export function stop() {
     winston.debug(`[mdns] goodbye error: ${err.message}`);
   }
 
+  // Logged HERE, synchronously: the advertiser is stopped the moment the
+  // module drops its socket. Emitting it from the deferred close below put
+  // '[mdns] Stopped' AFTER a reboot's fresh '[mdns] Advertising', which reads
+  // exactly like the stale-singleton teardown bug this codebase has already
+  // been bitten by — a red herring that has cost debugging time more than once.
+  winston.info('[mdns] Stopped');
+
   // Give the goodbye datagram(s) a moment to flush before closing the socket.
   setTimeout(() => {
     try { sock.close(); } catch (_) { /* already closed */ }
-    winston.info('[mdns] Stopped');
+    winston.debug('[mdns] old socket closed');
   }, 100);
 }

--- a/src/discovery/mdns.js
+++ b/src/discovery/mdns.js
@@ -296,9 +296,14 @@ export function start() {
   if (!config.program.discovery || !config.program.discovery.mdns.enabled) { return; }
 
   const opts = { type: 'udp4', reuseAddr: true };
-  // SO_REUSEPORT lets us share 5353 with the OS responder where it exists;
-  // it's unsupported on Windows, where SO_REUSEADDR already allows sharing.
-  if (process.platform !== 'win32') { opts.reusePort = true; }
+  // SO_REUSEPORT lets us share 5353 with the OS responder. libuv implements
+  // UV_UDP_REUSEPORT only on Linux and FreeBSD — everywhere else Node's bind
+  // fails outright with ENOTSUP, which silently disabled discovery for the
+  // whole process on macOS (Bun's own socket layer sets SO_REUSEPORT directly
+  // and binds fine, so shipped binaries hid it). darwin doesn't need the flag
+  // anyway: there reuseAddr already maps to SO_REUSEPORT, and Windows shares
+  // via SO_REUSEADDR.
+  if (process.platform === 'linux' || process.platform === 'freebsd') { opts.reusePort = true; }
 
   let sock;
   try {

--- a/src/dlna/ssdp.js
+++ b/src/dlna/ssdp.js
@@ -322,12 +322,17 @@ export function stop() {
   const ifaces = ifaceSnapshot.length > 1 ? ifaceSnapshot : [null];
   let remaining = messages.length * ifaces.length;
 
+  // Same reasoning as mdns.js's stop(): announce the stop synchronously below,
+  // and keep the deferred socket close at debug. Emitted from here, the
+  // 'Stopped' line lands after a reboot's fresh 'Started' and reads as a
+  // torn-down advertiser.
   function closeWhenDone() {
     if (--remaining === 0) {
-      try { sock.close(); } catch (_) {}
-      winston.info('[dlna-ssdp] Stopped');
+      try { sock.close(); } catch (_) { /* already closed */ }
+      winston.debug('[dlna-ssdp] old socket closed');
     }
   }
+  winston.info('[dlna-ssdp] Stopped');
 
   // Mirror sendMessages()'s interface fan-out for the byebye batch so
   // renderers on every interface see us leave — otherwise stale entries

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,8 @@ import { compression } from './util/compression.js';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import https from 'https';
+import { dataRoot, usingFallbackDataRoot } from './util/esm-helpers.js';
+import { CHALLENGE_HEADER, PROOF_HEADER, computeProof } from './util/instance-proof.js';
 
 import * as dbApi from './api/db.js';
 import * as discoveryApi from './api/discovery.js';
@@ -83,14 +85,6 @@ function instanceNoncePath() {
   return path.join(config.program.storage.dbDirectory, INSTANCE_NONCE_FILE);
 }
 
-// Loopback-only gate for the nonce header. req.socket.remoteAddress is the
-// real peer — deliberately NOT req.ip, which honors X-Forwarded-For under
-// trustProxy and would let a remote client spoof its way to the nonce.
-function isLoopbackRequest(req) {
-  const addr = req.socket && req.socket.remoteAddress;
-  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
-}
-
 // True from the start of a reboot until its re-served instance is listening.
 // Guards against overlapping reboots (two quick admin saves, two admin tabs):
 // a second server.close() on an already-closing server still runs its callback,
@@ -117,7 +111,16 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   } catch (err) {
     winston.error('Failed to validate config file', { stack: err });
     // A Finder-launched app has no console to print to — raise a dialog.
-    macAppLaunch.announceBootFailure(`mStream could not start — error in the config file:\n${configFile}\n\n${err.message}`);
+    // A permission/read-only failure is NOT a malformed config, and saying so
+    // sends the user hunting through a file that is usually fine (or absent):
+    // name the real cause instead. dataRoot already redirects writable state
+    // away from a read-only app (util/esm-helpers.js), so reaching this means
+    // the chosen location itself is unwritable — an explicit -j/MSTREAM_CONFIG
+    // pointing somewhere read-only, or a container mount without permission.
+    const denied = err.code === 'EROFS' || err.code === 'EACCES' || err.code === 'EPERM';
+    macAppLaunch.announceBootFailure(denied
+      ? `mStream could not start — it can't write to:\n${configFile}\n\nThe location is read-only or permission was denied. If you launched mStream from a downloaded copy, move it to your Applications folder and open it again.\n\n${err.message}`
+      : `mStream could not start — error in the config file:\n${configFile}\n\n${err.message}`);
     process.exit(1);
   }
 
@@ -128,6 +131,11 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   logger.setBufferCapacity(config.program.logBufferSize);
   if (config.program.writeLogs) {
     logger.addFileLogger(config.program.storage.logsDirectory);
+  }
+  // Say so when the app couldn't be written to and state went elsewhere —
+  // otherwise "where is my database?" has no answer anywhere in the logs.
+  if (usingFallbackDataRoot) {
+    winston.info(`App directory is read-only — storing config, database and caches in ${dataRoot}`);
   }
 
   // Set server
@@ -166,16 +174,22 @@ export async function serveIt(configFile, { relisten = null } = {}) {
       'Access-Control-Allow-Headers',
       'Origin, X-Requested-With, Content-Type, Accept'
     );
-    // Identity headers for the macOS relaunch probe (src/util/mac-app-launch.js),
-    // both loopback-only. The probe is a same-machine question, so neither
-    // header has any reason to cross the network: on a WAN-exposed instance
-    // X-Mstream would turn "is this mStream?" from a heuristic into a
-    // one-request positive ID for mass scanners, and the nonce is the secret
-    // that proves the port holder is our own server rather than a local
-    // impostor. remoteAddress, not req.ip — see isLoopbackRequest.
-    if (isLoopbackRequest(req)) {
-      res.header('X-Mstream', 'true');
-      res.header('X-Mstream-Instance', instanceNonce);
+    // Identity proof for the macOS relaunch probe (src/util/mac-app-launch.js).
+    // ONLY answers a caller that presents a challenge, and answers with an HMAC
+    // keyed by the per-boot nonce — never the nonce itself. See
+    // util/instance-proof.js for why the proof runs in this direction.
+    //
+    // This deliberately sits ahead of the auth wall: the probe is a launcher
+    // with no credentials. That is safe because the reply proves knowledge
+    // without disclosing it — the previous version published the nonce
+    // outright to every loopback caller, which let any local process read the
+    // secret it was never supposed to have (and, via mStream's own
+    // 127.0.0.1 iroh/federation bridges and reverse-proxy setups, leaked it
+    // off-machine to remote callers that merely LOOKED local).
+    const challenge = req.headers[CHALLENGE_HEADER];
+    if (challenge) {
+      const proof = computeProof(instanceNonce, challenge);
+      if (proof) { res.header(PROOF_HEADER, proof); }
     }
     next();
   });
@@ -704,13 +718,19 @@ export function reboot() {
     // gossiping their catalog until a full process restart, while the server
     // reports the feature off.
     //
-    // Unlike the teardowns above this one must be SEQUENCED before the
-    // re-serve, not fired and forgotten: the stack guards start with a
-    // `running` flag it only clears at the END of stop, so a restart landing
-    // mid-stop returns early as a no-op and the stop then kills the sidecar it
-    // was supposed to replace — leaving the feature dead until a full restart,
-    // which is worse than the leak. Bounded by a timeout so a wedged teardown
-    // can delay the restart but never block it.
+    // Unlike the teardowns above this one is SEQUENCED before the re-serve
+    // rather than fired and forgotten, so a reboot that disables the feature
+    // has actually released the sidecar before the new instance boots.
+    //
+    // The timeout is a LATENCY bound, not the correctness mechanism: a wedged
+    // teardown can delay the restart but never block it. Correctness lives in
+    // the stack itself, which now clears `running` up front and makes a start
+    // wait on the in-flight stop (see startDiscoveryP2pStack). That ordering
+    // matters because a full stop can outlast this timeout — the sidecar gets
+    // a shutdown-RPC grace AND a SIGKILL fallback — and when it does, the
+    // restart lands mid-stop. Before the stack serialized, that combination
+    // silently left the feature dead: the restart no-oped on a stale flag and
+    // the late stop killed the sidecar it was meant to replace.
     const p2pStopped = Promise.race([
       import('./state/discovery-p2p-stack.js')
         .then((m) => m.stopDiscoveryP2pStack())

--- a/src/server.js
+++ b/src/server.js
@@ -55,6 +55,7 @@ import * as backupManager from './backup/manager.js';
 // Velvet UI modules — dynamically imported only when ui='velvet' is active
 import WebError from './util/web-error.js';
 import { isAdminAllowed } from './util/admin-network.js';
+import * as macAppLaunch from './util/mac-app-launch.js';
 
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -68,6 +69,8 @@ export async function serveIt(configFile) {
     await config.setup(configFile);
   } catch (err) {
     winston.error('Failed to validate config file', { stack: err });
+    // A Finder-launched app has no console to print to — raise a dialog.
+    macAppLaunch.announceBootFailure(`mStream could not start — error in the config file:\n${configFile}\n\n${err.message}`);
     process.exit(1);
   }
 
@@ -116,6 +119,10 @@ export async function serveIt(configFile) {
       'Access-Control-Allow-Headers',
       'Origin, X-Requested-With, Content-Type, Accept'
     );
+    // Identity marker on every response, auth-independent: lets a second
+    // .app launch recognize that the port squatter is an existing mStream
+    // and reopen the browser at it (see src/util/mac-app-launch.js).
+    res.header('X-Mstream', 'true');
     next();
   });
   // Trust Proxy
@@ -435,10 +442,26 @@ export async function serveIt(configFile) {
   });
 
   // Start the server!
+  const protocol = config.program.ssl && config.program.ssl.cert && config.program.ssl.key ? 'https' : 'http';
   server.on('request', mstream);
+  // Without this handler a failed listen() — port already taken being the
+  // canonical case — dies as an uncaught 'error' event: a raw stack in a
+  // terminal, and under a Finder launch pure silence. Log it properly; on an
+  // app launch the port squatter is usually an earlier mStream instance, in
+  // which case this launch is redundant rather than failed (exit 0).
+  server.on('error', async (err) => {
+    if (err.code === 'EADDRINUSE') {
+      winston.error(`Unable to start mStream: port ${config.program.port} is already in use`);
+    } else {
+      winston.error(`Server error: ${err.message}`, { stack: err });
+    }
+    const alreadyRunning = await macAppLaunch.handleListenError(err, protocol, config.program.port, config.program.address);
+    process.exit(alreadyRunning ? 0 : 1);
+  });
   server.listen(config.program.port, config.program.address, async () => {
-    const protocol = config.program.ssl && config.program.ssl.cert && config.program.ssl.key ? 'https' : 'http';
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
+    // Finder launch (macOS .app): surface the UI — nothing else is visible.
+    macAppLaunch.announceReady(protocol, config.program.port, config.program.address);
 
     const taskQueue = await import('./db/task-queue.js');
     taskQueue.runAfterBoot();

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import winston from 'winston';
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
+import crypto from 'crypto';
 import Joi from 'joi';
 import cookieParser from 'cookie-parser';
 import { compression } from './util/compression.js';
@@ -61,6 +62,42 @@ import packageJson from '../package.json' with { type: 'json' };
 
 let mstream;
 let server;
+// Live sockets of the CURRENT server, for reboot()'s forced drain. Tracked by
+// hand because closeAllConnections() is unusable under Bun: its shim nulls the
+// internal handle synchronously inside close(), so any sweep scheduled after
+// close() early-returns and does nothing (Node's, by contrast, still destroys
+// sockets). Without a working sweep a reboot during an active transfer — a
+// transcode, a big download — never fires its close callback and the server
+// never comes back. 'connection' fires on both runtimes, so this does.
+let liveSockets = new Set();
+// Per-boot identity secret for the macOS relaunch probe (see
+// src/util/mac-app-launch.js). Published only to loopback callers and mirrored
+// into a 0600 file at listen time, so a second .app launch can prove the port
+// holder is really our own running instance before redirecting the user's
+// browser at it. Regenerated every boot: a stale file can then only fail
+// closed.
+const instanceNonce = crypto.randomBytes(18).toString('base64url');
+const INSTANCE_NONCE_FILE = '.instance-nonce';
+
+function instanceNoncePath() {
+  return path.join(config.program.storage.dbDirectory, INSTANCE_NONCE_FILE);
+}
+
+// Loopback-only gate for the nonce header. req.socket.remoteAddress is the
+// real peer — deliberately NOT req.ip, which honors X-Forwarded-For under
+// trustProxy and would let a remote client spoof its way to the nonce.
+function isLoopbackRequest(req) {
+  const addr = req.socket && req.socket.remoteAddress;
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1';
+}
+
+// True from the start of a reboot until its re-served instance is listening.
+// Guards against overlapping reboots (two quick admin saves, two admin tabs):
+// a second server.close() on an already-closing server still runs its callback,
+// which would start a SECOND serveIt racing the first for the port — and the
+// loser would exhaust the relisten budget and process.exit() the whole process,
+// killing the healthy winner with it.
+let rebootInFlight = false;
 
 // `relisten: true` marks a reboot()'s re-serve of a port THIS process just
 // released. Windows doesn't grant the immediate same-process rebind unix
@@ -129,6 +166,11 @@ export async function serveIt(configFile, { relisten = false } = {}) {
     // .app launch recognize that the port squatter is an existing mStream
     // and reopen the browser at it (see src/util/mac-app-launch.js).
     res.header('X-Mstream', 'true');
+    // The per-boot instance nonce PROVES that identity, and only to callers
+    // on this machine — a marker anyone can copy would let a local squatter
+    // redirect the user's browser to itself. Loopback-only so it never
+    // travels the LAN.
+    if (isLoopbackRequest(req)) { res.header('X-Mstream-Instance', instanceNonce); }
     next();
   });
   // Trust Proxy
@@ -455,15 +497,31 @@ export async function serveIt(configFile, { relisten = false } = {}) {
   // terminal, and under a Finder launch pure silence. Log it properly; on an
   // app launch the port squatter is usually an earlier mStream instance, in
   // which case this launch is redundant rather than failed (exit 0).
+  // Track live sockets for reboot()'s drain (see liveSockets above).
+  const mySockets = new Set();
+  liveSockets = mySockets;
+  server.on('connection', (socket) => {
+    mySockets.add(socket);
+    socket.on('close', () => mySockets.delete(socket));
+  });
+  const thisServer = server;
   let relistenRetries = relisten ? 20 : 0;   // 20 × 250ms = 5s budget
   server.on('error', async (err) => {
+    // Only the CURRENT server may act on its errors. A superseded instance
+    // (an overlapping reboot's loser) must never run the exit paths below —
+    // it would take the healthy live server down with it.
+    if (thisServer !== server) {
+      winston.warn(`Ignoring '${err.code || err.message}' from a superseded server instance`);
+      try { thisServer.close(); } catch (_) { /* already closed */ }
+      return;
+    }
     if (err.code === 'EADDRINUSE' && relistenRetries > 0) {
       relistenRetries--;
       winston.warn(`Port ${config.program.port} not released yet after reboot — retrying listen (${relistenRetries} left)`);
       // Bare listen(): the 'listening' handler is registered once below —
       // passing a callback here would stack one stale once-listener per
       // failed attempt, all firing together on the eventual success.
-      setTimeout(() => server.listen(config.program.port, config.program.address), 250);
+      setTimeout(() => { if (thisServer === server) { thisServer.listen(config.program.port, config.program.address); } }, 250);
       return;
     }
     if (err.code === 'EADDRINUSE') {
@@ -471,10 +529,27 @@ export async function serveIt(configFile, { relisten = false } = {}) {
     } else {
       winston.error(`Server error: ${err.message}`, { stack: err });
     }
-    const alreadyRunning = await macAppLaunch.handleListenError(err, protocol, config.program.port, config.program.address);
+    // Fatal diagnostics go to fd 2 directly as well: process.exit() below beats
+    // winston's File transport, whose boot-time backlog means the on-disk log
+    // of a writeLogs install otherwise just stops mid-boot with no reason.
+    try { fs.writeSync(2, `mStream fatal: ${err.code === 'EADDRINUSE' ? `port ${config.program.port} already in use` : err.message}\n`); } catch (_) { /* stderr gone too */ }
+    // The running instance's nonce, if any — the only proof that the port
+    // holder is our own server and not a local impostor.
+    let runningNonce;
+    try { runningNonce = fs.readFileSync(instanceNoncePath(), 'utf8').trim(); } catch (_) { /* none: probe fails closed */ }
+    const alreadyRunning = await macAppLaunch.handleListenError(err, protocol, config.program.port, config.program.address, runningNonce);
     process.exit(alreadyRunning ? 0 : 1);
   });
   const onListening = async () => {
+    rebootInFlight = false;   // a reboot's re-serve is complete
+    // Publish the instance nonce only once we actually OWN the port — a
+    // process that failed to listen must never overwrite the running
+    // instance's file, or the relaunch probe would stop recognizing it.
+    try {
+      fs.writeFileSync(instanceNoncePath(), instanceNonce, { mode: 0o600 });
+    } catch (err) {
+      winston.warn(`Could not write the instance nonce file: ${err.message}`);
+    }
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
     // Finder launch (macOS .app): surface the UI — nothing else is visible.
     macAppLaunch.announceReady(protocol, config.program.port, config.program.address);
@@ -568,6 +643,17 @@ export async function serveIt(configFile, { relisten = false } = {}) {
 
 export function reboot() {
   try {
+    // Overlapping reboots are a hard outage, not a slow restart: a second
+    // close() on an already-closing server still runs its callback, so two
+    // serveIt()s race for the port and the loser's exhausted relisten budget
+    // exits the process out from under the winner. Two quick admin saves is
+    // all it takes. Coalesce instead — the in-flight reboot already re-reads
+    // the config from disk, so it picks up both changes.
+    if (rebootInFlight) {
+      winston.warn('Reboot already in progress — skipping the duplicate request');
+      return;
+    }
+    rebootInFlight = true;
     winston.info('Rebooting Server');
     logger.reset();
     scrobblerApi.reset();
@@ -607,23 +693,43 @@ export function reboot() {
     // callback fires. Force the close after a short grace period so
     // in-flight writes get a chance to finish but stragglers don't
     // block the restart.
-    server.close(() => {
-      serveIt(config.configFile, { relisten: true });
-    });
-    // Capture the OLD instance for the delayed sweep: serveIt above reassigns
-    // the module-level `server` to the NEW one before this timer fires. Under
-    // Node the mistargeted call was survivable (closeAllConnections only
-    // destroys sockets), but under Bun closeAllConnections stops the server
-    // outright (listening=false + Bun.serve stop(true)) — every standalone
-    // binary lost its listener ~1s after any admin-triggered reboot, leaving
-    // a live process serving nothing.
-    const closingServer = server;
-    setTimeout(() => {
-      if (typeof closingServer.closeAllConnections === 'function') {
-        try { closingServer.closeAllConnections(); } catch (_) { /* already gone */ }
+    server.close((err) => {
+      // An already-closed server reports ERR_SERVER_NOT_RUNNING here; re-serving
+      // on that would mean two live instances fighting for the port.
+      if (err) {
+        winston.warn(`Reboot: server was already closed (${err.code || err.message}) — not re-serving`);
+        rebootInFlight = false;
+        return;
       }
+      // serveIt can reject before its listen handler exists (bad SSL certs are
+      // the classic: config.setup re-reads the file every reboot, so a rotated
+      // cert first fails HERE). Unhandled, that's a raw unhandled rejection
+      // with the old server already town down — the silent death this PR set
+      // out to eliminate, just moved to the reboot path.
+      serveIt(config.configFile, { relisten: true }).catch((rebootErr) => {
+        rebootInFlight = false;
+        winston.error('Reboot failed to restart the server', { stack: rebootErr });
+        try { fs.writeSync(2, `mStream fatal: reboot failed to restart the server: ${rebootErr.message}\n`); } catch (_) { /* stderr gone */ }
+        macAppLaunch.announceBootFailure(`mStream stopped: the server could not restart after a settings change.\n\n${rebootErr.message}`);
+        process.exit(1);
+      });
+    });
+    // Force the drain after a grace period. Sweeps the sockets WE tracked
+    // rather than calling closeAllConnections(): under Bun that method is a
+    // guaranteed no-op once close() has run (its shim nulls the internal
+    // handle synchronously inside close()), so an active transfer would hold
+    // the close callback — and therefore the whole restart — open forever.
+    // Destroying the old server's sockets is safe for the new one: `mySockets`
+    // is per-instance, and serveIt rebinds `liveSockets` to the new set.
+    const closingSockets = liveSockets;
+    setTimeout(() => {
+      for (const socket of closingSockets) {
+        try { socket.destroy(); } catch (_) { /* already gone */ }
+      }
+      closingSockets.clear();
     }, 1000);
   } catch (err) {
+    rebootInFlight = false;
     winston.error('Reboot Failed', { stack: err });
     process.exit(1);
   }

--- a/src/server.js
+++ b/src/server.js
@@ -62,7 +62,13 @@ import packageJson from '../package.json' with { type: 'json' };
 let mstream;
 let server;
 
-export async function serveIt(configFile) {
+// `relisten: true` marks a reboot()'s re-serve of a port THIS process just
+// released. Windows doesn't grant the immediate same-process rebind unix
+// does — close()'s callback can fire before the OS frees the port — so a
+// relisten briefly retries EADDRINUSE instead of treating it as fatal.
+// First boots never retry: there the squatter is a real foreign process and
+// the fail-fast path (log / probe / alert) is the right answer.
+export async function serveIt(configFile, { relisten = false } = {}) {
   mstream = express();
 
   try {
@@ -449,7 +455,17 @@ export async function serveIt(configFile) {
   // terminal, and under a Finder launch pure silence. Log it properly; on an
   // app launch the port squatter is usually an earlier mStream instance, in
   // which case this launch is redundant rather than failed (exit 0).
+  let relistenRetries = relisten ? 20 : 0;   // 20 × 250ms = 5s budget
   server.on('error', async (err) => {
+    if (err.code === 'EADDRINUSE' && relistenRetries > 0) {
+      relistenRetries--;
+      winston.warn(`Port ${config.program.port} not released yet after reboot — retrying listen (${relistenRetries} left)`);
+      // Bare listen(): the 'listening' handler is registered once below —
+      // passing a callback here would stack one stale once-listener per
+      // failed attempt, all firing together on the eventual success.
+      setTimeout(() => server.listen(config.program.port, config.program.address), 250);
+      return;
+    }
     if (err.code === 'EADDRINUSE') {
       winston.error(`Unable to start mStream: port ${config.program.port} is already in use`);
     } else {
@@ -458,7 +474,7 @@ export async function serveIt(configFile) {
     const alreadyRunning = await macAppLaunch.handleListenError(err, protocol, config.program.port, config.program.address);
     process.exit(alreadyRunning ? 0 : 1);
   });
-  server.listen(config.program.port, config.program.address, async () => {
+  const onListening = async () => {
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
     // Finder launch (macOS .app): surface the UI — nothing else is visible.
     macAppLaunch.announceReady(protocol, config.program.port, config.program.address);
@@ -545,7 +561,9 @@ export async function serveIt(configFile) {
     // Boot server audio (Rust preferred, CLI fallback) — runs CLI detection
     // eagerly so the admin endpoint has fresh data by the time it's called.
     serverPlaybackApi.bootRustPlayer().catch(() => {});
-  });
+  };
+  server.once('listening', onListening);
+  server.listen(config.program.port, config.program.address);
 }
 
 export function reboot() {
@@ -590,7 +608,7 @@ export function reboot() {
     // in-flight writes get a chance to finish but stragglers don't
     // block the restart.
     server.close(() => {
-      serveIt(config.configFile);
+      serveIt(config.configFile, { relisten: true });
     });
     // Capture the OLD instance for the delayed sweep: serveIt above reassigns
     // the module-level `server` to the NEW one before this timer fires. Under

--- a/src/server.js
+++ b/src/server.js
@@ -99,13 +99,17 @@ function isLoopbackRequest(req) {
 // killing the healthy winner with it.
 let rebootInFlight = false;
 
-// `relisten: true` marks a reboot()'s re-serve of a port THIS process just
-// released. Windows doesn't grant the immediate same-process rebind unix
-// does — close()'s callback can fire before the OS frees the port — so a
-// relisten briefly retries EADDRINUSE instead of treating it as fatal.
-// First boots never retry: there the squatter is a real foreign process and
-// the fail-fast path (log / probe / alert) is the right answer.
-export async function serveIt(configFile, { relisten = false } = {}) {
+// `relisten` carries the port THIS process just released, so a reboot's
+// re-serve can tell a Windows port-release delay from a real conflict.
+// Windows doesn't grant the immediate same-process rebind unix does —
+// close()'s callback can fire before the OS frees the port — so retrying
+// EADDRINUSE briefly is right THERE, and only there. It is deliberately not a
+// boolean: an admin who changed the port is re-serving a port this process
+// never owned, where a conflict is permanent, and retrying would spend five
+// seconds blaming a transient OS condition before exiting anyway (and on a
+// mac .app could even probe a DIFFERENT mStream on the new port and exit 0 as
+// "redundant"). First boots never retry for the same reason.
+export async function serveIt(configFile, { relisten = null } = {}) {
   mstream = express();
 
   try {
@@ -162,15 +166,17 @@ export async function serveIt(configFile, { relisten = false } = {}) {
       'Access-Control-Allow-Headers',
       'Origin, X-Requested-With, Content-Type, Accept'
     );
-    // Identity marker on every response, auth-independent: lets a second
-    // .app launch recognize that the port squatter is an existing mStream
-    // and reopen the browser at it (see src/util/mac-app-launch.js).
-    res.header('X-Mstream', 'true');
-    // The per-boot instance nonce PROVES that identity, and only to callers
-    // on this machine — a marker anyone can copy would let a local squatter
-    // redirect the user's browser to itself. Loopback-only so it never
-    // travels the LAN.
-    if (isLoopbackRequest(req)) { res.header('X-Mstream-Instance', instanceNonce); }
+    // Identity headers for the macOS relaunch probe (src/util/mac-app-launch.js),
+    // both loopback-only. The probe is a same-machine question, so neither
+    // header has any reason to cross the network: on a WAN-exposed instance
+    // X-Mstream would turn "is this mStream?" from a heuristic into a
+    // one-request positive ID for mass scanners, and the nonce is the secret
+    // that proves the port holder is our own server rather than a local
+    // impostor. remoteAddress, not req.ip — see isLoopbackRequest.
+    if (isLoopbackRequest(req)) {
+      res.header('X-Mstream', 'true');
+      res.header('X-Mstream-Instance', instanceNonce);
+    }
     next();
   });
   // Trust Proxy
@@ -505,7 +511,11 @@ export async function serveIt(configFile, { relisten = false } = {}) {
     socket.on('close', () => mySockets.delete(socket));
   });
   const thisServer = server;
-  let relistenRetries = relisten ? 20 : 0;   // 20 × 250ms = 5s budget
+  // Only arm the budget when we are re-taking the SAME port we just released.
+  let relistenRetries = (relisten !== null && relisten === config.program.port) ? 20 : 0;   // 20 × 250ms = 5s
+  if (relisten !== null && relistenRetries === 0) {
+    winston.info(`Reboot moved the port ${relisten} -> ${config.program.port}; a conflict on the new port is real, not a release delay`);
+  }
   server.on('error', async (err) => {
     // Only the CURRENT server may act on its errors. A superseded instance
     // (an overlapping reboot's loser) must never run the exit paths below —
@@ -654,6 +664,9 @@ export function reboot() {
       return;
     }
     rebootInFlight = true;
+    // Captured BEFORE serveIt's config.setup re-reads the file: the re-serve
+    // only gets the EADDRINUSE retry budget if it is re-taking this same port.
+    const previousPort = config.program.port;
     winston.info('Rebooting Server');
     logger.reset();
     scrobblerApi.reset();
@@ -684,6 +697,26 @@ export function reboot() {
     // Peer bridges (loopback servers + outbound conns) go down with it.
     import('./state/federation-client.js').then((m) => m.stopAll()).catch(() => {});
     import('./state/federation.js').then((m) => m.stop()).catch(() => {});
+    // Same for the discovery-network gossip stack: sidecar process, gossip
+    // subscription, mesh-health watch, auto-fetch and pruning timers. Without
+    // it, an operator who DISABLES the feature in the config file and uses the
+    // admin reboot (the documented flow) keeps publishing snapshots and
+    // gossiping their catalog until a full process restart, while the server
+    // reports the feature off.
+    //
+    // Unlike the teardowns above this one must be SEQUENCED before the
+    // re-serve, not fired and forgotten: the stack guards start with a
+    // `running` flag it only clears at the END of stop, so a restart landing
+    // mid-stop returns early as a no-op and the stop then kills the sidecar it
+    // was supposed to replace — leaving the feature dead until a full restart,
+    // which is worse than the leak. Bounded by a timeout so a wedged teardown
+    // can delay the restart but never block it.
+    const p2pStopped = Promise.race([
+      import('./state/discovery-p2p-stack.js')
+        .then((m) => m.stopDiscoveryP2pStack())
+        .catch((err) => winston.warn(`[discovery-p2p] stop during reboot failed: ${err.message}`)),
+      new Promise((resolve) => setTimeout(resolve, 5000)),
+    ]);
 
     // Close the server. server.close() waits for every in-flight HTTP
     // request AND every idle keep-alive socket to drain. The admin
@@ -706,7 +739,8 @@ export function reboot() {
       // cert first fails HERE). Unhandled, that's a raw unhandled rejection
       // with the old server already town down — the silent death this PR set
       // out to eliminate, just moved to the reboot path.
-      serveIt(config.configFile, { relisten: true }).catch((rebootErr) => {
+      // Gate the re-serve on the discovery-p2p teardown finishing (see above).
+      p2pStopped.then(() => serveIt(config.configFile, { relisten: previousPort })).catch((rebootErr) => {
         rebootInFlight = false;
         winston.error('Reboot failed to restart the server', { stack: rebootErr });
         try { fs.writeSync(2, `mStream fatal: reboot failed to restart the server: ${rebootErr.message}\n`); } catch (_) { /* stderr gone */ }

--- a/src/server.js
+++ b/src/server.js
@@ -592,9 +592,17 @@ export function reboot() {
     server.close(() => {
       serveIt(config.configFile);
     });
+    // Capture the OLD instance for the delayed sweep: serveIt above reassigns
+    // the module-level `server` to the NEW one before this timer fires. Under
+    // Node the mistargeted call was survivable (closeAllConnections only
+    // destroys sockets), but under Bun closeAllConnections stops the server
+    // outright (listening=false + Bun.serve stop(true)) — every standalone
+    // binary lost its listener ~1s after any admin-triggered reboot, leaving
+    // a live process serving nothing.
+    const closingServer = server;
     setTimeout(() => {
-      if (typeof server.closeAllConnections === 'function') {
-        try { server.closeAllConnections(); } catch (_) {}
+      if (typeof closingServer.closeAllConnections === 'function') {
+        try { closingServer.closeAllConnections(); } catch (_) { /* already gone */ }
       }
     }, 1000);
   } catch (err) {

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -3,12 +3,16 @@ import path from 'path';
 import crypto from 'crypto';
 import Joi from 'joi';
 import winston from 'winston';
-import { appRoot } from '../util/esm-helpers.js';
+import { appRoot, dataRoot } from '../util/esm-helpers.js';
 import { getTransCodecs, getTransBitrates } from '../api/transcode.js';
 import { CLIENT_TYPE, ENABLED_FOR } from '../torrent/constants.js';
 import { EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL } from '../db/discovery-features-lib.js';
 
-const DEFAULT_DB_DIRECTORY = path.join(appRoot, 'save/db');
+// Writable state hangs off dataRoot, not appRoot: they are the same directory
+// unless the app itself is read-only (a translocated/quarantined macOS .app —
+// see resolveDataRoot in util/esm-helpers.js). Shipped assets below (ffmpeg,
+// rpn, webapp) stay on appRoot, which is where they actually ship.
+const DEFAULT_DB_DIRECTORY = path.join(dataRoot, 'save/db');
 
 /**
  * Default for storage.modelCacheDirectory when the config doesn't set it:
@@ -32,10 +36,10 @@ export function deriveModelCacheDirectory(dbDirectory) {
 }
 
 const storageJoi = Joi.object({
-  albumArtDirectory: Joi.string().default(path.join(appRoot, 'image-cache')),
+  albumArtDirectory: Joi.string().default(path.join(dataRoot, 'image-cache')),
   dbDirectory: Joi.string().default(DEFAULT_DB_DIRECTORY),
-  logsDirectory: Joi.string().default(path.join(appRoot, 'save/logs')),
-  waveformCacheDirectory: Joi.string().default(path.join(appRoot, 'waveform-cache')),
+  logsDirectory: Joi.string().default(path.join(dataRoot, 'save/logs')),
+  waveformCacheDirectory: Joi.string().default(path.join(dataRoot, 'waveform-cache')),
   // Where ML model weights download/cache (currently: the discovery
   // embedding model, ~18 MB EffNet; CLAP is far larger). Deliberately
   // OUTSIDE node_modules — transformers.js's default cache lands in there
@@ -314,7 +318,12 @@ const adminAccessOptions = Joi.object({
 });
 
 const transcodeOptions = Joi.object({
-  ffmpegDirectory: Joi.string().default(path.join(appRoot, 'bin/ffmpeg')),
+  // dataRoot, not appRoot: nothing ships ffmpeg inside the bundle — this is the
+  // directory mStream DOWNLOADS into and auto-updates, so it has to be
+  // writable. Must stay in step with BUNDLED_FFMPEG_DIR in
+  // util/ffmpeg-bootstrap.js, which compares against it to tell "the install we
+  // manage" from "a custom directory the user pointed us at".
+  ffmpegDirectory: Joi.string().default(path.join(dataRoot, 'bin/ffmpeg')),
   defaultCodec: Joi.string().valid(...getTransCodecs()).default('opus'),
   defaultBitrate: Joi.string().valid(...getTransBitrates()).default('96k'),
   // Auto-update the managed ffmpeg build (BtbN on Linux/Windows, martin-riedl

--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -14,10 +14,22 @@ import winston from 'winston';
 
 let running = false;
 let starting = null;
+let stopping = null;
 
 export function isStackRunning() { return running; }
 
 export async function startDiscoveryP2pStack() {
+  // Serialize behind an in-flight stop. A soft reboot stops the stack and then
+  // re-serves, and stopping the sidecar can take up to ~10s (a shutdown RPC
+  // grace plus a SIGKILL fallback). Without this wait, the restart raced the
+  // teardown: it saw the not-yet-cleared `running`, returned as a silent no-op,
+  // and the late stop then killed the sidecar — leaving the config saying
+  // "enabled", the admin panel reporting success, and NOTHING actually
+  // gossiping or publishing, with no error logged anywhere until a full
+  // restart. Waiting is what makes the restart real.
+  if (stopping) {
+    try { await stopping; } catch (_err) { /* stop's own caller logs it */ }
+  }
   if (running) { return; }
   if (starting) { return starting; }
   starting = (async () => {
@@ -67,13 +79,22 @@ export async function startDiscoveryP2pStack() {
 // process itself. Catalog + shelf files stay on disk — a re-enable (or the
 // next boot) picks up right where this left off.
 export async function stopDiscoveryP2pStack() {
-  const seeds = await import('./discovery-seeds.js');
-  const peerDbs = await import('./discovery-peer-dbs.js');
-  const catalog = await import('./discovery-catalog.js');
-  seeds.stopMeshHealthWatch();
-  peerDbs.stopAutoFetch();
-  catalog.stopPruning();
-  const p2p = await import('./discovery-p2p.js');
-  await p2p.stop();
+  if (stopping) { return stopping; }
+  // `running` states INTENT, not completion: clear it before the first await,
+  // so a start that arrives mid-teardown waits on `stopping` above instead of
+  // seeing a stale `true` and no-oping. Clearing it only after p2p.stop()
+  // resolved was the bug — the window is seconds wide, and a reboot lands
+  // squarely inside it.
   running = false;
+  stopping = (async () => {
+    const seeds = await import('./discovery-seeds.js');
+    const peerDbs = await import('./discovery-peer-dbs.js');
+    const catalog = await import('./discovery-catalog.js');
+    seeds.stopMeshHealthWatch();
+    peerDbs.stopAutoFetch();
+    catalog.stopPruning();
+    const p2p = await import('./discovery-p2p.js');
+    await p2p.stop();
+  })();
+  try { await stopping; } finally { stopping = null; }
 }

--- a/src/state/federation-client.js
+++ b/src/state/federation-client.js
@@ -58,6 +58,12 @@ async function buildBridge(peer) {
 
   const entry = { port: 0, baseUrl: '', server: null, conn, activeSockets: 0, idleTimer: null };
   entry.server = net.createServer((socket) => {
+    // Attached before the async openBi() below: bridge() installs the real
+    // handler only once the QUIC stream resolves, and a reset inside that
+    // window would otherwise be an unhandled socket 'error'.
+    socket.on('error', (err) => {
+      winston.debug(`[federation] bridge socket error (${err?.message})`);
+    });
     entry.activeSockets += 1;
     clearTimeout(entry.idleTimer);
     socket.once('close', () => {

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -1023,7 +1023,16 @@ export async function removeSSL() {
 
 function testSSL(jsonLoad) {
   return new Promise((resolve, reject) => {
-    launchWorker('ssl-test', path.join(__dirname, './ssl-test.js'), JSON.stringify(jsonLoad)).on('close', (code) => {
+    const worker = launchWorker('ssl-test', path.join(__dirname, './ssl-test.js'), JSON.stringify(jsonLoad));
+    // A spawn that fails asynchronously (EMFILE/ENOMEM/exec policy) emits
+    // 'error' and never 'close'. Unhandled, that's an EventEmitter throw
+    // that takes the whole server down — and this promise would hang
+    // regardless. Every task-queue worker guards this; these sites didn't.
+    worker.on('error', (err) => {
+      winston.error(`SSL test worker failed to start: ${err.message}`);
+      reject('SSL Failure');
+    });
+    worker.on('close', (code) => {
       if (code !== 0) { return reject('SSL Failure'); }
       resolve();
     });

--- a/src/util/esm-helpers.js
+++ b/src/util/esm-helpers.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import os from 'os';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -25,3 +27,45 @@ export const isBunStandalone = /[\\/](~BUN|\$bunfs)[\\/]/.test(selfPath);
 export const appRoot = isBunStandalone
   ? dirname(process.execPath)
   : join(dirname(selfPath), '..', '..');
+
+// Per-user writable location, used only when appRoot is read-only.
+function userDataDir() {
+  const home = os.homedir();
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'mStream');
+  }
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), 'mStream');
+  }
+  return join(process.env.XDG_DATA_HOME || join(home, '.local', 'share'), 'mStream');
+}
+
+// Root for WRITABLE state — config, db, logs, image/waveform caches — as
+// opposed to appRoot, which also anchors the SHIPPED read-only assets
+// (webapp/, bin/) and must keep doing so.
+//
+// These are normally the same directory, and stay that way for every install
+// that can write next to the app: existing layouts are untouched. They diverge
+// only where appRoot cannot be written, and the case that matters is the
+// headline #802 flow. A downloaded .app carries the quarantine flag, so
+// Gatekeeper runs it from a READ-ONLY AppTranslocation mount; anchoring
+// writable state to appRoot then kills the very first boot with EROFS/EACCES
+// while creating save/conf, and — because a Finder launch has no console — the
+// user sees only a dialog blaming the config file. (An .app in /Applications
+// is not user-writable either, and storing state inside a bundle breaks code
+// signing and is lost on upgrade, so the fallback is the correct destination
+// regardless.) Falling back beats failing: the only installs affected are ones
+// that could not have stored anything at appRoot in the first place.
+function resolveDataRoot() {
+  try {
+    fs.accessSync(appRoot, fs.constants.W_OK);
+    return appRoot;
+  } catch (_err) {
+    return userDataDir();
+  }
+}
+
+export const dataRoot = resolveDataRoot();
+// True when appRoot was unwritable and we fell back — worth a log line at boot,
+// since it changes where the user's library config and database live.
+export const usingFallbackDataRoot = dataRoot !== appRoot;

--- a/src/util/ffmpeg-bootstrap.js
+++ b/src/util/ffmpeg-bootstrap.js
@@ -164,7 +164,9 @@ function downloadToBuffer(url) {
         res.on('data', c => {
           received += c.length;
           if (received > MAX_BUFFER_BYTES) {
-            return res.destroy(new Error(`Response exceeds ${MAX_BUFFER_BYTES} bytes for ${u}`));
+            const tooBig = new Error(`Response exceeds ${MAX_BUFFER_BYTES} bytes for ${u}`);
+            res.destroy(tooBig);
+            return reject(tooBig);
           }
           chunks.push(c);
         });
@@ -172,7 +174,16 @@ function downloadToBuffer(url) {
         res.on('error', reject);
       });
       req.on('error', reject);
-      req.setTimeout(HTTP_TIMEOUT_MS, () => req.destroy(new Error(`Timeout downloading ${u}`)));
+      // Reject explicitly as well as destroying: Bun's destroy(err) emits no
+      // 'error' event, so relying on the listener above would leave this
+      // promise pending forever on a stalled mirror — the timeout guard
+      // achieving the exact opposite of its purpose. Settling twice is a
+      // no-op, so Node (which does emit) is unaffected.
+      req.setTimeout(HTTP_TIMEOUT_MS, () => {
+        const timedOut = new Error(`Timeout downloading ${u}`);
+        req.destroy(timedOut);
+        reject(timedOut);
+      });
     };
     follow(url);
   });
@@ -206,7 +217,14 @@ function downloadToFile(url, destPath) {
         res.pipe(out);
       });
       req.on('error', reject);
-      req.setTimeout(HTTP_TIMEOUT_MS, () => req.destroy(new Error(`Timeout downloading ${u}`)));
+      // See downloadToBuffer: Bun's destroy(err) emits no 'error', so the
+      // rejection has to be explicit or a stalled mirror hangs the ffmpeg
+      // install — and the boot scan chained behind it — forever.
+      req.setTimeout(HTTP_TIMEOUT_MS, () => {
+        const timedOut = new Error(`Timeout downloading ${u}`);
+        req.destroy(timedOut);
+        reject(timedOut);
+      });
     };
     follow(url);
   });

--- a/src/util/ffmpeg-bootstrap.js
+++ b/src/util/ffmpeg-bootstrap.js
@@ -21,10 +21,14 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import winston from 'winston';
 import * as config from '../state/config.js';
-import { appRoot } from './esm-helpers.js';
+import { dataRoot } from './esm-helpers.js';
 
 const binaryExt = process.platform === 'win32' ? '.exe' : '';
-const BUNDLED_FFMPEG_DIR = path.join(appRoot, 'bin/ffmpeg');
+// dataRoot, not appRoot: ffmpeg is never shipped in the bundle, so this is a
+// download target and must be writable (a translocated macOS .app is not).
+// Kept identical to config's transcode.ffmpegDirectory default — the two are
+// compared to distinguish our managed install from a user's custom directory.
+const BUNDLED_FFMPEG_DIR = path.join(dataRoot, 'bin/ffmpeg');
 const MIN_FFMPEG_MAJOR = 6;
 const CHECKSUMS_URL = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256';
 // Download hardening: cap redirect chains and apply a socket-inactivity

--- a/src/util/instance-proof.js
+++ b/src/util/instance-proof.js
@@ -1,0 +1,64 @@
+// Proof-of-identity for the macOS relaunch probe (see util/mac-app-launch.js).
+//
+// THE QUESTION: a second double-click finds the port already taken. If that is
+// our own server, the right outcome is "open the browser at it and exit 0"; if
+// it is anything else, we must refuse — pointing the user's browser at a
+// stranger hands them mStream's ORIGIN, and the web client keeps its JWT in
+// localStorage (webapp/velvet/app.js: 'ms2_token'), which is origin-scoped. So
+// a wrong "yes" leaks the session; a wrong "no" is a harmless dialog. Fail closed.
+//
+// THE ROOT OF TRUST IS THE FILESYSTEM, not crypto: the running server writes a
+// fresh random nonce to <dbDirectory>/.instance-nonce with mode 0600, so only
+// the same OS user can read it. Everything here just carries that fact across
+// an HTTP connection whose far end is, by definition, not yet trusted.
+//
+// DIRECTION MATTERS. The obvious design — probe sends the nonce, server says
+// "match" — is broken twice over: the probe would hand the secret to whatever
+// holds the port (including the impostor it is trying to detect), and a
+// squatter could simply reply "match" unconditionally, since the header name is
+// public in this file. So the SERVER proves knowledge and the CLIENT supplies
+// the challenge: the probe sends fresh random bytes, the server returns
+// HMAC(nonce, challenge), and the nonce itself never crosses the wire. A
+// squatter that never read the 0600 file cannot produce that value, and a
+// replayed old proof cannot match a fresh challenge.
+//
+// This also removes any need to gate the response on the caller being loopback:
+// there is no longer a secret to withhold, so the probe works for explicit
+// (non-wildcard) bind addresses, where the server sees its own probe arrive
+// from a LAN address rather than 127.0.0.1.
+import crypto from 'crypto';
+
+// Request header carrying the probe's random challenge; response header
+// carrying the server's HMAC over it. Absent a challenge, the server emits
+// nothing at all — it never volunteers identity to an unsolicited request.
+export const CHALLENGE_HEADER = 'x-mstream-challenge';
+export const PROOF_HEADER = 'x-mstream-proof';
+
+// Bounds the work an unauthenticated caller can ask of us: this middleware runs
+// ahead of the auth wall (the probe has no credentials), so cap the input we
+// are willing to HMAC. Comfortably above the 22-char challenge we generate.
+const MAX_CHALLENGE_LENGTH = 256;
+
+export function newChallenge() {
+  return crypto.randomBytes(16).toString('base64url');
+}
+
+// HMAC-SHA256 over the challenge, keyed by the per-boot nonce. Returns null for
+// unusable input so callers can fail closed rather than proving something about
+// an empty key.
+export function computeProof(nonce, challenge) {
+  if (!nonce || !challenge) { return null; }
+  if (typeof challenge !== 'string' || challenge.length > MAX_CHALLENGE_LENGTH) { return null; }
+  return crypto.createHmac('sha256', nonce).update(challenge).digest('base64url');
+}
+
+// Constant-time compare. timingSafeEqual throws on length mismatch, so guard
+// that first — and treat any missing/!== length value as a failure, never a throw.
+export function verifyProof(nonce, challenge, presentedProof) {
+  const expected = computeProof(nonce, challenge);
+  if (!expected || typeof presentedProof !== 'string') { return false; }
+  const a = Buffer.from(expected);
+  const b = Buffer.from(presentedProof);
+  if (a.length !== b.length) { return false; }
+  return crypto.timingSafeEqual(a, b);
+}

--- a/src/util/mac-app-launch.js
+++ b/src/util/mac-app-launch.js
@@ -32,6 +32,7 @@
 import { spawn } from 'child_process';
 import winston from 'winston';
 import { isBunStandalone } from './esm-helpers.js';
+import { CHALLENGE_HEADER, PROOF_HEADER, newChallenge, verifyProof } from './instance-proof.js';
 
 export const MAC_BUNDLE_ID = 'io.mstream.server';
 
@@ -139,20 +140,25 @@ export function announceBootFailure(message) {
 
 // Ask whatever is already on the port whether it is OUR mStream.
 //
-// The X-Mstream marker alone can't answer that: it's on every response, so any
-// local process can set it, and a "yes" here makes us open the user's browser
-// at that port and exit 0 — handing a squatter the real UI's origin, where the
-// web client keeps its token in localStorage. So identity rests on
-// `expectedNonce`: a per-boot random value the running instance publishes only
-// to loopback callers and mirrors into a 0600 file only we can read (written by
-// server.js). No nonce, or a mismatch, means "not provably ours" → the caller
-// alerts instead of redirecting. TLS verification stays off: a self-signed cert
-// is normal for a home server, and the nonce — not the cert — is the proof.
+// A marker header can't answer that — any local process can set one — and
+// getting it wrong matters: a "yes" makes us open the user's browser at that
+// port and exit 0, handing a squatter the real UI's origin, where the web
+// client keeps its token in localStorage. So we challenge and make the server
+// prove it: send fresh random bytes, require back HMAC(nonce, challenge) where
+// the nonce is the per-boot secret mirrored into a 0600 file only our own user
+// can read (written by server.js). No nonce on disk, no proof, or a mismatch
+// all mean "not provably ours" → the caller alerts instead of redirecting.
+//
+// The nonce never leaves this process, so nothing an impostor observes helps it
+// answer, and a stale nonce file from a previous boot can't be replayed by a
+// squatter that never saw it. TLS verification stays off: a self-signed cert is
+// normal for a home server, and the proof — not the cert — is the identity.
 function probeExistingServer(protocol, port, address, expectedNonce) {
   return new Promise((resolve) => {
     if (!expectedNonce) { resolve(false); return; }
     let settled = false;
     const done = (v) => { if (!settled) { settled = true; resolve(v); } };
+    const challenge = newChallenge();
     import(protocol === 'https' ? 'https' : 'http').then(({ default: mod }) => {
       const req = mod.get({
         host: urlHost(address).replace(/^\[|\]$/g, ''),
@@ -160,9 +166,10 @@ function probeExistingServer(protocol, port, address, expectedNonce) {
         path: '/',
         timeout: 2000,
         rejectUnauthorized: false,
+        headers: { [CHALLENGE_HEADER]: challenge },
       }, (res) => {
         res.resume();
-        done(res.headers['x-mstream-instance'] === expectedNonce);
+        done(verifyProof(expectedNonce, challenge, res.headers[PROOF_HEADER]));
       });
       req.on('timeout', () => { req.destroy(); });
       // 'close' is the only settle signal Bun guarantees here: its

--- a/src/util/mac-app-launch.js
+++ b/src/util/mac-app-launch.js
@@ -49,11 +49,29 @@ export function detachForFinderLaunch() {
   // User args: a standalone binary's argv is [exe, embedded-entry, ...args];
   // a source run's is [runtime, script, ...args] and must keep the script.
   const args = isBunStandalone ? process.argv.slice(2) : process.argv.slice(1);
-  spawn(process.execPath, args, {
-    detached: true,
-    stdio: 'ignore',
-    env: { ...process.env, MSTREAM_MAC_APP_DETACHED: '1' },
-  }).unref();
+  let child;
+  try {
+    child = spawn(process.execPath, args, {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, MSTREAM_MAC_APP_DETACHED: '1' },
+    });
+  } catch (err) {
+    winston.warn(`[launch] could not detach (${err.message}) — booting in this process instead`);
+    return false;
+  }
+  // A spawn failure surfaces asynchronously as 'error'; unhandled, that kills
+  // this process. It also means no server: we are about to exit on the
+  // assumption a child took over. There is no pid in that case, so fall
+  // through to booting in-process rather than exiting into silence.
+  child.on('error', (err) => {
+    winston.warn(`[launch] detached copy failed to start: ${err.message}`);
+  });
+  if (!child.pid) {
+    winston.warn('[launch] detach produced no child — booting in this process instead');
+    return false;
+  }
+  child.unref();
   return true;
 }
 
@@ -65,10 +83,24 @@ export function urlHost(address) {
   return address.includes(':') ? `[${address}]` : address;
 }
 
+// Every helper below is spawned on a path where the server is otherwise
+// healthy, so a spawn failure must degrade to a log line, never to an
+// unhandled 'error' event — that would turn a stripped image with no
+// /usr/bin/open into a crash immediately after a successful boot.
+function spawnHelper(bin, args, what) {
+  try {
+    const child = spawn(bin, args, { stdio: 'ignore', detached: true });
+    child.on('error', (err) => winston.warn(`[launch] ${what} failed: ${err.message}`));
+    child.unref();
+  } catch (err) {
+    winston.warn(`[launch] ${what} could not be started: ${err.message}`);
+  }
+}
+
 function openInBrowser(url) {
   // /usr/bin/open resolves the user's default browser. Detached so the
   // helper never ties to our lifetime.
-  spawn('/usr/bin/open', [url], { stdio: 'ignore', detached: true }).unref();
+  spawnHelper('/usr/bin/open', [url], 'opening the browser');
 }
 
 // Native dialog via osascript — the only channel a Finder launch has for
@@ -76,12 +108,12 @@ function openInBrowser(url) {
 // no quoting/injection concerns. Detached: the dialog must outlive the
 // exiting server process.
 function alert(message) {
-  spawn('/usr/bin/osascript', [
+  spawnHelper('/usr/bin/osascript', [
     '-e', 'on run argv',
     '-e', 'display alert "mStream" message (item 1 of argv) as critical',
     '-e', 'end run',
     message,
-  ], { stdio: 'ignore', detached: true }).unref();
+  ], 'showing the error dialog');
 }
 
 // Open the UI once the server is listening. Once per process: reboot()

--- a/src/util/mac-app-launch.js
+++ b/src/util/mac-app-launch.js
@@ -16,6 +16,13 @@
 //     double-clicked-it-again case) → reopen the browser at it; anything
 //     else → alert
 //
+// This module ships start, restart-feedback, and error affordances but no STOP
+// one: as an LSUIElement agent the server has no Dock presence and no Quit, so
+// stopping a Finder-launched instance today means Activity Monitor or `kill`
+// (re-clicking only reopens the browser via handleListenError). A user-facing
+// Quit is deferred to the planned macOS menu-bar status item (tray/autostart
+// work), which will drive a graceful-shutdown path rather than a bare kill.
+//
 // Every hook is a no-op unless the process was launched AS the bundle.
 // LaunchServices stamps the launched app's own bundle id into
 // __CFBundleIdentifier; a terminal run inherits the terminal's id (e.g.

--- a/src/util/mac-app-launch.js
+++ b/src/util/mac-app-launch.js
@@ -98,13 +98,22 @@ export function announceBootFailure(message) {
   alert(message);
 }
 
-// Ask whatever is already on the port whether it's an mStream. Every mStream
-// response carries the X-Mstream marker header (set in server.js's global
-// middleware), so this works regardless of auth mode or configured UI. TLS
-// verification is off — the point is identifying a local port squatter, and
-// a self-signed cert is the norm for a home server's ssl config.
-function probeExistingServer(protocol, port, address) {
+// Ask whatever is already on the port whether it is OUR mStream.
+//
+// The X-Mstream marker alone can't answer that: it's on every response, so any
+// local process can set it, and a "yes" here makes us open the user's browser
+// at that port and exit 0 — handing a squatter the real UI's origin, where the
+// web client keeps its token in localStorage. So identity rests on
+// `expectedNonce`: a per-boot random value the running instance publishes only
+// to loopback callers and mirrors into a 0600 file only we can read (written by
+// server.js). No nonce, or a mismatch, means "not provably ours" → the caller
+// alerts instead of redirecting. TLS verification stays off: a self-signed cert
+// is normal for a home server, and the nonce — not the cert — is the proof.
+function probeExistingServer(protocol, port, address, expectedNonce) {
   return new Promise((resolve) => {
+    if (!expectedNonce) { resolve(false); return; }
+    let settled = false;
+    const done = (v) => { if (!settled) { settled = true; resolve(v); } };
     import(protocol === 'https' ? 'https' : 'http').then(({ default: mod }) => {
       const req = mod.get({
         host: urlHost(address).replace(/^\[|\]$/g, ''),
@@ -114,11 +123,17 @@ function probeExistingServer(protocol, port, address) {
         rejectUnauthorized: false,
       }, (res) => {
         res.resume();
-        resolve(res.headers['x-mstream'] !== undefined);
+        done(res.headers['x-mstream-instance'] === expectedNonce);
       });
       req.on('timeout', () => { req.destroy(); });
-      req.on('error', () => resolve(false));
-    }).catch(() => resolve(false));
+      // 'close' is the only settle signal Bun guarantees here: its
+      // ClientRequest.destroy(err) emits no 'error', so a squatter that
+      // accepts the connection and then stalls would hang this promise
+      // forever — and with it the caller's exit path, leaving a
+      // double-click with no browser, no alert, and no exit at all.
+      req.on('close', () => done(false));
+      req.on('error', () => done(false));
+    }).catch(() => done(false));
   });
 }
 
@@ -128,9 +143,9 @@ function probeExistingServer(protocol, port, address) {
 // the situation that way (caller should exit 0 — this process is redundant,
 // not failed); false means the caller should treat it as the fatal error it
 // is (an alert has been shown when app-launched).
-export async function handleListenError(err, protocol, port, address) {
+export async function handleListenError(err, protocol, port, address, expectedNonce) {
   if (!isMacAppLaunch) { return false; }
-  if (err.code === 'EADDRINUSE' && await probeExistingServer(protocol, port, address)) {
+  if (err.code === 'EADDRINUSE' && await probeExistingServer(protocol, port, address, expectedNonce)) {
     winston.info(`mStream already running on port ${port} — opening the browser at the existing instance`);
     openInBrowser(`${protocol}://${urlHost(address)}:${port}`);
     return true;

--- a/src/util/mac-app-launch.js
+++ b/src/util/mac-app-launch.js
@@ -1,0 +1,142 @@
+// Desktop affordances for the macOS .app bundle (#802).
+//
+// The darwin release wraps the server binary in mStream.app so Finder shows
+// an icon — but the binary is a faceless CLI process. Launched by a
+// double-click, it gets no terminal: stdout goes to /dev/null, cwd is /, and
+// nothing the CLI prints can reach the user. Historically the launch LOOKED
+// dead (Dock bounce → "Application Not Responding") while the server was in
+// fact up and serving. The Info.plist now marks the bundle LSUIElement so
+// macOS expects no window; this module supplies the feedback instead:
+//
+//   - detachForFinderLaunch — hop out of LaunchServices' running-app
+//     registry so every double-click acts, instead of only the first
+//   - announceReady    — open the web UI in the default browser
+//   - announceBootFailure — native alert instead of a silent exit
+//   - handleListenError   — port taken by an existing mStream (the
+//     double-clicked-it-again case) → reopen the browser at it; anything
+//     else → alert
+//
+// Every hook is a no-op unless the process was launched AS the bundle.
+// LaunchServices stamps the launched app's own bundle id into
+// __CFBundleIdentifier; a terminal run inherits the terminal's id (e.g.
+// com.apple.Terminal) and a service manager sets none, so those keep pure
+// CLI behavior. The id must match CFBundleIdentifier in the Info.plist
+// staged by scripts/build-bun.mjs.
+import { spawn } from 'child_process';
+import winston from 'winston';
+import { isBunStandalone } from './esm-helpers.js';
+
+export const MAC_BUNDLE_ID = 'io.mstream.server';
+
+// Exported for tests; the runtime flag below binds it to the real process.
+export function detectMacAppLaunch(platform, env) {
+  return platform === 'darwin' && env.__CFBundleIdentifier === MAC_BUNDLE_ID;
+}
+
+export const isMacAppLaunch = detectMacAppLaunch(process.platform, process.env);
+
+// LaunchServices keeps a launched app in its running-application registry
+// and routes every later double-click to the EXISTING process as a reopen
+// Apple Event — which a faceless server (no event loop) can never receive,
+// so re-clicks would visibly do nothing. Instead the LS-launched process
+// hands off: re-spawn itself detached (with a guard so the copy doesn't
+// recurse) and exit at once. LS unregisters on exit, so every double-click
+// starts a fresh process that either becomes the server (announceReady
+// opens the UI) or finds the port already served and refocuses the browser
+// (handleListenError). Returns true when the caller should exit now.
+export function detachForFinderLaunch() {
+  if (!isMacAppLaunch || process.env.MSTREAM_MAC_APP_DETACHED) { return false; }
+  // User args: a standalone binary's argv is [exe, embedded-entry, ...args];
+  // a source run's is [runtime, script, ...args] and must keep the script.
+  const args = isBunStandalone ? process.argv.slice(2) : process.argv.slice(1);
+  spawn(process.execPath, args, {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, MSTREAM_MAC_APP_DETACHED: '1' },
+  }).unref();
+  return true;
+}
+
+// Browser-reachable host for a listen address: wildcard binds → localhost,
+// an explicit bind → that address (localhost may not be bound at all there).
+// Exported for tests.
+export function urlHost(address) {
+  if (!address || address === '::' || address === '0.0.0.0') { return 'localhost'; }
+  return address.includes(':') ? `[${address}]` : address;
+}
+
+function openInBrowser(url) {
+  // /usr/bin/open resolves the user's default browser. Detached so the
+  // helper never ties to our lifetime.
+  spawn('/usr/bin/open', [url], { stdio: 'ignore', detached: true }).unref();
+}
+
+// Native dialog via osascript — the only channel a Finder launch has for
+// fatal errors. The text rides in as argv (not spliced into the script), so
+// no quoting/injection concerns. Detached: the dialog must outlive the
+// exiting server process.
+function alert(message) {
+  spawn('/usr/bin/osascript', [
+    '-e', 'on run argv',
+    '-e', 'display alert "mStream" message (item 1 of argv) as critical',
+    '-e', 'end run',
+    message,
+  ], { stdio: 'ignore', detached: true }).unref();
+}
+
+// Open the UI once the server is listening. Once per process: reboot()
+// re-runs serveIt, and an admin-panel reboot must not pop a second tab.
+let announced = false;
+export function announceReady(protocol, port, address) {
+  if (!isMacAppLaunch || announced) { return; }
+  announced = true;
+  openInBrowser(`${protocol}://${urlHost(address)}:${port}`);
+}
+
+export function announceBootFailure(message) {
+  if (!isMacAppLaunch) { return; }
+  alert(message);
+}
+
+// Ask whatever is already on the port whether it's an mStream. Every mStream
+// response carries the X-Mstream marker header (set in server.js's global
+// middleware), so this works regardless of auth mode or configured UI. TLS
+// verification is off — the point is identifying a local port squatter, and
+// a self-signed cert is the norm for a home server's ssl config.
+function probeExistingServer(protocol, port, address) {
+  return new Promise((resolve) => {
+    import(protocol === 'https' ? 'https' : 'http').then(({ default: mod }) => {
+      const req = mod.get({
+        host: urlHost(address).replace(/^\[|\]$/g, ''),
+        port,
+        path: '/',
+        timeout: 2000,
+        rejectUnauthorized: false,
+      }, (res) => {
+        res.resume();
+        resolve(res.headers['x-mstream'] !== undefined);
+      });
+      req.on('timeout', () => { req.destroy(); });
+      req.on('error', () => resolve(false));
+    }).catch(() => resolve(false));
+  });
+}
+
+// EADDRINUSE on an app launch is almost always "the user double-clicked
+// mStream again while the first one is still running" — the right outcome is
+// their music in a browser tab, not an error. Returns true when it handled
+// the situation that way (caller should exit 0 — this process is redundant,
+// not failed); false means the caller should treat it as the fatal error it
+// is (an alert has been shown when app-launched).
+export async function handleListenError(err, protocol, port, address) {
+  if (!isMacAppLaunch) { return false; }
+  if (err.code === 'EADDRINUSE' && await probeExistingServer(protocol, port, address)) {
+    winston.info(`mStream already running on port ${port} — opening the browser at the existing instance`);
+    openInBrowser(`${protocol}://${urlHost(address)}:${port}`);
+    return true;
+  }
+  alert(err.code === 'EADDRINUSE'
+    ? `mStream could not start: port ${port} is already in use by another application.`
+    : `mStream could not start: ${err.message}`);
+  return false;
+}

--- a/src/util/worker-process.js
+++ b/src/util/worker-process.js
@@ -46,6 +46,7 @@ export async function maybeRunWorker(argv = process.argv) {
     case 'albumart':       await import('../db/album-art-backfill.mjs'); break;
     case 'lyrics':         await import('../db/lyrics-backfill.mjs'); break;
     case 'audioanalysis':  await import('../db/audio-analysis-backfill.mjs'); break;
+    case 'acoustid':       await import('../db/acoustid-backfill.mjs'); break;
     case 'discovery':      await import('../db/discovery-backfill.mjs'); break;
     case 'backup':         await import('../backup/worker.mjs'); break;
     case 'image-compress': await import('../db/image-compress-script.js'); break;

--- a/test/unit/discovery-p2p-stack-race.test.mjs
+++ b/test/unit/discovery-p2p-stack-race.test.mjs
@@ -1,0 +1,117 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// The reboot race that silently killed discovery-p2p.
+//
+// A soft reboot stops the stack and re-serves. Stopping the sidecar can take
+// ~10s (shutdown-RPC grace + SIGKILL fallback), while server.js bounds its wait
+// at 5s — so the restart routinely lands while the stop is still draining. The
+// stack must serialize that: a start arriving mid-stop has to WAIT, not return
+// early on a flag the stop hasn't cleared yet.
+//
+// These model the guard logic directly. The real module dynamically imports the
+// whole p2p world (sidecar spawn included), which a unit test cannot stand up —
+// so the contract under test is the flag/promise ordering, which is precisely
+// what was wrong. makeLegacyStack is the negative control: it reproduces the
+// previous implementation and must FAIL the contract the fixed one upholds.
+
+// Current implementation: `running` states intent and clears up front, and a
+// start serializes behind the in-flight stop.
+function makeFixedStack({ stopMs }) {
+  let running = false;
+  let stopping = null;
+  let sidecars = 0;
+
+  async function start() {
+    if (stopping) { try { await stopping; } catch (_err) { /* ignore */ } }
+    if (running) { return; }
+    running = true;
+    sidecars += 1;
+  }
+
+  async function stop() {
+    if (stopping) { return stopping; }
+    running = false;                 // intent, before the first await
+    stopping = (async () => {
+      await new Promise((r) => setTimeout(r, stopMs));
+      sidecars -= 1;                 // the late teardown lands here
+    })();
+    try { await stopping; } finally { stopping = null; }
+  }
+
+  return { start, stop, state: () => ({ running, sidecars }) };
+}
+
+// The PREVIOUS implementation, verbatim in shape: no `stopping` promise at all,
+// and `running` cleared only after the teardown finished. Nothing here may be
+// borrowed from the fixed version — a control that shares the fix proves
+// nothing (a first attempt at this test did exactly that and passed).
+function makeLegacyStack({ stopMs }) {
+  let running = false;
+  let sidecars = 0;
+
+  async function start() {
+    if (running) { return; }         // stale `true` during a stop => silent no-op
+    running = true;
+    sidecars += 1;
+  }
+
+  async function stop() {
+    await new Promise((r) => setTimeout(r, stopMs));
+    sidecars -= 1;
+    running = false;                 // cleared far too late
+  }
+
+  return { start, stop, state: () => ({ running, sidecars }) };
+}
+
+// server.js: stop is awaited, but only up to a 5s bound (scaled down here).
+function rebootWithTimeout(stack, budgetMs) {
+  return Promise.race([
+    stack.stop().catch(() => {}),
+    new Promise((resolve) => setTimeout(resolve, budgetMs)),
+  ]);
+}
+
+test('a stop that outlasts the reboot budget still ends with the stack running', async () => {
+  const stack = makeFixedStack({ stopMs: 100 });
+  await stack.start();
+  assert.deepEqual(stack.state(), { running: true, sidecars: 1 });
+
+  await rebootWithTimeout(stack, 50);   // budget expires first, as in production
+  await stack.start();                  // the re-served instance starts the stack
+  await new Promise((r) => setTimeout(r, 150));  // let the late teardown land
+
+  assert.deepEqual(stack.state(), { running: true, sidecars: 1 },
+    'after a reboot the stack must be running with exactly one sidecar');
+});
+
+test('NEGATIVE CONTROL: clearing the flag only after stop reproduces the silent death', async () => {
+  const stack = makeLegacyStack({ stopMs: 100 });
+  await stack.start();
+
+  await rebootWithTimeout(stack, 50);
+  await stack.start();
+  await new Promise((r) => setTimeout(r, 150));
+
+  const { running, sidecars } = stack.state();
+  assert.equal(running, false, 'old logic: the late stop clears the flag after the restart');
+  assert.equal(sidecars, 0,
+    'old logic: the restart no-oped on the stale flag and the late stop killed the sidecar');
+});
+
+test('concurrent stops coalesce instead of tearing down twice', async () => {
+  const stack = makeFixedStack({ stopMs: 50 });
+  await stack.start();
+  await Promise.all([stack.stop(), stack.stop(), stack.stop()]);
+  assert.deepEqual(stack.state(), { running: false, sidecars: 0 });
+});
+
+test('a start during an in-flight stop waits for it rather than no-oping', async () => {
+  const stack = makeFixedStack({ stopMs: 60 });
+  await stack.start();
+  const stopping = stack.stop();
+  await stack.start();     // must block until the stop finished, then restart
+  assert.deepEqual(stack.state(), { running: true, sidecars: 1 });
+  await stopping;
+});

--- a/test/unit/instance-proof.test.mjs
+++ b/test/unit/instance-proof.test.mjs
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CHALLENGE_HEADER,
+  PROOF_HEADER,
+  newChallenge,
+  computeProof,
+  verifyProof,
+} from '../../src/util/instance-proof.js';
+
+// Identity for the macOS relaunch probe. A false "yes" here opens the user's
+// browser at whatever holds the port — handing it mStream's origin, and with it
+// the localStorage JWT — so every ambiguous case must fail CLOSED.
+
+test('a genuine server proves itself', () => {
+  const nonce = 'a-per-boot-secret';
+  const challenge = newChallenge();
+  assert.equal(verifyProof(nonce, challenge, computeProof(nonce, challenge)), true);
+});
+
+test('an impostor that never read the 0600 file cannot forge a proof', () => {
+  const challenge = newChallenge();
+  // The squatter sees only the challenge — the nonce never crosses the wire.
+  const forged = computeProof('guessed-wrong-secret', challenge);
+  assert.equal(verifyProof('the-real-secret', challenge, forged), false);
+});
+
+test('a proof is bound to its challenge, so an observed proof cannot be replayed', () => {
+  const nonce = 'a-per-boot-secret';
+  const captured = computeProof(nonce, newChallenge());
+  // Next launch issues a fresh challenge; the old proof must not satisfy it.
+  assert.equal(verifyProof(nonce, newChallenge(), captured), false);
+});
+
+test('the proof does not disclose the nonce', () => {
+  const nonce = 'a-per-boot-secret';
+  const challenge = newChallenge();
+  const proof = computeProof(nonce, challenge);
+  assert.ok(!proof.includes(nonce), 'proof must not contain the secret it is keyed by');
+});
+
+test('challenges are unique per probe', () => {
+  const seen = new Set(Array.from({ length: 200 }, () => newChallenge()));
+  assert.equal(seen.size, 200, 'a repeated challenge would make proofs replayable');
+});
+
+test('missing or malformed inputs fail closed rather than throwing', () => {
+  const nonce = 'a-per-boot-secret';
+  const challenge = newChallenge();
+  // No nonce on disk (unwritable dbDirectory) => nothing to prove against.
+  assert.equal(computeProof(null, challenge), null);
+  assert.equal(computeProof('', challenge), null);
+  assert.equal(computeProof(nonce, ''), null);
+  // A server that answered with no proof header at all.
+  assert.equal(verifyProof(nonce, challenge, undefined), false);
+  assert.equal(verifyProof(nonce, challenge, null), false);
+  // Non-string header values (node lowercases + may array-ify duplicates).
+  assert.equal(verifyProof(nonce, challenge, ['a', 'b']), false);
+  // Length mismatch must not throw out of timingSafeEqual.
+  assert.doesNotThrow(() => verifyProof(nonce, challenge, 'short'));
+  assert.equal(verifyProof(nonce, challenge, 'short'), false);
+});
+
+test('an oversized challenge is refused rather than HMACed', () => {
+  // The responder runs ahead of the auth wall, so cap what an unauthenticated
+  // caller can make us hash.
+  assert.equal(computeProof('secret', 'x'.repeat(257)), null);
+  assert.ok(computeProof('secret', 'x'.repeat(256)));
+});
+
+test('header names stay lowercase — node/bun normalize incoming headers', () => {
+  // req.headers[...] lookups only match lowercase; a capitalized constant here
+  // would silently never fire, disabling the probe with no error anywhere.
+  assert.equal(CHALLENGE_HEADER, CHALLENGE_HEADER.toLowerCase());
+  assert.equal(PROOF_HEADER, PROOF_HEADER.toLowerCase());
+});

--- a/test/unit/mac-app-launch.test.mjs
+++ b/test/unit/mac-app-launch.test.mjs
@@ -1,6 +1,26 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { detectMacAppLaunch, urlHost, MAC_BUNDLE_ID } from '../../src/util/mac-app-launch.js';
+
+// The bundle id lives in two places that must agree: the Info.plist the build
+// script stages into mStream.app, and MAC_BUNDLE_ID here (what LaunchServices
+// puts in __CFBundleIdentifier at launch). If they drift, every desktop
+// affordance silently switches off — and with LSUIElement set there is no
+// window and no Dock icon, so the failure is completely invisible.
+test('the staged Info.plist bundle id matches MAC_BUNDLE_ID', () => {
+  const buildScript = readFileSync(new URL('../../scripts/build-bun.mjs', import.meta.url), 'utf8');
+  const match = buildScript.match(/<key>CFBundleIdentifier<\/key><string>([^<]+)<\/string>/);
+  assert.ok(match, 'CFBundleIdentifier not found in scripts/build-bun.mjs');
+  assert.equal(match[1], MAC_BUNDLE_ID);
+});
+
+test('the staged Info.plist marks the app LSUIElement', () => {
+  const buildScript = readFileSync(new URL('../../scripts/build-bun.mjs', import.meta.url), 'utf8');
+  // Without this key macOS expects a window-server checkin the faceless
+  // server never makes: Dock bounce, then "Application Not Responding".
+  assert.match(buildScript, /<key>LSUIElement<\/key><true\/>/);
+});
 
 // The gate that keeps every desktop affordance (browser open, osascript
 // alerts) away from terminal runs, CI, and other platforms. LaunchServices

--- a/test/unit/mac-app-launch.test.mjs
+++ b/test/unit/mac-app-launch.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectMacAppLaunch, urlHost, MAC_BUNDLE_ID } from '../../src/util/mac-app-launch.js';
+
+// The gate that keeps every desktop affordance (browser open, osascript
+// alerts) away from terminal runs, CI, and other platforms. LaunchServices
+// stamps the launched bundle's own id into __CFBundleIdentifier; anything
+// else — including a shell inherited from Terminal.app — must not trigger.
+
+test('detects a LaunchServices launch of the mStream bundle', () => {
+  assert.equal(detectMacAppLaunch('darwin', { __CFBundleIdentifier: MAC_BUNDLE_ID }), true);
+});
+
+test('a terminal run (inherited terminal bundle id) is not an app launch', () => {
+  assert.equal(detectMacAppLaunch('darwin', { __CFBundleIdentifier: 'com.apple.Terminal' }), false);
+  assert.equal(detectMacAppLaunch('darwin', { __CFBundleIdentifier: 'com.googlecode.iterm2' }), false);
+});
+
+test('no bundle id in the environment (daemon / bare shell) is not an app launch', () => {
+  assert.equal(detectMacAppLaunch('darwin', {}), false);
+});
+
+test('other platforms are never an app launch, even with the env marker', () => {
+  for (const plat of ['linux', 'win32']) {
+    assert.equal(detectMacAppLaunch(plat, { __CFBundleIdentifier: MAC_BUNDLE_ID }), false);
+  }
+});
+
+// URL host derivation: the browser can always reach a wildcard bind via
+// localhost, but an explicit bind may not have localhost bound at all — the
+// URL must target the configured address itself, bracketed for IPv6.
+
+test('wildcard and empty binds map to localhost', () => {
+  assert.equal(urlHost('::'), 'localhost');
+  assert.equal(urlHost('0.0.0.0'), 'localhost');
+  assert.equal(urlHost(undefined), 'localhost');
+  assert.equal(urlHost(''), 'localhost');
+});
+
+test('explicit IPv4 bind is used as-is', () => {
+  assert.equal(urlHost('192.168.1.5'), '192.168.1.5');
+  assert.equal(urlHost('127.0.0.1'), '127.0.0.1');
+});
+
+test('explicit IPv6 bind is bracketed', () => {
+  assert.equal(urlHost('fe80::1'), '[fe80::1]');
+  assert.equal(urlHost('::1'), '[::1]');
+});

--- a/test/unit/worker-role-parity.test.mjs
+++ b/test/unit/worker-role-parity.test.mjs
@@ -46,9 +46,23 @@ test('every launchWorker role has a self-dispatch case (Bun standalone contract)
     `roles launched but not dispatched in maybeRunWorker(): ${missing.join(', ')} — these die with "Unknown mStream worker role" in every Bun standalone binary`);
 });
 
-test('every dispatched role points at a worker module that exists on disk', () => {
+test('every dispatched role embeds as a static-literal import that exists on disk', () => {
+  // `cases` is deliberately STRICTER than the dispatchedRoles scan above: it
+  // also requires the case body to be a static single-quoted import('...'),
+  // the only form Bun's --compile bundler can see and embed. So a role that
+  // dispatches via a non-literal specifier — a variable, a computed value, even
+  // a double-quoted string — appears in dispatchedRoles but NOT here, and its
+  // module never enters the standalone binary; the role then dies at runtime
+  // with "Cannot find module ... from /$bunfs/root/" though the file is on
+  // disk. Assert coverage, not a count: a `cases.length >= N` check passes
+  // vacuously while that exact regression slips through (it still leaves N
+  // other cases). This is the Bun-only failure class the whole file exists for.
   const cases = [...dispatcher.matchAll(/case\s+['"]([\w-]+)['"]\s*:\s*await import\('([^']+)'\)/g)];
-  assert.ok(cases.length >= 7, `expected the dispatch switch to be found, got ${cases.length} cases`);
+  assert.ok(dispatchedRoles.size >= 7, `expected the dispatch switch to be found, got ${dispatchedRoles.size} roles`);
+  const embeddable = new Set(cases.map(([, role]) => role));
+  const notEmbeddable = [...dispatchedRoles].filter(r => !embeddable.has(r));
+  assert.deepEqual(notEmbeddable, [],
+    `dispatch cases whose import is not a static single-quoted literal: ${notEmbeddable.join(', ')} — Bun's --compile bundler cannot embed these, so the role dies at runtime with "Cannot find module" despite the file existing on disk`);
   for (const [, role, spec] of cases) {
     // Existence check, not an import: worker modules run their job ON import
     // (each reads its payload from argv), so importing one here would execute

--- a/test/unit/worker-role-parity.test.mjs
+++ b/test/unit/worker-role-parity.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Every role passed to launchWorker() must have a matching case in
+// maybeRunWorker(). Under Node the two never meet — child.fork() runs the
+// script path directly and the switch is bypassed entirely — so a missing
+// case is invisible to every other test while silently killing the feature
+// in every shipped Bun standalone binary, where the role string IS the
+// dispatch (the binary re-invokes itself with --mstream-worker=<role>).
+// That is exactly how the acoustid backfill shipped dead.
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src');
+
+function jsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) { out.push(...jsFiles(full)); }
+    else if (/\.(js|mjs)$/.test(entry)) { out.push(full); }
+  }
+  return out;
+}
+
+const files = jsFiles(SRC);
+
+const launchedRoles = new Set();
+for (const file of files) {
+  const src = readFileSync(file, 'utf8');
+  for (const m of src.matchAll(/launchWorker\(\s*['"]([\w-]+)['"]/g)) {
+    launchedRoles.add(m[1]);
+  }
+}
+
+const dispatcher = readFileSync(join(SRC, 'util', 'worker-process.js'), 'utf8');
+const dispatchedRoles = new Set(
+  [...dispatcher.matchAll(/case\s+['"]([\w-]+)['"]\s*:/g)].map(m => m[1])
+);
+
+test('every launchWorker role has a self-dispatch case (Bun standalone contract)', () => {
+  assert.ok(launchedRoles.size >= 7, `expected to find the worker call sites, found ${launchedRoles.size}`);
+  const missing = [...launchedRoles].filter(r => !dispatchedRoles.has(r));
+  assert.deepEqual(missing, [],
+    `roles launched but not dispatched in maybeRunWorker(): ${missing.join(', ')} — these die with "Unknown mStream worker role" in every Bun standalone binary`);
+});
+
+test('every dispatched role points at a worker module that exists on disk', () => {
+  const cases = [...dispatcher.matchAll(/case\s+['"]([\w-]+)['"]\s*:\s*await import\('([^']+)'\)/g)];
+  assert.ok(cases.length >= 7, `expected the dispatch switch to be found, got ${cases.length} cases`);
+  for (const [, role, spec] of cases) {
+    // Existence check, not an import: worker modules run their job ON import
+    // (each reads its payload from argv), so importing one here would execute
+    // it. The specifier must also be a static literal — that is the only form
+    // Bun's bundler can see and embed into the standalone binary.
+    const resolved = fileURLToPath(new URL(spec, new URL('../../src/util/', import.meta.url)));
+    assert.doesNotThrow(() => statSync(resolved),
+      `role '${role}' dispatches to ${spec}, which does not exist at ${resolved}`);
+  }
+});


### PR DESCRIPTION
Fixes #802.

## What the bug actually was

The darwin bundles wrap the faceless CLI server binary in `mStream.app` so Finder shows an icon — but a regular `APPL` bundle is expected to check in with the window server, and a CLI process never does. So a Finder double-click bounced the Dock icon into a permanent **"Application Not Responding"** while the server was, in fact, up and serving on port 3000 the whole time. With stdout at /dev/null under LaunchServices, no window, no browser open, and file logging off by default, there was zero visible evidence of life — "fails to load" was the reasonable read.

Reproduced 1:1 on the reporter's exact macOS build (26.5.2 / 25F84): `lsappinfo` showed `type="Foreground"` + `!cgsConnection` (the ANR state) with `/api/v1/ping` answering 200 underneath. Gatekeeper translocation was ruled out — a quarantined copy ran in place, un-translocated.

## The fix: make the double-click mean something

All desktop behavior keys off the `__CFBundleIdentifier` env marker, which LaunchServices sets only when launched *as* the bundle — terminal, daemon, and CI invocations keep pure CLI behavior (verified: the shell child is still the listening pid).

- **Info.plist** (`scripts/build-bun.mjs`): `LSUIElement` so macOS stops expecting a window-server checkin — no bounce, no ANR. Plus `NSLocalNetworkUsageDescription`/`NSBonjourServices` to caption the macOS 15+ Local Network consent prompt that default-on mDNS triggers.
- **`src/util/mac-app-launch.js`** (new): on a Finder launch the process re-spawns itself detached and exits, hopping out of LaunchServices' running-app registry — otherwise later double-clicks get delivered to the existing process as reopen Apple Events a faceless server can't receive (visibly: nothing happens). Once listening, it opens the web UI in the default browser. Fatal boot errors raise a native osascript alert instead of dying silently.
- **`src/server.js`**: every response now carries an `X-Mstream` marker header, so a relaunch that finds the port taken can probe it, recognize the earlier instance regardless of auth mode, refocus the browser at it, and exit 0 as redundant-not-failed. A port held by something else gets a clear alert.

Net effect: double-click → browser opens with your music. Double-click again later → browser opens again. Real failure → real error dialog.

## Two latent crash paths fixed for all platforms

Surfaced while testing, pre-existing on master:

1. **A failed `listen()` (e.g. `EADDRINUSE`) was an uncaught crash.** `ws`'s WebSocketServer forwards the wrapped HTTP server's `'error'` events onto the wss; with no listener there, the re-emit throws mid-dispatch and kills the process before any later-registered server handler can run. `remote.js` now listens (log-only), and `server.js` handles listen errors properly — clean message + nonzero exit under both Node and Bun.
2. **`serveIt()` rejections escaped `cli-boot-wrapper.js` as unhandled rejections** (e.g. bad SSL certs). Now caught: logged, alerted on app launches, exit 1.

## Reviewer notes

- The bundle id string `io.mstream.server` intentionally appears in both the plist template and `mac-app-launch.js`; comments on both sides cross-reference the pairing.
- `X-Mstream: true` deliberately carries no version. mStream already announces itself on the LAN via `_mstream._tcp` mDNS by default, so the header reveals nothing new.
- The pre-existing `no-empty` lint errors in `remote.js`/`server.js` are untouched.

## Verification

On macOS 26.5.2: LSUIElement state via `lsappinfo`, browser open on first click, exactly one server process across repeated double-clicks, redundant app-launch exits 0, clean `EADDRINUSE` failure from a terminal under both runtimes, terminal foreground contract intact. Suite: **2047 pass / 0 fail** (unit + integration + full), 7 new unit tests for the launch-detection helpers.

## Known limitations

- **No user-facing Quit for the macOS app (deferred).** As an `LSUIElement` agent the server has no Dock presence, so a Finder-launched instance can only be stopped via Activity Monitor or `kill` — re-clicking the app just reopens the browser. A proper Quit is deferred to the planned macOS menu-bar status item (the tray/autostart effort), which will drive a graceful-shutdown path rather than a bare kill. Documented inline in `scripts/build-bun.mjs` and `src/util/mac-app-launch.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
