### PR TITLE
test(federation): harden the discovery-aggregate suite against two boot races

### DIFF
--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -58,14 +58,40 @@ async function waitForReady(baseUrl, { timeoutMs = 90_000, getExitError = () => 
 
 // Same loaded-CI-runner ceiling as waitForReady — the scan (plus the
 // embedding pass some discovery suites run behind it) shares the risk.
+//
+// "Complete" must mean the whole QUEUE of scans, not "no scan active this
+// instant": boot scans enqueue ONE TASK PER LIBRARY (task-queue scanAll()),
+// and onScanClose nulls the active task BEFORE nextTask() dispatches the
+// next one — so /db/status's `locked` bit reads false between two
+// per-library scans while later libraries are still unscanned. This 50ms
+// poll slipped through exactly that gap on a contended runner (PR #803's
+// ubuntu full-ci shard) and returned a half-scanned fixture to a suite
+// using extraFolders. So gate on /api/v1/scan/status, which exposes the
+// queue itself: done means no scan task ACTIVE and none QUEUED. Enrichment
+// kinds (waveform, albumart, ...) are deliberately not waited on — same
+// reasoning as isScanning() ignoring them; a throttled art pass can run for
+// minutes after the library is fully browsable. The totalFileCount > 0
+// guard (from /db/status, as before) covers the window before the boot scan
+// is enqueued at all (scanOptions.bootScanDelay), when the queue is exactly
+// as empty as when everything finished.
 async function waitForScanComplete(baseUrl, timeoutMs = 90_000) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
-      const r = await fetch(`${baseUrl}/api/v1/db/status`);
-      if (r.ok) {
-        const j = await r.json();
-        if (!j.locked && j.totalFileCount > 0) { return j.totalFileCount; }
+      const [statusR, queueR] = await Promise.all([
+        fetch(`${baseUrl}/api/v1/db/status`),
+        fetch(`${baseUrl}/api/v1/scan/status`),
+      ]);
+      if (statusR.ok && queueR.ok) {
+        const status = await statusR.json();
+        const { queue } = await queueR.json();
+        // queue.scanning covers an active scan OR backup (the old `locked`
+        // bit); the two kind checks close the between-tasks and not-yet-
+        // dispatched gaps that bit can't see.
+        const pending = queue.scanning
+          || queue.activeTask === 'scan'
+          || queue.queued.includes('scan');
+        if (!pending && status.totalFileCount > 0) { return status.totalFileCount; }
       }
     } catch { /* retry */ }
     await sleep(50);

--- a/test/integration/federation-discovery-aggregate.test.mjs
+++ b/test/integration/federation-discovery-aggregate.test.mjs
@@ -158,6 +158,29 @@ describe('discovery federation aggregate (B queries A over iroh)', { skip: avail
       assert.equal(added.status, 200);
       peerIds.push(added.body.id);
     }
+
+    // Readiness gate: the federation iroh endpoint boots ASYNCHRONOUSLY and
+    // can lag well past HTTP-ready — measured ~9s under slow relay bootstrap
+    // (2026-08-11), while the aggregate's per-peer budget (PEER_TIMEOUT_MS,
+    // src/api/discovery-federation.js) is 4s with the dial included. That
+    // budget is a deliberate product choice — a slow peer must not hold the
+    // Discover panel hostage — so it stays; the TESTS must instead not start
+    // until the peers are genuinely dialable. Poll the aggregate itself until
+    // both peer rows answer: each unreachable round costs one 4s budget, and
+    // the 60s ceiling matches the helper's other loaded-CI allowances. This
+    // also pre-warms the B→A bridges, which is precisely the state the
+    // assertions below mean to probe (reachable peers); the dead-peer test
+    // still adds its own genuinely-dead row and stays meaningful.
+    const ready = Date.now() + 60_000;
+    for (;;) {
+      const probe = await aggregate({ filePath: SEED_PATH, limit: 1 });
+      if (probe.status === 200
+          && probe.body?.searched?.peers === 2
+          && probe.body.searched.unreachable === 0) { break; }
+      assert.ok(Date.now() < ready,
+        `federation peers never became reachable: last searched=${JSON.stringify(probe.body?.searched)}`);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
   });
 
   after(async () => {

--- a/test/integration/hash-transition-applier.test.mjs
+++ b/test/integration/hash-transition-applier.test.mjs
@@ -155,9 +155,19 @@ describe('hash-transition applier (discovery ON — live worker)', () => {
   });
 
   test('a chained re-key lands the embedding at the terminal identity with invariants intact', async () => {
-    // Wait for the test-fake worker to embed the eligible track.
+    // Wait for the test-fake worker to embed the eligible track. 480 ticks
+    // (4 min): this file shares its shard with the heaviest suites (p2p
+    // sidecars, federation e2e), and node --test runs files CONCURRENTLY —
+    // a small CI runner can starve the worker into needing minutes, not
+    // seconds (the old 240-tick budget expired on macos-latest 2026-08-12
+    // while the shard's neighbors churned). The wait is self-diagnosing,
+    // not just longer: a pass reporting 'disabled', or a run that finished
+    // 'failed' with still no row, means more waiting is pointless — fail
+    // NOW with the reason, so the next CI failure names its cause instead
+    // of presenting as a mystery timeout.
     let seed = null;
-    for (let i = 0; i < 240 && !seed; i++) {
+    let passState = null;
+    for (let i = 0; i < 480 && !seed; i++) {
       try {
         seed = withDb(ddbPath, (d) => {
           const r = d.prepare(
@@ -165,9 +175,23 @@ describe('hash-transition applier (discovery ON — live worker)', () => {
           return r ? { ...r } : null;
         });
       } catch { /* db not created yet */ }
-      if (!seed) { await sleep(500); }
+      if (seed) { break; }
+      try {
+        const st = await fetch(`${server.baseUrl}/api/v1/scan/status`).then((r) => r.json());
+        passState = st.enrichment?.find((p) => p.pass === 'discovery') ?? null;
+        assert.notEqual(passState?.state, 'disabled',
+          `discovery pass reports disabled: ${passState?.disabledReason}`);
+        if (passState?.lastRun?.outcome === 'failed') {
+          assert.fail(`discovery pass ran and FAILED with no row embedded: ${JSON.stringify(passState.lastRun)}`);
+        }
+      } catch (err) {
+        if (err.code === 'ERR_ASSERTION') { throw err; }
+        // status probe is best-effort — keep waiting on transient fetch noise
+      }
+      await sleep(500);
     }
-    assert.ok(seed, 'discovery worker embedded the eligible track');
+    assert.ok(seed,
+      `discovery worker embedded the eligible track (last pass state: ${JSON.stringify(passState)})`);
 
     // Chain seed→mid→fin. The middle hop never exists as a row; the
     // terminal is the LIVE short track's canon, so the worker's orphan


### PR DESCRIPTION
Test-infra only — no `src/` changes. Fixes the two timing races that made `federation-discovery-aggregate` fail twice in 48 hours in two different ways (once on #803's `full-ci` ubuntu shard, once locally under slow iroh relay bootstrap).

## Race 1 — the scan wait could return between per-library scans

`waitForScanComplete()` keyed off `/db/status`'s `!locked && totalFileCount > 0`. But `locked` is just "a task is active *right now*", boot scans enqueue **one task per library**, and `onScanClose` nulls the active task before dispatching the next — so between two per-library scans the poll sees `locked:false` with the first library committed and can hand a half-scanned fixture to the suite (which then dies in `seedDiscoveryDb` with "fixture track must exist with a hash", cancelling all ten subtests — exactly #803's shard failure).

The helper now gates on `/api/v1/scan/status`'s queue block: done = no `scan`-kind task **active or queued**, plus the old `scanning` bit and the `count > 0` guard for the pre-`bootScanDelay` window. Enrichment kinds (waveform/albumart) are deliberately not waited on — same reasoning as `isScanning()` ignoring them. The wait runs before user creation, so the unauthenticated fetch works in every suite that uses the helper.

## Race 2 — the suite dialed peers before the federation endpoint existed

The federation iroh endpoint boots asynchronously; under slow relay bootstrap it came up **~9s after HTTP-ready** (captured in logs: the aggregate's two dials failed at the 4s budget, then `[federation] endpoint up` appeared a second later and the very next dial succeeded). `PEER_TIMEOUT_MS = 4000` is a deliberate product budget ("a slow peer must not hold the Discover panel hostage") and is untouched — instead the suite's `before()` now polls the aggregate until both peer rows genuinely answer (60s ceiling, matching the helper's other loaded-CI allowances) before any deadline-capped assertion runs. That also pre-warms the B→A bridges, which is precisely the state the assertions probe; the dead-peer test still adds its own genuinely-dead row, so its "unreachable within the deadline, not the dial timeout" contract stays meaningful.

## Verification

A live testbed did the proving: this machine reproduced race 2 deterministically (8 pass / 2 fail — three consecutive runs, on three different code states including one that had passed the same morning). With the gate: **10/10, three consecutive runs, same adverse conditions.** Full suite: **2277 pass / 0 fail** (6 pre-existing skips), which regression-gates the helper change across every integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)