### PR TITLE
feat(federation): per-key bandwidth limits + key expiry (V62)

### DIFF
--- a/docs/federation-ticket.md
+++ b/docs/federation-ticket.md
@@ -34,10 +34,16 @@ mstrfed<V>:<base64url(JSON payload)>
   "k": "fedk_…",           // REQUIRED — the minted read-only API key
                            // ('fedk_' + 32 random bytes base64url)
   "n": "Paul's mStream",   // optional — display name for the add-peer UI
-  "l": ["Music", "Vinyl"]  // optional — granted library (vpath) names.
+  "l": ["Music", "Vinyl"], // optional — granted library (vpath) names.
                            // Informational preview only: the live grant
                            // list comes from GET /api/v1/federation/health
                            // after pairing.
+  "e": "2026-09-03T12:00:00Z" // optional — ISO expiry of the key.
+                           // Informational preview only: the minting
+                           // server's row is the truth, and an expired key
+                           // fails its auth wall + pipe handshake
+                           // regardless of what the ticket says. Absent =
+                           // never expires.
 }
 ```
 
@@ -78,6 +84,13 @@ payload missing `t` or `k`.
   every HTTP request, and any live connections. Rotating the server's
   `federation.secretKey` changes its EndpointId and invalidates the `t` in
   every issued ticket (peers must re-add).
+- **Expiry** is per-key and server-side (`federation_keys.expires_at`,
+  NULL = never): past the cutoff the key fails both the auth wall and new
+  pipe handshakes, and a pipe that was already open is severed on the
+  key's next request. An expired-but-never-redeemed ticket can no longer
+  TOFU-bind, which quietly retires lost tickets. The admin can renew
+  (set a new future date) or clear the expiry at any time — the key row
+  and its usage history survive expiry.
 - **"Friend reinstalled" case:** their endpoint identity changed, so TOFU
   rejects them. The admin UI's reset-binding action clears the binding
   without re-minting; the next successful handshake re-binds.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6071,6 +6071,8 @@ paths:
                     daily_mb: { type: integer, description: Per-UTC-day transfer quota. 0 = unlimited. }
                     max_streams: { type: integer, description: Concurrent /media response cap. 0 = unlimited. }
                     usage_today_bytes: { type: integer, description: Bytes served to this key today (UTC), live — includes traffic not yet flushed to the DB. }
+                    expires_at: { type: string, nullable: true, description: "UTC cutoff ('YYYY-MM-DD HH:MM:SS'); null = never. Past it the key fails the auth wall and the pipe handshake." }
+                    expired: { type: integer, description: 1 when expires_at has passed. The row survives expiry so the key can be renewed. }
         "405": { $ref: "#/components/responses/AdminLocked" }
     post:
       tags: [Federation]
@@ -6092,6 +6094,7 @@ paths:
                 streamKbps: { type: integer, minimum: 0, description: Rate cap in kbps. 0 = unlimited. Default from config. }
                 dailyMb: { type: integer, minimum: 0, description: Daily quota in MB. 0 = unlimited. Default from config. }
                 maxStreams: { type: integer, minimum: 0, description: Concurrent stream cap. 0 = unlimited. Default from config. }
+                expiresAt: { type: string, format: date-time, nullable: true, description: ISO 8601 expiry, must be in the future. Absent/null = never. Also rides the ticket as the informational `e` field. }
       responses:
         "200":
           description: The minted key + swap-ready ticket (null when the endpoint isn't running).
@@ -6107,6 +6110,7 @@ paths:
                   streamKbps: { type: integer }
                   dailyMb: { type: integer }
                   maxStreams: { type: integer }
+                  expiresAt: { type: string, nullable: true, description: ISO 8601, as stored (normalized to UTC). }
         "400": { description: Validation failure. }
         "404": { description: Unknown library name. }
         "405": { $ref: "#/components/responses/AdminLocked" }
@@ -6126,8 +6130,8 @@ paths:
   /api/v1/admin/federation/keys/{id}/limits:
     post:
       tags: [Federation]
-      summary: Edit a key's bandwidth limits (live)
-      description: Applies from the key's next request; an already-open stream keeps the rate it started with. 0 = unlimited on any field.
+      summary: Edit a key's bandwidth limits and expiry (live)
+      description: Applies from the key's next request; an already-open stream keeps the rate it started with. 0 = unlimited on any bandwidth field. `expiresAt` is tri-state — absent = unchanged, null = never, a future ISO date sets (or renews) the cutoff.
       parameters:
         - { name: id, in: path, required: true, schema: { type: integer } }
       requestBody:
@@ -6141,6 +6145,7 @@ paths:
                 streamKbps: { type: integer, minimum: 0 }
                 dailyMb: { type: integer, minimum: 0 }
                 maxStreams: { type: integer, minimum: 0 }
+                expiresAt: { type: string, format: date-time, nullable: true, description: Absent = unchanged; null = never; future ISO date = new cutoff. }
       responses:
         "200":
           description: The updated key row.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6010,6 +6010,13 @@ paths:
                   endpointId: { type: string, nullable: true }
                   online: { type: boolean }
                   relayUrl: { type: string, nullable: true }
+                  limitDefaults:
+                    type: object
+                    description: Config defaults (federation.limits) that pre-fill the mint dialog. 0 = unlimited.
+                    properties:
+                      streamKbps: { type: integer }
+                      dailyMb: { type: integer }
+                      maxStreams: { type: integer }
         "405": { $ref: "#/components/responses/AdminLocked" }
     post:
       tags: [Federation]
@@ -6060,10 +6067,15 @@ paths:
                       type: array
                       items: { type: string }
                     ticket: { type: string, nullable: true }
+                    stream_kbps: { type: integer, description: Rate cap on /media responses, shared across the key's streams. 0 = unlimited. }
+                    daily_mb: { type: integer, description: Per-UTC-day transfer quota. 0 = unlimited. }
+                    max_streams: { type: integer, description: Concurrent /media response cap. 0 = unlimited. }
+                    usage_today_bytes: { type: integer, description: Bytes served to this key today (UTC), live — includes traffic not yet flushed to the DB. }
         "405": { $ref: "#/components/responses/AdminLocked" }
     post:
       tags: [Federation]
       summary: Mint a read-only key for selected libraries
+      description: Omitted limit fields fall back to the config defaults (federation.limits). A federated reader over a cap gets 429 on the byte-heavy routes (media); browse and health keep answering.
       requestBody:
         required: true
         content:
@@ -6077,6 +6089,9 @@ paths:
                   type: array
                   items: { type: string }
                   minItems: 1
+                streamKbps: { type: integer, minimum: 0, description: Rate cap in kbps. 0 = unlimited. Default from config. }
+                dailyMb: { type: integer, minimum: 0, description: Daily quota in MB. 0 = unlimited. Default from config. }
+                maxStreams: { type: integer, minimum: 0, description: Concurrent stream cap. 0 = unlimited. Default from config. }
       responses:
         "200":
           description: The minted key + swap-ready ticket (null when the endpoint isn't running).
@@ -6089,6 +6104,9 @@ paths:
                   name: { type: string }
                   key: { type: string }
                   ticket: { type: string, nullable: true }
+                  streamKbps: { type: integer }
+                  dailyMb: { type: integer }
+                  maxStreams: { type: integer }
         "400": { description: Validation failure. }
         "404": { description: Unknown library name. }
         "405": { $ref: "#/components/responses/AdminLocked" }
@@ -6102,6 +6120,31 @@ paths:
         - { name: id, in: path, required: true, schema: { type: integer } }
       responses:
         "200": { $ref: "#/components/responses/EmptySuccess" }
+        "404": { description: Key not found. }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/keys/{id}/limits:
+    post:
+      tags: [Federation]
+      summary: Edit a key's bandwidth limits (live)
+      description: Applies from the key's next request; an already-open stream keeps the rate it started with. 0 = unlimited on any field.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [streamKbps, dailyMb, maxStreams]
+              properties:
+                streamKbps: { type: integer, minimum: 0 }
+                dailyMb: { type: integer, minimum: 0 }
+                maxStreams: { type: integer, minimum: 0 }
+      responses:
+        "200":
+          description: The updated key row.
+        "400": { description: Validation failure. }
         "404": { description: Key not found. }
         "405": { $ref: "#/components/responses/AdminLocked" }
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6067,10 +6067,10 @@ paths:
                       type: array
                       items: { type: string }
                     ticket: { type: string, nullable: true }
-                    stream_kbps: { type: integer, description: Rate cap on /media responses, shared across the key's streams. 0 = unlimited. }
+                    stream_kbps: { type: integer, description: "Rate cap on /media responses, shared across the key's streams. 0 = unlimited." }
                     daily_mb: { type: integer, description: Per-UTC-day transfer quota. 0 = unlimited. }
                     max_streams: { type: integer, description: Concurrent /media response cap. 0 = unlimited. }
-                    usage_today_bytes: { type: integer, description: Bytes served to this key today (UTC), live — includes traffic not yet flushed to the DB. }
+                    usage_today_bytes: { type: integer, description: "Bytes served to this key today (UTC), live — includes traffic not yet flushed to the DB." }
                     expires_at: { type: string, nullable: true, description: "UTC cutoff ('YYYY-MM-DD HH:MM:SS'); null = never. Past it the key fails the auth wall and the pipe handshake." }
                     expired: { type: integer, description: 1 when expires_at has passed. The row survives expiry so the key can be renewed. }
         "405": { $ref: "#/components/responses/AdminLocked" }
@@ -6094,7 +6094,7 @@ paths:
                 streamKbps: { type: integer, minimum: 0, description: Rate cap in kbps. 0 = unlimited. Default from config. }
                 dailyMb: { type: integer, minimum: 0, description: Daily quota in MB. 0 = unlimited. Default from config. }
                 maxStreams: { type: integer, minimum: 0, description: Concurrent stream cap. 0 = unlimited. Default from config. }
-                expiresAt: { type: string, format: date-time, nullable: true, description: ISO 8601 expiry, must be in the future. Absent/null = never. Also rides the ticket as the informational `e` field. }
+                expiresAt: { type: string, format: date-time, nullable: true, description: "ISO 8601 expiry, must be in the future. Absent/null = never. Also rides the ticket as the informational `e` field." }
       responses:
         "200":
           description: The minted key + swap-ready ticket (null when the endpoint isn't running).
@@ -6110,7 +6110,7 @@ paths:
                   streamKbps: { type: integer }
                   dailyMb: { type: integer }
                   maxStreams: { type: integer }
-                  expiresAt: { type: string, nullable: true, description: ISO 8601, as stored (normalized to UTC). }
+                  expiresAt: { type: string, nullable: true, description: "ISO 8601, as stored (normalized to UTC)." }
         "400": { description: Validation failure. }
         "404": { description: Unknown library name. }
         "405": { $ref: "#/components/responses/AdminLocked" }

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -43,6 +43,22 @@ function resolveLimits(body) {
   };
 }
 
+// Key expiry (V63): ISO datetime, must be in the future (renewing an
+// expired key means picking a new future date), null = never. joiValidate
+// doesn't write Joi's converted value back into req.body, so routes
+// normalize the accepted string themselves.
+const expirySchema = Joi.date().iso().greater('now').allow(null);
+
+function normalizeExpiry(bodyValue) {
+  return bodyValue ? new Date(bodyValue).toISOString() : null;
+}
+
+// Rows store SQLite's canonical UTC 'YYYY-MM-DD HH:MM:SS'; tickets and API
+// consumers get real ISO.
+function sqliteUtcToIso(s) {
+  return s ? `${s.replace(' ', 'T')}Z` : null;
+}
+
 // Build the swap-ready ticket for a minted key, or null when the endpoint
 // isn't running (native module missing / feature off).
 async function ticketForKey(keyRow) {
@@ -55,6 +71,7 @@ async function ticketForKey(keyRow) {
       key: keyRow.key,
       serverName: config.program.federation.serverName || os.hostname(),
       libraries: keyRow.library_names,
+      expiresAt: sqliteUtcToIso(keyRow.expires_at),
     });
   } catch (_err) {
     return null; // native binary not present on this platform
@@ -132,6 +149,7 @@ export function register(mstream) {
       name: Joi.string().min(1).max(64).required(),
       vpaths: Joi.array().items(Joi.string()).min(1).unique().required(),
       ...limitsSchema,
+      expiresAt: expirySchema,
     });
     joiValidate(schema, req.body);
 
@@ -144,30 +162,47 @@ export function register(mstream) {
     });
 
     const limits = resolveLimits(req.body);
-    const minted = fedDb.createFederationKey(req.body.name, libraryIds, limits);
+    const expiresAt = normalizeExpiry(req.body.expiresAt);
+    const minted = fedDb.createFederationKey(req.body.name, libraryIds, limits, expiresAt);
     winston.info(`[federation] ${req.user.username} minted key '${minted.name}' for libraries [${req.body.vpaths.join(', ')}] `
-      + `(limits: ${limits.streamKbps} kbps, ${limits.dailyMb} MB/day, ${limits.maxStreams} streams)`);
-    const ticket = await ticketForKey({ ...minted, library_names: req.body.vpaths });
-    res.json({ id: minted.id, name: minted.name, key: minted.key, ticket, ...limits });
+      + `(limits: ${limits.streamKbps} kbps, ${limits.dailyMb} MB/day, ${limits.maxStreams} streams; `
+      + `expires: ${expiresAt || 'never'})`);
+    // Re-read for the stored (normalized) expiry so the ticket's `e` field
+    // matches the row exactly.
+    const fresh = fedDb.getFederationKeyById(minted.id);
+    const ticket = await ticketForKey({ ...fresh, library_names: req.body.vpaths });
+    res.json({
+      id: minted.id, name: minted.name, key: minted.key, ticket, ...limits,
+      expiresAt: sqliteUtcToIso(fresh.expires_at),
+    });
   });
 
   // Live per-key limit edit — applies from the next request on. A stream
   // that is already open keeps the rate it started with (the wrapper
-  // captured it); revoking the key remains the hard stop.
+  // captured it); revoking the key remains the hard stop. `expiresAt` is
+  // tri-state: absent = unchanged, null = never, ISO = new future cutoff
+  // (which is also how an expired key gets renewed).
   mstream.post('/api/v1/admin/federation/keys/:id/limits', (req, res) => {
     joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), req.params);
     joiValidate(Joi.object({
       streamKbps: limitsSchema.streamKbps.required(),
       dailyMb: limitsSchema.dailyMb.required(),
       maxStreams: limitsSchema.maxStreams.required(),
+      expiresAt: expirySchema,
     }), req.body);
 
     const id = Number(req.params.id);
     if (!fedDb.setFederationKeyLimits(id, req.body)) {
       throw new WebError('Key not found', 404);
     }
+    let expiryNote = '';
+    if ('expiresAt' in req.body) {
+      const expiresAt = normalizeExpiry(req.body.expiresAt);
+      fedDb.setFederationKeyExpiry(id, expiresAt);
+      expiryNote = `; expires: ${expiresAt || 'never'}`;
+    }
     winston.info(`[federation] ${req.user.username} set limits on key id=${id}: `
-      + `${req.body.streamKbps} kbps, ${req.body.dailyMb} MB/day, ${req.body.maxStreams} streams`);
+      + `${req.body.streamKbps} kbps, ${req.body.dailyMb} MB/day, ${req.body.maxStreams} streams${expiryNote}`);
     res.json(fedDb.getFederationKeyById(id));
   });
 

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -23,6 +23,25 @@ import * as config from '../state/config.js';
 import * as admin from '../util/admin.js';
 import * as db from '../db/manager.js';
 import * as fedDb from '../db/federation.js';
+import * as fedLimits from './federation-limits.js';
+
+// Per-key bandwidth caps (0 = unlimited). Optional at mint time — absent
+// fields fall back to config.federation.limits, which is also what the UI
+// pre-fills, so "just hit Mint" applies the configured defaults.
+const limitsSchema = {
+  streamKbps: Joi.number().integer().min(0).max(10000000),
+  dailyMb: Joi.number().integer().min(0).max(100000000),
+  maxStreams: Joi.number().integer().min(0).max(1000),
+};
+
+function resolveLimits(body) {
+  const defaults = config.program.federation.limits;
+  return {
+    streamKbps: body.streamKbps ?? defaults.streamKbps,
+    dailyMb: body.dailyMb ?? defaults.dailyMb,
+    maxStreams: body.maxStreams ?? defaults.maxStreams,
+  };
+}
 
 // Build the swap-ready ticket for a minted key, or null when the endpoint
 // isn't running (native module missing / feature off).
@@ -58,7 +77,12 @@ export function register(mstream) {
     } catch (_err) {
       available = false; // native binary not present on this platform
     }
-    res.json({ enabled, available, running: endpointId !== null, endpointId, online: relayUrl !== null, relayUrl });
+    res.json({
+      enabled, available, running: endpointId !== null, endpointId,
+      online: relayUrl !== null, relayUrl,
+      // What the mint dialog pre-fills; per-key values live on the key rows.
+      limitDefaults: config.program.federation.limits,
+    });
   });
 
   mstream.post('/api/v1/admin/federation', async (req, res) => {
@@ -96,6 +120,9 @@ export function register(mstream) {
     const keys = fedDb.getFederationKeys();
     for (const k of keys) {
       k.ticket = await ticketForKey(k);
+      // Live figure: DB baseline plus the accumulator's unflushed remainder,
+      // so the UI never lags the flush interval.
+      k.usage_today_bytes = fedLimits.usedTodayBytes(k.id);
     }
     res.json(keys);
   });
@@ -104,6 +131,7 @@ export function register(mstream) {
     const schema = Joi.object({
       name: Joi.string().min(1).max(64).required(),
       vpaths: Joi.array().items(Joi.string()).min(1).unique().required(),
+      ...limitsSchema,
     });
     joiValidate(schema, req.body);
 
@@ -115,10 +143,32 @@ export function register(mstream) {
       return lib.id;
     });
 
-    const minted = fedDb.createFederationKey(req.body.name, libraryIds);
-    winston.info(`[federation] ${req.user.username} minted key '${minted.name}' for libraries [${req.body.vpaths.join(', ')}]`);
+    const limits = resolveLimits(req.body);
+    const minted = fedDb.createFederationKey(req.body.name, libraryIds, limits);
+    winston.info(`[federation] ${req.user.username} minted key '${minted.name}' for libraries [${req.body.vpaths.join(', ')}] `
+      + `(limits: ${limits.streamKbps} kbps, ${limits.dailyMb} MB/day, ${limits.maxStreams} streams)`);
     const ticket = await ticketForKey({ ...minted, library_names: req.body.vpaths });
-    res.json({ id: minted.id, name: minted.name, key: minted.key, ticket });
+    res.json({ id: minted.id, name: minted.name, key: minted.key, ticket, ...limits });
+  });
+
+  // Live per-key limit edit — applies from the next request on. A stream
+  // that is already open keeps the rate it started with (the wrapper
+  // captured it); revoking the key remains the hard stop.
+  mstream.post('/api/v1/admin/federation/keys/:id/limits', (req, res) => {
+    joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), req.params);
+    joiValidate(Joi.object({
+      streamKbps: limitsSchema.streamKbps.required(),
+      dailyMb: limitsSchema.dailyMb.required(),
+      maxStreams: limitsSchema.maxStreams.required(),
+    }), req.body);
+
+    const id = Number(req.params.id);
+    if (!fedDb.setFederationKeyLimits(id, req.body)) {
+      throw new WebError('Key not found', 404);
+    }
+    winston.info(`[federation] ${req.user.username} set limits on key id=${id}: `
+      + `${req.body.streamKbps} kbps, ${req.body.dailyMb} MB/day, ${req.body.maxStreams} streams`);
+    res.json(fedDb.getFederationKeyById(id));
   });
 
   mstream.delete('/api/v1/admin/federation/keys/:id', async (req, res) => {

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -43,7 +43,7 @@ function resolveLimits(body) {
   };
 }
 
-// Key expiry (V63): ISO datetime, must be in the future (renewing an
+// Key expiry (V62): ISO datetime, must be in the future (renewing an
 // expired key means picking a new future date), null = never. joiValidate
 // doesn't write Joi's converted value back into req.body, so routes
 // normalize the accepted string themselves.

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -95,6 +95,13 @@ export function authenticateFederationKey(key, req) {
     username: `federation:${row.name}`,
     federation: true,
     federationKeyId: row.id,
+    // Bandwidth caps ride along so the limits middleware (registered right
+    // after this wall) never needs a second key lookup. 0 = unlimited.
+    federationLimits: {
+      streamKbps: row.stream_kbps || 0,
+      dailyMb: row.daily_mb || 0,
+      maxStreams: row.max_streams || 0,
+    },
     admin: false,
     vpaths: grants.map((g) => g.name),
     libraryIds: grants.map((g) => g.id),

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -82,6 +82,19 @@ export function authenticateFederationKey(key, req) {
     throw new WebError('Authentication Error', 401);
   }
 
+  if (row.expired) {
+    winston.warn(`[federation] rejected expired key '${row.name}' from ${req.ip} on ${req.path}`);
+    // Lazy severing: an iroh pipe opened before the cutoff would otherwise
+    // coast on keep-alives (each request inside it dies here anyway, but
+    // the connection itself should go too). Fire-and-forget — the module
+    // is import-safe without the native binary, and the reply must not
+    // wait on it.
+    import('../state/federation.js')
+      .then((federation) => federation.closeConnectionsForKey(row.id))
+      .catch(() => { /* native binary absent — nothing live to sever */ });
+    throw new WebError('Authentication Error', 401);
+  }
+
   if (!isFederationPathAllowed(req)) {
     winston.warn(`[federation] key '${row.name}' denied off-allowlist route ${req.method} ${req.path} from ${req.ip}`);
     throw new WebError('Forbidden', 403);

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -86,12 +86,18 @@ export function authenticateFederationKey(key, req) {
     winston.warn(`[federation] rejected expired key '${row.name}' from ${req.ip} on ${req.path}`);
     // Lazy severing: an iroh pipe opened before the cutoff would otherwise
     // coast on keep-alives (each request inside it dies here anyway, but
-    // the connection itself should go too). Fire-and-forget — the module
-    // is import-safe without the native binary, and the reply must not
-    // wait on it.
-    import('../state/federation.js')
-      .then((federation) => federation.closeConnectionsForKey(row.id))
-      .catch(() => { /* native binary absent — nothing live to sever */ });
+    // the connection itself should go too). DELAYED a beat on purpose:
+    // severing in-line races this 401 through the bridge — the pipe died
+    // under the in-flight response and the peer saw "unreachable" instead
+    // of the clean auth error (caught by the two-server live smoke). Two
+    // seconds lets the rejection flush; anything the peer sends in the
+    // window still dies at this wall.
+    const sever = setTimeout(() => {
+      import('../state/federation.js')
+        .then((federation) => federation.closeConnectionsForKey(row.id))
+        .catch(() => { /* native binary absent — nothing live to sever */ });
+    }, 2000);
+    if (sever.unref) { sever.unref(); }
     throw new WebError('Authentication Error', 401);
   }
 

--- a/src/api/federation-limits.js
+++ b/src/api/federation-limits.js
@@ -1,0 +1,316 @@
+// Bandwidth limits for federated readers (the V62 columns on federation_keys).
+//
+// Registered as middleware immediately after the auth wall, so it sees every
+// request a federation key makes — the wall already resolved the key and
+// attached its limits to the synthetic req.user (api/federation-auth.js).
+// Non-federation requests pass through untouched.
+//
+// Three per-key caps, all "0 = unlimited":
+//   maxStreams — concurrent /media responses. Checked before the handler
+//                runs; over the cap is a 429.
+//   dailyMb    — per-UTC-day transfer quota over EVERYTHING the key pulls
+//                (media, art, metadata JSON). Enforced with a 429 on the
+//                byte-heavy routes only: browse and health keep answering,
+//                so the peer's UI can still say WHY playback stopped. An
+//                in-flight response is never cut, so a day can overshoot by
+//                at most one file.
+//   streamKbps — a token-bucket rate cap on /media responses, with the
+//                bucket SHARED across the key's concurrent streams (two
+//                parallel downloads split the same budget).
+//
+// Accounting is an in-process accumulator flushed to federation_key_usage
+// every ~15s (never a DB write per request — same reasoning as
+// touchFederationKeyLastUsed). Quota checks read baseline-from-DB plus the
+// unflushed remainder, so restarts can't forget a day and bursts can't
+// outrun the flusher.
+//
+// Throttling wraps res.write/res.end (the compression-middleware technique).
+// The wrapper preserves pipe semantics: a delayed chunk makes write() return
+// false (pausing the producing file stream), and once the chunk actually
+// goes out we emit 'drain' to resume it. Chunks are dispatched strictly FIFO
+// so a delayed body chunk can never be overtaken by end().
+
+import winston from 'winston';
+import WebError from '../util/web-error.js';
+import * as fedDb from '../db/federation.js';
+
+const MB = 1024 * 1024;
+// Test override, same pattern as MSTREAM_TEST_DISCOVERY_PRUNE_MS: production
+// installs should never set it.
+const FLUSH_INTERVAL_MS = Number(process.env.MSTREAM_TEST_FED_FLUSH_MS) || 15 * 1000;
+const FLUSH_THRESHOLD_BYTES = 8 * MB; // don't let a fast pull sit unflushed
+const USAGE_KEEP_DAYS = 90;
+
+function utcDay() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function secondsToUtcMidnight() {
+  const now = Date.now();
+  const d = new Date(now);
+  const next = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1);
+  return Math.max(1, Math.ceil((next - now) / 1000));
+}
+
+// ── Usage accounting ─────────────────────────────────────────────────────────
+
+const pending = new Map(); // keyId -> { day, bytes, requests } (unflushed)
+const dbBaseline = new Map(); // keyId -> { day, bytes } (DB value at first touch today)
+let flushTimer = null;
+let lastPruneDay = null;
+
+function ensureFlushTimer() {
+  if (flushTimer) { return; }
+  flushTimer = setInterval(() => flushUsage(), FLUSH_INTERVAL_MS);
+  if (flushTimer.unref) { flushTimer.unref(); }
+  // Best-effort final flush — node:sqlite is synchronous, so this is safe in
+  // an exit handler. Losing it costs at most one interval of quota memory.
+  process.once('exit', () => { try { flushUsage(); } catch (_err) { /* db already closed */ } });
+}
+
+function flushKey(keyId, entry) {
+  if (entry.bytes === 0 && entry.requests === 0) { pending.delete(keyId); return; }
+  fedDb.recordFederationKeyUsage(keyId, entry.day, entry.bytes, entry.requests);
+  const base = dbBaseline.get(keyId);
+  if (base && base.day === entry.day) { base.bytes += entry.bytes; }
+  pending.delete(keyId);
+}
+
+export function flushUsage() {
+  for (const [keyId, entry] of [...pending]) {
+    try {
+      flushKey(keyId, entry);
+    } catch (err) {
+      // Keep accumulating and retry next interval — a locked/closing DB
+      // must not lose the day's count or take a stream down with it.
+      winston.warn(`[federation] usage flush failed for key id=${keyId}: ${err.message}`);
+      return;
+    }
+  }
+  const today = utcDay();
+  if (lastPruneDay !== today) {
+    lastPruneDay = today;
+    try { fedDb.pruneFederationKeyUsage(USAGE_KEEP_DAYS); } catch (err) {
+      winston.warn(`[federation] usage prune failed: ${err.message}`);
+    }
+  }
+}
+
+function addUsage(keyId, bytes, requests = 0) {
+  const day = utcDay();
+  let entry = pending.get(keyId);
+  if (entry && entry.day !== day) {
+    // UTC day rolled over mid-accumulation: bank yesterday before counting.
+    try { flushKey(keyId, entry); } catch (err) {
+      winston.warn(`[federation] day-rollover flush failed for key id=${keyId}: ${err.message}`);
+    }
+    entry = pending.get(keyId);
+  }
+  if (!entry) { entry = { day, bytes: 0, requests: 0 }; pending.set(keyId, entry); }
+  entry.bytes += bytes;
+  entry.requests += requests;
+  ensureFlushTimer();
+  if (entry.bytes >= FLUSH_THRESHOLD_BYTES) {
+    try { flushKey(keyId, entry); } catch (_err) { /* interval flush retries */ }
+  }
+}
+
+// Today's total for a key, unflushed remainder included — what the quota
+// gate compares and what the admin key list shows as "today".
+export function usedTodayBytes(keyId) {
+  const day = utcDay();
+  let base = dbBaseline.get(keyId);
+  if (!base || base.day !== day) {
+    base = { day, bytes: fedDb.getFederationKeyUsage(keyId, day).bytes };
+    dbBaseline.set(keyId, base);
+  }
+  const entry = pending.get(keyId);
+  return base.bytes + (entry && entry.day === day ? entry.bytes : 0);
+}
+
+// ── Shared token buckets (per key, /media responses only) ────────────────────
+
+const buckets = new Map(); // keyId -> { tokens, last }
+
+// Deduct `size` bytes; returns how long this chunk must wait (ms). Tokens go
+// negative (debt), which is what serializes successive chunks — each caller
+// inherits the debt the previous one left. Burst capacity is one second of
+// rate, so playback starts and seeks stay snappy.
+function takeTokens(keyId, bytesPerSec, size) {
+  const now = Date.now();
+  let b = buckets.get(keyId);
+  if (!b) { b = { tokens: bytesPerSec, last: now }; buckets.set(keyId, b); }
+  b.tokens = Math.min(bytesPerSec, b.tokens + ((now - b.last) / 1000) * bytesPerSec);
+  b.last = now;
+  b.tokens -= size;
+  if (b.tokens >= 0) { return 0; }
+  return Math.ceil((-b.tokens / bytesPerSec) * 1000);
+}
+
+// ── Response metering (count always, throttle when asked) ────────────────────
+
+function chunkBytes(chunk, encoding) {
+  if (chunk == null) { return 0; }
+  if (typeof chunk === 'string') { return Buffer.byteLength(chunk, encoding || 'utf8'); }
+  return chunk.byteLength || chunk.length || 0;
+}
+
+// Wrap res.write/res.end. bytesPerSec 0 = count only (cheap pass-through).
+function meterResponse(res, keyId, bytesPerSec) {
+  const origWrite = res.write.bind(res);
+  const origEnd = res.end.bind(res);
+
+  if (bytesPerSec <= 0) {
+    res.write = function write(chunk, encoding, cb) {
+      if (typeof encoding === 'function') { cb = encoding; encoding = undefined; }
+      addUsage(keyId, chunkBytes(chunk, encoding));
+      return origWrite(chunk, encoding, cb);
+    };
+    res.end = function end(chunk, encoding, cb) {
+      if (typeof chunk === 'function') { cb = chunk; chunk = null; encoding = undefined; }
+      else if (typeof encoding === 'function') { cb = encoding; encoding = undefined; }
+      addUsage(keyId, chunkBytes(chunk, encoding));
+      return origEnd(chunk, encoding, cb);
+    };
+    return;
+  }
+
+  // Throttled path. Invariants:
+  //  - at most one chunk is "in flight" (waiting on its timer);
+  //  - queue holds everything that arrived while one was in flight, in
+  //    order, with end() as a terminal queue item;
+  //  - once we've returned false, the producer is resumed exactly once, by
+  //    'drain' — ours when the underlying write succeeded, the socket's own
+  //    when it reported backpressure.
+  const queue = [];
+  let inFlight = false;
+  let timer = null;
+  let closed = false;
+
+  res.once('close', () => {
+    closed = true;
+    if (timer) { clearTimeout(timer); timer = null; }
+    // Unstick any producer waiting on a write callback we'll never issue.
+    for (const item of queue.splice(0)) {
+      if (item.cb) { try { item.cb(); } catch (_err) { /* producer gone */ } }
+    }
+  });
+
+  function dispatchNext(lastWriteOk) {
+    if (closed) { return; }
+    const next = queue.shift();
+    if (!next) {
+      // Queue drained: if the socket took our last chunk without complaint,
+      // wake the producer we paused; otherwise its own 'drain' will.
+      if (lastWriteOk) { res.emit('drain'); }
+      return;
+    }
+    if (next.kind === 'end') { origEnd(next.cb); return; }
+    schedule(next, takeTokens(keyId, bytesPerSec, next.size));
+  }
+
+  function schedule(item, delayMs) {
+    if (delayMs <= 0) {
+      const ok = origWrite(item.chunk, item.encoding, item.cb);
+      dispatchNext(ok);
+      return;
+    }
+    inFlight = true;
+    timer = setTimeout(() => {
+      timer = null;
+      inFlight = false;
+      if (closed) { if (item.cb) { try { item.cb(); } catch (_err) { /* noop */ } } return; }
+      const ok = origWrite(item.chunk, item.encoding, item.cb);
+      dispatchNext(ok);
+    }, delayMs);
+  }
+
+  res.write = function write(chunk, encoding, cb) {
+    if (typeof encoding === 'function') { cb = encoding; encoding = undefined; }
+    const size = chunkBytes(chunk, encoding);
+    addUsage(keyId, size);
+    if (closed) { if (cb) { cb(); } return false; }
+    if (!inFlight && queue.length === 0) {
+      const delayMs = takeTokens(keyId, bytesPerSec, size);
+      if (delayMs <= 0) { return origWrite(chunk, encoding, cb); }
+      schedule({ kind: 'write', chunk, encoding, cb, size }, delayMs);
+      return false;
+    }
+    queue.push({ kind: 'write', chunk, encoding, cb, size });
+    return false;
+  };
+
+  res.end = function end(chunk, encoding, cb) {
+    if (typeof chunk === 'function') { cb = chunk; chunk = null; encoding = undefined; }
+    else if (typeof encoding === 'function') { cb = encoding; encoding = undefined; }
+    if (closed) { if (cb) { cb(); } return this; }
+    if (chunk != null) {
+      const size = chunkBytes(chunk, encoding);
+      addUsage(keyId, size);
+      if (!inFlight && queue.length === 0) {
+        const delayMs = takeTokens(keyId, bytesPerSec, size);
+        if (delayMs <= 0) { return origEnd(chunk, encoding, cb); }
+        queue.push({ kind: 'end', cb });
+        schedule({ kind: 'write', chunk, encoding, cb: undefined, size }, delayMs);
+        return this;
+      }
+      queue.push({ kind: 'write', chunk, encoding, cb: undefined, size });
+      queue.push({ kind: 'end', cb });
+      return this;
+    }
+    if (!inFlight && queue.length === 0) { return origEnd(cb); }
+    queue.push({ kind: 'end', cb });
+    return this;
+  };
+}
+
+// ── Concurrency + the middleware ─────────────────────────────────────────────
+
+const activeStreams = new Map(); // keyId -> live /media response count
+
+export function activeStreamCount(keyId) {
+  return activeStreams.get(keyId) || 0;
+}
+
+// The byte-heavy surface: media files. Art files are counted against the
+// quota like everything else but stay off the stream cap / throttle — they
+// are small, and starving a UI of thumbnails punishes nobody who matters.
+function isHeavy(req) {
+  return req.method === 'GET' && req.path.startsWith('/media/');
+}
+
+export function setup(mstream) {
+  mstream.use((req, res, next) => {
+    const user = req.user;
+    if (!user || user.federation !== true) { return next(); }
+
+    const keyId = user.federationKeyId;
+    const limits = user.federationLimits || {};
+    addUsage(keyId, 0, 1);
+
+    const heavy = isHeavy(req);
+    if (heavy) {
+      if (limits.maxStreams > 0 && activeStreamCount(keyId) >= limits.maxStreams) {
+        winston.warn(`[federation] ${user.username} over the concurrent-stream cap `
+          + `(${limits.maxStreams}) on ${req.path} from ${req.ip}`);
+        res.set('Retry-After', '5');
+        throw new WebError('Too many concurrent streams', 429);
+      }
+      if (limits.dailyMb > 0 && usedTodayBytes(keyId) >= limits.dailyMb * MB) {
+        winston.warn(`[federation] ${user.username} over the daily transfer quota `
+          + `(${limits.dailyMb} MB) on ${req.path} from ${req.ip}`);
+        res.set('Retry-After', String(secondsToUtcMidnight()));
+        throw new WebError('Daily transfer quota exceeded', 429);
+      }
+      activeStreams.set(keyId, activeStreamCount(keyId) + 1);
+      res.once('close', () => {
+        const n = activeStreamCount(keyId) - 1;
+        if (n <= 0) { activeStreams.delete(keyId); } else { activeStreams.set(keyId, n); }
+      });
+    }
+
+    // kbps -> bytes/sec (* 1000 / 8). Throttle only media; count everything.
+    meterResponse(res, keyId, heavy && limits.streamKbps > 0 ? limits.streamKbps * 125 : 0);
+    next();
+  });
+}

--- a/src/db/federation.js
+++ b/src/db/federation.js
@@ -21,12 +21,16 @@ export function generateFederationKey() {
 // Mint a key granting read-only access to the given library ids. The insert
 // and its grants are one transaction so a failed grant can't leave a key with
 // access to nothing (or worse, everything a later bug assumes).
-export function createFederationKey(name, libraryIds) {
+// `limits` are the V62 bandwidth caps; 0 (the default) means unlimited.
+export function createFederationKey(name, libraryIds, limits = {}) {
   const db = getDB();
   const key = generateFederationKey();
   db.exec('BEGIN');
   try {
-    const result = db.prepare('INSERT INTO federation_keys (key, name) VALUES (?, ?)').run(key, name);
+    const result = db.prepare(`
+      INSERT INTO federation_keys (key, name, stream_kbps, daily_mb, max_streams)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(key, name, limits.streamKbps || 0, limits.dailyMb || 0, limits.maxStreams || 0);
     const keyId = Number(result.lastInsertRowid);
     const grant = db.prepare('INSERT INTO federation_key_libraries (key_id, library_id) VALUES (?, ?)');
     for (const libId of libraryIds) { grant.run(keyId, libId); }
