### PR TITLE
fix(launcher): drop the libxdo hard-link that broke the v6.20.0 linux bundle; add bundle READMEs

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -149,7 +149,7 @@ jobs:
 
           echo "building $NAME ($TARGET)"
           if [ "${{ runner.os }}" = "Linux" ]; then
-            sudo apt-get update -qq && sudo apt-get install -y -qq libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+            sudo apt-get update -qq && sudo apt-get install -y -qq libgtk-3-dev libayatana-appindicator3-dev
           fi
           rustup target add "$TARGET"
           cargo build --release --locked --target "$TARGET" --manifest-path rust-launcher/Cargo.toml

--- a/.github/workflows/build-rust-launcher.yml
+++ b/.github/workflows/build-rust-launcher.yml
@@ -65,7 +65,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -125,7 +125,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y curl ca-certificates git build-essential pkg-config zstd \
-            libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+            libgtk-3-dev libayatana-appindicator3-dev
 
       - uses: actions/checkout@v6
 
@@ -156,6 +156,36 @@ jobs:
           worst=$(printf '%s\n2.31\n' "$max" | sort -V | tail -1)
           if [ -n "$max" ] && [ "$worst" != "2.31" ] && [ "$max" != "2.31" ]; then
             echo "::error::launcher links GLIBC_$max > 2.31 — the container floor regressed"
+            exit 1
+          fi
+
+      # The launcher must stay runnable on a STOCK desktop install: its only
+      # acceptable hard runtime deps are glibc and GTK3 (universal on desktop
+      # distros). Any other NEEDED entry means a dependency grew a link-time
+      # requirement most user machines won't satisfy — exactly how tray-icon's
+      # default `libxdo` feature shipped a launcher that died at the dynamic
+      # loader (libxdo.so.3 is xdotool's lib), caught only by the v6.20.0 tag
+      # smoke. The appindicator lib is deliberately NOT allowlisted: tray-icon
+      # dlopens it at runtime, where a miss degrades to "tray unavailable"
+      # instead of a binary that won't start — the shape we want new deps to
+      # take. This can't run on the PR leg (no linux binary is built there),
+      # so it guards the shipped artifact, the one that matters.
+      - name: Assert NEEDED libs are glibc + GTK3 only
+        if: matrix.container
+        run: |
+          bin="rust-launcher/target/${{ matrix.target }}/release/mstream-launcher"
+          objdump -p "$bin" | awk '/NEEDED/{print "  NEEDED", $2}'
+          bad=""
+          for so in $(objdump -p "$bin" | awk '/NEEDED/{print $2}'); do
+            case "$so" in
+              libgtk-3.so.*|libgdk-3.so.*|libgdk_pixbuf-2.0.so.*|libcairo.so.*) ;;
+              libglib-2.0.so.*|libgobject-2.0.so.*|libgio-2.0.so.*) ;;
+              libc.so.*|libm.so.*|libdl.so.*|libpthread.so.*|librt.so.*|libgcc_s.so.*) ;;
+              *) bad="$bad $so" ;;
+            esac
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::launcher hard-links non-stock libs:$bad — make the dep dlopen (like appindicator) or drop the feature that links it"
             exit 1
           fi
 

--- a/rust-launcher/Cargo.lock
+++ b/rust-launcher/Cargo.lock
@@ -997,25 +997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libxdo"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
-dependencies = [
- "libxdo-sys",
-]
-
-[[package]]
-name = "libxdo-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
-dependencies = [
- "libc",
- "x11",
-]
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1077,6 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "libxdo",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",

--- a/rust-launcher/Cargo.toml
+++ b/rust-launcher/Cargo.toml
@@ -13,7 +13,13 @@ path = "src/main.rs"
 # cross-platform pump (win32 message loop / NSApplication / gtk). Linux
 # build deps: libgtk-3-dev + libayatana-appindicator3-dev; at runtime a
 # missing StatusNotifier host degrades gracefully (server still runs).
-tray-icon = "0.19"
+# default-features = false drops the `libxdo` feature: it hard-links
+# libxdo.so.3 (xdotool's lib — NOT part of any stock desktop) yet muda only
+# uses it for predefined Copy/Cut/Paste items this menu doesn't have. With
+# it on, the shipped binary died at the dynamic loader on every machine
+# without xdotool installed — caught by the v6.20.0 tag smoke. The
+# remaining hard links are glibc + GTK3 only; CI asserts exactly that set.
+tray-icon = { version = "0.19", default-features = false }
 tao = "0.30"
 # Login-item registration: HKCU Run key (Windows), LaunchAgent plist (macOS,
 # see set_use_launch_agent below — the AppleScript default would tie us to

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -233,6 +233,11 @@ if (isMac) {
     linuxDesktopEntry(launcherStaged ? 'mstream-desktop' : serverName, launcherStaged));
 }
 
