### PR TITLE
perf(dlna): stop enumerating network adapters per DIDL item, memoize the browse surface, bound Search

### DIFF
--- a/src/api/dlna.js
+++ b/src/api/dlna.js
@@ -23,6 +23,16 @@ const subscribers = new Map();
 // consuming excessive memory (~5MB at 512 bytes/item and this cap).
 const MAX_BROWSE_COUNT = 10000;
 
+// UPnP lets the server pick the page size when RequestedCount is 0. Browse
+// keeps MAX_BROWSE_COUNT there — a renderer drilling into a container expects
+// its listing, and some don't page. Search is a different shape: it spans the
+// whole server rather than one container, `SearchCriteria` of '*' matches
+// every track, and the action is only ever issued by control points that do
+// page. Choosing a page rather than 10,000 items keeps one unauthenticated
+// SOAP request from assembling a multi-megabyte DIDL document. An explicit
+// RequestedCount is still honoured, up to MAX_BROWSE_COUNT.
+const DEFAULT_SEARCH_COUNT = 500;
+
 // Hard cap on concurrent GENA subscribers. Each entry is tiny but we still
 // don't want a malicious client to grow the Map without bound by SUBSCRIBEing
 // repeatedly without UNSUBSCRIBEing.
@@ -54,6 +64,76 @@ function libraryIndex(libraries) {
   return m;
 }
 
+// ── Browse memos ─────────────────────────────────────────────────────────────
+//
+// Two caches with two different invalidation signals, because the browse
+// surface has two kinds of expensive question.
+//
+// 1. Library shape (artists, album-artists, albums, genres, track count, the
+//    sorted filepath list). One click on a library container runs six of
+//    these whole-library aggregates, and every folder click re-reads and
+//    re-sorts the library's entire filepath list — none of which changes
+//    until a scan changes the library. That is exactly what SystemUpdateID
+//    already signals to control points, so key on it. The TTL is a safety
+//    net rather than the invalidation: anything that edits a library WITHOUT
+//    bumping SystemUpdateID goes stale for at most a minute instead of until
+//    the next scan.
+//
+// 2. Smart-container totals (Recently Played, Most Played, Favorites,
+//    Shuffle, Recently Added, By Year, Playlists). These aggregate play
+//    history and ratings, which move on every scrobble and never touch
+//    SystemUpdateID — so they get a short time memo instead. Its job is to
+//    collapse the burst: one root-container click runs nine of these, and
+//    renderers re-browse the root constantly as the user navigates.
+//
+// Callers MUST treat the returned arrays as read-only — they are shared.
+// Both windows are test-overridable so a suite can make a direct DB edit
+// visible without sleeping one out; `0` disables the memo entirely.
+const TEST_CACHE_TTL_MS = process.env.MSTREAM_TEST_DLNA_CACHE_TTL_MS;
+const LIB_CACHE_TTL_MS = TEST_CACHE_TTL_MS !== undefined ? Number(TEST_CACHE_TTL_MS) : 60_000;
+const SMART_CACHE_TTL_MS = TEST_CACHE_TTL_MS !== undefined ? Number(TEST_CACHE_TTL_MS) : 5000;
+// Seven entry kinds per library, so this holds ~9 libraries' worth. The
+// filepath list is the only large one (~100 bytes/track); retaining one copy
+// per browsed library costs what the uncached code allocated and threw away
+// on every single click.
+const LIB_CACHE_MAX_ENTRIES = 64;
+
+const libCache = new Map();
+// Fixed, finite key set (one per smart container), so no eviction needed.
+const smartCache = new Map();
+
+function libMemo(key, build) {
+  const hit = libCache.get(key);
+  if (hit && hit.updateId === systemUpdateID && Date.now() - hit.at < LIB_CACHE_TTL_MS) {
+    libCache.delete(key);           // LRU: re-insert so the freshest key is last
+    libCache.set(key, hit);
+    return hit.value;
+  }
+  const value = build();
+  libCache.delete(key);
+  libCache.set(key, { updateId: systemUpdateID, at: Date.now(), value });
+  while (libCache.size > LIB_CACHE_MAX_ENTRIES) {
+    libCache.delete(libCache.keys().next().value);
+  }
+  return value;
+}
+
+function smartMemo(key, build) {
+  const hit = smartCache.get(key);
+  if (hit && Date.now() - hit.at < SMART_CACHE_TTL_MS) { return hit.value; }
+  const value = build();
+  smartCache.set(key, { at: Date.now(), value });
+  return value;
+}
+
+// Drop both memos. Called on every SystemUpdateID bump (a scan changed the
+// library) so the retained filepath lists are released immediately rather
+// than lingering until their keys are next probed; also the test hook.
+export function invalidateBrowseCaches() {
+  libCache.clear();
+  smartCache.clear();
+}
+
 // ── XML / SOAP helpers ───────────────────────────────────────────────────────
 
 // Characters forbidden in XML 1.0 content: C0 control chars except TAB, LF, CR.
