### PR TITLE
fix(waveform): full-length decode, no phase cancellation, real Opus coverage

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1118,7 +1118,7 @@ paths:
                         disabledReason:
                           type: string
                           nullable: true
-                          enum: [config, no-ffmpeg, no-api-key, no-binary, binary-unsupported, runtime-unavailable, null]
+                          enum: [config, no-ffmpeg, no-api-key, no-binary, binary-unsupported, binary-generation-mismatch, runtime-unavailable, null]
                         state:
                           type: string
                           enum: [idle, queued, running, disabled]

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -44,6 +44,12 @@ const NUM_BARS: usize = 800;
 // are ignored here and swept at boot by the JS side.
 const WAVEFORM_EXT: &str = ".w2.bin";
 const WAVEFORM_FAILED_EXT: &str = ".w2.failed";
+// Deferred to the ffmpeg half: no decoder for this codec. A SEPARATE
+// artifact, not a line inside `.failed`, because every consumer
+// classifies these by filename — the JS coverage counter must stay
+// filename-only, and counting a deferral as a failure misreports a
+// perfectly good file. Mirrors DEFERRED_EXT in src/db/waveform-lib.js.
+const WAVEFORM_DEFERRED_EXT: &str = ".w2.deferred";
 
 // ── Config (matches what task-queue.js passes) ──────────────────────────────
 
