### PR TITLE
test: private boot helpers must kill the child when readiness times out

### DIFF
--- a/test/integration/db-stats.test.mjs
+++ b/test/integration/db-stats.test.mjs
@@ -66,7 +66,16 @@ async function boot(tmpDir, musicDir) {
     { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } });
   proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl };
 }
 

--- a/test/integration/file-explorer-metadata.test.mjs
+++ b/test/integration/file-explorer-metadata.test.mjs
@@ -84,7 +84,16 @@ async function bootMstream(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 

--- a/test/integration/genre-agg-endpoints.test.mjs
+++ b/test/integration/genre-agg-endpoints.test.mjs
@@ -85,7 +85,16 @@ async function bootMstream(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 

--- a/test/integration/lastfm-status.test.mjs
+++ b/test/integration/lastfm-status.test.mjs
@@ -76,7 +76,16 @@ async function bootMstream(tmpDir, musicDir, extraConfig = {}) {
   proc.stderr.on('data', () => {});
   proc.stdout.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl };
 }
 

--- a/test/integration/playlist-load.test.mjs
+++ b/test/integration/playlist-load.test.mjs
@@ -80,7 +80,16 @@ async function bootMstream(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 

--- a/test/integration/public-mode-library-filter.test.mjs
+++ b/test/integration/public-mode-library-filter.test.mjs
@@ -103,7 +103,16 @@ async function bootMstream(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 

--- a/test/integration/public-mode-privacy.test.mjs
+++ b/test/integration/public-mode-privacy.test.mjs
@@ -106,7 +106,16 @@ async function bootMstream(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 
@@ -523,6 +532,15 @@ async function bootMstreamLocked(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }

--- a/test/integration/random-route.test.mjs
+++ b/test/integration/random-route.test.mjs
@@ -389,7 +389,16 @@ async function bootMstream(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 

--- a/test/integration/random-similar-artists.test.mjs
+++ b/test/integration/random-similar-artists.test.mjs
@@ -150,7 +150,16 @@ async function bootMstream(tmpDir, musicDir) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 

--- a/test/integration/search-route.test.mjs
+++ b/test/integration/search-route.test.mjs
@@ -88,7 +88,16 @@ async function bootMstream(tmpDir, musicDir, extraLibraries = {}) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 

--- a/test/subsonic/subsonic-search.test.mjs
+++ b/test/subsonic/subsonic-search.test.mjs
@@ -99,7 +99,16 @@ async function bootMstream(tmpDir, musicDir, port) {
   proc.stdout.on('data', () => {});
   proc.stderr.on('data', () => {});
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForReady(baseUrl);
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // A ready-timeout must not leak the child: the server can boot late but
+    // healthy on a loaded runner, and a live orphan's stdio keeps this file's
+    // event loop open — the run then hangs at exit instead of reporting the
+    // timeout. test/helpers/server.mjs kills on this path for the same reason.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
   return { proc, baseUrl, port };
 }
 
@@ -219,7 +228,11 @@ describe('Subsonic search3/search2 with FTS5 (PR3)', () => {
       }),
     });
     if (!userResp.ok) {
-      throw new Error(`failed to create user: ${userResp.status} ${await userResp.text()}`);
+      // Kill before throwing: node:test skips after() when before() throws,
+      // so a live child here would leak and hang the file at exit.
+      const body = await userResp.text();
+      await killProc(server.proc);
+      throw new Error(`failed to create user: ${userResp.status} ${body}`);
     }
     await killProc(server.proc);
     await sleep(200);


### PR DESCRIPTION
## Problem

Eleven test files boot mStream through their own **private copy** of a boot helper (spawn `cli-boot-wrapper.js` + ready-poll loop) instead of `test/helpers/server.mjs`. In every copy, a ready-wait timeout **threw while the spawned server kept running**:

- On a loaded runner the server can boot **late but healthy** — the poll gives up at 30s, but the child comes up moments later and stays alive.
- The live orphan's piped stdio keeps the test file's event loop open, so the file **hangs at exit instead of reporting the timeout**. This is exactly what hung a CI runner for 45 minutes via `admin-access.test.mjs` (fixed 2026-08-13).
- `node:test` skips `after()` when `before()` throws, so no cleanup hook can save this — **the kill must happen inside the helper**, on the throw path itself.

## Fix

Mirror the pattern already landed in `admin-access.test.mjs`: wrap `waitForReady` in try/catch, `SIGKILL` the child on the timeout path, then rethrow.

**12 helper copies fixed across 11 files** (`public-mode-privacy.test.mjs` carries two copies — `bootMstream` and `bootMstreamLocked`):

- `test/subsonic/subsonic-search.test.mjs`
- `test/integration/search-route.test.mjs`
- `test/integration/random-route.test.mjs`
- `test/integration/genre-agg-endpoints.test.mjs`
- `test/integration/db-stats.test.mjs`
- `test/integration/random-similar-artists.test.mjs`
- `test/integration/public-mode-privacy.test.mjs` (×2)
- `test/integration/public-mode-library-filter.test.mjs`
- `test/integration/playlist-load.test.mjs`
- `test/integration/lastfm-status.test.mjs`
- `test/integration/file-explorer-metadata.test.mjs`

One extra window closed while auditing: `subsonic-search.test.mjs`'s `before()` throws on a failed user-creation response **while the first server is still alive** — it now kills the child before throwing, for the same skipped-`after()` reason.

## Audited, no change needed

- `test/unit/boot-config.test.mjs` — references `cli-boot-wrapper.js` but only `execFile`s `--help` / `--version`, which exit on their own; there is no boot-then-poll shape.
- All multi-boot `before()` blocks (boot → kill → seed → reboot) already kill the first server before the second boot, so the in-helper fix covers every remaining leak path.

## Verification

`node --test` over all 11 touched files: **188 tests, 20 suites, 0 failures**. Lint clean (`npx eslint` on the changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)