### PR TITLE
perf(wrapped): SQL histograms + frozen earliest_play fix, V65 play_events index (audit PR-I)

### DIFF
--- a/src/api/wrapped.js
+++ b/src/api/wrapped.js
@@ -257,25 +257,43 @@ export function setup(mstream) {
     const coverage = Math.min(100, (allTimePlayed / totalTracks) * 100);
 
     // ── Listening by hour and weekday ──────────────────────────
+    // One indexed GROUP BY replaces fetching every in-period row and paying
+    // a fresh Intl.DateTimeFormat per row — that loop blocked the event
+    // loop for 8.4 s at 50k in-period events (2026-07 audit H7). strftime
+    // bins by the stored (UTC) digits, which is what the old code's
+    // local-parse-then-getHours() read back out for these
+    // 'YYYY-MM-DD HH:MM:SS' strings, so the buckets are unchanged (modulo
+    // the old path's DST artifact, where a spring-forward local hour
+    // shifted a stored 02:xx into the 03 bucket).
     const hourData = new Array(24).fill(0);
     const weekdayData = new Array(7).fill(0);
-    const timeRows = d().prepare(`
-      SELECT started_at FROM play_events
+    for (const b of d().prepare(`
+      SELECT CAST(strftime('%H', started_at) AS INTEGER) AS h,
+             CAST(strftime('%w', started_at) AS INTEGER) AS w,
+             COUNT(*) AS c
+      FROM play_events
       WHERE user_id = ? AND started_at >= ? AND started_at < ?
-    `).all(uid, start, end);
-
-    let earliestPlay = null;
-    for (const row of timeRows) {
-      try {
-        const dt = new Date(row.started_at);
-        hourData[dt.getHours()]++;
-        weekdayData[dt.getDay()]++;
-        const timeStr = dt.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
-        if (!earliestPlay || dt.getHours() < new Date('2000-01-01T' + earliestPlay).getHours()) {
-          earliestPlay = timeStr;
-        }
-      } catch (_) {}
+      GROUP BY h, w
+    `).all(uid, start, end)) {
+      if (b.h >= 0 && b.h < 24) { hourData[b.h] += b.c; }
+      if (b.w >= 0 && b.w < 7) { weekdayData[b.w] += b.c; }
     }