@@ -36,6 +40,12 @@ export function createFederationKey(name, libraryIds) {
     try { db.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
     throw err;
   }
+}
+
+export function setFederationKeyLimits(id, { streamKbps, dailyMb, maxStreams }) {
+  return getDB().prepare(`
+    UPDATE federation_keys SET stream_kbps = ?, daily_mb = ?, max_streams = ? WHERE id = ?
+  `).run(streamKbps || 0, dailyMb || 0, maxStreams || 0, id).changes > 0;
 }
 
 // All minted keys with their granted library names aggregated (UI listing).
@@ -110,6 +120,40 @@ export function touchFederationKeyLastUsed(id) {
   if (prev !== undefined && now - prev < LAST_USED_THROTTLE_MS) { return; }
   lastTouched.set(id, now);
   getDB().prepare(`UPDATE federation_keys SET last_used = datetime('now') WHERE id = ?`).run(id);
+}
+
+// ── Usage counters (per key, per UTC day) ────────────────────────────────────
+// Written by api/federation-limits.js's throttled accumulator, never per
+// request. `day` is 'YYYY-MM-DD' (UTC) everywhere.
+
+export function recordFederationKeyUsage(keyId, day, bytes, requests) {
+  getDB().prepare(`
+    INSERT INTO federation_key_usage (key_id, day, bytes, requests) VALUES (?, ?, ?, ?)
+    ON CONFLICT (key_id, day) DO UPDATE SET bytes = bytes + excluded.bytes,
+                                            requests = requests + excluded.requests
+  `).run(keyId, day, bytes, requests);
+}
+
+export function getFederationKeyUsage(keyId, day) {
+  return getDB().prepare(`
+    SELECT bytes, requests FROM federation_key_usage WHERE key_id = ? AND day = ?
+  `).get(keyId, day) || { bytes: 0, requests: 0 };
+}
+
+// One day's usage for every key at once (admin key-list decoration).
+export function getFederationUsageForDay(day) {
+  const rows = getDB().prepare(`
+    SELECT key_id, bytes, requests FROM federation_key_usage WHERE day = ?
+  `).all(day);
+  return new Map(rows.map((r) => [r.key_id, { bytes: r.bytes, requests: r.requests }]));
+}
+
+// Quota history has no value past the admin's "recent traffic" window; the
+// flusher calls this at most once a day.
+export function pruneFederationKeyUsage(keepDays = 90) {
+  return getDB().prepare(`
+    DELETE FROM federation_key_usage WHERE day < date('now', ?)
+  `).run(`-${keepDays} days`).changes;
 }
 
 // ── Peers (outbound: servers we can read) ────────────────────────────────────

