### PR TITLE
fix(webapp): reactive metadata + Auto-DJ anchors; cut boot and render cost

### DIFF
--- a/test/scanner/waveform-fallback.test.mjs
+++ b/test/scanner/waveform-fallback.test.mjs
@@ -54,6 +54,39 @@ after(async () => {
   if (tmp) { await fsp.rm(tmp, { recursive: true, force: true }).catch(() => {}); }
 });
 
+// Encode each DISTINCT fixture once for the whole file and copy it per
+// case. Every test wants the same handful of one-second tones, so
+// re-encoding them per case spent an extra ffmpeg spawn or two on top of
+// the one the code under test needs.
+//
+// Measured: this is a wash locally (89s -> 91s, inside the noise) because
+// a spawn here costs ~1s. It is worth keeping anyway because the cost it
+// removes is spawns, and spawns are what is expensive on the Windows CI
+// runner — there a single ffmpeg spawn measured ~15s, the ffmpeg tests in
+// this file ran 27-30s apiece, and one of them blew a 60s timeout with
+// nothing actually wrong. The rust-binary waveform suites, which spawn
+// nothing per case, stayed at 2-8s on that same runner.
+const fixtureCache = new Map();
+async function fixtureFor(name, codec, freq) {
+  const ext = path.extname(name);
+  // `codec` override lets a test put Opus inside a .ogg container — the
+  // case the extension alone cannot classify.
+  const useOpus = codec === 'opus' || ext === '.opus';
+  const key = `${ext}|${useOpus ? 'opus' : 'mp3'}|${freq}`;
+  if (fixtureCache.has(key)) { return fixtureCache.get(key); }
+
+  const codecArgs = useOpus
+    ? ['-c:a', 'libopus', '-b:a', '64k', ...(ext === '.opus' ? ['-f', 'opus'] : [])]
+    : ['-c:a', 'libmp3lame', '-b:a', '64k'];
+  const out = path.join(tmp, `fixture-${fixtureCache.size}${ext}`);
+  await runFfmpeg([
+    '-f', 'lavfi', '-i', `sine=frequency=${freq}:duration=1:sample_rate=48000`,
+    ...codecArgs, out,
+  ]);
+  fixtureCache.set(key, out);
+  return out;
+}
+
 // A minimal DB with hand-written track rows: this module reads
 // tracks+libraries and nothing else, so a real scan would only add
 // runtime and a rust-binary dependency the fallback itself doesn't have.
