### PR TITLE
perf(subsonic): stabilization pass (audit PR-G) + formal deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The iOS app is currently in review. You can get early access to it here: https:/
 * DLNA Support
 * Automatic Backup Feature - Backup your music to any drive connected to your server
 * Transcoding
-* Subsonic API support
+* Subsonic API support - *deprecated: removal planned once the first-party apps ship — [details](docs/subsonic-deprecation.md)*
 * Auto DJ - Automatically queue up songs
 * Lyrics Support - includes being able to search by lyrics
 * Jukebox Mode - Control your browser remotely

--- a/docs/subsonic-deprecation.md
+++ b/docs/subsonic-deprecation.md
@@ -1,0 +1,42 @@
+# Subsonic API — deprecation notice
+
+**Status: deprecated as of v6.20 (2026-08). Removal is planned for a future
+major release, once the first-party mStream apps are released.**
+
+## Why
+
+mStream's development focus is the first-party apps. They carry the one
+feature no third-party Subsonic client can offer: **iroh-based Quick
+Connect** — scan a QR code and stream from your server anywhere, with no
+port forwarding, no reverse proxy, no dynamic DNS.
+
+The Subsonic surface, by contrast, is a me-too feature in a field with
+dedicated implementations (Navidrome, Gonic, Airsonic-Advanced) whose whole
+project is that protocol. Every subsonic client has its own quirks, and
+matching that ecosystem's expectations is a maintenance commitment that
+competes directly with the first-party work. It also carries a standing
+security cost mStream would rather not keep: classic Subsonic token auth
+requires a recoverable password, which is why the surface keeps a separate
+encrypted password column and a second authentication wall.
+
+## What deprecation means today
+
+- The API keeps working exactly as before. Nothing is removed yet.
+- The surface is **frozen**: crash and security fixes only, no new
+  endpoints, no OpenSubsonic extension work.
+- A warning is logged at boot when the API is enabled, and the admin panel
+  shows a deprecation notice on the Subsonic page.
+- The bundled Subsonic web UI (`ui: 'subsonic'`) is deprecated with it.
+
+## If you rely on it
+
+Say so — real usage reports are what decide the removal timeline:
+
+- <https://github.com/IrosTheBeggar/mStream/issues>
+- The mStream Discord (link in the README)
+
+## Timeline
+
+Removal will not happen before the first-party apps are generally
+available, and will be announced in release notes at least one release
+before it happens.

--- a/docs/subsonic-phase3.md
+++ b/docs/subsonic-phase3.md
@@ -1,5 +1,10 @@
 # Subsonic API — Phase 3 (shipped) + future work
 
+> **⚠ Deprecated (2026-08):** the Subsonic API is deprecated and the surface
+> is frozen — crash and security fixes only. The "future work" items below
+> are historical record, not a roadmap. See
+> [subsonic-deprecation.md](subsonic-deprecation.md).
+
 > **Status:** Phase 3 landed. This document now doubles as a record of what
 > shipped vs. what was intentionally deferred. Remaining items are in the
 > "Deferred / out of scope" section at the bottom.

--- a/src/api/dlna.js
+++ b/src/api/dlna.js
@@ -2175,6 +2175,13 @@ function handleUnsubscribe(req, res) {
   res.status(200).end();
 }
 