--- a/src/db/federation.js
+++ b/src/db/federation.js
@@ -22,15 +22,18 @@ export function generateFederationKey() {
 // and its grants are one transaction so a failed grant can't leave a key with
 // access to nothing (or worse, everything a later bug assumes).
 // `limits` are the V62 bandwidth caps; 0 (the default) means unlimited.
-export function createFederationKey(name, libraryIds, limits = {}) {
+// `expiresAt` (V63) is an ISO datetime or null (= never); datetime(?)
+// normalizes it to SQLite's canonical UTC form so the stored value compares
+// lexicographically against datetime('now').
+export function createFederationKey(name, libraryIds, limits = {}, expiresAt = null) {
   const db = getDB();
   const key = generateFederationKey();
   db.exec('BEGIN');
   try {
     const result = db.prepare(`
-      INSERT INTO federation_keys (key, name, stream_kbps, daily_mb, max_streams)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(key, name, limits.streamKbps || 0, limits.dailyMb || 0, limits.maxStreams || 0);
+      INSERT INTO federation_keys (key, name, stream_kbps, daily_mb, max_streams, expires_at)
+      VALUES (?, ?, ?, ?, ?, datetime(?))
+    `).run(key, name, limits.streamKbps || 0, limits.dailyMb || 0, limits.maxStreams || 0, expiresAt);
     const keyId = Number(result.lastInsertRowid);
     const grant = db.prepare('INSERT INTO federation_key_libraries (key_id, library_id) VALUES (?, ?)');
     for (const libId of libraryIds) { grant.run(keyId, libId); }
@@ -48,10 +51,24 @@ export function setFederationKeyLimits(id, { streamKbps, dailyMb, maxStreams }) 
   `).run(streamKbps || 0, dailyMb || 0, maxStreams || 0, id).changes > 0;
 }
 
+// Set or clear (null = never) a key's expiry. Setting a future date on an
+// already-expired key is the renewal path — nothing else needs resetting.
+export function setFederationKeyExpiry(id, expiresAt) {
+  return getDB().prepare(`
+    UPDATE federation_keys SET expires_at = datetime(?) WHERE id = ?
+  `).run(expiresAt ?? null, id).changes > 0;
+}
+
+// Every key read carries a computed `expired` (0/1). The comparison lives
+// in SQL on purpose: both sides are datetime('now')-format UTC strings, so
+// it's chronologically correct — JS Date.parse would read the stored
+// format as LOCAL time and drift the cutoff by the machine's UTC offset.
+const EXPIRED_SQL = `(expires_at IS NOT NULL AND expires_at <= datetime('now')) AS expired`;
+
 // All minted keys with their granted library names aggregated (UI listing).
 export function getFederationKeys() {
   return getDB().prepare(`
-    SELECT k.*,
+    SELECT k.*, ${EXPIRED_SQL},
            (SELECT json_group_array(l.name)
               FROM federation_key_libraries kl
               JOIN libraries l ON l.id = kl.library_id
@@ -65,12 +82,12 @@ export function getFederationKeys() {
 }
 
 export function getFederationKeyById(id) {
-  return getDB().prepare('SELECT * FROM federation_keys WHERE id = ?').get(id);
+  return getDB().prepare(`SELECT *, ${EXPIRED_SQL} FROM federation_keys WHERE id = ?`).get(id);
 }
 
 // Auth-wall lookup: the presented credential -> the key row, or undefined.
 export function getFederationKeyByKey(key) {
-  return getDB().prepare('SELECT * FROM federation_keys WHERE key = ?').get(key);
+  return getDB().prepare(`SELECT *, ${EXPIRED_SQL} FROM federation_keys WHERE key = ?`).get(key);
 }
 
 // The libraries a key grants, as [{ id, name }] (auth wall + UI).

--- a/src/db/federation.js
+++ b/src/db/federation.js
@@ -22,8 +22,8 @@ export function generateFederationKey() {
 // and its grants are one transaction so a failed grant can't leave a key with
 // access to nothing (or worse, everything a later bug assumes).
 // `limits` are the V62 bandwidth caps; 0 (the default) means unlimited.
-// `expiresAt` (V63) is an ISO datetime or null (= never); datetime(?)
-// normalizes it to SQLite's canonical UTC form so the stored value compares
+// `expiresAt` is an ISO datetime or null (= never); datetime(?) normalizes
+// it to SQLite's canonical UTC form so the stored value compares
 // lexicographically against datetime('now').
 export function createFederationKey(name, libraryIds, limits = {}, expiresAt = null) {
   const db = getDB();

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -78,7 +78,10 @@ import { HASH_GENERATION } from './audio-hash.js';
 // daily_mb / max_streams, 0 = unlimited) and the federation_key_usage
 // per-day byte/request counters that back the daily quota and the admin
 // usage readout. See SCHEMA_V62.
-export const SCHEMA_VERSION = 62;
+// V63 adds federation_keys.expires_at (NULL = never) — time-boxed keys.
+// Deliberately NOT folded into V62: that migration shipped on the same PR
+// branch and may already be stamped into dev DBs. See SCHEMA_V63.
+export const SCHEMA_VERSION = 63;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2325,6 +2328,24 @@ export const SCHEMA_V62 = `
   );
 `;
 
+// ── Federation key expiry ────────────────────────────────────────────────────
+//
+// expires_at is a hard cutoff for the whole credential: past it, the key
+// fails the auth wall AND the iroh pipe handshake (shared `expired` check
+// computed in SQL — db/federation.js). NULL = never expires, which is what
+// every pre-V63 key gets. One semantic on purpose: it time-boxes a friend's
+// access AND quietly kills a ticket that was never redeemed, without a
+// second "redeem-by" concept. The row survives expiry so the admin can
+// renew (edit the date) or revoke; usage history stays intact.
+//
+// Stored in SQLite's canonical UTC 'YYYY-MM-DD HH:MM:SS' via datetime(?),
+// so lexicographic comparison against datetime('now') is chronological —
+// the check never round-trips through JS Date parsing (which reads that
+// format as LOCAL time).
+export const SCHEMA_V63 = `
+  ALTER TABLE federation_keys ADD COLUMN expires_at TEXT;
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2696,4 +2717,7 @@ export const MIGRATIONS = [
   // counters behind the daily quota. Additive columns + a new empty
   // table — no rescan needed. See SCHEMA_V62.
   { version: 62, sql: SCHEMA_V62 },
+  // V63 adds federation_keys.expires_at (NULL = never, so existing keys
+  // are untouched). Additive column — no rescan needed. See SCHEMA_V63.
+  { version: 63, sql: SCHEMA_V63 },
 ];

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -74,14 +74,11 @@ import { HASH_GENERATION } from './audio-hash.js';
 // See SCHEMA_V60.
 // V61 adds composite (user_id, <stat>) indexes on user_metadata so the
 // homepage-stats endpoints seek instead of scanning tracks. See SCHEMA_V61.
-// V62 adds per-key bandwidth limits on federation_keys (stream_kbps /
-// daily_mb / max_streams, 0 = unlimited) and the federation_key_usage
-// per-day byte/request counters that back the daily quota and the admin
-// usage readout. See SCHEMA_V62.
-// V63 adds federation_keys.expires_at (NULL = never) — time-boxed keys.
-// Deliberately NOT folded into V62: that migration shipped on the same PR
-// branch and may already be stamped into dev DBs. See SCHEMA_V63.
-export const SCHEMA_VERSION = 63;
+// V62 adds per-key bandwidth limits + expiry on federation_keys
+// (stream_kbps / daily_mb / max_streams, 0 = unlimited; expires_at, NULL =
+// never) and the federation_key_usage per-day byte/request counters that
+// back the daily quota and the admin usage readout. See SCHEMA_V62.
+export const SCHEMA_VERSION = 62;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2296,7 +2293,7 @@ export const SCHEMA_V61 = `
   CREATE INDEX IF NOT EXISTS idx_user_metadata_user_rating     ON user_metadata(user_id, rating);
 `;
 
-// ── Federation bandwidth limits (per minted key) ────────────────────────────
+// ── Federation bandwidth limits + expiry (per minted key) ──────────────────
 //
 // Abuse control for federated readers: every response to an x-federation-key
 // request is metered (api/federation-limits.js), and the three limit columns
@@ -2311,6 +2308,18 @@ export const SCHEMA_V61 = `
 //                 and the peer's UI can say WHY playback stopped;
 //   max_streams — concurrent /media response cap.
 //
+// expires_at is a hard cutoff for the whole credential: past it, the key
+// fails the auth wall AND the iroh pipe handshake (shared `expired` check
+// computed in SQL — db/federation.js). NULL = never expires, which is what
+// every pre-V62 key gets. One semantic on purpose: it time-boxes a friend's
+// access AND quietly kills a ticket that was never redeemed, without a
+// second "redeem-by" concept. The row survives expiry so the admin can
+// renew (edit the date) or revoke; usage history stays intact. Stored in
+// SQLite's canonical UTC 'YYYY-MM-DD HH:MM:SS' via datetime(?), so
+// lexicographic comparison against datetime('now') is chronological — the
+// check never round-trips through JS Date parsing (which reads that format
+// as LOCAL time).
+//
 // federation_key_usage is the quota's memory: one row per key per UTC day,
 // written by a throttled in-process accumulator (not per request). Rows
 // older than ~90 days are pruned opportunistically by the same flusher.
@@ -2318,6 +2327,7 @@ export const SCHEMA_V62 = `
   ALTER TABLE federation_keys ADD COLUMN stream_kbps INTEGER NOT NULL DEFAULT 0;
   ALTER TABLE federation_keys ADD COLUMN daily_mb INTEGER NOT NULL DEFAULT 0;
   ALTER TABLE federation_keys ADD COLUMN max_streams INTEGER NOT NULL DEFAULT 0;
+  ALTER TABLE federation_keys ADD COLUMN expires_at TEXT;
 
   CREATE TABLE IF NOT EXISTS federation_key_usage (
     key_id INTEGER NOT NULL REFERENCES federation_keys(id) ON DELETE CASCADE,
@@ -2326,24 +2336,6 @@ export const SCHEMA_V62 = `
     requests INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (key_id, day)
   );
-`;
-
-// ── Federation key expiry ────────────────────────────────────────────────────
-//
-// expires_at is a hard cutoff for the whole credential: past it, the key
-// fails the auth wall AND the iroh pipe handshake (shared `expired` check
-// computed in SQL — db/federation.js). NULL = never expires, which is what
-// every pre-V63 key gets. One semantic on purpose: it time-boxes a friend's
-// access AND quietly kills a ticket that was never redeemed, without a
-// second "redeem-by" concept. The row survives expiry so the admin can
-// renew (edit the date) or revoke; usage history stays intact.
-//
-// Stored in SQLite's canonical UTC 'YYYY-MM-DD HH:MM:SS' via datetime(?),
-// so lexicographic comparison against datetime('now') is chronological —
-// the check never round-trips through JS Date parsing (which reads that
-// format as LOCAL time).
-export const SCHEMA_V63 = `
-  ALTER TABLE federation_keys ADD COLUMN expires_at TEXT;
 `;
 
 export const SCHEMA_V58 = `
@@ -2712,12 +2704,9 @@ export const MIGRATIONS = [
   // user_metadata so the homepage-stats endpoints can be served from
   // user_metadata instead of a full tracks scan. Index-only, no rescan.
   { version: 61, sql: SCHEMA_V61 },
-  // V62 adds the per-key federation bandwidth limits (0 = unlimited, so
-  // existing keys are untouched) and the federation_key_usage per-day
-  // counters behind the daily quota. Additive columns + a new empty
-  // table — no rescan needed. See SCHEMA_V62.
+  // V62 adds the per-key federation bandwidth limits (0 = unlimited) and
+  // expiry (NULL = never) — existing keys are untouched by both — plus the
+  // federation_key_usage per-day counters behind the daily quota. Additive
+  // columns + a new empty table — no rescan needed. See SCHEMA_V62.
   { version: 62, sql: SCHEMA_V62 },
-  // V63 adds federation_keys.expires_at (NULL = never, so existing keys
-  // are untouched). Additive column — no rescan needed. See SCHEMA_V63.
-  { version: 63, sql: SCHEMA_V63 },
 ];

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -74,7 +74,11 @@ import { HASH_GENERATION } from './audio-hash.js';
 // See SCHEMA_V60.
 // V61 adds composite (user_id, <stat>) indexes on user_metadata so the
 // homepage-stats endpoints seek instead of scanning tracks. See SCHEMA_V61.
-export const SCHEMA_VERSION = 61;
+// V62 adds per-key bandwidth limits on federation_keys (stream_kbps /
+// daily_mb / max_streams, 0 = unlimited) and the federation_key_usage
+// per-day byte/request counters that back the daily quota and the admin
+// usage readout. See SCHEMA_V62.
+export const SCHEMA_VERSION = 62;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2289,6 +2293,38 @@ export const SCHEMA_V61 = `
   CREATE INDEX IF NOT EXISTS idx_user_metadata_user_rating     ON user_metadata(user_id, rating);
 `;
 
+// ── Federation bandwidth limits (per minted key) ────────────────────────────
+//
+// Abuse control for federated readers: every response to an x-federation-key
+// request is metered (api/federation-limits.js), and the three limit columns
+// bound what one key may pull. 0 means unlimited on all three — existing
+// keys get 0 via the ALTER defaults, so upgrades change nothing until an
+// admin sets a limit.
+//
+//   stream_kbps — token-bucket rate cap shared across the key's concurrent
+//                 /media streams;
+//   daily_mb    — per-UTC-day transfer quota. Enforced with a 429 on the
+//                 byte-heavy routes only, so browse/health keep answering
+//                 and the peer's UI can say WHY playback stopped;
+//   max_streams — concurrent /media response cap.
+//
+// federation_key_usage is the quota's memory: one row per key per UTC day,
+// written by a throttled in-process accumulator (not per request). Rows
+// older than ~90 days are pruned opportunistically by the same flusher.
+export const SCHEMA_V62 = `
+  ALTER TABLE federation_keys ADD COLUMN stream_kbps INTEGER NOT NULL DEFAULT 0;
+  ALTER TABLE federation_keys ADD COLUMN daily_mb INTEGER NOT NULL DEFAULT 0;
+  ALTER TABLE federation_keys ADD COLUMN max_streams INTEGER NOT NULL DEFAULT 0;
+
+  CREATE TABLE IF NOT EXISTS federation_key_usage (
+    key_id INTEGER NOT NULL REFERENCES federation_keys(id) ON DELETE CASCADE,
+    day TEXT NOT NULL,
+    bytes INTEGER NOT NULL DEFAULT 0,
+    requests INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (key_id, day)
+  );
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2655,4 +2691,9 @@ export const MIGRATIONS = [
   // user_metadata so the homepage-stats endpoints can be served from
   // user_metadata instead of a full tracks scan. Index-only, no rescan.
   { version: 61, sql: SCHEMA_V61 },
+  // V62 adds the per-key federation bandwidth limits (0 = unlimited, so
+  // existing keys are untouched) and the federation_key_usage per-day
+  // counters behind the daily quota. Additive columns + a new empty
+  // table — no rescan needed. See SCHEMA_V62.
+  { version: 62, sql: SCHEMA_V62 },
 ];

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,7 @@ import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // scanner.js removed — parser now writes directly to SQLite
 import * as federationApi from './api/federation.js';
 import * as federationDiscoveryApi from './api/federation-discovery.js';
+import * as federationLimitsApi from './api/federation-limits.js';
 import * as federationStreamApi from './api/federation-stream.js';
 import * as ytdlApi from './api/ytdl.js';
 import * as torrentApi from './api/torrent.js';
@@ -299,6 +300,11 @@ export async function serveIt(configFile) {
 
   // Everything below this line requires authentication
   authApi.setup(mstream);
+
+  // Bandwidth caps for federated readers — must sit right after the wall
+  // (needs req.user.federation) and before every route/static mount whose
+  // responses it meters.
+  federationLimitsApi.setup(mstream);
 
   adminApi.setup(mstream);
   irohApi.setup(mstream);

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -387,10 +387,23 @@ const irohOptions = Joi.object({
 //   serverName — display name embedded in minted tickets so the friend's
 //                add-peer UI can label this server; '' falls back to
 //                os.hostname() at mint time.
+// Default bandwidth limits for newly minted federation keys (0 = unlimited).
+// These only PRE-FILL the mint dialog — the actual limits live per key in
+// federation_keys, so editing these never changes an already-minted key.
+// Defaults are sized for "a friend streaming music": 8 Mbps is comfortable
+// FLAC + seeking headroom, 2 GB/day and 3 concurrent streams are hostile to
+// bulk mirroring without getting in the way of listening.
+const federationLimitsOptions = Joi.object({
+  streamKbps: Joi.number().integer().min(0).max(10000000).default(8000),
+  dailyMb: Joi.number().integer().min(0).max(100000000).default(2048),
+  maxStreams: Joi.number().integer().min(0).max(1000).default(3),
+});
+
 const federationOptions = Joi.object({
   enabled: Joi.boolean().default(false),
   secretKey: Joi.string().optional(),
   serverName: Joi.string().max(64).allow('').default(''),
+  limits: federationLimitsOptions.default(federationLimitsOptions.validate({}).value),
 });
 
 // The music-discovery P2P layer (p2p-sidecar: iroh-blobs snapshot sharing

--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -67,6 +67,9 @@ const liveConns = new Map(); // keyId -> Set<conn>
 //   n  (optional) server display name, for the friend's add-peer preview
 //   l  (optional) granted vpath names — informational; the health endpoint
 //                 is the live source of truth after pairing
+//   e  (optional) ISO expiry of the key — informational, for the friend's
+//                 add-peer preview; the minting server's row is the truth
+//                 and enforcement never reads the ticket
 // Unknown fields are ignored (forward compat). Spec: docs/federation-ticket.md.
 // Unlike the tunnel QR, this carries a STANDING credential — swap it over a
 // private channel; TOFU burn-on-redeem + per-key revocation are the backstops.
@@ -75,10 +78,11 @@ const liveConns = new Map(); // keyId -> Set<conn>
 export const FEDERATION_TICKET_PREFIX = 'mstrfed';
 export const FEDERATION_TICKET_VERSION = 1;
 
-export function buildFederationTicket({ endpointTicket, key, serverName, libraries }) {
+export function buildFederationTicket({ endpointTicket, key, serverName, libraries, expiresAt }) {
   const payload = { t: endpointTicket, k: key };
   if (serverName) { payload.n = serverName; }
   if (Array.isArray(libraries) && libraries.length > 0) { payload.l = libraries; }
+  if (typeof expiresAt === 'string' && expiresAt) { payload.e = expiresAt; }
   return buildEnvelope(FEDERATION_TICKET_PREFIX, FEDERATION_TICKET_VERSION, payload);
 }
 
@@ -100,6 +104,7 @@ export function parseFederationTicket(str) {
     apiKey: payload.k,
     name: typeof payload.n === 'string' ? payload.n : null,
     libraries: Array.isArray(payload.l) ? payload.l.filter((x) => typeof x === 'string') : [],
+    expiresAt: typeof payload.e === 'string' ? payload.e : null,
   };
 }
 
@@ -140,6 +145,11 @@ async function authenticateConnection(conn, remote, onAuthorized) {
   let ok = false;
   if (!keyRow) {
     winston.warn(`[federation] rejected connection from ${remote}: unknown key`);
+  } else if (keyRow.expired) {
+    // Checked BEFORE the TOFU block: an expired-but-unredeemed ticket must
+    // die without ever binding. The admin renewing the date re-arms it.
+    winston.warn(`[federation] rejected expired key '${keyRow.name}' from ${remote}`);
+    keyRow = null;
   } else {
     if (keyRow.bound_endpoint_id === null) {
       // TOFU: first redemption binds the key to this dialer. The guarded
@@ -150,7 +160,7 @@ async function authenticateConnection(conn, remote, onAuthorized) {
       }
       keyRow = fedDb.getFederationKeyById(keyRow.id);
     }
-    ok = Boolean(keyRow && keyRow.bound_endpoint_id === remote);
+    ok = Boolean(keyRow && !keyRow.expired && keyRow.bound_endpoint_id === remote);
     if (keyRow && !ok) {
       // The one log line that matters most: a KNOWN key from the WRONG
       // endpoint means the ticket leaked (or the friend reinstalled — the

--- a/test/db/db-federation-limits.test.mjs
+++ b/test/db/db-federation-limits.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * V62 schema semantics for the federation bandwidth limits:
+ *  - the three limit columns default to 0 (= unlimited) for fresh inserts
+ *    AND for rows that predate the migration (the ALTER default);
+ *  - federation_key_usage's (key_id, day) primary key supports the
+ *    accumulate-on-conflict UPSERT the flusher uses;
+ *  - usage rows die with their key (ON DELETE CASCADE — manager.js runs
+ *    with PRAGMA foreign_keys = ON).
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+
+// Mirrors db/federation.js recordFederationKeyUsage — the semantics under
+// test here are the schema's (conflict target + accumulation), not the JS.
+const UPSERT = `
+  INSERT INTO federation_key_usage (key_id, day, bytes, requests) VALUES (?, ?, ?, ?)
+  ON CONFLICT (key_id, day) DO UPDATE SET bytes = bytes + excluded.bytes,
+                                          requests = requests + excluded.requests
+`;
+
+function freshDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON'); // matches src/db/manager.js:61
+  applyAllMigrations(db);
+  return db;
+}
+
+describe('V62 federation bandwidth limits schema', () => {
+  test('limit columns default to 0 on fresh inserts', () => {
+    const db = freshDb();
+    db.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_test', 'Bob')`).run();
+    const row = db.prepare(`SELECT stream_kbps, daily_mb, max_streams FROM federation_keys`).get();
+    assert.deepEqual({ ...row }, { stream_kbps: 0, daily_mb: 0, max_streams: 0 });
+  });
+
+  test('keys minted before V62 come out of the upgrade unlimited', () => {
+    const db = new DatabaseSync(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    applyAllMigrations(db, { upToVersion: 61 });
+    db.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_old', 'pre-upgrade')`).run();
+
+    applyAllMigrations(db, { fromVersion: 61 });
+    const row = db.prepare(`SELECT stream_kbps, daily_mb, max_streams FROM federation_keys`).get();
+    assert.deepEqual({ ...row }, { stream_kbps: 0, daily_mb: 0, max_streams: 0 });
+  });
+
+  test('usage UPSERT accumulates within a (key, day) and separates days', () => {
+    const db = freshDb();
+    db.prepare(`INSERT INTO federation_keys (id, key, name) VALUES (1, 'fedk_test', 'Bob')`).run();
+
+    db.prepare(UPSERT).run(1, '2026-08-04', 1000, 1);
+    db.prepare(UPSERT).run(1, '2026-08-04', 234, 2);
+    db.prepare(UPSERT).run(1, '2026-08-05', 50, 1);
+
+    const day1 = db.prepare(`SELECT bytes, requests FROM federation_key_usage WHERE key_id = 1 AND day = '2026-08-04'`).get();
+    assert.deepEqual({ ...day1 }, { bytes: 1234, requests: 3 });
+    const day2 = db.prepare(`SELECT bytes, requests FROM federation_key_usage WHERE key_id = 1 AND day = '2026-08-05'`).get();
+    assert.deepEqual({ ...day2 }, { bytes: 50, requests: 1 });
+  });
+
+  test('usage rows die with their key (ON DELETE CASCADE)', () => {
+    const db = freshDb();
+    db.prepare(`INSERT INTO federation_keys (id, key, name) VALUES (7, 'fedk_test', 'Bob')`).run();
+    db.prepare(UPSERT).run(7, '2026-08-04', 42, 1);
+
+    db.prepare(`DELETE FROM federation_keys WHERE id = 7`).run();
+    const left = db.prepare(`SELECT COUNT(*) AS n FROM federation_key_usage`).get();
+    assert.equal(left.n, 0);
+  });
+});

--- a/test/db/db-federation-limits.test.mjs
+++ b/test/db/db-federation-limits.test.mjs
@@ -71,3 +71,35 @@ describe('V62 federation bandwidth limits schema', () => {
     assert.equal(left.n, 0);
   });
 });
