### PR TITLE
Desktop player: minimize to system tray on Linux/Windows (#795)

### DIFF
--- a/webapp/index.js
+++ b/webapp/index.js
@@ -1,7 +1,11 @@
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow, Tray, Menu } = require('electron')
+const path = require('path')
+
+let win
+let tray
 
 function createWindow () {
-  const win = new BrowserWindow({
+  win = new BrowserWindow({
     autoHideMenuBar: true,
     backgroundColor: '#1e2228',
     width: 1200,
@@ -11,11 +15,68 @@ function createWindow () {
       nodeIntegration: false
     }
   })
+
+  // Minimize hides to the tray on Linux/Windows instead of camping in the
+  // taskbar — playback keeps running in the background (#795). Close (X)
+  // still quits, so the default close behaviour is unchanged. macOS keeps
+  // its native minimize-to-Dock.
+  if (process.platform !== 'darwin') {
+    win.on('minimize', (event) => {
+      event.preventDefault()
+      win.hide()
+    })
+  }
+
   win.loadFile('./index.html')
+}
+
+function showWindow () {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow()
+    return
+  }
+  win.show()
+  win.focus()
+}
+
+function createTray () {
+  // velvet/build, NOT the top-level build/: that one is electron-builder's
+  // buildResources dir and gets stripped from the packaged app — the
+  // webapp's own copy under velvet/ is what actually ships in the asar.
+  const icon = process.platform === 'darwin'
+    ? 'velvet/build/tray-icon-osx.png'
+    : 'velvet/build/tray-icon.png'
+  try {
+    tray = new Tray(path.join(__dirname, icon))
+  } catch (_err) {
+    // No tray host (some minimal desktops, CI) — the window keeps working,
+    // and without a tray the minimize interception above would strand the
+    // app, so put minimize back to its native behaviour.
+    tray = null
+    if (win) { win.removeAllListeners('minimize') }
+    return
+  }
+  tray.setToolTip('mStream Desktop')
+  // The context menu is the reliable way back: the StatusNotifierItem spec
+  // leaves "activation" ambiguous across Linux environments (single click
+  // in some, double click in others), so the left-click handler below is
+  // best-effort and Show here is the guaranteed path.
+  tray.setContextMenu(Menu.buildFromTemplate([
+    { label: 'Show mStream', click: showWindow },
+    { type: 'separator' },
+    {
+      label: 'Quit',
+      click: () => {
+        app.quit()
+      }
+    }
+  ]))
+  tray.on('click', showWindow)
 }
 
 app.whenReady().then(() => {
   createWindow()
+  createTray()
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mstream-desktop-app",
-  "version": "6.0.0",
+  "version": "6.10.0",
   "description": "mStream Desktop Player",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Implements the minimize-to-tray ask from #795, targeting the new `desktop-player` branch (cut from `v6.9.1-DESKTOP_PLAYER`, the last player release) — which also answers the issue's blocking question: the Electron player was deliberately removed from `master` in 8ea5a74a, so this branch is now where desktop-player patches land.

## What changes

`webapp/index.js` (the player's whole main process) grows a tray:

- **Minimize → hide to tray** on Linux/Windows; playback continues with no taskbar/window-list slot. **Close (X) is unchanged** — it still quits, so nobody's muscle memory breaks and no preference plumbing is needed.
- **Tray context menu — Show mStream / Quit — is the reliable path back.** As the issue rightly flags, StatusNotifierItem "activation" is ambiguous across Linux environments, so the `click → show` handler is best-effort on top, not the only way home.
- **macOS keeps native minimize-to-Dock** (the tray still appears, with Show/Quit).
- **No-tray-host fallback:** if `new Tray` throws (minimal desktops, CI), the minimize interception is removed again — the window can never be stranded with no way back.

Plus `webapp/package.json` 6.0.0 → **6.10.0**: every release to date has shipped inner version 6.0.0 (check any release's asset names), so electron-updater's feed has never advertised an update to an existing install. This makes the next release the first one updaters can actually see.

## The icon subtlety

The issue suggested reusing `velvet/build/tray-icon.png` — that path specifically, and it matters: the top-level `build/` is electron-builder's `buildResources` directory and is **stripped from the packaged app**. Verified against the shipped 6.9.1 AppImage's asar: it contains `velvet/build/tray-icon*.png` but no `build/`. The code loads from `velvet/build/`.

## Verification (Docker, linux/arm64, Xvfb, Electron 41)

Headless before/after probe that loads the real main, synthesizes the minimize event, and attempts tray construction from the shipping icon path:

| | shipped 6.9.1 asar | this branch (packaged-parity*) |
|---|---|---|
| window visible after minimize | **true** (the bug) | **false** (hidden to tray) |
| `new Tray(velvet/build/tray-icon.png)` | ok | ok |

\* buildResources + electron-builder-excluded dirs deleted before the run, matching what actually ships.

Not covered headlessly: real tray interaction on a live desktop (no StatusNotifier host in a container) — worth one manual pass on a real Linux session before releasing.

## Release note for the maintainer

The tag-era workflows (`build.yml`, `build-webapp.yml`) fire on `v*` tag pushes, so shipping this means tagging from this branch (e.g. `v6.9.2`) — that will also rebuild the server-side Electron tray app from this tree. Nothing here touches the server.

Closes the feature half of #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)