@@ -70,18 +103,8 @@ async function makeCase(tracks) {
 
   for (const t of tracks) {
     if (t.create !== false) {
-      // `codec` override lets a test put Opus inside a .ogg container —
-      // the case the extension alone can't classify.
-      const codecArgs =
-        t.codec === 'opus' || t.name.endsWith('.opus')
-          ? ['-c:a', 'libopus', '-b:a', '64k',
-             ...(t.name.endsWith('.opus') ? ['-f', 'opus'] : [])]
-          : ['-c:a', 'libmp3lame', '-b:a', '64k'];
-      await runFfmpeg([
-        '-f', 'lavfi', '-i', `sine=frequency=${t.freq || 440}:duration=1:sample_rate=48000`,
-        ...codecArgs,
-        path.join(lib, t.name),
-      ]);
+      const src = await fixtureFor(t.name, t.codec, t.freq || 440);
+      await fsp.copyFile(src, path.join(lib, t.name));
     }
     db.prepare(`INSERT INTO tracks (library_id, filepath, title, audio_hash)
                 VALUES (1, ?, ?, ?)`).run(t.name, t.name, t.hash);
@@ -92,7 +115,7 @@ async function makeCase(tracks) {
 const newAbort = () => ({ stopped: false });
 
 describe('waveform ffmpeg fallback', () => {
-  test('generates a waveform for Opus, which symphonia cannot decode', { timeout: 60_000 }, async (t) => {
+  test('generates a waveform for Opus, which symphonia cannot decode', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
 
@@ -108,7 +131,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')), 'success leaves no marker');
   });
 
-  test('mp3s are left to the rust pass; only unsupported codecs are picked up', { timeout: 60_000 }, async (t) => {
+  test('mp3s are left to the rust pass; only unsupported codecs are picked up', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([
       { name: 'a.opus', hash: 'aaa' },
@@ -123,7 +146,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(cacheFilePath(cache, 'bbb')));
   });
 
-  test('an already-cached key is skipped', { timeout: 60_000 }, async (t) => {
+  test('an already-cached key is skipped', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
     await fsp.writeFile(cacheFilePath(cache, 'aaa'), Buffer.alloc(NUM_BARS, 7));
@@ -135,7 +158,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa'))[0], 7, 'existing cache untouched');
   });
 
-  test('a symphonia-only marker is retried and cleared when ffmpeg succeeds', { timeout: 60_000 }, async (t) => {
+  test('a symphonia-only marker is retried and cleared when ffmpeg succeeds', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // An mp3 symphonia choked on: not an unsupported codec, so it only
     // reaches the fallback via its marker.
@@ -151,7 +174,7 @@ describe('waveform ffmpeg fallback', () => {
       'a marker that is no longer true must be removed');
   });
 
-  test('a marker naming ffmpeg is not retried', { timeout: 60_000 }, async (t) => {
+  test('a marker naming ffmpeg is not retried', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
     await fsp.writeFile(failedMarkerPath(cache, 'aaa'), 'symphonia\nffmpeg\n');
@@ -163,7 +186,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(cacheFilePath(cache, 'aaa')));
   });
 
-  test('undecodable content records an ffmpeg failure exactly once', { timeout: 60_000 }, async (t) => {
+  test('undecodable content records an ffmpeg failure exactly once', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([{ name: 'a.opus', hash: 'aaa', create: false }]);
     await fsp.writeFile(path.join(lib, 'a.opus'), 'this is not an opus stream');
@@ -178,7 +201,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(second.total, 0, 'a recorded failure is not re-attempted');
   });
 
-  test('duplicate content decodes once; a vanished copy falls through to a live one', { timeout: 60_000 }, async (t) => {
+  test('duplicate content decodes once; a vanished copy falls through to a live one', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([
       { name: 'gone.opus', hash: 'dup' },
@@ -194,7 +217,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(fs.existsSync(cacheFilePath(cache, 'dup')));
   });
 
-  test('a key whose every copy has vanished leaves no marker', { timeout: 60_000 }, async (t) => {
+  test('a key whose every copy has vanished leaves no marker', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
     fs.rmSync(path.join(lib, 'a.opus'));
@@ -208,7 +231,7 @@ describe('waveform ffmpeg fallback', () => {
       'the file may come back unchanged — do not poison the key');
   });
 
-  test('abort stops the run without generating anything further', { timeout: 60_000 }, async (t) => {
+  test('abort stops the run without generating anything further', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([
       { name: 'a.opus', hash: 'aaa' },
@@ -227,7 +250,7 @@ describe('waveform ffmpeg fallback', () => {
 
   // ── Regressions from the adversarial review of PR #818 ────────────────────
 
-  test('an unreachable cache dir reports zero DURABLE progress — the self-chain spin guard', { timeout: 60_000 }, async (t) => {
+  test('an unreachable cache dir reports zero DURABLE progress — the self-chain spin guard', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // The dir vanished after boot (unmounted volume, deleted tree). Every
     // decode succeeds but nothing can persist; the old chain gate counted
@@ -253,7 +276,7 @@ describe('waveform ffmpeg fallback', () => {
       'the chain gate must refuse a round that landed nothing');
   });
 
-  test('a cache-write failure is NOT recorded as ffmpeg’s verdict on the audio', { timeout: 60_000 }, async (t) => {
+  test('a cache-write failure is NOT recorded as ffmpeg’s verdict on the audio', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, lib } = await makeCase([{ name: 'good.opus', hash: 'aaa' }]);
     // The cache "directory" is a FILE. Every write into it fails, and —
@@ -284,7 +307,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa')).length, NUM_BARS);
   });
 
-  test('an undecodable file whose marker cannot be written counts no durable progress', { timeout: 60_000 }, async (t) => {
+  test('an undecodable file whose marker cannot be written counts no durable progress', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // Pins recordFfmpegFailure's boolean return AND the markersRecorded
     // gate, in both directions: the decode genuinely fails (so `failed`
@@ -305,7 +328,7 @@ describe('waveform ffmpeg fallback', () => {
       'a round that recorded nothing must not chain');
   });
 
-  test('an unreadable file is not given a permanent ffmpeg verdict', { timeout: 60_000 }, async (t) => {
+  test('an unreadable file is not given a permanent ffmpeg verdict', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // A path that exists but cannot be READ — a lock, an ACL change, a
     // stale mount. ffmpeg exits non-zero exactly as it would for corrupt
@@ -333,7 +356,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(retry.generated, 1, 'the key must still be reachable once readable again');
   });
 
-  test('a deferred artifact routes the key here whatever its container', { timeout: 60_000 }, async (t) => {
+  test('a deferred artifact routes the key here whatever its container', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // The rust pass writes a `.w2.deferred` artifact for a codec it has no
     // decoder for. The container may be one CANDIDATE_EXTS never queries
@@ -357,7 +380,7 @@ describe('waveform ffmpeg fallback', () => {
       'and a deferral must never have been a failure');
   });
 
-  test('an unreadable copy does not end the walk while a good copy remains', { timeout: 60_000 }, async (t) => {
+  test('an unreadable copy does not end the walk while a good copy remains', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([
       { name: 'bad.opus', hash: 'dup2', create: false },
@@ -378,7 +401,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(failedMarkerPath(cache, 'dup2')));
   });
 
-  test('opus inside a .ogg container is picked up via the extension source', { timeout: 60_000 }, async (t) => {
+  test('opus inside a .ogg container is picked up via the extension source', { timeout: 120_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // The rust pass probes these, finds no decoder, and skips them
     // silently (no marker) — so the ONLY route to a waveform is this

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -152,7 +152,11 @@ const VUEPLAYERCORE = (() => {
       altLayout: mstreamModule.altLayout,
       meta: MSTREAMPLAYER.playerStats.metadata,
       livePlaylist: mstreamModule.livePlaylist,
-      discover: discoverState
+      discover: discoverState,
+      // Owned here rather than in each playlist-item so that one shared
+      // value has one subscriber instead of one per queue row — see the
+      // note on the playlist-item component.
+      positionCache: MSTREAMPLAYER.positionCache
     },
     watch: {
       // Refresh the Discover panel when the playing song changes.
@@ -410,7 +414,7 @@ const VUEPLAYERCORE = (() => {
   // Template for playlist items
   Vue.component('playlist-item', {
     template: `
-      <li v-on:click="goToSong($event)" class="noselect np-queue-item" v-bind:class="{ 'np-queue-active': (this.index === positionCache.val), playError: (this.songError && this.songError === true) }">
+      <li v-on:click="goToSong($event)" class="noselect np-queue-item" v-bind:class="{ playError: (this.songError && this.songError === true) }">
         <span onclick="event.stopPropagation()" class="drag-handle">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="16" height="16"><path fill="#666" d="M4 7v2h24V7Zm0 8v2h24v-2Zm0 8v2h24v-2Z"/></svg>
         </span>
@@ -438,11 +442,15 @@ const VUEPLAYERCORE = (() => {
 
     props: ['index', 'song'],
 
-    // We need the positionCache to track the currently playing song
+    // positionCache deliberately does NOT live here. It is a single shared
+    // object, so putting it in per-row data made every row in the queue a
+    // reactive subscriber to a value that changes once per track change —
+    // advancing a track re-rendered the whole list. The active-row class is
+    // now bound by the parent (#playlist) on the v-for in index.html, which
+    // re-renders one row instead of N. Measured with the bundled Vue 2.7.16:
+    // 500 rows 69.3ms -> 5.1ms per track change, 2000 rows 353ms -> 34.5ms.
     data: function () {
-      return {
-        positionCache: MSTREAMPLAYER.positionCache
-      }
+      return {};
     },
 
     // Methods used by playlist item events
@@ -647,6 +655,18 @@ const VUEPLAYERCORE = (() => {
         } else {
           if (_waveformData) _stopWaveformRaf();
         }
+      },
+      // Seeking while PAUSED moves the playhead with no rAF loop running,
+      // and nothing else repaints the canvas, so the orange played/unplayed
+      // split used to freeze in place while the time label moved — the bar
+      // disagreed with the clock until playback resumed. Guarded on the
+      // loop being idle, so during playback this watcher costs a comparison
+      // and nothing else (the loop already owns repainting then).
+      'playerStats.currentTime': function () {
+        if (_waveformRaf) { return; }
+        if (!this.altLayout.waveformBar || !_waveformData) { return; }
+        _wfInvalidate();
+        _drawWaveform();
       }
     },
     created: function () {
@@ -959,7 +979,20 @@ const VUEPLAYERCORE = (() => {
 
       if (response.metadata) {
         newSong.metadata = response.metadata;
-        MSTREAMPLAYER.resetCurrentMetadata();
+        // Only refresh the now-playing card when the track we just
+        // enriched IS the one playing. resetCurrentMetadata() reads
+        // getCurrentPlayer().songObject, so calling it for some other
+        // queued track re-rendered the same values it already had — but
+        // it also runs _updateAutoDjAnchorsOnSongChange(), and the
+        // playing song is not flagged _djPicked, so that took the
+        // "manual pick" branch and called AUTODJ.resetAnchors(): six
+        // localStorage writes wiping bpmHistory, the Camelot anchor and
+        // the sonic seed. Queueing one track from the file browser threw
+        // away the Auto-DJ session. Identity compare is safe — the
+        // engine's add/insert/setMedia paths all preserve the object.
+        if (MSTREAMPLAYER.getCurrentSong() === newSong) {
+          MSTREAMPLAYER.resetCurrentMetadata();
+        }
       }
     }
   };
@@ -1107,8 +1140,30 @@ const VUEPLAYERCORE = (() => {
     for (const k of toRemove) localStorage.removeItem(k);
   }
 
+  // Cleared whenever anything the canvas depends on changes, so the rAF
+  // loop's skip check below can never hold a stale "already drawn" belief.
+  let _wfLastSplitPx = -1;
+  function _wfInvalidate() { _wfLastSplitPx = -1; }
+
   function _setWaveformReady(val) {
+    // Every path that swaps or clears the bar data calls through here, which
+    // makes this the one place that has to invalidate the frame cache.
+    _wfInvalidate();
     if (playerVue) playerVue.waveformReady = val;
+  }
+
+  // Draw once Vue has flushed. The four "waveform is ready" call sites used
+  // to draw synchronously, but `wf-active` — the class that un-hides the
+  // canvas — is applied by Vue on the next tick. So the canvas was still
+  // display:none, offsetWidth was 0, and _drawWaveform bailed at its size
+  // guard without painting. Since spa.css hides the plain .determinate bar
+  // as soon as wf-active lands, the common "queue a track with autoplay
+  // off" path showed an entirely blank progress bar until the user pressed
+  // play. Only the ready=true sites need this; the ready=false ones draw to
+  // clear a canvas that is still visible, and must stay synchronous.
+  function _drawWaveformSoon() {
+    if (typeof Vue !== 'undefined' && Vue.nextTick) { Vue.nextTick(_drawWaveform); }
+    else { _drawWaveform(); }
   }
 
   async function _fetchWaveform(filepath) {
@@ -1128,7 +1183,7 @@ const VUEPLAYERCORE = (() => {
     // In-memory cache hit
     if (_waveformFp === filepath && _waveformData) {
       _setWaveformReady(true);
-      _drawWaveform();
+      _drawWaveformSoon();
       if (MSTREAMPLAYER.playerStats.playing) _startWaveformRaf();
       return;
     }
@@ -1139,7 +1194,7 @@ const VUEPLAYERCORE = (() => {
       _waveformData = cached;
       _waveformFp   = filepath;
       _setWaveformReady(true);
-      _drawWaveform();
+      _drawWaveformSoon();
       if (MSTREAMPLAYER.playerStats.playing) _startWaveformRaf();
       return;
     }
@@ -1165,7 +1220,7 @@ const VUEPLAYERCORE = (() => {
         _waveformFp   = filepath;
         _wfLsSet(filepath, d.waveform);
         _setWaveformReady(true);
-        _drawWaveform();
+        _drawWaveformSoon();
         if (MSTREAMPLAYER.playerStats.playing) _startWaveformRaf();
       }
     } catch (_e) { /* waveform unavailable — plain bar stays */ }
@@ -1183,7 +1238,14 @@ const VUEPLAYERCORE = (() => {
   //   - radio/http(s) streams (no waveform on the server side)
   //   - anything already in-memory or already in localStorage
   //   - duplicate enqueues (dedup'd by filepath)
-  const _WF_PREFETCH_MAX = 2;
+  // Deliberately 1, not 2. The server allows MAX_CONCURRENT_FFMPEG = 2
+  // concurrent decodes (src/api/waveform.js), so a prefetch cap of 2 let
+  // background warm-up hold BOTH slots — on a cold cache the waveform for
+  // the track actually playing then queued behind album prefetches
+  // (measured: 0.6-1.2s for mp3, 7.4s for flac, versus 0-1ms at a cap of
+  // 1). Warm-up throughput barely moves (8 tracks: 6.2s -> 7.7s), and
+  // nobody is watching the prefetch.
+  const _WF_PREFETCH_MAX = 1;
   const _wfPrefetchQueue = [];
   const _wfPrefetchSeen = new Set(); // filepaths already queued/done this session
   let _wfPrefetchActive = 0;
@@ -1224,7 +1286,7 @@ const VUEPLAYERCORE = (() => {
             _waveformData = d.waveform;
             _waveformFp   = filepath;
             _setWaveformReady(true);
-            _drawWaveform();
+            _drawWaveformSoon();
             if (MSTREAMPLAYER.playerStats.playing) { _startWaveformRaf(); }
           }
         } catch (_e) { /* swallow — best-effort */ }
@@ -1290,21 +1352,47 @@ const VUEPLAYERCORE = (() => {
     ctx.restore();
   }
 
+  // The only thing that moves between frames is the playhead, and
+  // playerStats.currentTime is written from the audio element's timeupdate
+  // event, which fires ~4 times a second. At 60 fps that means the vast
+  // majority of frames redraw a bitmap identical to the one already on
+  // screen — pixel-diffed at 97.4%. Each of those redraws is 1600
+  // fillRects across two clipped passes, so the loop was burning a few
+  // percent of a core continuously, for the whole of playback, to produce
+  // no visible change.
+  //
+  // Skipping is keyed on the split position rounded to a whole pixel,
+  // which is the only per-frame input to the drawing. The guard lives HERE
+  // rather than inside _drawWaveform deliberately: several callers rely on
+  // that function to CLEAR the canvas on track change, and short-circuiting
+  // it would leave the previous song's waveform on screen.
   function _startWaveformRaf() {
     if (_waveformRaf) return;
     (function loop() {
-      _drawWaveform();
+      const canvas = document.getElementById('waveform-canvas');
+      const w = canvas ? canvas.offsetWidth : 0;
+      const dur = MSTREAMPLAYER.playerStats.duration;
+      const pct = dur > 0 ? MSTREAMPLAYER.playerStats.currentTime / dur : 0;
+      const splitPx = Math.round(pct * w);
+      if (splitPx !== _wfLastSplitPx) {
+        _wfLastSplitPx = splitPx;
+        _drawWaveform();
+      }
       _waveformRaf = requestAnimationFrame(loop);
     }());
   }
 
   function _stopWaveformRaf() {
     if (_waveformRaf) { cancelAnimationFrame(_waveformRaf); _waveformRaf = null; }
+    _wfInvalidate();
     _drawWaveform(); // final redraw at resting position
   }
 
   // Redraw on window resize so the canvas doesn't appear stretched while paused
-  window.addEventListener('resize', () => { if (_waveformData) _drawWaveform(); });
+  window.addEventListener('resize', () => {
+    _wfInvalidate();   // width changed, so the cached split pixel means nothing
+    if (_waveformData) _drawWaveform();
+  });
 
   mstreamModule.triggerWaveformFetch = _fetchWaveform;
 

--- a/webapp/assets/js/mstream.player.js
+++ b/webapp/assets/js/mstream.player.js
@@ -1069,6 +1069,17 @@ const MSTREAMPLAYER = (() => {
     shouldLoopOne: false,
     shuffle: false,
     volume: 100,
+    // EVERY field resetCurrentMetadata() writes must be declared here.
+    // Vue 2 can only make properties reactive at observation time, so a
+    // field that only ever appears via assignment gets no accessor and no
+    // dependency tracking: watchers and computeds that read it never
+    // invalidate. `musical-key` was missing, which froze the key shown on
+    // the now-playing card at whatever the first keyed track of the
+    // session was, for every track after it. `bpm` survived only because
+    // it happens to be interpolated directly rather than through a
+    // computed, and `replaygain-track-db` has no default-UI reader today
+    // — both are declared anyway so the next reader doesn't inherit the
+    // same silent breakage.
     metadata: {
       "artist": "",
       "album": "",
@@ -1079,6 +1090,9 @@ const MSTREAMPLAYER = (() => {
       "filepath": "",
       "has-lyrics": false,
       "has-synced-lyrics": false,
+      "bpm": null,
+      "musical-key": null,
+      "replaygain-track-db": "",
     },
     replayGain: false,
     replayGainPreGainDb: 0

--- a/webapp/assets/js/t.js
+++ b/webapp/assets/js/t.js
@@ -169,11 +169,25 @@ var VIZ = (() => {
     }
     isInit = true;
 
-    loadButterchurn().then(startVisualizer, function (err) {
-      console.error('[viz] ' + err.message);
-      butterchurnLoad = null;   // allow a retry
-      isInit = false;
-    });
+    // .catch AFTER .then, not a second .then argument: an onRejected
+    // handler passed to .then only sees rejections from the promise BEFORE
+    // it, so a throw inside startVisualizer — createVisualizer does throw
+    // when the browser has no WebGL2, which is a real configuration —
+    // would escape as an unhandled rejection with isInit stuck true,
+    // leaving the visualizer permanently dead for the session and never
+    // running the recovery below.
+    loadButterchurn()
+      .catch(function (err) {
+        // The download itself failed; drop the cached promise so a later
+        // click re-fetches rather than reusing a rejected one.
+        butterchurnLoad = null;
+        throw err;
+      })
+      .then(startVisualizer)
+      .catch(function (err) {
+        console.error('[viz] ' + err.message);
+        isInit = false;   // let a later click try again
+      });
   }
 
   function startVisualizer() {

--- a/webapp/assets/js/t.js
+++ b/webapp/assets/js/t.js
@@ -25,9 +25,15 @@ var VIZ = (() => {
     if(source) {
       renderSource = source;
     }
-    if(isInit === true && renderSource) {
+    // Gate on `visualizer`, not `isInit`. Since the butterchurn bundles are
+    // now fetched on demand, isInit goes true the moment the overlay opens
+    // but the visualizer object does not exist until the load resolves — a
+    // song change in that window reaches here via VIZ.connect and would
+    // dereference null. renderSource is still recorded above, and
+    // startVisualizer() ends with a bare startRenderer() that picks it up.
+    if(visualizer && isInit === true && renderSource) {
       visualizer.connectAudio(renderSource);
-  
+
       requestAnimationFrame(() => startRenderer());
       visualizer.render();
     }
@@ -109,7 +115,10 @@ var VIZ = (() => {
   }
 
   function reportWindowSize() {
-    if (!document.getElementById("viz-canvas").clientWidth || !isInit) {
+    // `visualizer` for the same reason as startRenderer: isInit can be true
+    // while the on-demand bundle load is still in flight, and updateSize
+    // calls straight into visualizer.setRendererSize.
+    if (!document.getElementById("viz-canvas").clientWidth || !isInit || !visualizer) {
       return;
     }
     vizModule.updateSize();
@@ -122,12 +131,52 @@ var VIZ = (() => {
     VIZ.initPlayer();
   }
 
+  // butterchurn + its two preset packs are ~1.65 MB unminified — the single
+  // largest thing the webapp used to download, on every page load, for a
+  // feature behind a click. They are fetched here on first open instead.
+  // The promise is cached, so a second open (or a double click) reuses the
+  // in-flight or completed load rather than injecting the tags twice.
+  var butterchurnLoad = null;
+  function loadButterchurn() {
+    if (butterchurnLoad) { return butterchurnLoad; }
+    // Order matters: the preset packs register themselves against globals
+    // the core defines, so they are chained rather than fired in parallel.
+    var files = [
+      'assets/js/lib/butterchurn.min.js',
+      'assets/js/lib/butterchurn-presets.min.js',
+      'assets/js/lib/butterchurn-presets-extra.js'
+    ];
+    butterchurnLoad = files.reduce(function (chain, src) {
+      return chain.then(function () {
+        return new Promise(function (resolve, reject) {
+          var s = document.createElement('script');
+          s.src = src;
+          s.onload = resolve;
+          // Reject rather than hang: initPlayer resets isInit on failure so
+          // a later click can retry (a flaky first load shouldn't kill the
+          // visualizer for the rest of the session).
+          s.onerror = function () { reject(new Error('failed to load ' + src)); };
+          document.head.appendChild(s);
+        });
+      });
+    }, Promise.resolve());
+    return butterchurnLoad;
+  }
+
   vizModule.initPlayer = function () {
     if(isInit === true) {
       return false;
     }
     isInit = true;
 
+    loadButterchurn().then(startVisualizer, function (err) {
+      console.error('[viz] ' + err.message);
+      butterchurnLoad = null;   // allow a retry
+      isInit = false;
+    });
+  }
+
+  function startVisualizer() {
     var canvas = document.getElementById('viz-canvas');
     // audioContext = new AudioContext();
     presets = {};

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -73,11 +73,10 @@
   <script defer src="assets/js/lib/qr.js"></script>
   <script defer src="assets/js/quick-connect.js"></script>
   
-  <!-- Visualizer -->
+  <!-- Visualizer. butterchurn and its two preset packs are ~1.65 MB of the
+       boot payload for a feature reached by one click, so t.js injects them
+       on first open instead (VIZ.initPlayer). Do not put them back here. -->
   <script src="assets/js/t.js"></script>
-  <script async src="assets/js/lib/butterchurn.min.js"></script>
-  <script async src="assets/js/lib/butterchurn-presets.min.js"></script>
-  <script async src="assets/js/lib/butterchurn-presets-extra.js"></script>
 
   <script src="assets/js/lib/dropzone.js"></script>
 </head>
@@ -882,7 +881,7 @@
             </div>
           </div>
           <draggable class="collection scroll-auto grow" tag="ul" :list="playlist" handle=".drag-handle" @end="checkMove" >
-            <li v-for="(song, index) in playlist" is="playlist-item" :key="index" :index="index" :song="song">
+            <li v-for="(song, index) in playlist" is="playlist-item" :key="index" :index="index" :song="song" :class="{ 'np-queue-active': index === positionCache.val }">
             </li>
           </draggable>
 


### PR DESCRIPTION
Follow-up to #818. Two user-visible bugs and four measured performance
fixes, from an adversarially-verified audit of the waveform and player
paths (29 candidate findings, 16 refuted on verification).

> **Base branch:** targets `claude/waveform-correctness-fixes` (#818) so the
> diff shows only this work. GitHub will retarget to `master` when #818
> merges.

**Not included, by request:** flipping `compression.mode` off `'none'`
(`src/state/config.js:278`). That is the single biggest win available —
~2.9 MB → ~640 KB cold load — and is deferred to the v7 release.

## Bugs

**Musical key froze on the now-playing card.** `playerStats.metadata`
declared nine fields; `resetCurrentMetadata()` writes twelve. Vue 2 installs
reactive accessors only at observation time, so `musical-key` never got one
and the `djKeyLabel` computed never invalidated — the key displayed was
whatever the *first* keyed track of the session had, for every track after.

Proven in-browser against the bundled Vue 2.7.16:

| | track 1 | track 2 | track 3 |
|---|---|---|---|
| undeclared (shipped) | A minor | A minor | A minor |
| declared (fixed) | A minor | G minor | F major |

`bpm` and `replaygain-track-db` were missing the same way and are declared
too — `bpm` survived only because it happens to be interpolated directly
rather than read through a computed.

**Queueing a track destroyed the Auto-DJ session.** `addSongWizard` called
`resetCurrentMetadata()` unconditionally after a metadata lookup, but that
function reads the *currently playing* song. Enriching some other queued
track still ran `_updateAutoDjAnchorsOnSongChange()` against the playing
one, which isn't flagged `_djPicked` and so took the "manual pick" branch:
`AUTODJ.resetAnchors()`, six localStorage writes wiping `bpmHistory`, the
Camelot anchor and the sonic seed. Adding one track from the file browser
threw the session away.

## Performance

- **Prefetch cap 2 → 1** (`vp.js`). It exactly equalled the server's
  `MAX_CONCURRENT_FFMPEG`, so background warm-up could hold both decode
  slots while the *playing* track's waveform waited — measured 0.6–1.2 s
  (mp3) and 7.4 s (flac), versus 0–1 ms at 1.
- **Queue rows no longer each subscribe to `positionCache`.** One track
  change re-rendered all N rows; the active-row class moves to the parent's
  `v-for`. 500 rows 69.3 → 5.1 ms, 2000 rows 353 → 34.5 ms.
- **rAF loop skips identical frames.** Its only per-frame input is written
  at ~4 Hz, so ~97% of frames redrew 1600 `fillRect`s for no visible change.
- **butterchurn lazy-loaded** — ~1.65 MB, the largest single thing the
  webapp downloaded, now injected on first visualizer open.

## Rendering correctness

The four "waveform ready" draws now defer to `Vue.nextTick`. They ran before
Vue applied `wf-active`, so the canvas was still `display:none`,
`offsetWidth` was 0, and the draw bailed — while CSS had already hidden the
plain `.determinate` fallback. On the common *queue with autoplay off* path
the progress bar was **entirely blank** until play was pressed.

Seeking while paused also now repaints; previously the split froze while the
time label moved.

## Verification

Run against a real booted server with the fixture library, not just read:

- boot fetches **0 bytes** of butterchurn (1,305,030 total); opening the
  visualizer pulls all three files, builds 245 presets, and a second open
  does not re-inject
- active row tracks the playing song — exactly one row, 0→1→2
- `djKeyLabel` updates per track on both the player and queue cards
- blank-bar fix: 706 painted pixels where there were none
- seek-while-paused: one redraw per seek (1600 `fillRect`s), orange grows
  70 → 1268 px, and re-seeking to the same time repaints **zero** times
- console clean; `test/unit` + `test/db` 697 tests, 0 failures

One trap worth flagging for review: lazy-loading means `isInit` goes true
while the bundle is still in flight, so `startRenderer` and
`reportWindowSize` now gate on `visualizer` instead — a song change in that
window would otherwise dereference null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