+// Signpost at the bundle root: which binary is the desktop face, which is the
+// headless entry. The launcher is a GTK3 tray app and can't even LOAD on a
+// bare server box, so the box can't explain itself — this file has to.
+writeFileSync(join(stageDir, 'README.txt'), bundleReadme(pkg.version, t, launcherStaged, serverName));
+
 const archivePath = join(root, 'dist', `${bundleName}.zip`);
 rmSync(archivePath, { force: true });
 console.log(`Bundling -> dist/${bundleName}.zip`);
@@ -340,6 +345,49 @@ Icon=%INSTALL_DIR%/mStream.png
 Terminal=${isLauncher ? 'false' : 'true'}
 Categories=AudioVideo;Audio;Network;
 `;
+}
+
+// The bundle-root README.txt. Kept to one screen: it exists to answer exactly
+// one question — "which of these two binaries do I run?" — for the person who
+// just extracted the zip, especially on a headless box where the launcher
+// fails at the dynamic loader before it can say anything.
+function bundleReadme(version, t, launcherStaged, serverName) {
+  const osName = { win32: 'Windows', darwin: 'macOS', linux: 'Linux' }[t.plat];
+  const dataDir = { win32: '%LOCALAPPDATA%\\mStream', darwin: '~/Library/Application Support/mStream', linux: '~/.local/share/mstream' }[t.plat];
+  const server = t.plat === 'darwin' ? `mStream.app/Contents/MacOS/${serverName}` : serverName;
+  const run = t.plat === 'win32' ? '' : './';
+  const lines = [`mStream ${version}  (${osName} ${t.arch}${t.musl ? ', static musl build' : ''})`, ''];
+  if (launcherStaged) {
+    const face = { win32: 'mStream.exe', darwin: 'open mStream.app', linux: './mstream-desktop' }[t.plat];
+    lines.push(
+      `Desktop:   ${face}`,
+      '           Runs the server in the background with a tray icon and opens',
+      '           the web app. Also works from a terminal (output stays attached).',
+      t.plat === 'linux'
+        ? '           Needs a graphical session with GTK3 (any stock desktop has it).'
+        : null,
+      '',
+      `Headless:  ${run}${server}`,
+      '           The server alone - no tray, no GUI libraries needed. Use this',
+      `           over SSH, in containers, and as a service (${t.plat === 'win32' ? 'NSSM, sc.exe' : t.plat === 'darwin' ? 'launchd' : 'systemd'}).`,
+    );
+  } else {
+    lines.push(
+      `This bundle is server-only (no desktop launcher for this target):`,
+      `           ${run}${server}`,
+      t.musl
+        ? '           Fully static - runs on any Linux, including Alpine and NAS systems.'
+        : null,
+    );
+  }
+  lines.push(
+    '',
+    `The web app serves on http://localhost:3000 - set up your library there.`,
+    `Data lives in ${dataDir}; pass --portable to keep it next to the binaries.`,
+    '',
+    `Docs: https://mstream.io        More flags: ${run}${server} --help`,
+  );
+  return lines.filter((l) => l !== null).join('\n') + '\n';
 }
 
 // NAPI-RS target triple for @number0/iroh's platform package / .node filename


### PR DESCRIPTION
## What broke

The v6.20.0 tag build failed on linux-x64: the launcher smoke died with
`mstream-desktop: error while loading shared libraries: libxdo.so.3`, which skipped the release-attach step.

**Root cause:** tray-icon's default `libxdo` cargo feature hard-links `libxdo.so.3` (xdotool's library — not part of any stock desktop). muda only uses it for predefined Copy/Cut/Paste menu items our tray menu doesn't have. Every earlier smoke passed because PR runs rebuild the launcher on-runner, and installing `libxdo-dev` as a build dep silently satisfied the runtime dependency; the tag run was the first to execute the committed debian-built binary on a bare machine — the same environment as an end user's desktop. Verified on a zero-package Debian 11 (glibc 2.31 floor): with libxdo gone, the launcher's remaining hard links are glibc + GTK3 only, and libayatana-appindicator is dlopened (a miss degrades to "tray unavailable", never a dead binary).

## Changes

- `tray-icon = { version = "0.19", default-features = false }` + regenerated Cargo.lock (only libxdo/libxdo-sys drop out). 11/11 unit tests and clippy `-D warnings` pass.
- `libxdo-dev` removed from all three apt lists so nothing can silently re-link it.
- New CI assertion on the container leg of build-rust-launcher: the shipped binary's NEEDED set must be **glibc + GTK3 only** — the class guard, not just the instance fix.
- Bundles now stage a one-screen `README.txt` at the zip root: desktop face vs headless `mstream-server`, per-OS data dir, `--portable`. Server-only bundles (linux-arm64, musl) say so; verified rendering for all shapes, plus a full local win-x64 bundle build.

## Release mechanics after merge

build-rust-launcher will rebuild + commit fresh binaries (rust-launcher/ changed). **Wait for that commit, then delete and re-tag `v6.20.0` on top of it** — the tag currently points at `bc1aa99b`, which contains the broken linux launcher, and build-bun's provenance assert requires the tag to sit at/after the binaries commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)