+// Read-only view of the counter for other surfaces that want a cheap
+// "library content changed" signal — the subsonic getArtists memo keys on
+// it (task-queue bumps on every scan batch that changed the DB, whether or
+// not DLNA is enabled, so it is a process-wide content epoch, not a
+// DLNA-only one).
+export function getSystemUpdateID() { return systemUpdateID; }
+
 export function bumpSystemUpdateID() {
   // SystemUpdateID is a UPnP ui4 (32-bit unsigned). Wrap to stay in range.
   systemUpdateID = (systemUpdateID + 1) >>> 0;

--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -420,16 +420,33 @@ function enrichSongsWithUserMeta(req, songs) {
 // string here instead of touching the app-wide parser setting.
 // URLSearchParams has no parameter cap; the practical bound is Node's
 // header-size limit, which the transport enforces before we ever run.
-function arrayParam(req, name) {
+function _rawQuery(req) {
   if (req._rawQueryParams === undefined) {
     const u = req.originalUrl || req.url || '';
     const qi = u.indexOf('?');
     req._rawQueryParams = qi === -1 ? null : new URLSearchParams(u.slice(qi + 1));
   }
-  if (req._rawQueryParams) { return req._rawQueryParams.getAll(name); }
+  return req._rawQueryParams;
+}
+
+function arrayParam(req, name) {
+  const raw = _rawQuery(req);
+  if (raw) { return raw.getAll(name); }
   const v = req.query[name];
   if (v == null) { return []; }
   return Array.isArray(v) ? v : [v];
+}
+
+// Scalar sibling of arrayParam, for routes that ALSO accept big repeated
+// lists: any scalar that arrives after the thousandth parameter is past the
+// qs cliff and reads as undefined from req.query — savePlayQueue's `current`
+// landed after 1,500 `id` params and the restored queue silently lost its
+// position. Returns undefined when absent, first occurrence otherwise.
+function qparam(req, name) {
+  const raw = _rawQuery(req);
+  if (raw) { const v = raw.get(name); return v === null ? undefined : v; }
+  const v = req.query[name];
+  return Array.isArray(v) ? v[0] : v;
 }
 
 // Build a Subsonic Song object from a DB row. The query supplying `row` must
@@ -1647,7 +1664,9 @@ export function scrobble(req, res) {
   if (!songIds.length) { return SubErr.NOT_FOUND(req, res, 'Song'); }
 
   const times = arrayParam(req, 'time').map(v => parseInt(v, 10));
-  const submission = req.query.submission !== 'false';
+  // qparam: a bulk scrobble's `submission` flag can trail a long id list
+  // past the qs parsing cliff. Absent still means true.
+  const submission = qparam(req, 'submission') !== 'false';
 
   // submission=false (now-playing): Subsonic spec says a scrobble without
   // submission shouldn't register more than one track. We honour the
@@ -2363,8 +2382,11 @@ function addSongsToPlaylist(playlistId, songIds, startPosition) {
 }
 
 export function createPlaylist(req, res) {
-  const name = String(req.query.name || '').trim();
-  const updatePlaylistId = decodePlaylistId(req.query.playlistId);
+  // qparam for the scalars: `name`/`playlistId` can trail a 1,000+-song
+  // songId list past the qs parsing cliff, and req.query then drops them —
+  // a big "save as playlist" would MISSING_PARAM on a name that was sent.
+  const name = String(qparam(req, 'name') || '').trim();
+  const updatePlaylistId = decodePlaylistId(qparam(req, 'playlistId'));
   const songIds = arrayParam(req, 'songId').map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
   const d = db.getDB();
 
@@ -2383,6 +2405,9 @@ export function createPlaylist(req, res) {
       addSongsToPlaylist(updatePlaylistId, songIds, 0);
       if (name) { d.prepare('UPDATE playlists SET name = ? WHERE id = ?').run(name, updatePlaylistId); }
     });
+    // Synthetic-query handoff: getPlaylist must keep reading req.query.id
+    // DIRECTLY — the spread carries the cached raw-query params of the
+    // ORIGINAL url, so qparam/arrayParam would not see this synthetic id.
     return getPlaylist({ ...req, query: { ...req.query, id: `pl-${updatePlaylistId}` } }, res);
   }
 
@@ -2397,8 +2422,10 @@ export function createPlaylist(req, res) {
 }
 
 export function updatePlaylist(req, res) {
-  if (req.query.playlistId == null) { return SubErr.MISSING_PARAM(req, res, 'playlistId'); }
-  const id = decodePlaylistId(req.query.playlistId);
+  // qparam throughout: every scalar here can trail a big songIdToAdd /
+  // songIndexToRemove list past the qs parsing cliff.
+  if (qparam(req, 'playlistId') == null) { return SubErr.MISSING_PARAM(req, res, 'playlistId'); }
+  const id = decodePlaylistId(qparam(req, 'playlistId'));
   if (id == null) { return SubErr.NOT_FOUND(req, res, 'Playlist'); }
   const meta = playlistMeta(id, req.user.id);
   if (!meta) { return SubErr.NOT_FOUND(req, res, 'Playlist'); }
@@ -2410,11 +2437,13 @@ export function updatePlaylist(req, res) {
   // transaction so the playlist is never observed half-updated and the append
   // loop costs a single fsync.
   db.transaction(() => {
-    if (req.query.name) { d.prepare('UPDATE playlists SET name = ? WHERE id = ?').run(String(req.query.name), id); }
+    const newName = qparam(req, 'name');
+    if (newName) { d.prepare('UPDATE playlists SET name = ? WHERE id = ?').run(String(newName), id); }
     // V15 added the `public` column — honour the flag. Subsonic `comment`
     // is still accepted but dropped (no column for it).
-    if ('public' in req.query) {
-      const pub = req.query.public === 'true' ? 1 : 0;
+    const pubRaw = qparam(req, 'public');
+    if (pubRaw !== undefined) {
+      const pub = pubRaw === 'true' ? 1 : 0;
       d.prepare('UPDATE playlists SET public = ? WHERE id = ?').run(pub, id);
     }
 
@@ -3302,16 +3331,20 @@ export function getPlayQueue(req, res) {
 
 export function savePlayQueue(req, res) {
   const songIds = arrayParam(req, 'id').map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
-  const currentId = decodeId(req.query.current, 'song')?.id;
+  // qparam, not req.query: clients put `current` / `position` / `c` AFTER
+  // the id list, and with a 1,000+-track queue that is past the qs parsing
+  // cliff — the queue saved but its position silently vanished.
+  const currentId = decodeId(qparam(req, 'current'), 'song')?.id;
   // Resolve every queue id (plus the optional current id) to its canonical hash
   // in one batched query instead of a SELECT per id.
   const hashById = trackHashesByIds(currentId ? [...songIds, currentId] : songIds);
   const canonOf = (id) => { const hr = hashById.get(id); return hr ? (hr.audio_hash || hr.file_hash) : undefined; };
   const hashes = songIds.map(canonOf).filter(Boolean);
   const currentHash = currentId ? canonOf(currentId) : null;
-  const position = parseInt(req.query.position, 10);
+  const position = parseInt(qparam(req, 'position'), 10);
   const posMs = Number.isFinite(position) && position >= 0 ? position : null;
-  const changedBy = req.query.c ? String(req.query.c) : null;
+  const changedByRaw = qparam(req, 'c');
+  const changedBy = changedByRaw ? String(changedByRaw) : null;
 
   db.getDB().prepare(`
     INSERT INTO user_play_queue

--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -26,6 +26,7 @@ import * as dbQueue from '../../db/task-queue.js';
 import * as adminUtil from '../../util/admin.js';
 import { ffmpegBin, getResolvedSource } from '../../util/ffmpeg-bootstrap.js';
 import { serveAlbumArtFile } from '../album-art.js';
+import { getSystemUpdateID } from '../dlna.js';
 import * as serverPlayback from '../server-playback.js';
 import { sendOk, sendError, SubErr } from './response.js';
 import * as nowPlaying from './now-playing.js';
@@ -228,11 +229,22 @@ function contentTypeFor(suffix) {
 // fragment + its params, ready to concat into a larger query.
 function libraryScope(req) {
   const vpaths = req.user?.vpaths || [];
-  if (vpaths.length === 0) { return { clause: '1=0', params: [] }; }
+  if (vpaths.length === 0) { return { clause: '1=0', demotedClause: '1=0', params: [] }; }
   const libs = db.getAllLibraries().filter(l => vpaths.includes(l.name));
-  if (libs.length === 0) { return { clause: '1=0', params: [] }; }
+  if (libs.length === 0) { return { clause: '1=0', demotedClause: '1=0', params: [] }; }
   const placeholders = libs.map(() => '?').join(',');
-  return { clause: `t.library_id IN (${placeholders})`, params: libs.map(l => l.id) };
+  return {
+    clause: `t.library_id IN (${placeholders})`,
+    // `+t.library_id` — unary plus makes the term ineligible as an index
+    // driver. For the hash-probe queries (getBookmarks / getPlayQueue) the
+    // planner otherwise abandons the OR-optimization over the two hash
+    // indexes and scans idx_tracks_library across the whole visible set
+    // per chunk — the 2026-06 prod-incident shape (measured 640×). Only
+    // the hash probes use this; everywhere else the library index is a
+    // legitimate driver.
+    demotedClause: `+t.library_id IN (${placeholders})`,
+    params: libs.map(l => l.id)
+  };
 }
 
 // Look up a user's metadata row for a given track. Used by star/rating/
@@ -277,6 +289,19 @@ function chunkedHashes(hashes) {
   return out;
 }
 
+// Single-bind cousin of chunkedHashes for queries that bind each id ONCE.
+// 900 stays far under every build's SQLITE_MAX_VARIABLE_NUMBER; before this,
+// enrichSongsWithUserMeta bound one variable per song and a whole-library
+// search3 response on a >32,766-track library was a guaranteed 500 (audit M4).
+const ID_BIND_CHUNK = 900;
+function chunkedIds(ids) {
+  const out = [];
+  for (let i = 0; i < ids.length; i += ID_BIND_CHUNK) {
+    out.push(ids.slice(i, i + ID_BIND_CHUNK));
+  }
+  return out;
+}
+
 // Upsert a user_metadata row, setting the supplied fields. Leaves other
 // fields untouched — clients that only call setRating shouldn't clobber
 // starred_at, and vice versa.
@@ -299,12 +324,14 @@ function upsertUserMeta(userId, trackHash, fields) {
 // don't fire one SELECT per id. Returns Map<id, { file_hash, audio_hash }>.
 function trackHashesByIds(ids) {
   const uniq = [...new Set(ids)];
-  if (!uniq.length) { return new Map(); }
-  const ph = uniq.map(() => '?').join(',');
-  const rows = db.getDB().prepare(
-    `SELECT id, file_hash, audio_hash FROM tracks WHERE id IN (${ph})`
-  ).all(...uniq);
-  return new Map(rows.map(r => [r.id, r]));
+  const out = new Map();
+  for (const chunk of chunkedIds(uniq)) {
+    const ph = chunk.map(() => '?').join(',');
+    for (const r of db.getDB().prepare(
+      `SELECT id, file_hash, audio_hash FROM tracks WHERE id IN (${ph})`
+    ).all(...chunk)) { out.set(r.id, r); }
+  }
+  return out;
 }
 
 // Look up the star-timestamp for a set of album or artist ids for the caller.
@@ -338,30 +365,35 @@ function enrichSongsWithUserMeta(req, songs) {
     .filter(Number.isFinite);
   if (!trackIds.length) { return songs; }
 
-  const placeholders = trackIds.map(() => '?').join(',');
-  const rows = db.getDB().prepare(`
-    SELECT t.id, um.starred_at, um.rating, um.play_count
-    FROM tracks t
-    LEFT JOIN user_metadata um
-      ON um.track_hash = COALESCE(t.audio_hash, t.file_hash) AND um.user_id = ?
-    WHERE t.id IN (${placeholders})
-  `).all(req.user.id, ...trackIds);
-
-  const meta = new Map(rows.map(r => [r.id, r]));
-
-  // OpenSubsonic: batch-fetch per-track artist arrays (V17). One query,
-  // fan into a Map<track_id, [{id, name}, ...]>.
-  const artistRows = db.getDB().prepare(`
-    SELECT ta.track_id, ta.position, a.id, a.name
-    FROM track_artists ta
-    JOIN artists a ON a.id = ta.artist_id
-    WHERE ta.track_id IN (${placeholders})
-    ORDER BY ta.track_id, ta.position
-  `).all(...trackIds);
+  // Chunked: both queries bind one variable per song id, and callers can
+  // legitimately hand us big lists (playqueue restores, capped-but-large
+  // search pages). Uncapped, a whole-library list past 32,766 tracks threw
+  // "too many SQL variables" and 500'd the request (audit M4).
+  const meta = new Map();
   const artistsByTrack = new Map();
-  for (const r of artistRows) {
-    if (!artistsByTrack.has(r.track_id)) { artistsByTrack.set(r.track_id, []); }
-    artistsByTrack.get(r.track_id).push({ id: encArtist(r.id), name: r.name });
+  for (const chunk of chunkedIds(trackIds)) {
+    const placeholders = chunk.map(() => '?').join(',');
+    for (const r of db.getDB().prepare(`
+      SELECT t.id, um.starred_at, um.rating, um.play_count
+      FROM tracks t
+      LEFT JOIN user_metadata um
+        ON um.track_hash = COALESCE(t.audio_hash, t.file_hash) AND um.user_id = ?
+      WHERE t.id IN (${placeholders})
+    `).all(req.user.id, ...chunk)) { meta.set(r.id, r); }
+
+    // OpenSubsonic: batch-fetch per-track artist arrays (V17), fanned into
+    // Map<track_id, [{id, name}, ...]>. ORDER BY position within the chunk —
+    // per-track ordering only needs the track's own rows adjacent.
+    for (const r of db.getDB().prepare(`
+      SELECT ta.track_id, ta.position, a.id, a.name
+      FROM track_artists ta
+      JOIN artists a ON a.id = ta.artist_id
+      WHERE ta.track_id IN (${placeholders})
+      ORDER BY ta.track_id, ta.position
+    `).all(...chunk)) {
+      if (!artistsByTrack.has(r.track_id)) { artistsByTrack.set(r.track_id, []); }
+      artistsByTrack.get(r.track_id).push({ id: encArtist(r.id), name: r.name });
+    }
   }
 
   for (const song of songs) {
@@ -378,10 +410,24 @@ function enrichSongsWithUserMeta(req, songs) {
   return songs;
 }
 
-// Normalise a repeated query param — Express gives us an Array when it's
-// passed multiple times (`id=1&id=2`) or a string when it's passed once.
-// Always returns an Array (possibly empty).
-function arrayParam(v) {
+// Collect every occurrence of a repeated query param (`id=1&id=2`) for the
+// given request. NOT read from `req.query`: Express's default query parser
+// (qs) silently stops parsing after 1000 parameters, so a savePlayQueue with
+// a 2,000-track queue arrived as ~997 ids and the tail was DROPPED — the
+// queue truncation survived the round-trip and the client's next restore
+// made it permanent. Subsonic is the one surface where thousand-param GETs
+// are normal (savePlayQueue, star, updatePlaylist), so parse the raw query
+// string here instead of touching the app-wide parser setting.
+// URLSearchParams has no parameter cap; the practical bound is Node's
+// header-size limit, which the transport enforces before we ever run.
+function arrayParam(req, name) {
+  if (req._rawQueryParams === undefined) {
+    const u = req.originalUrl || req.url || '';
+    const qi = u.indexOf('?');
+    req._rawQueryParams = qi === -1 ? null : new URLSearchParams(u.slice(qi + 1));
+  }
+  if (req._rawQueryParams) { return req._rawQueryParams.getAll(name); }
+  const v = req.query[name];
   if (v == null) { return []; }
   return Array.isArray(v) ? v : [v];
 }
@@ -483,8 +529,53 @@ function indexLetter(name) {
 // up even though no track has it as its primary track-artist. Album
 // count per artist = distinct albums where the artist appears on any
 // role.
+//
+// Memoised per (visible-library set, content epoch): clients call
+// getArtists/getIndexes on every connect and refresh, the query walks two
+// tracks-scaled UNION arms (~50 ms at 33k tracks), and the result only
+// changes when library content does. The epoch is DLNA's SystemUpdateID —
+// task-queue bumps it after every scan batch that changed the DB, DLNA
+// enabled or not. The TTL is a safety net for content changes that bypass
+// the scanner (hand-edits, hash-transition applies), same stance as the
+// DLNA browse memo.
+const ARTISTS_MEMO_TTL_MS = 60_000;
+const ARTISTS_MEMO_MAX_ENTRIES = 16;   // distinct library-grant shapes
+const artistsMemo = new Map();         // key → { rows, epoch, at, lastModifiedMs }
+
+// The `lastModified` getIndexes advertises. One timestamp per observed
+// epoch transition: stable across calls within an epoch (so conditional
+// fetches can actually hit), fresh the first time a new epoch is seen.
+let lastSeenEpoch = null;
+let lastModifiedMs = Date.now();
+
+function contentEpoch() {
+  const epoch = getSystemUpdateID();
+  if (epoch !== lastSeenEpoch) {
+    lastSeenEpoch = epoch;
+    lastModifiedMs = Date.now();
+  }
+  return epoch;
+}
+
 function getArtistsCore(req) {
   const { clause, params } = libraryScope(req);
+  const epoch = contentEpoch();
+  const key = params.join(',');
+  const hit = artistsMemo.get(key);
+  if (hit && hit.epoch === epoch && Date.now() - hit.at < ARTISTS_MEMO_TTL_MS) {
+    artistsMemo.delete(key); artistsMemo.set(key, hit);   // LRU touch
+    return hit.rows;
+  }
+  const rows = _getArtistsRows(clause, params);
+  artistsMemo.delete(key);
+  artistsMemo.set(key, { rows, epoch, at: Date.now() });
+  while (artistsMemo.size > ARTISTS_MEMO_MAX_ENTRIES) {
+    artistsMemo.delete(artistsMemo.keys().next().value);
+  }
+  return rows;
+}
+
+function _getArtistsRows(clause, params) {
   return db.getDB().prepare(`
     SELECT a.id, a.name,
            COUNT(DISTINCT al.id) AS albumCount,
@@ -530,6 +621,21 @@ export function getArtists(req, res) {
 
 // Legacy getIndexes — older clients use this instead of getArtists.
 export function getIndexes(req, res) {
+  // `lastModified` is the content-epoch timestamp, NOT Date.now() — a
+  // value that changes on every call tells the client its cache is always
+  // stale and defeats the conditional-fetch protocol this field exists
+  // for (2026-07 audit M15).
+  contentEpoch();
+  // Spec: "If specified, only return a result if the artist collection has
+  // changed since the given time." Unchanged → envelope without `index`,
+  // so clients that pass ifModifiedSince keep their cache; clients that
+  // don't are unaffected.
+  const ims = parseInt(req.query.ifModifiedSince, 10);
+  if (Number.isFinite(ims) && lastModifiedMs <= ims) {
+    return sendOk(req, res, {
+      indexes: { ignoredArticles: IGNORED_ARTICLES, lastModified: lastModifiedMs },
+    });
+  }
   const artists = getArtistsCore(req);
   const buckets = new Map();
   for (const a of artists) {
@@ -542,7 +648,7 @@ export function getIndexes(req, res) {
   sendOk(req, res, {
     indexes: {
       ignoredArticles: IGNORED_ARTICLES,
-      lastModified: Date.now(),
+      lastModified: lastModifiedMs,
       index,
     },
   });
@@ -1131,9 +1237,19 @@ function _searchScope(req) {
 // albumCount, songCount) `0` is a meaningful "return zero of these"
 // signal — Navidrome and other reference servers respect it — so we
 // need an explicit NaN check.
-function parseCount(value, defaultValue) {
+// `max` caps COUNT params only — never pass it for offsets, which must
+// range over the whole library for paging. 500 matches the caps
+// getRandomSongs / getSongsByGenre / buildAlbumListQuery already enforce;
+// before the cap, `search3?query=&songCount=100000` returned the entire
+// library in one response (~750 ms, 12 MB at 33k tracks) and past 32,766
+// tracks it didn't even do that — enrichSongsWithUserMeta blew SQLite's
+// per-statement bound-variable limit and the request 500'd (2026-07 audit
+// M4). Clients page with songOffset, so a cap loses nothing.
+const MAX_COUNT = 500;
+function parseCount(value, defaultValue, max = Infinity) {
   const n = parseInt(value, 10);
-  return Number.isFinite(n) && n >= 0 ? n : defaultValue;
+  const v = Number.isFinite(n) && n >= 0 ? n : defaultValue;
+  return Math.min(v, max);
 }
 
 // Empty-query OpenSubsonic listing — search3 only. Returns the same
@@ -1142,9 +1258,9 @@ function parseCount(value, defaultValue) {
 // The spec says "A blank query will return everything"; we paginate
 // via the existing artistCount/albumCount/songCount/Offset params.
 function _buildEmptyListingPayload(req) {
-  const artistCount  = parseCount(req.query.artistCount,  20);
-  const albumCount   = parseCount(req.query.albumCount,   20);
-  const songCount    = parseCount(req.query.songCount,    20);
+  const artistCount  = parseCount(req.query.artistCount,  20, MAX_COUNT);
+  const albumCount   = parseCount(req.query.albumCount,   20, MAX_COUNT);
+  const songCount    = parseCount(req.query.songCount,    20, MAX_COUNT);
   const artistOffset = parseCount(req.query.artistOffset,  0);
   const albumOffset  = parseCount(req.query.albumOffset,   0);
   const songOffset   = parseCount(req.query.songOffset,    0);
@@ -1172,25 +1288,41 @@ function _buildEmptyListingPayload(req) {
   // Qualify artist_id in each subquery: track_artists and album_artists
   // and tracks all have an artist_id column, so SQLite errors with
   // "ambiguous column name: artist_id" if the qualifier is dropped.
+  // Every section pages with a TOTAL order — `name/title NOCASE, id` — on
+  // both the inner id-page and the outer projection. ORDER BY name alone
+  // left tie order to the plan, and OFFSET paging over a non-total order
+  // can duplicate or drop rows when a tie straddles a page boundary — for
+  // a full-library sync client that means silently missing tracks.
+  //
+  // EXISTS probes replace the IN-materialisations / whole-library joins:
+  // the IN form built the entire visible track set before paging could
+  // narrow anything (audit M7), and the songs query sorted WIDE rows —
+  // per-row correlated genre subqueries included — in a temp b-tree just
+  // to keep 500 of them. Page ids first, project only the page.
   const artists = d.prepare(`
-    SELECT DISTINCT a.id, a.name
+    SELECT a.id, a.name
     FROM artists a
-    WHERE a.id IN (SELECT ta.artist_id FROM track_artists ta JOIN tracks t ON t.id = ta.track_id WHERE ${scope.clause})
-       OR a.id IN (SELECT aa.artist_id FROM album_artists aa JOIN albums al ON al.id = aa.album_id JOIN tracks t ON t.album_id = al.id WHERE ${scope.clause})
-    ORDER BY a.name COLLATE NOCASE
+    WHERE EXISTS (SELECT 1 FROM track_artists ta JOIN tracks t ON t.id = ta.track_id
+                  WHERE ta.artist_id = a.id AND ${scope.clause})
+       OR EXISTS (SELECT 1 FROM album_artists aa JOIN albums al ON al.id = aa.album_id
+                  JOIN tracks t ON t.album_id = al.id
+                  WHERE aa.artist_id = a.id AND ${scope.clause})
+    ORDER BY a.name COLLATE NOCASE, a.id
     LIMIT ? OFFSET ?
   `).all(...scope.params, ...scope.params, artistCount, artistOffset);
 
   const albums = d.prepare(`
-    SELECT DISTINCT al.id, al.name, al.year, al.album_art_file, al.artist_id,
-                    a.name AS artist_name
-    FROM albums al
+    SELECT al.id, al.name, al.year, al.album_art_file, al.artist_id,
+           a.name AS artist_name
+    FROM (
+      SELECT al2.id FROM albums al2
+      WHERE EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al2.id AND ${scope.clause})
+      ORDER BY al2.name COLLATE NOCASE, al2.id
+      LIMIT ? OFFSET ?
+    ) page
+    JOIN albums al ON al.id = page.id
     LEFT JOIN artists a ON a.id = al.artist_id
-    JOIN tracks t ON t.album_id = al.id
-    WHERE ${scope.clause}
-    GROUP BY al.id
-    ORDER BY al.name COLLATE NOCASE
-    LIMIT ? OFFSET ?
+    ORDER BY al.name COLLATE NOCASE, al.id
   `).all(...scope.params, albumCount, albumOffset);
 
   const songs = d.prepare(`
@@ -1200,12 +1332,16 @@ function _buildEmptyListingPayload(req) {
            t.replaygain_track_db, t.sample_rate, t.channels, t.bit_depth,
            a.id AS artist_id, a.name AS artist_name,
            al.id AS album_id, al.name AS album_name
-    FROM tracks t
+    FROM (
+      SELECT t2.id FROM tracks t2
+      WHERE ${scope.clause.replaceAll('t.', 't2.')}
+      ORDER BY t2.title COLLATE NOCASE, t2.id
+      LIMIT ? OFFSET ?
+    ) page
+    JOIN tracks t ON t.id = page.id
     LEFT JOIN artists a  ON a.id = t.artist_id
     LEFT JOIN albums  al ON al.id = t.album_id
-    WHERE ${scope.clause}
-    ORDER BY t.title COLLATE NOCASE
-    LIMIT ? OFFSET ?
+    ORDER BY t.title COLLATE NOCASE, t.id
   `).all(...scope.params, songCount, songOffset);
 
   return _shapePayload(req, artists, albums, songs);
@@ -1246,9 +1382,9 @@ function _shapePayload(req, artists, albums, songs) {
 // pre-PR3 behaviour: empty query → empty envelope.
 function buildSearchPayload(req, { listOnEmpty = false } = {}) {
   const q = normalizeQueryFragment(req.query.query);
-  const artistCount  = parseCount(req.query.artistCount,  20);
-  const albumCount   = parseCount(req.query.albumCount,   20);
-  const songCount    = parseCount(req.query.songCount,    20);
+  const artistCount  = parseCount(req.query.artistCount,  20, MAX_COUNT);
+  const albumCount   = parseCount(req.query.albumCount,   20, MAX_COUNT);
+  const songCount    = parseCount(req.query.songCount,    20, MAX_COUNT);
   const artistOffset = parseCount(req.query.artistOffset,  0);
   const albumOffset  = parseCount(req.query.albumOffset,   0);
   const songOffset   = parseCount(req.query.songOffset,    0);
@@ -1502,7 +1638,7 @@ export function scrobble(req, res) {
   // `time` is shorter than `id` (or missing entirely), unmatched entries
   // fall back to "now". submission=false is the "now playing" hint and
   // never bumps play counts.
-  const rawIds = arrayParam(req.query.id);
+  const rawIds = arrayParam(req, 'id');
   if (!rawIds.length) { return SubErr.MISSING_PARAM(req, res, 'id'); }
   const songIds = rawIds.map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
   // All ids were present but none decoded to an mStream song — same
@@ -1510,7 +1646,7 @@ export function scrobble(req, res) {
   // not found vs param absent).
   if (!songIds.length) { return SubErr.NOT_FOUND(req, res, 'Song'); }
 
-  const times = arrayParam(req.query.time).map(v => parseInt(v, 10));
+  const times = arrayParam(req, 'time').map(v => parseInt(v, 10));
   const submission = req.query.submission !== 'false';
 
   // submission=false (now-playing): Subsonic spec says a scrobble without
@@ -1572,9 +1708,9 @@ export function scrobble(req, res) {
 
 function collectIds(req) {
   return {
-    songIds:   arrayParam(req.query.id).map(v => decodeId(v, 'song')?.id).filter(Number.isFinite),
-    albumIds:  arrayParam(req.query.albumId).map(v => decodeId(v, 'album')?.id).filter(Number.isFinite),
-    artistIds: arrayParam(req.query.artistId).map(v => decodeId(v, 'artist')?.id).filter(Number.isFinite),
+    songIds:   arrayParam(req, 'id').map(v => decodeId(v, 'song')?.id).filter(Number.isFinite),
+    albumIds:  arrayParam(req, 'albumId').map(v => decodeId(v, 'album')?.id).filter(Number.isFinite),
+    artistIds: arrayParam(req, 'artistId').map(v => decodeId(v, 'artist')?.id).filter(Number.isFinite),
   };
 }
 
@@ -1642,9 +1778,9 @@ function unstarArtists(userId, artistIds) {
 // "client called us with no ids" (MISSING_PARAM) from "client gave
 // us ids but none decoded" (NOT_FOUND).
 function noIdParamsPresent(req) {
-  return !arrayParam(req.query.id).length
-      && !arrayParam(req.query.albumId).length
-      && !arrayParam(req.query.artistId).length;
+  return !arrayParam(req, 'id').length
+      && !arrayParam(req, 'albumId').length
+      && !arrayParam(req, 'artistId').length;
 }
 
 export function star(req, res) {
@@ -1783,18 +1919,183 @@ export function getStarred(req, res) {
 
 // ── Album lists ────────────────────────────────────────────────────────────
 
-// Shared album-list query: returns albums ordered by the given SQL tail
-// (ORDER BY + LIMIT/OFFSET), scoped to the caller's libraries. `type` decides
-// which ordering we synthesize.
-function buildAlbumListQuery(req, type, params = {}) {
+// Album lists are built in two steps (2026-07 audit M12). The old shape
+// aggregated EVERY visible album — whole-library tracks join, a um COALESCE
+// probe per track, GROUP BY all albums — and only then applied LIMIT 20, so
+// each home-screen list call cost 80–140 ms at 33k tracks and clients fire
+// 3–5 of them at once.
+//
+//   Step 1 (albumListPageIds): the cheapest query that can decide the PAGE —
+//     ids only, per-type filter and order, LIMIT/OFFSET pushed down.
+//   Step 2 (albumListRowsByIds): the full projection (track aggregates, um,
+//     stars, genres) for JUST the page's albums, re-ordered to the page.
+//
+// The um-driven types (recent / frequent / highest) still aggregate um over
+// the visible library in step 1 — that IS their order key and there is no
+// smaller driving set (the um-side rewrite was refuted in the DLNA round:
+// um is only ~3× smaller than tracks and the COALESCE join direction can't
+// use the hash indexes) — but they now group narrow (album_id, aggregate)
+// rows instead of wide ones, and step 2 does the expensive projection for 20
+// albums, not 2,200.
+//
+// Every ORDER BY carries an `al.id` / `t.album_id` tiebreak: OFFSET paging
+// over a non-total order can duplicate or drop a row when a tie straddles a
+// page boundary (the PR #813 lesson — plan-dependent tie order is also why
+// two calls could disagree).
+function albumListPageIds(req, type, params = {}) {
   const size   = Math.min(Math.max(parseInt(params.size, 10) || 10, 1), 500);
   const offset = Math.max(0, parseInt(params.offset, 10) || 0);
   const { clause, params: libParams } = libraryScope(req);
+  const d = db.getDB();
+  // An album is in scope iff it has ≥1 visible track — the two-step twin of
+  // the old `JOIN tracks … WHERE ${clause} … HAVING songCount > 0`.
+  const VIS = `EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND ${clause})`;
 
-  // Base select + join schema used by every type. user_album_stars is joined
-  // at the album level so the `starred` column reflects proper album-level
-  // star state (not "any one track is starred" — fixed in Phase 3).
-  const base = `
+  let sql, args;
+  switch (type) {
+    case 'newest':
+      // Order key = first-scanned VISIBLE track, matching the old
+      // MIN(t.created_at) over the scoped join. Correlated per candidate
+      // album on idx_tracks_album — album-count-sized, not track-count.
+      sql = `SELECT al.id FROM albums al WHERE ${VIS}
+             ORDER BY (SELECT MIN(t.created_at) FROM tracks t
+                       WHERE t.album_id = al.id AND ${clause}) DESC, al.id
+             LIMIT ? OFFSET ?`;
+      args = [...libParams, ...libParams, size, offset];
+      break;
+    // The three um-driven types share one shape: um rows carrying the
+    // signal, resolved to visible tracks, grouped per album. The COALESCE
+    // hash match is decomposed into TWO UNION ALL arms — one per hash
+    // column — because each arm is then a plain equality join the planner
+    // drives off a single index in every build. The obvious one-query
+    // forms are traps: joining on COALESCE(...) can use no index at all,
+    // and an OR join needs the OR-optimization, which the planner refused
+    // on a stats-less DB for the play_count variant and fell to a
+    // per-row table scan — 36 SECONDS per call at 33k tracks, measured
+    // while building this. Same OR→UNION ALL move as artists-albums
+    // (PR #813). A track cannot enter both arms (arm 2 requires
+    // audio_hash IS NULL), so UNION ALL duplicates nothing.
+    //
+    // The WHERE pre-filters are equivalent to the old LEFT JOIN + HAVING
+    // forms: play_count is never negative, MAX ignores no non-NULL, and
+    // any album the old HAVING kept has ≥1 signal-bearing um row.
+    case 'recent':
+      sql = `SELECT id FROM (
+               SELECT t.album_id AS id, um.last_played AS lp
+               FROM user_metadata um JOIN tracks t ON t.audio_hash = um.track_hash
+               WHERE um.user_id = ? AND um.last_played IS NOT NULL
+                 AND ${clause} AND t.album_id IS NOT NULL
+               UNION ALL
+               SELECT t.album_id, um.last_played
+               FROM user_metadata um JOIN tracks t ON t.file_hash = um.track_hash
+               WHERE t.audio_hash IS NULL AND um.user_id = ? AND um.last_played IS NOT NULL
+                 AND ${clause} AND t.album_id IS NOT NULL
+             )
+             GROUP BY id ORDER BY MAX(lp) DESC, id
+             LIMIT ? OFFSET ?`;
+      args = [req.user.id, ...libParams, req.user.id, ...libParams, size, offset];
+      break;
+    case 'frequent':
+      sql = `SELECT id FROM (
+               SELECT t.album_id AS id, um.play_count AS pc
+               FROM user_metadata um JOIN tracks t ON t.audio_hash = um.track_hash
+               WHERE um.user_id = ? AND um.play_count > 0
+                 AND ${clause} AND t.album_id IS NOT NULL
+               UNION ALL
+               SELECT t.album_id, um.play_count
+               FROM user_metadata um JOIN tracks t ON t.file_hash = um.track_hash
+               WHERE t.audio_hash IS NULL AND um.user_id = ? AND um.play_count > 0
+                 AND ${clause} AND t.album_id IS NOT NULL
+             )
+             GROUP BY id ORDER BY SUM(pc) DESC, id
+             LIMIT ? OFFSET ?`;
+      args = [req.user.id, ...libParams, req.user.id, ...libParams, size, offset];
+      break;
+    case 'highest':
+      sql = `SELECT id FROM (
+               SELECT t.album_id AS id, um.rating AS rt
+               FROM user_metadata um JOIN tracks t ON t.audio_hash = um.track_hash
+               WHERE um.user_id = ? AND um.rating IS NOT NULL
+                 AND ${clause} AND t.album_id IS NOT NULL
+               UNION ALL
+               SELECT t.album_id, um.rating
+               FROM user_metadata um JOIN tracks t ON t.file_hash = um.track_hash
+               WHERE t.audio_hash IS NULL AND um.user_id = ? AND um.rating IS NOT NULL
+                 AND ${clause} AND t.album_id IS NOT NULL
+             )
+             GROUP BY id ORDER BY MAX(rt) DESC, id
+             LIMIT ? OFFSET ?`;
+      args = [req.user.id, ...libParams, req.user.id, ...libParams, size, offset];
+      break;
+    case 'starred':
+      sql = `SELECT al.id FROM user_album_stars uas
+             JOIN albums al ON al.id = uas.album_id
+             WHERE uas.user_id = ? AND ${VIS}
+             ORDER BY uas.starred_at DESC, al.id
+             LIMIT ? OFFSET ?`;
+      args = [req.user.id, ...libParams, size, offset];
+      break;
+    case 'random':
+      sql = `SELECT al.id FROM albums al WHERE ${VIS} ORDER BY RANDOM() LIMIT ? OFFSET ?`;
+      args = [...libParams, size, offset];
+      break;
+    case 'byYear': {
+      const from = parseInt(params.fromYear, 10);
+      const to   = parseInt(params.toYear, 10);
+      if (!Number.isFinite(from) || !Number.isFinite(to)) { return null; }
+      const order = from <= to ? 'al.year ASC' : 'al.year DESC';
+      sql = `SELECT al.id FROM albums al
+             WHERE al.year BETWEEN ? AND ? AND ${VIS}
+             ORDER BY ${order}, al.name COLLATE NOCASE, al.id
+             LIMIT ? OFFSET ?`;
+      args = [Math.min(from, to), Math.max(from, to), ...libParams, size, offset];
+      break;
+    }
+    case 'byGenre': {
+      if (!params.genre) { return null; }
+      // V34 semantics preserved: the album qualifies via a VISIBLE track
+      // carrying the genre (case-insensitive M2M match).
+      sql = `SELECT al.id FROM albums al
+             WHERE EXISTS (
+               SELECT 1 FROM tracks t
+               JOIN track_genres tg ON tg.track_id = t.id
+               JOIN genres g ON g.id = tg.genre_id
+               WHERE t.album_id = al.id AND ${clause} AND g.name COLLATE NOCASE = ?
+             )
+             ORDER BY al.name COLLATE NOCASE, al.id
+             LIMIT ? OFFSET ?`;
+      args = [...libParams, params.genre, size, offset];
+      break;
+    }
+    case 'alphabeticalByArtist':
+      sql = `SELECT al.id FROM albums al
+             LEFT JOIN artists a ON a.id = al.artist_id
+             WHERE ${VIS}
+             ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, al.id
+             LIMIT ? OFFSET ?`;
+      args = [...libParams, size, offset];
+      break;
+    case 'alphabeticalByName':
+    default:
+      sql = `SELECT al.id FROM albums al WHERE ${VIS}
+             ORDER BY al.name COLLATE NOCASE, al.id
+             LIMIT ? OFFSET ?`;
+      args = [...libParams, size, offset];
+  }
+  return { ids: d.prepare(sql).all(...args).map(r => r.id) };
+}
+
+// Step 2: full projection for a page of album ids, in page order. Column
+// set matches the old base select exactly, so albumFromListRow — and the
+// wire shape — are unchanged. user_album_stars is joined at the album level
+// so `starred` reflects proper album-level star state (not "any one track
+// is starred" — fixed in Phase 3). The scope clause is kept so songCount /
+// duration count only VISIBLE tracks.
+function albumListRowsByIds(req, ids) {
+  if (!ids.length) { return []; }
+  const { clause, params: libParams } = libraryScope(req);
+  const ph = ids.map(() => '?').join(',');
+  const rows = db.getDB().prepare(`
     SELECT al.id, al.name, al.year, al.album_art_file, al.artist_id,
            a.name AS artist_name,
            COUNT(t.id) AS songCount, SUM(t.duration) AS duration,
@@ -1808,57 +2109,11 @@ function buildAlbumListQuery(req, type, params = {}) {
     JOIN tracks t ON t.album_id = al.id
     LEFT JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash) AND um.user_id = ?
     LEFT JOIN user_album_stars uas ON uas.album_id = al.id AND uas.user_id = ?
-    WHERE ${clause}
-  `;
-  const tailParams = [req.user.id, req.user.id, ...libParams];
-
-  let where   = '';           // row-level filter (WHERE clause tail)
-  let having  = 'songCount > 0'; // group-level filter (HAVING clause)
-  let order   = 'al.name COLLATE NOCASE';
-
-  switch (type) {
-    case 'newest':    order = 'MIN(t.created_at) DESC'; break;
-    case 'recent':    having += ' AND MAX(um.last_played) IS NOT NULL'; order = 'MAX(um.last_played) DESC'; break;
-    case 'frequent':  having += ' AND plays > 0';                        order = 'plays DESC'; break;
-    case 'highest':   having += ' AND rating_max IS NOT NULL';           order = 'rating_max DESC'; break;
-    case 'starred':   having += ' AND uas.starred_at IS NOT NULL';       order = 'uas.starred_at DESC'; break;
-    case 'random':    order = 'RANDOM()'; break;
-    case 'byYear': {
-      const from = parseInt(params.fromYear, 10);
-      const to   = parseInt(params.toYear, 10);
-      if (!Number.isFinite(from) || !Number.isFinite(to)) { return null; }
-      where = 'AND al.year BETWEEN ? AND ?';
-      tailParams.push(Math.min(from, to), Math.max(from, to));
-      order = from <= to ? 'al.year ASC' : 'al.year DESC';
-      break;
-    }
-    case 'byGenre': {
-      if (!params.genre) { return null; }
-      // V34: filter via M2M with case-insensitive comparison. Folds in
-      // the case-sensitivity fix flagged in the genre scout — pre-V34
-      // this query rejected case-mismatched names (Subsonic clients
-      // pass back exactly what they got from getGenres, so this was
-      // mostly cosmetic, but the fix makes the surface uniform).
-      where = `AND EXISTS (
-        SELECT 1 FROM track_genres tg
-        JOIN genres g ON g.id = tg.genre_id
-        WHERE tg.track_id = t.id AND g.name COLLATE NOCASE = ?
-      )`;
-      tailParams.push(params.genre);
-      // order stays at the default alphabetical
-      break;
-    }
-    case 'alphabeticalByArtist': order = 'a.name COLLATE NOCASE, al.name COLLATE NOCASE'; break;
-    case 'alphabeticalByName':
-    default:
-      order = 'al.name COLLATE NOCASE';
-  }
-
-  tailParams.push(size, offset);
-  return {
-    sql: `${base} ${where} GROUP BY al.id HAVING ${having} ORDER BY ${order} LIMIT ? OFFSET ?`,
-    params: tailParams,
-  };
+    WHERE al.id IN (${ph}) AND ${clause}
+    GROUP BY al.id
+  `).all(req.user.id, req.user.id, ...ids, ...libParams);
+  const byId = new Map(rows.map(r => [r.id, r]));
+  return ids.map(id => byId.get(id)).filter(Boolean);
 }
 
 function albumFromListRow(al) {
@@ -1886,18 +2141,18 @@ function albumFromListRow(al) {
 
 export function getAlbumList2(req, res) {
   const type = String(req.query.type || 'alphabeticalByName');
-  const query = buildAlbumListQuery(req, type, req.query);
-  if (!query) { return SubErr.MISSING_PARAM(req, res, type === 'byYear' ? 'fromYear/toYear' : 'genre'); }
-  const rows = db.getDB().prepare(query.sql).all(...query.params);
+  const page = albumListPageIds(req, type, req.query);
+  if (!page) { return SubErr.MISSING_PARAM(req, res, type === 'byYear' ? 'fromYear/toYear' : 'genre'); }
+  const rows = albumListRowsByIds(req, page.ids);
   sendOk(req, res, { albumList2: { album: rows.map(albumFromListRow) } });
 }
 
 // v1 client path. Same payload under the older tag.
 export function getAlbumList(req, res) {
   const type = String(req.query.type || 'alphabeticalByName');
-  const query = buildAlbumListQuery(req, type, req.query);
-  if (!query) { return SubErr.MISSING_PARAM(req, res, type === 'byYear' ? 'fromYear/toYear' : 'genre'); }
-  const rows = db.getDB().prepare(query.sql).all(...query.params);
+  const page = albumListPageIds(req, type, req.query);
+  if (!page) { return SubErr.MISSING_PARAM(req, res, type === 'byYear' ? 'fromYear/toYear' : 'genre'); }
+  const rows = albumListRowsByIds(req, page.ids);
   sendOk(req, res, { albumList: { album: rows.map(albumFromListRow) } });
 }
 
@@ -2110,7 +2365,7 @@ function addSongsToPlaylist(playlistId, songIds, startPosition) {
 export function createPlaylist(req, res) {
   const name = String(req.query.name || '').trim();
   const updatePlaylistId = decodePlaylistId(req.query.playlistId);
-  const songIds = arrayParam(req.query.songId).map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
+  const songIds = arrayParam(req, 'songId').map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
   const d = db.getDB();
 
   if (updatePlaylistId != null) {
@@ -2164,7 +2419,7 @@ export function updatePlaylist(req, res) {
     }
 
     // Remove entries by zero-based index (into current sorted position list).
-    const removeIdx = arrayParam(req.query.songIndexToRemove).map(v => parseInt(v, 10)).filter(Number.isFinite);
+    const removeIdx = arrayParam(req, 'songIndexToRemove').map(v => parseInt(v, 10)).filter(Number.isFinite);
     if (removeIdx.length) {
       const rows = d.prepare('SELECT id FROM playlist_tracks WHERE playlist_id = ? ORDER BY position').all(id);
       const toDelete = removeIdx.filter(i => i >= 0 && i < rows.length).map(i => rows[i].id);
@@ -2175,7 +2430,7 @@ export function updatePlaylist(req, res) {
     }
 
     // Append new songs at the end.
-    const toAdd = arrayParam(req.query.songIdToAdd).map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
+    const toAdd = arrayParam(req, 'songIdToAdd').map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
     if (toAdd.length) {
       const maxPos = d.prepare('SELECT COALESCE(MAX(position), -1) + 1 AS p FROM playlist_tracks WHERE playlist_id = ?').get(id).p;
       addSongsToPlaylist(id, toAdd, maxPos);
@@ -2297,7 +2552,7 @@ export async function createUser(req, res) {
   const adminRole    = req.query.adminRole === 'true';
   const uploadRole   = req.query.uploadRole !== 'false';
   // Subsonic's `musicFolderId` is repeatable — map each id back to a vpath.
-  const folderIds = arrayParam(req.query.musicFolderId)
+  const folderIds = arrayParam(req, 'musicFolderId')
     .map(v => decodeId(v, 'folder')?.id)
     .filter(Number.isFinite);
   const libs = db.getAllLibraries();
@@ -2338,7 +2593,7 @@ export async function updateUser(req, res) {
     row.allow_file_modify == null ? true : !!row.allow_file_modify);
 
   if ('musicFolderId' in req.query) {
-    const folderIds = arrayParam(req.query.musicFolderId)
+    const folderIds = arrayParam(req, 'musicFolderId')
       .map(v => decodeId(v, 'folder')?.id)
       .filter(Number.isFinite);
     const libs = db.getAllLibraries();
@@ -2776,7 +3031,7 @@ export function createShare(req, res) {
   // Same two-stage check as scrobble/star/unstar: distinguish "no id
   // params at all" from "ids given but none decoded" so clients see
   // the right Subsonic error code.
-  const rawIds = arrayParam(req.query.id);
+  const rawIds = arrayParam(req, 'id');
   if (!rawIds.length) { return SubErr.MISSING_PARAM(req, res, 'id'); }
   const songIds = rawIds.map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
   if (!songIds.length) { return SubErr.NOT_FOUND(req, res, 'Song'); }
@@ -2901,13 +3156,16 @@ export function getBookmarks(req, res) {
   // here are by hash value, not a join, so match both columns. Chunked:
   // each hash binds twice, and big bookmark lists can pass the
   // per-statement variable cap.
-  const { clause, params } = libraryScope(req);
+  const { demotedClause, params } = libraryScope(req);
   let songRows = [];
   for (const chunk of chunkedHashes(hashes)) {
     const ph = chunk.map(() => '?').join(',');
+    // demotedClause: keep the planner on the two hash-index probes —
+    // bounded by chunk size (≤400×2) regardless of library size, so there
+    // is no shape where the library-index plan wins. See libraryScope.
     songRows = songRows.concat(db.getDB().prepare(`
       ${songQueryBase()}
-      WHERE (t.audio_hash IN (${ph}) OR t.file_hash IN (${ph})) AND ${clause}
+      WHERE (t.audio_hash IN (${ph}) OR t.file_hash IN (${ph})) AND ${demotedClause}
     `).all(...chunk, ...chunk, ...params));
   }
   // Songs don't expose hashes in songQueryBase — resolve all matched rows'
@@ -2995,8 +3253,9 @@ export function getPlayQueue(req, res) {
   // or file_hash (legacy rows / formats without audio-region parsing).
   // Chunked: each hash binds twice, and Subsonic clients save queues of
   // arbitrary length — a big queue can pass the per-statement variable
-  // cap and 500 the restore.
-  const { clause, params } = libraryScope(req);
+  // cap and 500 the restore. demotedClause: keep the planner on the hash
+  // probes, not idx_tracks_library — see libraryScope.
+  const { demotedClause, params } = libraryScope(req);
   let songRows = [];
   for (const chunk of chunkedHashes(hashes)) {
     const ph = chunk.map(() => '?').join(',');
@@ -3010,7 +3269,7 @@ export function getPlayQueue(req, res) {
       FROM tracks t
       LEFT JOIN artists a  ON a.id = t.artist_id
       LEFT JOIN albums  al ON al.id = t.album_id
-      WHERE (t.audio_hash IN (${ph}) OR t.file_hash IN (${ph})) AND ${clause}
+      WHERE (t.audio_hash IN (${ph}) OR t.file_hash IN (${ph})) AND ${demotedClause}
     `).all(...chunk, ...chunk, ...params));
   }
 
@@ -3042,7 +3301,7 @@ export function getPlayQueue(req, res) {
 }
 
 export function savePlayQueue(req, res) {
-  const songIds = arrayParam(req.query.id).map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
+  const songIds = arrayParam(req, 'id').map(v => decodeId(v, 'song')?.id).filter(Number.isFinite);
   const currentId = decodeId(req.query.current, 'song')?.id;
   // Resolve every queue id (plus the optional current id) to its canonical hash
   // in one batched query instead of a SELECT per id.
@@ -3366,7 +3625,7 @@ export async function jukeboxControl(req, res) {
   // ── Queue-mutating actions ──────────────────────────────────────────
 
   if (action === 'set' || action === 'add') {
-    const songIds = arrayParam(req.query.id)
+    const songIds = arrayParam(req, 'id')
       .map(v => decodeId(v, 'song')?.id)
       .filter(Number.isFinite);
     const files = songIds.map(id => songIdToVpath(req, id)).filter(Boolean);

--- a/src/api/subsonic/index.js
+++ b/src/api/subsonic/index.js
@@ -13,6 +13,7 @@
  * Subsonic's historical `.view` suffix (`/rest/ping.view`). Both are accepted.
  */
 
+import winston from 'winston';
 import { subsonicAuth } from './auth.js';
 import { SubErr } from './response.js';
 import * as H from './handlers.js';
@@ -164,6 +165,16 @@ export function methodStatusTable() {
 }
 
 export function setup(mstream) {
+  // Runs once per boot for whichever mode mounts the surface (same-port
+  // via server.js, separate-port via subsonic-server.js) — never when the
+  // mode is 'disabled', so a server that has not opted in stays silent.
+  winston.warn(
+    '[subsonic] The Subsonic API is DEPRECATED and will be removed in a future '
+    + 'release once the first-party mStream apps are available — development '
+    + 'focus is on the first-party apps and their iroh-based Quick Connect. '
+    + 'If you rely on the Subsonic API, please say so: '
+    + 'https://github.com/IrosTheBeggar/mStream/issues (see docs/subsonic-deprecation.md)');
+
   // Single handler for both `/rest/:method` and `/rest/:method.view`. We
   // normalise the method name (stripping any ".view"), look it up in the
   // METHODS table, authenticate, and dispatch.

--- a/test/db/discovery-infra-churn.test.mjs
+++ b/test/db/discovery-infra-churn.test.mjs
@@ -30,7 +30,16 @@ import { DatabaseSync } from 'node:sqlite';
 
 // Captured at import by discovery-similarity.js / discovery-peer-dbs.js —
 // must be set before the dynamic imports below.
-process.env.MSTREAM_TEST_SIM_STALE_REBUILD_MS = '80';
+//
+// 1000, not 80: the safety-net test's "inside the window" probe must run
+// build → upsert → getIndex before this many ms elapse, and a loaded CI
+// runner routinely stalls longer than 80 ms between two statements — the
+// windows-latest shard failed exactly that way (2026-08-05, PR #813 run)
+// while every ubuntu/macOS shard passed. The probe is additionally
+// elapsed-guarded in the test body; this constant just keeps the guard
+// from skipping in practice.
+process.env.MSTREAM_TEST_SIM_STALE_REBUILD_MS = '1000';
+const SIM_STALE_MS = 1000;
 
 let testRoot;
 let config, ddb, sim, manager, novelty, peerDbs, discoveryExport;
@@ -111,10 +120,19 @@ describe('H5: similarity index epoch invalidation', () => {
 
   test('safety net: unpublished drift rebuilds once the debounce window passes', async () => {
     sim.invalidate();
+    const t0 = Date.now();
     const base = sim.getIndex();             // fresh build → builtAt = now
     upsert('h-d', [0, 0, 0, 1]);             // drift, no publish
-    assert.equal(sim.getIndex(), base, 'inside the window: still cached');
-    await sleep(120);                         // > MSTREAM_TEST_SIM_STALE_REBUILD_MS
+    const probe = sim.getIndex();
+    // Elapsed-guarded: on a stalled runner the window can genuinely have
+    // passed by the time we probe, and then a rebuild is CORRECT behaviour,
+    // not a failure. The cached-inside-the-window property itself is pinned
+    // time-free by the published-epoch test above; this test's unique claim
+    // is the rebuild AFTER the window, asserted unconditionally below.
+    if (Date.now() - t0 < SIM_STALE_MS) {
+      assert.equal(probe, base, 'inside the window: still cached');
+    }
+    await sleep(SIM_STALE_MS + 200);          // > MSTREAM_TEST_SIM_STALE_REBUILD_MS
     const i2 = sim.getIndex();
     assert.notEqual(i2, base, 'aged cache + drift → rebuilt despite the epoch');
     assert.equal(i2.entries.length, 4);

--- a/test/subsonic/subsonic-surface-perf.test.mjs
+++ b/test/subsonic/subsonic-surface-perf.test.mjs
@@ -1,0 +1,313 @@
+/**
+ * Pins for the 2026-07 audit's subsonic-surface fixes (PR-G):
+ *
+ *   M4  — count params are capped at 500 and a whole-library response can no
+ *         longer blow SQLite's bound-variable limit (chunked enrichment);
+ *   M7  — blank-query search3 pages with a TOTAL order: pages tile exactly;
+ *   M12 — getAlbumList(2)'s two-step page/project returns exactly what the
+ *         old single-pass aggregation returned, for every type;
+ *   M15 — getArtists memo is per-(library-set, epoch): a scoped user never
+ *         sees another grant's cached rows; getIndexes' lastModified is
+ *         stable and ifModifiedSince is honoured;
+ *   pin — getPlayQueue / getBookmarks keep the hash-index probes (the
+ *         `+t.library_id` demotion) and restore queues past 1,000 entries
+ *         (the Express qs parameterLimit silently dropped ids beyond ~997).
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { startServer } from '../helpers/server.mjs';
+
+const N_TRACKS = 1300;          // > 1000 for the param-loss pin, > 900 for chunking
+let server, bigDir, mdbPath;
+let keyAll, keyScoped;
+
+async function login(username) {
+  const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password: 'p' }),
+  });
+  return (await r.json()).token;
+}
+async function mintKey(token, name) {
+  const r = await fetch(`${server.baseUrl}/api/v1/user/api-keys`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', 'x-access-token': token },
+    body: JSON.stringify({ name }),
+  });
+  return (await r.json()).key;
+}
+function url(key, method, params = {}) {
+  const q = new URLSearchParams();
+  q.set('f', 'json'); q.set('apiKey', key);
+  for (const [k, v] of Object.entries(params)) {
+    if (Array.isArray(v)) { for (const x of v) { q.append(k, x); } }
+    else if (v != null) { q.set(k, String(v)); }
+  }
+  return `${server.baseUrl}/rest/${method}?${q}`;
+}
+async function call(key, method, params = {}) {
+  const r = await fetch(url(key, method, params));
+  return (await r.json())['subsonic-response'];
+}
+function withDb(fn) {
+  const d = new DatabaseSync(mdbPath);
+  try { return fn(d); } finally { d.close(); }
+}
+
+before(async () => {
+  bigDir = fs.mkdtempSync(path.join(process.env.TEMP || '/tmp', 'mstream-sperf-'));
+  fs.writeFileSync(path.join(bigDir, 'placeholder.txt'), 'x');
+  server = await startServer({
+    dlnaMode: 'disabled',
+    extraFolders: { biglib: bigDir },
+    users: [
+      { username: 'all', password: 'p', admin: true, vpaths: ['testlib', 'biglib'] },
+      { username: 'scoped', password: 'p', admin: false, vpaths: ['testlib'] },
+    ],
+  });
+  mdbPath = path.join(server.tmpDir, 'db', 'mstream.db');
+
+  // Seed biglib straight into the DB: enough tracks to cross both the
+  // 1,000-param and 900-id-chunk lines, album/um structure for every
+  // getAlbumList type, and a LEGACY slice (audio_hash NULL, um keyed on
+  // file_hash) so the UNION ALL hash arms are both exercised.
+  withDb((d) => {
+    const libId = d.prepare("SELECT id FROM libraries WHERE name='biglib'").get().id;
+    const userId = d.prepare("SELECT id FROM users WHERE username='all'").get().id;
+    d.exec('BEGIN');
+    const insArtist = d.prepare('INSERT INTO artists (name) VALUES (?)');
+    const artistIds = [];
+    for (let i = 0; i < 20; i++) {
+      artistIds.push(Number(insArtist.run(`Perf Artist ${String(i).padStart(2, '0')}`).lastInsertRowid));
+    }
+    const insAlbum = d.prepare('INSERT INTO albums (name, artist_id, year) VALUES (?, ?, ?)');
+    const albumIds = [];
+    for (let i = 0; i < 65; i++) {
+      albumIds.push(Number(insAlbum.run(`Perf Album ${String(i).padStart(2, '0')}`,
+        artistIds[i % 20], 1980 + (i % 40)).lastInsertRowid));
+    }
+    d.prepare("INSERT INTO genres (name) VALUES ('PerfGenre')").run();
+    const gid = d.prepare("SELECT id FROM genres WHERE name='PerfGenre'").get().id;
+    const insTrack = d.prepare(`INSERT INTO tracks
+      (filepath, library_id, title, artist_id, album_id, created_at, audio_hash, file_hash, duration, year)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+    const insTA = d.prepare("INSERT INTO track_artists (track_id, artist_id, position, role) VALUES (?, ?, 0, 'main')");
+    const insTg = d.prepare('INSERT OR IGNORE INTO track_genres (track_id, genre_id) VALUES (?, ?)');
+    const insUm = d.prepare(`INSERT INTO user_metadata (user_id, track_hash, rating, play_count, last_played)
+      VALUES (?, ?, ?, ?, ?)`);
+    for (let i = 0; i < N_TRACKS; i++) {
+      const albumIdx = i % 65;
+      const legacy = i % 9 === 0;
+      const tid = Number(insTrack.run(`perf${i}.mp3`, libId, `Perf Track ${String(i).padStart(4, '0')}`,
+        artistIds[albumIdx % 20], albumIds[albumIdx],
+        `20${10 + (i % 15)}-${String((i % 12) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')} 00:00:00`,
+        legacy ? null : `pf-a-${i}`, `pf-f-${i}`, 200, 1980 + (i % 40)).lastInsertRowid);
+      insTA.run(tid, artistIds[albumIdx % 20]);
+      if (i % 4 === 0) { insTg.run(tid, gid); }
+      if (i % 5 === 0) {
+        insUm.run(userId, legacy ? `pf-f-${i}` : `pf-a-${i}`, (i % 5) + 1, (i % 30) + 1,
+          `2026-0${(i % 6) + 1}-10 09:00:00`);
+      }
+    }
+    d.exec('COMMIT');
+  });
+
+  keyAll = await mintKey(await login('all'), 'perf-all');
+  keyScoped = await mintKey(await login('scoped'), 'perf-scoped');
+});
+
+after(async () => {
+  if (server) { await server.stop(); }
+  try { fs.rmSync(bigDir, { recursive: true, force: true }); } catch { /* win locks */ }
+  setImmediate(() => process.exit(0));
+});
+
+// ── M4: count cap + chunked enrichment ──────────────────────────────────────
+
+describe('search3 count cap (M4)', () => {
+  test('songCount=100000 is capped at 500, not an error', async () => {
+    const r = await call(keyAll, 'search3', { query: '', songCount: 100000, artistCount: 0, albumCount: 0 });
+    assert.equal(r.status, 'ok', JSON.stringify(r.error || {}));
+    assert.equal(r.searchResult3.song.length, 500);
+  });
+
+  test('a zero count is still honoured as zero', async () => {
+    const r = await call(keyAll, 'search3', { query: '', songCount: 0, artistCount: 0, albumCount: 5 });
+    assert.equal(r.status, 'ok');
+    assert.equal((r.searchResult3.song ?? []).length, 0, 'no songs requested, none returned');
+    assert.equal(r.searchResult3.album.length, 5);
+  });
+
+  test('offsets are NOT capped — paging reaches past 500', async () => {
+    const r = await call(keyAll, 'search3', { query: '', songCount: 10, songOffset: 1200, artistCount: 0, albumCount: 0 });
+    assert.equal(r.status, 'ok');
+    assert.ok(r.searchResult3.song.length > 0, 'rows exist past offset 1200');
+  });
+});
+
+// ── M7: blank-listing pagination law ────────────────────────────────────────
+
+describe('search3 blank-query paging (M7)', () => {
+  test('pages tile the song set exactly — no dups, no gaps, stable order', async () => {
+    const seen = [];
+    for (let off = 0; off < N_TRACKS + 500; off += 500) {
+      const r = await call(keyAll, 'search3',
+        { query: '', songCount: 500, songOffset: off, artistCount: 0, albumCount: 0 });
+      for (const s of (r.searchResult3.song || [])) { seen.push(s.id); }
+    }
+    const total = withDb((d) => d.prepare('SELECT COUNT(*) n FROM tracks').get().n);
+    assert.equal(seen.length, total, 'every track appears once');
+    assert.equal(new Set(seen).size, seen.length, 'no duplicates across page boundaries');
+  });
+
+  test('artist and album sections page too, and tile', async () => {
+    const ids = [];
+    for (let off = 0; off < 100; off += 20) {
+      const r = await call(keyAll, 'search3',
+        { query: '', artistCount: 20, artistOffset: off, songCount: 0, albumCount: 0 });
+      for (const a of (r.searchResult3.artist || [])) { ids.push(a.id); }
+    }
+    assert.equal(new Set(ids).size, ids.length, 'artist pages do not overlap');
+    assert.ok(ids.length >= 20, 'multiple artist pages returned');
+  });
+});
+
+// ── M12: album lists match the pre-PR aggregation ───────────────────────────
+
+describe('getAlbumList2 two-step (M12)', () => {
+  // The old single-pass query, kept as the oracle. Returns the id set the
+  // pre-PR SQL produced for the type (order compared separately — the old
+  // order was plan-dependent within ties, which is part of what changed).
+  function oracleIds(type, userId, libIds, size = 500) {
+    const ph = libIds.map(() => '?').join(',');
+    let having = 'songCount > 0';
+    let order = 'al.name COLLATE NOCASE';
+    if (type === 'newest')   { order = 'MIN(t.created_at) DESC'; }
+    if (type === 'recent')   { having += ' AND MAX(um.last_played) IS NOT NULL'; order = 'MAX(um.last_played) DESC'; }
+    if (type === 'frequent') { having += ' AND SUM(COALESCE(um.play_count, 0)) > 0'; order = 'SUM(COALESCE(um.play_count, 0)) DESC'; }
+    if (type === 'highest')  { having += ' AND MAX(um.rating) IS NOT NULL'; order = 'MAX(um.rating) DESC'; }
+    return withDb((d) => d.prepare(`
+      SELECT al.id, COUNT(t.id) AS songCount
+      FROM albums al
+      JOIN tracks t ON t.album_id = al.id
+      LEFT JOIN user_metadata um ON um.track_hash = COALESCE(t.audio_hash, t.file_hash) AND um.user_id = ?
+      WHERE t.library_id IN (${ph})
+      GROUP BY al.id HAVING ${having} ORDER BY ${order} LIMIT ?
+    `).all(userId, ...libIds, size).map((r) => r.id));
+  }
+  const libIds = () => withDb((d) => d.prepare('SELECT id FROM libraries ORDER BY id').all().map((r) => r.id));
+  const userId = () => withDb((d) => d.prepare("SELECT id FROM users WHERE username='all'").get().id);
+  const decode = (id) => parseInt(String(id).replace(/^[a-z]+-/, ''), 10) || parseInt(id, 10);
+
+  for (const type of ['alphabeticalByName', 'alphabeticalByArtist', 'newest', 'recent', 'frequent', 'highest']) {
+    test(`type=${type} returns exactly the old query's album set`, async () => {
+      const r = await call(keyAll, 'getAlbumList2', { type, size: 500 });
+      assert.equal(r.status, 'ok', JSON.stringify(r.error || {}));
+      const got = (r.albumList2.album || []).map((a) => decode(a.id)).sort((x, y) => x - y);
+      const want = oracleIds(type, userId(), libIds()).sort((x, y) => x - y);
+      assert.deepEqual(got, want);
+    });
+  }
+
+  test('byYear respects the reversed-range DESC contract', async () => {
+    const r = await call(keyAll, 'getAlbumList2', { type: 'byYear', fromYear: 2019, toYear: 1980, size: 500 });
+    const years = (r.albumList2.album || []).map((a) => a.year);
+    assert.ok(years.length > 0);
+    assert.deepEqual(years, [...years].sort((a, b) => b - a), 'toYear < fromYear pages newest-first');
+  });
+
+  test('paging tiles without dups across a page boundary', async () => {
+    const p1 = await call(keyAll, 'getAlbumList2', { type: 'alphabeticalByName', size: 30, offset: 0 });
+    const p2 = await call(keyAll, 'getAlbumList2', { type: 'alphabeticalByName', size: 30, offset: 30 });
+    const ids = [...p1.albumList2.album, ...p2.albumList2.album].map((a) => a.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+
+  test('getAlbumList (v1) carries the same payload under the older tag', async () => {
+    const v1 = await call(keyAll, 'getAlbumList', { type: 'alphabeticalByName', size: 10 });
+    const v2 = await call(keyAll, 'getAlbumList2', { type: 'alphabeticalByName', size: 10 });
+    assert.deepEqual(v1.albumList.album.map((a) => a.id), v2.albumList2.album.map((a) => a.id));
+  });
+
+  test('missing byGenre param is still MISSING_PARAM, not a crash', async () => {
+    const r = await call(keyAll, 'getAlbumList2', { type: 'byGenre' });
+    assert.equal(r.status, 'failed');
+    assert.equal(r.error.code, 10);
+  });
+});
+
+// ── M15: memo scoping + conditional fetch ───────────────────────────────────
+
+describe('getArtists memo + getIndexes lastModified (M15)', () => {
+  test('a scoped user never sees another grant\'s cached artist list', async () => {
+    const all = await call(keyAll, 'getArtists');
+    const scoped = await call(keyScoped, 'getArtists');
+    const names = (idx) => (idx || []).flatMap((b) => b.artist.map((a) => a.name));
+    assert.ok(names(all.artists.index).some((n) => n.startsWith('Perf Artist')),
+      'all-access sees the seeded biglib artists');
+    assert.ok(!names(scoped.artists.index).some((n) => n.startsWith('Perf Artist')),
+      'scoped (testlib-only) must not — the memo key is the library set');
+  });
+
+  test('lastModified is stable across calls within an epoch', async () => {
+    const a = await call(keyAll, 'getIndexes');
+    const b = await call(keyAll, 'getIndexes');
+    assert.equal(a.indexes.lastModified, b.indexes.lastModified);
+    assert.ok(Array.isArray(a.indexes.index) && a.indexes.index.length > 0);
+  });
+
+  test('ifModifiedSince at/after lastModified returns no index; before returns it', async () => {
+    const now = (await call(keyAll, 'getIndexes')).indexes.lastModified;
+    const unchanged = await call(keyAll, 'getIndexes', { ifModifiedSince: now });
+    assert.equal(unchanged.status, 'ok');
+    assert.equal(unchanged.indexes.index ?? undefined, undefined, 'unchanged → envelope without index');
+    const changed = await call(keyAll, 'getIndexes', { ifModifiedSince: now - 10_000 });
+    assert.ok(Array.isArray(changed.indexes.index), 'older client timestamp → full index');
+  });
+});
+
+// ── pin + param-loss: play queue and bookmarks ──────────────────────────────
+
+describe('getPlayQueue / getBookmarks (pin + raw params)', () => {
+  test('a 1,300-entry queue round-trips COMPLETE — ids past the qs 1000-param cliff survive', async () => {
+    const ids = withDb((d) =>
+      d.prepare("SELECT id FROM tracks WHERE filepath LIKE 'perf%' ORDER BY id").all().map((r) => r.id));
+    assert.ok(ids.length >= N_TRACKS);
+    const save = await fetch(url(keyAll, 'savePlayQueue', { id: ids, current: ids[0], position: 1234 }));
+    assert.equal((await save.json())['subsonic-response'].status, 'ok');
+
+    const r = await call(keyAll, 'getPlayQueue');
+    assert.equal(r.playQueue.entry.length, ids.length,
+      'every saved id comes back (was ~997 before the raw-query parse)');
+    // Stored order preserved end to end, including the tail.
+    assert.equal(String(r.playQueue.entry[0].id), String(ids[0]));
+    assert.equal(String(r.playQueue.entry.at(-1).id), String(ids.at(-1)));
+  });
+
+  test('the scoped user cannot restore hidden-library entries', async () => {
+    const someIds = withDb((d) =>
+      d.prepare("SELECT id FROM tracks WHERE filepath LIKE 'perf%' ORDER BY id LIMIT 20").all().map((r) => r.id));
+    await fetch(url(keyScoped, 'savePlayQueue', { id: someIds, current: someIds[0] }));
+    const r = await call(keyScoped, 'getPlayQueue');
+    assert.equal((r.playQueue.entry ?? []).length, 0,
+      'biglib tracks are invisible to a testlib-only grant');
+  });
+
+  test('bookmarks list resolves songs for both hash generations', async () => {
+    // One canonical-hash track and one legacy (file_hash-only) track.
+    const [modern, legacy] = withDb((d) => [
+      d.prepare("SELECT id FROM tracks WHERE audio_hash IS NOT NULL AND filepath LIKE 'perf%' LIMIT 1").get().id,
+      d.prepare("SELECT id FROM tracks WHERE audio_hash IS NULL AND filepath LIKE 'perf%' LIMIT 1").get().id,
+    ]);
+    await fetch(url(keyAll, 'createBookmark', { id: modern, position: 111 }));
+    await fetch(url(keyAll, 'createBookmark', { id: legacy, position: 222 }));
+    const r = await call(keyAll, 'getBookmarks');
+    const entries = r.bookmarks.bookmark.filter((b) => b.entry);
+    const entryIds = entries.map((b) => String(b.entry.id));
+    assert.ok(entryIds.includes(String(modern)), 'audio_hash-keyed bookmark resolves');
+    assert.ok(entryIds.includes(String(legacy)), 'file_hash-keyed bookmark resolves');
+  });
+});

--- a/test/subsonic/subsonic-surface-perf.test.mjs
+++ b/test/subsonic/subsonic-surface-perf.test.mjs
@@ -276,7 +276,9 @@ describe('getPlayQueue / getBookmarks (pin + raw params)', () => {
     const ids = withDb((d) =>
       d.prepare("SELECT id FROM tracks WHERE filepath LIKE 'perf%' ORDER BY id").all().map((r) => r.id));
     assert.ok(ids.length >= N_TRACKS);
-    const save = await fetch(url(keyAll, 'savePlayQueue', { id: ids, current: ids[0], position: 1234 }));
+    // `current`/`position` are appended AFTER the id list — the shape real
+    // clients send, and exactly what put them past the qs parsing cliff.
+    const save = await fetch(url(keyAll, 'savePlayQueue', { id: ids, current: ids[42], position: 1234 }));
     assert.equal((await save.json())['subsonic-response'].status, 'ok');
 
     const r = await call(keyAll, 'getPlayQueue');
@@ -285,6 +287,9 @@ describe('getPlayQueue / getBookmarks (pin + raw params)', () => {
     // Stored order preserved end to end, including the tail.
     assert.equal(String(r.playQueue.entry[0].id), String(ids[0]));
     assert.equal(String(r.playQueue.entry.at(-1).id), String(ids.at(-1)));
+    assert.equal(String(r.playQueue.current), String(ids[42]),
+      'scalars trailing the id list survive too (qparam)');
+    assert.equal(r.playQueue.position, 1234);
   });
 
   test('the scoped user cannot restore hidden-library entries', async () => {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -4535,6 +4535,10 @@ const subsonicView = Vue.component('subsonic-view', {
           <div class="card">
             <div class="card-content">
               <span class="card-title">Subsonic REST API</span>
+              <div class="card-panel amber lighten-4" style="margin-top:12px">
+                <p><b>Deprecated:</b> the Subsonic API will be removed in a future release once the first-party mStream apps are available. Development focus is on the first-party apps and their iroh-based Quick Connect, which no third-party client can offer. The Subsonic surface is frozen &mdash; crash and security fixes only, no new endpoints.</p>
+                <p style="margin-top:8px">If you rely on the Subsonic API, please say so on <a href="https://github.com/IrosTheBeggar/mStream/issues" target="_blank" rel="noopener">GitHub</a> or Discord &mdash; real usage reports are what decide the removal timeline.</p>
+              </div>
               <p>The Subsonic API lets you use third-party music apps &mdash; DSub, Symfonium, Substreamer, play:Sub, Feishin, Sonixd, and many others &mdash; as clients for your mStream library. Each user signs in with their mStream username and password (or an API key they generate on their profile) from inside the client app.</p>
               <div style="margin-top:16px">
                 <p><b>Current mode:</b> {{params.mode || 'disabled'}}</p>


### PR DESCRIPTION
## What this is

The Subsonic API is now **deprecated** in favor of the first-party apps and their iroh-based Quick Connect. Deprecation is exactly why this stabilization pass ships: the surface stays live until the first-party apps are released, so its known hard-failures and worst costs get fixed once, and then the surface is **frozen** — crash and security fixes only.

### Deprecation messaging
- **Boot warning** when `subsonic.mode` ≠ disabled (verified live)
- **Admin-panel notice** on the Subsonic page with a call for usage reports (verified in-browser)
- README bullet + [docs/subsonic-deprecation.md](docs/subsonic-deprecation.md) (rationale, freeze policy, feedback channels, timeline promise); phase-3 roadmap doc marked historical

## Audit findings fixed (33k-track fixture, real /rest HTTP)

| leg | before | after |
|---|---|---|
| **M4** `search3?songCount=100000` | 746 ms / 12 MB, **hard 500 past 32,766 tracks** ("too many SQL variables") | **19 ms / 500 songs** |
| **M15** getArtists / getIndexes | 52.3 / 49.1 ms every call; `lastModified: Date.now()` defeated client caching | **5.1 / 4.1 ms**; lastModified stable per content epoch; `ifModifiedSince` honoured |
| **M12** getAlbumList2 (7 types) | 82–93 ms each; home screens fire 3–5 at once | **10–32 ms** (alphabetical 9.7, newest 19.6, frequent 21.3, recent 31.8, random 12.3, byYear 10.7) |
| **M7** blank-query search3, late page (offset 30k) | 162 ms; full sync ~3.0 s+ | **33 ms; ~1.4 s** |
| **pin** getPlayQueue hash probes | 27.4 ms/chunk (idx_tracks_library scan — the 2026-06 prod-incident shape) | **0.72 ms/chunk** (MULTI-INDEX OR), getBookmarks 42→9.2 ms |

Mechanics: count params capped at 500 like every sibling (offsets untouched — paging still reaches the whole library); user-meta enrichment chunked at 900 ids; blank-listing pages id-first with a **total (title, id) order** — OFFSET paging can no longer dup/drop rows when a tie straddles a page boundary; album lists split into id-page + projection with per-type minimal page queries; getArtists memoized per (library-grant set, content epoch = the SystemUpdateID task-queue already bumps on scan batches); `+t.library_id` demotion keeps the planner on the two hash indexes for queue/bookmark restores.

**A trap this PR measured and dodged:** the um-driven album-list types (recent/frequent/highest) were first rewritten as an OR-join on the two hash columns — on a stats-less DB the planner refused the OR-optimization for the play_count variant and fell to a per-row scan: **36 seconds per call**. Shipped shape decomposes the COALESCE match into two UNION ALL equality arms, each planner-proof off a single index (same move as #813's artists-albums). Old-vs-new id sets verified identical for all three signals, legacy (file_hash-keyed) rows included.

## Two real data-loss bugs found while measuring

- **Express's qs `parameterLimit` silently drops query params past ~1,000.** A 2,000-track `savePlayQueue` kept 997 entries — and the truncation became permanent on the client's next save. All subsonic repeated-param reads now parse the raw query string (`arrayParam`).
- **The scalar half of the same cliff** (caught by the smoke round): `current`/`position`/`name`/`submission` trail the id list in real client URLs, so big saves kept the queue but lost the position, and a big "save as playlist" would 10-error on a name that was sent. New `qparam()` covers every scalar on the four repeated-param routes.

## Verification

- New pins: `test/subsonic/subsonic-surface-perf.test.mjs` — 21 cases incl. **old-query oracles for every album-list type**, page-tiling laws, memo scoping across user grants (a scoped user must never see another grant's cached artists), ifModifiedSince round-trip, and the >1,000-param queue restore with trailing scalars
- Full subsonic ring **353/353** · full suite **2167 pass / 0 fail** · lint clean
- Live smoke **13/13**: Symfonium-style connect + home-screen burst (87 ms for 5 lists), full-sync walk (every track exactly once, max ping 25 ms), **end-to-end epoch flip** (real file → real scan → lastModified moves → stale client gets the fresh index), 1,500-entry queue round-trip, 1,200-song playlist create, 1,100-id star call, deprecation warn in the live-log ring + admin banner rendered
- Carries the `discovery-infra-churn` deflake (same commit as on #813) so CI can't trip on that known-flaky window probe

Follow-up left in the audit: PR-I (wrapped stats). `artists-albums-multi`'s old OR-of-three stays as-is — velvet-only, and velvet is slated for removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)