### PR TITLE
feat(discovery): sidecar direct messages — the federation-requests transport

### DIFF
--- a/p2p-sidecar/src/main.rs
+++ b/p2p-sidecar/src/main.rs
@@ -33,6 +33,17 @@
 // gossip Message's `delivered_from` is the last hop, NOT the author —
 // without app-level signatures any peer could impersonate any other.
 //
+// DM (direct messages): a third ALPN for ADDRESSED, non-gossip delivery —
+// the transport under federation requests ("this discovery peer wants to
+// pair"). `dm` dials ONE peer and hands over a small JSON payload; the
+// receiving side forwards it to Node as an event and acks. Sender identity
+// is the QUIC-authenticated remote endpoint id — no app-level signature
+// needed (unlike gossip, where delivered_from is just the last hop).
+// Fail-closed: inbound DMs are refused until Node opts in via
+// `setDmAccept` (the operator's "accept requests" toggle), so the sender
+// gets an immediate typed refusal instead of silence. Rust caps sizes and
+// rate-limits; payload CONTENT is Node's problem.
+//
 // Protocol (one JSON object per line):
 //   → {"id":1,"cmd":"status"}
 //   → {"id":2,"cmd":"publish","path":"C:/.../discovery-export.db"}
@@ -42,12 +53,18 @@
 //   → {"id":6,"cmd":"announce","payload":{"hash":"...","size":1,"rowCount":1,
 //        "modelId":"...","modelVersion":"...","snapshotSeq":1,"name":"...",
 //        "description":"..."}}   (description optional, ≤180 chars)
-//   → {"id":7,"cmd":"shutdown"}
+//   → {"id":7,"cmd":"dm","to":"<endpoint ticket | endpoint id>","payload":{...}}
+//        ← {"id":7,"ok":true,"delivered":true}                    (accepted)
+//        ← {"id":7,"ok":true,"delivered":false,"reason":"..."}    (peer refused)
+//        ← {"id":7,"ok":false,"error":"..."}                      (never reached)
+//   → {"id":8,"cmd":"setDmAccept","accept":true}
+//   → {"id":9,"cmd":"shutdown"}
 //   ← {"id":N,"ok":true,...} | {"id":N,"ok":false,"error":"..."}
 // Unsolicited events:
 //   ← {"event":"ready","endpointId":"...","ticket":"..."}
 //   ← {"event":"announcement","from":"...","payload":{...}}
 //   ← {"event":"neighbor","up":true|false,"id":"..."}
+//   ← {"event":"dm","from":"<endpoint id>","payload":{...}}
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -101,6 +118,22 @@ const HOLDS_SIGNING_CONTEXT: &str = "mstream-discovery-holds-v1";
 const MAX_HOLDS: usize = 64;
 const MAX_HOLDS_BYTES: usize = 8192;
 
