### PR TITLE
fix(scanner): orphan reaper never forgets an unverifiable live orphan; 30s js-only CIM probe

### DIFF
--- a/src/db/scan-pidfile.js
+++ b/src/db/scan-pidfile.js
@@ -21,7 +21,8 @@
 // means a reboot() re-entry or a second server instance whose scan is
 // healthy and managed), AND verifiably a scanner (image/command-line
 // check — a reused pid must never get an innocent process killed), it is
-// terminated.
+// terminated. An identity that can't be established either way keeps the
+// record for a later boot: never kill blind, never forget a live orphan.
 //
 // Everything here is synchronous on purpose: it runs once, at boot,
 // before anything else touches the DB.
@@ -89,8 +90,12 @@ function sleepSync(ms) {
 // { image: <lowercased executable basename>, cmdline: <string|null> }
 // or null when the process can't be inspected (caller keeps the record
 // and retries on a later boot rather than killing blind).
+// `needCmdline` gates the command-line lookup: only js-kind records need
+// it (rust/waveform verdicts are image-only), and on Windows it is a
+// PowerShell CIM query whose cold start can take double-digit seconds on
+// a loaded machine — the preferred rust scanner should never pay that.
 // `pid` is integer-validated by the caller, so interpolation is safe.
-function probeProcess(pid) {
+function probeProcess(pid, needCmdline) {
   try {
     if (process.platform === 'win32') {
       const r = child.spawnSync('tasklist',
@@ -101,14 +106,20 @@ function probeProcess(pid) {
       const image = line.split('","')[0].replace(/^"/, '').toLowerCase();
       // The command line needs a CIM query (tasklist doesn't expose it).
       // Only required to vet generic images like node.exe; a failure
-      // leaves cmdline null and the caller refuses to kill on it.
+      // leaves cmdline null and the caller refuses to kill on it. The
+      // budget is deliberately generous: PowerShell's cold start blew an
+      // 8s cap on a loaded CI runner (2026-08-04), and a timeout here
+      // demotes a real orphan to "unverifiable" — alive until a later
+      // boot manages to inspect it.
       let cmdline = null;
-      const ps = child.spawnSync('powershell',
-        ['-NoProfile', '-NonInteractive', '-Command',
-          `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CommandLine`],
-        { timeout: 8000 });
-      if (ps.status === 0) {
-        cmdline = (ps.stdout || '').toString().trim() || null;
+      if (needCmdline) {
+        const ps = child.spawnSync('powershell',
+          ['-NoProfile', '-NonInteractive', '-Command',
+            `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CommandLine`],
+          { timeout: 30000 });
+        if (ps.status === 0) {
+          cmdline = (ps.stdout || '').toString().trim() || null;
+        }
       }
       return { image, cmdline };
     }
@@ -124,40 +135,59 @@ function probeProcess(pid) {
     const comm = (child.spawnSync('ps', ['-p', String(pid), '-o', 'comm='], { timeout: 5000 })
       .stdout || '').toString().trim();
     if (!comm) { return null; }
-    const args = (child.spawnSync('ps', ['-p', String(pid), '-o', 'args='], { timeout: 5000 })
-      .stdout || '').toString().trim();
-    return { image: path.basename(comm).toLowerCase(), cmdline: args || null };
+    let cmdline = null;
+    if (needCmdline) {
+      const args = (child.spawnSync('ps', ['-p', String(pid), '-o', 'args='], { timeout: 5000 })
+        .stdout || '').toString().trim();
+      cmdline = args || null;
+    }
+    return { image: path.basename(comm).toLowerCase(), cmdline };
   } catch (_err) {
     return null;
   }
 }
 
 // A reused pid must NEVER get an innocent process killed, so the bar is
-// "provably a scanner", not "probably":
+// "provably a scanner", not "probably". Three verdicts, and the caller
+// must compare them EXPLICITLY — they are truthy strings, so a boolean
+// test would treat 'stranger' as a kill license:
+//  - 'scanner':  provably the recorded scanner — the only kill verdict.
+//  - 'stranger': provably NOT a scanner — the pid was recycled by an
+//    unrelated process; the record is permanently stale, safe to drop.
+//  - 'unknown':  identity could not be established either way (generic
+//    image, no readable command line). Neither kill nor forget: the
+//    caller keeps the record so a later boot retries.
+// Rules:
 //  - rust: the image must match what we recorded AND carry the
 //    distinctive rust-parser prefix (rust-parser-<platform>-<arch>[.exe]
-//    prebuilt, rust-parser[.exe] local build).
+//    prebuilt, rust-parser[.exe] local build). The image comes from a
+//    successful tasklist/ps probe, so a mismatch is definitive.
 //  - js: the image (node/electron) is far too generic on its own —
 //    require the command line to reference the recorded scanner.mjs path
 //    too (falling back to the bare filename for records that predate the
-//    marker field). If the platform can't produce a command line,
-//    refuse: a leaked scanner is less dangerous than killing an
-//    unrelated node process.
-function looksLikeScanner(probe, rec) {
+//    marker field). If the platform can't produce a command line, the
+//    verdict is 'unknown': a leaked scanner is less dangerous than
+//    killing an unrelated node process — but forgetting a live orphan
+//    is a real cost too, so the record must survive for a retry.
+// Exported for unit tests: the verdict table IS the safety contract.
+export function looksLikeScanner(probe, rec) {
   const expectedImage = String(rec.image || '').toLowerCase();
   if (rec.kind === 'rust' || rec.kind === 'waveform') {
     // 'waveform' is the post-scan enrichment pass — same rust-parser
     // binary, same provability rule. (It never holds a DB handle while
     // decoding, so reaping it is about CPU hygiene, not lock safety.)
-    return probe.image === expectedImage && probe.image.startsWith('rust-parser');
+    return probe.image === expectedImage && probe.image.startsWith('rust-parser')
+      ? 'scanner' : 'stranger';
   }
   if (rec.kind === 'js') {
-    if (probe.image !== expectedImage) { return false; }
-    if (typeof probe.cmdline !== 'string') { return false; }
+    if (probe.image !== expectedImage) { return 'stranger'; }
+    if (typeof probe.cmdline !== 'string') { return 'unknown'; }
     const needle = typeof rec.marker === 'string' && rec.marker ? rec.marker : 'scanner.mjs';
-    return probe.cmdline.includes(needle);
+    return probe.cmdline.includes(needle) ? 'scanner' : 'stranger';
   }
-  return false;
+  // Unrecognized kind: the record can never be verified — treat it as
+  // permanently stale rather than retrying forever.
+  return 'stranger';
 }
 
 // Boot-time reap. Call BEFORE dbManager.initDB() — the entire point is
@@ -204,7 +234,8 @@ export function reapOrphanedScanner(dbDirectory) {
       '(another mStream instance on this DB?) — leaving it alone.');
     return;
   }
-  const probe = probeProcess(pid);
+  const needCmdline = rec.kind === 'js';
+  const probe = probeProcess(pid, needCmdline);
   if (!probe) {
     // Couldn't inspect the process (constrained PowerShell, exotic
     // platform). Keep the record so a later boot can retry rather than
@@ -214,15 +245,30 @@ export function reapOrphanedScanner(dbDirectory) {
       'inspected — leaving it alone; will retry next boot.');
     return;
   }
-  if (!looksLikeScanner(probe, rec)) {
-    // Live, inspectable, but not a scanner: the pid was recycled by an
-    // unrelated process. The record is permanently stale — drop it.
+  const verdict = looksLikeScanner(probe, rec);
+  if (verdict === 'unknown') {
+    // Live and wearing the right image, but the command line could not
+    // be read, so a recycled pid can't be ruled out — and killing blind
+    // is forbidden. Keep the record: it clears itself once the pid dies,
+    // and until then a later boot retries the inspection.
+    winston.warn(
+      `Scanner pidfile points at live pid ${pid} (${probe.image}) whose ` +
+      'command line could not be read to confirm it is a scanner — ' +
+      'leaving it alone; will retry next boot.');
+    return;
+  }
+  if (verdict === 'stranger') {
+    // Live, inspectable, and provably not a scanner: the pid was
+    // recycled by an unrelated process. The record is permanently
+    // stale — drop it.
     winston.warn(
       `Scanner pidfile pointed at live pid ${pid} (${probe.image}), ` +
       'which is not a scanner — pid was recycled; dropping the stale record.');
     clearScannerPidfile(dbDirectory);
     return;
   }
+  // verdict === 'scanner': provably ours. This is the ONLY verdict that
+  // may reach the kill below — never use these strings as booleans.
 
   winston.warn(
     `Found orphaned ${rec.kind} scanner from a previous run ` +
@@ -235,8 +281,8 @@ export function reapOrphanedScanner(dbDirectory) {
   // SIGKILL must never hit a stranger.
   for (let i = 0; i < 20 && isAlive(pid); i++) { sleepSync(100); }
   if (isAlive(pid)) {
-    const recheck = probeProcess(pid);
-    if (recheck && looksLikeScanner(recheck, rec)) {
+    const recheck = probeProcess(pid, needCmdline);
+    if (recheck && looksLikeScanner(recheck, rec) === 'scanner') {
       try { process.kill(pid, 'SIGKILL'); } catch (_err) { /* gone */ }
       for (let i = 0; i < 10 && isAlive(pid); i++) { sleepSync(100); }
     }

--- a/test/scanner/scanner-schema-guard.test.mjs
+++ b/test/scanner/scanner-schema-guard.test.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'node:url';
 import { MIGRATIONS, SCHEMA_VERSION } from '../../src/db/schema.js';
 import {
   writeScannerPidfile, clearScannerPidfile, reapOrphanedScanner,
+  looksLikeScanner,
 } from '../../src/db/scan-pidfile.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -475,14 +476,19 @@ describe('orphan reaper (scan-pidfile.js)', () => {
     }
   });
 
-  test('live orphaned JS scanner is killed', { timeout: 60000 }, async () => {
+  test('live orphaned JS scanner is killed', { timeout: 90000 }, async () => {
     const tmp = makeTmp('orphan');
     // A real "orphan": a node process running a file named scanner.mjs,
     // which is what the identity check requires before killing a
     // node-image pid. The recording server process is dead, so the file
-    // is written by hand with a foreign ppid. (The command-line probe
-    // shells out — on Windows via PowerShell CIM — hence the generous
-    // timeout.)
+    // is written by hand with a foreign ppid.
+    //
+    // Timing: reapOrphanedScanner is fully synchronous, and for a js
+    // record on Windows it shells out twice (tasklist ≤5s, then the
+    // PowerShell CIM command-line query ≤30s) — up to ~35s on a loaded
+    // runner before it even decides to kill. Only once it returns can
+    // the event loop deliver the child's exit, so the wait below must be
+    // generous too; the declared timeout has to cover reap + wait.
     const fakeScanner = path.join(tmp, 'scanner.mjs');
     fs.writeFileSync(fakeScanner, 'setInterval(() => {}, 1000);\n');
     const p = child.spawn(process.execPath, [fakeScanner], { stdio: 'ignore' });
@@ -496,12 +502,88 @@ describe('orphan reaper (scan-pidfile.js)', () => {
         startedAt: 'x',
       }));
       reapOrphanedScanner(tmp);
-      const died = await waitFor(() => p.exitCode !== null || p.signalCode !== null, 10000);
+      const died = await waitFor(() => p.exitCode !== null || p.signalCode !== null, 45000);
       assert.ok(died, 'orphaned scanner should be terminated by the reaper');
       assert.ok(!fs.existsSync(path.join(tmp, '.scanner.pid.json')));
     } finally {
       try { p.kill(); } catch (_) { /* already dead */ }
     }
+  });
+});
+
+// ── looksLikeScanner verdict table ──────────────────────────────────────────
+// The tri-state is the reaper's safety contract: it kills ONLY on
+// 'scanner', drops the record only on 'stranger' (provably recycled pid),
+// and keeps the record on 'unknown' so a later boot retries instead of
+// forgetting a live orphan. The verdicts are truthy STRINGS — a caller
+// using them as booleans would treat 'stranger' as a kill license — so
+// these tests pin the exact values, with hand-built probes (no process
+// spawning, no shell-outs).
+describe('looksLikeScanner verdicts (kill only on provable identity)', () => {
+  const rustImage = 'rust-parser-win32-x64.exe';
+
+  test('rust: image match with the rust-parser prefix → scanner', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: rustImage, cmdline: null },
+      { kind: 'rust', image: rustImage }), 'scanner');
+  });
+
+  test('rust: recycled pid (different image) → stranger', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: 'node.exe', cmdline: null },
+      { kind: 'rust', image: rustImage }), 'stranger');
+  });
+
+  test('rust: matching but non-rust-parser image (corrupt record) → stranger, never scanner', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: 'node.exe', cmdline: null },
+      { kind: 'rust', image: 'node.exe' }), 'stranger');
+  });
+
+  test('waveform follows the rust rule', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: rustImage, cmdline: null },
+      { kind: 'waveform', image: rustImage }), 'scanner');
+  });
+
+  test('js: matching image + marker in the command line → scanner', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: 'node.exe', cmdline: '"C:\\node.exe" C:\\app\\src\\db\\scanner.mjs {"dbPath":"x"}' },
+      { kind: 'js', image: 'node.exe', marker: 'C:\\app\\src\\db\\scanner.mjs' }), 'scanner');
+  });
+
+  test('js: pre-marker record falls back to the bare scanner.mjs needle', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: 'node', cmdline: 'node /srv/mstream/src/db/scanner.mjs payload' },
+      { kind: 'js', image: 'node' }), 'scanner');
+  });
+
+  test('js: image mismatch → stranger, even when the cmdline mentions the marker', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: 'python.exe', cmdline: 'python watch.py scanner.mjs' },
+      { kind: 'js', image: 'node.exe', marker: 'scanner.mjs' }), 'stranger');
+  });
+
+  test('js: matching image but NO readable command line → unknown (keep + retry, never kill)', () => {
+    // The 2026-08-04 CI failure mode: PowerShell CIM timed out, cmdline
+    // came back null, and the old boolean collapse dropped the record —
+    // permanently forgetting a live orphan. 'unknown' is what makes the
+    // reaper retry on the next boot instead.
+    assert.strictEqual(looksLikeScanner(
+      { image: 'node.exe', cmdline: null },
+      { kind: 'js', image: 'node.exe', marker: 'scanner.mjs' }), 'unknown');
+  });
+
+  test('js: matching image, unrelated command line → stranger', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: 'node.exe', cmdline: '"C:\\node.exe" C:\\somewhere\\server.js' },
+      { kind: 'js', image: 'node.exe', marker: 'scanner.mjs' }), 'stranger');
+  });
+
+  test('unrecognized kind can never be verified → stranger', () => {
+    assert.strictEqual(looksLikeScanner(
+      { image: 'node.exe', cmdline: 'node scanner.mjs' },
+      { kind: 'zig', image: 'node.exe' }), 'stranger');
   });
 });
 