+
+describe('V63 federation key expiry schema', () => {
+  // The same expression db/federation.js computes on every key read.
+  const EXPIRED = `(expires_at IS NOT NULL AND expires_at <= datetime('now')) AS expired`;
+
+  test('expires_at defaults NULL (never) for fresh inserts and pre-V63 rows', () => {
+    const db = freshDb();
+    db.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_a', 'fresh')`).run();
+    assert.equal(db.prepare(`SELECT expires_at FROM federation_keys`).get().expires_at, null);
+
+    const old = new DatabaseSync(':memory:');
+    old.exec('PRAGMA foreign_keys = ON');
+    applyAllMigrations(old, { upToVersion: 62 });
+    old.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_b', 'pre-upgrade')`).run();
+    applyAllMigrations(old, { fromVersion: 62 });
+    const row = old.prepare(`SELECT expires_at, ${EXPIRED} FROM federation_keys`).get();
+    assert.equal(row.expires_at, null);
+    assert.equal(row.expired, 0);
+  });
+
+  test('the expired computation follows datetime(now) and ISO input normalizes', () => {
+    const db = freshDb();
+    db.prepare(`INSERT INTO federation_keys (id, key, name, expires_at) VALUES (1, 'fedk_past', 'past', datetime('now', '-1 hour'))`).run();
+    db.prepare(`INSERT INTO federation_keys (id, key, name, expires_at) VALUES (2, 'fedk_future', 'future', datetime('now', '+1 hour'))`).run();
+    // The write path stores datetime(?) of an ISO string (Z suffix) — the
+    // stored form must compare correctly against datetime('now').
+    db.prepare(`INSERT INTO federation_keys (id, key, name, expires_at) VALUES (3, 'fedk_iso', 'iso', datetime('2020-01-01T00:00:00.000Z'))`).run();
+
+    const rows = db.prepare(`SELECT id, ${EXPIRED} FROM federation_keys ORDER BY id`).all();
+    assert.deepEqual(rows.map((r) => r.expired), [1, 0, 1]);
+  });
+});