+// Direct messages. The ALPN is versioned like the catalog topic: a future
+// incompatible envelope moves to /2 and old nodes fail the dial cleanly
+// (the sender maps that to "older mStream or offline").
+const DM_ALPN: &[u8] = b"mstream/discovery-dm/1";
+// A DM is a federation request/accept/reject envelope — name, message,
+// uuid, a ticket at most. 8 KB is generous; anything bigger is abuse.
+const MAX_DM_BYTES: usize = 8192;
+const MAX_DM_ACK_BYTES: usize = 256;
+const DM_CONNECT_TIMEOUT: Duration = Duration::from_secs(25);
+// Inbound abuse caps, enforced BEFORE the payload is even parsed. Legit
+// traffic is a handful of messages per pairing, ever — these numbers are
+// generous for humans and hostile to loops.
+const DM_WINDOW: Duration = Duration::from_secs(60);
+const DM_PER_REMOTE_MAX: usize = 6;
+const DM_GLOBAL_MAX: usize = 30;
+
 #[derive(Deserialize, Debug)]
 struct Request {
     id: u64,
@@ -113,8 +146,12 @@ struct Request {
     #[serde(rename = "outDir")]
     out_dir: Option<String>,
     bootstrap: Option<Vec<String>>,
-    payload: Option<AnnouncePayload>,
+    // Untyped here because two commands share it: `announce` parses it into
+    // AnnouncePayload, `dm` forwards it opaquely (content is Node's concern).
+    payload: Option<Value>,
     hashes: Option<Vec<String>>,
+    to: Option<String>,
+    accept: Option<bool>,
 }
 
 // What a server says about its current snapshot. `snapshot_seq` is the
@@ -199,6 +236,9 @@ struct Node {
     // "kind:origin" -> (last accepted instant, seq/marker). Flood guard:
     // same-content heartbeats coalesce, genuinely-new content passes.
     last_accepted: Mutex<HashMap<String, (Instant, u64)>>,
+    // Direct-message state shared with the DM_ALPN protocol handler
+    // (accept flag + inbound rate limiter).
+    dm: Arc<DmState>,
     out_tx: mpsc::UnboundedSender<Value>,
 }
 
@@ -261,21 +301,30 @@ async fn run(data_dir: PathBuf) -> Result<()> {
     let store = FsStore::load_with_opts(blobs_root.join("blobs.db"), store_opts)
         .await
         .map_err(|e| anyhow!("blob store load failed: {e}"))?;
+    // Single writer task owns stdout; handlers post JSON values to it. Keeps
+    // concurrent responses from interleaving mid-line. Created before the
+    // router because the DM protocol handler forwards inbound messages
+    // through it.
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<Value>();
+
+    let dm = Arc::new(DmState {
+        accept: std::sync::atomic::AtomicBool::new(false),
+        limiter: Mutex::new(DmLimiter::default()),
+        out_tx: out_tx.clone(),
+    });
+
     let blobs = BlobsProtocol::new(&store, None);
     let gossip = Gossip::builder().spawn(endpoint.clone());
     let router = Router::builder(endpoint.clone())
         .accept(iroh_blobs::ALPN, blobs)
         .accept(iroh_gossip::ALPN, gossip.clone())
+        .accept(DM_ALPN, DmProtocol(dm.clone()))
         .spawn();
 
     // Bounded wait for a home relay so tickets carry relay info — mirrors the
     // awaitOnline race in src/state/iroh.js. Offline hosts proceed anyway
     // (tickets then hold direct addresses only, which still works on a LAN).
     let _ = tokio::time::timeout(Duration::from_secs(8), endpoint.online()).await;
-
-    // Single writer task owns stdout; handlers post JSON values to it. Keeps
-    // concurrent responses from interleaving mid-line.
-    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<Value>();
     // The writer exits on a JSON `null` sentinel, NOT on channel close: a
     // sender clone lives inside the Arc<Node> (shared with the gossip loops,
     // which never finish), so the channel can never close — awaiting that
@@ -305,6 +354,7 @@ async fn run(data_dir: PathBuf) -> Result<()> {
         heartbeat: std::sync::atomic::AtomicU64::new(0),
         neighbor_count: AtomicI64::new(0),
         last_accepted: Mutex::new(HashMap::new()),
+        dm,
         out_tx: out_tx.clone(),
     });
 
@@ -508,7 +558,9 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
         }
 
         "announce" => {
-            let payload = req.payload.context("announce needs `payload`")?;
+            let payload: AnnouncePayload =
+                serde_json::from_value(req.payload.context("announce needs `payload`")?)
+                    .map_err(|e| anyhow!("bad announce payload: {e}"))?;
             let payload = validate_payload(payload)?;
             let canonical = canonical_bytes(&node.endpoint.id().to_string(), &payload);
             let sig = node.secret_key.sign(&canonical);
@@ -580,9 +632,162 @@ async fn handle(node: Arc<Node>, req: Request) -> Result<Value> {
             Ok(json!({ "forgotten": removed > 0, "tagsRemoved": removed }))
         }
 
+        // Send one direct message. Structured outcome (see the header):
+        // Ok{delivered:true} = the peer took it; Ok{delivered:false,reason}
+        // = the peer was REACHED and refused (terminal — don't retry);
+        // Err = never reached (unreachable / timeout / no DM support).
+        "dm" => {
+            let to = req.to.context("dm needs `to`")?;
+            let payload = req.payload.context("dm needs `payload`")?;
+            if !payload.is_object() { bail!("dm payload must be a JSON object"); }
+            let wire = serde_json::to_vec(&payload)?;
+            if wire.len() > MAX_DM_BYTES {
+                bail!("dm payload too large ({} > {MAX_DM_BYTES} bytes)", wire.len());
+            }
+
+            // Same dual addressing as `join` bootstrap entries: a ticket is
+            // self-contained (and seeds MemoryLookup for future bare-id
+            // dials — the catalog flow); a bare id leans on N0 discovery.
+            let addr: iroh::EndpointAddr = if let Ok(t) = EndpointTicket::from_str(&to) {
+                let a = t.endpoint_addr().clone();
+                node.memory_lookup.add_endpoint_info(a.clone());
+                a
+            } else if let Ok(id) = EndpointId::from_str(&to) {
+                id.into()
+            } else {
+                bail!("dm `to` is neither an endpoint ticket nor an endpoint id");
+            };
+
+            let conn = tokio::time::timeout(DM_CONNECT_TIMEOUT, node.endpoint.connect(addr, DM_ALPN))
+                .await
+                .map_err(|_| anyhow!("dm connect timed out after {}s", DM_CONNECT_TIMEOUT.as_secs()))?
+                .map_err(|e| {
+                    // ALPN rejection = the peer runs a build without the DM
+                    // protocol. Best-effort string sniff — the sender's UX
+                    // hint, not a security decision.
+                    let msg = e.to_string();
+                    if msg.to_ascii_lowercase().contains("protocol") || msg.to_ascii_lowercase().contains("alpn") {
+                        anyhow!("peer does not support direct messages (older mStream, or offline): {msg}")
+                    } else {
+                        anyhow!("peer unreachable: {msg}")
+                    }
+                })?;
+            let (mut send, mut recv) = conn.open_bi().await
+                .map_err(|e| anyhow!("dm stream open failed: {e}"))?;
+            send.write_all(&wire).await.map_err(|e| anyhow!("dm send failed: {e}"))?;
+            send.finish().map_err(|e| anyhow!("dm send close failed: {e}"))?;
+            let ack_bytes = recv.read_to_end(MAX_DM_ACK_BYTES).await
+                .map_err(|e| anyhow!("dm ack read failed: {e}"))?;
+            conn.close(0u32.into(), b"done");
+            let ack: Value = serde_json::from_slice(&ack_bytes)
+                .map_err(|e| anyhow!("dm ack unparseable: {e}"))?;
+            if ack.get("ok").and_then(|v| v.as_bool()) == Some(true) {
+                Ok(json!({ "delivered": true }))
+            } else {
+                let reason = ack.get("reason").and_then(|v| v.as_str()).unwrap_or("refused");
+                Ok(json!({ "delivered": false, "reason": reason }))
+            }
+        }
+
+        // Node's inbound-DM policy switch (the "accept federation requests"
+        // toggle). Fail-closed: the flag starts false on every boot and
+        // stays false until Node says otherwise.
+        "setDmAccept" => {
+            let accept = req.accept.context("setDmAccept needs `accept`")?;
+            node.dm.accept.store(accept, Ordering::Relaxed);
+            Ok(json!({ "accept": accept }))
+        }
+
         "shutdown" => Ok(json!({})),
 
         other => Err(anyhow!("unknown command: {other}")),
+    }
+}
+
+// ── Direct messages (DM_ALPN) ───────────────────────────────────────────────
+
+// Sliding-window counters for inbound DMs, per remote + global. Pure (the
+// caller passes `now`) so the arithmetic gets direct unit tests. Vec scans
+// are fine: the caps keep every list tiny by construction.
+#[derive(Debug, Default)]
+struct DmLimiter {
+    per_remote: HashMap<String, Vec<Instant>>,
+    global: Vec<Instant>,
+}
+
+impl DmLimiter {
+    fn check(&mut self, remote: &str, now: Instant) -> Result<(), &'static str> {
+        let fresh = |t: &Instant| now.duration_since(*t) < DM_WINDOW;
+        self.global.retain(fresh);
+        if self.global.len() >= DM_GLOBAL_MAX { return Err("rate-limited"); }
+        let entries = self.per_remote.entry(remote.to_string()).or_default();
+        entries.retain(fresh);
+        if entries.len() >= DM_PER_REMOTE_MAX { return Err("rate-limited"); }
+        entries.push(now);
+        self.global.push(now);
+        // Drop empty per-remote entries so a scanning stranger can't grow
+        // the map unboundedly with one-shot identities.
+        self.per_remote.retain(|_, v| !v.is_empty());
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct DmState {
+    // Fail-closed: refused until Node's setDmAccept says otherwise.
+    accept: std::sync::atomic::AtomicBool,
+    limiter: Mutex<DmLimiter>,
+    out_tx: mpsc::UnboundedSender<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct DmProtocol(Arc<DmState>);
+
+impl iroh::protocol::ProtocolHandler for DmProtocol {
+    async fn accept(&self, conn: iroh::endpoint::Connection) -> Result<(), iroh::protocol::AcceptError> {
+        let state = self.0.clone();
+        let remote = conn.remote_id().to_string();
+
+        let (mut send, mut recv) = conn.accept_bi().await?;
+        // The refusal path still reads the (capped) payload first: QUIC
+        // gives no way to ack before the peer finishes sending anyway, and
+        // TooLong closes the read without buffering past the cap.
+        let verdict: Result<Value, &'static str> = match recv.read_to_end(MAX_DM_BYTES).await {
+            Err(_) => Err("too-large"),
+            Ok(bytes) => {
+                if !state.accept.load(Ordering::Relaxed) {
+                    Err("not-accepting")
+                } else if state.limiter.lock().await.check(&remote, Instant::now()).is_err() {
+                    Err("rate-limited")
+                } else {
+                    match serde_json::from_slice::<Value>(&bytes) {
+                        Ok(v) if v.is_object() => Ok(v),
+                        _ => Err("malformed"),
+                    }
+                }
+            }
+        };
+
+        let ack = match &verdict {
+            Ok(payload) => {
+                let _ = state.out_tx.send(json!({ "event": "dm", "from": remote, "payload": payload }));
+                json!({ "ok": true })
+            }
+            Err(reason) => {
+                eprintln!("[p2p-sidecar] refused dm from {remote}: {reason}");
+                json!({ "ok": false, "reason": reason })
+            }
+        };
+        // A failed ack write means the dialer already hung up — there is
+        // nobody left to tell, so it is not an accept error.
+        if send.write_all(&serde_json::to_vec(&ack).unwrap_or_default()).await.is_err() {
+            return Ok(());
+        }
+        send.finish().ok();
+        // Give the dialer a moment to read the ack before the Router drops
+        // the connection; it closes from its side once it has the bytes.
+        let _ = tokio::time::timeout(Duration::from_secs(5), conn.closed()).await;
+        Ok(())
     }
 }
 
@@ -1037,5 +1242,36 @@ mod tests {
         let sk = SecretKey::generate();
         let wire = signed_holds(&sk, vec!["ef".repeat(32)], true);
         assert!(verify_wire(&wire).is_err(), "padded hold set must not verify");
+    }
+
+    #[test]
+    fn dm_limiter_caps_per_remote_and_recovers_after_the_window() {
+        let mut l = DmLimiter::default();
+        let t0 = Instant::now();
+        for i in 0..DM_PER_REMOTE_MAX {
+            assert!(l.check("peer-a", t0).is_ok(), "send {i} within the cap must pass");
+        }
+        assert!(l.check("peer-a", t0).is_err(), "over the per-remote cap must be refused");
+        // A different remote has its own budget.
+        assert!(l.check("peer-b", t0).is_ok());
+        // Past the window, the budget refills.
+        let later = t0 + DM_WINDOW + Duration::from_secs(1);
+        assert!(l.check("peer-a", later).is_ok(), "budget must refill after the window");
+    }
+
+    #[test]
+    fn dm_limiter_global_cap_spans_remotes() {
+        let mut l = DmLimiter::default();
+        let t0 = Instant::now();
+        let mut accepted = 0;
+        // Many one-shot identities (the cheap sybil pattern): the per-remote
+        // cap never trips, the global one must.
+        for i in 0..(DM_GLOBAL_MAX + 5) {
+            if l.check(&format!("stranger-{i}"), t0).is_ok() { accepted += 1; }
+        }
+        assert_eq!(accepted, DM_GLOBAL_MAX, "global cap must bound total accepts");
+        // And the per-remote map must not have grown a tombstone per stranger
+        // beyond the accepted ones (empty entries are pruned on the way out).
+        assert!(l.per_remote.len() <= DM_GLOBAL_MAX);
     }
 }

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -37,6 +37,12 @@ import * as config from './config.js';
 //   'announcement' → { from, payload }   a peer's signed catalog announcement
 //                                        (signature already verified in Rust)
 //   'neighbor'     → { up, id }          gossip mesh membership changes
