### PR TITLE
test(hash-transitions): stage the forged ledger atomically — fix the windows CI flake

### DIFF
--- a/test/integration/hash-transition-applier.test.mjs
+++ b/test/integration/hash-transition-applier.test.mjs
@@ -58,10 +58,31 @@ function canonOfTrack(mstreamDbPath, filepathLike) {
   });
 }
 
-function seedTransition(mstreamDbPath, oldHash, newHash) {
+// Seed forged transition hops in ONE transaction. Atomicity is load-bearing:
+// applyHashTransitions() fires on EVERY queue-drain event (task-queue calls
+// checkQueueDrainedSideEffects from every task-completion site, and the gate
+// counts enrichment passes as "drained"), so the server can consume this
+// ledger at any moment — including while a test is still staging it. Seeding
+// a chain as separate autocommitted INSERTs opens a window where the applier
+// sees only the first hop and re-keys the embedding to a mid-chain identity
+// that is never live; the discovery worker's next orphan prune then deletes
+// it, and the terminal row this suite asserts on never materializes. That is
+// exactly the windows-latest CI flake this helper's shape caused (PR #801,
+// run 30958877312: drain saw 0 but no row at `fin`). One transaction means
+// any drain sees the whole chain or none of it — either of which converges
+// on the same asserted end state.
+function seedTransitions(mstreamDbPath, hops) {
   withDb(mstreamDbPath, (d) => {
-    d.prepare('INSERT OR REPLACE INTO hash_transitions (old_hash, new_hash) VALUES (?, ?)')
-      .run(oldHash, newHash);
+    const ins = d.prepare(
+      'INSERT OR REPLACE INTO hash_transitions (old_hash, new_hash) VALUES (?, ?)');
+    d.exec('BEGIN');
+    try {
+      for (const [oldHash, newHash] of hops) { ins.run(oldHash, newHash); }
+      d.exec('COMMIT');
+    } catch (err) {
+      d.exec('ROLLBACK');
+      throw err;
+    }
   });
 }
 
@@ -150,12 +171,16 @@ describe('hash-transition applier (discovery ON — live worker)', () => {
     const mid = 'a'.repeat(32);
     const fin = canonOfTrack(mdb, 'terminal.mp3');
     assert.ok(fin, 'terminal fixture scanned');
-    seedTransition(mdb, seed.audio_hash, mid);
-    seedTransition(mdb, mid, fin);
 
-    // Waveform artifacts at the seed identity must follow to `fin`.
+    // Stage order is load-bearing (see seedTransitions): the waveform
+    // artifacts go on disk BEFORE the ledger rows become visible, because
+    // whichever drain event consumes the ledger — the boot chain's tail or
+    // the post-force-rescan drain — must see the complete stage. Ledger
+    // first would let an early drain move the embedding and clear the
+    // ledger while {seed}.bin doesn't exist yet, so nothing ever renames.
     await fsp.writeFile(path.join(waveDir, `${seed.audio_hash}.bin`), 'wavedata');
     await fsp.writeFile(path.join(waveDir, `${seed.audio_hash}.failed`), 'symphonia\n');
+    seedTransitions(mdb, [[seed.audio_hash, mid], [mid, fin]]);
 
     await forceRescanAndDrain(server, mdb);
 
@@ -214,8 +239,9 @@ describe('hash-transition applier (discovery collection OFF)', () => {
   test('the ledger drains (and waveforms rename) with no discovery.db, without creating one', async () => {
     const p = 'b'.repeat(32);
     const q = 'c'.repeat(32);
-    seedTransition(mdb, p, q);
+    // Artifacts before ledger — same stage-ordering rule as the ON suite.
     await fsp.writeFile(path.join(waveDir, `${p}.bin`), 'wavedata');
+    seedTransitions(mdb, [[p, q]]);
 
     await forceRescanAndDrain(server, mdb);
 
@@ -237,8 +263,7 @@ describe('hash-transition applier (discovery collection OFF)', () => {
       upsertDiscoveryTrack({ audioHash: a, artist: 'stale' });   // older rowversion
       upsertDiscoveryTrack({ audioHash: b, artist: 'fresh' });   // newer rowversion
     } finally { closeDiscoveryDb(); }
-    seedTransition(mdb, a, b);
-    seedTransition(mdb, b, c);
+    seedTransitions(mdb, [[a, b], [b, c]]);
 
     await forceRescanAndDrain(server, mdb);
 
@@ -262,8 +287,10 @@ describe('hash-transition applier (discovery collection OFF)', () => {
     initDiscoveryDb(ddbPath);
     try { upsertDiscoveryTrack({ audioHash: y, artist: 'cyc' }); }
     finally { closeDiscoveryDb(); }
-    seedTransition(mdb, x, y);
-    seedTransition(mdb, y, x);
+    // Atomic for a second reason here: a drain that saw only x→y wouldn't
+    // be a cycle at all — it would resolve as a plain move and the test
+    // would no longer exercise the cycle-resolution path it exists for.
+    seedTransitions(mdb, [[x, y], [y, x]]);
 
     await forceRescanAndDrain(server, mdb);
 


### PR DESCRIPTION
Fixes the `windows-latest` CI flake first seen on #801 (run 30958877312, `test (windows-latest · 2/3)`): `hash-transition-applier.test.mjs` → "a chained re-key lands the embedding at the terminal identity" failing with `finRow` null after a successful drain.

## Root cause — a race in the test's staging, not in the applier

`applyHashTransitions()` fires on **every queue-drain event**: `checkQueueDrainedSideEffects` is called from every task-completion site in task-queue, and its gate counts enrichment passes as "drained". The suite forged its transition chain as **two separate autocommitted INSERTs**, and its seed-row poll returns the moment the boot discovery worker commits the row — i.e. while the boot chain is still finishing. On the loaded runner, the boot discovery pass completed **between the two INSERTs**:

1. Applier consumed the half-built ledger: saw only `seed→mid`, re-keyed the embedding to `mid` (`'a'×32` — never a live hash), cleared the ledger
2. The force-rescan's chained discovery worker's `pruneOrphans` deleted the row at `mid` (dead hash) and re-embedded the long track back at `seed`
3. The final drain applied `mid→fin` against nothing — ledger drained to 0, **no row at `fin`**

That's the exact line-168 failure, and it explains the timing tell: the CI failure took 1.6s where a local pass takes 3.6s — the final applier had no work left to do.

**Reproduced deterministically** by inserting a full rescan+drain cycle between the two hops (semantically identical to the drain landing in the window): identical failure shape — `finRow: null`, mid pruned, seed re-embedded with `has_embedding: 1`.

A sibling window existed too: drain landing after both hops but before the test wrote the waveform artifacts → the rename assertions (lines 180-182) fail instead. Same root cause.

## Why production is unaffected

Real transitions are recorded only mid-scan, while the queue is busy and the drain gate is closed — every recorded hop is complete before any applier can see it. Cross-scan chains (A→B in scan 1, B→C in scan 2) apply stepwise correctly because each hop's `new_hash` is live at its own drain. The race is an artifact of **out-of-band ledger writes, which only tests do** — so this is a test-side fix; the applier is untouched.

## Changes (one file)

- `seedTransition` → `seedTransitions`: all hops of a chain written in **one transaction** — any drain sees the whole chain or none of it
- Waveform artifacts staged **before** the ledger becomes visible, so whichever drain consumes the stage also performs the renames
- All four call sites converted (both suites). The cycle test gains a correctness bonus: a partial view of `x→y→x` isn't a cycle at all, so atomicity is what keeps it exercising the cycle-resolution path it exists for

Both consumption orderings now converge on the same asserted end state — **proven under forced early consumption** (adverse-drain harness: early consume + real drain → the suite's full assertion set holds).

## Verification

- Deterministic repro of the old staging fails with the CI's exact shape ✔
- Convergence harness for the new staging passes under forced adverse timing ✔
- Fixed suite: 5 × 4/4 pass locally on Windows (the failing platform)
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
