### PR TITLE
perf(discovery): JS hot loops — topK ranking, two-pass pathBetween, SQL sonic pool, tier-aware bounded waterfall

### DIFF
--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -180,9 +180,11 @@ export function setup(mstream) {
     }
 
     const filter = libraryFilter(req.user);
-    const ranked = sim.rankTracks(index, seedEntry.vec, canonHash);
-    const results = [];
     const maxConsidered = considerBudget(body.limit);
+    // topK = the walk's own cap: ranking past it was a 25k-object
+    // allocation + full sort per Discover refresh (audit M9).
+    const ranked = sim.rankTracks(index, seedEntry.vec, canonHash, maxConsidered);
+    const results = [];
     let considered = 0;
     let capped = false;
     for (const { entry, similarity } of ranked) {

--- a/src/api/federation-discovery.js
+++ b/src/api/federation-discovery.js
@@ -93,7 +93,8 @@ export function setup(mstream) {
     const maxConsidered = Math.max(body.limit * 50, 2000);
     let considered = 0;
     let capped = false;
-    for (const { entry, similarity } of sim.rankTracks(index, q, null)) {
+    // topK = the walk's cap (see the local similar/tracks route — audit M9).
+    for (const { entry, similarity } of sim.rankTracks(index, q, null, maxConsidered)) {
       if (results.length >= body.limit) { break; }
       if (++considered > maxConsidered) { capped = true; break; }
       const row = resolveVisible(uid, filter, entry.hash, { withGenres: false });

--- a/src/api/random.js
+++ b/src/api/random.js
@@ -13,9 +13,13 @@
 //     requireBpm / requireMusicalKey set) — runs a fallback waterfall
 //     that progressively relaxes the BPM/key constraints until at least
 //     one track matches, then applies a tier filter so an in-range pick
-//     wins over an unknown-tag pick wins over a known-wrong pick. The
-//     waterfall keeps its full candidate sets — the tier filter needs
-//     every row to classify, and the filters already bound the set.
+//     wins over an unknown-tag pick wins over a known-wrong pick. Every
+//     step's query is bounded the same way simple mode is: the SQL ORDER
+//     BY sorts by a tier expression mirroring the JS classifier before
+//     the RANDOM() tiebreak, so the small pool always contains the best
+//     tier present in scope and the tier filter keeps its authority
+//     (audit M5 — any BPM/key param used to disable bounding, and the
+//     terminal step then materialised the whole library per pick).
 //
 // The `ignoreList` the client round-trips holds the last-served TRACK
 // IDS (newest last). Pre-rework lists held candidate-set INDICES, which
@@ -330,6 +334,52 @@ export function applyTierFilter(rows, opts) {
   return tier2;
 }
 
+// SQL twin of classifyRow, built against the ORIGINAL request constraints
+// (exactly what the JS applyTierFilter call at the end of runRandomSongs
+// classifies with — tight ranges + expanded key names). Used as the leading
+// ORDER BY term of every bounded waterfall query: rows sort best-tier-first
+// before the RANDOM() tiebreak, so a LIMIT-sized pool provably contains the
+// best tier present in scope and sampling can't starve the tier filter.
+// The JS filter stays the authority — this only shapes what gets sampled.
+//
+// Emission order matters: params are pushed by the emit* helpers as the
+// template literal evaluates left-to-right, keeping placeholder order and
+// bind order in lockstep by construction. BPM bounds are Joi-validated
+// numbers (0-1000, min<=max) and are inlined as literals; key names are
+// strings and stay parameterised.
+//
+// Exported for tests.
+export function buildTierOrderExpr(body) {
+  const haveBpm = Array.isArray(body.bpmRanges) && body.bpmRanges.length > 0;
+  const haveKey = Array.isArray(body.musicalKeys) && body.musicalKeys.length > 0;
+  if (!haveBpm && !haveKey) { return null; }
+
+  const params = [];
+  const ranges = haveBpm
+    ? body.bpmRanges.map((r) => `(t.bpm BETWEEN ${Number(r.min)} AND ${Number(r.max)})`).join(' OR ')
+    : null;
+  const keys = haveKey ? expandCamelotCodes(body.musicalKeys) : null;
+  const keyPh = haveKey ? keys.map(() => '?').join(',') : null;
+
+  // 'good' = present AND inside the set; 'wrong' = present AND outside.
+  // A missing dimension is neither (classifyRow's 'na').
+  const bpm = (negate) => {
+    if (!haveBpm) { return '0'; }
+    return `(t.bpm IS NOT NULL AND ${negate ? 'NOT ' : ''}(${ranges}))`;
+  };
+  const key = (negate) => {
+    if (!haveKey) { return '0'; }
+    params.push(...keys);
+    return `(t.musical_key IS NOT NULL AND t.musical_key ${negate ? 'NOT ' : ''}IN (${keyPh}))`;
+  };
+
+  const expr = `CASE
+    WHEN (${bpm(false)} AND NOT ${key(true)}) OR (${key(false)} AND NOT ${bpm(true)}) THEN 0
+    WHEN NOT ${bpm(true)} AND NOT ${key(true)} THEN 1
+    ELSE 2 END`;
+  return { expr, params };
+}
+
 // ── Waterfall ───────────────────────────────────────────────────────────────
 //
 // Returns the first non-empty result-set encountered while progressively
@@ -365,14 +415,15 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
   const sql = clauses.length > 0
     ? `${baseSql} AND ${clauses.join(' AND ')}`
     : baseSql;
-  if (!bounded) { return d.prepare(sql).all(...baseParams, ...params); }
 
-  // Bounded step (request has no BPM/key constraints, no sonic pool —
-  // see runRandomSongs): sample a small random pool instead of
-  // materialising every match. The id cooldown is excluded in SQL
-  // first; when that alone empties the step, retry the SAME step
-  // without it, so cooldown exhaustion falls back to repeats WITHIN
-  // this step's constraints (matching finalisePick's fallback).
+  // Every step samples a small pool instead of materialising every match
+  // (audit M5 — the terminal step used to ship the entire in-scope library
+  // to JS per pick). When the request carries BPM/key constraints,
+  // `tierOrder` leads the ORDER BY so the pool always contains the best
+  // tier present (see buildTierOrderExpr); the id cooldown is excluded in
+  // SQL first, and when that alone empties the step, the SAME step retries
+  // without it so cooldown exhaustion falls back to repeats WITHIN this
+  // step's constraints (matching finalisePick's fallback).
   //
   // The retry is skipped for artist-cooldown-ENFORCING steps
   // (allowRepeatRetry false): their all-cooled rows would be rejected
@@ -380,13 +431,17 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
   // returning empty lets the waterfall advance toward the
   // drop-cooldown step without paying for a query whose result is
   // discarded.
-  const { ignoreIds, allowRepeatRetry } = bounded;
+  const { ignoreIds, allowRepeatRetry, tierOrder } = bounded;
+  const orderBy = tierOrder
+    ? `ORDER BY ${tierOrder.expr}, RANDOM()`
+    : 'ORDER BY RANDOM()';
+  const tierParams = tierOrder ? tierOrder.params : [];
   const attempt = (excludeIgnored) => {
     const exclude = excludeIgnored && ignoreIds.length > 0
       ? ` AND t.id NOT IN (${ignoreIds.map(() => '?').join(',')})`
       : '';
-    return d.prepare(`${sql}${exclude} ORDER BY RANDOM() LIMIT ${SIMPLE_POOL_LIMIT}`)
-      .all(...baseParams, ...params, ...(exclude ? ignoreIds : []));
+    return d.prepare(`${sql}${exclude} ${orderBy} LIMIT ${SIMPLE_POOL_LIMIT}`)
+      .all(...baseParams, ...params, ...(exclude ? ignoreIds : []), ...tierParams);
   };
   const rows = attempt(true);
   if (rows.length > 0 || ignoreIds.length === 0 || !allowRepeatRetry) { return rows; }
@@ -416,6 +471,17 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
 // (requireIndex), 404 unknown/forbidden seed path (resolveSeedTrack),
 // 400 with a distinct message for a seed that exists but has no embedding
 // yet (transient — the client can toast "pick a different seed").
+// Computed pools cached per (index identity, seed set, threshold). A
+// locked-anchor session and the client's queue-ahead calls repeat the exact
+// same key on every pick, so the full-index dot scan (audit H8's third leg)
+// runs once per anchor instead of once per pick; the rolling anchor changes
+// its seed set each pick and recomputes — one pass over the (now
+// contiguous) matrix, cheap. WeakMap on the index: a rebuilt index drops
+// every cached pool with it. Entries are shared by reference and must be
+// treated as immutable by callers.
+const sonicPoolCache = new WeakMap();   // index -> Map<key, {seedVec, allowed, json}>
+const SONIC_POOL_CACHE_MAX = 8;
+
 function buildSonicPool(req, body) {
   const index = requireIndex();
 
@@ -432,13 +498,30 @@ function buildSonicPool(req, body) {
     seedHashes.push(canonHash);
   }
 
+  const cacheKey = `${[...seedHashes].sort().join('|')}@${body.minSimilarity}`;
+  let perIndex = sonicPoolCache.get(index);
+  if (!perIndex) { perIndex = new Map(); sonicPoolCache.set(index, perIndex); }
+  const hit = perIndex.get(cacheKey);
+  if (hit) {
+    perIndex.delete(cacheKey); perIndex.set(cacheKey, hit);   // LRU touch
+    return { index, ...hit };
+  }
+
   const seedVec = sim.centroidOf(vecs);
   const allowed = sim.hashesWithinThreshold(index, seedVec, body.minSimilarity);
   // The seeds are the session's recent picks (rolling anchor) or the
   // currently-playing song (locked anchor) — Auto-DJ must never answer
   // "what's next" with "the song you just played".
   for (const h of seedHashes) { allowed.delete(h); }
-  return { index, seedVec, allowed };
+  // The JSON form is what the SQL pool constraint binds (json_each) —
+  // stringified once here so locked-anchor picks don't re-serialize a
+  // potentially many-thousand-hash set every request.
+  const entry = { seedVec, allowed, json: JSON.stringify([...allowed]) };
+  perIndex.set(cacheKey, entry);
+  while (perIndex.size > SONIC_POOL_CACHE_MAX) {
+    perIndex.delete(perIndex.keys().next().value);
+  }
+  return { index, ...entry };
 }
 
 // Server-side cooldown ceiling for the round-tripped ignoreList. Deep
@@ -469,9 +552,6 @@ export function runRandomSongs(req, body) {
   const sonic = (Array.isArray(body.similarTo) && body.similarTo.length > 0)
     ? buildSonicPool(req, body)
     : null;
-  const sonicFilter = sonic
-    ? (rows) => rows.filter((r) => sonic.allowed.has(r.audio_hash || r.file_hash))
-    : (rows) => rows;
 
   const filter = libraryFilter(req.user, body.ignoreVPaths);
   const baseConditions = [filter.clause];
@@ -500,6 +580,23 @@ export function runRandomSongs(req, body) {
   // step loop below). COALESCE keeps legacy NULL-format rows as candidates.
   baseConditions.push("COALESCE(t.format, '') <> 'm3u'");
 
+  // Sonic pool as a BASE condition, enforced in SQL: the allowed hashes
+  // bind as one JSON array through json_each, so every candidate query can
+  // stay a bounded random sample. The old shape materialised the entire
+  // in-scope library into JS per pick just to intersect it with the Set
+  // (audit H8 — 420-640 ms per pick at 25k tracks), because sampling
+  // BEFORE intersecting could empty a pool that had matches; intersecting
+  // IN the query dissolves that objection. Same relaxation contract as
+  // before: the waterfall relaxes BPM/key/artist constraints WITHIN the
+  // pool and never the pool itself. (COALESCE is an expression, so no
+  // tracks index applies to this clause — but the ephemeral json_each
+  // table gets the index, and the bounded scan was already paying the
+  // library walk; measured as the cheap side of the trade.)
+  if (sonic) {
+    baseConditions.push('COALESCE(t.audio_hash, t.file_hash) IN (SELECT value FROM json_each(?))');
+    baseParams.push(sonic.json);
+  }
+
   // Skip the trackQuery `tg_agg` aggregation for the candidate-set
   // query — only the picked row's genres survive to the response, and
   // SQLite MATERIALIZEs the aggregation over the full tracks table
@@ -525,38 +622,30 @@ export function runRandomSongs(req, body) {
   // step-5b "drop cooldown" fallback if the user pruned themselves
   // into an empty pool.)
   if (!hasBpm && !hasBpmWide && !hasKey && !hasArtists && !hasIgnoreArtists) {
-    if (!sonic) {
-      // Bounded pick: exclude the cooldown ids in SQL and let SQLite keep
-      // only a small random pool — the whole in-scope library is never
-      // materialised into JS. (Sonic mode below still needs the full
-      // in-scope set: the allowed-hash intersection happens in JS, and
-      // sampling before intersecting could empty a pool that actually
-      // has matches.)
-      const ignoreIds = ignoreIdsFrom(body);
-      const bounded = (excludeIgnored) => {
-        const exclude = excludeIgnored && ignoreIds.length > 0
-          ? ` AND t.id NOT IN (${ignoreIds.map(() => '?').join(',')})`
-          : '';
-        return d.prepare(
-          `${baseSql}${exclude} ORDER BY RANDOM() LIMIT ${SIMPLE_POOL_LIMIT}`
-        ).all(...baseParams, ...(exclude ? ignoreIds : []));
-      };
-      let rows = bounded(true);
-      if (rows.length === 0 && ignoreIds.length > 0) {
-        // Cooldown covers everything in scope — allow repeats rather
-        // than stalling the session (same contract as the waterfall's
-        // drop-cooldown steps).
-        rows = bounded(false);
-      }
-      if (rows.length === 0) {
-        throw new WebError('No songs that match criteria', 400);
-      }
-      return finalisePick(rows, body, null);
+    // Bounded pick — sonic or not: the pool constraint (when present) is
+    // already a base condition above, so both shapes exclude the cooldown
+    // ids in SQL and let SQLite keep only a small random pool. The whole
+    // in-scope library is never materialised into JS.
+    const ignoreIds = ignoreIdsFrom(body);
+    const bounded = (excludeIgnored) => {
+      const exclude = excludeIgnored && ignoreIds.length > 0
+        ? ` AND t.id NOT IN (${ignoreIds.map(() => '?').join(',')})`
+        : '';
+      return d.prepare(
+        `${baseSql}${exclude} ORDER BY RANDOM() LIMIT ${SIMPLE_POOL_LIMIT}`
+      ).all(...baseParams, ...(exclude ? ignoreIds : []));
+    };
+    let rows = bounded(true);
+    if (rows.length === 0 && ignoreIds.length > 0) {
+      // Cooldown covers everything in scope — allow repeats rather
+      // than stalling the session (same contract as the waterfall's
+      // drop-cooldown steps).
+      rows = bounded(false);
     }
-
-    const rows = sonicFilter(d.prepare(baseSql).all(...baseParams));
     if (rows.length === 0) {
-      throw new WebError('No songs within the similarity range match criteria', 400);
+      throw new WebError(sonic
+        ? 'No songs within the similarity range match criteria'
+        : 'No songs that match criteria', 400);
     }
     return finalisePick(rows, body, sonic);
   }
@@ -701,14 +790,12 @@ export function runRandomSongs(req, body) {
     });
   }
 
-  // With no BPM/key constraints anywhere on the request, the post-chain
-  // tier filter has nothing to classify, and without sonic there is no
-  // JS-side pool intersection — so every step's query can be bounded the
-  // same way simple mode is. This is the shape real alpha DJ sessions
-  // take: the client sends ignoreArtists from pick #2 onward (artist
-  // cooldown has no off switch), which routes them through the waterfall
-  // even when BPM/key/similar features are all disabled.
-  const boundedMode = !hasBpm && !hasBpmWide && !hasKey && !sonic;
+  // Every step's query is bounded the same way simple mode is. The two
+  // reasons bounding used to switch off are both gone: the sonic pool is
+  // now a SQL base condition (no JS-side intersection to starve), and BPM/
+  // key requests lead the ORDER BY with a tier expression so the pool
+  // provably contains the best tier present (buildTierOrderExpr above).
+  const tierOrder = (hasBpm || hasKey) ? buildTierOrderExpr(body) : null;
   const ignoreIds = ignoreIdsFrom(body);
   const ignoreSet = new Set(ignoreIds);
 
@@ -730,14 +817,14 @@ export function runRandomSongs(req, body) {
     // all-cooled rows (finalisePick then repeats), so the session
     // still never stalls.
     const enforcesCooldown = Array.isArray(opts.ignoreArtists) && opts.ignoreArtists.length > 0;
-    // The sonic pool intersects EVERY step's result before the emptiness
-    // check that drives relaxation — the waterfall relaxes BPM/key/artist
-    // constraints WITHIN the pool and never relaxes the pool itself
-    // (including the final unrestricted step).
-    const candidate = sonicFilter(runWaterfallQuery(
+    // The sonic pool constrains EVERY step via the base conditions — the
+    // waterfall relaxes BPM/key/artist constraints WITHIN the pool and
+    // never relaxes the pool itself (including the final unrestricted
+    // step).
+    const candidate = runWaterfallQuery(
       d, baseSql, baseParams, opts,
-      boundedMode ? { ignoreIds, allowRepeatRetry: !enforcesCooldown } : null,
-    ));
+      { ignoreIds, allowRepeatRetry: !enforcesCooldown, tierOrder },
+    );
     if (candidate.length === 0) { continue; }
     if (enforcesCooldown && candidate.every((r) => ignoreSet.has(r.id))) { continue; }
     rows = candidate;

--- a/src/db/discovery-similarity.js
+++ b/src/db/discovery-similarity.js
@@ -114,9 +114,28 @@ export function getIndex() {
     if (r.genre_tags) {
       try { genreTags = JSON.parse(r.genre_tags); } catch (_e) { /* stays null */ }
     }
-    const entry = { hash: r.audio_hash, artist: r.artist || null, title: r.title || null, vec, genreTags };
+    const entry = {
+      hash: r.audio_hash, artist: r.artist || null, title: r.title || null, vec, genreTags,
+      // Same-song dedupe key, precomputed ONCE — pathBetween used to rebuild
+      // it per entry per waypoint (two trims + lowercases × 25k × waypoints).
+      // Rows without a title dedupe by hash alone (null key).
+      nameKey: r.title
+        ? `${(r.artist || '').trim().toLowerCase()}|${r.title.trim().toLowerCase()}`
+        : null,
+    };
     entries.push(entry);
     byHash.set(entry.hash, entry);
+  }
+
+  // Re-home every vector into ONE contiguous Float32Array and hand each
+  // entry a subarray view of it. API-identical (entry.vec still indexes the
+  // same floats), but the brute-force scans (rankTracks, pathBetween,
+  // hashesWithinThreshold) now stream a single sequential buffer instead of
+  // pointer-chasing 25k separately allocated arrays.
+  const matrix = new Float32Array(entries.length * (dim || 0));
+  for (let i = 0; i < entries.length; i++) {
+    matrix.set(entries[i].vec, i * dim);
+    entries[i].vec = matrix.subarray(i * dim, (i + 1) * dim);
   }
 
   // Artist centroids: mean of the artist's track vectors, re-normalized.
@@ -144,7 +163,7 @@ export function getIndex() {
   }
 
   const modelVersion = discoveryDb.getMeta('embedding_model_version') || null;
-  cache = { seq, rowSeq, builtAt: Date.now(), modelId, modelVersion, dim, entries, byHash, artists };
+  cache = { seq, rowSeq, builtAt: Date.now(), modelId, modelVersion, dim, entries, byHash, artists, matrix };
   winston.info(`discovery similarity index built: ${entries.length} tracks, ${artists.size} artists, ${dim}-d (${Date.now() - started} ms)`);
   return cache;
 }
@@ -172,9 +191,11 @@ export function centroidOf(vecs) {
  * promise the index can make about vectors it has.
  */
 export function hashesWithinThreshold(index, seedVec, minSimilarity) {
+  const n = index.entries.length;
+  const scores = scoresInto(new Float64Array(n), index, seedVec);
   const out = new Set();
-  for (const e of index.entries) {
-    if (dot(seedVec, e.vec) >= minSimilarity) { out.add(e.hash); }
+  for (let i = 0; i < n; i++) {
+    if (scores[i] >= minSimilarity) { out.add(index.entries[i].hash); }
   }
   return out;
 }
@@ -188,19 +209,94 @@ export function similarityToHash(index, seedVec, hash) {
   return e ? dot(seedVec, e.vec) : null;
 }
 
+// Scores of every entry vs `seedVec`, written into `out` (Float64Array so
+// near-tie ordering matches the old per-entry float64 dots exactly). The
+// fast path is one flat monomorphic loop over the contiguous matrix — the
+// per-entry dot() calls it replaces paid call + bounds overhead 25k times
+// per scan and were the dominant cost of every ranking. Hand-built indexes
+// without a matrix (tests, embedders) fall back to per-entry dots.
+function scoresInto(out, index, seedVec) {
+  const entries = index.entries;
+  const n = entries.length;
+  const dim = seedVec.length;
+  const m = index.matrix;
+  if (m && m.length === n * dim) {
+    for (let i = 0, off = 0; i < n; i++, off += dim) {
+      let s = 0;
+      for (let k = 0; k < dim; k++) { s += seedVec[k] * m[off + k]; }
+      out[i] = s;
+    }
+  } else {
+    for (let i = 0; i < n; i++) { out[i] = dot(seedVec, entries[i].vec); }
+  }
+  return out;
+}
+
+// The K highest-scoring indices in [0, n), descending, considering only
+// indices `eligible` accepts. Bounded min-heap over indices — O(n log K)
+// and zero per-candidate allocation, vs the build-25k-objects-and-sort
+// pattern this replaces (audit M9 / C3-JS-half). K >= n degrades to a
+// plain filter + full sort, which is the correct fallback shape.
+function selectTopKDesc(scores, n, k, eligible) {
+  if (k >= n) {
+    const all = [];
+    for (let i = 0; i < n; i++) { if (eligible(i)) { all.push(i); } }
+    all.sort((a, b) => scores[b] - scores[a]);
+    return all;
+  }
+  const heap = new Int32Array(k);   // min-heap on scores[heap[i]]
+  let size = 0;
+  for (let i = 0; i < n; i++) {
+    if (!eligible(i)) { continue; }
+    if (size < k) {
+      // sift up
+      let c = size++;
+      heap[c] = i;
+      while (c > 0) {
+        const p = (c - 1) >> 1;
+        if (scores[heap[p]] <= scores[heap[c]]) { break; }
+        const t = heap[p]; heap[p] = heap[c]; heap[c] = t;
+        c = p;
+      }
+    } else if (scores[i] > scores[heap[0]]) {
+      // replace the root, sift down
+      heap[0] = i;
+      let p = 0;
+      for (;;) {
+        const l = 2 * p + 1;
+        const r = l + 1;
+        let m = p;
+        if (l < size && scores[heap[l]] < scores[heap[m]]) { m = l; }
+        if (r < size && scores[heap[r]] < scores[heap[m]]) { m = r; }
+        if (m === p) { break; }
+        const t = heap[p]; heap[p] = heap[m]; heap[m] = t;
+        p = m;
+      }
+    }
+  }
+  const out = Array.from(heap.subarray(0, size));
+  out.sort((a, b) => scores[b] - scores[a]);
+  return out;
+}
+
 /**
- * All entries ranked by similarity to `seedVec`, descending, excluding
+ * Entries ranked by similarity to `seedVec`, descending, excluding
  * `excludeHash`. The caller walks the ranking and applies its own
  * access/exclusion filters until it has enough results.
+ *
+ * `topK` truncates the ranking to the caller's consideration budget —
+ * every route already caps its walk (max(limit*50, 2000) since the
+ * 2026-07 audit), so ranking past the cap was pure waste: a 25k-object
+ * allocation + full sort per Discover refresh. Omit it (Infinity) for the
+ * legacy full ranking.
  */
-export function rankTracks(index, seedVec, excludeHash) {
-  const out = [];
-  for (const e of index.entries) {
-    if (e.hash === excludeHash) { continue; }
-    out.push({ entry: e, similarity: dot(seedVec, e.vec) });
-  }
-  out.sort((a, b) => b.similarity - a.similarity);
-  return out;
+export function rankTracks(index, seedVec, excludeHash, topK = Infinity) {
+  const entries = index.entries;
+  const n = entries.length;
+  const scores = scoresInto(new Float64Array(n), index, seedVec);
+  const k = Number.isFinite(topK) ? Math.max(0, topK) : n;
+  const idx = selectTopKDesc(scores, n, k, (i) => entries[i].hash !== excludeHash);
+  return idx.map((i) => ({ entry: entries[i], similarity: scores[i] }));
 }
 
 /**
@@ -252,39 +348,87 @@ export function pathBetween(index, hashA, hashB, waypoints, visible) {
 
   // Hash dedupe alone isn't enough: real libraries hold the same SONG as
   // several files (single vs EP master, re-encodes) with distinct audio
-  // hashes, and a journey that plays "Mistaken" twice is broken. Same
-  // normalized artist+title key the federation route dedupes with; rows
-  // missing a title fall back to hash-only dedupe.
-  const nameKey = (e) => {
-    if (!e || !e.title) { return null; }
-    return `${(e.artist || '').trim().toLowerCase()}|${e.title.trim().toLowerCase()}`;
+  // hashes, and a journey that plays "Mistaken" twice is broken. The
+  // normalized artist+title key is precomputed at index build
+  // (entry.nameKey); hand-built indexes (tests, embedders) get it memoized
+  // on first touch. Rows missing a title fall back to hash-only dedupe.
+  const keyOf = (e) => {
+    if (e.nameKey === undefined) {
+      e.nameKey = e.title
+        ? `${(e.artist || '').trim().toLowerCase()}|${e.title.trim().toLowerCase()}`
+        : null;
+    }
+    return e.nameKey;
+  };
+  const used = new Set([hashA, hashB]);
+  const usedNames = new Set([keyOf(a), keyOf(b)].filter(Boolean));
+  const out = [];
+
+  // Per-waypoint cost used to be 25k dots + a 25k-object allocation + a full
+  // sort, × every waypoint (2.2–5.7 s per /path request — audit C3-JS-half).
+  // Two rework layers:
+  //   1. slerp(a,b,t) is a LINEAR combination of the two endpoint vectors
+  //      (wa·a + wb·b in both of its branches), so every waypoint's cosine
+  //      against entry e is wa·dot(a,e) + wb·dot(b,e) — two full dot passes
+  //      up front replace one per waypoint, and each waypoint's scores are
+  //      a 25k-element multiply-add;
+  //   2. the full sort per waypoint becomes a bounded top-K selection — the
+  //      pick is nearly always in the first few candidates, and the rare
+  //      pathological waypoint (every top candidate invisible to this
+  //      caller) escalates to the full ordering once.
+  const entries = index.entries;
+  const n = entries.length;
+  const dotA = scoresInto(new Float64Array(n), index, a.vec);
+  const dotB = scoresInto(new Float64Array(n), index, b.vec);
+  const scores = new Float64Array(n);
+  const BATCH = 256;
+  const eligible = (i) => {
+    const e = entries[i];
+    if (used.has(e.hash)) { return false; }
+    const key = keyOf(e);
+    return !(key && usedNames.has(key));
   };
 
-  const used = new Set([hashA, hashB]);
-  const usedNames = new Set([nameKey(a), nameKey(b)].filter(Boolean));
-  const out = [];
+  // Waypoint weights, replicating slerp()'s two branches on scalars: the
+  // spherical weights when sin Ω is healthy, the normalized-lerp weights
+  // when the seeds are near-parallel.
+  let d = dot(a.vec, b.vec);
+  if (d > 1) { d = 1; } else if (d < -1) { d = -1; }
+  const omega = Math.acos(d);
+  const sinOmega = Math.sin(omega);
+  const weightsAt = (t) => {
+    if (sinOmega < 1e-6) {
+      const norm = Math.sqrt((1 - t) * (1 - t) + t * t + 2 * t * (1 - t) * d) || 1;
+      return [(1 - t) / norm, t / norm];
+    }
+    return [Math.sin((1 - t) * omega) / sinOmega, Math.sin(t * omega) / sinOmega];
+  };
+
   for (let k = 1; k <= waypoints; k++) {
     const t = k / (waypoints + 1);
-    const w = slerp(a.vec, b.vec, t);
-
-    const ranked = [];
-    for (const e of index.entries) {
-      if (used.has(e.hash)) { continue; }
-      const key = nameKey(e);
-      if (key && usedNames.has(key)) { continue; }
-      ranked.push({ hash: e.hash, key, similarity: dot(w, e.vec) });
-    }
-    ranked.sort((x, y) => y.similarity - x.similarity);
+    const [wa, wb] = weightsAt(t);
+    for (let i = 0; i < n; i++) { scores[i] = wa * dotA[i] + wb * dotB[i]; }
 
     let pick = null;
-    for (const cand of ranked) {
-      if (visible(cand.hash)) { pick = cand; break; }
-      used.add(cand.hash);
+    const walk = (indices) => {
+      for (const i of indices) {
+        if (!eligible(i)) { continue; }   // `used` grows during the walk
+        const e = entries[i];
+        if (visible(e.hash)) { pick = { entry: e, similarity: scores[i] }; return; }
+        // A rejected hash is rejected for every later waypoint too.
+        used.add(e.hash);
+      }
+    };
+    const batch = selectTopKDesc(scores, n, BATCH, eligible);
+    walk(batch);
+    if (!pick && batch.length === BATCH) {
+      walk(selectTopKDesc(scores, n, n, eligible));
     }
+
     if (!pick) { break; }
-    used.add(pick.hash);
-    if (pick.key) { usedNames.add(pick.key); }
-    out.push({ hash: pick.hash, similarity: pick.similarity, t });
+    used.add(pick.entry.hash);
+    if (pick.entry.nameKey) { usedNames.add(pick.entry.nameKey); }
+    out.push({ hash: pick.entry.hash, similarity: pick.similarity, t });
   }
   return out;
 }

--- a/test/db/discovery-hot-loops.test.mjs
+++ b/test/db/discovery-hot-loops.test.mjs
@@ -1,0 +1,319 @@
+/**
+ * Tests for the discovery JS hot-loop rework (audit PR-B: M9, C3-JS-half,
+ * H8, M5):
+ *
+ *   - rankTracks topK must return exactly the head of the full ranking
+ *     (the bounded heap is an optimization, never a semantic change);
+ *   - pathBetween's batched selection + escalation must produce the same
+ *     paths as the old full-sort walk, including when the visibility
+ *     filter rejects more than a whole batch;
+ *   - buildTierOrderExpr (the SQL twin of classifyRow) must order rows
+ *     exactly as the JS classifier tiers them — placeholder/bind lockstep
+ *     included;
+ *   - runRandomSongs with BPM constraints must keep the tier-0 guarantee
+ *     even when scope is far larger than the bounded pool (the M5 fix's
+ *     core invariant), and sonic mode must keep the pool promise with the
+ *     intersection pushed into SQL.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+let testRoot;
+let config, manager, ddb, sim, random;
+
+const DIM = 16;
+const vec = (...xs) => {
+  const v = new Float32Array(DIM);
+  xs.forEach((x, i) => { v[i] = x; });
+  let n = 0;
+  for (const x of v) { n += x * x; }
+  n = Math.sqrt(n) || 1;
+  for (let i = 0; i < DIM; i++) { v[i] /= n; }
+  return v;
+};
+
+// A deterministic hand-built index the pure-function tests share.
+function buildFakeIndex(n) {
+  const entries = [];
+  const byHash = new Map();
+  for (let i = 0; i < n; i++) {
+    const e = {
+      hash: `h${i}`,
+      artist: `Artist ${i % 40}`,
+      title: `Title ${i}`,
+      vec: vec(Math.cos(i * 0.37), Math.sin(i * 0.37), (i % 7) / 7),
+      genreTags: null,
+    };
+    entries.push(e);
+    byHash.set(e.hash, e);
+  }
+  return { entries, byHash, dim: DIM };
+}
+
+before(async () => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-hotloops-'));
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(testRoot, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+    },
+    folders: { rig: { root: path.join(testRoot, 'lib') } },
+    port: 0,
+  }, null, 2));
+
+  config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  config.program.scanOptions.collectDiscoveryData = true;
+  config.program.scanOptions.discoveryModel = 'test-fake';
+
+  manager = await import('../../src/db/manager.js');
+  manager.initDB();
+  ddb = await import('../../src/db/discovery-db.js');
+  ddb.initDiscoveryDb(path.join(testRoot, 'db', 'discovery.db'));
+  sim = await import('../../src/db/discovery-similarity.js');
+  random = await import('../../src/api/random.js');
+});
+
+after(() => {
+  try { manager.close(); } catch (_e) { /* closed */ }
+  try { ddb.closeDiscoveryDb(); } catch (_e) { /* closed */ }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_e) { /* win locks */ }
+  setImmediate(() => process.exit(0));
+});
+
+// ── rankTracks topK ─────────────────────────────────────────────────────────
+
+describe('rankTracks topK', () => {
+  test('topK returns exactly the head of the full ranking, same order', () => {
+    const index = buildFakeIndex(500);
+    const seed = vec(1, 0.2, 0.1);
+    const full = sim.rankTracks(index, seed, 'h3');
+    for (const k of [1, 7, 50, 499, 500, 5000]) {
+      const bounded = sim.rankTracks(index, seed, 'h3', k);
+      assert.equal(bounded.length, Math.min(k, full.length), `k=${k} length`);
+      for (let i = 0; i < bounded.length; i++) {
+        assert.equal(bounded[i].entry.hash, full[i].entry.hash, `k=${k} rank ${i}`);
+        assert.equal(bounded[i].similarity, full[i].similarity, `k=${k} score ${i}`);
+      }
+    }
+  });
+
+  test('excludeHash never appears at any k', () => {
+    const index = buildFakeIndex(100);
+    const seed = index.byHash.get('h10').vec;
+    for (const k of [5, 100]) {
+      assert.ok(sim.rankTracks(index, seed, 'h10', k).every((r) => r.entry.hash !== 'h10'));
+    }
+  });
+});
+
+// ── pathBetween equivalence ─────────────────────────────────────────────────
+
+// The pre-rework algorithm, kept verbatim as the oracle.
+function oldPathBetween(index, hashA, hashB, waypoints, visible) {
+  const a = index.byHash.get(hashA);
+  const b = index.byHash.get(hashB);
+  if (!a || !b || waypoints <= 0) { return []; }
+  const dot = (x, y) => { let s = 0; for (let i = 0; i < x.length; i++) { s += x[i] * y[i]; } return s; };
+  const nameKey = (e) => {
+    if (!e || !e.title) { return null; }
+    return `${(e.artist || '').trim().toLowerCase()}|${e.title.trim().toLowerCase()}`;
+  };
+  const used = new Set([hashA, hashB]);
+  const usedNames = new Set([nameKey(a), nameKey(b)].filter(Boolean));
+  const out = [];
+  for (let k = 1; k <= waypoints; k++) {
+    const t = k / (waypoints + 1);
+    const w = sim.slerp(a.vec, b.vec, t);
+    const ranked = [];
+    for (const e of index.entries) {
+      if (used.has(e.hash)) { continue; }
+      const key = nameKey(e);
+      if (key && usedNames.has(key)) { continue; }
+      ranked.push({ hash: e.hash, key, similarity: dot(w, e.vec) });
+    }
+    ranked.sort((x, y) => y.similarity - x.similarity);
+    let pick = null;
+    for (const cand of ranked) {
+      if (visible(cand.hash)) { pick = cand; break; }
+      used.add(cand.hash);
+    }
+    if (!pick) { break; }
+    used.add(pick.hash);
+    if (pick.key) { usedNames.add(pick.key); }
+    out.push({ hash: pick.hash, similarity: pick.similarity, t });
+  }
+  return out;
+}
+
+describe('pathBetween equivalence with the old full-sort walk', () => {
+  test('everything visible: identical paths', () => {
+    const index = buildFakeIndex(700);   // > one 256 batch
+    const got = sim.pathBetween(index, 'h0', 'h699', 8, () => true);
+    const want = oldPathBetween(buildFakeIndex(700), 'h0', 'h699', 8, () => true);
+    assert.ok(got.length > 0, 'path produced');
+    assert.deepEqual(got.map((p) => p.hash), want.map((p) => p.hash));
+  });
+
+  test('hostile visibility (rejects past a whole batch): escalation matches', () => {
+    // Reject everything except a handful of high-index entries — the top
+    // 256 candidates of early waypoints are all invisible, forcing the
+    // full-ordering escalation.
+    const allow = new Set(['h650', 'h651', 'h652', 'h653', 'h654', 'h655']);
+    const visible = (h) => allow.has(h);
+    const got = sim.pathBetween(buildFakeIndex(700), 'h0', 'h699', 4, visible);
+    const want = oldPathBetween(buildFakeIndex(700), 'h0', 'h699', 4, visible);
+    assert.ok(want.length > 0, 'oracle found picks');
+    assert.deepEqual(got.map((p) => p.hash), want.map((p) => p.hash));
+  });
+
+  test('same-name dedupe still applies (memoized nameKey on hand-built entries)', () => {
+    const index = buildFakeIndex(300);
+    // Give three distinct hashes the same artist+title as the likely first
+    // pick's — only one of the name-group may ever appear.
+    const first = sim.pathBetween(buildFakeIndex(300), 'h0', 'h299', 6, () => true)[0];
+    const twin = index.entries.find((e) => e.hash === first.hash);
+    for (const h of ['h100', 'h200']) {
+      const e = index.byHash.get(h);
+      e.artist = twin.artist; e.title = twin.title;
+      delete e.nameKey;   // hand-built indexes have no precomputed key
+    }
+    const got = sim.pathBetween(index, 'h0', 'h299', 6, () => true);
+    const names = got.map((p) => {
+      const e = index.byHash.get(p.hash);
+      return `${e.artist}|${e.title}`.toLowerCase();
+    });
+    assert.equal(new Set(names).size, names.length, 'no artist+title repeats on the path');
+  });
+});
+
+// ── buildTierOrderExpr ⇄ classifyRow lockstep ──────────────────────────────
+
+describe('buildTierOrderExpr mirrors the JS tier classifier', () => {
+  test('SQL tier ordering matches applyTierFilter tiers for every row shape', () => {
+    const mem = new DatabaseSync(':memory:');
+    mem.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, bpm REAL, musical_key TEXT)');
+    const ins = mem.prepare('INSERT INTO t (bpm, musical_key) VALUES (?, ?)');
+    const rows = [
+      [120, 'C major'],   // good bpm, good key      → tier 0
+      [120, null],        // good bpm, unknown key   → tier 0
+      [120, 'F minor'],   // good bpm, WRONG key     → tier 2
+      [null, 'C major'],  // unknown bpm, good key   → tier 0
+      [null, null],       // unknown both            → tier 1
+      [null, 'F minor'],  // unknown bpm, wrong key  → tier 2
+      [80, 'C major'],    // WRONG bpm, good key     → tier 2
+      [80, null],         // wrong bpm, unknown key  → tier 2
+      [80, 'F minor'],    // wrong both              → tier 2
+    ];
+    for (const [bpm, key] of rows) { ins.run(bpm, key); }
+
+    const body = { bpmRanges: [{ min: 110, max: 130 }], musicalKeys: ['8B'] };  // 8B = C major
+    const tier = random.buildTierOrderExpr(body);
+    assert.ok(tier, 'constraints present → expression built');
+
+    const sqlTiers = mem.prepare(
+      `SELECT id, ${tier.expr} AS tier FROM t ORDER BY id`
+    ).all(...tier.params).map((r) => r.tier);
+
+    // The JS authority, tier by tier.
+    const all = mem.prepare('SELECT id, bpm, musical_key FROM t ORDER BY id').all();
+    const t0 = new Set(random.applyTierFilter(all, body).map((r) => r.id));
+    const rest = all.filter((r) => !t0.has(r.id));
+    const t1 = new Set(random.applyTierFilter(rest, body).map((r) => r.id));
+    const jsTiers = all.map((r) => (t0.has(r.id) ? 0 : t1.has(r.id) ? 1 : 2));
+
+    assert.deepEqual(sqlTiers, jsTiers, 'SQL CASE and classifyRow must agree row-for-row');
+    mem.close();
+  });
+
+  test('no constraints → null (no ORDER BY term)', () => {
+    assert.equal(random.buildTierOrderExpr({}), null);
+    assert.equal(random.buildTierOrderExpr({ bpmRanges: [], musicalKeys: [] }), null);
+  });
+});
+
+// ── runRandomSongs invariants at scale (> the bounded pool) ────────────────
+
+describe('runRandomSongs bounded pools keep their guarantees', () => {
+  const IN_RANGE = 12;      // tier-0 rows, deliberately rarer than the pool
+  const SONIC_OK = 15;      // hashes inside the similarity range
+  let inRangeIds;
+  let sonicHashes;
+
+  before(() => {
+    const m = manager.getDB();
+    m.exec('BEGIN');
+    // initDB seeds the libraries table from config.folders — the 'rig'
+    // library already exists; just resolve its id.
+    const libId = m.prepare("SELECT id FROM libraries WHERE name='rig'").get().id;
+    const ins = m.prepare(`INSERT INTO tracks (filepath, library_id, title, bpm, musical_key, audio_hash, format)
+                           VALUES (?, ?, ?, ?, ?, ?, 'mp3')`);
+    inRangeIds = new Set();
+    // 400 rows: 12 in-range BPM (tier 0), the rest split unknown/wrong.
+    for (let i = 0; i < 400; i++) {
+      const bpm = i < IN_RANGE ? 120 : (i % 2 === 0 ? null : 80);
+      const r = ins.run(`f${i}.mp3`, libId, `T${i}`, bpm, null, `rh-${i}`);
+      if (i < IN_RANGE) { inRangeIds.add(Number(r.lastInsertRowid)); }
+    }
+    m.exec('COMMIT');
+
+    // Discovery rows: the seed + SONIC_OK near vectors + far ballast.
+    const d = ddb.getDiscoveryDb();
+    d.exec('BEGIN');
+    sonicHashes = new Set();
+    for (let i = 0; i < 400; i++) {
+      const near = i > 0 && i <= SONIC_OK;
+      const v = i === 0 ? vec(1, 0) : near ? vec(0.95, 0.31) : vec(0, 1);
+      ddb.upsertDiscoveryTrack({
+        audioHash: `rh-${i}`, artist: `A${i % 40}`, title: `T${i}`, duration: 100,
+        modelId: 'test-fake', modelVersion: '1',
+        embedding: Buffer.from(v.buffer, v.byteOffset, v.byteLength),
+      });
+      if (near) { sonicHashes.add(`rh-${i}`); }
+    }
+    d.exec('COMMIT');
+    ddb.publishIndexEpoch();
+    sim.invalidate();
+  });
+
+  test('tier-0 rows always win although 97% of scope is tier-1/2 (M5 invariant)', () => {
+    const req = { user: undefined };
+    for (let i = 0; i < 25; i++) {
+      const out = random.runRandomSongs(req, { bpmRanges: [{ min: 110, max: 130 }] });
+      // resolve the picked id back through the ignoreList round-trip shape
+      const pickedId = out.ignoreList[out.ignoreList.length - 1];
+      assert.ok(inRangeIds.has(pickedId),
+        `pick ${i} must be tier-0 (got track id ${pickedId})`);
+    }
+  });
+
+  test('sonic pool promise holds with the intersection in SQL (H8 shape)', () => {
+    const req = { user: undefined };
+    const seen = new Set();
+    for (let i = 0; i < 25; i++) {
+      const out = random.runRandomSongs(req, {
+        similarTo: ['rig/f0.mp3'], minSimilarity: 0.9, ignoreList: [],
+      });
+      assert.equal(out.sonic.poolSize, SONIC_OK, 'poolSize reflects the allowed set');
+      const picked = out.songs[0];
+      seen.add(picked.metadata.title);
+      assert.ok(out.sonic.similarity >= 0.9, `pick similarity ${out.sonic.similarity}`);
+    }
+    assert.ok(seen.size > 3, `picks vary across the pool (saw ${seen.size} distinct)`);
+  });
+
+  test('sonic + impossible threshold → clean 400, nothing materialised', () => {
+    const req = { user: undefined };
+    assert.throws(
+      () => random.runRandomSongs(req, { similarTo: ['rig/f0.mp3'], minSimilarity: 0.9999 }),
+      /similarity range/);
+  });
+});


### PR DESCRIPTION
Audit **PR-B** (findings M9, C3-JS-half, H8, M5): the pure-JS half of the discovery cost. All numbers measured on a 25k-track × 1280-d fixture; every behavioral equivalence is pinned by tests running the **pre-rework algorithms as oracles**.

## M9 — `rankTracks` full sort per Discover refresh

Built a 25k-object array and fully sorted it per call, while every caller only ever walked its consideration budget (`max(limit*50, 2000)` since #792). New `topK` parameter — callers pass the budget they already had — with bounded min-heap selection and zero per-candidate allocation. The index also re-homes all vectors into **one contiguous `Float32Array`** (entries keep subarray views, API unchanged) and rankings score through a flat monomorphic scan.

**129 → 106 ms/call.** The remaining ~95 ms is the brute-force dot product floor (25k × 1280 multiply-adds) — honest scalar-JS cost, shared by every path below.

## C3-JS — `pathBetween` (Sonic Path)

Paid 25k dots + a full sort + per-entry nameKey string rebuilds **per waypoint**. Three layers:
1. `nameKey` precomputed at index build (memoized fallback for hand-built indexes);
2. the algebraic win: `slerp(a,b,t)` is a linear combination of its endpoints in both branches, so every waypoint's cosine is `wa·dot(a,e) + wb·dot(b,e)` — **two dot passes up front replace one per waypoint**, and each waypoint's scores become a 25k multiply-add;
3. the sort becomes a bounded top-K selection, with a full-ordering escalation for waypoints whose entire batch is invisible to the caller.

**10-waypoint `/path`: 1461 → 271 ms all-visible, 1507 → 262 ms with half the library invisible** (~5.5×; the audit measured 2.2–5.7 s for this route).

## H8 — sonic Auto-DJ pick

Materialised the **entire in-scope library into JS per pick** just to intersect it with the allowed-hash Set (the code's own comment explained why sampling-before-intersecting couldn't work), and re-ran the full-index dot scan per pick. Now:
- the pool is a **SQL base condition** — allowed hashes bind as one JSON array via `json_each`, so the intersection happens in the query and every candidate query is a bounded random sample;
- computed pools are **cached per (index, seed set, threshold)** — locked anchors and the client's queue-ahead calls repeat the same key every pick; a rebuilt index drops the cache via WeakMap. Rolling anchors recompute one (now contiguous-scan) dot pass.

**~374 → 25 ms/pick steady** (first pick 124 ms computes the pool once). Pool promise, `poolSize`, relaxation contract, and the empty-pool 400 all pinned by the existing sonic suite + new tests.

## M5 — waterfall bounding under BPM/key

Any BPM/key param disabled bounding entirely and the terminal step shipped the whole library to JS per pick. Every step now samples a bounded pool like simple mode; the new `buildTierOrderExpr` — a SQL twin of `classifyRow`, **tested in row-for-row lockstep against the JS classifier** — leads the `ORDER BY`, so the LIMIT-sized pool provably contains the best tier present in scope and the JS `applyTierFilter` keeps its authority.

**257 → 8.5 ms/pick**, with a 25-pick test pinning that tier-0 rows always win even when 97% of scope is tier-1/2.

## Tests

- New `test/db/discovery-hot-loops.test.mjs` (10 cases): topK ≡ head of the full ranking at every k; pathBetween ≡ the verbatim old algorithm (including the hostile-visibility escalation path and same-name dedupe); SQL⇄JS tier lockstep across all nine row shapes; `runRandomSongs` invariants at 8× the pool size (tier-0 guarantee, sonic pool promise, clean 400).
- **204 green** across the 9 affected suites (DJ ×3, discovery-similarity, federation ×2, discovery-path, hot-loops, infra-churn). Changed files lint clean.

With this, every default-config finding from the 2026-07-30 audit is fixed (A #792, C #809, D #793, F #794, B here). Remaining: E (status/admin), G (subsonic), H (DLNA), I (wrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)