+//   'dm'           → { from, payload }   a direct message from a peer. `from`
+//                                        is the QUIC-authenticated endpoint
+//                                        id; payload is size-capped but
+//                                        otherwise UNVALIDATED JSON — the
+//                                        consumer (federation requests)
+//                                        owns content validation.
 // The catalog module (discovery-catalog.js) is the main subscriber.
 export const events = new EventEmitter();
 
@@ -437,6 +443,31 @@ export function setHolds(hashes) {
 export function forget(hash) {
   if (!isRunning()) { return Promise.resolve({ forgotten: false, offline: true }); }
   return rpc('forget', { hash });
+}
+
+// ── Direct messages (federation requests transport) ─────────────────────────
+
+// A dm dial can take the full 25s connect budget against an offline peer.
+const DM_TIMEOUT_MS = 40 * 1000;
+
+// Send one addressed message. `to` = endpoint ticket or bare endpoint id
+// (catalog entries are bare ids; N0 discovery resolves them). Resolves
+// { delivered: true } when the peer accepted, { delivered: false, reason }
+// when the peer was reached and REFUSED (not-accepting / rate-limited /
+// too-large / malformed — terminal, don't retry), and REJECTS when the
+// peer was never reached (offline, or a build without the DM protocol).
+export async function sendDm(to, payload) {
+  await start();
+  return rpc('dm', { to, payload }, DM_TIMEOUT_MS);
+}
+
+// Inbound-DM policy: the sidecar boots fail-closed and refuses DMs at the
+// transport until this says otherwise, so senders get an immediate typed
+// refusal instead of silence. Lenient offline — the flag is re-pushed on
+// every stack start.
+export function setDmAccept(accept) {
+  if (!isRunning()) { return Promise.resolve({ set: false, offline: true }); }
+  return rpc('setDmAccept', { accept: accept === true });
 }
 
 // The blob hash of our own currently-published snapshot (null before the

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -34,6 +34,12 @@ import * as config from './config.js';
 //   'announcement' → { from, payload }   a peer's signed catalog announcement
 //                                        (signature already verified in Rust)
 //   'neighbor'     → { up, id }          gossip mesh membership changes
+//   'dm'           → { from, payload }   a direct message from a peer. `from`
+//                                        is the QUIC-authenticated endpoint
+//                                        id; payload is size-capped but
+//                                        otherwise UNVALIDATED JSON — the
+//                                        consumer (federation requests)
+//                                        owns content validation.
 // The catalog module (discovery-catalog.js) is the main subscriber.
 export const events = new EventEmitter();
 
@@ -236,6 +242,31 @@ export function setHolds(hashes) {
 export function forget(hash) {
   if (!isRunning()) { return Promise.resolve({ forgotten: false, offline: true }); }
   return rpc('forget', { hash });
+}
+
+// ── Direct messages (federation requests transport) ─────────────────────────
+
+// A dm dial can take the full 25s connect budget against an offline peer.
+const DM_TIMEOUT_MS = 40 * 1000;
+
+// Send one addressed message. `to` = endpoint ticket or bare endpoint id
+// (catalog entries are bare ids; N0 discovery resolves them). Resolves
+// { delivered: true } when the peer accepted, { delivered: false, reason }
+// when the peer was reached and REFUSED (not-accepting / rate-limited /
+// too-large / malformed — terminal, don't retry), and REJECTS when the
+// peer was never reached (offline, or a build without the DM protocol).
+export async function sendDm(to, payload) {
+  await start();
+  return rpc('dm', { to, payload }, DM_TIMEOUT_MS);
+}
+
+// Inbound-DM policy: the sidecar boots fail-closed and refuses DMs at the
+// transport until this says otherwise, so senders get an immediate typed
+// refusal instead of silence. Lenient offline — the flag is re-pushed on
+// every stack start.
+export function setDmAccept(accept) {
+  if (!isRunning()) { return Promise.resolve({ set: false, offline: true }); }
+  return rpc('setDmAccept', { accept: accept === true });
 }
 
 // The blob hash of our own currently-published snapshot (null before the

--- a/test/helpers/raw-sidecar.mjs
+++ b/test/helpers/raw-sidecar.mjs
@@ -1,0 +1,77 @@
+/**
+ * A bare p2p-sidecar child for protocol-level tests: spawn the binary, speak
+ * line-JSON RPC, collect unsolicited events. This is the same shape
+ * discovery-p2p.test.mjs uses inline for its two-peer suites — extracted for
+ * new protocol suites (first consumer: the DM tests) so they don't re-clone
+ * it. The inline copy in discovery-p2p.test.mjs predates this helper;
+ * folding it over is deliberate follow-up churn, not this PR's job.
+ */
+
+import { spawn } from 'node:child_process';
+import readline from 'node:readline';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export async function pollUntil(fn, { timeoutMs = 20000, stepMs = 100, what = 'condition' } = {}) {
+  const start = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) { return v; }
+    if (Date.now() - start > timeoutMs) { throw new Error(`timed out waiting for ${what}`); }
+    await sleep(stepMs);
+  }
+}
+
+export class RawSidecar {
+  constructor(bin, dataDir) {
+    this.proc = spawn(bin, ['--data-dir', dataDir], { stdio: ['pipe', 'pipe', 'pipe'] });
+    this.pending = new Map();
+    this.nextId = 1;
+    this.events = [];   // every unsolicited event, in arrival order
+    this.endpointId = null;
+    this.ticket = null;
+    this.ready = new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('sidecar never became ready')), 30000);
+      readline.createInterface({ input: this.proc.stdout }).on('line', (line) => {
+        const msg = JSON.parse(line);
+        if (msg.event === 'ready') {
+          clearTimeout(t);
+          this.endpointId = msg.endpointId;
+          this.ticket = msg.ticket;
+          resolve(msg);
+          return;
+        }
+        if (msg.event) { this.events.push(msg); return; }
+        const w = this.pending.get(msg.id);
+        if (w) { this.pending.delete(msg.id); msg.ok ? w.resolve(msg) : w.reject(new Error(msg.error)); }
+      });
+      this.proc.once('exit', () => reject(new Error('sidecar exited before ready')));
+    });
+  }
+
+  rpc(cmd, params = {}, timeoutMs = 60000) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.proc.stdin.write(JSON.stringify({ id, cmd, ...params }) + '\n');
+      setTimeout(() => {
+        if (this.pending.delete(id)) { reject(new Error(`sidecar rpc timeout (${cmd})`)); }
+      }, timeoutMs).unref();
+    });
+  }
+
+  waitForEvent(type, predicate = () => true, timeoutMs = 20000) {
+    return pollUntil(
+      () => this.events.find((e) => e.event === type && predicate(e)),
+      { timeoutMs, what: `sidecar event '${type}'` },
+    );
+  }
+
+  async stop() {
+    try { this.proc.stdin.end(); } catch (_err) { /* noop */ }
+    await new Promise((resolve) => {
+      const t = setTimeout(() => { this.proc.kill(); resolve(); }, 5000);
+      this.proc.once('exit', () => { clearTimeout(t); resolve(); });
+    });
+  }
+}

