### PR TITLE
fix(launcher): survive bare environments - tray-library panic + missing HKCU Run key (v6.20.0 tag blockers)

### DIFF
--- a/rust-launcher/Cargo.lock
+++ b/rust-launcher/Cargo.lock
@@ -1064,6 +1064,7 @@ dependencies = [
  "tao",
  "tray-icon",
  "windows-sys 0.59.0",
+ "winreg",
  "winresource",
 ]
 

--- a/rust-launcher/Cargo.toml
+++ b/rust-launcher/Cargo.toml
@@ -39,6 +39,10 @@ serde_json = "1"
 png = "0.17"
 
 [target.'cfg(windows)'.dependencies]
+# Pre-create the HKCU Run key before auto-launch touches it: auto-launch 0.5
+# only ever OPENS it and errors on fresh profiles where it doesn't exist yet.
+# Same winreg version auto-launch itself compiles — no second copy.
+winreg = "0.10"
 windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_System_Console",

--- a/rust-launcher/src/autostart.rs
+++ b/rust-launcher/src/autostart.rs
@@ -46,14 +46,23 @@ pub fn set_enabled(on: bool) -> Result<(), String> {
     r.map_err(|e| e.to_string())
 }
 
-// auto-launch writes a file into a per-user dir it does NOT create:
-// ~/.config/autostart on Linux, ~/Library/LaunchAgents on macOS. Real
-// desktop sessions always have them, but fresh or minimal accounts may
-// not — surfaced by the Docker smoke, where enable() failed with ENOENT
-// in a bare-$HOME container. Windows registers via the registry; nothing
-// to create there. Best-effort: a failure here just re-surfaces in
-// enable()'s own error.
+// auto-launch writes into a per-user CONTAINER it does NOT create:
+// ~/.config/autostart on Linux, ~/Library/LaunchAgents on macOS, and the
+// HKCU Run key on Windows (enable/disable/is_enabled all use
+// open_subkey_with_flags — open, never create). Real lived-in accounts
+// always have them, but fresh or minimal profiles may not — the Linux gap
+// surfaced as ENOENT in a bare-$HOME Docker smoke, the Windows one as
+// `os error 2` on a fresh CI runner image at the v6.20.0 tag build.
+// Best-effort: a failure here just re-surfaces in enable()'s own error.
 fn ensure_autostart_parent_dir() {
+    #[cfg(windows)]
+    {
+        // create_subkey is open-or-create; plain HKCU write access, no
+        // elevation. Same key path auto-launch 0.5 hardcodes (AL_REGKEY).
+        use winreg::{enums::HKEY_CURRENT_USER, RegKey};
+        let _ = RegKey::predef(HKEY_CURRENT_USER)
+            .create_subkey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run");
+    }
     #[cfg(target_os = "macos")]
     {
         let _ = std::fs::create_dir_all(

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -213,18 +213,33 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&quit_item);
                 autostart_item = Some(auto_item);
 
-                match TrayIconBuilder::new()
-                    .with_tooltip("mStream Server")
-                    .with_menu(Box::new(menu))
-                    .with_icon(load_icon())
-                    .build()
-                {
-                    Ok(t) => tray = Some(t),
-                    Err(e) => {
-                        // No tray host (minimal desktops, headless-ish
-                        // sessions). The server is still running and
-                        // reachable; say so once and keep serving.
+                // catch_unwind because "no tray" arrives two ways: as a
+                // build Err (no StatusNotifier host), but ALSO as a PANIC —
+                // libappindicator-sys dlopens libayatana-appindicator3 at
+                // first use and panic!()s when no variant is installed
+                // (stock Fedora/Arch desktops without an appindicator
+                // package), which would take down the whole launcher here.
+                // Both fold into the same degrade: server keeps serving.
+                let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    TrayIconBuilder::new()
+                        .with_tooltip("mStream Server")
+                        .with_menu(Box::new(menu))
+                        .with_icon(load_icon())
+                        .build()
+                }));
+                match built {
+                    Ok(Ok(t)) => tray = Some(t),
+                    Ok(Err(e)) => {
                         log.line(&format!("tray unavailable ({e}) - server continues without it"));
+                    }
+                    Err(p) => {
+                        let msg = p
+                            .downcast_ref::<String>()
+                            .map(|s| s.as_str())
+                            .or_else(|| p.downcast_ref::<&str>().copied())
+                            .unwrap_or("panic in the tray library")
+                            .replace('\n', " / ");
+                        log.line(&format!("tray unavailable ({msg}) - server continues without it"));
                     }
                 }
             }


### PR DESCRIPTION
The second v6.20.0 tag attempt failed on both smoke legs, each exposing a real launcher bug that only bare environments (CI tag runners, and real user machines) hit. Same masking pattern as libxdo, one layer deeper: every environment that *builds* the launcher also installs the packages that satisfy its runtime assumptions.

## linux-x64: a missing appindicator library must degrade, not crash

`libappindicator-sys` dlopens `libayatana-appindicator3` at first use and **panic!()s** when no variant is installed — the unwind sailed past our `Err`-arm degrade handling and took down the launcher, so supervision dutifully killed the healthy server. Stock Fedora/Arch desktops without an appindicator package would crash identically. Fix: `catch_unwind` around tray construction, folding the panic into the existing "tray unavailable — server continues" path.

**Empirically proven** in a container with GTK3 but the appindicator libs deleted (stock-Fedora simulation): launcher survives the panic, logs the degrade line with the full dlopen chain, and the server keeps serving:
```
tray unavailable (Failed to load ayatana-appindicator3 or appindicator3 dynamic library / libayatana-appindicator3.so.1: cannot open shared object file ...) - server continues without it
```

## win-x64: pre-create the HKCU Run key

auto-launch 0.5 only ever **opens** `HKCU\...\CurrentVersion\Run` (`open_subkey_with_flags` in enable/disable/is_enabled) and fails with `os error 2` on profiles where the key doesn't exist — fresh/minimal accounts, and the tag runner's image (the first tag attempt passed on a different image: runner lottery). `ensure_autostart_parent_dir()` already creates the per-user container auto-launch won't on Linux/macOS; this adds the Windows arm its comment wrongly declared unnecessary. `create_subkey` is open-or-create under plain HKCU access, via the same winreg 0.10.1 auto-launch itself compiles (no new crate versions).

11/11 unit tests, clippy `-D warnings`, and a fresh linux release build all pass.

## Release mechanics after merge

Same dance as #822: wait for build-rust-launcher's binaries commit on master, then **delete + re-tag v6.20.0** on top of it (third attempt — current tag `50b750fb` ships the panicking linux launcher and the keyless-registry autostart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)