### PR TITLE
feat(launcher): tray 'View logs' — terminal with the full session's server log

### DIFF
--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -213,7 +213,10 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
     {
         use std::os::windows::process::CommandExt;
         // The launcher is a GUI-subsystem exe with no console of its own to
-        // lend — give the tail a brand-new console window.
+        // lend — give the tail a brand-new console window. -Encoding UTF8 on
+        // both reads: the server writes UTF-8 (winston's em-dashes), and
+        // Windows PowerShell 5.1's Get-Content defaults to the ANSI codepage
+        // for BOM-less files — without it every "—" renders as "â€"".
         const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
         let dir = logs_dir.display().to_string().replace('\'', "''");
         std::process::Command::new("powershell.exe")
@@ -223,9 +226,9 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
                 "-Command",
                 &format!(
                     "Set-Location '{dir}'; Write-Host '== launcher.log =='; \
-                     Get-Content .\\launcher.log -Tail 50 -ErrorAction SilentlyContinue; \
+                     Get-Content .\\launcher.log -Tail 50 -Encoding UTF8 -ErrorAction SilentlyContinue; \
                      Write-Host ''; Write-Host '== server-console.log: full server log for this session (following; close the window to stop) =='; \
-                     Get-Content .\\server-console.log -Wait"
+                     Get-Content .\\server-console.log -Wait -Encoding UTF8"
                 ),
             ])
             .creation_flags(CREATE_NEW_CONSOLE)

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -173,3 +173,116 @@ pub fn fatal_alert(msg: &str) {
         eprintln!("mStream: {msg}");
     }
 }