--- a/test/integration/discovery-dm.test.mjs
+++ b/test/integration/discovery-dm.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Direct messages over the sidecar's third ALPN (mstream/discovery-dm/1) —
+ * the transport under federation requests. Two bare sidecars on loopback,
+ * real iroh dials:
+ *
+ *  - fail-closed: a peer that never opted in refuses with 'not-accepting'
+ *    (delivered:false — REACHED and refused, distinct from unreachable);
+ *  - round-trip: after setDmAccept, a dm lands as a {event:'dm'} with the
+ *    QUIC-authenticated sender id, and the sender sees delivered:true;
+ *  - addressing: an endpoint ticket works cold; a bare endpoint id works
+ *    once the ticket dial seeded the address book (the catalog flow);
+ *  - sender-side size cap refuses oversized payloads before dialing;
+ *  - per-remote rate limit: a fresh sender gets DM_PER_REMOTE_MAX through,
+ *    then 'rate-limited';
+ *  - a dead peer REJECTS (unreachable) rather than resolving refused — the
+ *    retry/terminal distinction PR 3's request queue is built on.
+ *
+ * ⚠ PROTOCOL-PR CI RULE: CI runs master's prebuilt sidecar, which predates
+ * the `dm` command — every test skips (with a reason) when the probe says
+ * so. Local dev always has the fresh cargo build; CI covers this suite for
+ * real once the post-merge binaries rebuild lands.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { RawSidecar } from '../helpers/raw-sidecar.mjs';
+import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
+
+const SIDECAR_BIN = resolveSidecarBinary();
+const PER_REMOTE_MAX = 6; // mirrors DM_PER_REMOTE_MAX in p2p-sidecar/src/main.rs
+
+(SIDECAR_BIN ? describe : describe.skip)('discovery-dm — sidecar direct messages', () => {
+  let tmpDir;
+  let alice, bob; // alice sends, bob receives
+  let sidecarHasDm = false;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-dm-'));
+    alice = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'alice'));
+    bob = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'bob'));
+    await alice.ready; await bob.ready;
+    try {
+      await alice.rpc('setDmAccept', { accept: false });
+      sidecarHasDm = true;
+    } catch (_err) {
+      sidecarHasDm = false; // old binary: "unknown command: setDmAccept"
+    }
+  });
+
+  after(async () => {
+    if (alice) { await alice.stop(); }
+    if (bob) { await bob.stop(); }
+    if (tmpDir) { fs.rmSync(tmpDir, { recursive: true, force: true }); }
+  });
+
+  const gate = (t) => {
+    if (!sidecarHasDm) { t.skip('prebuilt sidecar predates the dm protocol (rebuilds post-merge)'); return true; }
+    return false;
+  };
+
+  test('fail-closed: a peer that never opted in refuses, typed and immediate', async (t) => {
+    if (gate(t)) { return; }
+    // Bob has NOT called setDmAccept — boot state must refuse.
+    const r = await alice.rpc('dm', { to: bob.ticket, payload: { type: 'probe', uuid: 'dm-0' } });
+    assert.equal(r.delivered, false);
+    assert.equal(r.reason, 'not-accepting');
+    assert.equal(bob.events.filter((e) => e.event === 'dm').length, 0,
+      'a refused dm must never surface to Node');
+  });
+
+  test('round-trip: dm lands as an event with the authenticated sender id', async (t) => {
+    if (gate(t)) { return; }
+    await bob.rpc('setDmAccept', { accept: true });
+    const payload = { type: 'federation-request', uuid: 'dm-1', name: "Alice's mStream", msg: 'hello' };
+    const r = await alice.rpc('dm', { to: bob.ticket, payload });
+    assert.equal(r.delivered, true);
+
+    const evt = await bob.waitForEvent('dm', (e) => e.payload && e.payload.uuid === 'dm-1');
+    assert.equal(evt.from, alice.endpointId, 'from must be the QUIC-authenticated sender');
+    assert.deepEqual(evt.payload, payload, 'payload must arrive verbatim');
+  });
+
+  test('bare endpoint id addresses a peer the address book already knows', async (t) => {
+    if (gate(t)) { return; }
+    // The ticket dial above seeded MemoryLookup — a bare id (what the
+    // catalog stores) must now dial without any external discovery.
+    const r = await alice.rpc('dm', { to: bob.endpointId, payload: { type: 'probe', uuid: 'dm-2' } });
+    assert.equal(r.delivered, true);
+    await bob.waitForEvent('dm', (e) => e.payload && e.payload.uuid === 'dm-2');
+  });
+
+  test('sender refuses an oversized payload before dialing', async (t) => {
+    if (gate(t)) { return; }
+    await assert.rejects(
+      alice.rpc('dm', { to: bob.ticket, payload: { type: 'bloat', blob: 'x'.repeat(9000) } }),
+      /too large/);
+  });
+
+  test('per-remote rate limit trips on a fresh sender, typed refusal', async (t) => {
+    if (gate(t)) { return; }
+    // A fresh identity gets a clean per-remote budget against bob.
+    const mallory = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'mallory'));
+    try {
+      await mallory.ready;
+      for (let i = 0; i < PER_REMOTE_MAX; i++) {
+        const r = await mallory.rpc('dm', { to: bob.ticket, payload: { type: 'spam', uuid: `m-${i}` } });
+        assert.equal(r.delivered, true, `send ${i + 1}/${PER_REMOTE_MAX} is inside the budget`);
+      }
+      const over = await mallory.rpc('dm', { to: bob.ticket, payload: { type: 'spam', uuid: 'm-over' } });
+      assert.equal(over.delivered, false);
+      assert.equal(over.reason, 'rate-limited');
+    } finally {
+      await mallory.stop();
+    }
+  });
+
+  test('a dead peer rejects (unreachable) — never a typed refusal', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // PR 3's queue retries transport errors and treats refusals as
+    // terminal, so the two must never blur. Kill a sidecar, keep its
+    // ticket, dial it. (The dial burns its failure budget — up to the 25s
+    // connect timeout — hence this test's own generous timeout.)
+    const ghost = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'ghost'));
+    await ghost.ready;
+    const ghostTicket = ghost.ticket;
+    await ghost.stop();
+
+    await assert.rejects(
+      alice.rpc('dm', { to: ghostTicket, payload: { type: 'probe', uuid: 'dm-ghost' } }),
+      /unreachable|timed out|support direct messages/);
+  });
+});

