### PR TITLE
ci: re-enable the website version stamper for the new download page

### DIFF
--- a/.github/workflows/update-website.yaml
+++ b/.github/workflows/update-website.yaml
@@ -2,12 +2,14 @@
 name: Update Website
 
 on:
-  # DISABLED pending the mstream-website download-page fix: templates/express.html
-  # still advertises the removed Electron installers, so we don't want a release to
-  # auto-bump the version on a stale page. Re-enable by restoring the release
-  # trigger below (and remove workflow_dispatch if you don't want manual runs).
-  #   release:
-  #     types: [published]
+  # Stamps the published server version into the mstream.io download page.
+  # CONVENTION this depends on: in mstream-website's templates/express.html,
+  # every x.y.z string IS the release version (table header + the version
+  # embedded twice in each release-asset URL) — that's what the global sed
+  # below rewrites. Keep that page free of any other three-part version
+  # number, or replace this sed with a template variable.
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -46,6 +48,13 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
+          # No-op runs must stay green: the page may already carry this
+          # version (first release after a manual page rewrite, or a
+          # re-published release) and `git commit` errors on an empty stage.
+          if git diff --cached --quiet; then
+            echo "page already at $VERS - nothing to stamp"
+            exit 0
+          fi
           git commit -m "action: update server"
           git push
 


### PR DESCRIPTION
Companion to [mstream-website#3](https://github.com/IrosTheBeggar/mstream-website/pull/3) (the download-page rewrite). Two changes to `update-website.yaml`:

- **Restore the `release: published` trigger** (was commented out precisely because the page still advertised the removed Electron installers — auto-bumping the version there would have refreshed dead links). The DISABLED note is replaced with documentation of the convention the sed depends on: every `x.y.z` in `templates/express.html` IS the release version. `workflow_dispatch` stays for manual runs.
- **No-op runs stay green**: the very first release-triggered run after the manual page rewrite seds nothing (the page already says 6.20.0), and `git commit` errors on an empty stage. Now it logs and exits 0.

## Merge order for the 6.20.0 release
1. Merge mstream-website#3 (page goes live pointing at the draft — links 404 until publish)
2. Merge this
3. Publish the v6.20.0 draft release — the stamper fires, finds the page already stamped, and no-ops green

(1 and 2 can swap; the only rule is the website rewrite must land before a release is *published* while this trigger is live.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)