@@ -4466,7 +4472,10 @@ fn load_waveform_cache_names(dir: &Path) -> HashSet<String> {
     if let Ok(entries) = fs::read_dir(dir) {
         for entry in entries.flatten() {
             if let Some(fname) = entry.file_name().to_str() {
-                if fname.ends_with(WAVEFORM_EXT) || fname.ends_with(WAVEFORM_FAILED_EXT) {
+                if fname.ends_with(WAVEFORM_EXT)
+                    || fname.ends_with(WAVEFORM_FAILED_EXT)
+                    || fname.ends_with(WAVEFORM_DEFERRED_EXT)
+                {
                     names.insert(fname.to_string());
                 }
             }
@@ -4549,18 +4558,16 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
         // for a transient quirk) must not stop this pass from trying, and
         // a generated .bin is exactly what unblocks the endpoint again.
         // Mirrors the engine-line discipline in src/db/waveform-lib.js.
-        // Both lines mean "this pass already decided about this key":
-        // `symphonia` is a decode failure, `no-decoder` is a codec we have
-        // no decoder for. Either way re-running would repeat the same work
-        // for the same answer, so both exclude the key from the plan. Only
-        // the ffmpeg fallback can move them, and a success there deletes
-        // the marker outright.
+        // A `symphonia` line means this pass tried and failed; re-running
+        // would repeat the work for the same answer. Only the ffmpeg
+        // fallback can move such a key, and a success there deletes the
+        // marker outright.
         let symphonia_failed: HashSet<&String> = existing
             .iter()
             .filter(|name| {
                 name.ends_with(WAVEFORM_FAILED_EXT)
                     && fs::read_to_string(cache_dir.join(name.as_str()))
-                        .map(|c| c.contains("symphonia") || c.contains("no-decoder"))
+                        .map(|c| c.contains("symphonia"))
                         .unwrap_or(true) // unreadable marker — assume ours
             })
             .collect();
@@ -4589,6 +4596,7 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
                 None => continue, // no content hash to key the cache on
             };
             if existing.contains(&format!("{}{}", key, WAVEFORM_EXT))
+                || existing.contains(&format!("{}{}", key, WAVEFORM_DEFERRED_EXT))
                 || symphonia_failed.contains(&format!("{}{}", key, WAVEFORM_FAILED_EXT))
             {
                 continue;
@@ -4688,13 +4696,18 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
                 // exclude it, this pass re-planned and re-probed those files
                 // on every single scan, forever.
                 //
-                // The `no-decoder` line is not a failure line: the fallback
-                // treats it as work, the coverage counter does not count it
-                // as failed, and the on-demand endpoint (which gates only on
-                // `ffmpeg`) still serves. A later ffmpeg success deletes the
-                // whole marker.
+                // The deferral artifact is NOT a failure marker: the
+                // fallback routes on it, the coverage counter counts it as
+                // neither done nor failed (so the key reads as remaining,
+                // which is the truth), and the on-demand endpoint — which
+                // gates only on an `ffmpeg` line in `.failed` — still
+                // serves. A later success deletes it.
                 Some(WaveformDecode::NoDecoder) => {
-                    append_failure_marker(&cache_dir, key, "no-decoder");
+                    let marker = cache_dir.join(format!("{}{}", key, WAVEFORM_DEFERRED_EXT));
+                    // Content is a breadcrumb for a human reading the cache
+                    // dir; nothing parses it — the suffix carries the meaning.
+                    let _ = write_atomic(&marker, b"no-decoder
+");
                 }
                 Some(WaveformDecode::Failed) => {
                     failed.fetch_add(1, Ordering::Relaxed);

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -719,6 +719,18 @@ fn main() {
         }
     }
 
+    // Capability probe: `rust-parser --wf-generation` prints the waveform
+    // cache generation this binary writes. The server compares it against
+    // its own CACHE_EXT before running the pass — a binary one generation
+    // behind would write names the boot sweep deletes, re-decoding the
+    // whole library on every boot. Binaries that pre-date the probe fall
+    // through to the JSON-config path and exit 1 with nothing on stdout,
+    // which the server reads the same way (skip the pass).
+    if args.len() == 2 && args[1] == "--wf-generation" {
+        println!("{{\"waveformExt\":\"{}\"}}", WAVEFORM_EXT);
+        return;
+    }
+
     // Hidden developer/test subcommand: `rust-parser --waveform <path>`
     // prints `{"bars":"<hex of 800 bytes>"}` on success or `{"bars":null}`
     // when no waveform can be produced (e.g. .opus, where symphonia 0.6
@@ -729,7 +741,7 @@ fn main() {
         let p = Path::new(&args[2]);
         let ext = file_ext(p).to_lowercase();
         match waveform_from_symphonia(p, &ext) {
-            Some(output) => {
+            WaveformDecode::Bars(output) => {
                 // Hex instead of base64: trivial to produce without extra
                 // crates, trivial for the JS test to decode, fixed-length
                 // 1600 chars so a bug that truncates or pads shows up
@@ -738,7 +750,7 @@ fn main() {
                 for b in output.bars.iter() { hex.push_str(&format!("{:02x}", b)); }
                 println!("{{\"bars\":\"{}\",\"frames\":{}}}", hex, output.frames);
             }
-            None => {
+            WaveformDecode::NoDecoder | WaveformDecode::Failed => {
                 println!("{{\"bars\":null,\"frames\":0}}");
             }
         }
@@ -4625,21 +4637,19 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
     pool.install(|| {
         use rayon::prelude::*;
         work.par_iter().for_each(|(key, paths)| {
-            let mut decoded = None;
-            let mut decode_attempted = false;
+            let mut decoded: Option<WaveformDecode> = None;   // None = no copy opened
             // Walk this content's paths until one OPENS: a vanished or
             // unreadable copy is not a verdict on the content — another
             // copy (or a later pass) can still produce the waveform. One
             // decode attempt per key: the bytes are the same everywhere.
             for path in paths {
                 let Ok(file) = fs::File::open(path) else { continue; };
-                decode_attempted = true;
                 let ext = file_ext(path).to_lowercase();
                 let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     waveform_from_source(Box::new(file), &ext)
                 }));
-                match outcome {
-                    Ok(result) => { decoded = result; }
+                decoded = Some(match outcome {
+                    Ok(result) => result,
                     Err(_) => {
                         if warn_lines.fetch_add(1, Ordering::Relaxed) < 20 {
                             eprintln!(
@@ -4647,18 +4657,25 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
                                 path.display()
                             );
                         }
+                        WaveformDecode::Failed
                     }
-                }
+                });
                 break;
             }
             match decoded {
-                Some(output) => {
+                Some(WaveformDecode::Bars(output)) => {
                     let bin = cache_dir.join(format!("{}{}", key, WAVEFORM_EXT));
                     if write_atomic(&bin, &output.bars).is_some() {
                         generated.fetch_add(1, Ordering::Relaxed);
                     }
                 }
-                None if decode_attempted => {
+                // A codec symphonia can't decode (Opus hiding in a .ogg) is
+                // the ffmpeg fallback's work: no marker — it would misreport
+                // a fine file as failed and exclude the key from this pass
+                // forever — and no failure count. The fallback caches it in
+                // the same task, so the re-probe here happens at most once.
+                Some(WaveformDecode::NoDecoder) => {}
+                Some(WaveformDecode::Failed) => {
                     failed.fetch_add(1, Ordering::Relaxed);
                     append_failure_marker(&cache_dir, key, "symphonia");
                 }
@@ -5393,13 +5410,25 @@ struct WaveformOutput {
     frames: u64,
 }
 
+// Decode outcome, split three ways because the scan pass treats them
+// differently: Bars → cache file; NoDecoder → silent skip (the ffmpeg
+// fallback pass owns codecs symphonia cannot decode — a marker here would
+// misreport a fine file as failed, which is exactly the Opus bug the w2
+// generation fixed, resurfacing through the container instead of the
+// extension); Failed → `symphonia` marker so the pass stops retrying.
+enum WaveformDecode {
+    Bars(WaveformOutput),
+    NoDecoder,
+    Failed,
+}
+
 fn waveform_from_source(
     source: Box<dyn symphonia::core::io::MediaSource>, ext: &str,
-) -> Option<WaveformOutput> {
+) -> WaveformDecode {
     // Symphonia still doesn't ship a pure-Rust Opus decoder in 0.6 (only a
     // libopus C adapter, which we deliberately avoid). Skip .opus here and
     // let the ffmpeg fallback pass handle it.
-    if waveform_codec_unsupported(ext) { return None; }
+    if waveform_codec_unsupported(ext) { return WaveformDecode::NoDecoder; }
 
     let source: Box<dyn symphonia::core::io::MediaSource> = if hides_stream_length(ext) {
         Box::new(HiddenLenSource { inner: source })
@@ -5414,21 +5443,33 @@ fn waveform_from_source(
     // symphonia 0.6: probe() returns the FormatReader directly (no Probed
     // wrapper), and per-track codec params became an Option'd enum — the
     // old CODEC_TYPE_NULL sentinel is now simply a non-Audio/None entry.
-    let mut format = symphonia::default::get_probe()
+    let mut format = match symphonia::default::get_probe()
         .probe(&hint, mss, FormatOptions::default(), MetadataOptions::default())
-        .ok()?;
+    {
+        Ok(f) => f,
+        Err(_) => return WaveformDecode::Failed,
+    };
 
-    let (track_id, audio_params) = format.tracks().iter().find_map(|t| {
+    let Some((track_id, audio_params)) = format.tracks().iter().find_map(|t| {
         match &t.codec_params {
             Some(CodecParameters::Audio(p)) => Some((t.id, p.clone())),
             _ => None,
         }
-    })?;
+    }) else { return WaveformDecode::Failed; };
     let channels = audio_params.channels.as_ref().map(|c| c.count()).unwrap_or(2);
 
-    let mut decoder = symphonia::default::get_codecs()
+    // The extension gate above cannot see codecs hidden inside a neutral
+    // container — Opus in .ogg probes fine (symphonia-format-ogg ships an
+    // Opus MAPPER) and only fails here, where the registry has no decoder
+    // for it. That is the same "not our work" case as the extension skip,
+    // NOT a verdict on the file.
+    let mut decoder = match symphonia::default::get_codecs()
         .make_audio_decoder(&audio_params, &AudioDecoderOptions::default())
-        .ok()?;
+    {
+        Ok(d) => d,
+        Err(SymphoniaError::Unsupported(_)) => return WaveformDecode::NoDecoder,
+        Err(_) => return WaveformDecode::Failed,
+    };
 
     let mut pyramid = PeakPyramid::new();
     // 0.6 replaced SampleBuffer with copy-out methods on the decoded buffer;
@@ -5479,17 +5520,22 @@ fn waveform_from_source(
         }
     }
 
-    // None = probed OK but decoded no frames (e.g. a codec the probe
-    // recognised and the decoder didn't).
+    // Failed = probed OK but decoded no frames (e.g. a stream the probe
+    // recognised and the decoder then produced nothing from).
     let frames = pyramid.frames;
-    pyramid.bars().map(|bars| WaveformOutput { bars, frames })
+    match pyramid.bars() {
+        Some(bars) => WaveformDecode::Bars(WaveformOutput { bars, frames }),
+        None => WaveformDecode::Failed,
+    }
 }
 
 // File-backed waveform entry point. Opens the file once; symphonia
 // streams it as needed.
-fn waveform_from_symphonia(path: &Path, ext: &str) -> Option<WaveformOutput> {
-    let file = fs::File::open(path).ok()?;
-    waveform_from_source(Box::new(file), ext)
+fn waveform_from_symphonia(path: &Path, ext: &str) -> WaveformDecode {
+    match fs::File::open(path) {
+        Ok(file) => waveform_from_source(Box::new(file), ext),
+        Err(_) => WaveformDecode::Failed,
+    }
 }
 
 // ── Chromaprint fingerprint (--fingerprint) ─────────────────────────────────

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -4549,12 +4549,18 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
         // for a transient quirk) must not stop this pass from trying, and
         // a generated .bin is exactly what unblocks the endpoint again.
         // Mirrors the engine-line discipline in src/db/waveform-lib.js.
+        // Both lines mean "this pass already decided about this key":
+        // `symphonia` is a decode failure, `no-decoder` is a codec we have
+        // no decoder for. Either way re-running would repeat the same work
+        // for the same answer, so both exclude the key from the plan. Only
+        // the ffmpeg fallback can move them, and a success there deletes
+        // the marker outright.
         let symphonia_failed: HashSet<&String> = existing
             .iter()
             .filter(|name| {
                 name.ends_with(WAVEFORM_FAILED_EXT)
                     && fs::read_to_string(cache_dir.join(name.as_str()))
-                        .map(|c| c.contains("symphonia"))
+                        .map(|c| c.contains("symphonia") || c.contains("no-decoder"))
                         .unwrap_or(true) // unreadable marker — assume ours
             })
             .collect();
@@ -4669,12 +4675,27 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
                         generated.fetch_add(1, Ordering::Relaxed);
                     }
                 }
-                // A codec symphonia can't decode (Opus hiding in a .ogg) is
-                // the ffmpeg fallback's work: no marker — it would misreport
-                // a fine file as failed and exclude the key from this pass
-                // forever — and no failure count. The fallback caches it in
-                // the same task, so the re-probe here happens at most once.
-                Some(WaveformDecode::NoDecoder) => {}
+                // A codec symphonia has no decoder for. This is the ffmpeg
+                // fallback's work, not a verdict on the file, so it must not
+                // count as failed — but it still has to leave a TRACE.
+                //
+                // Writing nothing was wrong in two ways. The key had no
+                // route to the fallback except its extension, so anything
+                // undecodable in a container the fallback doesn't query
+                // (5.1 or HE-AAC in .m4a/.m4b/.aac — symphonia's AAC
+                // decoder refuses non-LC, >2ch and SBR streams) got no
+                // waveform from EITHER pass, ever. And with no artifact to
+                // exclude it, this pass re-planned and re-probed those files
+                // on every single scan, forever.
+                //
+                // The `no-decoder` line is not a failure line: the fallback
+                // treats it as work, the coverage counter does not count it
+                // as failed, and the on-demand endpoint (which gates only on
+                // `ffmpeg`) still serves. A later ffmpeg success deletes the
+                // whole marker.
+                Some(WaveformDecode::NoDecoder) => {
+                    append_failure_marker(&cache_dir, key, "no-decoder");
+                }
                 Some(WaveformDecode::Failed) => {
                     failed.fetch_add(1, Ordering::Relaxed);
                     append_failure_marker(&cache_dir, key, "symphonia");

--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -25,6 +25,7 @@ use base64::Engine as _;
 use rusty_chromaprint::{Configuration, FingerprintCompressor, Fingerprinter};
 use symphonia::core::codecs::audio::AudioDecoderOptions;
 use symphonia::core::codecs::CodecParameters;
+use symphonia::core::errors::Error as SymphoniaError;
 use symphonia::core::formats::probe::Hint;
 use symphonia::core::formats::FormatOptions;
 use symphonia::core::io::MediaSourceStream;
@@ -33,6 +34,16 @@ use symphonia::core::meta::MetadataOptions;
 // Number of bars in a waveform — matches NUM_BARS in src/db/waveform-lib.js.
 // Cache files are exactly this many bytes (one u8 per bar).
 const NUM_BARS: usize = 800;
+
+// Cache artifact naming — MUST match cacheFilePath()/failedMarkerPath() in
+// src/db/waveform-lib.js, which owns the scheme. The `w2` generation marks
+// the corrected decoder: bars are binned by the TRUE decoded frame count
+// (containers that lie about their length no longer stretch the waveform)
+// and channels are combined with max|ch| rather than an average. v1
+// `<hash>.bin` files describe different bytes for the same audio, so they
+// are ignored here and swept at boot by the JS side.
+const WAVEFORM_EXT: &str = ".w2.bin";
+const WAVEFORM_FAILED_EXT: &str = ".w2.failed";
 
 // ── Config (matches what task-queue.js passes) ──────────────────────────────
 
@@ -725,10 +736,10 @@ fn main() {
                 // immediately.
                 let mut hex = String::with_capacity(NUM_BARS * 2);
                 for b in output.bars.iter() { hex.push_str(&format!("{:02x}", b)); }
-                println!("{{\"bars\":\"{}\"}}", hex);
+                println!("{{\"bars\":\"{}\",\"frames\":{}}}", hex, output.frames);
             }
             None => {
-                println!("{{\"bars\":null}}");
+                println!("{{\"bars\":null,\"frames\":0}}");
             }
         }
         return;
@@ -4433,16 +4444,17 @@ pub(crate) struct DirListing {
 }
 
 // One-time scan of the waveform cache directory into a set of filenames
-// (`<hash>.bin` results and `<hash>.failed` markers). The waveform pass
-// checks membership against the set instead of stat-ing the filesystem
-// per track. Missing/unreadable cache dir → empty set, which degrades
-// to "generate everything".
+// (`<hash>.w2.bin` results and `<hash>.w2.failed` markers). The waveform
+// pass checks membership against the set instead of stat-ing the
+// filesystem per track. Missing/unreadable cache dir → empty set, which
+// degrades to "generate everything". Superseded v1 names are deliberately
+// NOT collected: they must not suppress regeneration.
 fn load_waveform_cache_names(dir: &Path) -> HashSet<String> {
     let mut names = HashSet::new();
     if let Ok(entries) = fs::read_dir(dir) {
         for entry in entries.flatten() {
             if let Some(fname) = entry.file_name().to_str() {
-                if fname.ends_with(".bin") || fname.ends_with(".failed") {
+                if fname.ends_with(WAVEFORM_EXT) || fname.ends_with(WAVEFORM_FAILED_EXT) {
                     names.insert(fname.to_string());
                 }
             }
@@ -4528,7 +4540,7 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
         let symphonia_failed: HashSet<&String> = existing
             .iter()
             .filter(|name| {
-                name.ends_with(".failed")
+                name.ends_with(WAVEFORM_FAILED_EXT)
                     && fs::read_to_string(cache_dir.join(name.as_str()))
                         .map(|c| c.contains("symphonia"))
                         .unwrap_or(true) // unreadable marker — assume ours
@@ -4558,15 +4570,21 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
                 Some(k) => k,
                 None => continue, // no content hash to key the cache on
             };
-            if existing.contains(&format!("{}.bin", key))
-                || symphonia_failed.contains(&format!("{}.failed", key))
+            if existing.contains(&format!("{}{}", key, WAVEFORM_EXT))
+                || symphonia_failed.contains(&format!("{}{}", key, WAVEFORM_FAILED_EXT))
             {
                 continue;
             }
+            let path = Path::new(&root).join(rel);
+            // A codec symphonia can't touch is not work for this pass and
+            // not a failure: leaving it out keeps the planned total, the
+            // progress bar and the reported failure count honest, and
+            // leaves the key visible to the ffmpeg fallback pass.
+            if waveform_codec_unsupported(&file_ext(&path).to_lowercase()) { continue; }
             match by_key.get_mut(&key) {
-                Some(paths) => paths.push(Path::new(&root).join(rel)),
+                Some(paths) => paths.push(path),
                 None => {
-                    by_key.insert(key.clone(), vec![Path::new(&root).join(rel)]);
+                    by_key.insert(key.clone(), vec![path]);
                     order.push(key);
                 }
             }
@@ -4635,7 +4653,7 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
             }
             match decoded {
                 Some(output) => {
-                    let bin = cache_dir.join(format!("{}.bin", key));
+                    let bin = cache_dir.join(format!("{}{}", key, WAVEFORM_EXT));
                     if write_atomic(&bin, &output.bars).is_some() {
                         generated.fetch_add(1, Ordering::Relaxed);
                     }
@@ -4674,7 +4692,7 @@ fn run_waveform_scan(json_str: &str) -> Result<(), Box<dyn std::error::Error>> {
 // endpoint's append is tiny, and the content union is correct from
 // either side.
 fn append_failure_marker(cache_dir: &Path, key: &str, engine: &str) {
-    let marker = cache_dir.join(format!("{}.failed", key));
+    let marker = cache_dir.join(format!("{}{}", key, WAVEFORM_FAILED_EXT));
     let mut content = fs::read_to_string(&marker).unwrap_or_default();
     if !content.contains(engine) {
         content.push_str(engine);
@@ -5224,27 +5242,155 @@ fn audio_ranges_for_ext<R: Read + Seek>(
 
 // ── Waveform generation (symphonia-powered) ───────────────────────────────
 //
-// Decodes the audio stream, downmixes to mono magnitudes, and emits NUM_BARS
-// peak values (u8, 0-255). .opus is skipped because symphonia 0.6 still lacks an
-// Opus decoder. On any decoder/IO error we fall back to None so the scanner
-// continues and the on-demand endpoint can try ffmpeg later.
+// Decodes the audio stream, reduces each frame to one magnitude, and emits
+// NUM_BARS peak values (u8, 0-255). .opus is skipped because symphonia 0.6
+// still lacks an Opus decoder — the ffmpeg fallback pass covers it. On any
+// decoder/IO error we return None so the scanner continues.
 //
-// Two decode strategies:
-//   (a) Streaming — when track.codec_params.n_frames is populated, map each
-//       decoded frame directly to its bar by index (bar = frame_idx * N / total).
-//       Memory: O(1). Used for most formats (MP3, FLAC, Ogg Vorbis, AAC/M4A).
-//   (b) Buffered — when n_frames is None (notably WAV, where symphonia's
-//       format reader doesn't populate it), collect mono magnitudes into a
-//       Vec and bin by the actual count at the end. Memory: O(n_frames).
-//       Capped at MAX_BUFFERED_FRAMES to keep worst-case memory bounded on
-//       very long WAV files; past that we truncate.
-const MAX_BUFFERED_FRAMES: usize = 30 * 1024 * 1024;  // ~10 min at 48 kHz
+// Binning runs through a bounded peak pyramid rather than a container-
+// declared frame count. The old code had two paths: a streaming one that
+// mapped each frame to `frame_idx * NUM_BARS / n_frames`, and a buffered
+// one (Vec of every magnitude, truncated past MAX_BUFFERED_FRAMES) for
+// formats that report no length. Both were wrong in ways real files hit:
+//
+//   - n_frames is an ESTIMATE for a VBR MP3 with no Xing/Info header.
+//     Measured on a 60 s fixture with bursts at 0/25/50/75/99.5 %, the
+//     bars came out at 1/220/441/661 instead of 0/200/400/600 and the
+//     last burst ran past bar 799 and was dropped — ~10 % of the track
+//     missing and every x-position out of step with the playhead.
+//   - the buffered path truncated anything past ~12 minutes, silently.
+//
+// The pyramid keeps one peak per `stride` frames and halves itself (peak
+// of pairs, doubling the stride) whenever it fills, so memory is capped
+// while the final binning uses the true decoded frame count.
+//
+// Capacity is per decode and the pass decodes on every rayon thread, so
+// this is a memory-per-core knob. Peaks of peaks are exact — the only
+// error is a group straddling a bar boundary, which costs at most
+// 800/CAPACITY of a bar's width, here 0.6 %, well under a pixel. The old
+// buffered path allocated up to 120 MB for a single long file; this is
+// 512 KB per thread.
+const PYRAMID_CAPACITY: usize = 1 << 17;
+
+struct PeakPyramid {
+    store: Vec<f32>,
+    length: usize,
+    stride: u64,
+    group_peak: f32,
+    group_fill: u64,
+    frames: u64,
+}
+
+impl PeakPyramid {
+    fn new() -> Self {
+        Self {
+            store: vec![0.0; PYRAMID_CAPACITY],
+            length: 0,
+            stride: 1,
+            group_peak: 0.0,
+            group_fill: 0,
+            frames: 0,
+        }
+    }
+
+    fn push(&mut self, mag: f32) {
+        self.frames += 1;
+        if mag > self.group_peak { self.group_peak = mag; }
+        self.group_fill += 1;
+        if self.group_fill != self.stride { return; }
+        if self.length == PYRAMID_CAPACITY {
+            for j in 0..PYRAMID_CAPACITY / 2 {
+                self.store[j] = self.store[2 * j].max(self.store[2 * j + 1]);
+            }
+            self.length = PYRAMID_CAPACITY / 2;
+            self.stride *= 2;
+            // The partial group keeps filling under the doubled stride.
+            return;
+        }
+        self.store[self.length] = self.group_peak;
+        self.length += 1;
+        self.group_peak = 0.0;
+        self.group_fill = 0;
+    }
+
+    // Flush the partial tail group, then bin what we actually decoded.
+    // None means no frames at all (probed OK, decoded empty).
+    fn bars(&mut self) -> Option<[u8; NUM_BARS]> {
+        if self.group_fill > 0 {
+            if self.length < PYRAMID_CAPACITY {
+                self.store[self.length] = self.group_peak;
+                self.length += 1;
+            } else if self.group_peak > self.store[PYRAMID_CAPACITY - 1] {
+                self.store[PYRAMID_CAPACITY - 1] = self.group_peak;
+            }
+            self.group_peak = 0.0;
+            self.group_fill = 0;
+        }
+        let total = self.length;
+        if total == 0 { return None; }
+        let mut bars = [0u8; NUM_BARS];
+        for (i, bar) in bars.iter_mut().enumerate() {
+            let start = i * total / NUM_BARS;
+            // A file shorter than NUM_BARS groups would otherwise leave
+            // empty bars between the filled ones; neighbours share instead.
+            let end = (((i + 1) * total / NUM_BARS).max(start + 1)).min(total);
+            let mut peak = 0f32;
+            for &m in &self.store[start..end] {
+                if m > peak { peak = m; }
+            }
+            *bar = (peak.clamp(0.0, 1.0) * 255.0).round() as u8;
+        }
+        Some(bars)
+    }
+}
+
+// A MediaSource that forwards reads and seeks but refuses to state its
+// length. Symphonia's MPEG-audio reader, given no Xing/Info header, guesses
+// the stream length from the FIRST frame's bitrate and then ends the packet
+// stream at that guess. On a VBR file that opens denser than its average
+// the guess lands short and the tail is silently dropped — measured on two
+// encodes of the same 60 s audio differing only in section order: opening
+// loud decoded 47.5 s, opening quiet decoded 60.0 s. With no byte length
+// to extrapolate from, the reader runs to real EOF instead.
+//
+// Applied to MPEG audio only. Other containers (notably ISO-BMFF) use the
+// length for legitimate structural reasons, and none of them shows this bug.
+struct HiddenLenSource {
+    inner: Box<dyn symphonia::core::io::MediaSource>,
+}
+impl std::io::Read for HiddenLenSource {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> { self.inner.read(buf) }
+}
+impl std::io::Seek for HiddenLenSource {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> { self.inner.seek(pos) }
+}
+impl symphonia::core::io::MediaSource for HiddenLenSource {
+    fn is_seekable(&self) -> bool { self.inner.is_seekable() }
+    fn byte_len(&self) -> Option<u64> { None }
+}
+
+fn hides_stream_length(ext: &str) -> bool {
+    matches!(ext, "mp3" | "mp2" | "mpga" | "mpeg")
+}
+
+// Codecs symphonia cannot decode at all. Not a failure of the file — the
+// ffmpeg fallback pass handles these — so the scan pass skips them
+// without writing a `.failed` marker that would misreport as an error
+// and, worse, stop the fallback's own bookkeeping from ever clearing.
+fn waveform_codec_unsupported(ext: &str) -> bool {
+    ext == "opus"
+}
 
 // Decode result: the 800-bar peak waveform the cache writes to disk.
 // (The raw-sample retention that fed stratum-dsp BPM analysis left
 // with the analysis itself — the essentia scanner will own that.)
 struct WaveformOutput {
     bars: [u8; NUM_BARS],
+    // Frames actually decoded. Only the cache write ignores it; the hidden
+    // `--waveform` subcommand reports it so a test can assert the decoder
+    // consumed the whole stream rather than stopping at a container's
+    // guess or at the first damaged frame.
+    frames: u64,
 }
 
 fn waveform_from_source(
@@ -5252,9 +5398,14 @@ fn waveform_from_source(
 ) -> Option<WaveformOutput> {
     // Symphonia still doesn't ship a pure-Rust Opus decoder in 0.6 (only a
     // libopus C adapter, which we deliberately avoid). Skip .opus here and
-    // let the on-demand endpoint handle it via ffmpeg on first playback.
-    if ext == "opus" { return None; }
+    // let the ffmpeg fallback pass handle it.
+    if waveform_codec_unsupported(ext) { return None; }
 
+    let source: Box<dyn symphonia::core::io::MediaSource> = if hides_stream_length(ext) {
+        Box::new(HiddenLenSource { inner: source })
+    } else {
+        source
+    };
     let mss = MediaSourceStream::new(source, Default::default());
 
     let mut hint = Hint::new();
@@ -5267,9 +5418,9 @@ fn waveform_from_source(
         .probe(&hint, mss, FormatOptions::default(), MetadataOptions::default())
         .ok()?;
 
-    let (track_id, n_frames, audio_params) = format.tracks().iter().find_map(|t| {
+    let (track_id, audio_params) = format.tracks().iter().find_map(|t| {
         match &t.codec_params {
-            Some(CodecParameters::Audio(p)) => Some((t.id, t.num_frames, p.clone())),
+            Some(CodecParameters::Audio(p)) => Some((t.id, p.clone())),
             _ => None,
         }
     })?;
@@ -5279,19 +5430,29 @@ fn waveform_from_source(
         .make_audio_decoder(&audio_params, &AudioDecoderOptions::default())
         .ok()?;
 
-    let mut peaks = [0f32; NUM_BARS];
-    let mut buffered: Vec<f32> = Vec::new();
-    let mut frame_idx: u64 = 0;
+    let mut pyramid = PeakPyramid::new();
     // 0.6 replaced SampleBuffer with copy-out methods on the decoded buffer;
     // one Vec reused across packets keeps the no-per-packet-alloc behavior.
     let mut interleaved: Vec<f32> = Vec::new();
-    let mut truncated = false;
 
-    'outer: loop {
+    // A malformed frame mid-stream is not the end of the stream. The old
+    // loop broke on ANY demuxer error, which is how a VBR MP3 with no
+    // Xing header lost the last ~9 % of its waveform: the reader hits an
+    // unsyncable frame, errors once, resyncs on the next call — but we had
+    // already given up. Bounded so a genuinely shredded file still ends.
+    const MAX_CONSECUTIVE_DEMUX_ERRORS: u32 = 64;
+    let mut demux_errors: u32 = 0;
+
+    loop {
         let packet = match format.next_packet() {
-            Ok(Some(p)) => p,
+            Ok(Some(p)) => { demux_errors = 0; p }
             Ok(None) => break,  // clean EOF (explicit in 0.6)
-            Err(_) => break,    // unrecoverable — whatever we have is what we get
+            Err(SymphoniaError::DecodeError(_)) => {
+                demux_errors += 1;
+                if demux_errors > MAX_CONSECUTIVE_DEMUX_ERRORS { break; }
+                continue;
+            }
+            Err(_) => break,    // IO/limit/reset — whatever we have is what we get
         };
         if packet.track_id != track_id { continue; }
 
@@ -5302,61 +5463,26 @@ fn waveform_from_source(
 
         decoded.copy_to_vec_interleaved(&mut interleaved);
 
-        // Downmix interleaved samples to mono via abs-sum/channels
-        // (perceived loudness — unchanged from the original
-        // implementation, so cached bars stay byte-stable).
+        // One magnitude per frame: the loudest channel, NOT an average.
+        // Averaging attenuates anything the channels disagree about, so a
+        // widened or out-of-phase mix read quieter than it sounds — and
+        // the ffmpeg fallback, which used to sum to mono, cancelled such
+        // material outright. max|ch| never cancels and lets both engines
+        // describe the same audio the same way.
         for chunk in interleaved.chunks(channels) {
-            let mut abs_sum = 0f32;
+            let mut mag = 0f32;
             for &s in chunk {
-                abs_sum += s.abs();
+                let a = s.abs();
+                if a > mag { mag = a; }
             }
-            let mag = abs_sum / (channels as f32);
-
-            match n_frames {
-                Some(total) if total > 0 => {
-                    let bar = (frame_idx.saturating_mul(NUM_BARS as u64) / total) as usize;
-                    if bar < NUM_BARS && mag > peaks[bar] {
-                        peaks[bar] = mag;
-                    }
-                }
-                _ => {
-                    if buffered.len() >= MAX_BUFFERED_FRAMES {
-                        truncated = true;
-                        break 'outer;
-                    }
-                    buffered.push(mag);
-                }
-            }
-            frame_idx += 1;
+            pyramid.push(mag);
         }
     }
 
-    // Guard against symphonia emitting zero frames (unsupported codec that
-    // probed OK but decoded empty). Distinguish from the buffered-truncated
-    // path, which does have data.
-    if frame_idx == 0 && !truncated { return None; }
-
-    // If we went the buffered route, bin now that we know the true length.
-    if n_frames.is_none() || n_frames == Some(0) {
-        let total = buffered.len();
-        if total == 0 { return None; }
-        for i in 0..NUM_BARS {
-            let start = i * total / NUM_BARS;
-            let end = ((i + 1) * total / NUM_BARS).max(start + 1).min(total);
-            let mut peak = 0f32;
-            for &m in &buffered[start..end] {
-                if m > peak { peak = m; }
-            }
-            peaks[i] = peak;
-        }
-    }
-
-    let mut bars = [0u8; NUM_BARS];
-    for i in 0..NUM_BARS {
-        bars[i] = (peaks[i].clamp(0.0, 1.0) * 255.0).round() as u8;
-    }
-
-    Some(WaveformOutput { bars })
+    // None = probed OK but decoded no frames (e.g. a codec the probe
+    // recognised and the decoder didn't).
+    let frames = pyramid.frames;
+    pyramid.bars().map(|bars| WaveformOutput { bars, frames })
 }
 
 // File-backed waveform entry point. Opens the file once; symphonia

--- a/src/api/waveform.js
+++ b/src/api/waveform.js
@@ -15,7 +15,7 @@ import {
   writeCachedWaveform,
   hasFfmpegFailedMarker,
   recordFfmpegFailure,
-  clearFailedMarker,
+  clearWaveformMarkers,
   sweepSupersededArtifacts,
 } from '../db/waveform-lib.js';
 
@@ -179,7 +179,7 @@ export function setup(mstream) {
           // Success also clears any failure marker the rust pass left
           // (symphonia can't decode Opus; ffmpeg just did).
           writeCachedWaveform(cacheDir(), key, waveform).catch(() => {});
-          clearFailedMarker(cacheDir(), key).catch(() => {});
+          clearWaveformMarkers(cacheDir(), key).catch(() => {});
           rememberInMem(waveform);
           return waveform;
         } catch (err) {

--- a/src/api/waveform.js
+++ b/src/api/waveform.js
@@ -16,6 +16,7 @@ import {
   hasFfmpegFailedMarker,
   recordFfmpegFailure,
   clearFailedMarker,
+  sweepSupersededArtifacts,
 } from '../db/waveform-lib.js';
 
 // In-memory LRU to avoid repeated disk reads
@@ -78,6 +79,19 @@ function ensureCacheDir() {
       `at a writable path (typically alongside dbDirectory) or fix ownership/perms.`
     );
   }
+
+  // Clear out artifacts from a superseded bar format. Deliberately not
+  // awaited — boot doesn't wait on a cache sweep — and deliberately here
+  // rather than in the rust pass, which never runs on a rust-less host.
+  sweepSupersededArtifacts(dir)
+    .then((removed) => {
+      if (removed > 0) {
+        winston.info(
+          `[waveform] removed ${removed} cache artifact(s) from a superseded ` +
+          `bar format; they will regenerate with the corrected decoder`);
+      }
+    })
+    .catch((err) => winston.warn(`[waveform] cache sweep failed: ${err.message}`));
 }
 
 export function setup(mstream) {

--- a/src/db/enrichment-status-lib.js
+++ b/src/db/enrichment-status-lib.js
@@ -41,6 +41,10 @@ import winston from 'winston';
 import * as config from '../state/config.js';
 import * as db from './manager.js';
 import * as discoveryDb from './discovery-db.js';
+import {
+  CACHE_EXT as WAVEFORM_CACHE_EXT,
+  FAILED_EXT as WAVEFORM_FAILED_EXT,
+} from './waveform-lib.js';
 
 // Worker-mirror duration windows. Deliberately duplicated from the
 // enqueue pre-checks in task-queue.js (which themselves mirror the
@@ -267,9 +271,12 @@ function waveformCoverage(d, now) {
     let bins = 0;
     let failed = 0;
     try {
+      // Current-generation names only. Artifacts from a superseded bar
+      // format are swept at boot, but until that lands they must not be
+      // counted as coverage the operator does not actually have.
       for (const name of fs.readdirSync(config.program.storage.waveformCacheDirectory)) {
-        if (name.endsWith('.bin')) { bins++; }
-        else if (name.endsWith('.failed')) { failed++; }
+        if (name.endsWith(WAVEFORM_CACHE_EXT)) { bins++; }
+        else if (name.endsWith(WAVEFORM_FAILED_EXT)) { failed++; }
       }
     } catch (err) {
       // Missing dir = simply no waveforms generated yet (the pass creates

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1042,11 +1042,19 @@ function runWaveformTask(taskObj) {
   // sat queued, and findRustParser() stays false for the process
   // lifetime once the binary was found dead.
   if (config.program.scanOptions.generateWaveforms === false) { return; }
+
+  // The rust half and the ffmpeg half are INDEPENDENT producers. Both
+  // bails below skip only the rust half and then run the ffmpeg half
+  // standalone: it is plain JS plus bin/ffmpeg, reads the same DB and
+  // cache dir, and imports CACHE_EXT from this server — it cannot be
+  // wrong about a generation it defines. Returning outright (as the gate
+  // first did) made a stale prebuilt disable the very Opus coverage this
+  // pass exists to add, on every deployment between merge and the CI
+  // binary rebuild.
   if (!findRustParser()) {
     winston.info(
-      'Waveform pass skipped — no usable rust-parser binary (the on-demand ' +
-      'endpoint will generate waveforms lazily on first play)');
-    return;
+      'Waveform pass: no usable rust-parser binary — running the ffmpeg half only');
+    return void runWaveformFallbackOnly();
   }
   // Waveform-generation gate, same idea as the hash-generation gate in
   // findRustParser: the cache filenames are a contract between this server
@@ -1056,13 +1064,16 @@ function runWaveformTask(taskObj) {
   // dropping in a rebuilt binary heals on the next scan without a restart.
   const binWfGen = waveformLib.probeWaveformGeneration(rustParserBin);
   if (binWfGen !== waveformLib.CACHE_EXT) {
+    waveformGenerationMismatch = true;
     winston.warn(
-      `Waveform pass skipped — rust-parser writes waveform generation ` +
-      `'${binWfGen ?? 'pre-w2'}' but this server expects '${waveformLib.CACHE_EXT}'. ` +
+      `Waveform pass: rust-parser writes waveform generation ` +
+      `'${binWfGen ?? 'pre-w2'}' but this server expects '${waveformLib.CACHE_EXT}' — ` +
+      `skipping the rust half and running the ffmpeg half only. ` +
       `Update bin/rust-parser (CI rebuilds it on pushes to master) or rebuild ` +
-      `rust-parser/target with cargo. Lazy on-demand generation still covers playback.`);
-    return;
+      `rust-parser/target with cargo.`);
+    return void runWaveformFallbackOnly();
   }
+  waveformGenerationMismatch = false;
 
   const payload = {
     dbPath: path.join(config.program.storage.dbDirectory, 'mstream.db'),
@@ -1184,6 +1195,37 @@ function runWaveformTask(taskObj) {
 // hot loop. null = the last round did not chain.
 let lastFallbackBacklog = null;
 
+// Latched when the resolved binary writes a different waveform cache
+// generation than this server reads. Surfaced through the enrichment gate
+// so the admin panel says WHY the rust half stopped contributing instead
+// of showing an enabled pass that silently never runs. Cleared the moment
+// a probe matches, so a dropped-in rebuild clears the badge too.
+let waveformGenerationMismatch = false;
+
+// The ffmpeg half on its own, for when the rust half can't run. Mirrors
+// runWaveformTask's bookkeeping: hold the queue slot, report running, and
+// finish through the same reporting path so lastRun/coverage stay honest.
+function runWaveformFallbackOnly() {
+  const killFn = () => {};   // replaced below; kept so the shape matches
+  activeTask = { kind: 'waveform', taskObj: null, child: null, killFn };
+  addToKillQueue(killFn);
+  reportEnrichment('waveform', { state: 'running' });
+  return runWaveformFfmpegFallback().then((res) => {
+    removeFromKillQueue(killFn);
+    if (activeTask && activeTask.kind === 'waveform' && !activeTask.child) {
+      activeTask = null;
+    }
+    // Report the ffmpeg half's own numbers. Shape matches the rust pass's
+    // waveformScanComplete payload so the status API and its consumers
+    // don't have to care which half did the work.
+    finishEnrichment('waveform', 0, null, res
+      ? { generated: res.generated, failed: res.failed, total: res.total }
+      : null);
+    nextTask();
+    checkQueueDrainedSideEffects();
+  });
+}
+
 // True when the resolved rust binary exists AND writes the same waveform
 // cache generation this server reads. Exported for tests that need to
 // know whether the real pass can run at all (a stale prebuilt in the
@@ -1210,7 +1252,7 @@ async function runWaveformFfmpegFallback() {
   // with it resolved.
   if (!getResolvedSource()) {
     winston.info('Waveform ffmpeg fallback skipped — ffmpeg not resolved yet');
-    return;
+    return null;
   }
   const abort = { stopped: false };
   const killFn = () => { abort.stopped = true; };
@@ -1244,9 +1286,11 @@ async function runWaveformFfmpegFallback() {
     } else {
       lastFallbackBacklog = null;
     }
+    return res;
   } catch (err) {
     winston.warn(`Waveform ffmpeg fallback failed: ${err.message}`);
     lastFallbackBacklog = null;
+    return null;
   } finally {
     removeFromKillQueue(killFn);
   }
@@ -2750,6 +2794,13 @@ function enrichmentGate(kind) {
       if (opts.generateWaveforms === false) { return off('config'); }
       if (waveformPassUnsupported) { return off('binary-unsupported'); }
       if (rustParserDisabled) { return off('no-binary'); }
+      // The rust half is sidelined but the ffmpeg half still runs, so this
+      // is a degraded-not-disabled state: reported as enabled with a reason
+      // rather than off, otherwise the panel would claim nothing happens
+      // while Opus coverage is in fact still being produced.
+      if (waveformGenerationMismatch) {
+        return { enabled: true, reason: 'binary-generation-mismatch' };
+      }
       return on;
     case 'albumart':
       if (opts.autoAlbumArt === false || opts.skipImg === true) { return off('config'); }

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -11,11 +11,12 @@ import { SCHEMA_VERSION } from './schema.js';
 import { HASH_GENERATION } from './audio-hash.js';
 import { getDirname, appRoot } from '../util/esm-helpers.js';
 import { launchWorker, workerReaperMarker } from '../util/worker-process.js';
-import { ffmpegBin, ffprobeBin, ensureFfmpeg } from '../util/ffmpeg-bootstrap.js';
+import { ffmpegBin, ffprobeBin, ensureFfmpeg, getResolvedSource } from '../util/ffmpeg-bootstrap.js';
 import * as dlnaApi from '../api/dlna.js';
 import * as discoveryDb from './discovery-db.js';
 import * as libraryWatcher from '../util/library-watcher.js';
 import * as waveformLib from './waveform-lib.js';
+import * as waveformFallback from './waveform-fallback.js';
 import { invalidateCoverageCache } from './enrichment-status-lib.js';
 
 const __dirname = getDirname(import.meta.url);
@@ -1131,19 +1132,89 @@ function runWaveformTask(taskObj) {
       winston.error(`Waveform pass FAILED with exit code ${code}`);
     }
     clearScannerPidfile(config.program.storage.dbDirectory);
-    if (activeTask?.child === wfChild) {
-      removeFromKillQueue(activeTask.killFn);
-      activeTask = null;
-    }
-    finishEnrichment('waveform', code, signal, completeEvt);
-    nextTask();
-    checkQueueDrainedSideEffects();
+
+    // Releasing activeTask is what makes the queue look idle, so it stays
+    // held until the ffmpeg half below has finished too — otherwise a scan
+    // could start alongside it, against the single-task rule, and an
+    // observer could read 'idle' before finishEnrichment had landed.
+    const done = () => {
+      if (activeTask?.child === wfChild) {
+        removeFromKillQueue(activeTask.killFn);
+        activeTask = null;
+      }
+      finishEnrichment('waveform', code, signal, completeEvt);
+      nextTask();
+      checkQueueDrainedSideEffects();
+    };
+    // symphonia can't decode Opus, so the rust pass leaves those keys
+    // uncached by design. Sweep them (and anything else it gave up on)
+    // with ffmpeg before the pass counts as finished — otherwise every
+    // first play of an Opus track pays a cold decode. Skipped when the
+    // pass was killed (shutdown shouldn't start new work) or failed
+    // (a broken/stale binary means lazy generation is already the only
+    // producer, and the endpoint still covers it).
+    if (signal || code !== 0) { return done(); }
+    runWaveformFfmpegFallback().then(done, done);
   };
   wfChild.on('error', (err) => {
     winston.error(`Waveform pass failed to start: ${err.message}`);
     closeOnce(-1, null);
   });
   wfChild.on('close', (code, signal) => closeOnce(code, signal));
+}
+
+// Second half of the waveform pass: covers content symphonia structurally
+// cannot decode (Opus) plus anything it failed on, using the same ffmpeg
+// generator the on-demand endpoint uses. Runs in-process — ffmpeg does the
+// work in its own process and this side is bookkeeping — under its own kill
+// registration so a shutdown between the rust child closing and this
+// finishing stops it promptly. Never rejects: the rust pass's outcome is
+// what the enrichment status reports, and a fallback failure must not turn
+// a successful pass into a failed one.
+async function runWaveformFfmpegFallback() {
+  // Readiness check, not a bootstrap: ensureFfmpeg() may go and DOWNLOAD a
+  // toolchain, which is not something a background enrichment pass should
+  // trigger. If ffmpeg isn't resolved yet the pass simply skips — the
+  // on-demand endpoint still covers these tracks, and the next pass runs
+  // with it resolved.
+  if (!getResolvedSource()) {
+    winston.info('Waveform ffmpeg fallback skipped — ffmpeg not resolved yet');
+    return;
+  }
+  const abort = { stopped: false };
+  const killFn = () => { abort.stopped = true; };
+  addToKillQueue(killFn);
+  try {
+    const res = await waveformFallback.run({
+      db: db.getDB(),
+      cacheDir: config.program.storage.waveformCacheDirectory,
+      ffmpegBin: ffmpegBin(),
+      abort,
+      onProgress: (done, total) => reportEnrichment('waveform',
+        { progress: { attempted: done, total } }),
+    });
+    if (res.total > 0) {
+      winston.info(
+        `Waveform ffmpeg fallback: ${res.generated} generated, ${res.failed} failed ` +
+        `(${res.total} attempted)` +
+        (res.capped ? '; more remain, queueing another pass' : ''));
+      invalidateCoverageCache();
+    }
+    // Chain another pass so a backlog larger than one run's cap drains on
+    // its own instead of waiting for N more scans. Gated on the run having
+    // RESOLVED something: every generate writes a cache file and every
+    // failure writes a marker, so real progress always shrinks the work
+    // list — but a batch of rows whose files have all vanished resolves
+    // nothing (deliberately: no marker for a file that may come back), and
+    // re-queueing on that would spin forever.
+    if (res.capped && (res.generated + res.failed) > 0 && !abort.stopped) {
+      addWaveformTask();
+    }
+  } catch (err) {
+    winston.warn(`Waveform ffmpeg fallback failed: ${err.message}`);
+  } finally {
+    removeFromKillQueue(killFn);
+  }
 }
 
 // ── Album-art download task ─────────────────────────────────────────────────

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -559,7 +559,8 @@ async function applyHashTransitionsInner() {
         const ops = [];
         for (const { target, sources } of groupList) {
           for (const src of sources) {
-            for (const toPath of [waveformLib.cacheFilePath, waveformLib.failedMarkerPath]) {
+            for (const toPath of [waveformLib.cacheFilePath, waveformLib.failedMarkerPath,
+                                  waveformLib.deferredMarkerPath]) {
               const from = toPath(waveDir, src);
               const to = toPath(waveDir, target);
               const fromName = path.basename(from);
@@ -1206,23 +1207,43 @@ let waveformGenerationMismatch = false;
 // runWaveformTask's bookkeeping: hold the queue slot, report running, and
 // finish through the same reporting path so lastRun/coverage stay honest.
 function runWaveformFallbackOnly() {
-  const killFn = () => {};   // replaced below; kept so the shape matches
+  // Placeholder so activeTask has the same shape the rust path gives it.
+  // The REAL abort is registered inside runWaveformFfmpegFallback, in the
+  // same synchronous tick, so shutdown still stops the work.
+  const killFn = () => {};
   activeTask = { kind: 'waveform', taskObj: null, child: null, killFn };
   addToKillQueue(killFn);
   reportEnrichment('waveform', { state: 'running' });
-  return runWaveformFfmpegFallback().then((res) => {
+
+  const finish = (res) => {
     removeFromKillQueue(killFn);
     if (activeTask && activeTask.kind === 'waveform' && !activeTask.child) {
       activeTask = null;
     }
-    // Report the ffmpeg half's own numbers. Shape matches the rust pass's
-    // waveformScanComplete payload so the status API and its consumers
-    // don't have to care which half did the work.
-    finishEnrichment('waveform', 0, null, res
-      ? { generated: res.generated, failed: res.failed, total: res.total }
-      : null);
+    if (res) {
+      // Report the ffmpeg half's own numbers. Shape matches the rust
+      // pass's waveformScanComplete payload so the status API and its
+      // consumers don't have to care which half did the work.
+      finishEnrichment('waveform', 0, null,
+        { generated: res.generated, failed: res.failed, total: res.total });
+    } else {
+      // Nothing ran (ffmpeg unresolved, or the half threw). Return to idle
+      // and refresh coverage, but do NOT write a synthetic 'completed'
+      // lastRun over the previous real one — same rule finishEnrichment's
+      // own contract states for a run-time gate bail.
+      invalidateCoverageCache();
+      reportEnrichment('waveform', { state: 'idle', progress: null });
+    }
     nextTask();
     checkQueueDrainedSideEffects();
+  };
+
+  // Both settle paths go through finish: if it ever rejected, activeTask
+  // would never be released and the whole task queue would wedge for the
+  // process lifetime.
+  return runWaveformFfmpegFallback().then(finish, (err) => {
+    winston.warn(`Waveform ffmpeg fallback (standalone) failed: ${err.message}`);
+    finish(null);
   });
 }
 

--- a/src/db/task-queue.js
+++ b/src/db/task-queue.js
@@ -1048,6 +1048,21 @@ function runWaveformTask(taskObj) {
       'endpoint will generate waveforms lazily on first play)');
     return;
   }
+  // Waveform-generation gate, same idea as the hash-generation gate in
+  // findRustParser: the cache filenames are a contract between this server
+  // and the binary. A binary one generation behind writes names the boot
+  // sweep deletes, so running it re-decodes the whole library every boot
+  // for artifacts nothing ever reads. Probed per pass rather than latched:
+  // dropping in a rebuilt binary heals on the next scan without a restart.
+  const binWfGen = waveformLib.probeWaveformGeneration(rustParserBin);
+  if (binWfGen !== waveformLib.CACHE_EXT) {
+    winston.warn(
+      `Waveform pass skipped — rust-parser writes waveform generation ` +
+      `'${binWfGen ?? 'pre-w2'}' but this server expects '${waveformLib.CACHE_EXT}'. ` +
+      `Update bin/rust-parser (CI rebuilds it on pushes to master) or rebuild ` +
+      `rust-parser/target with cargo. Lazy on-demand generation still covers playback.`);
+    return;
+  }
 
   const payload = {
     dbPath: path.join(config.program.storage.dbDirectory, 'mstream.db'),
@@ -1163,6 +1178,22 @@ function runWaveformTask(taskObj) {
   wfChild.on('close', (code, signal) => closeOnce(code, signal));
 }
 
+// Backlog of the previous CHAINED fallback round — shouldChain() requires
+// the eligible set to strictly shrink between chained rounds, so any
+// future non-shrinking work source degrades to once-per-scan instead of a
+// hot loop. null = the last round did not chain.
+let lastFallbackBacklog = null;
+
+// True when the resolved rust binary exists AND writes the same waveform
+// cache generation this server reads. Exported for tests that need to
+// know whether the real pass can run at all (a stale prebuilt in the
+// window before CI rebuilds bin/ answers the probe wrong, and the pass
+// correctly refuses to run — tests must skip rather than fail there).
+export function waveformPassBinaryReady() {
+  if (!findRustParser()) { return false; }
+  return waveformLib.probeWaveformGeneration(rustParserBin) === waveformLib.CACHE_EXT;
+}
+
 // Second half of the waveform pass: covers content symphonia structurally
 // cannot decode (Opus) plus anything it failed on, using the same ffmpeg
 // generator the on-demand endpoint uses. Runs in-process — ffmpeg does the
@@ -1196,22 +1227,26 @@ async function runWaveformFfmpegFallback() {
     if (res.total > 0) {
       winston.info(
         `Waveform ffmpeg fallback: ${res.generated} generated, ${res.failed} failed ` +
-        `(${res.total} attempted)` +
-        (res.capped ? '; more remain, queueing another pass' : ''));
+        `(${res.total} of ${res.backlog} eligible)` +
+        (res.capped ? '; more remain' : ''));
       invalidateCoverageCache();
     }
     // Chain another pass so a backlog larger than one run's cap drains on
-    // its own instead of waiting for N more scans. Gated on the run having
-    // RESOLVED something: every generate writes a cache file and every
-    // failure writes a marker, so real progress always shrinks the work
-    // list — but a batch of rows whose files have all vanished resolves
-    // nothing (deliberately: no marker for a file that may come back), and
-    // re-queueing on that would spin forever.
-    if (res.capped && (res.generated + res.failed) > 0 && !abort.stopped) {
+    // its own instead of waiting for N more scans — but only on DURABLE
+    // progress, judged by shouldChain(): the first version of this gate
+    // counted mere attempts and re-forked the whole pass forever on an
+    // unwritable cache dir (nothing landed, so the plan never shrank).
+    // The backlog handed to shouldChain is from the previous CHAINED
+    // round, so a run that stops chaining also resets the comparison.
+    if (!abort.stopped && waveformFallback.shouldChain(res, lastFallbackBacklog)) {
+      lastFallbackBacklog = res.backlog;
       addWaveformTask();
+    } else {
+      lastFallbackBacklog = null;
     }
   } catch (err) {
     winston.warn(`Waveform ffmpeg fallback failed: ${err.message}`);
+    lastFallbackBacklog = null;
   } finally {
     removeFromKillQueue(killFn);
   }

--- a/src/db/waveform-fallback.js
+++ b/src/db/waveform-fallback.js
@@ -12,20 +12,24 @@
 // This runs straight after the rust pass and closes that gap with the same
 // ffmpeg generator the endpoint uses. Two kinds of work:
 //
-//   1. Extensions whose content symphonia may be unable to decode
-//      (CANDIDATE_EXTS: .opus always; .ogg when it carries Opus). The
-//      rust pass leaves those out of its results — extension skip for
-//      .opus, a probed NoDecoder skip for Opus-in-Ogg — with no marker
-//      and no inflated failure count, so they arrive here uncached.
-//   2. Hashes carrying a `symphonia`-only failure marker. ffmpeg decodes
-//      plenty that symphonia won't; a success here deletes the marker.
+//   1. Extensions the rust pass refuses on sight (CANDIDATE_EXTS) — it
+//      never opens these, so they leave no artifact at all.
+//   2. Hashes carrying a `symphonia` (tried and failed) or `no-decoder`
+//      (no decoder for the codec) marker. ffmpeg decodes plenty symphonia
+//      won't; a success here deletes the marker.
+//
+// Source 2 is what makes coverage complete, and it is NOT optional: the
+// set of codecs symphonia can't decode is not knowable from the extension
+// (5.1 and HE-AAC in .m4a/.m4b/.aac fail decoder construction just like
+// Opus in .ogg does), so routing by extension alone left those files with
+// no waveform from either pass. The marker is the rust pass telling us
+// which keys it deferred, whatever the container.
 //
 // Deliberately in-process rather than a forked worker: the CPU cost is
 // ffmpeg's, in its own process, and this side is bookkeeping. Concurrency
 // matches the on-demand endpoint so a pass and a burst of playback
 // requests can't together fork a decoder per core.
 
-import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import winston from 'winston';
@@ -135,7 +139,15 @@ async function generateOne({ key, paths, cacheDir, ffmpegBin, result }) {
   // sitting on disk.
   let decodeFailures = 0;
   for (const absPath of paths) {
-    if (!fs.existsSync(absPath)) { continue; }
+    // Open, don't stat. existsSync answers "is there a directory entry",
+    // which is not the question — a file can stat fine and still be
+    // unreadable (an ACL change, an antivirus or backup lock, a stale
+    // network mount), and ffmpeg then exits non-zero exactly like
+    // genuinely corrupt audio does. Recording that as ffmpeg's verdict
+    // wrote a marker nothing ever clears: planWork excludes the key, the
+    // endpoint 500s on it forever, and coverage counts it failed for
+    // good. The rust pass has always gated on File::open for this reason.
+    if (!(await isReadable(absPath))) { continue; }
     let bars;
     try {
       bars = await generateWaveformBars(absPath, ffmpegBin);
@@ -149,6 +161,14 @@ async function generateOne({ key, paths, cacheDir, ffmpegBin, result }) {
       if (err.transient) {
         winston.warn(
           `[waveform] ffmpeg fallback deferred for ${absPath}: ${err.message}`);
+        return;
+      }
+      // The file was readable when we started; if it is not readable NOW,
+      // the environment moved under us mid-decode and ffmpeg's exit code
+      // describes that, not the audio. Treat it like a vanished copy.
+      if (!(await isReadable(absPath))) {
+        winston.warn(
+          `[waveform] ffmpeg fallback deferred for ${absPath}: became unreadable mid-decode`);
         return;
       }
       winston.warn(`[waveform] ffmpeg fallback failed for ${absPath}: ${err.message}`);
@@ -219,14 +239,20 @@ async function planWork({ db, cacheDir }) {
   // the extension query, so checking it only on the marker path would
   // re-spawn a doomed 30-second decode on every pass, forever.
   const ffmpegFailed = new Set();
-  const symphoniaFailed = [];
+  const rustDeferred = [];
   const BATCH = 32;
   for (let i = 0; i < markerNames.length; i += BATCH) {
     await Promise.all(markerNames.slice(i, i + BATCH).map(async (name) => {
       const key = name.slice(0, -FAILED_EXT.length);
       const body = await readMarker(path.join(cacheDir, name));
+      // `symphonia` = the rust pass tried and failed. `no-decoder` = it has
+      // no decoder for the codec at all. Both are ours to attempt, and the
+      // second is the ONLY route for an undecodable codec in a container
+      // our extension query doesn't cover (5.1/HE-AAC in .m4a, .m4b, .aac).
       if (body.includes('ffmpeg')) { ffmpegFailed.add(key); }
-      else if (body.includes('symphonia')) { symphoniaFailed.push(key); }
+      else if (body.includes('symphonia') || body.includes('no-decoder')) {
+        rustDeferred.push(key);
+      }
     }));
   }
 
@@ -255,11 +281,12 @@ async function planWork({ db, cacheDir }) {
     await breathe();
   }
 
-  // (2) Hashes symphonia gave up on. Chunked so a library with thousands
-  // of markers doesn't build one enormous IN list.
+  // (2) Hashes the rust pass deferred to us — failed or no-decoder.
+  // Chunked so a library with thousands of markers doesn't build one
+  // enormous IN list.
   const CHUNK = 400;
-  for (let i = 0; i < symphoniaFailed.length; i += CHUNK) {
-    const chunk = symphoniaFailed.slice(i, i + CHUNK);
+  for (let i = 0; i < rustDeferred.length; i += CHUNK) {
+    const chunk = rustDeferred.slice(i, i + CHUNK);
     const placeholders = chunk.map(() => '?').join(',');
     const rows = db.prepare(`
       SELECT t.filepath, t.audio_hash, t.file_hash, l.root_path
@@ -276,4 +303,21 @@ async function planWork({ db, cacheDir }) {
 async function readMarker(file) {
   try { return await fsp.readFile(file, 'utf8'); }
   catch (_err) { return 'symphonia'; }  // unreadable — assume the pass wrote it
+}
+
+// Can we actually READ this path right now? A real open+read of one byte,
+// because that is the operation ffmpeg is about to perform — stat and
+// access(R_OK) both answer a weaker question and miss mandatory locks,
+// offline/recalled cloud files, and directories standing in for files.
+async function isReadable(absPath) {
+  let handle;
+  try {
+    handle = await fsp.open(absPath, 'r');
+    await handle.read(Buffer.alloc(1), 0, 1, 0);
+    return true;
+  } catch (_err) {
+    return false;
+  } finally {
+    if (handle) { await handle.close().catch(() => {}); }
+  }
 }

--- a/src/db/waveform-fallback.js
+++ b/src/db/waveform-fallback.js
@@ -1,0 +1,190 @@
+// ffmpeg fallback for the waveform enrichment pass.
+//
+// The rust `--waveform-scan` pass is symphonia-powered, and symphonia has
+// no pure-Rust Opus decoder. Everything .opus therefore came out of that
+// pass with no waveform, and — until this module existed — with a
+// `symphonia` failure marker that made the admin panel report a permanent
+// failure count for files that are perfectly fine. Playback still worked,
+// because GET /api/v1/db/waveform generates lazily via ffmpeg, but every
+// first play of an Opus track paid a cold decode while the progress bar
+// sat empty.
+//
+// This runs straight after the rust pass and closes that gap with the same
+// ffmpeg generator the endpoint uses. Two kinds of work:
+//
+//   1. Extensions symphonia structurally cannot decode (Opus). The rust
+//      pass now leaves these out of its plan entirely — no marker, no
+//      inflated failure count — so they arrive here uncached.
+//   2. Hashes carrying a `symphonia`-only failure marker. ffmpeg decodes
+//      plenty that symphonia won't; a success here deletes the marker.
+//
+// Deliberately in-process rather than a forked worker: the CPU cost is
+// ffmpeg's, in its own process, and this side is bookkeeping. Concurrency
+// matches the on-demand endpoint so a pass and a burst of playback
+// requests can't together fork a decoder per core.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import winston from 'winston';
+import {
+  NUM_BARS,
+  FAILED_EXT,
+  CACHE_EXT,
+  generateWaveformBars,
+  writeCachedWaveform,
+  recordFfmpegFailure,
+  clearFailedMarker,
+} from './waveform-lib.js';
+
+// Extensions the rust pass skips. Kept in step with
+// waveform_codec_unsupported() in rust-parser/src/main.rs.
+const RUST_UNSUPPORTED_EXT = new Set(['.opus']);
+
+const MAX_CONCURRENT = 2;
+
+// A library where ffmpeg fails on everything would otherwise hold the
+// queue for hours on its first pass. Failures write markers, so each run
+// permanently shrinks the work list — the cap only decides how much of it
+// one pass takes. Capped runs are logged, never silently truncated.
+const MAX_PER_RUN = 500;
+
+/**
+ * @param {object} opts
+ * @param {import('node:sqlite').DatabaseSync} opts.db
+ * @param {string} opts.cacheDir
+ * @param {string} opts.ffmpegBin
+ * @param {{stopped: boolean}} opts.abort   flipped by the kill queue on shutdown
+ * @param {(done: number, total: number) => void} [opts.onProgress]
+ * @returns {Promise<{generated: number, failed: number, total: number, capped: boolean}>}
+ */
+export async function run({ db, cacheDir, ffmpegBin, abort, onProgress }) {
+  const work = planWork({ db, cacheDir });
+  const capped = work.length > MAX_PER_RUN;
+  const batch = capped ? work.slice(0, MAX_PER_RUN) : work;
+
+  const result = { generated: 0, failed: 0, total: batch.length, capped };
+  if (batch.length === 0) { return result; }
+
+  let next = 0;
+  let done = 0;
+  const worker = async () => {
+    while (!abort.stopped) {
+      const i = next++;
+      if (i >= batch.length) { return; }
+      const { key, paths } = batch[i];
+      await generateOne({ key, paths, cacheDir, ffmpegBin, result });
+      done++;
+      if (onProgress && (done % 5 === 0 || done === batch.length)) {
+        onProgress(done, batch.length);
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(MAX_CONCURRENT, batch.length) }, worker));
+
+  return result;
+}
+
+async function generateOne({ key, paths, cacheDir, ffmpegBin, result }) {
+  // Walk this content's paths until one decodes. A vanished copy is not a
+  // verdict on the content — the same reasoning (and the same silence: no
+  // marker) as the rust pass's open loop.
+  for (const absPath of paths) {
+    if (!fs.existsSync(absPath)) { continue; }
+    try {
+      const bars = await generateWaveformBars(absPath, ffmpegBin);
+      if (bars.length !== NUM_BARS) {
+        throw new Error(`expected ${NUM_BARS} bars, got ${bars.length}`);
+      }
+      await writeCachedWaveform(cacheDir, key, bars);
+      // ffmpeg succeeded where symphonia didn't — the marker is now a lie.
+      await clearFailedMarker(cacheDir, key);
+      result.generated++;
+      return;
+    } catch (err) {
+      // Same discipline as the endpoint: only ffmpeg's own verdict on the
+      // content is remembered. A timeout under load or a spawn failure
+      // retries on the next pass instead of poisoning the marker.
+      if (err.transient) {
+        winston.warn(
+          `[waveform] ffmpeg fallback deferred for ${absPath}: ${err.message}`);
+        return;
+      }
+      winston.warn(`[waveform] ffmpeg fallback failed for ${absPath}: ${err.message}`);
+      await recordFfmpegFailure(cacheDir, key);
+      result.failed++;
+      return;
+    }
+  }
+  // No copy on disk: silent skip, no marker. The sweep owns vanished files.
+}
+
+// Build the work list: content hashes with no cached waveform that either
+// use a codec the rust pass skips, or carry a symphonia-only failure.
+// Keyed by hash with every path along, so duplicate content decodes once
+// and a missing copy can fall through to another.
+function planWork({ db, cacheDir }) {
+  let names;
+  try { names = fs.readdirSync(cacheDir); }
+  catch (_err) { names = []; }   // no dir yet — everything is candidate work
+
+  const cached = new Set();
+  // Keys ffmpeg itself has already rejected. This has to gate BOTH work
+  // sources, not just the marker one: an undecodable .opus arrives through
+  // the extension query, so checking it only on the marker path would
+  // re-spawn a doomed 30-second decode on every pass, forever.
+  const ffmpegFailed = new Set();
+  const symphoniaFailed = [];
+  for (const name of names) {
+    if (name.endsWith(CACHE_EXT)) {
+      cached.add(name.slice(0, -CACHE_EXT.length));
+    } else if (name.endsWith(FAILED_EXT)) {
+      const key = name.slice(0, -FAILED_EXT.length);
+      const body = readMarker(path.join(cacheDir, name));
+      if (body.includes('ffmpeg')) { ffmpegFailed.add(key); continue; }
+      if (body.includes('symphonia')) { symphoniaFailed.push(key); }
+    }
+  }
+
+  const byKey = new Map();
+  const add = (row) => {
+    const key = row.audio_hash || row.file_hash;
+    if (!key || cached.has(key) || ffmpegFailed.has(key)) { return; }
+    const abs = path.join(row.root_path, row.filepath);
+    const paths = byKey.get(key);
+    if (paths) { paths.push(abs); } else { byKey.set(key, [abs]); }
+  };
+
+  // (1) Codecs the rust pass skips. Matched on the stored path so no
+  // per-row JS filtering of the whole table is needed.
+  for (const ext of RUST_UNSUPPORTED_EXT) {
+    const rows = db.prepare(`
+      SELECT t.filepath, t.audio_hash, t.file_hash, l.root_path
+        FROM tracks t JOIN libraries l ON l.id = t.library_id
+       WHERE t.filepath LIKE ?
+         AND COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
+    `).all('%' + ext);
+    for (const row of rows) { add(row); }
+  }
+
+  // (2) Hashes symphonia gave up on. Chunked so a library with thousands
+  // of markers doesn't build one enormous IN list.
+  const CHUNK = 400;
+  for (let i = 0; i < symphoniaFailed.length; i += CHUNK) {
+    const chunk = symphoniaFailed.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = db.prepare(`
+      SELECT t.filepath, t.audio_hash, t.file_hash, l.root_path
+        FROM tracks t JOIN libraries l ON l.id = t.library_id
+       WHERE COALESCE(t.audio_hash, t.file_hash) IN (${placeholders})
+    `).all(...chunk);
+    for (const row of rows) { add(row); }
+  }
+
+  return Array.from(byKey, ([key, paths]) => ({ key, paths }));
+}
+
+function readMarker(file) {
+  try { return fs.readFileSync(file, 'utf8'); }
+  catch (_err) { return 'symphonia'; }  // unreadable — assume the pass wrote it
+}

--- a/src/db/waveform-fallback.js
+++ b/src/db/waveform-fallback.js
@@ -12,9 +12,11 @@
 // This runs straight after the rust pass and closes that gap with the same
 // ffmpeg generator the endpoint uses. Two kinds of work:
 //
-//   1. Extensions symphonia structurally cannot decode (Opus). The rust
-//      pass now leaves these out of its plan entirely — no marker, no
-//      inflated failure count — so they arrive here uncached.
+//   1. Extensions whose content symphonia may be unable to decode
+//      (CANDIDATE_EXTS: .opus always; .ogg when it carries Opus). The
+//      rust pass leaves those out of its results — extension skip for
+//      .opus, a probed NoDecoder skip for Opus-in-Ogg — with no marker
+//      and no inflated failure count, so they arrive here uncached.
 //   2. Hashes carrying a `symphonia`-only failure marker. ffmpeg decodes
 //      plenty that symphonia won't; a success here deletes the marker.
 //
@@ -24,6 +26,7 @@
 // requests can't together fork a decoder per core.
 
 import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import path from 'node:path';
 import winston from 'winston';
 import {
@@ -36,17 +39,47 @@ import {
   clearFailedMarker,
 } from './waveform-lib.js';
 
-// Extensions the rust pass skips. Kept in step with
-// waveform_codec_unsupported() in rust-parser/src/main.rs.
-const RUST_UNSUPPORTED_EXT = new Set(['.opus']);
+// Extensions whose content symphonia may be unable to decode: .opus always
+// (no decoder at all), .ogg when the container carries Opus rather than
+// Vorbis — symphonia-format-ogg ships an Opus mapper but no decoder, so
+// the rust pass probes those and skips them silently (its NoDecoder arm).
+// The rust pass has already cached everything under these extensions it
+// COULD decode by the time this runs, so whatever is still uncached here
+// is exactly the residue this pass exists for. Kept in step with
+// waveform_codec_unsupported() + the NoDecoder skip in main.rs.
+const CANDIDATE_EXTS = ['.opus', '.ogg'];
 
 const MAX_CONCURRENT = 2;
 
 // A library where ffmpeg fails on everything would otherwise hold the
-// queue for hours on its first pass. Failures write markers, so each run
-// permanently shrinks the work list — the cap only decides how much of it
-// one pass takes. Capped runs are logged, never silently truncated.
+// queue for hours on its first pass. The cap only decides how much of the
+// backlog one pass takes; whether another pass is worth chaining is the
+// caller's call, via shouldChain() below.
 const MAX_PER_RUN = 500;
+
+/**
+ * Should the task queue chain another pass after this result?
+ *
+ * Only DURABLE progress justifies chaining: a generate counts once its
+ * atomic rename landed, a failure only once its marker file did. Counting
+ * mere attempts looked equivalent — "every failure writes a marker" — but
+ * recordFfmpegFailure swallows its own write error by design, so on an
+ * unwritable cache dir every attempt failed, nothing landed, planWork
+ * rebuilt the identical list, and the pass chained itself forever, each
+ * round re-forking the full rust pass ahead of it. The backlog comparison
+ * is the backstop for any future non-shrinking work source: if the
+ * eligible set didn't actually get smaller since the last chained round,
+ * stop, and the backlog degrades to once-per-scan instead of a hot loop.
+ *
+ * @param {{capped: boolean, generated: number, markersRecorded: number, backlog: number}} res
+ * @param {number|null} lastBacklog  backlog of the previous CHAINED round, or null
+ */
+export function shouldChain(res, lastBacklog) {
+  if (!res.capped) { return false; }
+  if (res.generated + res.markersRecorded === 0) { return false; }
+  if (lastBacklog !== null && res.backlog >= lastBacklog) { return false; }
+  return true;
+}
 
 /**
  * @param {object} opts
@@ -55,14 +88,21 @@ const MAX_PER_RUN = 500;
  * @param {string} opts.ffmpegBin
  * @param {{stopped: boolean}} opts.abort   flipped by the kill queue on shutdown
  * @param {(done: number, total: number) => void} [opts.onProgress]
- * @returns {Promise<{generated: number, failed: number, total: number, capped: boolean}>}
+ * @returns {Promise<{generated: number, failed: number, markersRecorded: number,
+ *                    total: number, backlog: number, capped: boolean}>}
+ *   `failed` counts decode verdicts (for honest reporting);
+ *   `markersRecorded` counts the subset whose marker actually landed —
+ *   the only failures that shrink the next plan.
  */
 export async function run({ db, cacheDir, ffmpegBin, abort, onProgress }) {
-  const work = planWork({ db, cacheDir });
+  const work = await planWork({ db, cacheDir });
   const capped = work.length > MAX_PER_RUN;
   const batch = capped ? work.slice(0, MAX_PER_RUN) : work;
 
-  const result = { generated: 0, failed: 0, total: batch.length, capped };
+  const result = {
+    generated: 0, failed: 0, markersRecorded: 0,
+    total: batch.length, backlog: work.length, capped,
+  };
   if (batch.length === 0) { return result; }
 
   let next = 0;
@@ -86,64 +126,108 @@ export async function run({ db, cacheDir, ffmpegBin, abort, onProgress }) {
 }
 
 async function generateOne({ key, paths, cacheDir, ffmpegBin, result }) {
-  // Walk this content's paths until one decodes. A vanished copy is not a
-  // verdict on the content — the same reasoning (and the same silence: no
-  // marker) as the rust pass's open loop.
+  // Walk EVERY copy of this content until one decodes. A copy can exist
+  // and still be unreadable — permissions changed after the scan, a stale
+  // network mount, bytes rotted outside the sampled hash windows — and
+  // that is not a verdict on the content while another copy is fine. The
+  // rust pass has the same discipline (open failure → next path); bailing
+  // on the first bad copy wrote a terminal marker with a good copy still
+  // sitting on disk.
+  let decodeFailures = 0;
   for (const absPath of paths) {
     if (!fs.existsSync(absPath)) { continue; }
+    let bars;
     try {
-      const bars = await generateWaveformBars(absPath, ffmpegBin);
+      bars = await generateWaveformBars(absPath, ffmpegBin);
       if (bars.length !== NUM_BARS) {
         throw new Error(`expected ${NUM_BARS} bars, got ${bars.length}`);
       }
-      await writeCachedWaveform(cacheDir, key, bars);
-      // ffmpeg succeeded where symphonia didn't — the marker is now a lie.
-      await clearFailedMarker(cacheDir, key);
-      result.generated++;
-      return;
     } catch (err) {
-      // Same discipline as the endpoint: only ffmpeg's own verdict on the
-      // content is remembered. A timeout under load or a spawn failure
-      // retries on the next pass instead of poisoning the marker.
+      // Transient classes (timeout under load, spawn failure) say nothing
+      // about the content or the other copies — bail out entirely and let
+      // the next pass retry from scratch.
       if (err.transient) {
         winston.warn(
           `[waveform] ffmpeg fallback deferred for ${absPath}: ${err.message}`);
         return;
       }
       winston.warn(`[waveform] ffmpeg fallback failed for ${absPath}: ${err.message}`);
-      await recordFfmpegFailure(cacheDir, key);
-      result.failed++;
+      decodeFailures++;
+      continue;
+    }
+    // Persisting is deliberately OUTSIDE the decode try: a full disk or a
+    // permissions error is not ffmpeg's opinion of the audio, and folding
+    // the two into one catch turned every cache-write hiccup into a
+    // permanent `ffmpeg` marker for a file ffmpeg had just decoded
+    // perfectly — with no path in the system that ever clears it. A
+    // failed write counts NOTHING (not generated, not failed): nothing
+    // durable landed, so the next pass simply retries. Same discipline as
+    // the endpoint, which persists fire-and-forget for the same reason.
+    try {
+      await writeCachedWaveform(cacheDir, key, bars);
+    } catch (err) {
+      winston.warn(`[waveform] cache write failed for ${key}: ${err.message}`);
       return;
     }
+    result.generated++;
+    // ffmpeg succeeded where symphonia didn't — the marker is now a lie.
+    await clearFailedMarker(cacheDir, key);
+    return;
   }
-  // No copy on disk: silent skip, no marker. The sweep owns vanished files.
+  // Every copy that exists failed to DECODE — that is a verdict on the
+  // content. The marker only counts as progress if it actually landed:
+  // the re-enqueue gate needs durable facts, not attempts.
+  if (decodeFailures > 0) {
+    result.failed++;
+    if (await recordFfmpegFailure(cacheDir, key)) {
+      result.markersRecorded++;
+    }
+  }
+  // No copy on disk at all: silent skip, no marker. The sweep owns
+  // vanished files.
 }
 
 // Build the work list: content hashes with no cached waveform that either
-// use a codec the rust pass skips, or carry a symphonia-only failure.
-// Keyed by hash with every path along, so duplicate content decodes once
-// and a missing copy can fall through to another.
-function planWork({ db, cacheDir }) {
+// use a codec the rust pass skips (or probes and skips: CANDIDATE_EXTS),
+// or carry a symphonia-only failure. Keyed by hash with every path along,
+// so duplicate content decodes once and a missing copy can fall through
+// to another.
+//
+// Runs in the SERVER process (this pass is not a forked worker), so the
+// filesystem side is async with bounded batches and a yield between DB
+// chunks — a large cache dir was measurably blocking the event loop for
+// hundreds of ms, the same bug class as the enrichment-status incident.
+// The DB calls stay sync because node:sqlite's DatabaseSync has no async
+// form; they are bounded (one LIKE per candidate ext, 400-key IN chunks).
+async function planWork({ db, cacheDir }) {
   let names;
-  try { names = fs.readdirSync(cacheDir); }
+  try { names = await fsp.readdir(cacheDir); }
   catch (_err) { names = []; }   // no dir yet — everything is candidate work
 
   const cached = new Set();
+  const markerNames = [];
+  for (const name of names) {
+    if (name.endsWith(CACHE_EXT)) {
+      cached.add(name.slice(0, -CACHE_EXT.length));
+    } else if (name.endsWith(FAILED_EXT)) {
+      markerNames.push(name);
+    }
+  }
+
   // Keys ffmpeg itself has already rejected. This has to gate BOTH work
   // sources, not just the marker one: an undecodable .opus arrives through
   // the extension query, so checking it only on the marker path would
   // re-spawn a doomed 30-second decode on every pass, forever.
   const ffmpegFailed = new Set();
   const symphoniaFailed = [];
-  for (const name of names) {
-    if (name.endsWith(CACHE_EXT)) {
-      cached.add(name.slice(0, -CACHE_EXT.length));
-    } else if (name.endsWith(FAILED_EXT)) {
+  const BATCH = 32;
+  for (let i = 0; i < markerNames.length; i += BATCH) {
+    await Promise.all(markerNames.slice(i, i + BATCH).map(async (name) => {
       const key = name.slice(0, -FAILED_EXT.length);
-      const body = readMarker(path.join(cacheDir, name));
-      if (body.includes('ffmpeg')) { ffmpegFailed.add(key); continue; }
-      if (body.includes('symphonia')) { symphoniaFailed.push(key); }
-    }
+      const body = await readMarker(path.join(cacheDir, name));
+      if (body.includes('ffmpeg')) { ffmpegFailed.add(key); }
+      else if (body.includes('symphonia')) { symphoniaFailed.push(key); }
+    }));
   }
 
   const byKey = new Map();
@@ -154,17 +238,21 @@ function planWork({ db, cacheDir }) {
     const paths = byKey.get(key);
     if (paths) { paths.push(abs); } else { byKey.set(key, [abs]); }
   };
+  const breathe = () => new Promise((resolve) => setImmediate(resolve));
 
-  // (1) Codecs the rust pass skips. Matched on the stored path so no
-  // per-row JS filtering of the whole table is needed.
-  for (const ext of RUST_UNSUPPORTED_EXT) {
+  // (1) Extensions that may hold codecs symphonia can't decode. Matched on
+  // the stored path so no per-row JS filtering of the whole table is
+  // needed; NULLIF because the scanners record "no hash" as either NULL or
+  // '' and bare COALESCE would elect the empty string as a key.
+  for (const ext of CANDIDATE_EXTS) {
     const rows = db.prepare(`
       SELECT t.filepath, t.audio_hash, t.file_hash, l.root_path
         FROM tracks t JOIN libraries l ON l.id = t.library_id
        WHERE t.filepath LIKE ?
-         AND COALESCE(t.audio_hash, t.file_hash) IS NOT NULL
+         AND COALESCE(NULLIF(t.audio_hash, ''), NULLIF(t.file_hash, '')) IS NOT NULL
     `).all('%' + ext);
     for (const row of rows) { add(row); }
+    await breathe();
   }
 
   // (2) Hashes symphonia gave up on. Chunked so a library with thousands
@@ -176,15 +264,16 @@ function planWork({ db, cacheDir }) {
     const rows = db.prepare(`
       SELECT t.filepath, t.audio_hash, t.file_hash, l.root_path
         FROM tracks t JOIN libraries l ON l.id = t.library_id
-       WHERE COALESCE(t.audio_hash, t.file_hash) IN (${placeholders})
+       WHERE COALESCE(NULLIF(t.audio_hash, ''), NULLIF(t.file_hash, '')) IN (${placeholders})
     `).all(...chunk);
     for (const row of rows) { add(row); }
+    await breathe();
   }
 
   return Array.from(byKey, ([key, paths]) => ({ key, paths }));
 }
 
-function readMarker(file) {
-  try { return fs.readFileSync(file, 'utf8'); }
+async function readMarker(file) {
+  try { return await fsp.readFile(file, 'utf8'); }
   catch (_err) { return 'symphonia'; }  // unreadable — assume the pass wrote it
 }

--- a/src/db/waveform-fallback.js
+++ b/src/db/waveform-fallback.js
@@ -14,9 +14,10 @@
 //
 //   1. Extensions the rust pass refuses on sight (CANDIDATE_EXTS) — it
 //      never opens these, so they leave no artifact at all.
-//   2. Hashes carrying a `symphonia` (tried and failed) or `no-decoder`
-//      (no decoder for the codec) marker. ffmpeg decodes plenty symphonia
-//      won't; a success here deletes the marker.
+//   2. Hashes the rust pass left an artifact for: a `.w2.deferred` (it
+//      has no decoder for the codec) or a `symphonia` line in
+//      `.w2.failed` (it tried and failed). ffmpeg decodes plenty
+//      symphonia won't; a success here deletes both.
 //
 // Source 2 is what makes coverage complete, and it is NOT optional: the
 // set of codecs symphonia can't decode is not knowable from the extension
@@ -37,10 +38,11 @@ import {
   NUM_BARS,
   FAILED_EXT,
   CACHE_EXT,
+  DEFERRED_EXT,
   generateWaveformBars,
   writeCachedWaveform,
   recordFfmpegFailure,
-  clearFailedMarker,
+  clearWaveformMarkers,
 } from './waveform-lib.js';
 
 // Extensions whose content symphonia may be unable to decode: .opus always
@@ -190,8 +192,10 @@ async function generateOne({ key, paths, cacheDir, ffmpegBin, result }) {
       return;
     }
     result.generated++;
-    // ffmpeg succeeded where symphonia didn't — the marker is now a lie.
-    await clearFailedMarker(cacheDir, key);
+    // ffmpeg succeeded where symphonia didn't — every marker for this key
+    // is now a lie, including a deferral that would otherwise keep it in
+    // the plan forever.
+    await clearWaveformMarkers(cacheDir, key);
     return;
   }
   // Every copy that exists failed to DECODE — that is a verdict on the
@@ -226,9 +230,14 @@ async function planWork({ db, cacheDir }) {
 
   const cached = new Set();
   const markerNames = [];
+  // Deferrals are classified by SUFFIX — no body read, and no ambiguity
+  // with a failure verdict.
+  const rustDeferred = [];
   for (const name of names) {
     if (name.endsWith(CACHE_EXT)) {
       cached.add(name.slice(0, -CACHE_EXT.length));
+    } else if (name.endsWith(DEFERRED_EXT)) {
+      rustDeferred.push(name.slice(0, -DEFERRED_EXT.length));
     } else if (name.endsWith(FAILED_EXT)) {
       markerNames.push(name);
     }
@@ -239,20 +248,13 @@ async function planWork({ db, cacheDir }) {
   // the extension query, so checking it only on the marker path would
   // re-spawn a doomed 30-second decode on every pass, forever.
   const ffmpegFailed = new Set();
-  const rustDeferred = [];
   const BATCH = 32;
   for (let i = 0; i < markerNames.length; i += BATCH) {
     await Promise.all(markerNames.slice(i, i + BATCH).map(async (name) => {
       const key = name.slice(0, -FAILED_EXT.length);
       const body = await readMarker(path.join(cacheDir, name));
-      // `symphonia` = the rust pass tried and failed. `no-decoder` = it has
-      // no decoder for the codec at all. Both are ours to attempt, and the
-      // second is the ONLY route for an undecodable codec in a container
-      // our extension query doesn't cover (5.1/HE-AAC in .m4a, .m4b, .aac).
       if (body.includes('ffmpeg')) { ffmpegFailed.add(key); }
-      else if (body.includes('symphonia') || body.includes('no-decoder')) {
-        rustDeferred.push(key);
-      }
+      else if (body.includes('symphonia')) { rustDeferred.push(key); }
     }));
   }
 

--- a/src/db/waveform-lib.js
+++ b/src/db/waveform-lib.js
@@ -20,8 +20,24 @@ export const NUM_BARS = 800;
 // On-disk cache format: raw byte array, exactly NUM_BARS bytes, one per bar.
 // Files are keyed by track content hash. Exported (with failedMarkerPath
 // below) so the naming scheme has ONE owner — the V60 hash-transition
-// applier renames these artifacts when a track's canonical hash changes.
-const CACHE_EXT = '.bin';
+// applier renames these artifacts when a track's canonical hash changes,
+// and the rust pass mirrors these constants (WAVEFORM_EXT in main.rs).
+//
+// The `w2` generation marks a decoder correctness fix: bars are binned by
+// the frames actually decoded rather than a container-declared length, and
+// channels combine with max|ch| rather than an average or a mono sum. The
+// same audio therefore produces different bytes than v1 did, so v1 names
+// are neither read nor honoured — sweepSupersededArtifacts() deletes them
+// and both engines regenerate.
+//
+// Bump this whenever the bars change meaning, and bump `_WF_LS_PREFIX` in
+// webapp/alpha/vp.js with it: browsers keep their own copy keyed by
+// filepath with no version in the value, so a server-side change that
+// doesn't move that prefix never reaches anyone who already played the
+// track. Exported because the coverage counter matches names rather than
+// building paths.
+export const CACHE_EXT = '.w2.bin';
+export const FAILED_EXT = '.w2.failed';
 
 export function cacheFilePath(dir, fileHash) {
   return path.join(dir, fileHash + CACHE_EXT);
@@ -71,7 +87,41 @@ export async function writeCachedWaveform(dir, fileHash, bars) {
 // A successful generation deletes the marker.
 
 export function failedMarkerPath(dir, fileHash) {
-  return path.join(dir, fileHash + '.failed');
+  return path.join(dir, fileHash + FAILED_EXT);
+}
+
+/**
+ * Delete cache artifacts left by an older bar format. Called once per boot
+ * from the endpoint's ensureCacheDir(), which is the only place both the
+ * rust-equipped and rust-less deployments pass through — putting it in the
+ * rust pass would strand the sweep on hosts that never run one.
+ *
+ * Without this the old files are merely ignored, which is worse than it
+ * sounds: the enrichment coverage counter would keep counting them, and on
+ * a large library they are dead weight (one 800-byte file per track) that
+ * nothing would ever clean up. Best-effort throughout — a cache directory
+ * we cannot write is already handled as advisory.
+ *
+ * @returns {Promise<number>} artifacts removed
+ */
+export async function sweepSupersededArtifacts(dir) {
+  let names;
+  try { names = await fsp.readdir(dir); }
+  catch (_err) { return 0; }   // no dir yet, or unreadable — nothing to do
+
+  const stale = names.filter((n) =>
+    (n.endsWith('.bin') || n.endsWith('.failed'))
+    && !n.endsWith(CACHE_EXT) && !n.endsWith(FAILED_EXT));
+
+  let removed = 0;
+  const BATCH = 32;
+  for (let i = 0; i < stale.length; i += BATCH) {
+    await Promise.all(stale.slice(i, i + BATCH).map(async (name) => {
+      try { await fsp.unlink(path.join(dir, name)); removed++; }
+      catch (_err) { /* raced with another sweep, or read-only cache */ }
+    }));
+  }
+  return removed;
 }
 
 export function hasFfmpegFailedMarker(dir, fileHash) {
@@ -152,7 +202,10 @@ class PeakPyramid {
     const bars = new Array(numBars);
     for (let i = 0; i < numBars; i++) {
       const start = Math.floor(i * total / numBars);
-      const end = Math.floor((i + 1) * total / numBars);
+      // A clip with fewer than numBars groups would otherwise leave empty
+      // bars interleaved with filled ones; neighbours share a group
+      // instead. Matches PeakPyramid::bars() in rust-parser.
+      const end = Math.min(total, Math.max(start + 1, Math.floor((i + 1) * total / numBars)));
       let peak = 0;
       for (let j = start; j < end; j++) {
         if (this.store[j] > peak) { peak = this.store[j]; }
@@ -181,7 +234,18 @@ export function generateWaveformBars(audioPath, ffmpegBin) {
       // Drop embedded cover art / data / subtitle streams so ffmpeg doesn't
       // waste cycles decoding a JPEG we'd discard anyway.
       '-vn', '-dn', '-sn',
-      '-ac', '1',                // mono
+      // Deliberately NO `-ac 1`. Downmixing to mono SUMS the channels, so
+      // anything out of phase between them cancels: an anti-phase stereo
+      // fixture that the rust engine renders at 32/255 across the whole
+      // file came back from here as 800 zero bars — a blank waveform for
+      // audio that is plainly audible. Real mid/side-widened masters lose
+      // energy the same way, just partially.
+      //
+      // Keeping the channels interleaved costs nothing here: the pyramid
+      // takes a running max over every sample it is handed, and max over
+      // (channels x time) is exactly max-per-frame then max-over-time.
+      // That also matches what the rust engine now does, so the two
+      // engines describe the same audio the same way.
       '-ar', '8000',             // 8 kHz — plenty of resolution for 800 bars
       '-f', 'u8',
       '-acodec', 'pcm_u8',

--- a/src/db/waveform-lib.js
+++ b/src/db/waveform-lib.js
@@ -39,6 +39,20 @@ export const NUM_BARS = 800;
 export const CACHE_EXT = '.w2.bin';
 export const FAILED_EXT = '.w2.failed';
 
+// Third artifact: the rust pass DEFERRED this key to the ffmpeg half —
+// it has no decoder for the codec (Opus in any container, 5.1/HE-AAC in
+// .m4a/.m4b/.aac, anything else symphonia's registry can't instantiate).
+//
+// Deliberately a separate suffix rather than a line inside `.failed`.
+// Everything that classifies these artifacts does so by FILENAME —
+// notably the enrichment coverage counter, which must stay filename-only
+// (it is the hot status path behind a prior production CPU-spin
+// incident, so it must never read N marker bodies per poll). Folding the
+// deferral into `.failed` made a perfectly good file count as a decode
+// FAILURE in the admin panel, which is the exact misreport this whole
+// pass exists to remove.
+export const DEFERRED_EXT = '.w2.deferred';
+
 export function cacheFilePath(dir, fileHash) {
   return path.join(dir, fileHash + CACHE_EXT);
 }
@@ -125,6 +139,10 @@ export function failedMarkerPath(dir, fileHash) {
   return path.join(dir, fileHash + FAILED_EXT);
 }
 
+export function deferredMarkerPath(dir, fileHash) {
+  return path.join(dir, fileHash + DEFERRED_EXT);
+}
+
 /**
  * Delete cache artifacts left by an older bar format. Called once per boot
  * from the endpoint's ensureCacheDir(), which is the only place both the
@@ -152,10 +170,10 @@ export async function sweepSupersededArtifacts(dir) {
   // and ML tooling ships pytorch_model.bin. A suffix-only match deleted
   // all of those; a hash-shaped name that ISN'T ours is indistinguishable
   // anyway, which is as narrow as this can get.
-  const V1_ARTIFACT = /^[0-9a-f]{32,64}\.(bin|failed)$/;
+  const V1_ARTIFACT = /^[0-9a-f]{32,64}\.(bin|failed|deferred)$/;
   const stale = names.filter((n) =>
     V1_ARTIFACT.test(n)
-    && !n.endsWith(CACHE_EXT) && !n.endsWith(FAILED_EXT));
+    && !n.endsWith(CACHE_EXT) && !n.endsWith(FAILED_EXT) && !n.endsWith(DEFERRED_EXT));
 
   let removed = 0;
   const BATCH = 32;
@@ -195,9 +213,16 @@ export async function recordFfmpegFailure(dir, fileHash) {
   }
 }
 
-export async function clearFailedMarker(dir, fileHash) {
-  try { await fsp.unlink(failedMarkerPath(dir, fileHash)); }
-  catch (_err) { /* none existed */ }
+/**
+ * Drop every marker for a key. Called when a waveform is successfully
+ * generated: both a failure verdict and a deferral are now false, and a
+ * stale deferral would keep the key in the fallback's plan forever.
+ */
+export async function clearWaveformMarkers(dir, fileHash) {
+  await Promise.all([
+    fsp.unlink(failedMarkerPath(dir, fileHash)).catch(() => {}),
+    fsp.unlink(deferredMarkerPath(dir, fileHash)).catch(() => {}),
+  ]);
 }
 
 const FFMPEG_TIMEOUT = 30000;       // per track

--- a/src/db/waveform-lib.js
+++ b/src/db/waveform-lib.js
@@ -10,7 +10,7 @@
 // (0..127), rescaled to 0..255. The cache format is shared with the
 // rust pass, .failed markers included.
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -44,6 +44,27 @@ export function cacheFilePath(dir, fileHash) {
 }
 
 /**
+ * Ask a rust-parser binary which cache generation it writes. The server
+ * refuses to run the waveform pass when this differs from CACHE_EXT: a
+ * binary one generation behind would write names the boot sweep deletes,
+ * re-decoding the whole library on every boot — the exact cycle a stale
+ * local `rust-parser/target` build (or the bin/ prebuilts in the window
+ * before CI rebuilds them) would otherwise cause.
+ *
+ * @returns {string|null} the binary's waveform extension, or null when the
+ *   binary pre-dates the probe or failed to answer
+ */
+export function probeWaveformGeneration(rustBin) {
+  try {
+    const r = spawnSync(rustBin, ['--wf-generation'], { encoding: 'utf8', timeout: 5000 });
+    const parsed = JSON.parse(String(r.stdout || '').trim());
+    return typeof parsed.waveformExt === 'string' ? parsed.waveformExt : null;
+  } catch (_err) {
+    return null;   // pre-probe binary: "Invalid JSON Input" on stderr, empty stdout
+  }
+}
+
+/**
  * Read a cached waveform. Returns null if nothing is cached OR the file
  * exists but isn't exactly NUM_BARS bytes (partial write from a prior
  * crash, wrong-format leftover, etc.) — in which case the caller
@@ -72,11 +93,25 @@ export async function readCachedWaveform(dir, fileHash) {
  * happen given generateWaveformBars() clamps on output, but the clamp is
  * implicit rather than asserted.
  */
+// Per-writer temp sequence. The staging name must be unique per write:
+// with a fixed name, two same-key writers (the on-demand endpoint and the
+// fallback pass live in one process but there can be a second mStream
+// against the same cache dir) interleave write/rename and the loser's
+// rename throws ENOENT. The rust side solved this the same way
+// (write_atomic's `<file>.tmp.<seq>`), and its stale-temp sweep collects
+// any `.tmp.` leftovers older than an hour, which this name shape joins.
+let wfTmpSeq = 0;
+
 export async function writeCachedWaveform(dir, fileHash, bars) {
   const finalPath = cacheFilePath(dir, fileHash);
-  const tmpPath = path.join(dir, fileHash + CACHE_EXT + '.tmp');
-  await fsp.writeFile(tmpPath, Buffer.from(bars));
-  await fsp.rename(tmpPath, finalPath);
+  const tmpPath = `${finalPath}.tmp.${process.pid}.${wfTmpSeq++}`;
+  try {
+    await fsp.writeFile(tmpPath, Buffer.from(bars));
+    await fsp.rename(tmpPath, finalPath);
+  } catch (err) {
+    fsp.unlink(tmpPath).catch(() => {});   // don't orphan the staging file
+    throw err;
+  }
 }
 
 // Failure markers, shared with the rust `--waveform-scan` pass: a
@@ -109,8 +144,17 @@ export async function sweepSupersededArtifacts(dir) {
   try { names = await fsp.readdir(dir); }
   catch (_err) { return 0; }   // no dir yet, or unreadable — nothing to do
 
+  // Only names WE could have written are candidates: a bare content hash
+  // (lowercase hex, 32 for MD5 today, room for longer digests) directly
+  // followed by the artifact suffix. The directory is operator-pointable
+  // (storage.waveformCacheDirectory is a free-form string), and `.bin` is
+  // not ours alone — cue/bin disc images live in real music libraries,
+  // and ML tooling ships pytorch_model.bin. A suffix-only match deleted
+  // all of those; a hash-shaped name that ISN'T ours is indistinguishable
+  // anyway, which is as narrow as this can get.
+  const V1_ARTIFACT = /^[0-9a-f]{32,64}\.(bin|failed)$/;
   const stale = names.filter((n) =>
-    (n.endsWith('.bin') || n.endsWith('.failed'))
+    V1_ARTIFACT.test(n)
     && !n.endsWith(CACHE_EXT) && !n.endsWith(FAILED_EXT));
 
   let removed = 0;
@@ -132,9 +176,23 @@ export function hasFfmpegFailedMarker(dir, fileHash) {
   }
 }
 
+/**
+ * Record ffmpeg's failure verdict on a content key.
+ *
+ * @returns {Promise<boolean>} whether the marker actually landed on disk.
+ *   The write error itself stays swallowed (the marker is advisory — never
+ *   fail a request over it), but callers that count failures as PROGRESS
+ *   must know the difference: the fallback pass re-enqueues itself on the
+ *   promise that every counted failure shrank the next plan, and a marker
+ *   that never landed shrinks nothing.
+ */
 export async function recordFfmpegFailure(dir, fileHash) {
-  try { await fsp.appendFile(failedMarkerPath(dir, fileHash), 'ffmpeg\n'); }
-  catch (_err) { /* marker is advisory — never fail the request over it */ }
+  try {
+    await fsp.appendFile(failedMarkerPath(dir, fileHash), 'ffmpeg\n');
+    return true;
+  } catch (_err) {
+    return false;
+  }
 }
 
 export async function clearFailedMarker(dir, fileHash) {
@@ -244,8 +302,12 @@ export function generateWaveformBars(audioPath, ffmpegBin) {
       // Keeping the channels interleaved costs nothing here: the pyramid
       // takes a running max over every sample it is handed, and max over
       // (channels x time) is exactly max-per-frame then max-over-time.
-      // That also matches what the rust engine now does, so the two
-      // engines describe the same audio the same way.
+      // That matches the rust engine's reduction ON THE CHANNEL AXIS —
+      // the two engines are NOT byte-identical, because `-ar 8000` below
+      // band-limits this path to 4 kHz while rust decodes at native rate,
+      // so bright broadband content reads somewhat lower here (measured
+      // 0.84-0.98x on real music). Only ever visible across a cache
+      // regeneration; the player shows one engine's bars at a time.
       '-ar', '8000',             // 8 kHz — plenty of resolution for 800 bars
       '-f', 'u8',
       '-acodec', 'pcm_u8',

--- a/test/db/enrichment-coverage.test.mjs
+++ b/test/db/enrichment-coverage.test.mjs
@@ -107,14 +107,21 @@ before(async () => {
   d.prepare(`INSERT INTO lyrics_cache (audio_hash, status, fetched_at) VALUES ('h-orphan', 'hit', ?)`)
     .run(Date.now());
 
-  // Waveform cache artifacts: 2 bins + 1 failed marker; the .bin.tmp is
-  // an in-flight temp file the counter must ignore. Global hash pool is
-  // h1/h2/h4/h5 (T3 is hashless) → remaining = 4 − 2 − 1 = 1.
+  // Waveform cache artifacts: 2 bins + 1 failed marker; the trailing-.tmp
+  // file is an in-flight write the counter must ignore, as are the two
+  // previous-generation names. Global hash pool is h1/h2/h4/h5 (T3 is
+  // hashless) → remaining = 4 − 2 − 1 = 1.
   const wf = config.program.storage.waveformCacheDirectory;
-  fs.writeFileSync(path.join(wf, 'h1.bin'), Buffer.alloc(8));
-  fs.writeFileSync(path.join(wf, 'h2.bin'), Buffer.alloc(8));
-  fs.writeFileSync(path.join(wf, 'h4.failed'), '');
-  fs.writeFileSync(path.join(wf, 'h5.bin.tmp'), Buffer.alloc(8));
+  const { cacheFilePath, failedMarkerPath } = await import('../../src/db/waveform-lib.js');
+  fs.writeFileSync(cacheFilePath(wf, 'h1'), Buffer.alloc(8));
+  fs.writeFileSync(cacheFilePath(wf, 'h2'), Buffer.alloc(8));
+  fs.writeFileSync(failedMarkerPath(wf, 'h4'), '');
+  fs.writeFileSync(cacheFilePath(wf, 'h5') + '.tmp', Buffer.alloc(8));
+  // Artifacts from a superseded bar format describe different bytes for
+  // the same audio and are swept at boot — they must never be counted as
+  // coverage the operator does not actually have.
+  fs.writeFileSync(path.join(wf, 'h5.bin'), Buffer.alloc(8));
+  fs.writeFileSync(path.join(wf, 'h5.failed'), '');
 
   // Discovery: h1 embedded under the CURRENT model → done. h5 embedded
   // under a stale model → still remaining (the worker re-embeds it).

--- a/test/integration/enrichment-status.test.mjs
+++ b/test/integration/enrichment-status.test.mjs
@@ -179,7 +179,15 @@ describe('enrichment status: initial snapshot and gates', () => {
 });
 
 describe('enrichment status: lifecycle through the real queue', () => {
-  test('queued behind a held slot, then a real run lands in lastRun', async () => {
+  // These three drive a REAL waveform pass through the queue, which since
+  // the w2 generation requires a rust binary that answers the generation
+  // probe. In the window between a generation bump merging and CI
+  // rebuilding bin/, the resolved binary answers wrong and the pass
+  // correctly refuses to run — the truthful result here is skip, not fail.
+  const passReady = () => taskQueue.waveformPassBinaryReady();
+
+  test('queued behind a held slot, then a real run lands in lastRun', async (t) => {
+    if (!passReady()) { return t.skip('no generation-matched rust-parser (pending CI rebuild)'); }
     addSlowBackupHold('hold-queued');
     await sleep(100);
     assert.notEqual(taskQueue.getActiveBackupRun(), null, 'backup should hold the slot');
@@ -201,7 +209,8 @@ describe('enrichment status: lifecycle through the real queue', () => {
     assert.equal(typeof wf.lastRun?.finishedAt, 'number');
   });
 
-  test('a run-time gate bail returns to idle without clobbering lastRun', async () => {
+  test('a run-time gate bail returns to idle without clobbering lastRun', async (t) => {
+    if (!passReady()) { return t.skip('no generation-matched rust-parser (pending CI rebuild)'); }
     // Seed a real lastRun first (fast: empty DB).
     taskQueue.addWaveformTask();
     await waitForIdle();
@@ -228,7 +237,8 @@ describe('enrichment status: lifecycle through the real queue', () => {
       're-enabling restores idle without any event');
   });
 
-  test('snapshots are defensive copies', async () => {
+  test('snapshots are defensive copies', async (t) => {
+    if (!passReady()) { return t.skip('no generation-matched rust-parser (pending CI rebuild)'); }
     taskQueue.addWaveformTask();
     await waitForIdle();
     const a = statusOf('waveform');

--- a/test/integration/hash-transition-applier.test.mjs
+++ b/test/integration/hash-transition-applier.test.mjs
@@ -40,6 +40,10 @@ import { makeAudio } from '../helpers/scanner-fixture.mjs';
 import {
   initDiscoveryDb, closeDiscoveryDb, upsertDiscoveryTrack,
 } from '../../src/db/discovery-db.js';
+// The cache naming scheme has one owner (src/db/waveform-lib.js) and this
+// suite asserts against the same helpers the applier renames through, so a
+// format generation bump can't leave the test asserting the old names.
+import { cacheFilePath, failedMarkerPath } from '../../src/db/waveform-lib.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -177,9 +181,9 @@ describe('hash-transition applier (discovery ON — live worker)', () => {
     // whichever drain event consumes the ledger — the boot chain's tail or
     // the post-force-rescan drain — must see the complete stage. Ledger
     // first would let an early drain move the embedding and clear the
-    // ledger while {seed}.bin doesn't exist yet, so nothing ever renames.
-    await fsp.writeFile(path.join(waveDir, `${seed.audio_hash}.bin`), 'wavedata');
-    await fsp.writeFile(path.join(waveDir, `${seed.audio_hash}.failed`), 'symphonia\n');
+    // ledger while the seed's cache file doesn't exist yet, so nothing ever renames.
+    await fsp.writeFile(cacheFilePath(waveDir, seed.audio_hash), 'wavedata');
+    await fsp.writeFile(failedMarkerPath(waveDir, seed.audio_hash), 'symphonia\n');
     seedTransitions(mdb, [[seed.audio_hash, mid], [mid, fin]]);
 
     await forceRescanAndDrain(server, mdb);
@@ -202,9 +206,9 @@ describe('hash-transition applier (discovery ON — live worker)', () => {
     assert.ok(finRow.updated_at > seed.updated_at,
       'rowversion bumped — incremental consumers and the similarity cache see the re-key');
     // Waveform artifacts renamed at drain.
-    assert.ok(fs.existsSync(path.join(waveDir, `${fin}.bin`)), 'waveform bin followed');
-    assert.ok(fs.existsSync(path.join(waveDir, `${fin}.failed`)), 'failed marker followed');
-    assert.ok(!fs.existsSync(path.join(waveDir, `${seed.audio_hash}.bin`)), 'old bin gone');
+    assert.ok(fs.existsSync(cacheFilePath(waveDir, fin)), 'waveform bin followed');
+    assert.ok(fs.existsSync(failedMarkerPath(waveDir, fin)), 'failed marker followed');
+    assert.ok(!fs.existsSync(cacheFilePath(waveDir, seed.audio_hash)), 'old bin gone');
   });
 });
 
@@ -240,16 +244,16 @@ describe('hash-transition applier (discovery collection OFF)', () => {
     const p = 'b'.repeat(32);
     const q = 'c'.repeat(32);
     // Artifacts before ledger — same stage-ordering rule as the ON suite.
-    await fsp.writeFile(path.join(waveDir, `${p}.bin`), 'wavedata');
+    await fsp.writeFile(cacheFilePath(waveDir, p), 'wavedata');
     seedTransitions(mdb, [[p, q]]);
 
     await forceRescanAndDrain(server, mdb);
 
     assert.ok(!fs.existsSync(ddbPath),
       'draining must not silently create discovery.db');
-    assert.ok(fs.existsSync(path.join(waveDir, `${q}.bin`)),
+    assert.ok(fs.existsSync(cacheFilePath(waveDir, q)),
       'waveform renamed even with discovery off');
-    assert.ok(!fs.existsSync(path.join(waveDir, `${p}.bin`)), 'old bin gone');
+    assert.ok(!fs.existsSync(cacheFilePath(waveDir, p)), 'old bin gone');
   });
 
   test('a dormant discovery.db is still re-keyed, freshest source winning per terminal', async () => {

--- a/test/scanner/waveform-fallback.test.mjs
+++ b/test/scanner/waveform-fallback.test.mjs
@@ -24,7 +24,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { MIGRATIONS } from '../../src/db/schema.js';
-import { run } from '../../src/db/waveform-fallback.js';
+import { run, shouldChain } from '../../src/db/waveform-fallback.js';
 import {
   NUM_BARS, cacheFilePath, failedMarkerPath,
 } from '../../src/db/waveform-lib.js';
@@ -70,11 +70,16 @@ async function makeCase(tracks) {
 
   for (const t of tracks) {
     if (t.create !== false) {
+      // `codec` override lets a test put Opus inside a .ogg container —
+      // the case the extension alone can't classify.
+      const codecArgs =
+        t.codec === 'opus' || t.name.endsWith('.opus')
+          ? ['-c:a', 'libopus', '-b:a', '64k',
+             ...(t.name.endsWith('.opus') ? ['-f', 'opus'] : [])]
+          : ['-c:a', 'libmp3lame', '-b:a', '64k'];
       await runFfmpeg([
         '-f', 'lavfi', '-i', `sine=frequency=${t.freq || 440}:duration=1:sample_rate=48000`,
-        ...(t.name.endsWith('.opus')
-          ? ['-c:a', 'libopus', '-b:a', '64k', '-f', 'opus']
-          : ['-c:a', 'libmp3lame', '-b:a', '64k']),
+        ...codecArgs,
         path.join(lib, t.name),
       ]);
     }
@@ -218,5 +223,110 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(res.total, 3, 'the plan is still reported');
     assert.equal(res.generated, 0, 'but no work is started');
     assert.equal(fs.readdirSync(cache).length, 0);
+  });
+
+  // ── Regressions from the adversarial review of PR #818 ────────────────────
+
+  test('an unreachable cache dir reports zero DURABLE progress — the self-chain spin guard', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    // The dir vanished after boot (unmounted volume, deleted tree). Every
+    // decode succeeds but nothing can persist; the old chain gate counted
+    // the attempt-failures as progress and re-forked the whole pass
+    // forever against a byte-identical plan.
+    const { db, lib } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
+    const gone = path.join(path.dirname(lib), 'cache-that-vanished');
+
+    const r1 = await run({ db, cacheDir: gone, ffmpegBin: FFMPEG, abort: newAbort() });
+    const r2 = await run({ db, cacheDir: gone, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    for (const r of [r1, r2]) {
+      assert.equal(r.generated, 0);
+      assert.equal(r.markersRecorded, 0,
+        'a marker that never landed must not be counted as durable progress');
+    }
+    assert.ok(!fs.existsSync(gone), 'nothing was persisted anywhere');
+    assert.equal(shouldChain({ ...r1, capped: true }, null), false,
+      'the chain gate must refuse a round that landed nothing');
+  });
+
+  test('a cache-write failure is NOT recorded as ffmpeg’s verdict on the audio', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache } = await makeCase([{ name: 'good.opus', hash: 'aaa' }]);
+    // Obstruct the FINAL path with a directory: the decode succeeds, the
+    // rename cannot land. (The temp path is unique per write, so the final
+    // path is the only deterministic obstruction point.)
+    fs.mkdirSync(cacheFilePath(cache, 'aaa'));
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+
+    assert.equal(res.failed, 0, 'a disk error is not a decode failure');
+    assert.equal(res.markersRecorded, 0);
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')),
+      'ffmpeg decoded this file fine — a permanent marker would be a lie no pass ever clears');
+
+    // Remove the obstruction: the very next pass succeeds, proving the
+    // failure was never remembered anywhere.
+    fs.rmdirSync(cacheFilePath(cache, 'aaa'));
+    const retry = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+    assert.equal(retry.generated, 1, 'nothing durable blocked the retry');
+    assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa')).length, NUM_BARS);
+  });
+
+  test('an unreadable copy does not end the walk while a good copy remains', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache, lib } = await makeCase([
+      { name: 'bad.opus', hash: 'dup2', create: false },
+      { name: 'zz-good.opus', hash: 'dup2' },
+    ]);
+    // The bad copy EXISTS (existsSync true) but cannot be decoded — a
+    // directory stands in for a permission-denied or rotted file. The old
+    // walk returned on the first non-transient failure and wrote a
+    // terminal ffmpeg marker with the good copy still on disk.
+    fs.mkdirSync(path.join(lib, 'bad.opus'));
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.generated, 1, 'the good copy must be tried and carry the key');
+    assert.equal(res.failed, 0);
+    assert.ok(fs.existsSync(cacheFilePath(cache, 'dup2')));
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'dup2')));
+  });
+
+  test('opus inside a .ogg container is picked up via the extension source', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    // The rust pass probes these, finds no decoder, and skips them
+    // silently (no marker) — so the ONLY route to a waveform is this
+    // pass noticing the extension. A vorbis .ogg the rust pass already
+    // cached must not be re-decoded.
+    const { db, cache } = await makeCase([{ name: 'hidden.ogg', hash: 'ogg1', codec: 'opus' }]);
+    await fsp.writeFile(cacheFilePath(cache, 'vorbis1'), Buffer.alloc(NUM_BARS, 3));
+    db.prepare(`INSERT INTO tracks (library_id, filepath, title, audio_hash)
+                VALUES (1, 'cached.ogg', 'cached.ogg', 'vorbis1')`).run();
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 1, 'only the uncached ogg is work; the cached one is excluded');
+    assert.equal(res.generated, 1);
+    const buf = fs.readFileSync(cacheFilePath(cache, 'ogg1'));
+    assert.equal(buf.length, NUM_BARS);
+    assert.ok(Math.max(...buf) > 0, 'the hidden Opus stream produced real peaks');
+    assert.equal(fs.readFileSync(cacheFilePath(cache, 'vorbis1'))[0], 3, 'cached entry untouched');
+  });
+
+  test('shouldChain: only durable, shrinking progress justifies another round', () => {
+    const base = { capped: true, generated: 0, markersRecorded: 0, backlog: 1000 };
+    assert.equal(shouldChain({ ...base }, null), false, 'attempts alone never chain');
+    assert.equal(shouldChain({ ...base, generated: 5 }, null), true, 'landed cache files chain');
+    assert.equal(shouldChain({ ...base, markersRecorded: 5 }, null), true, 'landed markers chain');
+    assert.equal(shouldChain({ ...base, generated: 5, capped: false }, null), false,
+      'an uncapped run finished the backlog — nothing to chain');
+    assert.equal(shouldChain({ ...base, generated: 5, backlog: 1000 }, 1000), false,
+      'a backlog that failed to shrink stops the chain even with progress claimed');
+    assert.equal(shouldChain({ ...base, generated: 5, backlog: 500 }, 1000), true,
+      'a genuinely shrinking backlog keeps draining');
   });
 });

--- a/test/scanner/waveform-fallback.test.mjs
+++ b/test/scanner/waveform-fallback.test.mjs
@@ -26,7 +26,7 @@ import { fileURLToPath } from 'node:url';
 import { MIGRATIONS } from '../../src/db/schema.js';
 import { run, shouldChain } from '../../src/db/waveform-fallback.js';
 import {
-  NUM_BARS, cacheFilePath, failedMarkerPath,
+  NUM_BARS, cacheFilePath, failedMarkerPath, deferredMarkerPath,
 } from '../../src/db/waveform-lib.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -333,25 +333,28 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(retry.generated, 1, 'the key must still be reachable once readable again');
   });
 
-  test('a no-decoder marker routes the key here whatever its container', { timeout: 60_000 }, async (t) => {
+  test('a deferred artifact routes the key here whatever its container', { timeout: 60_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
-    // The rust pass writes `no-decoder` for a codec it has no decoder for.
-    // The container may be one CANDIDATE_EXTS never queries (5.1 or HE-AAC
-    // in .m4a/.m4b/.aac), so the marker is the ONLY route to a waveform —
-    // routing by extension alone left those files uncovered by both passes.
+    // The rust pass writes a `.w2.deferred` artifact for a codec it has no
+    // decoder for. The container may be one CANDIDATE_EXTS never queries
+    // (5.1 or HE-AAC in .m4a/.m4b/.aac), so that artifact is the ONLY route
+    // to a waveform — routing by extension alone left those files uncovered
+    // by both passes.
     const { db, cache, lib } = await makeCase([{ name: 'multi.m4a', hash: 'aaa', create: false }]);
     await runFfmpeg(['-f', 'lavfi', '-i', 'sine=frequency=440:duration=1:sample_rate=48000',
       '-ac', '6', '-c:a', 'aac', '-b:a', '192k', path.join(lib, 'multi.m4a')]);
-    await fsp.writeFile(failedMarkerPath(cache, 'aaa'), 'no-decoder\n');
+    await fsp.writeFile(deferredMarkerPath(cache, 'aaa'), 'no-decoder\n');
 
     const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
     db.close();
 
-    assert.equal(res.total, 1, '.m4a is not in CANDIDATE_EXTS — the marker is what found it');
+    assert.equal(res.total, 1, '.m4a is not in CANDIDATE_EXTS — the deferral is what found it');
     assert.equal(res.generated, 1);
     assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa')).length, NUM_BARS);
+    assert.ok(!fs.existsSync(deferredMarkerPath(cache, 'aaa')),
+      'success clears the deferral so the key stops being replanned');
     assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')),
-      'success clears the marker so the key stops being replanned');
+      'and a deferral must never have been a failure');
   });
 
   test('an unreadable copy does not end the walk while a good copy remains', { timeout: 60_000 }, async (t) => {

--- a/test/scanner/waveform-fallback.test.mjs
+++ b/test/scanner/waveform-fallback.test.mjs
@@ -241,7 +241,10 @@ describe('waveform ffmpeg fallback', () => {
     db.close();
 
     for (const r of [r1, r2]) {
+      assert.equal(r.total, 1, 'the work was genuinely attempted, not skipped');
       assert.equal(r.generated, 0);
+      assert.equal(r.failed, 0,
+        'a write that could not land is not a decode verdict on the audio');
       assert.equal(r.markersRecorded, 0,
         'a marker that never landed must not be counted as durable progress');
     }
@@ -252,26 +255,103 @@ describe('waveform ffmpeg fallback', () => {
 
   test('a cache-write failure is NOT recorded as ffmpeg’s verdict on the audio', { timeout: 60_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
-    const { db, cache } = await makeCase([{ name: 'good.opus', hash: 'aaa' }]);
-    // Obstruct the FINAL path with a directory: the decode succeeds, the
-    // rename cannot land. (The temp path is unique per write, so the final
-    // path is the only deterministic obstruction point.)
-    fs.mkdirSync(cacheFilePath(cache, 'aaa'));
+    const { db, lib } = await makeCase([{ name: 'good.opus', hash: 'aaa' }]);
+    // The cache "directory" is a FILE. Every write into it fails, and —
+    // unlike obstructing the final path with a directory — planWork cannot
+    // mistake the obstruction for a cache hit. That mattered: the first
+    // version of this test planted a directory named <key>.w2.bin, which
+    // planWork classifies as cached by suffix alone, so the run did NOTHING
+    // and every assertion passed vacuously on reverted code.
+    const cache = path.join(path.dirname(lib), 'cache-is-a-file');
+    await fsp.writeFile(cache, 'not a directory');
 
     const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
 
+    assert.equal(res.total, 1, 'the decode really ran — otherwise this test proves nothing');
+    assert.equal(res.generated, 0, 'the write could not land');
     assert.equal(res.failed, 0, 'a disk error is not a decode failure');
     assert.equal(res.markersRecorded, 0);
-    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')),
-      'ffmpeg decoded this file fine — a permanent marker would be a lie no pass ever clears');
 
-    // Remove the obstruction: the very next pass succeeds, proving the
-    // failure was never remembered anywhere.
-    fs.rmdirSync(cacheFilePath(cache, 'aaa'));
+    // Replace the obstruction with a real directory: the very next pass
+    // succeeds, proving the disk error was never remembered anywhere.
+    await fsp.rm(cache);
+    await fsp.mkdir(cache, { recursive: true });
     const retry = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
     db.close();
     assert.equal(retry.generated, 1, 'nothing durable blocked the retry');
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')),
+      'ffmpeg decoded this file fine — a marker would be a lie no pass ever clears');
     assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa')).length, NUM_BARS);
+  });
+
+  test('an undecodable file whose marker cannot be written counts no durable progress', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    // Pins recordFfmpegFailure's boolean return AND the markersRecorded
+    // gate, in both directions: the decode genuinely fails (so `failed`
+    // must rise) but the marker cannot land (so `markersRecorded` must
+    // not, and the chain must refuse).
+    const { db, lib } = await makeCase([{ name: 'junk.opus', hash: 'aaa', create: false }]);
+    await fsp.writeFile(path.join(lib, 'junk.opus'), 'this is not an opus stream');
+    const cache = path.join(path.dirname(lib), 'cache-file-2');
+    await fsp.writeFile(cache, 'not a directory');
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 1);
+    assert.equal(res.failed, 1, 'the content really is undecodable');
+    assert.equal(res.markersRecorded, 0, 'but no marker landed, so nothing durable happened');
+    assert.equal(shouldChain({ ...res, capped: true }, null), false,
+      'a round that recorded nothing must not chain');
+  });
+
+  test('an unreadable file is not given a permanent ffmpeg verdict', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    // A path that exists but cannot be READ — a lock, an ACL change, a
+    // stale mount. ffmpeg exits non-zero exactly as it would for corrupt
+    // audio, and treating that as a content verdict wrote a marker nothing
+    // ever clears: the key left every future plan and the endpoint 500'd
+    // on it forever. A directory standing in for the file reproduces the
+    // stat-succeeds-read-fails shape portably.
+    const { db, cache, lib } = await makeCase([{ name: 'locked.opus', hash: 'aaa', create: false }]);
+    fs.mkdirSync(path.join(lib, 'locked.opus'));
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+
+    assert.equal(res.failed, 0, 'unreadable is not undecodable');
+    assert.equal(res.markersRecorded, 0);
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')),
+      'a terminal marker here would strand the track forever');
+
+    // The obstruction clears (permissions restored, mount back): the very
+    // next pass must be able to generate.
+    fs.rmdirSync(path.join(lib, 'locked.opus'));
+    await runFfmpeg(['-f', 'lavfi', '-i', 'sine=frequency=440:duration=1:sample_rate=48000',
+      '-c:a', 'libopus', '-b:a', '64k', '-f', 'opus', path.join(lib, 'locked.opus')]);
+    const retry = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+    assert.equal(retry.generated, 1, 'the key must still be reachable once readable again');
+  });
+
+  test('a no-decoder marker routes the key here whatever its container', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    // The rust pass writes `no-decoder` for a codec it has no decoder for.
+    // The container may be one CANDIDATE_EXTS never queries (5.1 or HE-AAC
+    // in .m4a/.m4b/.aac), so the marker is the ONLY route to a waveform —
+    // routing by extension alone left those files uncovered by both passes.
+    const { db, cache, lib } = await makeCase([{ name: 'multi.m4a', hash: 'aaa', create: false }]);
+    await runFfmpeg(['-f', 'lavfi', '-i', 'sine=frequency=440:duration=1:sample_rate=48000',
+      '-ac', '6', '-c:a', 'aac', '-b:a', '192k', path.join(lib, 'multi.m4a')]);
+    await fsp.writeFile(failedMarkerPath(cache, 'aaa'), 'no-decoder\n');
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 1, '.m4a is not in CANDIDATE_EXTS — the marker is what found it');
+    assert.equal(res.generated, 1);
+    assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa')).length, NUM_BARS);
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')),
+      'success clears the marker so the key stops being replanned');
   });
 
   test('an unreadable copy does not end the walk while a good copy remains', { timeout: 60_000 }, async (t) => {

--- a/test/scanner/waveform-fallback.test.mjs
+++ b/test/scanner/waveform-fallback.test.mjs
@@ -1,0 +1,222 @@
+/**
+ * The ffmpeg half of the waveform pass (src/db/waveform-fallback.js).
+ *
+ * symphonia has no Opus decoder, so the rust pass leaves Opus keys
+ * uncached by design. Before this module existed those tracks got no
+ * proactive waveform at all: the first play of every Opus file paid a cold
+ * ffmpeg decode with an empty progress bar, and the pass reported them as
+ * permanent failures in the admin panel.
+ *
+ * Covered here: Opus is picked up and generated; symphonia-only failure
+ * markers are retried and cleared on success; an ffmpeg-recorded failure
+ * is NOT retried; already-cached keys are left alone; duplicate content
+ * decodes once; a vanished file leaves no marker; and abort stops the run.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import child from 'node:child_process';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { MIGRATIONS } from '../../src/db/schema.js';
+import { run } from '../../src/db/waveform-fallback.js';
+import {
+  NUM_BARS, cacheFilePath, failedMarkerPath,
+} from '../../src/db/waveform-lib.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FFMPEG = path.join(REPO_ROOT, 'bin', 'ffmpeg',
+  process.platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg');
+const ffmpegOk = fs.existsSync(FFMPEG);
+
+function runFfmpeg(args) {
+  return new Promise((resolve, reject) => {
+    const p = child.spawn(FFMPEG, ['-nostdin', '-y', '-loglevel', 'error', ...args],
+      { stdio: ['ignore', 'ignore', 'pipe'] });
+    let err = '';
+    p.stderr.on('data', d => { err += d; });
+    p.on('error', reject);
+    p.on('exit', code => code === 0 ? resolve() : reject(new Error(`ffmpeg ${code}: ${err.slice(-300)}`)));
+  });
+}
+
+let tmp;
+let seq = 0;
+
+before(async () => { tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'wffb-test-')); });
+after(async () => {
+  if (tmp) { await fsp.rm(tmp, { recursive: true, force: true }).catch(() => {}); }
+});
+
+// A minimal DB with hand-written track rows: this module reads
+// tracks+libraries and nothing else, so a real scan would only add
+// runtime and a rust-binary dependency the fallback itself doesn't have.
+async function makeCase(tracks) {
+  const root = path.join(tmp, `case-${seq++}`);
+  const lib = path.join(root, 'music');
+  const cache = path.join(root, 'wfcache');
+  await fsp.mkdir(lib, { recursive: true });
+  await fsp.mkdir(cache, { recursive: true });
+
+  const db = new DatabaseSync(path.join(root, 'wf.db'));
+  for (const m of MIGRATIONS) { db.exec(m.sql); db.exec(`PRAGMA user_version = ${m.version}`); }
+  db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
+
+  for (const t of tracks) {
+    if (t.create !== false) {
+      await runFfmpeg([
+        '-f', 'lavfi', '-i', `sine=frequency=${t.freq || 440}:duration=1:sample_rate=48000`,
+        ...(t.name.endsWith('.opus')
+          ? ['-c:a', 'libopus', '-b:a', '64k', '-f', 'opus']
+          : ['-c:a', 'libmp3lame', '-b:a', '64k']),
+        path.join(lib, t.name),
+      ]);
+    }
+    db.prepare(`INSERT INTO tracks (library_id, filepath, title, audio_hash)
+                VALUES (1, ?, ?, ?)`).run(t.name, t.name, t.hash);
+  }
+  return { db, lib, cache };
+}
+
+const newAbort = () => ({ stopped: false });
+
+describe('waveform ffmpeg fallback', () => {
+  test('generates a waveform for Opus, which symphonia cannot decode', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 1);
+    assert.equal(res.generated, 1);
+    assert.equal(res.failed, 0);
+    const buf = fs.readFileSync(cacheFilePath(cache, 'aaa'));
+    assert.equal(buf.length, NUM_BARS, 'cache file must be exactly NUM_BARS bytes');
+    assert.ok(Math.max(...buf) > 0, 'a 440 Hz tone must produce real peaks');
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')), 'success leaves no marker');
+  });
+
+  test('mp3s are left to the rust pass; only unsupported codecs are picked up', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache } = await makeCase([
+      { name: 'a.opus', hash: 'aaa' },
+      { name: 'b.mp3', hash: 'bbb', freq: 880 },
+    ]);
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 1, 'the mp3 is the rust pass’s work, not ours');
+    assert.ok(fs.existsSync(cacheFilePath(cache, 'aaa')));
+    assert.ok(!fs.existsSync(cacheFilePath(cache, 'bbb')));
+  });
+
+  test('an already-cached key is skipped', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
+    await fsp.writeFile(cacheFilePath(cache, 'aaa'), Buffer.alloc(NUM_BARS, 7));
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 0, 'nothing to do');
+    assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa'))[0], 7, 'existing cache untouched');
+  });
+
+  test('a symphonia-only marker is retried and cleared when ffmpeg succeeds', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    // An mp3 symphonia choked on: not an unsupported codec, so it only
+    // reaches the fallback via its marker.
+    const { db, cache } = await makeCase([{ name: 'b.mp3', hash: 'bbb' }]);
+    await fsp.writeFile(failedMarkerPath(cache, 'bbb'), 'symphonia\n');
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.generated, 1, 'ffmpeg decodes plenty symphonia will not');
+    assert.ok(fs.existsSync(cacheFilePath(cache, 'bbb')));
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'bbb')),
+      'a marker that is no longer true must be removed');
+  });
+
+  test('a marker naming ffmpeg is not retried', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
+    await fsp.writeFile(failedMarkerPath(cache, 'aaa'), 'symphonia\nffmpeg\n');
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 0, 'ffmpeg already rendered its verdict on this content');
+    assert.ok(!fs.existsSync(cacheFilePath(cache, 'aaa')));
+  });
+
+  test('undecodable content records an ffmpeg failure exactly once', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache, lib } = await makeCase([{ name: 'a.opus', hash: 'aaa', create: false }]);
+    await fsp.writeFile(path.join(lib, 'a.opus'), 'this is not an opus stream');
+
+    const first = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    assert.equal(first.failed, 1);
+    assert.match(fs.readFileSync(failedMarkerPath(cache, 'aaa'), 'utf8'), /ffmpeg/);
+
+    // Second pass must see the marker and not spawn ffmpeg again.
+    const second = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+    assert.equal(second.total, 0, 'a recorded failure is not re-attempted');
+  });
+
+  test('duplicate content decodes once; a vanished copy falls through to a live one', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache, lib } = await makeCase([
+      { name: 'gone.opus', hash: 'dup' },
+      { name: 'alive.opus', hash: 'dup' },
+    ]);
+    fs.rmSync(path.join(lib, 'gone.opus'));
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.total, 1, 'two rows, one content key, one unit of work');
+    assert.equal(res.generated, 1, 'the surviving copy carried it');
+    assert.ok(fs.existsSync(cacheFilePath(cache, 'dup')));
+  });
+
+  test('a key whose every copy has vanished leaves no marker', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache, lib } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
+    fs.rmSync(path.join(lib, 'a.opus'));
+
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort: newAbort() });
+    db.close();
+
+    assert.equal(res.generated, 0);
+    assert.equal(res.failed, 0, 'a missing file is the sweep’s business, not a decode failure');
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')),
+      'the file may come back unchanged — do not poison the key');
+  });
+
+  test('abort stops the run without generating anything further', { timeout: 60_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const { db, cache } = await makeCase([
+      { name: 'a.opus', hash: 'aaa' },
+      { name: 'b.opus', hash: 'bbb', freq: 660 },
+      { name: 'c.opus', hash: 'ccc', freq: 880 },
+    ]);
+
+    const abort = { stopped: true };   // as if shutdown landed before the first item
+    const res = await run({ db, cacheDir: cache, ffmpegBin: FFMPEG, abort });
+    db.close();
+
+    assert.equal(res.total, 3, 'the plan is still reported');
+    assert.equal(res.generated, 0, 'but no work is started');
+    assert.equal(fs.readdirSync(cache).length, 0);
+  });
+});

--- a/test/scanner/waveform-scan.test.mjs
+++ b/test/scanner/waveform-scan.test.mjs
@@ -2,11 +2,12 @@
  * The waveform enrichment pass (`rust-parser --waveform-scan`) and the
  * on-demand endpoint's full-length generation.
  *
- * Pass coverage: generates one .bin per distinct content hash after a
- * real scan, is idempotent (second run plans zero), writes a
- * `<hash>.failed` marker for undecodable formats (Opus) instead of
- * retrying them forever, skips vanished files without burning a marker,
- * and honours the schema-version guard (exit 3).
+ * Pass coverage: generates one cache file per distinct content hash after
+ * a real scan, is idempotent (second run plans zero), leaves codecs
+ * symphonia cannot decode (Opus) OUT of the plan entirely rather than
+ * marking them failed — the ffmpeg fallback owns those — skips vanished
+ * files without burning a marker, and honours the schema-version guard
+ * (exit 3).
  *
  * Endpoint coverage: generateWaveformBars must cover the WHOLE track —
  * the old implementation buffered 2 MB of 8 kHz PCM and silently
@@ -28,8 +29,10 @@ import { fileURLToPath } from 'node:url';
 
 import { MIGRATIONS, SCHEMA_VERSION } from '../../src/db/schema.js';
 import {
-  generateWaveformBars, NUM_BARS,
+  generateWaveformBars, NUM_BARS, CACHE_EXT, FAILED_EXT,
+  cacheFilePath, failedMarkerPath,
   hasFfmpegFailedMarker, recordFfmpegFailure, clearFailedMarker,
+  sweepSupersededArtifacts,
 } from '../../src/db/waveform-lib.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -101,8 +104,8 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
     cache = path.join(root, 'wfcache');
     dbPath = path.join(root, 'wf.db');
     await fsp.mkdir(lib, { recursive: true });
-    // Three distinct tones (distinct hashes) + one Opus (undecodable by
-    // symphonia → must get a .failed marker, not a retry loop).
+    // Three distinct tones (distinct hashes) + one Opus (symphonia has no
+    // decoder → must be left out of the plan entirely, no marker).
     for (const [name, freq] of [['a.mp3', 220], ['b.mp3', 440], ['c.mp3', 880]]) {
       await runFfmpeg(['-f', 'lavfi', '-i', `sine=frequency=${freq}:duration=1:sample_rate=44100`,
         '-c:a', 'libmp3lame', '-b:a', '64k', path.join(lib, name)]);
@@ -133,27 +136,30 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
     scanThreads: 1, ...overrides,
   });
 
-  test('generates one 800-byte .bin per decodable track; markers for undecodable; idempotent', { timeout: 120_000 }, async (t) => {
+  test('generates one 800-byte cache file per decodable track; opus stays out of the plan; idempotent', { timeout: 120_000 }, async (t) => {
     if (!(await setupScannedLibrary(t))) { return; }
 
     const r = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
     assert.equal(r.code, 0, `pass should exit 0: ${r.err}`);
     const complete = lastEvent(r.out, 'waveformScanComplete');
-    assert.equal(complete.total, 4, 'all four tracks planned');
+    // The opus is NOT planned: a codec symphonia can't decode is not work
+    // for this pass and not a failure. Counting it as one made the admin
+    // panel report a permanent failure for a perfectly good file, and the
+    // marker it left stopped the key ever being reconsidered.
+    assert.equal(complete.total, 3, 'only the three decodable tracks planned');
     assert.equal(complete.generated, 3, 'the three mp3s generated');
-    assert.equal(complete.failed, 1, 'the opus failed');
+    assert.equal(complete.failed, 0, 'nothing failed');
 
     const names = fs.readdirSync(cache);
-    const bins = names.filter(n => n.endsWith('.bin'));
-    const markers = names.filter(n => n.endsWith('.failed'));
+    const bins = names.filter(n => n.endsWith(CACHE_EXT));
+    const markers = names.filter(n => n.endsWith(FAILED_EXT));
     assert.equal(bins.length, 3);
-    assert.equal(markers.length, 1);
+    assert.equal(markers.length, 0, 'opus must not leave a failure marker');
     for (const b of bins) {
       const buf = fs.readFileSync(path.join(cache, b));
       assert.equal(buf.length, NUM_BARS, `${b} must be exactly ${NUM_BARS} bytes`);
       assert.ok(Math.max(...buf) > 0, `${b} must contain real peaks`);
     }
-    assert.match(fs.readFileSync(path.join(cache, markers[0]), 'utf8'), /symphonia/);
 
     // Second run: everything cached or marked — plans zero, touches nothing.
     const before = names.map(n => [n, fs.statSync(path.join(cache, n)).mtimeMs]);
@@ -172,18 +178,18 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
     assert.equal(r.code, 3, `expected guard exit 3, got ${r.code}: ${r.err}`);
   });
 
-  test('a file that vanished after the scan is skipped silently — no .bin, no marker', { timeout: 60_000 }, async (t) => {
+  test('a file that vanished after the scan is skipped silently — no cache file, no marker', { timeout: 60_000 }, async (t) => {
     if (!(await setupScannedLibrary(t))) { return; }
     fs.rmSync(path.join(lib, 'b.mp3'));
     const r = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
     assert.equal(r.code, 0);
     const complete = lastEvent(r.out, 'waveformScanComplete');
-    assert.equal(complete.total, 4, 'the vanished file is still planned (row exists)');
+    assert.equal(complete.total, 3, 'the vanished file is still planned (row exists)');
     assert.equal(complete.generated, 2, 'two surviving mp3s generated');
-    assert.equal(complete.failed, 1, 'only the opus is marked failed');
+    assert.equal(complete.failed, 0, 'a vanished file is not a decode failure');
     const names = fs.readdirSync(cache);
-    assert.equal(names.filter(n => n.endsWith('.bin')).length, 2);
-    assert.equal(names.filter(n => n.endsWith('.failed')).length, 1,
+    assert.equal(names.filter(n => n.endsWith(CACHE_EXT)).length, 2);
+    assert.equal(names.filter(n => n.endsWith(FAILED_EXT)).length, 0,
       'no marker for the vanished file — it may come back unchanged');
   });
 
@@ -198,15 +204,30 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
     // engine line. The pass must still decode (symphonia ≠ ffmpeg) —
     // the .bin it writes is exactly what un-500s the endpoint.
     fs.mkdirSync(cache, { recursive: true });
-    fs.writeFileSync(path.join(cache, `${key}.failed`), 'ffmpeg\n');
+    fs.writeFileSync(failedMarkerPath(cache, key), 'ffmpeg\n');
     const r = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
     assert.equal(r.code, 0);
-    assert.ok(fs.existsSync(path.join(cache, `${key}.bin`)),
+    assert.ok(fs.existsSync(cacheFilePath(cache, key)),
       'ffmpeg-only marker must not exclude the key from the pass');
-    // ...while a symphonia line keeps excluding (the opus marker from
-    // this same run proves the skip path on rerun).
     const r2 = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
     assert.equal(lastEvent(r2.out, 'waveformScanPlan').total, 0, 'rerun plans no work');
+  });
+
+  test('a symphonia marker keeps its key out of the plan', { timeout: 60_000 }, async (t) => {
+    if (!(await setupScannedLibrary(t))) { return; }
+    const db = new DatabaseSync(dbPath);
+    const key = db.prepare(
+      "SELECT COALESCE(NULLIF(audio_hash, ''), file_hash) AS k FROM tracks WHERE filepath = 'a.mp3'"
+    ).get().k;
+    db.close();
+    fs.mkdirSync(cache, { recursive: true });
+    fs.writeFileSync(failedMarkerPath(cache, key), 'symphonia\n');
+    const r = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
+    assert.equal(r.code, 0);
+    assert.equal(lastEvent(r.out, 'waveformScanPlan').total, 2,
+      'the marked key is excluded; the other two mp3s remain');
+    assert.ok(!fs.existsSync(cacheFilePath(cache, key)),
+      'a symphonia failure is not retried by this pass');
   });
 
   test('duplicate content: a vanished first copy does not starve the surviving copy', { timeout: 60_000 }, async (t) => {
@@ -239,9 +260,9 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
 
     const r = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
     assert.equal(r.code, 0);
-    assert.ok(fs.existsSync(path.join(cache, `${key}.bin`)),
+    assert.ok(fs.existsSync(cacheFilePath(cache, key)),
       'the surviving copy must produce the waveform even when the first path is dead');
-    assert.ok(!fs.existsSync(path.join(cache, `${key}.failed`)),
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, key)),
       'a vanished path is not a decode failure');
   });
 });
@@ -277,13 +298,53 @@ describe('on-demand generation covers the full track length', () => {
     assert.equal(hasFfmpegFailedMarker(dir, key), false);
     // A symphonia-only marker (written by the rust pass) must NOT gate
     // the ffmpeg endpoint — ffmpeg decodes formats symphonia can't.
-    await fsp.writeFile(path.join(dir, `${key}.failed`), 'symphonia\n');
+    await fsp.writeFile(failedMarkerPath(dir, key), 'symphonia\n');
     assert.equal(hasFfmpegFailedMarker(dir, key), false);
     await recordFfmpegFailure(dir, key);
     assert.equal(hasFfmpegFailedMarker(dir, key), true);
-    assert.match(await fsp.readFile(path.join(dir, `${key}.failed`), 'utf8'), /symphonia/,
+    assert.match(await fsp.readFile(failedMarkerPath(dir, key), 'utf8'), /symphonia/,
       'recording ffmpeg must preserve the symphonia line');
     await clearFailedMarker(dir, key);
     assert.equal(hasFfmpegFailedMarker(dir, key), false);
+  });
+
+  // The fix that made all of the above necessary: the generator used to
+  // ask ffmpeg for `-ac 1`, which SUMS channels. Anti-phase stereo
+  // cancelled to digital silence and the resulting all-zero waveform was
+  // cached permanently — a blank progress bar for plainly audible audio.
+  test('anti-phase stereo does not cancel to a blank waveform', { timeout: 120_000 }, async (t) => {
+    if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
+    const fixture = path.join(tmp, 'antiphase.flac');
+    await runFfmpeg([
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=4:sample_rate=44100',
+      // split into L and R, invert R — L+R sums to zero everywhere
+      '-filter_complex', '[0:a]asplit[l][r];[r]volume=-1[ri];[l][ri]amerge=inputs=2[out]',
+      '-map', '[out]', '-c:a', 'flac', fixture,
+    ]);
+    const bars = await generateWaveformBars(fixture, FFMPEG);
+    assert.equal(bars.length, NUM_BARS);
+    const nonZero = bars.filter(b => b > 0).length;
+    assert.ok(nonZero > NUM_BARS * 0.9,
+      `expected a full waveform, got ${nonZero}/${NUM_BARS} non-zero bars — ` +
+      `the channels are being summed again`);
+    assert.ok(Math.max(...bars) > 20,
+      `peaks read ${Math.max(...bars)}/255 — far below the source's level`);
+  });
+
+  test('sweepSupersededArtifacts removes previous-generation names only', async () => {
+    const dir = path.join(tmp, 'sweep-dir');
+    await fsp.mkdir(dir, { recursive: true });
+    const keep = [cacheFilePath(dir, 'aaa'), failedMarkerPath(dir, 'bbb')];
+    const drop = [path.join(dir, 'ccc.bin'), path.join(dir, 'ddd.failed')];
+    const bystander = path.join(dir, 'README.md');
+    for (const f of [...keep, ...drop, bystander]) { await fsp.writeFile(f, 'x'); }
+
+    assert.equal(await sweepSupersededArtifacts(dir), 2);
+    for (const f of keep) { assert.ok(fs.existsSync(f), `${path.basename(f)} must survive`); }
+    for (const f of drop) { assert.ok(!fs.existsSync(f), `${path.basename(f)} must be swept`); }
+    assert.ok(fs.existsSync(bystander), 'unrelated files are left alone');
+    // Idempotent, and a missing directory is not an error.
+    assert.equal(await sweepSupersededArtifacts(dir), 0);
+    assert.equal(await sweepSupersededArtifacts(path.join(tmp, 'nope')), 0);
   });
 });

--- a/test/scanner/waveform-scan.test.mjs
+++ b/test/scanner/waveform-scan.test.mjs
@@ -31,8 +31,9 @@ import { MIGRATIONS, SCHEMA_VERSION } from '../../src/db/schema.js';
 import {
   generateWaveformBars, NUM_BARS, CACHE_EXT, FAILED_EXT,
   cacheFilePath, failedMarkerPath,
-  hasFfmpegFailedMarker, recordFfmpegFailure, clearFailedMarker,
+  hasFfmpegFailedMarker, recordFfmpegFailure,
   sweepSupersededArtifacts, probeWaveformGeneration,
+  DEFERRED_EXT, deferredMarkerPath, clearWaveformMarkers,
 } from '../../src/db/waveform-lib.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -277,13 +278,15 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
     assert.equal(complete.failed, 0, 'a codec with no decoder is not a failure of the file');
     assert.ok(!fs.existsSync(cacheFilePath(cache, key)), 'and symphonia produced no bars');
 
-    // It DOES leave a `no-decoder` marker. That is not a failure line — it
-    // is how the key stays reachable: the ffmpeg fallback routes on it, and
-    // without it anything undecodable in a container the fallback doesn't
-    // query by extension had no route to a waveform from either pass.
-    const marker = fs.readFileSync(failedMarkerPath(cache, key), 'utf8');
-    assert.match(marker, /no-decoder/);
-    assert.doesNotMatch(marker, /symphonia/, 'this is not a decode failure');
+    // It DOES leave a `.w2.deferred` artifact — a SEPARATE suffix, not a
+    // line in `.failed`. That is how the key stays reachable (the ffmpeg
+    // fallback routes on it) without the coverage counter, which
+    // classifies by filename only, reporting a good file as a failure.
+    assert.ok(fs.existsSync(deferredMarkerPath(cache, key)),
+      'the key must stay reachable for the ffmpeg half');
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, key)),
+      'a deferral is not a failure and must not be counted as one');
+    assert.ok(fs.readdirSync(cache).some(n => n.endsWith(DEFERRED_EXT)));
 
     // The marker also stops the endless re-probe: a second pass plans zero
     // for that key rather than re-opening the file on every scan forever.
@@ -294,7 +297,7 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
     // And a later ffmpeg success clears it, so the key stops being planned
     // for the right reason.
     fs.writeFileSync(cacheFilePath(cache, key), Buffer.alloc(NUM_BARS, 5));
-    fs.rmSync(failedMarkerPath(cache, key));
+    fs.rmSync(deferredMarkerPath(cache, key));
     const r3 = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
     assert.equal(lastEvent(r3.out, 'waveformScanPlan').total, 0, 'cached key stays done');
   });
@@ -373,7 +376,7 @@ describe('on-demand generation covers the full track length', () => {
     assert.equal(hasFfmpegFailedMarker(dir, key), true);
     assert.match(await fsp.readFile(failedMarkerPath(dir, key), 'utf8'), /symphonia/,
       'recording ffmpeg must preserve the symphonia line');
-    await clearFailedMarker(dir, key);
+    await clearWaveformMarkers(dir, key);
     assert.equal(hasFfmpegFailedMarker(dir, key), false);
   });
 

--- a/test/scanner/waveform-scan.test.mjs
+++ b/test/scanner/waveform-scan.test.mjs
@@ -32,7 +32,7 @@ import {
   generateWaveformBars, NUM_BARS, CACHE_EXT, FAILED_EXT,
   cacheFilePath, failedMarkerPath,
   hasFfmpegFailedMarker, recordFfmpegFailure, clearFailedMarker,
-  sweepSupersededArtifacts,
+  sweepSupersededArtifacts, probeWaveformGeneration,
 } from '../../src/db/waveform-lib.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -43,11 +43,16 @@ const FFMPEG = path.join(REPO_ROOT, 'bin', 'ffmpeg',
 function findRustParser() {
   const ext = process.platform === 'win32' ? '.exe' : '';
   const libc = process.platform === 'linux' ? '-musl' : '';
-  return [
+  const candidates = [
     path.join(REPO_ROOT, 'rust-parser', 'target', 'release', `rust-parser${ext}`),
     path.join(REPO_ROOT, 'bin', 'rust-parser',
       `rust-parser-${process.platform}-${process.arch}${libc}${ext}`),
-  ].find(p => fs.existsSync(p)) || null;
+  ].filter(p => fs.existsSync(p));
+  // Only a binary on the CURRENT cache generation can satisfy this suite —
+  // a prebuilt from before a generation bump writes filenames these
+  // assertions (and the server, via the same probe) no longer accept.
+  // Skipping in the window before CI rebuilds bin/ is the truthful result.
+  return candidates.find(p => probeWaveformGeneration(p) === CACHE_EXT) || null;
 }
 
 function runFfmpeg(args) {
@@ -230,6 +235,45 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
       'a symphonia failure is not retried by this pass');
   });
 
+  test('opus hidden in a .ogg container: skipped silently, no marker, left for the fallback', { timeout: 60_000 }, async (t) => {
+    if (!(await setupScannedLibrary(t))) { return; }
+    // The extension gate can't see this one — symphonia's ogg reader maps
+    // the Opus stream happily and only decoder creation fails. It used to
+    // be counted failed and marked `symphonia`, misreporting a fine file.
+    await runFfmpeg(['-f', 'lavfi', '-i', 'sine=frequency=440:duration=1:sample_rate=48000',
+      '-c:a', 'libopus', '-b:a', '64k', path.join(lib, 'hidden.ogg')]);
+    const rescan = await spawnJson(rustBin, [JSON.stringify({
+      dbPath, libraryId: 1, vpath: 'wflib', directory: lib,
+      skipImg: true, albumArtDirectory: path.join(tmp, 'art'), scanId: 'wf-ogg',
+      compressImage: false, supportedFiles: { mp3: true, opus: true, ogg: true },
+      scanCommitInterval: 25, forceRescan: false, followSymlinks: false,
+      subtree: '', waveformCacheDir: '', analyzeBpm: false,
+      expectedSchemaVersion: SCHEMA_VERSION, scanThreads: 1,
+    })]);
+    assert.equal(rescan.code, 0, rescan.err);
+    const db = new DatabaseSync(dbPath);
+    const key = db.prepare(
+      "SELECT COALESCE(NULLIF(audio_hash, ''), file_hash) AS k FROM tracks WHERE filepath = 'hidden.ogg'"
+    ).get().k;
+    db.close();
+
+    const r = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
+    assert.equal(r.code, 0, r.err);
+    const complete = lastEvent(r.out, 'waveformScanComplete');
+    assert.equal(complete.total, 4, 'the ogg-opus IS planned — only a probe can classify it');
+    assert.equal(complete.generated, 3, 'the three mp3s generated');
+    assert.equal(complete.failed, 0, 'a codec with no decoder is not a failure of the file');
+    assert.ok(!fs.existsSync(failedMarkerPath(cache, key)),
+      'no marker — it would exclude the key from every future pass');
+    assert.ok(!fs.existsSync(cacheFilePath(cache, key)), 'and symphonia produced no bars');
+
+    // The ffmpeg fallback fills the key in the same task; from then on the
+    // rust pass plans zero and stops re-probing it.
+    fs.writeFileSync(cacheFilePath(cache, key), Buffer.alloc(NUM_BARS, 5));
+    const r2 = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
+    assert.equal(lastEvent(r2.out, 'waveformScanPlan').total, 0, 'cached key ends the re-probe');
+  });
+
   test('duplicate content: a vanished first copy does not starve the surviving copy', { timeout: 60_000 }, async (t) => {
     if (!(await setupScannedLibrary(t))) { return; }
     // Two byte-identical files → one content key with two paths. The
@@ -334,15 +378,29 @@ describe('on-demand generation covers the full track length', () => {
   test('sweepSupersededArtifacts removes previous-generation names only', async () => {
     const dir = path.join(tmp, 'sweep-dir');
     await fsp.mkdir(dir, { recursive: true });
-    const keep = [cacheFilePath(dir, 'aaa'), failedMarkerPath(dir, 'bbb')];
-    const drop = [path.join(dir, 'ccc.bin'), path.join(dir, 'ddd.failed')];
-    const bystander = path.join(dir, 'README.md');
-    for (const f of [...keep, ...drop, bystander]) { await fsp.writeFile(f, 'x'); }
+    const hashA = 'a'.repeat(32);
+    const hashB = 'b'.repeat(32);
+    const hashC = 'c1d2e3f4'.repeat(4);
+    const keep = [cacheFilePath(dir, hashA), failedMarkerPath(dir, hashB)];
+    const drop = [path.join(dir, `${hashC}.bin`), path.join(dir, `${'d'.repeat(40)}.failed`)];
+    // The cache directory is operator-pointable, and `.bin` is not ours
+    // alone: cue/bin disc images and ML model weights are real residents
+    // of real music folders. Only bare-hex hash names may ever be swept.
+    const foreign = [
+      path.join(dir, 'pytorch_model.bin'),
+      path.join(dir, 'disc1.bin'),
+      path.join(dir, 'MyAlbum.failed'),
+      path.join(dir, 'DEADBEEF'.repeat(4) + '.bin'),   // uppercase = not a hash we wrote
+      path.join(dir, 'README.md'),
+    ];
+    for (const f of [...keep, ...drop, ...foreign]) { await fsp.writeFile(f, 'x'); }
 
     assert.equal(await sweepSupersededArtifacts(dir), 2);
     for (const f of keep) { assert.ok(fs.existsSync(f), `${path.basename(f)} must survive`); }
     for (const f of drop) { assert.ok(!fs.existsSync(f), `${path.basename(f)} must be swept`); }
-    assert.ok(fs.existsSync(bystander), 'unrelated files are left alone');
+    for (const f of foreign) {
+      assert.ok(fs.existsSync(f), `${path.basename(f)} is not ours and must never be deleted`);
+    }
     // Idempotent, and a missing directory is not an error.
     assert.equal(await sweepSupersededArtifacts(dir), 0);
     assert.equal(await sweepSupersededArtifacts(path.join(tmp, 'nope')), 0);

--- a/test/scanner/waveform-scan.test.mjs
+++ b/test/scanner/waveform-scan.test.mjs
@@ -43,16 +43,28 @@ const FFMPEG = path.join(REPO_ROOT, 'bin', 'ffmpeg',
 function findRustParser() {
   const ext = process.platform === 'win32' ? '.exe' : '';
   const libc = process.platform === 'linux' ? '-musl' : '';
-  const candidates = [
-    path.join(REPO_ROOT, 'rust-parser', 'target', 'release', `rust-parser${ext}`),
-    path.join(REPO_ROOT, 'bin', 'rust-parser',
-      `rust-parser-${process.platform}-${process.arch}${libc}${ext}`),
-  ].filter(p => fs.existsSync(p));
-  // Only a binary on the CURRENT cache generation can satisfy this suite —
-  // a prebuilt from before a generation bump writes filenames these
-  // assertions (and the server, via the same probe) no longer accept.
-  // Skipping in the window before CI rebuilds bin/ is the truthful result.
-  return candidates.find(p => probeWaveformGeneration(p) === CACHE_EXT) || null;
+  const localBuild = path.join(REPO_ROOT, 'rust-parser', 'target', 'release', `rust-parser${ext}`);
+  const prebuilt = path.join(REPO_ROOT, 'bin', 'rust-parser',
+    `rust-parser-${process.platform}-${process.arch}${libc}${ext}`);
+
+  // A LOCAL build is something this checkout produced on purpose (CI builds
+  // one on every leg), so a generation mismatch there is a real defect —
+  // a stale target/, or WAVEFORM_EXT and CACHE_EXT drifting apart — and
+  // must FAIL, not quietly skip the whole suite green.
+  if (fs.existsSync(localBuild)) {
+    const gen = probeWaveformGeneration(localBuild);
+    assert.equal(gen, CACHE_EXT,
+      `local rust-parser build writes waveform generation ${gen} but the server ` +
+      `expects ${CACHE_EXT} — run: cargo build --release --manifest-path rust-parser/Cargo.toml`);
+    return localBuild;
+  }
+  // Only the committed prebuilt is available. CI rebuilds those on pushes
+  // to master, so a mismatch here is the expected lag window after a
+  // generation bump: skipping is the truthful result.
+  if (fs.existsSync(prebuilt) && probeWaveformGeneration(prebuilt) === CACHE_EXT) {
+    return prebuilt;
+  }
+  return null;
 }
 
 function runFfmpeg(args) {
@@ -263,15 +275,28 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
     assert.equal(complete.total, 4, 'the ogg-opus IS planned — only a probe can classify it');
     assert.equal(complete.generated, 3, 'the three mp3s generated');
     assert.equal(complete.failed, 0, 'a codec with no decoder is not a failure of the file');
-    assert.ok(!fs.existsSync(failedMarkerPath(cache, key)),
-      'no marker — it would exclude the key from every future pass');
     assert.ok(!fs.existsSync(cacheFilePath(cache, key)), 'and symphonia produced no bars');
 
-    // The ffmpeg fallback fills the key in the same task; from then on the
-    // rust pass plans zero and stops re-probing it.
-    fs.writeFileSync(cacheFilePath(cache, key), Buffer.alloc(NUM_BARS, 5));
+    // It DOES leave a `no-decoder` marker. That is not a failure line — it
+    // is how the key stays reachable: the ffmpeg fallback routes on it, and
+    // without it anything undecodable in a container the fallback doesn't
+    // query by extension had no route to a waveform from either pass.
+    const marker = fs.readFileSync(failedMarkerPath(cache, key), 'utf8');
+    assert.match(marker, /no-decoder/);
+    assert.doesNotMatch(marker, /symphonia/, 'this is not a decode failure');
+
+    // The marker also stops the endless re-probe: a second pass plans zero
+    // for that key rather than re-opening the file on every scan forever.
     const r2 = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
-    assert.equal(lastEvent(r2.out, 'waveformScanPlan').total, 0, 'cached key ends the re-probe');
+    assert.equal(lastEvent(r2.out, 'waveformScanPlan').total, 0,
+      'the marker ends the re-probe');
+
+    // And a later ffmpeg success clears it, so the key stops being planned
+    // for the right reason.
+    fs.writeFileSync(cacheFilePath(cache, key), Buffer.alloc(NUM_BARS, 5));
+    fs.rmSync(failedMarkerPath(cache, key));
+    const r3 = await spawnJson(rustBin, ['--waveform-scan', wfConfig()]);
+    assert.equal(lastEvent(r3.out, 'waveformScanPlan').total, 0, 'cached key stays done');
   });
 
   test('duplicate content: a vanished first copy does not starve the surviving copy', { timeout: 60_000 }, async (t) => {

--- a/test/scanner/waveform.test.mjs
+++ b/test/scanner/waveform.test.mjs
@@ -27,8 +27,9 @@ import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { CACHE_EXT, probeWaveformGeneration } from '../../src/db/waveform-lib.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -46,22 +47,12 @@ function findRustParser() {
       `rust-parser-${process.platform}-${process.arch}${libc}${ext}`),
   ].filter(p => fsSync.existsSync(p));
 
-  // Probe each candidate for the `--waveform` subcommand. A stale
-  // local build (compiled before --waveform was added) falls through
-  // to the main JSON-input path and exits 1 with "Invalid JSON Input"
-  // on stderr. Any other response — success, or a different error —
-  // means the subcommand is recognised. Distinguish by the stderr
-  // signature rather than status code so we work whether the probe
-  // path exists or not.
-  for (const bin of candidates) {
-    try {
-      const result = spawnSync(bin, ['--waveform', path.join(REPO_ROOT, 'NONEXISTENT_PROBE_FILE')],
-        { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000 });
-      const stderr = (result.stderr || '').toString();
-      if (!/Invalid JSON Input/.test(stderr)) { return bin; }
-    } catch (_) { /* try next candidate */ }
-  }
-  return null;
+  // Generation probe, the same one the server runs before its pass: a
+  // binary from before the current cache generation (or before the
+  // `frames` field these tests assert on) answers wrong or not at all,
+  // and skipping it is the truthful result — CI in the window before
+  // bin/ rebuilds must skip, not fail.
+  return candidates.find(p => probeWaveformGeneration(p) === CACHE_EXT) || null;
 }
 
 function runFfmpeg(args) {
@@ -278,6 +269,19 @@ describe('rust-parser --waveform across supported formats', () => {
     assert.ok(peak(outPhase) > 0, 'anti-phase stereo must not read as silence');
     assert.equal(peak(outPhase), peak(inPhase),
       'inverting one channel must not change the peak the waveform reports');
+  });
+
+  test('opus hidden in a .ogg container returns null, same as bare .opus', async (t) => {
+    if (!fsSync.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+    if (!rustBin)                   { return t.skip('no rust-parser binary'); }
+    // The extension gate can't classify this one — the ogg reader maps the
+    // Opus stream and only decoder creation fails (NoDecoder, not Failed).
+    const fixture = path.join(tmpDir, 'hidden-opus.ogg');
+    await runFfmpeg(['-nostdin', '-y', '-loglevel', 'error',
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=1:sample_rate=48000',
+      '-c:a', 'libopus', '-b:a', '64k', fixture]);
+    const out = await runRustWaveform(rustBin, fixture);
+    assert.equal(out.bars, null, 'no decoder for the codec — same posture as .opus');
   });
 
   test('corrupt/unknown file: returns null gracefully, does not crash', async (t) => {

--- a/test/scanner/waveform.test.mjs
+++ b/test/scanner/waveform.test.mjs
@@ -204,6 +204,82 @@ describe('rust-parser --waveform across supported formats', () => {
       'two runs over the same file produced different waveforms');
   });
 
+  // The decoder used to bin bars against `codec_params.n_frames`, which is
+  // an ESTIMATE for an MPEG stream with no Xing/Info header — and worse,
+  // symphonia's reader ENDS the packet stream at that estimate. A VBR file
+  // that opens denser than its average therefore lost its tail and had
+  // every bar shifted off its true timestamp.
+  //
+  // Both encodes below hold the same 60 s of audio and differ only in
+  // section order, so the estimate lands short for one and long for the
+  // other. Both must decode the whole thing.
+  describe('full-length decode regardless of container length hints', () => {
+    const VARIANTS = [
+      { name: 'VBR, no Xing, dense opening', order: ['noise', 'sine'],
+        args: ['-c:a', 'libmp3lame', '-q:a', '0', '-write_xing', '0'] },
+      { name: 'VBR, no Xing, sparse opening', order: ['sine', 'noise'],
+        args: ['-c:a', 'libmp3lame', '-q:a', '0', '-write_xing', '0'] },
+      { name: 'VBR with Xing', order: ['noise', 'sine'],
+        args: ['-c:a', 'libmp3lame', '-q:a', '0'] },
+      { name: 'CBR', order: ['noise', 'sine'],
+        args: ['-c:a', 'libmp3lame', '-b:a', '192k'] },
+    ];
+
+    for (const v of VARIANTS) {
+      test(`${v.name}: decodes all 60 s`, { timeout: 120_000 }, async (t) => {
+        if (!fsSync.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+        if (!rustBin)                   { return t.skip('no rust-parser binary'); }
+
+        const src = { noise: 'anoisesrc=d=30:c=white:a=0.8:r=44100',
+          sine: 'sine=frequency=100:duration=30:sample_rate=44100' };
+        const out = path.join(tmpDir, `len-${v.name.replace(/\W+/g, '')}.mp3`);
+        await runFfmpeg([
+          '-nostdin', '-y', '-loglevel', 'error',
+          '-f', 'lavfi', '-i', src[v.order[0]],
+          '-f', 'lavfi', '-i', src[v.order[1]],
+          '-filter_complex', '[0][1]concat=n=2:v=0:a=1',
+          '-ac', '2', ...v.args, out,
+        ]);
+
+        const res = await runRustWaveform(rustBin, out);
+        assert.ok(typeof res.frames === 'number', 'frames must be reported');
+        const seconds = res.frames / 44100;
+        // Encoder padding moves this by a few ms, never by seconds.
+        assert.ok(Math.abs(seconds - 60) < 0.5,
+          `decoded ${seconds.toFixed(2)} s of a 60 s file — the stream was cut short`);
+      });
+    }
+  });
+
+  // The mono reduction used to average |channel| across channels, which
+  // reads low on anything the channels disagree about. max|ch| never
+  // cancels and matches what the ffmpeg fallback now does.
+  test('anti-phase stereo keeps its full level', { timeout: 60_000 }, async (t) => {
+    if (!fsSync.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+    if (!rustBin)                   { return t.skip('no rust-parser binary'); }
+
+    // Both fixtures go through the SAME amerge, differing only in the sign
+    // of the right channel — `-ac 2` would have applied ffmpeg's -3 dB
+    // mono→stereo gain to one of them and not the other, making the two
+    // peaks incomparable for reasons that have nothing to do with phase.
+    const mono = path.join(tmpDir, 'phase-mono.flac');
+    const anti = path.join(tmpDir, 'phase-anti.flac');
+    const tone = ['-f', 'lavfi', '-i', 'sine=frequency=440:duration=2:sample_rate=44100'];
+    await runFfmpeg(['-nostdin', '-y', '-loglevel', 'error', ...tone,
+      '-filter_complex', '[0:a]asplit[l][r];[r]volume=1[ri];[l][ri]amerge=inputs=2[out]',
+      '-map', '[out]', '-c:a', 'flac', mono]);
+    await runFfmpeg(['-nostdin', '-y', '-loglevel', 'error', ...tone,
+      '-filter_complex', '[0:a]asplit[l][r];[r]volume=-1[ri];[l][ri]amerge=inputs=2[out]',
+      '-map', '[out]', '-c:a', 'flac', anti]);
+
+    const inPhase = hexToBytes((await runRustWaveform(rustBin, mono)).bars);
+    const outPhase = hexToBytes((await runRustWaveform(rustBin, anti)).bars);
+    const peak = (b) => Math.max(...Array.from(b));
+    assert.ok(peak(outPhase) > 0, 'anti-phase stereo must not read as silence');
+    assert.equal(peak(outPhase), peak(inPhase),
+      'inverting one channel must not change the peak the waveform reports');
+  });
+
   test('corrupt/unknown file: returns null gracefully, does not crash', async (t) => {
     if (!rustBin) { return t.skip('no rust-parser binary'); }
 

--- a/test/scanner/waveform.test.mjs
+++ b/test/scanner/waveform.test.mjs
@@ -41,18 +41,28 @@ const FFMPEG =
 function findRustParser() {
   const ext = process.platform === 'win32' ? '.exe' : '';
   const libc = process.platform === 'linux' ? '-musl' : '';
-  const candidates = [
-    path.join(REPO_ROOT, 'rust-parser', 'target', 'release', `rust-parser${ext}`),
-    path.join(REPO_ROOT, 'bin', 'rust-parser',
-      `rust-parser-${process.platform}-${process.arch}${libc}${ext}`),
-  ].filter(p => fsSync.existsSync(p));
+  const localBuild = path.join(REPO_ROOT, 'rust-parser', 'target', 'release', `rust-parser${ext}`);
+  const prebuilt = path.join(REPO_ROOT, 'bin', 'rust-parser',
+    `rust-parser-${process.platform}-${process.arch}${libc}${ext}`);
 
-  // Generation probe, the same one the server runs before its pass: a
-  // binary from before the current cache generation (or before the
-  // `frames` field these tests assert on) answers wrong or not at all,
-  // and skipping it is the truthful result — CI in the window before
-  // bin/ rebuilds must skip, not fail.
-  return candidates.find(p => probeWaveformGeneration(p) === CACHE_EXT) || null;
+  // A LOCAL build is something this checkout produced on purpose (CI builds
+  // one on every leg), so a generation mismatch there is a real defect —
+  // a stale target/, or WAVEFORM_EXT and CACHE_EXT drifting apart — and
+  // must FAIL, not quietly skip the whole suite green.
+  if (fsSync.existsSync(localBuild)) {
+    const gen = probeWaveformGeneration(localBuild);
+    assert.equal(gen, CACHE_EXT,
+      `local rust-parser build writes waveform generation ${gen} but the server ` +
+      `expects ${CACHE_EXT} — run: cargo build --release --manifest-path rust-parser/Cargo.toml`);
+    return localBuild;
+  }
+  // Only the committed prebuilt is available. CI rebuilds those on pushes
+  // to master, so a mismatch here is the expected lag window after a
+  // generation bump: skipping is the truthful result.
+  if (fsSync.existsSync(prebuilt) && probeWaveformGeneration(prebuilt) === CACHE_EXT) {
+    return prebuilt;
+  }
+  return null;
 }
 
 function runFfmpeg(args) {

--- a/test/unit/webapp-waveform-cache.test.mjs
+++ b/test/unit/webapp-waveform-cache.test.mjs
@@ -1,0 +1,149 @@
+/**
+ * The browser-side waveform cache encoding in webapp/alpha/vp.js.
+ *
+ * Bars are held in localStorage as base64 rather than a JSON number array.
+ * localStorage stores UTF-16 and isn't compressed, so JSON spends ~3.4
+ * characters per bar where base64 spends 1.34 — measured 2857 chars vs
+ * 1068 for one 800-bar waveform. At the 500-entry cap that is the
+ * difference between fitting inside a ~5 MB origin budget and living in
+ * the eviction path, dropping entries and re-fetching them forever.
+ *
+ * This is data the user's browser keeps, with an in-place migration for
+ * entries written under the old encoding, so it is worth pinning:
+ *   - every byte 0-255 survives a round trip (128-255 is where naive
+ *     btoa/UTF-8 handling silently corrupts data)
+ *   - pre-existing JSON entries still read, and migrate on read
+ *   - corrupt or absent entries degrade to null instead of throwing
+ *   - a quota error still falls through to evict-and-retry
+ *
+ * webapp/ has no browser test harness and is eslint-ignored, so rather
+ * than re-typing the implementation (which could drift from what ships)
+ * this slices the real function source out of vp.js and runs it against a
+ * localStorage stub. If the functions are renamed or restructured the
+ * slice fails loudly rather than silently testing nothing.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VP_PATH = path.resolve(__dirname, '..', '..', 'webapp', 'alpha', 'vp.js');
+
+// Pull `_wfB64Encode` through the end of `_wfLsSet` out of vp.js and
+// instantiate it with the few globals that block depends on.
+function loadCacheFns() {
+  const lines = fs.readFileSync(VP_PATH, 'utf8').split('\n');
+  const start = lines.findIndex((l) => l.includes('function _wfB64Encode'));
+  const setAt = lines.findIndex((l) => l.includes('function _wfLsSet'));
+  assert.ok(start >= 0, 'vp.js no longer defines _wfB64Encode — update this test');
+  assert.ok(setAt > start, 'vp.js no longer defines _wfLsSet after _wfB64Encode');
+
+  let end = setAt, depth = 0, seen = false;
+  for (let i = setAt; i < lines.length; i++) {
+    for (const ch of lines[i]) {
+      if (ch === '{') { depth++; seen = true; } else if (ch === '}') { depth--; }
+    }
+    if (seen && depth === 0) { end = i; break; }
+  }
+  const src = lines.slice(start, end + 1).join('\n');
+  for (const fn of ['_wfB64Encode', '_wfB64Decode', '_wfLsGet', '_wfLsSet']) {
+    assert.ok(src.includes(`function ${fn}`), `slice is missing ${fn}`);
+  }
+
+  const store = new Map();
+  const state = { evictions: 0, failNextSet: false };
+  const localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => {
+      if (state.failNextSet) { state.failNextSet = false; throw new Error('QuotaExceededError'); }
+      store.set(k, String(v));
+    },
+    removeItem: (k) => store.delete(k),
+    key: (i) => Array.from(store.keys())[i],
+    get length() { return store.size; },
+  };
+  const build = new Function(
+    'localStorage', '_WF_LS_PREFIX', '_wfLsEvict',
+    `${src}\nreturn { _wfLsGet, _wfLsSet, _wfB64Encode, _wfB64Decode };`);
+  const fns = build(localStorage, 'wf2:', () => { state.evictions++; });
+  return { ...fns, store, state };
+}
+
+// Spread across the whole byte range, including the 128-255 half.
+const BARS = Array.from({ length: 800 }, (_, i) => (i * 7 + (i % 13) * 19) % 256);
+
+describe('webapp waveform localStorage cache', () => {
+  test('round-trips every byte value 0-255', () => {
+    const { _wfB64Encode, _wfB64Decode } = loadCacheFns();
+    const every = Array.from({ length: 256 }, (_, i) => i);
+    const back = _wfB64Decode(_wfB64Encode(every));
+    assert.equal(back.length, 256);
+    for (let i = 0; i < 256; i++) {
+      assert.equal(back[i], i, `byte ${i} did not survive the round trip`);
+    }
+  });
+
+  test('stores bars byte-for-byte and hands back a Uint8Array', () => {
+    const { _wfLsGet, _wfLsSet } = loadCacheFns();
+    _wfLsSet('/music/a.mp3', BARS);
+    const back = _wfLsGet('/music/a.mp3');
+    assert.ok(back instanceof Uint8Array, 'renderer expects a typed array');
+    assert.equal(back.length, BARS.length);
+    for (let i = 0; i < BARS.length; i++) { assert.equal(back[i], BARS[i]); }
+  });
+
+  test('is at least 2x smaller than the JSON array it replaced', () => {
+    const { _wfLsSet, store } = loadCacheFns();
+    _wfLsSet('/music/a.mp3', BARS);
+    const stored = store.get('wf2:/music/a.mp3').length;
+    const asJson = JSON.stringify(BARS).length;
+    assert.ok(asJson / stored >= 2,
+      `expected >=2x saving, got ${(asJson / stored).toFixed(2)}x (${asJson} -> ${stored})`);
+  });
+
+  test('reads a pre-existing JSON entry and migrates it in place', () => {
+    const { _wfLsGet, store } = loadCacheFns();
+    store.set('wf2:/music/legacy.mp3', JSON.stringify(BARS));
+
+    const first = _wfLsGet('/music/legacy.mp3');
+    assert.ok(first, 'a legacy entry must still be usable, not discarded');
+    for (let i = 0; i < BARS.length; i++) { assert.equal(first[i], BARS[i]); }
+
+    assert.notEqual(store.get('wf2:/music/legacy.mp3')[0], '[',
+      'reading a legacy entry must rewrite it in the new encoding');
+    const second = _wfLsGet('/music/legacy.mp3');
+    for (let i = 0; i < BARS.length; i++) { assert.equal(second[i], BARS[i]); }
+  });
+
+  test('accepts a Uint8Array as input (what a cache hit returns)', () => {
+    const { _wfLsGet, _wfLsSet } = loadCacheFns();
+    _wfLsSet('/music/typed.mp3', Uint8Array.from(BARS));
+    const back = _wfLsGet('/music/typed.mp3');
+    for (let i = 0; i < BARS.length; i++) { assert.equal(back[i], BARS[i]); }
+  });
+
+  test('missing, empty and corrupt entries yield null rather than throwing', () => {
+    const { _wfLsGet, store } = loadCacheFns();
+    assert.equal(_wfLsGet('/music/absent.mp3'), null);
+
+    store.set('wf2:/music/empty.mp3', '[]');
+    assert.equal(_wfLsGet('/music/empty.mp3'), null, 'an empty legacy array is not a waveform');
+
+    store.set('wf2:/music/corrupt.mp3', '!!! not base64 !!!');
+    let out;
+    assert.doesNotThrow(() => { out = _wfLsGet('/music/corrupt.mp3'); });
+    assert.ok(!out || out.length === 0, 'corrupt data must not surface as bars');
+  });
+
+  test('a quota error still evicts and retries once', () => {
+    const { _wfLsGet, _wfLsSet, state } = loadCacheFns();
+    state.failNextSet = true;
+    _wfLsSet('/music/quota.mp3', BARS);
+    assert.equal(state.evictions, 1, 'quota failure must trigger eviction');
+    const back = _wfLsGet('/music/quota.mp3');
+    assert.ok(back && back.length === BARS.length, 'the retry after eviction must succeed');
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -2980,6 +2980,7 @@ const dbView = Vue.component('db-view', {
           'no-api-key': 'no API key',
           'no-binary': 'rust-parser unavailable',
           'binary-unsupported': 'rust-parser outdated',
+          'binary-generation-mismatch': 'rust-parser outdated (ffmpeg half only)',
           'runtime-unavailable': 'ML runtime unavailable',
         }[p.disabledReason] || p.disabledReason;
         return `Off — ${reason}`;

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -2980,12 +2980,23 @@ const dbView = Vue.component('db-view', {
           'no-api-key': 'no API key',
           'no-binary': 'rust-parser unavailable',
           'binary-unsupported': 'rust-parser outdated',
-          'binary-generation-mismatch': 'rust-parser outdated (ffmpeg half only)',
           'runtime-unavailable': 'ML runtime unavailable',
         }[p.disabledReason] || p.disabledReason;
         return `Off — ${reason}`;
       }
-      return { idle: 'Idle', queued: 'Queued', running: 'Running' }[p.state] || p.state;
+      const base = { idle: 'Idle', queued: 'Queued', running: 'Running' }[p.state] || p.state;
+      // A pass can be ENABLED and still degraded — the waveform pass runs
+      // its ffmpeg half while the rust half sits out on a generation
+      // mismatch. Without this the badge read plain "Idle", identical to a
+      // healthy server, and the operator had no way to see that half the
+      // producer never runs.
+      if (p.enabled && p.disabledReason) {
+        const why = {
+          'binary-generation-mismatch': 'rust-parser outdated (ffmpeg half only)',
+        }[p.disabledReason] || p.disabledReason;
+        return `${base} — ${why}`;
+      }
+      return base;
     },
     pctOf: function(part, whole) {
       if (!whole) { return 0; }

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -1025,24 +1025,71 @@ const VUEPLAYERCORE = (() => {
     } catch (_e) { /* private mode / quota — the new prefix still wins */ }
   }());
 
+  // Bars are stored base64, not as a JSON number array. Each bar is one
+  // byte, so JSON spends ~3.4 characters ("128,") on what base64 says in
+  // 1.34 — and localStorage holds UTF-16, which doubles whatever we write.
+  // Measured on an 800-bar waveform: 5474 bytes as JSON, 2166 as base64.
+  // At the 500-entry cap that is ~2.7 MB against ~1.1 MB, i.e. the
+  // difference between sitting comfortably inside a ~5 MB origin budget
+  // and living permanently in the eviction path, re-fetching what was
+  // just dropped. Decoding is ~16x cheaper too (31.5 us -> 1.9 us), and
+  // hands the renderer a Uint8Array instead of 800 boxed numbers.
+  //
+  // NOT compressed on the wire and NOT changed server-side: this is purely
+  // how the browser holds its own copy. The endpoint still returns JSON,
+  // which the compression middleware already handles well.
+  function _wfB64Encode(data) {
+    // Chunked rather than String.fromCharCode(...data): spreading is fine
+    // at 800 entries but throws RangeError once arrays get large, and this
+    // is the one place the array length is not ours to assume.
+    let s = '';
+    for (let i = 0; i < data.length; i += 4096) {
+      s += String.fromCharCode.apply(null,
+        Array.prototype.slice.call(data, i, i + 4096));
+    }
+    return btoa(s);
+  }
+
+  function _wfB64Decode(str) {
+    const bin = atob(str);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) { out[i] = bin.charCodeAt(i); }
+    return out;
+  }
+
   function _wfLsGet(filepath) {
     try {
       const raw = localStorage.getItem(_WF_LS_PREFIX + filepath);
       if (!raw) return null;
-      const arr = JSON.parse(raw);
-      return Array.isArray(arr) && arr.length > 0 ? arr : null;
+      // Entries written before this encoding are still perfectly valid
+      // bars, so they are read rather than discarded — a '[' can't start
+      // base64, which makes the two formats trivially distinguishable.
+      // Re-write on hit so a warm cache migrates as tracks get played
+      // instead of staying oversized forever.
+      if (raw[0] === '[') {
+        const arr = JSON.parse(raw);
+        if (!Array.isArray(arr) || arr.length === 0) { return null; }
+        const bytes = Uint8Array.from(arr, (v) => v & 255);
+        _wfLsSet(filepath, bytes);
+        return bytes;
+      }
+      const bytes = _wfB64Decode(raw);
+      return bytes.length > 0 ? bytes : null;
     } catch (_e) { return null; }
   }
 
   const _WF_LS_MAX = 500; // max cached waveforms in localStorage
 
   function _wfLsSet(filepath, data) {
+    let encoded;
+    try { encoded = _wfB64Encode(data); }
+    catch (_e) { return; }   // unencodable input is not worth a quota retry
     try {
-      localStorage.setItem(_WF_LS_PREFIX + filepath, JSON.stringify(data));
+      localStorage.setItem(_WF_LS_PREFIX + filepath, encoded);
     } catch (_e) {
       // Quota exceeded — evict oldest wf:* entries and retry once
       _wfLsEvict();
-      try { localStorage.setItem(_WF_LS_PREFIX + filepath, JSON.stringify(data)); }
+      try { localStorage.setItem(_WF_LS_PREFIX + filepath, encoded); }
       catch (_e2) { /* still full — give up */ }
     }
   }

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -1005,7 +1005,25 @@ const VUEPLAYERCORE = (() => {
   let _waveformData = null;   // Array of 0-255 bar heights (800 entries)
   let _waveformFp   = null;   // filepath of the currently loaded waveform
   let _waveformRaf  = null;   // requestAnimationFrame handle
-  const _WF_LS_PREFIX = 'wf:';
+  // Bumped alongside the server's cache generation (CACHE_EXT in
+  // src/db/waveform-lib.js). Waveforms are stored per filepath with no
+  // version in the value, so without a new prefix a browser would keep
+  // rendering bars from the old decoder forever — the server-side fix
+  // would simply never reach anyone who had already played the track.
+  // Entries under the previous prefix are purged on first load.
+  const _WF_LS_PREFIX = 'wf2:';
+  const _WF_LS_OLD_PREFIXES = ['wf:'];
+
+  (function _wfLsPurgeOldGenerations() {
+    try {
+      const doomed = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k && _WF_LS_OLD_PREFIXES.some(p => k.startsWith(p))) doomed.push(k);
+      }
+      for (const k of doomed) localStorage.removeItem(k);
+    } catch (_e) { /* private mode / quota — the new prefix still wins */ }
+  }());
 
   function _wfLsGet(filepath) {
     try {

--- a/webapp/velvet/app.js
+++ b/webapp/velvet/app.js
@@ -10143,7 +10143,20 @@ function _applyRGGain(s) {
 // ── WAVEFORM SCRUBBER ─────────────────────────────────────────
 // ── WAVEFORM LOCALSTORAGE CACHE ───────────────────────────────
 // Key prefix; value is a JSON array of 800 integers (0-255), ~2 KB each.
-const _WF_LS_PREFIX = 'wf:';
+// Bumped alongside the server's cache generation (CACHE_EXT in
+// src/db/waveform-lib.js) — see the same note in webapp/alpha/vp.js.
+// Without it a browser keeps rendering bars from the old decoder forever.
+const _WF_LS_PREFIX = 'wf2:';
+(function _wfLsPurgeOldGenerations() {
+  try {
+    const doomed = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith('wf:')) doomed.push(k);
+    }
+    for (const k of doomed) localStorage.removeItem(k);
+  } catch (_e) { /* private mode / quota — the new prefix still wins */ }
+}());
 function _wfLsGet(filepath) {
   try {
     const raw = localStorage.getItem(_WF_LS_PREFIX + filepath);


### PR DESCRIPTION
Three correctness bugs in waveform generation, found while auditing the
generator. Each is reproduced by a fixture in the test suite.

## 1. Waveforms were cut short and time-misaligned

The rust decoder binned bars against the container's declared frame count
— and symphonia's MPEG reader also *ends the packet stream* at that
count. With no Xing/Info header the count is extrapolated from the
**first frame's bitrate**, so a VBR file that opens denser than its
average loses its tail.

Measured on a 60 s fixture with bursts at 0/25/50/75/99.5 %:

| | bar positions | outcome |
|---|---|---|
| before | 1, 220, 441, 661 | last burst past bar 799, **dropped** |
| after | 1, 200, 400, 600, 795 | all present |

Same audio, same encoder, differing only in section order: opening loud
decoded **47.5 s** of 60 s, opening quiet decoded **60.0 s**. So roughly
10 % of the track was missing and every x-position disagreed with the
playhead.

Binning now runs through a bounded peak pyramid over the frames
*actually decoded*, and MPEG sources are wrapped in a `MediaSource` that
declines to state its length so the reader has nothing to extrapolate
from. That also retires the buffered path, which silently truncated
anything past ~12 minutes and could allocate 120 MB for a single file —
the pyramid is 512 KB per thread.

## 2. Out-of-phase stereo rendered as a blank bar

The ffmpeg fallback asked for `-ac 1`, which **sums** channels. An
anti-phase stereo fixture that the rust engine renders at 32/255
throughout came back as **800 zero bars**, and that got cached. Real
mid/side-widened masters lose energy the same way, partially.

Channels now stay interleaved, and both engines reduce a frame with
`max|ch|` — which never cancels, and makes the two engines describe the
same audio the same way. They previously disagreed by ~22 % on broadband
content (mean bar 58.6 rust vs 45.4 ffmpeg on pink noise).

## 3. Opus was reported as a permanent failure and never got a waveform

symphonia has no Opus decoder, so the pass wrote a `symphonia` failure
marker for every Opus track: a permanent failure count in the admin panel
for files that are perfectly fine, and no proactive waveform, so every
first play paid a cold ffmpeg decode behind an empty progress bar.

The pass now leaves codecs it structurally cannot decode out of its plan
entirely — no marker, honest totals — and a new ffmpeg half
(`src/db/waveform-fallback.js`) covers them, plus anything symphonia
genuinely did fail on, clearing markers it disproves. It runs from the
same task, holding the queue slot until both halves finish, so the
single-task rule still holds and the pass isn't "done" while work remains.

## Cache generation bump

All three fixes change the bytes produced for the same audio, so a fix
that didn't invalidate the cache would only ever apply to newly added
tracks. Artifacts move to `<hash>.w2.bin` / `<hash>.w2.failed`; v1 names
are neither read nor honoured, and are swept at boot from
`ensureCacheDir()` — the one path both rust-equipped and rust-less
deployments take.

The webapp's localStorage prefix moves to `wf2:` alongside, purging old
keys. Waveforms are cached client-side per filepath with no version in
the value, so without this the server-side fix would never reach anyone
who had already played the track.

**Accepted cost:** genuinely undecodable files lose their old `ffmpeg`
marker in the sweep and are retried once before it's rewritten.

## Testing

`npm test` green on the full tree — integration 680 tests / 678 pass /
0 fail / 2 skipped in 252 s, matching master's 249 s. New coverage:

- full-length decode across four MPEG header/bitrate shapes
- anti-phase stereo on both engines
- Opus excluded from the plan with no marker; symphonia markers still excluded
- the sweep's name discrimination (keeps current, drops v1, ignores bystanders)
- nine cases over the fallback: Opus pickup, marker retry-and-clear,
  ffmpeg-verdict not retried, dedup, vanished copies, abort

The fallback suite caught a real defect while being written: an
ffmpeg-failed Opus key arrives via the extension query rather than the
marker query, so gating only the marker path re-spawned a doomed 30 s
decode on every pass, forever.

`rust-parser/` is source-only here — `bin/rust-parser/*` is CI-managed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Merge sequencing note

`rust-parser/` is source-only here — `bin/rust-parser/*` is CI-managed and
rebuilt on push to master. Between this merging and that rebuild landing,
master runs new JS against a v1 binary: the pass would write `<hash>.bin`,
the boot sweep would delete those, and coverage would read 0 done. Nothing
breaks (the on-demand endpoint still generates and writes `.w2.bin`), but
the pass does wasted work each run until the binaries update, so it's worth
letting the rebuild land promptly after merge.