--- a/test/integration/discovery-dm.test.mjs
+++ b/test/integration/discovery-dm.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * Direct messages over the sidecar's third ALPN (mstream/discovery-dm/1) —
+ * the transport under federation requests. Two bare sidecars on loopback,
+ * real iroh dials:
+ *
+ *  - fail-closed: a peer that never opted in refuses with 'not-accepting'
+ *    (delivered:false — REACHED and refused, distinct from unreachable);
+ *  - round-trip: after setDmAccept, a dm lands as a {event:'dm'} with the
+ *    QUIC-authenticated sender id, and the sender sees delivered:true;
+ *  - addressing: an endpoint ticket works cold; a bare endpoint id works
+ *    once the ticket dial seeded the address book (the catalog flow);
+ *  - sender-side size cap refuses oversized payloads before dialing;
+ *  - per-remote rate limit: a fresh sender gets DM_PER_REMOTE_MAX through,
+ *    then 'rate-limited';
+ *  - a dead peer REJECTS (unreachable) rather than resolving refused — the
+ *    retry/terminal distinction PR 3's request queue is built on.
+ *
+ * ⚠ SIDECAR-VERSION GATE: the transport lives in the sidecar repo
+ * (IrosTheBeggar/mstream-p2p-sidecar); the release this checkout pins
+ * (v1.0.2) predates the `dm` command. A checkout with no sidecar binary
+ * at all skips the whole suite (resolveSidecarBinary → null — fresh CI's
+ * state); a fetched pre-dm binary probes and skips each test with a
+ * reason; a dev cargo build of the DM branch (cloned into p2p-sidecar/)
+ * or a ≥v1.0.3 pin runs everything for real.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { RawSidecar } from '../helpers/raw-sidecar.mjs';
+import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
+
+const SIDECAR_BIN = resolveSidecarBinary();
+const PER_REMOTE_MAX = 6; // mirrors DM_PER_REMOTE_MAX in the sidecar repo's src/main.rs
+
+(SIDECAR_BIN ? describe : describe.skip)('discovery-dm — sidecar direct messages', () => {
+  let tmpDir;
+  let alice, bob; // alice sends, bob receives
+  let sidecarHasDm = false;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-dm-'));
+    alice = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'alice'));
+    bob = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'bob'));
+    await alice.ready; await bob.ready;
+    try {
+      await alice.rpc('setDmAccept', { accept: false });
+      sidecarHasDm = true;
+    } catch (_err) {
+      sidecarHasDm = false; // old binary: "unknown command: setDmAccept"
+    }
+  });
+
+  after(async () => {
+    if (alice) { await alice.stop(); }
+    if (bob) { await bob.stop(); }
+    if (tmpDir) { fs.rmSync(tmpDir, { recursive: true, force: true }); }
+  });
+
+  const gate = (t) => {
+    if (!sidecarHasDm) { t.skip('pinned sidecar predates the dm protocol (pin bumps after the sidecar release)'); return true; }
+    return false;
+  };
+
+  test('fail-closed: a peer that never opted in refuses, typed and immediate', async (t) => {
+    if (gate(t)) { return; }
+    // Bob has NOT called setDmAccept — boot state must refuse.
+    const r = await alice.rpc('dm', { to: bob.ticket, payload: { type: 'probe', uuid: 'dm-0' } });
+    assert.equal(r.delivered, false);
+    assert.equal(r.reason, 'not-accepting');
+    assert.equal(bob.events.filter((e) => e.event === 'dm').length, 0,
+      'a refused dm must never surface to Node');
+  });
+
+  test('round-trip: dm lands as an event with the authenticated sender id', async (t) => {
+    if (gate(t)) { return; }
+    await bob.rpc('setDmAccept', { accept: true });
+    const payload = { type: 'federation-request', uuid: 'dm-1', name: "Alice's mStream", msg: 'hello' };
+    const r = await alice.rpc('dm', { to: bob.ticket, payload });
+    assert.equal(r.delivered, true);
+
+    const evt = await bob.waitForEvent('dm', (e) => e.payload && e.payload.uuid === 'dm-1');
+    assert.equal(evt.from, alice.endpointId, 'from must be the QUIC-authenticated sender');
+    assert.deepEqual(evt.payload, payload, 'payload must arrive verbatim');
+  });
+
+  test('bare endpoint id addresses a peer the address book already knows', async (t) => {
+    if (gate(t)) { return; }
+    // The ticket dial above seeded MemoryLookup — a bare id (what the
+    // catalog stores) must now dial without any external discovery.
+    const r = await alice.rpc('dm', { to: bob.endpointId, payload: { type: 'probe', uuid: 'dm-2' } });
+    assert.equal(r.delivered, true);
+    await bob.waitForEvent('dm', (e) => e.payload && e.payload.uuid === 'dm-2');
+  });
+
+  test('sender refuses an oversized payload before dialing', async (t) => {
+    if (gate(t)) { return; }
+    await assert.rejects(
+      alice.rpc('dm', { to: bob.ticket, payload: { type: 'bloat', blob: 'x'.repeat(9000) } }),
+      /too large/);
+  });
+
+  test('per-remote rate limit trips on a fresh sender, typed refusal', async (t) => {
+    if (gate(t)) { return; }
+    // A fresh identity gets a clean per-remote budget against bob.
+    const mallory = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'mallory'));
+    try {
+      await mallory.ready;
+      for (let i = 0; i < PER_REMOTE_MAX; i++) {
+        const r = await mallory.rpc('dm', { to: bob.ticket, payload: { type: 'spam', uuid: `m-${i}` } });
+        assert.equal(r.delivered, true, `send ${i + 1}/${PER_REMOTE_MAX} is inside the budget`);
+      }
+      const over = await mallory.rpc('dm', { to: bob.ticket, payload: { type: 'spam', uuid: 'm-over' } });
+      assert.equal(over.delivered, false);
+      assert.equal(over.reason, 'rate-limited');
+    } finally {
+      await mallory.stop();
+    }
+  });
+
+  test('a dead peer rejects (unreachable) — never a typed refusal', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // PR 3's queue retries transport errors and treats refusals as
+    // terminal, so the two must never blur. Kill a sidecar, keep its
+    // ticket, dial it. (The dial burns its failure budget — up to the 25s
+    // connect timeout — hence this test's own generous timeout.)
+    const ghost = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'ghost'));
+    await ghost.ready;
+    const ghostTicket = ghost.ticket;
+    await ghost.stop();
+
+    await assert.rejects(
+      alice.rpc('dm', { to: ghostTicket, payload: { type: 'probe', uuid: 'dm-ghost' } }),
+      /unreachable|timed out|support direct messages/);
+  });
+});