### PR DESCRIPTION
## Root cause

The `windows-latest` flake on #805 (job 92051899068, `live orphaned JS scanner is killed`, 18.15s) was a production bug wearing a test costume. The failing run's own winston line says it:

> Scanner pidfile pointed at live pid 1448 (node.exe), which is not a scanner — pid was recycled; dropping the stale record.

PowerShell's cold start blew `probeProcess`'s **8s** CIM cap on the loaded runner (corroborated by the rust-kind sibling test burning 8.6s in the same run — tasklist ~0.6s + the full 8s CIM cap for a command line its verdict never reads). `cmdline` came back `null`, and `looksLikeScanner`'s boolean return collapsed *"could not verify"* into *"provably recycled"* — so the reaper **cleared the pidfile and permanently forgot a live orphan**. Nothing retries a cleared record. The 18.15s ≈ 8s CIM timeout + 10s `waitFor` polling a process nobody killed.

## Changes

**`src/db/scan-pidfile.js`**
- CIM command-line budget **8s → 30s**. The cost only applies where stalling boot is correct: a live pid whose recorded parent is dead. PowerShell *failures* still fail fast; only genuine hangs pay the cap.
- The CIM query (and macOS's `args=` ps call) now runs **only for `kind: 'js'` records** — rust/waveform verdicts are image-only, so the preferred rust scanner's reap path never touches PowerShell at all. tasklist stays at 5s (it completed fine even on the loaded runner).
- `looksLikeScanner` is now tri-state: `'scanner' | 'stranger' | 'unknown'`. **`'unknown'`** (matching generic image, unreadable command line) keeps the record and warns, so a later boot retries — the record still clears itself once the pid dies. `'stranger'` (provably recycled) clears as before. The caller compares verdicts **explicitly** — they're truthy strings, so any boolean shortcut would treat `'stranger'` as a kill license; only `=== 'scanner'` reaches the kill, including the SIGKILL-escalation recheck.
- Behavior parity otherwise: every path that killed before still kills, every path that cleared still clears. The only semantic change is **drop → keep** on the unverifiable-js case.

**`test/scanner/scanner-schema-guard.test.mjs`**
- The orphan-kill test's `waitFor` **10s → 45s** and declared timeout **60s → 90s** (worst-case synchronous reap is now ~35s = tasklist 5s + CIM 30s, and the child's exit can't be delivered until the sync reap returns; 35 + 45 = 80 < 90). It was the only sub-wait in the file mismatched against its declared intent — the fixed 300ms sleeps in the three negative-assertion siblings are correct as-is (a wrongful kill would have been issued inside the already-returned reap).
- New unit suite pinning the exact verdict strings with hand-built probes (no process spawning): the `'unknown'`-keeps-record case, the image-mismatch-beats-cmdline case, the corrupt-record cases, and the fallback needle for pre-marker records.

Not covered by an integration test: the caller's `'unknown'` branch (warn + keep) — it only arises when the platform genuinely can't produce a command line, which isn't reproducible deterministically. The verdict itself is unit-pinned; the branch is three lines.

## Verification

- `node --test test/scanner/scanner-schema-guard.test.mjs` — **29/29 pass** (19 existing + 10 new). The rust-kind pid-reuse test dropped 1530ms → 787ms locally now that it skips the CIM query.
- `npx eslint` on both files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)