+
+    // Earliest time-of-day in the period. The old per-row comparison fed
+    // its own '09:13 AM' output back through `new Date('2000-01-01T…')`,
+    // got Invalid Date → NaN comparison → false, and froze on row 1 — it
+    // reported the period's FIRST event, not its earliest hour. MIN over
+    // the stored time-of-day is the intended value; the single
+    // toLocaleTimeString call keeps the exact wire format.
+    const earliestTod = d().prepare(`
+      SELECT MIN(strftime('%H:%M:%S', started_at)) AS tod
+      FROM play_events
+      WHERE user_id = ? AND started_at >= ? AND started_at < ?
+    `).get(uid, start, end)?.tod;
+    const earliestPlay = earliestTod
+      ? new Date('2000-01-01 ' + earliestTod)
+        .toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+      : null;
 
     // ── Top listening day ──────────────────────────────────────
     const topDay = d().prepare(`
@@ -414,7 +432,6 @@ export function setup(mstream) {
     if (!candidates.length) return res.json([]);
 
     const earlyDate = new Date(candidates.sort()[0]);
-    const now = new Date();
     const periods = [];
 
     const configs = [

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -81,7 +81,7 @@ import { HASH_GENERATION } from './audio-hash.js';
 // V63 indexes cue_points.library_id and play_events.library_id so the
 // library-delete cascade seeks instead of scanning. See SCHEMA_V63.
 // V64 indexes tracks.year so the DLNA By-Year browse seeks. See SCHEMA_V64.
-export const SCHEMA_VERSION = 64;
+export const SCHEMA_VERSION = 65;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2362,6 +2362,17 @@ export const SCHEMA_V64 = `
   CREATE INDEX IF NOT EXISTS idx_tracks_year ON tracks(year) WHERE year IS NOT NULL;
 `;
 
+// Every wrapped-stats query is `WHERE user_id = ? AND started_at >= ? AND
+// started_at < ?`, and play_events grows without bound — the single-column
+// indexes (V7-era user_id, started_at) made the planner pick one and filter
+// the rest, which on a one-user server means walking the user's ENTIRE
+// listening history per stats query, ~10 queries per page view (2026-07
+// audit M2: 215 ms @13k events, 1.62 s @150k, statement-level). The
+// composite turns each into a tight range seek.
+export const SCHEMA_V65 = `
+  CREATE INDEX IF NOT EXISTS idx_play_events_user_time ON play_events(user_id, started_at);
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2739,4 +2750,7 @@ export const MIGRATIONS = [
   // V64 indexes tracks.year for the DLNA By-Year browse. Index-only, no
   // rescan. See SCHEMA_V64.
   { version: 64, sql: SCHEMA_V64 },
+  // V65 indexes play_events(user_id, started_at) for the wrapped-stats
+  // period windows. Index-only, no rescan. See SCHEMA_V65.
+  { version: 65, sql: SCHEMA_V65 },
 ];

--- a/test/unit/wrapped-stats.test.mjs
+++ b/test/unit/wrapped-stats.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * Pins for the wrapped-stats fixes (2026-07 audit PR-I):
+ *
+ *   H7 — listening_by_hour / listening_by_weekday come from one GROUP BY
+ *        strftime pass; buckets must equal what the old per-row
+ *        Date#getHours()/getDay() loop produced (oracle reimplemented here);
+ *   H7 — earliest_play is the period's true earliest TIME OF DAY. The old
+ *        loop compared against `new Date('2000-01-01T09:13 AM')` — Invalid
+ *        Date, NaN comparison — and froze on the first row, reporting the
+ *        period's first event instead;
+ *   M2 — the V65 composite index exists on a fresh DB.
+ *
+ * wrapped.setup() is mounted on a bare express app (it only needs config +
+ * db manager), with req.user injected directly — the same harness shape as
+ * test/db/db-read-paths.test.mjs.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import express from 'express';
+
+let testRoot, server, base;
+let config, manager, wrapped;
+let uid, uidOther;
+const pad = (n) => String(n).padStart(2, '0');
+
+// This month's window, in the DB's own 'YYYY-MM-DD HH:MM:SS' shape.
+const now = new Date();
+const Y = now.getUTCFullYear(), M = now.getUTCMonth();
+const ts = (day, hh, mm, ss = 0) => `${Y}-${pad(M + 1)}-${pad(day)} ${pad(hh)}:${pad(mm)}:${pad(ss)}`;
+
+before(async () => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-wrap-'));
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+    },
+    port: 0,
+  }, null, 2));
+
+  config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  manager = await import('../../src/db/manager.js');
+  manager.initDB();
+  wrapped = await import('../../src/api/wrapped.js');
+
+  const d = manager.getDB();
+  d.prepare(`INSERT INTO users (username, password, salt) VALUES ('wrapper', 'x', 'x')`).run();
+  d.prepare(`INSERT INTO users (username, password, salt) VALUES ('other', 'x', 'x')`).run();
+  uid = d.prepare("SELECT id FROM users WHERE username='wrapper'").get().id;
+  uidOther = d.prepare("SELECT id FROM users WHERE username='other'").get().id;
+
+  const ins = d.prepare(`INSERT INTO play_events
+    (event_id, user_id, filepath, library_id, session_id, track_duration_ms,
+     started_at, ended_at, outcome, played_ms, pause_count)
+    VALUES (?, ?, ?, NULL, ?, 200000, ?, ?, ?, ?, 0)`);
+  let n = 0;
+  const add = (userId, when, outcome = 'completed') =>
+    ins.run(`we-${n++}`, userId, `song${n % 7}.mp3`, `s-${Math.floor(n / 3)}`, when, when, outcome, 60000);
+
+  // The period's FIRST event is 09:13 on day 1; the true earliest
+  // time-of-day (04:07) happens later in the month — the frozen bug
+  // reported 09:13.
+  add(uid, ts(1, 9, 13));
+  add(uid, ts(1, 22, 40));
+  add(uid, ts(2, 4, 7));           // earliest time-of-day, NOT the first row
+  add(uid, ts(2, 4, 30));
+  add(uid, ts(3, 23, 59, 59));
+  // Bulk filler stays inside 06:00–22:59 so 04:07 remains the true minimum.
+  for (let i = 0; i < 40; i++) { add(uid, ts(4 + (i % 20), 6 + ((8 + i) % 17), i % 60), i % 4 === 0 ? 'skipped' : 'completed'); }
+  // Another user's plays in the same window must not leak in.
+  add(uidOther, ts(2, 1, 1));
+  add(uidOther, ts(2, 1, 2));
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => { req.user = { id: req.headers['x-uid'] ? Number(req.headers['x-uid']) : uid, libraryIds: [] }; next(); });
+  wrapped.setup(app);
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+  // Await the close: exiting while the listen handle is still tearing down
+  // trips libuv's UV_HANDLE_CLOSING assert on Windows.
+  try { if (server) { await new Promise((r) => server.close(r)); } } catch (_e) { /* closed */ }
+  try { manager.close(); } catch (_e) { /* closed */ }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_e) { /* win locks */ }
+  // No forced process.exit here: everything this suite starts is closed
+  // above and the process exits cleanly on its own — a setImmediate exit(0)
+  // raced libuv handle teardown on Windows and tripped
+  // `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)` (async.c).
+});
+
+async function getWrapped(params = 'period=monthly', headers = {}) {
+  const r = await fetch(`${base}/api/v1/user/wrapped?${params}`, { headers });
+  return r.json();
+}
+
+describe('wrapped H7: histograms + earliest_play', () => {
+  test('hour/weekday buckets equal the old per-row loop exactly', async () => {
+    const j = await getWrapped();
+    // Oracle: the pre-PR loop, verbatim semantics (local-parse + getHours/
+    // getDay), over the same rows.
+    const d = manager.getDB();
+    const { start, end } = wrapped.getPeriodRange('monthly', 0);
+    const rows = d.prepare(
+      'SELECT started_at FROM play_events WHERE user_id = ? AND started_at >= ? AND started_at < ?'
+    ).all(uid, start, end);
+    const hour = new Array(24).fill(0);
+    const weekday = new Array(7).fill(0);
+    for (const row of rows) {
+      const dt = new Date(row.started_at);
+      hour[dt.getHours()]++;
+      weekday[dt.getDay()]++;
+    }
+    assert.deepEqual(j.listening_by_hour, hour);
+    assert.deepEqual(j.listening_by_weekday, weekday);
+    assert.equal(j.listening_by_hour.reduce((a, b) => a + b, 0), j.total_plays,
+      'every play lands in exactly one hour bucket');
+  });
+
+  test('earliest_play is the true earliest time-of-day, not the first event', async () => {
+    const j = await getWrapped();
+    // Expected string built through the SAME toLocaleTimeString call the
+    // handler uses, so the assertion is ICU-version-proof.
+    const expected = new Date('2000-01-01 04:07:00')
+      .toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+    const frozen = new Date('2000-01-01 09:13:00')
+      .toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+    assert.equal(j.fun_facts.earliest_play, expected);
+    assert.notEqual(j.fun_facts.earliest_play, frozen,
+      'the frozen-on-row-1 value must be gone');
+  });
+
+  test('another user\'s plays in the window do not leak in', async () => {
+    const mine = await getWrapped();
+    const theirs = await getWrapped('period=monthly', { 'x-uid': String(uidOther) });
+    assert.equal(theirs.total_plays, 2);
+    assert.equal(mine.total_plays, 45);
+    // Their 01:01 play must not become my earliest.
+    assert.notEqual(mine.fun_facts.earliest_play, theirs.fun_facts.earliest_play);
+  });
+
+  test('an empty period is zeros and nulls, not a crash', async () => {
+    // monthly offset far in the past — no events there.
+    const j = await getWrapped('period=monthly&offset=-120');
+    assert.equal(j.total_plays, 0);
+    assert.deepEqual(j.listening_by_hour, new Array(24).fill(0));
+    assert.deepEqual(j.listening_by_weekday, new Array(7).fill(0));
+    assert.equal(j.fun_facts.earliest_play, null);
+  });
+});
+
+describe('wrapped M2: composite index', () => {
+  test('a fresh DB carries idx_play_events_user_time', () => {
+    const row = manager.getDB().prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_play_events_user_time'"
+    ).get();
+    assert.ok(row, 'V65 index present');
+  });
+
+  test('the period window query uses it', () => {
+    const plan = manager.getDB().prepare(`EXPLAIN QUERY PLAN
+      SELECT COUNT(*) FROM play_events WHERE user_id = ? AND started_at >= ? AND started_at < ?`)
+      .all(uid, '2026-01-01 00:00:00', '2026-02-01 00:00:00')
+      .map((r) => r.detail).join(' | ');
+    assert.match(plan, /idx_play_events_user_time/);
+  });
+});


### PR DESCRIPTION
## What this is

The 2026-07 perf audit's **final group (I)** — the wrapped/stats surface. `wrapped.js` mounts only when `ui: 'velvet'` (the audit's "opt-in, slated for removal" caveat), so this stays deliberately **minimal**: the H7 loop, its embedded correctness bug, and the M2 index. Measured over real HTTP on a 150k-event fixture (50k in the current month), seeded **chronologically** — more on why that matters below.

## The headline numbers

| leg | before | after |
|---|---|---|
| `GET /user/wrapped?period=monthly` (50k in-period) | **9,349 ms** | **872 ms** (10.7×) |
| `GET /user/wrapped?period=yearly` (~104k in-period) | **18,596 ms** | **1,404 ms** (13.2×) |
| `GET /user/wrapped/periods` | 31 ms | 6 ms |

Every one of those baseline seconds was synchronous main-thread time — a stats-page view blocked the whole server for 9–19 s.

## H7 — the loop, and the bug living inside it

The handler fetched **every in-period event row** and ran a JS loop building a fresh `Intl.DateTimeFormat` per row (`toLocaleTimeString`) to fill the hour/weekday histograms. Replaced with one covered-index `GROUP BY strftime('%H','%w')` pass — buckets verified **byte-identical** before→after (hour, weekday, plays, personality, top_day all captured and compared).

The loop also carried the audit's bonus find: the earliest-play comparison parsed its own `'09:13 AM'` output back through `new Date('2000-01-01T09:13 AM')` → **Invalid Date → NaN comparison → false forever** — `earliest_play` froze on row 1 and reported the period's *first event*, not its earliest time of day. Now `MIN(strftime('%H:%M:%S'))` + a single `toLocaleTimeString` call (same wire format). This is the PR's one deliberate output change: `'09:13 AM'` → `'04:07 AM'` on the fixture, visible in the velvet UI's ⏰ fun-fact card during smoke.

## M2 — V65: `play_events(user_id, started_at)`

Every stats query is a user+window range; the V7-era single-column indexes made the planner pick one and filter, walking the user's entire unbounded history per query. The composite: **~20% whole-page** on this fixture and **up to 47% per window query**, no regressions — and this single-user fixture is the index's *weakest* case (the user prefix selects nothing; multi-user servers and longer histories gain more).

**A measurement trap worth recording:** the first synthetic seed wrote events in scattered day order, which anti-correlates index order with rowid — every composite-index row fetch became a random page bounce and the A/B *inverted* (the index looked like a 24% regression). Real play logs are append-only chronological; re-seeded that way, the index wins across the board. Fixture write-order can flip an index verdict.

## Not done, deliberately

- **play_events retention** — nothing prunes the table; that's a product decision, not a perf fix.
- The residual ~0.9–1.4 s at 150k spreads across the other 9 aggregation queries (two of which are all-time-history by design); consolidation isn't worth it for a velvet-gated page.

## Verification

- New pins: `test/unit/wrapped-stats.test.mjs` — histogram oracle (the old loop reimplemented verbatim), true-earliest vs the frozen value, per-user isolation, empty-period shape, V65 presence + plan
- Full suite **2,200 pass / 0 fail** · lint clean (removed one pre-existing unused-var while in the file) · schema-guard + period-range suites green (no `=== 64` pins existed)
- Live smoke **8/8** on a booted velvet-mode server: real play-start → pause → play-end lands in the period stats; hour histogram == DB truth; per-user isolation; yearly view bounded under a concurrent pinger (~3 s contended / ~1.4 s alone, vs 16–19 s before); periods listing spans the 13-month history
- **Velvet UI click-through**: stats page renders fully from the rewritten handler — charts, personality, and the corrected earliest-play on screen; current page load = 21 resources, 0 failures

This closes the audit backlog: all nine groups (A–I) shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)