--- a/test/db/db-federation-limits.test.mjs
+++ b/test/db/db-federation-limits.test.mjs
@@ -1,11 +1,14 @@
 /**
- * V62 schema semantics for the federation bandwidth limits:
- *  - the three limit columns default to 0 (= unlimited) for fresh inserts
- *    AND for rows that predate the migration (the ALTER default);
+ * V62 schema semantics for the federation bandwidth limits + key expiry:
+ *  - the three limit columns default to 0 (= unlimited) and expires_at to
+ *    NULL (= never), for fresh inserts AND for rows that predate the
+ *    migration (the ALTER defaults);
  *  - federation_key_usage's (key_id, day) primary key supports the
  *    accumulate-on-conflict UPSERT the flusher uses;
  *  - usage rows die with their key (ON DELETE CASCADE — manager.js runs
- *    with PRAGMA foreign_keys = ON).
+ *    with PRAGMA foreign_keys = ON);
+ *  - the `expired` computation (the expression db/federation.js appends to
+ *    every key read) follows datetime('now') and normalized ISO input.
  */
 
 import { describe, test } from 'node:test';
@@ -21,6 +24,9 @@ const UPSERT = `
                                           requests = requests + excluded.requests
 `;
 
+// The same expression db/federation.js computes on every key read.
+const EXPIRED = `(expires_at IS NOT NULL AND expires_at <= datetime('now')) AS expired`;
+
 function freshDb() {
   const db = new DatabaseSync(':memory:');
   db.exec('PRAGMA foreign_keys = ON'); // matches src/db/manager.js:61
@@ -28,23 +34,24 @@ function freshDb() {
   return db;
 }
 
-describe('V62 federation bandwidth limits schema', () => {
-  test('limit columns default to 0 on fresh inserts', () => {
+describe('V62 federation bandwidth limits + expiry schema', () => {
+  test('limit columns default to 0 and expires_at to NULL on fresh inserts', () => {
     const db = freshDb();
     db.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_test', 'Bob')`).run();
-    const row = db.prepare(`SELECT stream_kbps, daily_mb, max_streams FROM federation_keys`).get();
-    assert.deepEqual({ ...row }, { stream_kbps: 0, daily_mb: 0, max_streams: 0 });
+    const row = db.prepare(`SELECT stream_kbps, daily_mb, max_streams, expires_at FROM federation_keys`).get();
+    assert.deepEqual({ ...row }, { stream_kbps: 0, daily_mb: 0, max_streams: 0, expires_at: null });
   });
 
-  test('keys minted before V62 come out of the upgrade unlimited', () => {
+  test('keys minted before V62 come out of the upgrade unlimited and never-expiring', () => {
     const db = new DatabaseSync(':memory:');
     db.exec('PRAGMA foreign_keys = ON');
     applyAllMigrations(db, { upToVersion: 61 });
     db.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_old', 'pre-upgrade')`).run();
 
     applyAllMigrations(db, { fromVersion: 61 });
-    const row = db.prepare(`SELECT stream_kbps, daily_mb, max_streams FROM federation_keys`).get();
-    assert.deepEqual({ ...row }, { stream_kbps: 0, daily_mb: 0, max_streams: 0 });
+    const row = db.prepare(`SELECT stream_kbps, daily_mb, max_streams, expires_at, ${EXPIRED} FROM federation_keys`).get();
+    assert.deepEqual({ ...row },
+      { stream_kbps: 0, daily_mb: 0, max_streams: 0, expires_at: null, expired: 0 });
   });
 
   test('usage UPSERT accumulates within a (key, day) and separates days', () => {
@@ -69,26 +76,6 @@ describe('V62 federation bandwidth limits schema', () => {
     db.prepare(`DELETE FROM federation_keys WHERE id = 7`).run();
     const left = db.prepare(`SELECT COUNT(*) AS n FROM federation_key_usage`).get();
     assert.equal(left.n, 0);
-  });
-});
-
-describe('V63 federation key expiry schema', () => {
-  // The same expression db/federation.js computes on every key read.
-  const EXPIRED = `(expires_at IS NOT NULL AND expires_at <= datetime('now')) AS expired`;
-
-  test('expires_at defaults NULL (never) for fresh inserts and pre-V63 rows', () => {
-    const db = freshDb();
-    db.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_a', 'fresh')`).run();
-    assert.equal(db.prepare(`SELECT expires_at FROM federation_keys`).get().expires_at, null);
-
-    const old = new DatabaseSync(':memory:');
-    old.exec('PRAGMA foreign_keys = ON');
-    applyAllMigrations(old, { upToVersion: 62 });
-    old.prepare(`INSERT INTO federation_keys (key, name) VALUES ('fedk_b', 'pre-upgrade')`).run();
-    applyAllMigrations(old, { fromVersion: 62 });
-    const row = old.prepare(`SELECT expires_at, ${EXPIRED} FROM federation_keys`).get();
-    assert.equal(row.expires_at, null);
-    assert.equal(row.expired, 0);
   });
 
   test('the expired computation follows datetime(now) and ISO input normalizes', () => {

--- a/test/integration/federation-handshake.test.mjs
+++ b/test/integration/federation-handshake.test.mjs
@@ -134,6 +134,21 @@ describe('federation endpoint handshake', { skip: available ? false : 'no @numbe
     assert.notEqual(resp, 'OK');
   });
 
+  test('an expired key is rejected before TOFU can bind; renewal re-arms it', async () => {
+    const expired = fedDb.createFederationKey('expired-peer', [], {},
+      new Date(Date.now() - 60_000).toISOString());
+    const { resp } = await dial(expired.key);
+    assert.notEqual(resp, 'OK');
+    // The expiry check runs BEFORE the TOFU block: a dead ticket must not
+    // claim a binding on its way out.
+    assert.equal(fedDb.getFederationKeyById(expired.id).bound_endpoint_id, null);
+
+    // Renewal (a new future date) is all it takes — same key, same ticket.
+    fedDb.setFederationKeyExpiry(expired.id, new Date(Date.now() + 3600_000).toISOString());
+    const again = await dial(expired.key);
+    assert.equal(again.resp, 'OK');
+  });
+
   test('closeConnectionsForKey severs a live authorized pipe', async () => {
     const fresh = fedDb.createFederationKey('sever-me', []);
     const { conn, resp } = await dial(fresh.key);

--- a/test/integration/federation-limits.test.mjs
+++ b/test/integration/federation-limits.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * Federation bandwidth limits end-to-end over plain HTTP (no iroh — the key
+ * is the credential, same trick as federation-e2e):
+ *
+ *  - minting without limit fields applies the config defaults
+ *    (federation.limits: 8000 kbps / 2048 MB / 3 streams); explicit fields
+ *    (including 0 = unlimited) stick, and the key list exposes them plus a
+ *    live usage_today_bytes;
+ *  - POST /keys/:id/limits edits live, 404s unknown ids, 400s garbage;
+ *  - an unlimited key streams byte-identical content, its usage is counted,
+ *    and the accumulator flushes to federation_key_usage on disk
+ *    (MSTREAM_TEST_FED_FLUSH_MS shrinks the interval);
+ *  - a daily quota 429s the byte-heavy routes with Retry-After while
+ *    health/browse keep answering;
+ *  - maxStreams 429s a second concurrent stream, and the slot frees on
+ *    completion;
+ *  - streamKbps paces a download without corrupting it (timing asserted
+ *    with WIDE margins — CI runners and Windows clocks are noisy).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { startServer } from '../helpers/server.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fedHeaders = (key) => ({ 'x-federation-key': key, 'Content-Type': 'application/json' });
+
+const KiB = 1024;
+const FILE_QUOTA = crypto.randomBytes(256 * KiB);   // 4 pulls = exactly 1 MiB
+const FILE_THROTTLE = crypto.randomBytes(300 * KiB);
+const FILE_CONC = crypto.randomBytes(200 * KiB);
+
+describe('federation bandwidth limits e2e', () => {
+  let srv, libDir, adminToken;
+  const keys = {}; // name -> mint response json
+
+  async function mintKey(name, extra = {}) {
+    const r = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ name, vpaths: ['shared'], ...extra }),
+    });
+    const text = await r.text();
+    assert.equal(r.status, 200, `mint '${name}' failed: ${text}`);
+    return JSON.parse(text);
+  }
+
+  async function listKeys() {
+    const r = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      headers: { 'x-access-token': adminToken },
+    });
+    assert.equal(r.status, 200);
+    return r.json();
+  }
+
+  before(async () => {
+    libDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-fedlimits-'));
+    await fs.writeFile(path.join(libDir, 'q.bin'), FILE_QUOTA);
+    await fs.writeFile(path.join(libDir, 't.bin'), FILE_THROTTLE);
+    await fs.writeFile(path.join(libDir, 'c.bin'), FILE_CONC);
+
+    srv = await startServer({
+      extraFolders: { shared: libDir },
+      extraConfig: { federation: { enabled: true } },
+      users: [{ username: 'boss', password: 'pw', admin: true, vpaths: ['testlib', 'shared'] }],
+      waitForScan: false,
+      env: { MSTREAM_TEST_FED_FLUSH_MS: '200' },
+    });
+
+    const login = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'boss', password: 'pw' }),
+    });
+    adminToken = (await login.json()).token;
+
+    keys.defaults = await mintKey('defaults');
+    keys.open = await mintKey('open', { streamKbps: 0, dailyMb: 0, maxStreams: 0 });
+    keys.edit = await mintKey('edit', { streamKbps: 0, dailyMb: 0, maxStreams: 0 });
+    keys.quota = await mintKey('quota', { streamKbps: 0, dailyMb: 1, maxStreams: 0 });
+    // 800 kbps = 100 KiB/s wire budget with a 1s burst bucket, so the
+    // 200 KiB file below holds its stream open for ~1s — long enough for
+    // the concurrency probe, short enough for CI.
+    keys.throttle = await mintKey('throttle', { streamKbps: 800, dailyMb: 0, maxStreams: 0 });
+    keys.conc = await mintKey('conc', { streamKbps: 800, dailyMb: 0, maxStreams: 1 });
+  });
+
+  after(async () => {
+    await srv?.stop();
+    if (libDir) { await fs.rm(libDir, { recursive: true, force: true }).catch(() => {}); }
+  });
+
+  test('minting without limit fields applies the config defaults', async () => {
+    assert.equal(keys.defaults.streamKbps, 8000);
+    assert.equal(keys.defaults.dailyMb, 2048);
+    assert.equal(keys.defaults.maxStreams, 3);
+
+    const rows = await listKeys();
+    const row = rows.find((k) => k.id === keys.defaults.id);
+    assert.equal(row.stream_kbps, 8000);
+    assert.equal(row.daily_mb, 2048);
+    assert.equal(row.max_streams, 3);
+    assert.equal(typeof row.usage_today_bytes, 'number');
+
+    const zero = rows.find((k) => k.id === keys.open.id);
+    assert.deepEqual(
+      { kbps: zero.stream_kbps, mb: zero.daily_mb, streams: zero.max_streams },
+      { kbps: 0, mb: 0, streams: 0 });
+  });
+
+  test('limits edit route updates live, 404s unknown ids, 400s garbage', async () => {
+    const ok = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/${keys.edit.id}/limits`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ streamKbps: 1234, dailyMb: 5, maxStreams: 2 }),
+    });
+    assert.equal(ok.status, 200);
+    const row = (await listKeys()).find((k) => k.id === keys.edit.id);
+    assert.deepEqual(
+      { kbps: row.stream_kbps, mb: row.daily_mb, streams: row.max_streams },
+      { kbps: 1234, mb: 5, streams: 2 });
+
+    const missing = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/999999/limits`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ streamKbps: 0, dailyMb: 0, maxStreams: 0 }),
+    });
+    assert.equal(missing.status, 404);
+
+    const garbage = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/${keys.edit.id}/limits`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ streamKbps: -5, dailyMb: 0, maxStreams: 0 }),
+    });
+    assert.equal(garbage.status, 400);
+  });
+
+  test('unlimited key streams intact, usage is counted live and flushed to disk', async () => {
+    const r = await fetch(`${srv.baseUrl}/media/shared/q.bin`, { headers: fedHeaders(keys.open.key) });
+    assert.equal(r.status, 200);
+    const body = Buffer.from(await r.arrayBuffer());
+    assert.equal(body.length, FILE_QUOTA.length);
+    assert.ok(body.equals(FILE_QUOTA), 'unthrottled body should be byte-identical');
+
+    // Live figure (includes the not-yet-flushed accumulator).
+    const row = (await listKeys()).find((k) => k.id === keys.open.id);
+    assert.ok(row.usage_today_bytes >= FILE_QUOTA.length,
+      `usage_today_bytes ${row.usage_today_bytes} should cover the ${FILE_QUOTA.length}B download`);
+
+    // Flush proof: the accumulator lands in federation_key_usage on disk
+    // (200ms interval via MSTREAM_TEST_FED_FLUSH_MS). WAL allows a
+    // read-only peek from this process while the server holds the DB.
+    let flushed = 0;
+    for (let i = 0; i < 40 && flushed < FILE_QUOTA.length; i++) {
+      await sleep(250);
+      try {
+        const db = new DatabaseSync(path.join(srv.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+        try {
+          const u = db.prepare('SELECT bytes FROM federation_key_usage WHERE key_id = ?').get(keys.open.id);
+          flushed = u ? Number(u.bytes) : 0;
+        } finally { db.close(); }
+      } catch { /* transient lock — retry */ }
+    }
+    assert.ok(flushed >= FILE_QUOTA.length,
+      `flushed bytes ${flushed} should cover the ${FILE_QUOTA.length}B download`);
+  });
+
+  test('daily quota 429s media with Retry-After while browse keeps answering', async () => {
+    // dailyMb=1: four 256 KiB pulls land exactly on the 1 MiB quota; the
+    // fifth heavy request must be refused before a byte is served.
+    for (let i = 0; i < 4; i++) {
+      const r = await fetch(`${srv.baseUrl}/media/shared/q.bin`, { headers: fedHeaders(keys.quota.key) });
+      assert.equal(r.status, 200, `pull ${i + 1} of 4 should still be inside the quota`);
+      await r.arrayBuffer();
+    }
+
+    const blocked = await fetch(`${srv.baseUrl}/media/shared/q.bin`, { headers: fedHeaders(keys.quota.key) });
+    assert.equal(blocked.status, 429);
+    assert.match((await blocked.json()).error, /quota/i);
+    const retryAfter = Number(blocked.headers.get('retry-after'));
+    assert.ok(Number.isInteger(retryAfter) && retryAfter >= 1 && retryAfter <= 24 * 3600,
+      `Retry-After should count down to UTC midnight, got '${blocked.headers.get('retry-after')}'`);
+
+    // The light surface stays up so the peer can see WHY playback stopped.
+    const health = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(keys.quota.key) });
+    assert.equal(health.status, 200);
+
+    const stillBlocked = await fetch(`${srv.baseUrl}/media/shared/q.bin`, { headers: fedHeaders(keys.quota.key) });
+    assert.equal(stillBlocked.status, 429);
+  });
+
+  test('maxStreams caps concurrent media responses and frees on completion', async () => {
+    // Stream A: 200 KiB at 800 kbps ≈ 1s on the wire (burst covers the
+    // first ~100 KiB). Fire B while A is mid-body.
+    const aPromise = fetch(`${srv.baseUrl}/media/shared/c.bin`, { headers: fedHeaders(keys.conc.key) });
+    const a = await aPromise; // headers arrive once the slot is taken
+    assert.equal(a.status, 200);
+
+    await sleep(150);
+    const b = await fetch(`${srv.baseUrl}/media/shared/c.bin`, { headers: fedHeaders(keys.conc.key) });
+    assert.equal(b.status, 429);
+    assert.match((await b.json()).error, /concurrent/i);
+
+    const aBody = Buffer.from(await a.arrayBuffer());
+    assert.ok(aBody.equals(FILE_CONC), 'the throttled first stream should still be byte-identical');
+
+    // Slot freed — the next stream is welcome. The server decrements on
+    // res 'close', which can land a beat after the client sees the last
+    // byte, so poll briefly instead of asserting the first attempt.
+    let cStatus = 0;
+    for (let i = 0; i < 20 && cStatus !== 200; i++) {
+      await sleep(100);
+      const c = await fetch(`${srv.baseUrl}/media/shared/c.bin`, { headers: fedHeaders(keys.conc.key) });
+      cStatus = c.status;
+      if (cStatus === 200) { await c.arrayBuffer(); }
+    }
+    assert.equal(cStatus, 200);
+  });
+
+  test('streamKbps paces the download without corrupting it', async () => {
+    // 300 KiB at 800 kbps (100 KiB/s): ~1s of burst + ~2s paced ⇒ expect
+    // roughly 2s. Assert only a 1s floor — wide margins on purpose
+    // (loaded CI runners stretch time; they never compress it).
+    const started = Date.now();
+    const r = await fetch(`${srv.baseUrl}/media/shared/t.bin`, { headers: fedHeaders(keys.throttle.key) });
+    assert.equal(r.status, 200);
+    const body = Buffer.from(await r.arrayBuffer());
+    const elapsed = Date.now() - started;
+
+    assert.ok(body.equals(FILE_THROTTLE), 'throttled body should be byte-identical');
+    assert.ok(elapsed >= 1000,
+      `300 KiB at 100 KiB/s should take well over 1s, finished in ${elapsed}ms`);
+  });
+});

--- a/test/integration/federation-limits.test.mjs
+++ b/test/integration/federation-limits.test.mjs
@@ -26,6 +26,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { startServer } from '../helpers/server.mjs';
+import { parseFederationTicket } from '../../src/state/federation.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const fedHeaders = (key) => ({ 'x-federation-key': key, 'Content-Type': 'application/json' });
@@ -220,6 +221,59 @@ describe('federation bandwidth limits e2e', () => {
       if (cStatus === 200) { await c.arrayBuffer(); }
     }
     assert.equal(cStatus, 200);
+  });
+
+  test('expiry: rejected in the past, enforced wall-wide, renewable, clearable', async () => {
+    // A past date never mints.
+    const past = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ name: 'past', vpaths: ['shared'], expiresAt: new Date(Date.now() - 60_000).toISOString() }),
+    });
+    assert.equal(past.status, 400);
+
+    // Mint a key that dies in ~2s (skew between this process and the
+    // spawned server is millisecond-scale; the margins here are seconds).
+    const iso = new Date(Date.now() + 2000).toISOString();
+    const k = await mintKey('shortlived', { streamKbps: 0, dailyMb: 0, maxStreams: 0, expiresAt: iso });
+    // Stored form drops sub-seconds; response and ticket both carry it.
+    const expectIso = `${iso.slice(0, 19)}Z`;
+    assert.equal(k.expiresAt, expectIso);
+    assert.equal(parseFederationTicket(k.ticket).expiresAt, expectIso);
+
+    // Alive before the cutoff…
+    const alive = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(k.key) });
+    assert.equal(alive.status, 200);
+
+    // …dead everywhere after it: the light surface too, not just media.
+    await sleep(4000);
+    const deadHealth = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(k.key) });
+    assert.equal(deadHealth.status, 401);
+    const deadMedia = await fetch(`${srv.baseUrl}/media/shared/q.bin`, { headers: fedHeaders(k.key) });
+    assert.equal(deadMedia.status, 401);
+    const row = (await listKeys()).find((r) => r.id === k.id);
+    assert.equal(row.expired, 1);
+
+    // Renewal: a new future date through the limits route re-arms the key.
+    const renew = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/${k.id}/limits`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ streamKbps: 0, dailyMb: 0, maxStreams: 0, expiresAt: new Date(Date.now() + 3600_000).toISOString() }),
+    });
+    assert.equal(renew.status, 200);
+    const renewed = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(k.key) });
+    assert.equal(renewed.status, 200);
+
+    // Clearing to null = never; omitting the field leaves expiry alone.
+    const clear = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/${k.id}/limits`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ streamKbps: 0, dailyMb: 0, maxStreams: 0, expiresAt: null }),
+    });
+    assert.equal(clear.status, 200);
+    const cleared = (await listKeys()).find((r) => r.id === k.id);
+    assert.equal(cleared.expires_at, null);
+    assert.equal(cleared.expired, 0);
   });
 
   test('streamKbps paces the download without corrupting it', async () => {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -63,6 +63,9 @@ const ADMINDATA = (() => {
   module.federationParamsUpdated = { ts: 0 };
   module.federationKeys = { list: [] };
   module.federationPeers = { list: [] };
+  // The key row the edit-limits modal is acting on (modals are global
+  // components, so per-row context rides shared state, not props).
+  module.federationLimitsTarget = { key: null };
   // torrent (UX-layer settings — client + whitelist gating)
   module.torrentParams = {
     client:       'disabled',
@@ -3532,6 +3535,25 @@ const federationView = Vue.component('federation-view', {
       modVM.currentViewModal = 'federation-new-ticket-modal';
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
     },
+    openLimitsModal(key) {
+      ADMINDATA.federationLimitsTarget.key = key;
+      modVM.currentViewModal = 'federation-edit-limits-modal';
+      M.Modal.getInstance(document.getElementById('admin-modal')).open();
+    },
+    fmtLimits(k) {
+      const parts = [];
+      if (k.stream_kbps > 0) { parts.push(k.stream_kbps >= 1000 ? `${+(k.stream_kbps / 1000).toFixed(1)} Mbps` : `${k.stream_kbps} kbps`); }
+      if (k.daily_mb > 0) { parts.push(k.daily_mb >= 1024 ? `${+(k.daily_mb / 1024).toFixed(1)} GB/day` : `${k.daily_mb} MB/day`); }
+      if (k.max_streams > 0) { parts.push(`${k.max_streams} stream${k.max_streams === 1 ? '' : 's'}`); }
+      return parts.length ? parts.join(' · ') : 'unlimited';
+    },
+    fmtBytes(n) {
+      if (!n) { return '0 B'; }
+      if (n >= 1024 * 1024 * 1024) { return `${+(n / (1024 * 1024 * 1024)).toFixed(2)} GB`; }
+      if (n >= 1024 * 1024) { return `${+(n / (1024 * 1024)).toFixed(1)} MB`; }
+      if (n >= 1024) { return `${+(n / 1024).toFixed(1)} KB`; }
+      return `${n} B`;
+    },
     async revokeKey(key) {
       this.setRowPending(key.id, true);
       try {
@@ -3659,11 +3681,13 @@ const federationView = Vue.component('federation-view', {
               <span class="card-title">Shared Libraries — Tickets You Minted</span>
               <p style="font-size:0.9em;color:#777">Each ticket is a read-only grant for the libraries you picked. Copy it and send it to the friend it's for.</p>
               <table v-if="keys.list.length > 0" class="striped">
-                <thead><tr><th>Name</th><th>Libraries</th><th>Last used</th><th>Redeemed</th><th style="width:280px"></th></tr></thead>
+                <thead><tr><th>Name</th><th>Libraries</th><th>Limits</th><th>Today</th><th>Last used</th><th>Redeemed</th><th style="width:280px"></th></tr></thead>
                 <tbody>
                   <tr v-for="k in keys.list" :key="k.id">
                     <td>{{ k.name }}</td>
                     <td>{{ k.library_names.join(', ') }}</td>
+                    <td style="font-size:0.85em"><a v-on:click="openLimitsModal(k)" style="cursor:pointer" title="Edit this key's bandwidth limits">{{ fmtLimits(k) }}</a></td>
+                    <td style="font-size:0.85em" title="Bytes served to this key today (UTC)">{{ fmtBytes(k.usage_today_bytes) }}</td>
                     <td>{{ fmtDate(k.last_used) }}</td>
                     <td>
                       <span v-if="k.bound_endpoint_id" style="color:#2e7d32">✔ claimed</span>
@@ -9641,10 +9665,16 @@ const lastFMModal = Vue.component('lastfm-modal', {
 // libraries it covers, mint, and copy the resulting mstrfed1: ticket.
 const federationNewTicketModal = Vue.component('federation-new-ticket-modal', {
   data() {
+    // Pre-fill the caps from config (federation.limits via the status
+    // route); the admin tunes or zeroes them per key right here.
+    const d = ADMINDATA.federationParams.limitDefaults || { streamKbps: 8000, dailyMb: 2048, maxStreams: 3 };
     return {
       directories: ADMINDATA.folders,
       name: '',
       selected: [],
+      streamKbps: d.streamKbps,
+      dailyMb: d.dailyMb,
+      maxStreams: d.maxStreams,
       submitPending: false,
       mintedTicket: null,
     };
@@ -9661,6 +9691,21 @@ const federationNewTicketModal = Vue.component('federation-new-ticket-modal', {
           <p v-for="(cfg, vpath) in directories" :key="vpath" style="margin:4px 0">
             <label><input type="checkbox" v-model="selected" :value="vpath"/><span>{{ vpath }}</span></label>
           </p>
+          <p style="margin:16px 0 4px"><b>Bandwidth limits</b> <span style="color:#777;font-size:0.85em">— 0 means unlimited</span></p>
+          <div class="row" style="margin-bottom:0">
+            <div class="input-field col s4">
+              <input id="fed-limit-kbps" type="number" min="0" v-model.number="streamKbps"/>
+              <label for="fed-limit-kbps" class="active">Stream rate (kbps)</label>
+            </div>
+            <div class="input-field col s4">
+              <input id="fed-limit-daily" type="number" min="0" v-model.number="dailyMb"/>
+              <label for="fed-limit-daily" class="active">Daily quota (MB)</label>
+            </div>
+            <div class="input-field col s4">
+              <input id="fed-limit-streams" type="number" min="0" v-model.number="maxStreams"/>
+              <label for="fed-limit-streams" class="active">Max streams</label>
+            </div>
+          </div>
         </div>
         <div v-else>
           <p><b>Ticket for '{{ name }}'</b> — copy it and send it to your friend over a private channel. Anyone holding it can read the granted libraries until it's claimed or revoked.</p>
@@ -9682,7 +9727,12 @@ const federationNewTicketModal = Vue.component('federation-new-ticket-modal', {
         const res = await API.axios({
           method: 'POST',
           url: `${API.url()}/api/v1/admin/federation/keys`,
-          data: { name: this.name.trim(), vpaths: this.selected },
+          data: {
+            name: this.name.trim(), vpaths: this.selected,
+            streamKbps: Number(this.streamKbps) || 0,
+            dailyMb: Number(this.dailyMb) || 0,
+            maxStreams: Number(this.maxStreams) || 0,
+          },
         });
         this.mintedTicket = res.data.ticket || res.data.key;
         if (!res.data.ticket) {
@@ -9691,6 +9741,69 @@ const federationNewTicketModal = Vue.component('federation-new-ticket-modal', {
         await ADMINDATA.getFederationKeys();
       } catch (err) {
         iziToast.error({ title: 'Failed to mint the ticket', position: 'topCenter', timeout: 3500 });
+      } finally {
+        this.submitPending = false;
+      }
+    },
+  },
+});
+
+const federationEditLimitsModal = Vue.component('federation-edit-limits-modal', {
+  data() {
+    const k = ADMINDATA.federationLimitsTarget.key || {};
+    return {
+      target: k,
+      streamKbps: k.stream_kbps || 0,
+      dailyMb: k.daily_mb || 0,
+      maxStreams: k.max_streams || 0,
+      submitPending: false,
+    };
+  },
+  template: `
+    <form @submit.prevent="save">
+      <div class="modal-content">
+        <h4>Limits for '{{ target.name }}'</h4>
+        <p style="color:#777;font-size:0.9em">Applies from this key's next request. 0 means unlimited.</p>
+        <div class="row" style="margin-bottom:0">
+          <div class="input-field col s4">
+            <input id="fed-edit-kbps" type="number" min="0" v-model.number="streamKbps"/>
+            <label for="fed-edit-kbps" class="active">Stream rate (kbps)</label>
+          </div>
+          <div class="input-field col s4">
+            <input id="fed-edit-daily" type="number" min="0" v-model.number="dailyMb"/>
+            <label for="fed-edit-daily" class="active">Daily quota (MB)</label>
+          </div>
+          <div class="input-field col s4">
+            <input id="fed-edit-streams" type="number" min="0" v-model.number="maxStreams"/>
+            <label for="fed-edit-streams" class="active">Max streams</label>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect btn-flat">Cancel</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending">
+          {{ submitPending ? 'Saving…' : 'Save' }}
+        </button>
+      </div>
+    </form>`,
+  methods: {
+    save: async function() {
+      this.submitPending = true;
+      try {
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/federation/keys/${this.target.id}/limits`,
+          data: {
+            streamKbps: Number(this.streamKbps) || 0,
+            dailyMb: Number(this.dailyMb) || 0,
+            maxStreams: Number(this.maxStreams) || 0,
+          },
+        });
+        await ADMINDATA.getFederationKeys();
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+        iziToast.success({ title: 'Limits updated', position: 'topCenter', timeout: 3500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to update the limits', position: 'topCenter', timeout: 3500 });
       } finally {
         this.submitPending = false;
       }
@@ -10273,6 +10386,7 @@ const modVM = new Vue({
     'edit-ssl-modal': editSslModal,
     'lastfm-modal': lastFMModal,
     'federation-new-ticket-modal': federationNewTicketModal,
+    'federation-edit-limits-modal': federationEditLimitsModal,
     'edit-rust-player-port-modal': editRustPlayerPortModal,
     'edit-album-art-services-modal': editAlbumArtServicesModal,
     'edit-log-buffer-size-modal': editLogBufferSizeModal,

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -3504,6 +3504,7 @@ const federationView = Vue.component('federation-view', {
           error: false,
           name: typeof payload.n === 'string' ? payload.n : '(unnamed server)',
           libraries: Array.isArray(payload.l) ? payload.l : [],
+          expires: typeof payload.e === 'string' ? payload.e.slice(0, 10) : null,
         };
       } catch (e) {
         return { error: true };
@@ -3553,6 +3554,12 @@ const federationView = Vue.component('federation-view', {
       if (n >= 1024 * 1024) { return `${+(n / (1024 * 1024)).toFixed(1)} MB`; }
       if (n >= 1024) { return `${+(n / 1024).toFixed(1)} KB`; }
       return `${n} B`;
+    },
+    // Rows carry SQLite UTC 'YYYY-MM-DD HH:MM:SS' — brand it UTC before
+    // parsing or the browser reads it as local time.
+    fmtExpiry(s) {
+      const days = Math.ceil((Date.parse(`${s.replace(' ', 'T')}Z`) - Date.now()) / 86400000);
+      return days <= 1 ? 'expires today' : `expires in ${days}d`;
     },
     async revokeKey(key) {
       this.setRowPending(key.id, true);
@@ -3686,7 +3693,11 @@ const federationView = Vue.component('federation-view', {
                   <tr v-for="k in keys.list" :key="k.id">
                     <td>{{ k.name }}</td>
                     <td>{{ k.library_names.join(', ') }}</td>
-                    <td style="font-size:0.85em"><a v-on:click="openLimitsModal(k)" style="cursor:pointer" title="Edit this key's bandwidth limits">{{ fmtLimits(k) }}</a></td>
+                    <td style="font-size:0.85em">
+                      <a v-on:click="openLimitsModal(k)" style="cursor:pointer" title="Edit this key's bandwidth limits and expiry">{{ fmtLimits(k) }}</a>
+                      <div v-if="k.expired" style="color:#c62828">expired</div>
+                      <div v-else-if="k.expires_at" style="color:#777">{{ fmtExpiry(k.expires_at) }}</div>
+                    </td>
                     <td style="font-size:0.85em" title="Bytes served to this key today (UTC)">{{ fmtBytes(k.usage_today_bytes) }}</td>
                     <td>{{ fmtDate(k.last_used) }}</td>
                     <td>
@@ -3745,6 +3756,7 @@ const federationView = Vue.component('federation-view', {
                 <div v-if="peerPreview && !peerPreview.error" class="card-panel green lighten-5" style="padding:10px">
                   <b>{{ peerPreview.name }}</b>
                   <span v-if="peerPreview.libraries.length"> — shares: {{ peerPreview.libraries.join(', ') }}</span>
+                  <span v-if="peerPreview.expires"> · valid until {{ peerPreview.expires }}</span>
                 </div>
                 <div class="input-field" style="max-width:320px">
                   <input id="fed-peer-name" type="text" v-model="peerName" placeholder="Optional display name"/>
@@ -9675,6 +9687,7 @@ const federationNewTicketModal = Vue.component('federation-new-ticket-modal', {
       streamKbps: d.streamKbps,
       dailyMb: d.dailyMb,
       maxStreams: d.maxStreams,
+      expireDays: 0,
       submitPending: false,
       mintedTicket: null,
     };
@@ -9693,17 +9706,21 @@ const federationNewTicketModal = Vue.component('federation-new-ticket-modal', {
           </p>
           <p style="margin:16px 0 4px"><b>Bandwidth limits</b> <span style="color:#777;font-size:0.85em">— 0 means unlimited</span></p>
           <div class="row" style="margin-bottom:0">
-            <div class="input-field col s4">
+            <div class="input-field col s3">
               <input id="fed-limit-kbps" type="number" min="0" v-model.number="streamKbps"/>
               <label for="fed-limit-kbps" class="active">Stream rate (kbps)</label>
             </div>
-            <div class="input-field col s4">
+            <div class="input-field col s3">
               <input id="fed-limit-daily" type="number" min="0" v-model.number="dailyMb"/>
               <label for="fed-limit-daily" class="active">Daily quota (MB)</label>
             </div>
-            <div class="input-field col s4">
+            <div class="input-field col s3">
               <input id="fed-limit-streams" type="number" min="0" v-model.number="maxStreams"/>
               <label for="fed-limit-streams" class="active">Max streams</label>
+            </div>
+            <div class="input-field col s3">
+              <input id="fed-limit-expire" type="number" min="0" v-model.number="expireDays"/>
+              <label for="fed-limit-expire" class="active">Expires (days)</label>
             </div>
           </div>
         </div>
@@ -9724,15 +9741,18 @@ const federationNewTicketModal = Vue.component('federation-new-ticket-modal', {
     mint: async function() {
       this.submitPending = true;
       try {
+        const data = {
+          name: this.name.trim(), vpaths: this.selected,
+          streamKbps: Number(this.streamKbps) || 0,
+          dailyMb: Number(this.dailyMb) || 0,
+          maxStreams: Number(this.maxStreams) || 0,
+        };
+        const days = Number(this.expireDays) || 0;
+        if (days > 0) { data.expiresAt = new Date(Date.now() + days * 86400000).toISOString(); }
         const res = await API.axios({
           method: 'POST',
           url: `${API.url()}/api/v1/admin/federation/keys`,
-          data: {
-            name: this.name.trim(), vpaths: this.selected,
-            streamKbps: Number(this.streamKbps) || 0,
-            dailyMb: Number(this.dailyMb) || 0,
-            maxStreams: Number(this.maxStreams) || 0,
-          },
+          data,
         });
         this.mintedTicket = res.data.ticket || res.data.key;
         if (!res.data.ticket) {
@@ -9756,8 +9776,18 @@ const federationEditLimitsModal = Vue.component('federation-edit-limits-modal', 
       streamKbps: k.stream_kbps || 0,
       dailyMb: k.daily_mb || 0,
       maxStreams: k.max_streams || 0,
+      // Tri-state, so saving limit tweaks can't silently restart an expiry
+      // clock: '' = leave expiry as it is, 0 = never, N = N days from now.
+      expireDays: '',
       submitPending: false,
     };
+  },
+  computed: {
+    currentExpiry() {
+      if (this.target.expired) { return 'expired'; }
+      if (!this.target.expires_at) { return 'never'; }
+      return `${this.target.expires_at.slice(0, 10)} (UTC)`;
+    },
   },
   template: `
     <form @submit.prevent="save">
@@ -9778,6 +9808,13 @@ const federationEditLimitsModal = Vue.component('federation-edit-limits-modal', 
             <label for="fed-edit-streams" class="active">Max streams</label>
           </div>
         </div>
+        <p style="margin:8px 0 4px"><b>Expiry</b> <span :style="{color: target.expired ? '#c62828' : '#777'}" style="font-size:0.85em">— currently: {{ currentExpiry }}</span></p>
+        <div class="row" style="margin-bottom:0">
+          <div class="input-field col s6">
+            <input id="fed-edit-expire" type="number" min="0" v-model="expireDays" placeholder="leave blank to keep"/>
+            <label for="fed-edit-expire" class="active">New expiry (days from now, 0 = never)</label>
+          </div>
+        </div>
       </div>
       <div class="modal-footer">
         <a href="#!" class="modal-close waves-effect btn-flat">Cancel</a>
@@ -9790,14 +9827,19 @@ const federationEditLimitsModal = Vue.component('federation-edit-limits-modal', 
     save: async function() {
       this.submitPending = true;
       try {
+        const data = {
+          streamKbps: Number(this.streamKbps) || 0,
+          dailyMb: Number(this.dailyMb) || 0,
+          maxStreams: Number(this.maxStreams) || 0,
+        };
+        if (String(this.expireDays).trim() !== '') {
+          const days = Number(this.expireDays) || 0;
+          data.expiresAt = days > 0 ? new Date(Date.now() + days * 86400000).toISOString() : null;
+        }
         await API.axios({
           method: 'POST',
           url: `${API.url()}/api/v1/admin/federation/keys/${this.target.id}/limits`,
-          data: {
-            streamKbps: Number(this.streamKbps) || 0,
-            dailyMb: Number(this.dailyMb) || 0,
-            maxStreams: Number(this.maxStreams) || 0,
-          },
+          data,
         });
         await ADMINDATA.getFederationKeys();
         M.Modal.getInstance(document.getElementById('admin-modal')).close();


### PR DESCRIPTION
PR 1 of the discovery→federation migration arc (plan: federation requests over the discovery network; this lands the abuse-control half first since it hardens existing federation on its own). Bandwidth limits + key expiry, **one V62 migration** (the interim V63 was folded in before merge — commit 3 — since the branch never shipped).

## Bandwidth limits

Three per-key caps on federation keys, enforced at the auth wall where every `x-federation-key` request already flows. **0 = unlimited on all three, and existing keys migrate to unlimited — upgrades change nothing until an admin sets a limit.**

- **`stream_kbps`** — token-bucket rate cap on `/media` responses, bucket **shared across the key's concurrent streams**. Implemented by wrapping `res.write`/`res.end` (compression-middleware technique) with strict FIFO dispatch and pipe-compatible backpressure (`false` + `'drain'`), so throttled bodies stay byte-identical.
- **`daily_mb`** — per-UTC-day transfer quota over everything the key pulls. Over quota → **429 + `Retry-After`** (seconds to UTC midnight) on byte-heavy routes **only**: browse/health keep answering so the peer's UI can say *why* playback stopped. An in-flight response is never cut (overshoot ≤ one file, documented).
- **`max_streams`** — concurrent `/media` response cap → 429.

Accounting is an in-process accumulator flushed to `federation_key_usage` every ~15s (no DB write per request). Quota checks read DB baseline + unflushed remainder, so bursts can't outrun the flusher and restarts can't forget a day. One row per key per UTC day, pruned at 90 days — the table's ceiling is keys×90 rows regardless of traffic.

## Key expiry

`federation_keys.expires_at` (NULL = never; every existing key stays that way). **One semantic: past the cutoff the key fails the auth wall AND the iroh pipe handshake** — it time-boxes a friend's access and quietly retires never-redeemed tickets. Details that matter:

- The expiry check runs **before the TOFU block** — a dead ticket can't bind on its way out (proven in the handshake suite).
- The `expired` flag is **computed in SQL** against `datetime('now')` on every key read — never via JS `Date` parsing, which reads SQLite's format as local time and would drift the cutoff by the UTC offset.
- An already-open pipe is **lazily severed** on the key's first post-expiry request.
- The limits route treats `expiresAt` as tri-state (absent = unchanged, null = never, future ISO = set/renew) — renewing an expired friend is one edit, and saving bandwidth tweaks can't silently restart the clock. The key row and usage history survive expiry.
- Tickets carry expiry as an informational **`e` field** (old parsers ignore unknown fields by design; the server row is the truth). The add-peer preview shows "valid until …". Spec updated in `docs/federation-ticket.md`.

## Surface

- Config `federation.limits` (8000 kbps / 2048 MB / 3 streams) — **pre-fills the mint dialog only**; per-key values live on the row, enforcement never reads config.
- Mint accepts optional limits + `expiresAt`; new `POST /api/v1/admin/federation/keys/:id/limits` edits both live; key list exposes limits, live `usage_today_bytes`, `expires_at`, `expired`. openapi documented.
- Admin UI: mint modal (three limit fields + Expires-days, "0 = unlimited/never"); keys table Limits ("8 Mbps · 2 GB/day · 3 streams", "expires in 30d" / red "expired") + Today columns; edit modal with current-expiry display and renewal field.

## Testing

- Schema suite: fresh defaults (limits 0, expiry NULL), single-hop pre-V62 upgrade (unlimited AND never-expiring), usage UPSERT accumulation, cascade delete, SQL cutoff math incl. ISO normalization.
- `federation-limits.test.mjs` e2e over plain HTTP: config-default mints, live edits (+404/400), byte-identical throttled streams, **exact** quota math (4×256 KiB = 1 MiB → 5th pull 429), concurrency cap with slot release, flush-to-disk proof, and the full expiry lifecycle (400 on past dates → alive → 401 wall-wide → renewal → clear-to-never, ticket `e` round-trip).
- `federation-handshake.test.mjs` (real iroh): expired key rejected **without TOFU-binding**, renewal re-arms the same ticket.
- Regression: all federation + discovery-over-federation + schema suites green. Lint clean on changed files.
- UI click-through on a live preview server; fresh-boot verified `user_version = 62` with all four columns from the single migration.

⚠ If you booted an earlier commit of this branch against a real DB, delete that DB (or `PRAGMA user_version = 61`) before running this one — the interim V62/V63 stamps predate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)