### PR DESCRIPTION
PR 2 of the discovery→federation migration arc (PR 1 = #805, merged). This adds the **transport primitive only** — a way for one discovery peer to send another an addressed message. The request/accept state machine that uses it is PR 3; nothing here is reachable in production until then (and inbound is fail-closed anyway).

> **Restructured after the sidecar extraction (#854):** the Rust half of this PR originally lived in the in-tree `p2p-sidecar/` crate, which has since moved to its own repo. The transport implementation is now [mstream-p2p-sidecar PR #1](https://github.com/IrosTheBeggar/mstream-p2p-sidecar/pull/1) (→ release v1.0.3); **this PR is the Node half**: the `sendDm` / `setDmAccept` client, the `dm` event contract, and the protocol integration suite.

## What (the transport, spread across the two PRs)

A third ALPN on the sidecar router — `mstream/discovery-dm/1` — for **addressed, non-gossip** delivery between discovery peers:

- **`dm {to, payload}`** dials one peer (endpoint ticket *or* bare endpoint id — same dual addressing as `join`; a ticket dial seeds the address book so later bare-id dials work, which is the catalog flow) and hands over a size-capped JSON payload. **Structured outcome**: `{delivered:true}` = accepted; `{delivered:false, reason}` = the peer was *reached and refused* (terminal — don't retry); RPC **error** = never reached (offline / timeout / pre-DM build). PR 3's retry queue is built on exactly this distinction.
- **`setDmAccept {accept}`** is the inbound policy switch, and it's **fail-closed**: every sidecar boot starts refusing at the transport (`not-accepting`) until Node opts in — senders get an immediate typed refusal instead of silence. Node wires it to the operator's "accept federation requests" toggle in PR 3.
- **Abuse caps live in Rust, before content is parsed**: 8 KB payload cap, 6/min per remote + 30/min global (sliding window), JSON-object-only. Sender identity = the **QUIC-authenticated remote endpoint id** — no app-level signatures needed (unlike gossip, where `delivered_from` is just the last hop). Accepted DMs surface to Node as `{event:'dm', from, payload}`; payload *content* validation deliberately stays with the consumer (PR 3).

**In this PR**: `sendDm()` / `setDmAccept()` wrappers in `discovery-p2p.js` (the generic event pipe already forwards `dm` events), the `RawSidecar` test helper, and the six-test protocol suite.

Why this shape: the announcement/gossip protocol is untouched, so there's **zero network-compat risk**, and the discovery↔federation persona linkage only ever happens pairwise, consensually, inside an encrypted direct dial — never in public announcements.

## Testing

- **New integration suite** (`test/integration/discovery-dm.test.mjs`, two bare sidecars over real iroh loopback): fail-closed refusal is immediate and never surfaces to Node; round-trip lands with the authenticated sender id and verbatim payload; bare-id addressing after a ticket dial; sender-side oversize refusal before dialing; per-remote rate limit (6 through, 7th `rate-limited`); dead peer **rejects** (unreachable) rather than resolving refused. **6/6 pass** against a dev build of the sidecar DM branch.
- **Version gating, verified both ways**: with no sidecar binary on disk the suite skips wholesale (`resolveSidecarBinary() → null` — fresh CI's state); against the pinned **v1.0.2** (pre-DM) binary, the capability probe skips each test with a reason. It runs for real against a dev build now, and against the fetched pin once it bumps to v1.0.3.
- Regression: `discovery-p2p.test.mjs` against the DM-branch dev build. JS lint clean.
- `RawSidecar` extracted to `test/helpers/raw-sidecar.mjs` for protocol suites; `discovery-p2p.test.mjs` keeps its inline copy — folding it over is deliberate follow-up churn, not this PR's job.

## Merge order

1. Sidecar PR merges → tag `v1.0.3` → CI drafts the release → publish.
2. This PR merges (safe in either order — everything gates).
3. Pin bump: `node scripts/update-p2p-sidecar-manifest.mjs v1.0.3` → small text PR → the DM suite goes live everywhere.
4. PR 3 (request engine + schema + admin API) rides on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