+
+/// Tray "View logs": open a terminal window showing the two launcher-owned
+/// logs — a static tail of the quiet launcher.log, then server-console.log
+/// FROM LINE 1, followed live (-F, so the per-session rotation doesn't end
+/// the view). Whole-file is deliberate: the same winston stream that feeds
+/// the admin panel's in-memory live-log ring (src/logger.js — Console +
+/// MemoryRingTransport on one root logger) is what the launcher captures
+/// into server-console.log, and the capture starts at server spawn — so
+/// from line 1 this window shows everything the admin viewer has, uncapped
+/// (the ring holds the last N entries, 4KB each), plus anything the ring
+/// already evicted. Fetching /api/v1/admin/logs/recent instead would add
+/// an auth dependency (the wall, once accounts exist) for a subset of this
+/// file. Per-OS "what is a terminal" seams; the caller logs a failure —
+/// a missing terminal emulator must never take the tray down.
+pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Terminal.app opens an executable .command file as a document — no
+        // AppleEvents automation consent (an osascript `tell app "Terminal"`
+        // would prompt "mStream wants to control Terminal" on first use).
+        // Regenerated on every click so it always reflects this build's
+        // idea of the logs dir; header says whose file it is.
+        let script = logs_dir.join("view-logs.command");
+        let body = format!(
+            "#!/bin/sh\n# Written by mStream's tray 'View logs' item - safe to delete.\ncd {dir}\necho '== launcher.log =='\ntail -n 50 launcher.log 2>/dev/null\necho\necho '== server-console.log: full server log for this session (following; close the window to stop) =='\nexec tail -n +1 -F server-console.log\n",
+            dir = sh_quote(logs_dir)
+        );
+        std::fs::write(&script, body).map_err(|e| format!("write {}: {e}", script.display()))?;
+        let _ = std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755));
+        std::process::Command::new("/usr/bin/open")
+            .arg(&script)
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| format!("open {}: {e}", script.display()))
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // The launcher is a GUI-subsystem exe with no console of its own to
+        // lend — give the tail a brand-new console window.
+        const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+        let dir = logs_dir.display().to_string().replace('\'', "''");
+        std::process::Command::new("powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoExit",
+                "-Command",
+                &format!(
+                    "Set-Location '{dir}'; Write-Host '== launcher.log =='; \
+                     Get-Content .\\launcher.log -Tail 50 -ErrorAction SilentlyContinue; \
+                     Write-Host ''; Write-Host '== server-console.log: full server log for this session (following; close the window to stop) =='; \
+                     Get-Content .\\server-console.log -Wait"
+                ),
+            ])
+            .creation_flags(CREATE_NEW_CONSOLE)
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| format!("spawn powershell: {e}"))
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        // No universal Linux terminal. Try the common emulators — each with
+        // its own execute-argument dialect — first successful spawn wins;
+        // with none present, degrade to the file manager on the logs dir
+        // (still a working "show me the logs", just not a live tail).
+        let cmd = format!(
+            "cd {dir}; echo '== launcher.log =='; tail -n 50 launcher.log 2>/dev/null; echo; echo '== server-console.log: full server log for this session (following; Ctrl+C to stop) =='; exec tail -n +1 -F server-console.log",
+            dir = sh_quote(logs_dir)
+        );
+        let candidates = [
+            ("x-terminal-emulator", ["-e", "sh", "-c", cmd.as_str()]),
+            ("gnome-terminal", ["--", "sh", "-c", cmd.as_str()]),
+            ("konsole", ["-e", "sh", "-c", cmd.as_str()]),
+            ("xfce4-terminal", ["-x", "sh", "-c", cmd.as_str()]),
+            ("xterm", ["-e", "sh", "-c", cmd.as_str()]),
+        ];
+        for (bin, args) in candidates {
+            if std::process::Command::new(bin).args(args).spawn().is_ok() {
+                return Ok(());
+            }
+        }
+        std::process::Command::new("xdg-open")
+            .arg(logs_dir)
+            .spawn()
+            .map(|_| ())
+            .map_err(|_| {
+                "no terminal emulator found (tried x-terminal-emulator, gnome-terminal, \
+                 konsole, xfce4-terminal, xterm) and xdg-open failed"
+                    .to_string()
+            })
+    }
+}
+
+/// POSIX single-quote a path for embedding in `sh -c` text — the macOS data
+/// home ("Application Support") guarantees a space.
+#[cfg(unix)]
+fn sh_quote(p: &std::path::Path) -> String {
+    format!("'{}'", p.display().to_string().replace('\'', "'\\''"))
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    #[test]
+    #[ignore = "spawns a real Terminal window - run manually with --ignored"]
+    fn manual_open_logs_terminal() {
+        let dir = std::env::temp_dir().join("mstream-viewlogs-demo").join("logs");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("launcher.log"), "[demo] launcher.log content\n").unwrap();
+        std::fs::write(dir.join("server-console.log"), "[demo] server-console.log content\n").unwrap();
+        super::open_logs_terminal(&dir).unwrap();
+    }
+}

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -202,6 +202,7 @@ pub fn run(args: LauncherArgs) -> ! {
                 let qc_item = MenuItem::with_id("quick-connect", "Quick Connect", true, None);
                 let auto_item =
                     CheckMenuItem::with_id("autostart", "Start at login", true, autostart::is_enabled(), None);
+                let logs_item = MenuItem::with_id("logs", "View logs", true, None);
                 let restart_item = MenuItem::with_id("restart", "Restart server", true, None);
                 let quit_item = MenuItem::with_id("quit", "Quit mStream", true, None);
                 let _ = menu.append(&open_item);
@@ -209,6 +210,7 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&auto_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
+                let _ = menu.append(&logs_item);
                 let _ = menu.append(&restart_item);
                 let _ = menu.append(&quit_item);
                 autostart_item = Some(auto_item);
@@ -264,6 +266,14 @@ pub fn run(args: LauncherArgs) -> ! {
                             } else {
                                 log.line(&format!("autostart {}", if want { "enabled" } else { "disabled" }));
                             }
+                        }
+                    }
+                    "logs" => {
+                        // Support surface: "click View logs and read me what it
+                        // says" beats digging paths out of Application Support.
+                        log.line("menu: view logs");
+                        if let Err(e) = platform::open_logs_terminal(&logs_dir) {
+                            log.line(&format!("view logs failed: {e}"));
                         }
                     }
                     "restart" => {


### PR DESCRIPTION
Adds a **View logs** item to the tray menu (grouped with Restart server). Clicking it opens a terminal window showing a short tail of `launcher.log`, then `server-console.log` **from line 1**, followed live (`-F`, so the per-session rotation never ends the view).

## Why whole-file instead of fetching the admin live-log buffer

The admin panel's live-log viewer is backed by an in-memory ring (`src/logger.js` — a `MemoryRingTransport` attached to the same winston root logger as the Console transport). Under the tray, the launcher captures that exact console stream into `server-console.log` starting at server spawn — so from line 1 the terminal shows everything the admin viewer has, **uncapped** (the ring keeps the last N entries at 4 KB each), plus any early-boot lines the ring already evicted, with winston's colors rendering natively in the terminal. Fetching `/api/v1/admin/logs/recent` instead would add an auth dependency (the wall, once accounts exist) for a strict subset of the file. The doc comment on `open_logs_terminal` records this equivalence so future logger-transport changes know the terminal depends on it.

## Per-OS "what is a terminal"

- **macOS** — writes an executable `view-logs.command` into the logs dir and `open`s it: Terminal runs it as a document, avoiding the AppleEvents automation-consent prompt that scripting Terminal directly would trigger.
- **Windows** — `powershell -NoExit … Get-Content -Wait` in a `CREATE_NEW_CONSOLE` window (the GUI-subsystem launcher has no console of its own to lend).
- **Linux** — first of `x-terminal-emulator` / `gnome-terminal` / `konsole` / `xfce4-terminal` / `xterm` that spawns (each has its own exec-argument dialect); with no emulator at all it degrades to `xdg-open` on the logs directory.

Failures are logged and can never take the tray down.

## Verification

- macOS: real end-to-end — the ignored manual test (`cargo test -- --ignored manual_open_logs_terminal`) opens an actual Terminal window; verified both log sections render, plus a direct BSD `tail -n +1 -F` whole-file-then-follow check, plus a live click-through on a running 6.20.0 bundle.
- `cargo build` + `clippy -D warnings` + tests green on darwin and the `x86_64-pc-windows-msvc` target.
- Windows/Linux terminal spawns are compile-verified; the command shapes are standard (`Get-Content -Wait`, per-emulator exec args) — worth one manual click on each platform before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)