### PR TITLE
perf(status/admin): SWR coverage, chunked library delete, bounded hash-transition drain, blob-free shared listing

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1628,34 +1628,35 @@ export function setup(mstream) {
     // user_id, playlist_json) but this list endpoint kept its
     // pre-migration `SELECT *`, so the UI bound to fields that no longer
     // existed — blank ids, blank user, and a per-row delete that posted
-    // `undefined` as the id. Mirror the POST /api/v1/share response
-    // shape. LEFT JOIN users so an orphaned share (user_id SET NULL when
-    // its owner is deleted) still lists, with user = null.
+    // `undefined` as the id. LEFT JOIN users so an orphaned share
+    // (user_id SET NULL when its owner is deleted) still lists, with
+    // user = null.
+    //
+    // The playlist blobs themselves never leave the DB: the admin UIs
+    // render id/user/expires and a per-row delete, nothing else, yet this
+    // endpoint used to fetch + JSON.parse + re-stringify EVERY share's
+    // full track list — and blob volume is controlled by NON-admin users
+    // (2026-07 audit M3: ~1 s and a 64 MB response at 200 shares × 5k
+    // tracks). json_array_length gives the UI a track count for the cost
+    // of reading the header; json_valid guards it (a corrupt blob would
+    // otherwise fail the whole statement, and corrupt shares must stay
+    // listable so the admin can delete them).
     const rows = d.prepare(`
-      SELECT s.share_id, s.playlist_json, s.expires, s.created_at, u.username
+      SELECT s.share_id, s.expires, s.created_at, u.username,
+             CASE WHEN json_valid(s.playlist_json)
+                  THEN json_array_length(s.playlist_json) ELSE 0 END AS track_count
       FROM shared_playlists s
       LEFT JOIN users u ON u.id = s.user_id
       ORDER BY s.id DESC
     `).all();
 
-    res.json(rows.map(r => {
-      let playlist = [];
-      try {
-        playlist = JSON.parse(r.playlist_json);
-      } catch (err) {
-        // A corrupt playlist_json shouldn't take the whole admin list
-        // down — log which share is bad and surface it with an empty
-        // track list so the admin can still see (and delete) it.
-        winston.warn(`Corrupt playlist_json for shared playlist ${r.share_id}: ${err.message}`);
-      }
-      return {
-        playlistId: r.share_id,
-        user: r.username,
-        playlist,
-        expires: r.expires,
-        created: r.created_at,
-      };
-    }));
+    res.json(rows.map(r => ({
+      playlistId: r.share_id,
+      user: r.username,
+      trackCount: r.track_count,
+      expires: r.expires,
+      created: r.created_at,
+    })));
   });
 
   mstream.delete("/api/v1/admin/db/shared", (req, res) => {

--- a/src/api/shared.js
+++ b/src/api/shared.js
@@ -64,7 +64,12 @@ export function setupAfterSecurity(mstream) {
 
   mstream.post('/api/v1/share', (req, res) => {
     const schema = Joi.object({
-      playlist: Joi.array().items(Joi.string()).required(),
+      // Bounded at the producer (2026-07 audit M3): share blobs are
+      // written by NON-admin users but read back in bulk by admin
+      // surfaces, so an unbounded array here is someone else's memory
+      // problem later. 5000 tracks is far past any real shared playlist;
+      // the per-item cap rejects degenerate megabyte "paths".
+      playlist: Joi.array().items(Joi.string().max(4096)).max(5000).required(),
       time: Joi.number().integer().positive().optional()
     });
     joiValidate(schema, req.body);

--- a/src/db/discovery-db.js
+++ b/src/db/discovery-db.js
@@ -33,7 +33,7 @@ import winston from 'winston';
 import * as config from '../state/config.js';
 
 // Independent version line — this is NOT mstream.db's SCHEMA_VERSION.
-export const DISCOVERY_SCHEMA_VERSION = 1;
+export const DISCOVERY_SCHEMA_VERSION = 2;
 
 // Contract constants for the embedding column. Declared here (and copied
 // into discovery_meta + every export snapshot) so a consumer never has to
@@ -115,8 +115,23 @@ const SCHEMA_V1 = `
   );
 `;
 
+// V2: covering partial index for the status API's coverage counts (2026-07
+// audit H6). Both the done-count (model_id = ? over embedded rows) and the
+// ATTACH'd NOT-EXISTS eligibility probe (model_id = ? AND audio_hash = ?)
+// resolve entirely inside this index instead of walking the table's
+// blob-laden pages. The win is the COLD case — the audit measured
+// 0.8–1.4 s per status recompute at 25k rows against uncached pages of a
+// ~140 MB file; with everything warm the difference shrinks, which is why
+// the request path additionally went stale-while-revalidate
+// (enrichment-status-lib.js).
+const SCHEMA_V2 = `
+  CREATE INDEX IF NOT EXISTS idx_discovery_tracks_embedded_model
+    ON discovery_tracks(model_id, audio_hash) WHERE embedding IS NOT NULL;
+`;
+
 const MIGRATIONS = [
   { version: 1, sql: SCHEMA_V1 },
+  { version: 2, sql: SCHEMA_V2 },
 ];
 
 export function discoveryDbPath() {
@@ -388,6 +403,14 @@ export function applyHashTransitionGroups(groups) {
   const out = { moved: 0, dropped: 0 };
   if (!groups || groups.length === 0) { return out; }
   const ddb = getDiscoveryDb();
+  // Rowversions for the moves are reserved as ONE block inside the
+  // transaction below (audit M1: per-move nextUpdateSeq() was one
+  // discovery_meta UPDATE per row across a 15k-row drain). At most one
+  // move per group, so groups.length covers it; unused reservations leave
+  // gaps in row_seq, which is fine — it's a monotonic version, not a count.
+  const reserveSeqs = ddb.prepare(
+    "UPDATE discovery_meta SET value = CAST(value AS INTEGER) + ? " +
+    "WHERE key = 'row_seq' RETURNING CAST(value AS INTEGER) AS seq");
   const stmts = {
     trackGet: ddb.prepare(
       'SELECT audio_hash, recording_mbid, updated_at FROM discovery_tracks WHERE audio_hash = ?'),
@@ -402,6 +425,8 @@ export function applyHashTransitionGroups(groups) {
   };
   ddb.exec('BEGIN');
   try {
+    const seqBase = reserveSeqs.get(groups.length).seq - groups.length;
+    let seqUsed = 0;
     for (const { target, sources } of groups) {
       const live = sources.map((s) => stmts.trackGet.get(s)).filter(Boolean);
       if (live.length > 0) {
@@ -410,7 +435,7 @@ export function applyHashTransitionGroups(groups) {
         } else {
           live.sort((a, b) => b.updated_at - a.updated_at);
           stmts.trackMove.run(target,
-            exportIdFor(live[0].recording_mbid, target), nextUpdateSeq(), live[0].audio_hash);
+            exportIdFor(live[0].recording_mbid, target), seqBase + (++seqUsed), live[0].audio_hash);
           out.moved++;
           for (const r of live.slice(1)) { stmts.trackDel.run(r.audio_hash); out.dropped++; }
         }

--- a/src/db/enrichment-status-lib.js
+++ b/src/db/enrichment-status-lib.js
@@ -16,11 +16,24 @@
 // a permissions error on the waveform cache) nulls out ITS pass instead
 // of failing the endpoint.
 //
-// Costs: one aggregate scan over tracks/albums per pass (all COUNT/SUM,
-// no row materialisation — single-digit ms at 100k tracks) plus one
-// readdir of the waveform cache. Cheap, but not free at poll frequency —
-// so results are memoised for CACHE_TTL_MS per libIds set (the fs
-// readdir for WAVEFORM_FS_TTL_MS globally).
+// Costs — honest numbers, not the "single-digit ms" this header used to
+// claim (2026-07 audit H6, off by ~100×): a full recompute is ~8
+// aggregate passes over tracks/albums plus the hash-ledger probes
+// (~430 ms at 25k tracks) plus the discovery.db counts (0.8–1.4 s
+// UNINDEXED; ~ms with the V2 partial index) plus one readdir of the
+// waveform cache. The endpoint is NOT admin-only and the dashboard polls
+// every 4 s, so the caching layer carries the load:
+//   • fresh hits (≤ CACHE_TTL_MS) serve the memo;
+//   • STALE hits serve the stale snapshot immediately and refresh
+//     off-request, one builder per event-loop tick, so a poll never
+//     blocks on a recompute (stale-while-revalidate);
+//   • the globally-scoped passes (waveform, discovery) are memoised once
+//     for all library signatures — their counts don't vary by caller;
+//   • only the FIRST request for a signature (or force:true) pays a
+//     synchronous full compute — there is nothing stale to serve yet.
+// Freshness at pass/scan boundaries still comes from
+// invalidateCoverageCache(), which also discards any refresh that was
+// mid-flight when the world changed.
 
 import fs from 'fs';
 import path from 'path';
@@ -44,7 +57,7 @@ const ACOUSTID_MAX_DURATION_SEC = 2 * 60 * 60;
 // recomputed the whole snapshot. Freshness at pass/scan boundaries comes
 // from invalidateCoverageCache(), not the TTL — this only bounds staleness
 // of mid-pass counts.
-const CACHE_TTL_MS = 15_000;
+const CACHE_TTL_MS = Number(process.env.MSTREAM_TEST_COVERAGE_TTL_MS) || 15_000;
 const WAVEFORM_FS_TTL_MS = 60_000;
 
 // key = sorted libIds signature → { at, data }. Bounded: a burst of
@@ -55,11 +68,24 @@ const COVERAGE_CACHE_MAX_ENTRIES = 64;
 
 let waveformFsCache = { at: 0, bins: 0, failed: 0 };
 
+// Globally-scoped pass results (waveform, discovery) — identical for
+// every library signature, so they're computed once per TTL window
+// instead of once per signature.
+let globalPassCache = { at: 0, values: {} };
+
+// Refreshes in flight (per signature) + a generation counter: a refresh
+// started before invalidateCoverageCache() must not land its
+// now-outdated snapshot as fresh.
+const refreshing = new Set();
+let cacheGeneration = 0;
+
 // Tests poke config/library state between calls; give them (and the
 // admin force-refresh, if one ever ships) a way to drop the memo.
 export function invalidateCoverageCache() {
   coverageCache.clear();
+  globalPassCache = { at: 0, values: {} };
   waveformFsCache = { at: 0, bins: 0, failed: 0 };
+  cacheGeneration++;
 }
 
 // `library_id IN (...)` filter for the caller's accessible libraries —
@@ -327,12 +353,94 @@ function discoveryCoverage() {
   };
 }
 
+// ── Compute + caching machinery ─────────────────────────────────────────────
+
+// One builder failing (locked discovery.db, mid-migration schema) nulls
+// out its pass, never the endpoint.
+function guard(label, fn) {
+  try { return fn(); } catch (err) {
+    winston.warn(`enrichment coverage: ${label} counts failed: ${err.message}`);
+    return null;
+  }
+}
+
+// Waveform + discovery counts ignore the caller's libraries entirely
+// (hash-keyed cache files / the separate discovery.db), so one result
+// serves every signature for a TTL window.
+function globalPass(label, now, fn) {
+  if (now - globalPassCache.at > CACHE_TTL_MS) {
+    globalPassCache = { at: now, values: {} };
+  }
+  if (!(label in globalPassCache.values)) {
+    globalPassCache.values[label] = guard(label, fn);
+  }
+  return globalPassCache.values[label];
+}
+
+// The compute, expressed as an ordered step list so the synchronous
+// first-call path and the chunked background refresh share one
+// definition. Each step assigns into `data` when it runs.
+function coverageSteps(d, ids, data) {
+  const lib = libClause('t.library_id', ids);
+  return [
+    () => { data.totals = guard('totals', () => ({
+      tracks: d.prepare(`SELECT COUNT(*) AS n FROM tracks t WHERE ${lib.clause}`)
+        .get(...lib.params).n,
+    })); },
+    () => { data.passes.waveform = globalPass('waveform', Date.now(), () => waveformCoverage(d, Date.now())); },
+    () => { data.passes.albumart = guard('albumart', () => albumartCoverage(d, ids)); },
+    () => { data.passes.lyrics = guard('lyrics', () => lyricsCoverage(d, ids)); },
+    () => { data.passes.audioanalysis = guard('audioanalysis', () => audioAnalysisCoverage(d, ids)); },
+    () => { data.passes.discovery = globalPass('discovery', Date.now(), () => discoveryCoverage()); },
+    () => { data.passes.acoustid = guard('acoustid', () => acoustidCoverage(d, ids)); },
+  ];
+}
+
+function storeEntry(key, data) {
+  if (coverageCache.size >= COVERAGE_CACHE_MAX_ENTRIES) { coverageCache.clear(); }
+  coverageCache.set(key, { at: Date.now(), data });
+}
+
+function computeSync(d, ids) {
+  const data = { passes: {} };
+  for (const step of coverageSteps(d, ids, data)) { step(); }
+  return data;
+}
+
+// Background refresh for a signature whose memo went stale: one builder
+// per event-loop tick, so no single tick blocks longer than the slowest
+// builder (~100 ms at 25k vs 0.5–2 s for the whole snapshot). The
+// generation check discards the result if the world changed mid-flight
+// (a pass finished, a scan landed) — the stale-serving caller already
+// scheduled a fresh refresh under the new generation by then.
+async function refreshInBackground(key, ids) {
+  if (refreshing.has(key)) { return; }
+  refreshing.add(key);
+  const startedGeneration = cacheGeneration;
+  try {
+    const d = db.getDB();
+    if (!d) { return; }
+    const data = { passes: {} };
+    for (const step of coverageSteps(d, ids, data)) {
+      step();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    if (cacheGeneration === startedGeneration) { storeEntry(key, data); }
+  } catch (err) {
+    winston.warn(`enrichment coverage: background refresh failed: ${err.message}`);
+  } finally {
+    refreshing.delete(key);
+  }
+}
+
 // ── Public API ──────────────────────────────────────────────────────────────
 
 // Coverage for every enrichment pass, memoised per accessible-library
 // set. Returns { totals: { tracks }, passes: { <kind>: {...}|null } };
 // null for the whole thing only when the library DB isn't open.
-// `force` drops the memo first (tests; admin refresh).
+// `force` drops the memo first and recomputes synchronously (tests;
+// admin refresh). A stale memo is served as-is while a chunked refresh
+// runs off-request — see the header comment.
 export function getEnrichmentCoverage(libIds, { force = false } = {}) {
   const d = db.getDB();
   if (!d) { return null; }
@@ -343,33 +451,15 @@ export function getEnrichmentCoverage(libIds, { force = false } = {}) {
   if (force) { coverageCache.delete(key); }
   const hit = coverageCache.get(key);
   if (hit && now - hit.at <= CACHE_TTL_MS) { return hit.data; }
+  if (hit) {
+    // Stale-while-revalidate: the poll gets the stale counts instantly;
+    // the next poll (or the one after) sees the refreshed ones.
+    refreshInBackground(key, ids);
+    return hit.data;
+  }
 
-  // One builder failing (locked discovery.db, mid-migration schema)
-  // nulls out its pass, never the endpoint.
-  const guard = (label, fn) => {
-    try { return fn(); } catch (err) {
-      winston.warn(`enrichment coverage: ${label} counts failed: ${err.message}`);
-      return null;
-    }
-  };
-
-  const lib = libClause('t.library_id', ids);
-  const data = {
-    totals: guard('totals', () => ({
-      tracks: d.prepare(`SELECT COUNT(*) AS n FROM tracks t WHERE ${lib.clause}`)
-        .get(...lib.params).n,
-    })),
-    passes: {
-      waveform: guard('waveform', () => waveformCoverage(d, now)),
-      albumart: guard('albumart', () => albumartCoverage(d, ids)),
-      lyrics: guard('lyrics', () => lyricsCoverage(d, ids)),
-      audioanalysis: guard('audioanalysis', () => audioAnalysisCoverage(d, ids)),
-      discovery: guard('discovery', () => discoveryCoverage()),
-      acoustid: guard('acoustid', () => acoustidCoverage(d, ids)),
-    },
-  };
-
-  if (coverageCache.size >= COVERAGE_CACHE_MAX_ENTRIES) { coverageCache.clear(); }
-  coverageCache.set(key, { at: now, data });
+  // First sight of this signature (or force): nothing stale to serve.
+  const data = computeSync(d, ids);
+  storeEntry(key, data);
   return data;
 }

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -78,7 +78,7 @@ import { HASH_GENERATION } from './audio-hash.js';
 // (stream_kbps / daily_mb / max_streams, 0 = unlimited; expires_at, NULL =
 // never) and the federation_key_usage per-day byte/request counters that
 // back the daily quota and the admin usage readout. See SCHEMA_V62.
-export const SCHEMA_VERSION = 62;
+export const SCHEMA_VERSION = 63;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2338,6 +2338,17 @@ export const SCHEMA_V62 = `
   );
 `;
 
+// Library deletes cascade into cue_points (library_id ON DELETE CASCADE)
+// and null out play_events.library_id (ON DELETE SET NULL). Neither table
+// indexed library_id — cue_points only has it as the SECOND column of
+// idx_cue_points_file — so every library delete paid a full scan of both
+// tables, and play_events grows without bound (2026-07 audit H2; part of
+// a 5.7 s writer-lock hold at 20k tracks).
+export const SCHEMA_V63 = `
+  CREATE INDEX IF NOT EXISTS idx_cue_points_library ON cue_points(library_id);
+  CREATE INDEX IF NOT EXISTS idx_play_events_library ON play_events(library_id);
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2709,4 +2720,7 @@ export const MIGRATIONS = [
   // federation_key_usage per-day counters behind the daily quota. Additive
   // columns + a new empty table — no rescan needed. See SCHEMA_V62.
   { version: 62, sql: SCHEMA_V62 },
+  // V63 indexes the two library_id foreign keys the library-delete cascade
+  // walks. Index-only, no rescan. See SCHEMA_V63.
+  { version: 63, sql: SCHEMA_V63 },
 ];

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -443,7 +443,33 @@ function checkQueueDrainedSideEffects() {
 // any failure leaves the ledger in place for the next drain. Covered
 // end-to-end (real drain hook, real discovery.db, discovery-off server)
 // by test/integration/hash-transition-applier.test.mjs.
-function applyHashTransitions() {
+//
+// Async + chunked since the 2026-07 audit (M1): the first drain of a
+// hash epoch used to apply the whole ledger as one synchronous
+// transaction (~4.4 s at 15k transitions) and then walk a sync rename
+// loop that threw ~15k ENOENTs (~44 s on NTFS) — all on the event loop.
+// Now the discovery re-key commits in bounded chunks with a yield
+// between them, and the waveform re-key enumerates the cache dir ONCE
+// and only touches files that exist, through fs.promises. The ledger
+// DELETE still happens only after everything applied; a crash mid-way
+// re-applies cleanly (moved groups have no live sources → no-ops).
+let hashTransitionsInFlight = false;
+// 250 groups ≈ 250 ms of block per chunk on the rig (each move pays a
+// per-row export-id re-derivation); 500 measured ~2× that.
+const HASH_TRANSITION_CHUNK = 250;
+const RENAME_CONCURRENCY = 16;
+
+async function applyHashTransitions() {
+  if (hashTransitionsInFlight) { return; }
+  hashTransitionsInFlight = true;
+  try {
+    await applyHashTransitionsInner();
+  } finally {
+    hashTransitionsInFlight = false;
+  }
+}
+
+async function applyHashTransitionsInner() {
   try {
     const mdb = db.getDB();
     if (!mdb) { return; }
@@ -486,11 +512,22 @@ function applyHashTransitions() {
     // openDiscoveryDbIfExists, NOT the throwing getter: with the feature
     // off (the default) the ledger must still drain — and a dormant
     // discovery.db left by a since-disabled collection still gets its
-    // embeddings re-keyed rather than stranded.
+    // embeddings re-keyed rather than stranded. Chunked: each slice is
+    // its own transaction (applyHashTransitionGroups keeps its
+    // atomicity per chunk; re-applying an already-moved group is a
+    // no-op) with a yield between slices so the event loop breathes.
     const ddb = discoveryDb.openDiscoveryDbIfExists();
-    const applied = ddb
-      ? discoveryDb.applyHashTransitionGroups(groupList)
-      : null;
+    let applied = null;
+    if (ddb) {
+      applied = { moved: 0, dropped: 0 };
+      for (let i = 0; i < groupList.length; i += HASH_TRANSITION_CHUNK) {
+        const part = discoveryDb.applyHashTransitionGroups(
+          groupList.slice(i, i + HASH_TRANSITION_CHUNK));
+        applied.moved += part.moved;
+        applied.dropped += part.dropped;
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    }
 
     // Waveform cache artifacts follow the re-key on disk ({hash}.bin +
     // {hash}.failed). Done HERE, not scanner-side: the drain runs after
@@ -500,22 +537,55 @@ function applyHashTransitions() {
     // engine, and the live config supplies the directory (the scan
     // payload's waveformCacheDir is a stale-binary transition field).
     // Same-content sources share one waveform, so first-in wins and
-    // later sources are dropped; every step tolerates missing files.
+    // later sources are dropped.
+    //
+    // The dir is enumerated ONCE and only files that exist are touched —
+    // the old per-source existsSync/rename walk threw ~15k ENOENTs per
+    // drain (most re-keyed tracks have no waveform yet) at ~3 ms per
+    // sync syscall on NTFS. What remains runs through fs.promises with
+    // bounded concurrency.
     const waveDir = config.program?.storage?.waveformCacheDirectory;
+    let renamed = 0;
     if (waveDir) {
-      for (const { target, sources } of groupList) {
-        for (const src of sources) {
-          for (const toPath of [waveformLib.cacheFilePath, waveformLib.failedMarkerPath]) {
-            try {
+      let present = null;
+      try { present = new Set(await fs.promises.readdir(waveDir)); }
+      catch (err) {
+        if (err.code !== 'ENOENT') {
+          winston.warn(`Waveform cache re-key: dir unreadable: ${err.message}`);
+        }
+      }
+      if (present) {
+        const ops = [];
+        for (const { target, sources } of groupList) {
+          for (const src of sources) {
+            for (const toPath of [waveformLib.cacheFilePath, waveformLib.failedMarkerPath]) {
               const from = toPath(waveDir, src);
-              if (fs.existsSync(toPath(waveDir, target))) { fs.unlinkSync(from); }
-              else { fs.renameSync(from, toPath(waveDir, target)); }
-            } catch (err) {
-              if (err.code !== 'ENOENT') {
-                winston.warn(`Waveform cache re-key ${src} → ${target} failed: ${err.message}`);
+              const to = toPath(waveDir, target);
+              const fromName = path.basename(from);
+              if (!present.has(fromName)) { continue; }
+              const toName = path.basename(to);
+              if (present.has(toName)) {
+                ops.push({ kind: 'unlink', from });
+              } else {
+                ops.push({ kind: 'rename', from, to });
+                present.add(toName);   // later sources of this target unlink
               }
+              present.delete(fromName);
             }
           }
+        }
+        for (let i = 0; i < ops.length; i += RENAME_CONCURRENCY) {
+          await Promise.all(ops.slice(i, i + RENAME_CONCURRENCY).map(async (op) => {
+            try {
+              if (op.kind === 'unlink') { await fs.promises.unlink(op.from); }
+              else { await fs.promises.rename(op.from, op.to); }
+              renamed++;
+            } catch (err) {
+              if (err.code !== 'ENOENT') {
+                winston.warn(`Waveform cache re-key ${op.from} failed: ${err.message}`);
+              }
+            }
+          }));
         }
       }
     }
@@ -523,7 +593,8 @@ function applyHashTransitions() {
     mdb.prepare('DELETE FROM hash_transitions').run();
     winston.info(`Applied ${rows.length} hash transition(s) (${groupList.length} identity group(s))`
       + (applied ? ` — discovery rows moved: ${applied.moved}, superseded: ${applied.dropped}`
-        : ' (discovery inactive — drained)'));
+        : ' (discovery inactive — drained)')
+      + (renamed > 0 ? `; ${renamed} waveform artifact(s) re-keyed` : ''));
   } catch (err) {
     winston.warn(`Hash-transition apply failed (will retry on next drain): ${err.message}`);
   }

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -106,6 +106,39 @@ export async function setLibraryFollowSymlinks(vpath, followSymlinks) {
   db.invalidateCache();
 }
 
+// Delete a library's rows: tracks first in bounded chunks, then the
+// libraries row. The single cascading DELETE used to remove 20k+ track
+// rows (each firing the FTS5 sync triggers) in ONE statement — 5.7 s of
+// synchronous main-thread work holding the writer lock past other
+// writers' 5 s busy_timeout (2026-07 audit H2). Chunking bounds each lock
+// hold AND each event-loop block to one chunk; the yield between chunks
+// lets queued handlers (and other writers) interleave. Total work is
+// unchanged — the FTS triggers still fire per row.
+//
+// Mid-delete visibility: a browser hitting this library sees it shrink
+// for a few seconds instead of vanishing atomically. Acceptable for an
+// admin-initiated delete that reboots the server at the end anyway; a
+// crash mid-way leaves a partial library the re-run (or next scan)
+// handles like any other library.
+//
+// Exported separately from removeDirectory (which also cancels backups
+// and reboots the server) so the delete mechanics are testable on a bare
+// DB.
+export async function deleteLibraryRows(d, libraryId) {
+  const deleteChunk = d.prepare(
+    'DELETE FROM tracks WHERE id IN (SELECT id FROM tracks WHERE library_id = ? LIMIT 500)');
+  for (;;) {
+    const { changes } = deleteChunk.run(libraryId);
+    if (changes === 0) { break; }
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  // CASCADE handles what's left: user_libraries, cue_points (indexed by
+  // V63), backup_destinations + their backup_history, and the SET NULL
+  // sweep over play_events.library_id (also indexed by V63 — this was a
+  // full ever-growing-table scan before).
+  d.prepare('DELETE FROM libraries WHERE id = ?').run(libraryId);
+}
+
 export async function removeDirectory(vpath) {
   const library = db.getLibraryByName(vpath);
   if (!library) { throw new Error(`'${vpath}' not found`); }
@@ -131,9 +164,7 @@ export async function removeDirectory(vpath) {
   }
 
   const d = db.getDB();
-  // CASCADE will delete tracks and user_libraries entries
-  // (and backup_destinations + their backup_history).
-  d.prepare('DELETE FROM libraries WHERE id = ?').run(library.id);
+  await deleteLibraryRows(d, library.id);
 
   // Clean up orphan albums / artists / genres left over after the
   // tracks cascade. Chunked + commits per chunk so the multi-second

--- a/test/db/status-admin-heavy.test.mjs
+++ b/test/db/status-admin-heavy.test.mjs
@@ -1,0 +1,234 @@
+/**
+ * Tests for the status/admin heavy-hitter fixes (audit PR-E: H6, H2, M1,
+ * M3):
+ *
+ *   - V63 puts library_id indexes on cue_points + play_events, and the
+ *     discovery V2 partial index backs the coverage counts;
+ *   - getEnrichmentCoverage serves STALE data on TTL expiry and refreshes
+ *     off-request (stale-while-revalidate), memoises the globally-scoped
+ *     passes across library signatures, and force:true still recomputes
+ *     synchronously;
+ *   - deleteLibraryRows removes >chunk-size libraries fully (tracks,
+ *     cascades, play_events SET NULL) without a single monolithic DELETE;
+ *   - POST /api/v1/share caps the playlist at the producer, and
+ *     GET /api/v1/admin/db/shared returns counts, never blobs (live
+ *     server).
+ *
+ * The M1 drain (chunked + async hash-transition apply) keeps its coverage
+ * in test/integration/hash-transition-applier.test.mjs, which runs the
+ * real drain hook end-to-end.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { startServer } from '../helpers/server.mjs';
+
+// Captured at import by enrichment-status-lib.js — set before the dynamic
+// imports below. Long enough that back-to-back calls in one test stay
+// inside the window, short enough that "aging out" is a quick sleep.
+process.env.MSTREAM_TEST_COVERAGE_TTL_MS = '150';
+
+let testRoot;
+let config, manager, ddb, coverage, adminUtil;
+let L1, L2, L3;
+
+before(async () => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-pre-'));
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+      waveformCacheDirectory: path.join(testRoot, 'waveforms'),
+    },
+    port: 0,
+  }, null, 2));
+
+  config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  manager = await import('../../src/db/manager.js');
+  manager.initDB();
+  ddb = await import('../../src/db/discovery-db.js');
+  ddb.initDiscoveryDb(path.join(testRoot, 'db', 'discovery.db'));
+  coverage = await import('../../src/db/enrichment-status-lib.js');
+  adminUtil = await import('../../src/util/admin.js');
+
+  const d = manager.getDB();
+  d.exec('BEGIN');
+  for (const name of ['lib1', 'lib2', 'lib3']) {
+    d.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks)
+               VALUES (?, ?, 'music', 0)`).run(name, path.join(testRoot, name));
+  }
+  manager.invalidateCache();
+  L1 = d.prepare("SELECT id FROM libraries WHERE name='lib1'").get().id;
+  L2 = d.prepare("SELECT id FROM libraries WHERE name='lib2'").get().id;
+  L3 = d.prepare("SELECT id FROM libraries WHERE name='lib3'").get().id;
+  const ins = d.prepare('INSERT INTO tracks (filepath, library_id, title) VALUES (?, ?, ?)');
+  for (let i = 0; i < 5; i++) { ins.run(`a${i}.mp3`, L1, `A${i}`); }
+  for (let i = 0; i < 3; i++) { ins.run(`b${i}.mp3`, L2, `B${i}`); }
+  d.exec('COMMIT');
+});
+
+after(() => {
+  try { manager.close(); } catch (_e) { /* closed */ }
+  try { ddb.closeDiscoveryDb(); } catch (_e) { /* closed */ }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_e) { /* win locks */ }
+  setImmediate(() => process.exit(0));
+});
+
+// ── migrations ──────────────────────────────────────────────────────────────
+
+describe('V63 + discovery V2 indexes', () => {
+  test('library_id indexes exist on cue_points and play_events', () => {
+    const names = manager.getDB().prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name IN "
+      + "('idx_cue_points_library','idx_play_events_library')"
+    ).all().map((r) => r.name).sort();
+    assert.deepEqual(names, ['idx_cue_points_library', 'idx_play_events_library']);
+  });
+
+  test('discovery.db lands at V2 with the embedded-model partial index', () => {
+    const d2 = ddb.getDiscoveryDb();
+    assert.equal(d2.prepare('PRAGMA user_version').get().user_version, 2);
+    const idx = d2.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_discovery_tracks_embedded_model'"
+    ).get();
+    assert.ok(idx, 'partial index present');
+    assert.match(idx.sql, /WHERE embedding IS NOT NULL/);
+  });
+});
+
+// ── H6: stale-while-revalidate coverage ─────────────────────────────────────
+
+describe('getEnrichmentCoverage caching', () => {
+  test('fresh window serves the memo; expiry serves STALE and refreshes off-request', async () => {
+    coverage.invalidateCoverageCache();
+    const c1 = coverage.getEnrichmentCoverage([L1]);
+    assert.equal(c1.totals.tracks, 5);
+    assert.equal(coverage.getEnrichmentCoverage([L1]), c1, 'inside the TTL: same object');
+
+    // Change the world, age the memo out.
+    manager.getDB().prepare("INSERT INTO tracks (filepath, library_id, title) VALUES ('a5.mp3', ?, 'A5')")
+      .run(L1);
+    await sleep(200);   // > MSTREAM_TEST_COVERAGE_TTL_MS
+
+    const stale = coverage.getEnrichmentCoverage([L1]);
+    assert.equal(stale, c1, 'expired memo is served AS-IS — the poll never blocks on a recompute');
+    assert.equal(stale.totals.tracks, 5, 'still the old count');
+
+    // The chunked background refresh lands within a few ticks.
+    let fresh;
+    for (let i = 0; i < 50; i++) {
+      await sleep(20);
+      fresh = coverage.getEnrichmentCoverage([L1]);
+      if (fresh !== c1) { break; }
+    }
+    assert.notEqual(fresh, c1, 'background refresh replaced the memo');
+    assert.equal(fresh.totals.tracks, 6, 'and it sees the new track');
+  });
+
+  test('globally-scoped passes are shared across library signatures', () => {
+    coverage.invalidateCoverageCache();
+    const a = coverage.getEnrichmentCoverage([L1]);
+    const b = coverage.getEnrichmentCoverage([L2]);
+    assert.notEqual(a, b, 'different signatures, different snapshots');
+    assert.equal(a.passes.waveform, b.passes.waveform,
+      'waveform counts computed once for both signatures');
+    assert.equal(a.passes.discovery, b.passes.discovery,
+      'discovery counts computed once for both signatures');
+    assert.equal(a.totals.tracks, 6);
+    assert.equal(b.totals.tracks, 3, 'library-scoped counts still differ');
+  });
+
+  test('force recomputes synchronously', () => {
+    const before_ = coverage.getEnrichmentCoverage([L1]);
+    manager.getDB().prepare("INSERT INTO tracks (filepath, library_id, title) VALUES ('a6.mp3', ?, 'A6')")
+      .run(L1);
+    const forced = coverage.getEnrichmentCoverage([L1], { force: true });
+    assert.notEqual(forced, before_);
+    assert.equal(forced.totals.tracks, 7, 'force sees the write immediately');
+  });
+});
+
+// ── H2: chunked library delete ──────────────────────────────────────────────
+
+describe('deleteLibraryRows', () => {
+  test('removes a >chunk-size library fully, cascades intact', async () => {
+    const d = manager.getDB();
+    d.exec('BEGIN');
+    const insT = d.prepare('INSERT INTO tracks (filepath, library_id, title) VALUES (?, ?, ?)');
+    for (let i = 0; i < 1200; i++) { insT.run(`c${i}.mp3`, L3, `C${i}`); }
+    d.prepare(`INSERT INTO users (username, password, salt) VALUES ('pe-user', 'x', 'y')`).run();
+    const uid = d.prepare("SELECT id FROM users WHERE username='pe-user'").get().id;
+    d.prepare(`INSERT INTO cue_points (filepath, library_id, position) VALUES ('c0.mp3', ?, 1.5)`).run(L3);
+    d.prepare(`INSERT INTO play_events (event_id, user_id, filepath, library_id)
+               VALUES ('pe-evt-1', ?, 'c0.mp3', ?)`).run(uid, L3);
+    d.exec('COMMIT');
+
+    await adminUtil.deleteLibraryRows(d, L3);
+
+    assert.equal(d.prepare('SELECT COUNT(*) AS n FROM tracks WHERE library_id = ?').get(L3).n, 0);
+    assert.equal(d.prepare('SELECT COUNT(*) AS n FROM libraries WHERE id = ?').get(L3).n, 0);
+    assert.equal(d.prepare('SELECT COUNT(*) AS n FROM cue_points WHERE library_id = ?').get(L3).n, 0,
+      'cue_points cascade');
+    const pe = d.prepare("SELECT library_id FROM play_events WHERE event_id = 'pe-evt-1'").get();
+    assert.ok(pe, 'play event survives the library');
+    assert.equal(pe.library_id, null, 'library_id nulled by the cascade');
+    // Other libraries untouched.
+    assert.equal(d.prepare('SELECT COUNT(*) AS n FROM tracks WHERE library_id = ?').get(L1).n, 7);
+  });
+});
+
+// ── M3: share producer cap + admin listing shape (live server) ──────────────
+
+describe('shared playlists: producer cap + admin listing', () => {
+  let server;
+  let token;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: true,
+      users: [{ username: 'admin', password: 'pw', admin: true }],
+    });
+    const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'admin', password: 'pw' }),
+    });
+    token = (await r.json()).token;
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  const post = (route, body) => fetch(`${server.baseUrl}${route}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', 'x-access-token': token },
+    body: JSON.stringify(body),
+  });
+
+  test('a normal share is accepted; the admin list carries counts, never blobs', async () => {
+    const r = await post('/api/v1/share', { playlist: ['testlib/a.mp3', 'testlib/b.mp3'] });
+    assert.equal(r.status, 200);
+    const { playlistId } = await r.json();
+    assert.ok(playlistId);
+
+    const list = await fetch(`${server.baseUrl}/api/v1/admin/db/shared`, {
+      headers: { 'x-access-token': token } });
+    assert.equal(list.status, 200);
+    const rows = await list.json();
+    const mine = rows.find((x) => x.playlistId === playlistId);
+    assert.ok(mine, 'share listed');
+    assert.equal(mine.trackCount, 2, 'count travels');
+    assert.equal(mine.user, 'admin');
+    assert.ok(!('playlist' in mine), 'the blob itself never leaves the DB');
+  });
+
+  test('an oversized share is rejected at the producer', async () => {
+    const r = await post('/api/v1/share', {
+      playlist: Array.from({ length: 5001 }, (_, i) => `testlib/x${i}.mp3`),
+    });
+    assert.equal(r.status, 400);
+  });
+});


### PR DESCRIPTION
Audit **PR-E** (findings H6, H2, M1, M3): the admin-facing and status-path heavy hitters. Numbers from a 25k-track fixture (20k for the delete leg), Windows/NTFS — the audit's worst case for the rename leg.

## H6 — coverage recompute on the request path

`GET /api/v1/scan/status` (not admin-only; the dashboard polls every 4s) recomputed the full coverage snapshot **on the request** at every TTL expiry — ~8 aggregate passes plus the discovery.db counts (~0.4s warm, 1.2–1.8s cold on the audit fixture; the header comment claimed "single-digit ms", off ~100×). Now:

- **Stale-while-revalidate**: an expired memo is served as-is, and a chunked refresh runs off-request — one builder per event-loop tick, so no tick blocks longer than the slowest single builder. A generation counter discards refreshes that raced a pass-boundary invalidation.
- **Global-pass sharing**: waveform and discovery counts don't vary by caller, so they're computed once per TTL window across all library signatures.
- **Discovery V2 migration**: a `(model_id, audio_hash) WHERE embedding IS NOT NULL` partial index serves both the done-count and the eligibility probe without touching blob-laden pages — that's the cold-cache killer (warm, the difference shrinks; which is exactly why the request path also went SWR).

**Steady-state request cost: 0 ms.** Only first-sight-of-a-signature and `force` pay a synchronous compute.

## H2 — library delete held the writer lock for seconds

One cascading `DELETE FROM libraries` removed 20k+ track rows (each firing FTS5 triggers) in a single statement — 5.7s at audit scale, holding the writer lock past other writers' 5s `busy_timeout` → concurrent `SQLITE_BUSY`. The cascade also **full-scanned** `play_events` (never pruned, grows forever) and `cue_points` for their `library_id` legs.

Now `deleteLibraryRows()`: tracks in 500-row chunks with yields, then the libraries row; **V63 indexes both `library_id` FKs**. Rig: 474ms solid lock hold → **max 64ms block**. (Total wall grows ~3× — the FTS work is unchanged, just bounded — a fine trade for an admin op.)

## M1 — the hash-transition drain

The first drain of a V60 hash epoch applied the whole ledger as one transaction (4.5s solid block at 15k transitions) and then walked a sync rename loop that threw ~57k ENOENTs (10s on the NTFS rig; the audit measured 44s). Now async + chunked:

- discovery re-keys commit in 250-group slices with yields (**max block ~200ms**), and rowversions are reserved as **one UPDATE per slice** instead of one per moved row;
- the waveform re-key enumerates the cache dir **once** and only touches files that exist, through `fs.promises` with bounded concurrency: **renames 10.1s → 1.8s**;
- the ledger DELETE still happens only after everything applied; re-application stays idempotent, and an in-flight guard prevents overlapping drains.

## M3 — `/admin/db/shared` shipped every blob

The route fetched + `JSON.parse`d + re-stringified **every share's full track list** — and blob volume is controlled by *non-admin* users. At 200 shares × 5k tracks: 284ms and a **36.8 MB** response. Now `json_array_length` (guarded by `json_valid` so corrupt shares stay listable/deletable): **59ms and 24 KB**, response carries `trackCount`, never the blob (neither admin UI ever rendered it). `POST /api/v1/share` now also caps the playlist at the producer (5000 items × 4096 chars).

## Migrations

- **mstream.db V63** — two FK indexes, index-only, no rescan.
- **discovery.db V2** — the partial index, its first migration past V1.

## Tests

New `test/db/status-admin-heavy.test.mjs` (8 cases): both migrations' indexes present; SWR serve-stale-then-refresh (TTL env knob) with the background refresh observed landing; global-pass sharing across signatures; `force` sync recompute; chunked delete at 1200 rows with the cue_points cascade and play_events SET-NULL pinned; the share cap 400; and the admin listing shape blob-free on a live server. The drain keeps its end-to-end coverage in `hash-transition-applier.test.mjs`, now exercising the async path. **~250 tests green** across the affected ring (status ×3, task-queue, hash-transition, discovery ×6, admin ×3, migrations); changed files lint clean — and the ring's lint pass caught a dangling reference in the `removeDirectory` refactor before it shipped.

With E landed, the audit's remaining items are the opt-in surfaces: G (subsonic), H (DLNA), I (wrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)