@@ -71,18 +151,43 @@ const XML_LONE_HIGH_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g;
 const XML_LONE_LOW_SURROGATE = /(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
 const XML_NONCHARS = /[\uFFFE\uFFFF]/g;
 
-function xmlEscape(str) {
+// The union of the four strip regexes above, non-global, as a single probe.
+// The strip passes exist for mojibake-ridden ID3 tags, which is to say:
+// almost never. Probing once and skipping all four when nothing can match
+// turns the common case into two scans instead of nine \u2014 and xmlEscape runs
+// on every field of every DIDL element plus once over the whole assembled
+// document, so those scans add up over a 10,000-item response. The surrogate
+// alternatives carry the same lookarounds as the strip regexes so a legit
+// astral character (an emoji in a title) does NOT drag the response onto the
+// slow path.
+// eslint-disable-next-line no-control-regex
+const XML_NEEDS_STRIP = /[\x00-\x08\x0B\x0C\x0E-\x1F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+// The five entity replacements as one pass. Escaping is where the per-field
+// cost actually lives (many short strings), and one callback-driven pass
+// beats five chained ones by ~3\u00D7 there; over the multi-megabyte document it
+// is a further ~13%.
+const XML_ENTITIES = /[&<>"']/g;
+const XML_ENTITY_FOR = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' };
+const escapeEntities = (c) => XML_ENTITY_FOR[c];
+
+// Exported so the suite can pin the fast path against the nine-pass original
+// byte-for-byte — the whole premise of the probe is that output is unchanged.
+export function xmlEscape(str) {
   if (str == null) { return ''; }
-  return String(str)
-    .replace(XML_INVALID_CTRL, '')
-    .replace(XML_LONE_HIGH_SURROGATE, '')
-    .replace(XML_LONE_LOW_SURROGATE, '')
-    .replace(XML_NONCHARS, '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
+  const s = String(str);
+  // Strip-then-escape, exactly as before \u2014 the strip classes and the entity
+  // characters are disjoint, so skipping the strip passes when the probe
+  // misses is output-identical (pinned by the equivalence test).
+  if (XML_NEEDS_STRIP.test(s)) {
+    return s
+      .replace(XML_INVALID_CTRL, '')
+      .replace(XML_LONE_HIGH_SURROGATE, '')
+      .replace(XML_LONE_LOW_SURROGATE, '')
+      .replace(XML_NONCHARS, '')
+      .replace(XML_ENTITIES, escapeEntities);
+  }
+  return s.replace(XML_ENTITIES, escapeEntities);
 }
 
 // Reverse of xmlEscape — converts XML entities back to raw characters so
@@ -323,19 +428,25 @@ function viewContainer(libId, view, childCount) {
 function libraryViewContainers(libId) {
   const mode = config.program.dlna.browse || 'dirs';
   const order = VIEW_ORDER_BY_MODE[mode] || VIEW_ORDER_BY_MODE.dirs;
-  // Counts are required per UPnP. Folders needs a filepath scan — the others
-  // are fast aggregate queries.
-  const allTracks = getLibraryFilepaths(libId);
-  const { dirs: rootDirs, items: rootItems } = dirChildren(allTracks, '');
-  const counts = {
-    folders:      rootDirs.length + rootItems.length,
-    artists:      getLibraryArtists(libId).length,
-    albumartists: getLibraryAlbumArtists(libId).length,
-    albums:       getLibraryAlbums(libId).length,
-    genres:       getLibraryGenres(libId).length,
-    tracks:       allTracks.length,
-  };
-  return order.map(v => viewContainer(libId, v, counts[v]));
+  // The whole rendered listing is memoized, not just its inputs: this runs
+  // six whole-library aggregates and is the first thing a renderer asks for
+  // after picking a library. `browse` is part of the key because an admin
+  // can change the default view without a rescan.
+  return libMemo(`views:${mode}:${libId}`, () => {
+    // Counts are required per UPnP. Folders needs a filepath scan — the others
+    // are fast aggregate queries.
+    const allTracks = getLibraryFilepaths(libId);
+    const { dirs: rootDirs, items: rootItems } = dirChildren(allTracks, '');
+    const counts = {
+      folders:      rootDirs.length + rootItems.length,
+      artists:      getLibraryArtists(libId).length,
+      albumartists: getLibraryAlbumArtists(libId).length,
+      albums:       getLibraryAlbums(libId).length,
+      genres:       getLibraryGenres(libId).length,
+      tracks:       allTracks.length,
+    };
+    return order.map(v => viewContainer(libId, v, counts[v]));
+  });
 }
 
 // ── Music root & smart containers ────────────────────────────────────────────
@@ -403,10 +514,12 @@ function trackItem(track, lib, parentId) {
 // ── DB queries ───────────────────────────────────────────────────────────────
 
 function getLibraryTrackCount(libraryId) {
-  const row = db.getDB()
-    .prepare('SELECT COUNT(*) AS n FROM tracks WHERE library_id = ?')
-    .get(libraryId);
-  return row ? row.n : 0;
+  return libMemo(`count:${libraryId}`, () => {
+    const row = db.getDB()
+      .prepare('SELECT COUNT(*) AS n FROM tracks WHERE library_id = ?')
+      .get(libraryId);
+    return row ? row.n : 0;
+  });
 }
 
 function getLibraryTracks(libraryId, start, count, orderBy = 'al.name, t.disc_number, t.track_number, t.title') {
@@ -432,9 +545,9 @@ function getLibraryTracks(libraryId, start, count, orderBy = 'al.name, t.disc_nu
 // ever touches filepaths, so this fetches only those; getTracksByIds() below
 // fetches the full row (incl. genre) for just the items rendered on a page.
 function getLibraryFilepaths(libraryId) {
-  return db.getDB().prepare(
+  return libMemo(`paths:${libraryId}`, () => db.getDB().prepare(
     'SELECT t.id, t.filepath FROM tracks t WHERE t.library_id = ? ORDER BY t.filepath'
-  ).all(libraryId);
+  ).all(libraryId));
 }
 
 // Full DIDL columns (incl. the per-row primary-genre subquery) for a specific
@@ -457,7 +570,7 @@ function getTracksByIds(ids) {
 }
 
 function getLibraryArtists(libraryId) {
-  return db.getDB().prepare(`
+  return libMemo(`artists:${libraryId}`, () => db.getDB().prepare(`
     SELECT COALESCE(t.artist_id, 0) AS id,
            COALESCE(a.name, 'Unknown Artist') AS name,
            COUNT(DISTINCT COALESCE(t.album_id, 0)) AS album_count,
@@ -471,7 +584,7 @@ function getLibraryArtists(libraryId) {
     WHERE t.library_id = ?
     GROUP BY COALESCE(t.artist_id, 0)
     ORDER BY COALESCE(a.name, '') COLLATE NOCASE
-  `).all(libraryId);
+  `).all(libraryId));
 }
 
 // Targeted single-row lookups for BrowseMetadata. artistId=0 means "Unknown
@@ -547,7 +660,7 @@ function getAlbumTracks(libraryId, albumId) {
 }
 
 function getLibraryAlbums(libraryId) {
-  return db.getDB().prepare(`
+  return libMemo(`albums:${libraryId}`, () => db.getDB().prepare(`
     SELECT COALESCE(t.album_id, 0) AS id,
            COALESCE(al.name, 'Unknown Album') AS name,
            COUNT(*) AS track_count,
@@ -557,7 +670,7 @@ function getLibraryAlbums(libraryId) {
     WHERE t.library_id = ?
     GROUP BY COALESCE(t.album_id, 0)
     ORDER BY COALESCE(al.name, '') COLLATE NOCASE
-  `).all(libraryId);
+  `).all(libraryId));
 }
 
 // V34 helper: build the WHERE-clause condition for "track matches this
@@ -593,6 +706,10 @@ function trackGenreCondition(genre) {
 }
 
 function getLibraryGenres(libraryId) {
+  return libMemo(`genres:${libraryId}`, () => getLibraryGenresUncached(libraryId));
+}
+
+function getLibraryGenresUncached(libraryId) {
   // V34: read tagged genres via the M2M JOIN, plus a separate query
   // for the "Unknown Genre" bucket (tracks with no track_genres row).
   // The DLNA browse historically surfaced an empty-name entry for
@@ -710,7 +827,7 @@ function getGenreArtistAlbums(libraryId, genre, artistId) {
 // so compilation albums don't explode into dozens of single-album entries.
 
 function getLibraryAlbumArtists(libraryId) {
-  return db.getDB().prepare(`
+  return libMemo(`albumartists:${libraryId}`, () => db.getDB().prepare(`
     SELECT COALESCE(a.id, 0) AS id,
            COALESCE(a.name, 'Unknown Artist') AS name,
            COUNT(DISTINCT al.id) AS album_count,
@@ -720,10 +837,19 @@ function getLibraryAlbumArtists(libraryId) {
     WHERE EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND t.library_id = ?)
     GROUP BY COALESCE(a.id, 0)
     ORDER BY COALESCE(a.name, '') COLLATE NOCASE
-  `).all(libraryId);
+  `).all(libraryId));
+}
+
+// artistId 0 is the "Unknown Artist" bucket (albums with a NULL artist_id).
+// Branching on it keeps the predicate on the bare column, so idx_albums_artist
+// applies — `COALESCE(al.artist_id, 0) = ?` is an expression and the planner
+// cannot use the index for it (2026-07 audit).
+function albumArtistCondition(artistId) {
+  return artistId === 0 ? 'al.artist_id IS NULL' : 'al.artist_id = ?';
 }
 
 function getAlbumArtistById(libraryId, artistId) {
+  const params = artistId === 0 ? [libraryId] : [libraryId, artistId];
   const row = db.getDB().prepare(`
     SELECT COALESCE(a.id, 0) AS id,
            COALESCE(a.name, 'Unknown Artist') AS name,
@@ -733,14 +859,15 @@ function getAlbumArtistById(libraryId, artistId) {
     FROM albums al
     LEFT JOIN artists a ON al.artist_id = a.id
     WHERE EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND t.library_id = ?)
-      AND COALESCE(al.artist_id, 0) = ?
-  `).get(libraryId, artistId);
+      AND ${albumArtistCondition(artistId)}
+  `).get(...params);
   if (!row || row._n === 0) return null;
   delete row._n;
   return row;
 }
 
 function getAlbumArtistAlbums(libraryId, artistId) {
+  const params = artistId === 0 ? [libraryId] : [libraryId, artistId];
   return db.getDB().prepare(`
     SELECT al.id,
            COALESCE(al.name, 'Unknown Album') AS name,
@@ -748,10 +875,10 @@ function getAlbumArtistAlbums(libraryId, artistId) {
            COALESCE(al.album_art_file, MIN(t.album_art_file)) AS album_art_file
     FROM albums al
     JOIN tracks t ON t.album_id = al.id
-    WHERE t.library_id = ? AND COALESCE(al.artist_id, 0) = ?
+    WHERE t.library_id = ? AND ${albumArtistCondition(artistId)}
     GROUP BY al.id
     ORDER BY al.year, COALESCE(al.name, '') COLLATE NOCASE
-  `).all(libraryId, artistId);
+  `).all(...params);
 }
 
 // ── Smart-container queries ─────────────────────────────────────────────────
@@ -764,13 +891,15 @@ const SMART_TRACK_COLS = `
 `;
 
 function getRecentPlayedCount() {
-  const row = db.getDB().prepare(`
-    SELECT COUNT(DISTINCT t.id) AS n
-    FROM tracks t
-    JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash)
-    WHERE um.last_played IS NOT NULL
-  `).get();
-  return Math.min(row?.n || 0, SMART_LIMIT);
+  return smartMemo('recentplayed', () => {
+    const row = db.getDB().prepare(`
+      SELECT COUNT(DISTINCT t.id) AS n
+      FROM tracks t
+      JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash)
+      WHERE um.last_played IS NOT NULL
+    `).get();
+    return Math.min(row?.n || 0, SMART_LIMIT);
+  });
 }
 
 function getRecentPlayedTracks(start, count) {
@@ -791,15 +920,17 @@ function getRecentPlayedTracks(start, count) {
 }
 
 function getMostPlayedCount() {
-  const row = db.getDB().prepare(`
-    SELECT COUNT(*) AS n FROM (
-      SELECT t.id FROM tracks t
-      JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash)
-      GROUP BY t.id
-      HAVING SUM(um.play_count) > 0
-    )
-  `).get();
-  return Math.min(row?.n || 0, SMART_LIMIT);
+  return smartMemo('mostplayed', () => {
+    const row = db.getDB().prepare(`
+      SELECT COUNT(*) AS n FROM (
+        SELECT t.id FROM tracks t
+        JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash)
+        GROUP BY t.id
+        HAVING SUM(um.play_count) > 0
+      )
+    `).get();
+    return Math.min(row?.n || 0, SMART_LIMIT);
+  });
 }
 
 function getMostPlayedTracks(start, count) {
@@ -819,20 +950,29 @@ function getMostPlayedTracks(start, count) {
   `).all(limit, start);
 }
 
+// Favorites is bounded by SMART_LIMIT like every sibling smart container.
+// It used to be the odd one out: an uncapped count paired with a `LIMIT -1`
+// fetch, so a library with thousands of 4-star tracks built the whole list
+// into one DIDL document (2026-07 audit M14).
 function getFavoriteCount() {
-  const row = db.getDB().prepare(`
-    SELECT COUNT(*) AS n FROM (
-      SELECT t.id FROM tracks t
-      JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash)
-      GROUP BY t.id
-      HAVING MAX(um.rating) >= 4
-    )
-  `).get();
-  return row?.n || 0;
+  return smartMemo('favorites', () => {
+    const row = db.getDB().prepare(`
+      SELECT COUNT(*) AS n FROM (
+        SELECT t.id FROM tracks t
+        JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash)
+        GROUP BY t.id
+        HAVING MAX(um.rating) >= 4
+        LIMIT ${SMART_LIMIT}
+      )
+    `).get();
+    return Math.min(row?.n || 0, SMART_LIMIT);
+  });
 }
 
 function getFavoriteTracks(start, count) {
-  const limit = count > 0 ? count : -1;
+  const available = Math.max(0, SMART_LIMIT - start);
+  const limit = count > 0 ? Math.min(count, available) : available;
+  if (limit <= 0) return [];
   return db.getDB().prepare(`
     SELECT ${SMART_TRACK_COLS}, MAX(um.rating) AS top_rating
     FROM tracks t
@@ -847,8 +987,10 @@ function getFavoriteTracks(start, count) {
 }
 
 function getShuffleCount() {
-  const row = db.getDB().prepare('SELECT COUNT(*) AS n FROM tracks').get();
-  return Math.min(row?.n || 0, SMART_LIMIT);
+  return smartMemo('shuffle', () => {
+    const row = db.getDB().prepare('SELECT COUNT(*) AS n FROM tracks').get();
+    return Math.min(row?.n || 0, SMART_LIMIT);
+  });
 }
 
 // Shuffle is re-rolled per request — no pagination semantics beyond "give me a
@@ -868,13 +1010,13 @@ function getShuffleTracks(count) {
 }
 
 function getYears() {
-  return db.getDB().prepare(`
+  return smartMemo('years', () => db.getDB().prepare(`
     SELECT t.year AS year, COUNT(*) AS track_count
     FROM tracks t
     WHERE t.year IS NOT NULL AND t.year > 0
     GROUP BY t.year
     ORDER BY t.year DESC
-  `).all();
+  `).all());
 }
 
 function getYearTrackCount(year) {
@@ -896,14 +1038,14 @@ function getYearTracks(year, start, count) {
 }
 
 function getAllPlaylists() {
-  return db.getDB().prepare(`
+  return smartMemo('playlists', () => db.getDB().prepare(`
     SELECT p.id, p.name, u.username, COUNT(pt.id) AS track_count
     FROM playlists p
     JOIN users u ON p.user_id = u.id
     LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
     GROUP BY p.id
     ORDER BY p.name COLLATE NOCASE
-  `).all();
+  `).all());
 }
 
 function getPlaylistById(playlistId) {
@@ -945,8 +1087,10 @@ function getPlaylistTracks(playlistId) {
 }
 
 function getRecentCount() {
-  const total = db.getDB().prepare('SELECT COUNT(*) AS n FROM tracks').get()?.n || 0;
-  return Math.min(total, RECENT_LIMIT);
+  return smartMemo('recent', () => {
+    const total = db.getDB().prepare('SELECT COUNT(*) AS n FROM tracks').get()?.n || 0;
+    return Math.min(total, RECENT_LIMIT);
+  });
 }
 
 function getRecentTracks(start, count) {
@@ -1633,7 +1777,7 @@ function handleSearch(body, res) {
   const criteria  = extractSoapField(body, 'SearchCriteria');
   const startIdx  = Math.max(0, parseInt(extractSoapField(body, 'StartingIndex') || '0', 10) || 0);
   const rawCount  = Math.max(0, parseInt(extractSoapField(body, 'RequestedCount') || '0', 10) || 0);
-  const reqCount  = rawCount === 0 ? MAX_BROWSE_COUNT : Math.min(rawCount, MAX_BROWSE_COUNT);
+  const reqCount  = rawCount === 0 ? DEFAULT_SEARCH_COUNT : Math.min(rawCount, MAX_BROWSE_COUNT);
   const sortTerms = parseSortCriteria(extractSoapField(body, 'SortCriteria'));
 
   const libraries = db.getAllLibraries();
@@ -2034,6 +2178,10 @@ function handleUnsubscribe(req, res) {
 export function bumpSystemUpdateID() {
   // SystemUpdateID is a UPnP ui4 (32-bit unsigned). Wrap to stay in range.
   systemUpdateID = (systemUpdateID + 1) >>> 0;
+  // The library memo keys on the id, so the bump alone already invalidates
+  // it. Clearing releases the retained filepath lists right away instead of
+  // holding them until each key is next probed.
+  invalidateBrowseCaches();
   winston.debug(`[dlna] SystemUpdateID bumped to ${systemUpdateID}`);
   broadcastToService('cds');
 }

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -78,7 +78,10 @@ import { HASH_GENERATION } from './audio-hash.js';
 // (stream_kbps / daily_mb / max_streams, 0 = unlimited; expires_at, NULL =
 // never) and the federation_key_usage per-day byte/request counters that
 // back the daily quota and the admin usage readout. See SCHEMA_V62.
-export const SCHEMA_VERSION = 63;
+// V63 indexes cue_points.library_id and play_events.library_id so the
+// library-delete cascade seeks instead of scanning. See SCHEMA_V63.
+// V64 indexes tracks.year so the DLNA By-Year browse seeks. See SCHEMA_V64.
+export const SCHEMA_VERSION = 64;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2349,6 +2352,16 @@ export const SCHEMA_V63 = `
   CREATE INDEX IF NOT EXISTS idx_play_events_library ON play_events(library_id);
 `;
 
+// tracks.year had no index, so DLNA's "By Year" surface full-scanned the
+// table three ways: the year list (GROUP BY year), each year's child count,
+// and each year's track page (2026-07 audit). Partial because roughly the
+// only rows that matter are the tagged ones — untagged tracks are excluded
+// from every By-Year query by `year IS NOT NULL AND year > 0`, and leaving
+// them out keeps the index small on libraries with sparse year tags.
+export const SCHEMA_V64 = `
+  CREATE INDEX IF NOT EXISTS idx_tracks_year ON tracks(year) WHERE year IS NOT NULL;
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2723,4 +2736,7 @@ export const MIGRATIONS = [
   // V63 indexes the two library_id foreign keys the library-delete cascade
   // walks. Index-only, no rescan. See SCHEMA_V63.
   { version: 63, sql: SCHEMA_V63 },
+  // V64 indexes tracks.year for the DLNA By-Year browse. Index-only, no
+  // rescan. See SCHEMA_V64.
+  { version: 64, sql: SCHEMA_V64 },
 ];

--- a/src/dlna/ssdp.js
+++ b/src/dlna/ssdp.js
@@ -32,9 +32,23 @@ let joinedInterfaces = [];
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-export function getLocalIp() {
-  const addr = config.program.address;
-  if (addr && addr !== '::' && addr !== '0.0.0.0') { return addr; }
+// Resolving the outbound address means enumerating every network adapter,
+// and `os.networkInterfaces()` is not cheap — ~13 ms per call on Windows.
+// That mattered enormously, because getBaseUrl() is called once per DIDL
+// element: trackItem() builds a media URL for every track and
+// containerArtXml() an art URL for every container. A single unauthenticated
+// SOAP `Search` for '*' (10,000 items) therefore spent over two minutes of
+// event loop inside this one syscall.
+//
+// The answer only changes when the host's networking does (DHCP renew, VPN
+// up/down, adapter swap), so a short TTL keeps the self-healing behaviour —
+// a stale media URL survives at most LOCAL_IP_TTL_MS — while collapsing a
+// per-item syscall into at most one per response.
+const LOCAL_IP_TTL_MS = 5000;
+let localIpCache = null;
+let localIpCachedAt = 0;
+
+function resolveLocalIp() {
   const ifaces = os.networkInterfaces();
   for (const name of Object.keys(ifaces)) {
     for (const iface of ifaces[name]) {
@@ -42,6 +56,25 @@ export function getLocalIp() {
     }
   }
   return '127.0.0.1';
+}
+
+export function getLocalIp() {
+  const addr = config.program.address;
+  // An explicitly configured address needs no lookup and no cache — it can
+  // only change on a config reload, which reloads this value anyway.
+  if (addr && addr !== '::' && addr !== '0.0.0.0') { return addr; }
+  const now = Date.now();
+  if (localIpCache !== null && now - localIpCachedAt < LOCAL_IP_TTL_MS) { return localIpCache; }
+  localIpCache = resolveLocalIp();
+  localIpCachedAt = now;
+  return localIpCache;
+}
+
+// Test hook: drop the memo so a suite can observe an adapter change without
+// waiting out the TTL.
+export function invalidateLocalIpCache() {
+  localIpCache = null;
+  localIpCachedAt = 0;
 }
 
 export function getBaseUrl() {

--- a/test/db/dlna-surface.test.mjs
+++ b/test/db/dlna-surface.test.mjs
@@ -1,0 +1,386 @@
+/**
+ * Tests for the DLNA browse/search surface fixes (audit PR-H: M6, M10, M14
+ * + the per-item getBaseUrl() syscall the audit missed):
+ *
+ *   - getLocalIp() memoises the adapter enumeration, so getBaseUrl() stops
+ *     being an O(DIDL-elements) syscall;
+ *   - xmlEscape's strip-probe fast path is byte-for-byte identical to the
+ *     nine-pass original, including on the pathological inputs the strip
+ *     passes exist for;
+ *   - library-shaped listings (view containers, filepath tree, artists,
+ *     albums, genres, counts) are memoised and SystemUpdateID invalidates
+ *     them;
+ *   - smart-container totals are memoised on a short window, and Favorites
+ *     is bounded by SMART_LIMIT like every sibling;
+ *   - Search picks a bounded page when RequestedCount is 0 but still honours
+ *     an explicit count, and TotalMatches stays truthful either way;
+ *   - V64 indexes tracks.year.
+ *
+ * The browse surface is driven the way a renderer drives it — real SOAP over
+ * HTTP against dlna.setup()'s own route table — so the assertions cover the
+ * handlers, not just the query helpers.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import express from 'express';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+// Captured at import by dlna.js. Long enough that back-to-back browses in one
+// test stay inside the window, short enough that "aging out" is a quick sleep.
+process.env.MSTREAM_TEST_DLNA_CACHE_TTL_MS = '150';
+
+const SMART_LIMIT = 200;      // mirrors dlna.js
+const RATED_TRACKS = 260;     // > SMART_LIMIT, so the Favorites cap is observable
+const TRACKS = 900;           // > DEFAULT_SEARCH_COUNT (500), so the cap is observable
+
+let testRoot, server, base;
+let config, manager, dlna, ssdp;
+let libId;
+
+function soap(action, fields) {
+  const inner = Object.entries(fields).map(([k, v]) => `<${k}>${v}</${k}>`).join('');
+  return '<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+    + `<s:Body><u:${action} xmlns:u="urn:schemas-upnp-org:service:ContentDirectory:1">${inner}`
+    + `</u:${action}></s:Body></s:Envelope>`;
+}
+
+async function cds(action, fields) {
+  const r = await fetch(`${base}/dlna/control/content-directory`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/xml',
+      SOAPACTION: `"urn:schemas-upnp-org:service:ContentDirectory:1#${action}"`,
+    },
+    body: soap(action, fields),
+  });
+  return { status: r.status, text: await r.text() };
+}
+
+const browse = (ObjectID, extra = {}) => cds('Browse', {
+  ObjectID, BrowseFlag: 'BrowseDirectChildren', Filter: '*',
+  StartingIndex: 0, RequestedCount: 0, SortCriteria: '', ...extra,
+});
+const search = (ContainerID, SearchCriteria, extra = {}) => cds('Search', {
+  ContainerID, SearchCriteria, Filter: '*',
+  StartingIndex: 0, RequestedCount: 0, SortCriteria: '', ...extra,
+});
+
+const numberReturned = (t) => Number((t.match(/<NumberReturned>(\d+)</) || [])[1]);
+const totalMatches = (t) => Number((t.match(/<TotalMatches>(\d+)</) || [])[1]);
+const childCountOf = (t) => Number((t.match(/childCount=&quot;(\d+)&quot;/) || [])[1]);
+
+before(async () => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-prh-'));
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+      waveformCacheDirectory: path.join(testRoot, 'waveforms'),
+    },
+    port: 0,
+    dlna: { mode: 'same-port', browse: 'dirs' },
+  }, null, 2));
+
+  config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  manager = await import('../../src/db/manager.js');
+  manager.initDB();
+  dlna = await import('../../src/api/dlna.js');
+  ssdp = await import('../../src/dlna/ssdp.js');
+
+  const d = manager.getDB();
+  d.exec('BEGIN');
+  d.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks)
+             VALUES ('prh', ?, 'music', 0)`).run(testRoot);
+  manager.invalidateCache();
+  libId = d.prepare("SELECT id FROM libraries WHERE name='prh'").get().id;
+  d.prepare("INSERT INTO users (username, password, salt) VALUES ('prh-user','x','y')").run();
+  const uid = d.prepare("SELECT id FROM users WHERE username='prh-user'").get().id;
+
+  const insArtist = d.prepare('INSERT INTO artists (name) VALUES (?)');
+  const insAlbum = d.prepare('INSERT INTO albums (name, artist_id) VALUES (?, ?)');
+  for (let i = 0; i < 12; i++) { insArtist.run(`Artist ${i}`); }
+  const artistIds = d.prepare('SELECT id FROM artists ORDER BY id').all().map((r) => r.id);
+  for (let i = 0; i < 30; i++) { insAlbum.run(`Album ${i}`, artistIds[i % artistIds.length]); }
+  const albumIds = d.prepare('SELECT id FROM albums ORDER BY id').all().map((r) => r.id);
+
+  const insTrack = d.prepare(`INSERT INTO tracks
+      (filepath, library_id, title, artist_id, album_id, year, audio_hash, duration, format)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 200, 'mp3')`);
+  for (let i = 0; i < TRACKS; i++) {
+    insTrack.run(`d${i % 6}/t${i}.mp3`, libId, `Track ${i}`,
+      artistIds[i % artistIds.length], albumIds[i % albumIds.length],
+      1990 + (i % 5), `ah-${i}`);
+  }
+  // Ratings for more tracks than the smart containers are allowed to show.
+  const insUm = d.prepare(`INSERT INTO user_metadata (user_id, track_hash, rating, play_count, last_played)
+                           VALUES (?, ?, 5, 3, 1700000000)`);
+  for (let i = 0; i < RATED_TRACKS; i++) { insUm.run(uid, `ah-${i}`); }
+  d.exec('COMMIT');
+
+  const app = express();
+  dlna.setup(app, { checkMode: false });
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  try { if (server) { server.close(); } } catch (_e) { /* closed */ }
+  try { manager.close(); } catch (_e) { /* closed */ }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_e) { /* win locks */ }
+  setImmediate(() => process.exit(0));
+});
+
+// ── migration ───────────────────────────────────────────────────────────────
+
+describe('V64', () => {
+  test('tracks.year is indexed and the By-Year queries seek', () => {
+    const d = manager.getDB();
+    const idx = d.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_tracks_year'").get();
+    assert.ok(idx, 'idx_tracks_year present');
+    assert.match(idx.sql, /WHERE year IS NOT NULL/);
+    const plan = d.prepare(
+      'EXPLAIN QUERY PLAN SELECT COUNT(*) FROM tracks WHERE year = ?').all()
+      .map((r) => r.detail).join(' | ');
+    assert.match(plan, /idx_tracks_year/, `expected the year index in: ${plan}`);
+  });
+});
+
+// ── the per-item syscall ────────────────────────────────────────────────────
+
+describe('getLocalIp memo', () => {
+  test('repeat calls are memoised and the test hook forces a re-resolve', () => {
+    ssdp.invalidateLocalIpCache();
+    const a = ssdp.getLocalIp();
+    assert.equal(ssdp.getLocalIp(), a, 'same answer inside the window');
+    ssdp.invalidateLocalIpCache();
+    assert.equal(ssdp.getLocalIp(), a, 'and the same answer after a forced re-resolve');
+  });
+
+  test('an explicitly configured address bypasses adapter enumeration entirely', () => {
+    const saved = config.program.address;
+    try {
+      config.program.address = '10.9.8.7';
+      ssdp.invalidateLocalIpCache();
+      assert.equal(ssdp.getLocalIp(), '10.9.8.7');
+      // No cache involved: a config change is visible immediately.
+      config.program.address = '10.9.8.6';
+      assert.equal(ssdp.getLocalIp(), '10.9.8.6');
+    } finally { config.program.address = saved; }
+  });
+
+  test('a DIDL response carries one consistent media host', async () => {
+    const { text } = await browse(`tracks-${libId}`, { RequestedCount: 50 });
+    const hosts = new Set([...text.matchAll(/http:\/\/([\d.]+:\d+)\/media\//g)].map((m) => m[1]));
+    assert.equal(hosts.size, 1, `expected a single media host, got ${[...hosts]}`);
+  });
+});
+
+// ── xmlEscape fast path ─────────────────────────────────────────────────────
+
+describe('xmlEscape strip-probe fast path', () => {
+  // The verbatim pre-PR implementation, kept as the oracle.
+  const CTRL = /[\x00-\x08\x0B\x0C\x0E-\x1F]/g;                 // eslint-disable-line no-control-regex
+  const HIGH = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g;
+  const LOW = /(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+  const NON = /[￾￿]/g;
+  const oldEscape = (str) => {
+    if (str == null) { return ''; }
+    return String(str)
+      .replace(CTRL, '').replace(HIGH, '').replace(LOW, '').replace(NON, '')
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+  };
+
+  test('matches the nine-pass original on an exhaustive hostile alphabet', () => {
+    // Every character class the strip passes care about, plus a valid
+    // surrogate PAIR (which must survive) and ordinary text.
+    const alphabet = ['a', 'é', '&', '<', '>', '"', "'", '\t', '\n',
+      '\x01', '\x0B', '\x1F', '￾', '￿',
+      '\uD800', '\uDC00', '\uD83D', '\uDE00'];
+    let checked = 0;
+    // All strings of length 1..3 over the alphabet: 18 + 324 + 5832 = 6174.
+    const walk = (prefix, depth) => {
+      if (depth === 0) {
+        assert.equal(dlna.xmlEscape(prefix), oldEscape(prefix),
+          `divergence on ${JSON.stringify(prefix)}`);
+        checked++;
+        return;
+      }
+      for (const c of alphabet) { walk(prefix + c, depth - 1); }
+    };
+    for (let len = 1; len <= 3; len++) { walk('', len); }
+    assert.ok(checked > 6000, `expected a broad sweep, checked ${checked}`);
+  });
+
+  test('a valid astral character survives and stays on the fast path', () => {
+    assert.equal(dlna.xmlEscape('Sig\u{1F600}nal'), 'Sig\u{1F600}nal');
+  });
+
+  test('the strip classes are still stripped and the entities still escaped', () => {
+    assert.equal(dlna.xmlEscape('a\x01b'), 'ab');
+    assert.equal(dlna.xmlEscape('a\uD800b'), 'ab');
+    assert.equal(dlna.xmlEscape('a\uDC00b'), 'ab');
+    assert.equal(dlna.xmlEscape('a￾b'), 'ab');
+    assert.equal(dlna.xmlEscape(`&<>"'`), '&amp;&lt;&gt;&quot;&apos;');
+    assert.equal(dlna.xmlEscape(null), '');
+  });
+
+  // A LONE SURROGATE deliberately isn't part of this case: it cannot reach
+  // the wire at all, because SQLite stores TEXT as UTF-8 and a half-pair has
+  // no UTF-8 encoding — node:sqlite hands it back as U+FFFD. Control
+  // characters and the two noncharacters do round-trip, so those are what an
+  // end-to-end test can actually exercise; the surrogate passes are pinned
+  // directly against the oracle above.
+  test('a hostile tag never reaches the wire as invalid XML', async () => {
+    const d = manager.getDB();
+    d.prepare('UPDATE tracks SET title = ? WHERE filepath = ?')
+      .run('Bad\x01Tag￾ & <stuff>', 'd0/t0.mp3');
+    dlna.invalidateBrowseCaches();
+    const { text } = await browse(`tracks-${libId}`, { RequestedCount: 900 });
+    assert.match(text, /BadTag &amp;amp; &amp;lt;stuff&amp;gt;/,
+      'control char and noncharacter stripped, entities double-escaped for <Result>');
+    assert.doesNotMatch(text, /[\x00-\x08\x0B\x0C\x0E-\x1F]/, // eslint-disable-line no-control-regex
+      'no raw control characters on the wire');
+    d.prepare('UPDATE tracks SET title = ? WHERE filepath = ?').run('Track 0', 'd0/t0.mp3');
+    dlna.invalidateBrowseCaches();
+  });
+});
+
+// ── M10: library-shaped memos ───────────────────────────────────────────────
+
+describe('library browse memos', () => {
+  test('the six view containers are served from the memo inside the window', async () => {
+    dlna.invalidateBrowseCaches();
+    const first = await browse(`lib-${libId}`);
+    assert.equal(numberReturned(first.text), 6);
+    assert.match(first.text, /All Tracks/);
+
+    // A direct edit that does NOT bump SystemUpdateID stays invisible while
+    // the memo is warm — that is the deal the cache makes.
+    const d = manager.getDB();
+    d.prepare(`INSERT INTO tracks (filepath, library_id, title, audio_hash)
+               VALUES ('d0/extra.mp3', ?, 'Extra', 'ah-extra')`).run(libId);
+    const warm = await browse(`lib-${libId}`);
+    assert.equal(warm.text, first.text, 'same rendered listing while the memo is warm');
+
+    // ...and the TTL is the safety net that eventually reconciles it.
+    await sleep(250);
+    const cold = await browse(`lib-${libId}`);
+    assert.notEqual(cold.text, first.text, 'TTL expiry picks the new track up');
+    d.prepare("DELETE FROM tracks WHERE filepath = 'd0/extra.mp3'").run();
+    dlna.invalidateBrowseCaches();
+  });
+
+  test('a SystemUpdateID bump invalidates immediately, without waiting for the TTL', async () => {
+    dlna.invalidateBrowseCaches();
+    const before = await browse(`lib-${libId}`);
+    const d = manager.getDB();
+    d.prepare(`INSERT INTO tracks (filepath, library_id, title, audio_hash)
+               VALUES ('d0/bumped.mp3', ?, 'Bumped', 'ah-bumped')`).run(libId);
+    dlna.bumpSystemUpdateID();
+    const after = await browse(`lib-${libId}`);
+    assert.notEqual(after.text, before.text, 'the bump dropped the memo');
+    d.prepare("DELETE FROM tracks WHERE filepath = 'd0/bumped.mp3'").run();
+    dlna.bumpSystemUpdateID();
+  });
+
+  test('the memoised filepath tree still paginates folders correctly', async () => {
+    dlna.invalidateBrowseCaches();
+    const p1 = await browse(`folders-${libId}`, { RequestedCount: 4 });
+    const p2 = await browse(`folders-${libId}`, { RequestedCount: 4, StartingIndex: 4 });
+    assert.equal(numberReturned(p1.text), 4);
+    assert.equal(totalMatches(p1.text), totalMatches(p2.text));
+    const ids = (t) => [...t.matchAll(/id=&quot;(dir-[^&]+)&quot;/g)].map((m) => m[1]);
+    const overlap = ids(p1.text).filter((x) => ids(p2.text).includes(x));
+    assert.equal(overlap.length, 0, 'pages do not repeat entries');
+  });
+});
+
+// ── M14: smart containers ───────────────────────────────────────────────────
+
+describe('smart containers', () => {
+  test('Favorites is bounded by SMART_LIMIT in both the count and the listing', async () => {
+    const { text } = await browse('favorites');
+    assert.equal(numberReturned(text), SMART_LIMIT,
+      `${RATED_TRACKS} rated tracks must still list at most ${SMART_LIMIT}`);
+    assert.equal(totalMatches(text), SMART_LIMIT, 'the advertised total matches the listing');
+  });
+
+  test('Favorites BrowseMetadata advertises the same bounded childCount', async () => {
+    const { text } = await browse('favorites', { BrowseFlag: 'BrowseMetadata' });
+    assert.equal(childCountOf(text), SMART_LIMIT);
+  });
+
+  test('paging past the cap returns nothing rather than spilling', async () => {
+    const { text } = await browse('favorites', { StartingIndex: SMART_LIMIT, RequestedCount: 50 });
+    assert.equal(numberReturned(text), 0);
+  });
+
+  test('the root listing still reports every container', async () => {
+    const { text } = await browse('music');
+    for (const title of ['Recently Added', 'Recently Played', 'Most Played',
+      'Favorites', 'Shuffle', 'By Year', 'Playlists']) {
+      assert.match(text, new RegExp(title.replace(' ', '\\s')), `missing ${title}`);
+    }
+  });
+
+  test('smart totals reconcile after the short window', async () => {
+    dlna.invalidateBrowseCaches();
+    const d = manager.getDB();
+    const before = totalMatches((await browse('favorites')).text);
+    assert.equal(before, SMART_LIMIT);
+    // Drop below the cap so the number has somewhere to move.
+    d.prepare('DELETE FROM user_metadata').run();
+    await sleep(250);
+    assert.equal(totalMatches((await browse('favorites')).text), 0,
+      'the short window reconciles play/rating changes, which never bump SystemUpdateID');
+    const uid = d.prepare("SELECT id FROM users WHERE username='prh-user'").get().id;
+    const insUm = d.prepare(`INSERT INTO user_metadata (user_id, track_hash, rating, play_count, last_played)
+                             VALUES (?, ?, 5, 3, 1700000000)`);
+    for (let i = 0; i < RATED_TRACKS; i++) { insUm.run(uid, `ah-${i}`); }
+    dlna.invalidateBrowseCaches();
+  });
+});
+
+// ── M6: search bounds ───────────────────────────────────────────────────────
+
+describe('Search response bounds', () => {
+  test('RequestedCount=0 returns a bounded page but a truthful TotalMatches', async () => {
+    const { text } = await search('0', '*');
+    const n = numberReturned(text);
+    assert.ok(n > 0 && n <= 500, `expected a bounded page, got ${n}`);
+    assert.equal(totalMatches(text), TRACKS,
+      'TotalMatches still advertises the full result set so clients can page');
+  });
+
+  test('an explicit RequestedCount is honoured', async () => {
+    const { text } = await search('0', '*', { RequestedCount: 700 });
+    assert.equal(numberReturned(text), 700);
+  });
+
+  test('paging with StartingIndex walks the whole result set', async () => {
+    const seen = new Set();
+    for (let start = 0; start < TRACKS; start += 500) {
+      const { text } = await search('0', '*', { StartingIndex: start });
+      for (const m of text.matchAll(/id=&quot;track-(\d+)&quot;/g)) { seen.add(m[1]); }
+    }
+    assert.equal(seen.size, TRACKS, 'every track is reachable by paging');
+  });
+
+  test('Browse is deliberately NOT capped the same way', async () => {
+    // Renderers drill into a container expecting its listing and some do not
+    // page; Browse keeps its historical ceiling.
+    const { text } = await browse(`tracks-${libId}`);
+    assert.equal(numberReturned(text), TRACKS);
+  });
+});


### PR DESCRIPTION
Audit PR-H — the DLNA findings from the [2026-07-30 perf-landmine audit](https://github.com/IrosTheBeggar/mStream/pull/792) (M6, M10, M14 + low-hangers), plus the mechanism the audit missed, which turned out to dominate every one of them.

Follows #792 (A), #793 (D), #794 (F), #809 (C), #810 (B), #811 (E).

## The thing the audit missed

The audit measured DLNA at the SQL/JS level. This PR's rig drives **real SOAP over HTTP** against `dlna.setup()`'s own route table, and that surfaced the actual dominant cost:

`trackItem()` builds a media URL for every track and `containerArtXml()` an art URL for every container. Both call `getBaseUrl()` → `getLocalIp()` → **`os.networkInterfaces()`**, which costs ~13 ms on Windows. The browse surface was paying that syscall **once per DIDL element**.

Measured on the 25k-track audit fixture (8,000 `user_metadata` rows), `RequestedCount=0`:

| | wall | event loop blocked |
|---|---|---|
| `Search '*'` | **61,276 ms** | **61,181 ms** |
| `tracks-N` browse | 57,101 ms | 57,034 ms |
| `favorites` browse | 11,073 ms | 22,599 ms |
| `albumartists-N` browse | 4,417 ms | 7,118 ms |

**One unauthenticated SOAP request pinned the server for a full minute.** DLNA is opt-in, but once on, the control surface takes no credentials.

`getLocalIp()` now memoizes for 5 s — long enough to collapse a 10,000-item response into a single lookup, short enough that a DHCP renew, VPN flip or adapter swap still self-heals within seconds. An explicitly configured `address` bypasses both the lookup and the cache, exactly as before.

## Browse memos (M10 + the dirs-mode low-hanger)

Library *shape* — artists, album-artists, albums, genres, track count, and the sorted filepath list — only changes when a scan changes the library. That is precisely what `SystemUpdateID` already signals to control points, so the memo keys on it, with:

- a 60 s TTL as a **safety net**, not the invalidation (a writer that skips the bump goes stale for a minute, not forever);
- an LRU entry cap — the filepath list is the only large entry, and retaining one copy per browsed library costs what the uncached code allocated and threw away on *every click*;
- an explicit clear on every bump, so those lists are released immediately.

Smart-container totals aggregate play history and ratings, which never move `SystemUpdateID`, so they get a 5 s window instead — enough to collapse the nine aggregates one root-container click fires.

## Bounded responses (M6, M14)

**Search** picks a 500-item page when `RequestedCount` is 0 — UPnP leaves that choice to the server, `SearchCriteria` of `'*'` matches every track on the whole server, and Search is only ever issued by control points that page. `TotalMatches` stays truthful, and an explicit `RequestedCount` is still honoured up to `MAX_BROWSE_COUNT`.

**Browse is deliberately left alone.** Renderers drill into a container expecting its listing and some don't page, so its ceiling is unchanged — a 10,000-item Browse is still ~320 ms, down from 57 s.

**Favorites** joins its siblings at `SMART_LIMIT`. It was the odd one out: an uncapped count paired with a `LIMIT -1` fetch. ⚠️ **Behaviour change** — a library with thousands of 4-star tracks now shows 200 in that container, matching Recently Played / Most Played / Shuffle.

## Also

- `xmlEscape` probes once for the four strip classes instead of always running them, then escapes the five entities in a single pass. Output is byte-identical — pinned against the verbatim nine-pass original over 6,174 hostile strings (control chars, both lone-surrogate halves, noncharacters, valid astral pairs, all five entities). ~3× on per-field escaping, ~13% on the document pass.
- **V64** indexes `tracks.year` (partial, `WHERE year IS NOT NULL`) — the By-Year surface full-scanned three ways.
- `getAlbumArtistById` / `getAlbumArtistAlbums` branch on `artistId === 0` instead of `COALESCE(al.artist_id, 0) = ?`, so `idx_albums_artist` applies.

## After, same rig

| | before | after | |
|---|---|---|---|
| `Search '*'` count=0 | 61,276 ms | **43 ms** | 1,412× |
| `tracks-N` browse count=0 | 57,101 ms | 327 ms | 175× |
| `favorites` browse | 11,073 ms | 32 ms | 351× |
| `albumartists-N` browse | 4,417 ms | 9 ms | 496× |
| `mostplayed` browse | 2,646 ms | 41 ms | 65× |
| `year-N` browse | 1,866 ms | 12 ms | 154× |
| `recentplayed` browse | 1,523 ms | 37 ms | 41× |
| `lib-N` browse (M10) | 222 ms | 5 ms | 43× |
| `music` root browse (M14) | 181 ms | 2 ms | 86× |
| `folders-N` browse | 90 ms | 23 ms | 4× |
| 5-click renderer session | 595 ms | 44 ms | 14× |

## Deliberately not done

The audit's proposed um-driven UNION-ALL rewrite of the smart-container hash joins. I measured it on the same fixture: **66 → 59 ms, ~10%** — not the O(plays)-vs-O(tracks) win it was expected to be. `user_metadata` is only 3× smaller than `tracks` there, and the rewrite adds a temp b-tree GROUP BY plus a second correlated probe back into `um`. Row counts matched exactly (866 / 4820 / 6329), so the rewrite is correct — just not worth the risk. The memo is the real fix. Recorded here so it isn't re-chased.

## Validation

- **New suite** `test/db/dlna-surface.test.mjs` — 20 cases: V64 index + plan, the `getLocalIp` memo, the escape equivalence sweep, memo hit/TTL/bump-invalidation, the Favorites cap (with 260 rated tracks), and the Search bounds incl. a full paging walk. 20/20.
- `test/integration/dlna.test.mjs` 77/77 · schema/migration ring 59/59 · `npm test` **2136 pass / 0 fail**.
- Lint clean on all changed files (the one `ssdp.js` `no-empty` is pre-existing, just shifted).
- **Live smoke, 16/16** — one booted server, DLNA same-port, 6,000-track second library, 400 rated tracks, driven by raw SOAP with **no credentials** while a client-side pinger watches `/api/` latency. Covers the bounded Search + a paging client reaching all 6,009 tracks, a 40-click `lib-N` burst (worst warm click 21 ms), a 40-click root burst (9 ms), the Favorites cap, By-Year, the full root→lib→folder→track drill, the advertised media URL streaming real bytes, and **a real `force-rescan` proving the memo cannot serve a stale listing** (childCount 8 → 0 as the rescan purged fileless rows).

One smoke assertion failed on the first run and was my harness, not the code: same-port DLNA puts `/media` behind the main auth wall — only separate-port mode serves media credential-free. Pre-existing and out of scope here.

## Remaining audit backlog

G (subsonic), I (wrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
