### PR TITLE
feat(launcher): left-click the tray icon for a Quick Connect QR popup

### DIFF
--- a/rust-launcher/Cargo.lock
+++ b/rust-launcher/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +94,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +134,16 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -244,6 +272,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "ctor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "dtor",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.7.4",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,16 +381,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -364,6 +438,12 @@ dependencies = [
  "memoffset",
  "rustc_version",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -566,6 +646,16 @@ dependencies = [
  "libc",
  "system-deps",
  "x11",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -931,6 +1021,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -988,6 +1089,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1106,12 @@ checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1033,6 +1150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,7 +1186,9 @@ dependencies = [
  "libc",
  "open",
  "png",
+ "qrcodegen",
  "serde_json",
+ "softbuffer",
  "tao",
  "tray-icon",
  "windows-sys 0.59.0",
@@ -1186,7 +1314,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -1231,7 +1359,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -1277,6 +1408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1441,18 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -1474,6 +1628,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcodegen"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4339fc7a1021c9c1621d87f5e3505f2805c8c105420ba2f2a4df86814590c142"
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1724,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1617,6 +1805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1827,37 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "softbuffer"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
+dependencies = [
+ "as-raw-xcb-connection",
+ "bytemuck",
+ "fastrand",
+ "js-sys",
+ "memmap2",
+ "ndk",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "raw-window-handle",
+ "redox_syscall",
+ "rustix",
+ "tiny-xlib",
+ "tracing",
+ "wasm-bindgen",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-sys",
+ "web-sys",
+ "windows-sys 0.61.2",
+ "x11rb",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1793,6 +2018,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-xlib"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
+dependencies = [
+ "as-raw-xcb-connection",
+ "ctor",
+ "libloading 0.8.9",
+ "pkg-config",
+ "tracing",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +2137,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+
+[[package]]
 name = "tray-icon"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2230,110 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -2298,6 +2656,27 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading 0.8.9",
+ "once_cell",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"

--- a/rust-launcher/Cargo.toml
+++ b/rust-launcher/Cargo.toml
@@ -20,7 +20,21 @@ path = "src/main.rs"
 # without xdotool installed — caught by the v6.20.0 tag smoke. The
 # remaining hard links are glibc + GTK3 only; CI asserts exactly that set.
 tray-icon = { version = "0.19", default-features = false }
-tao = "0.30"
+# rwh_06: the Quick Connect popup (qr_popup.rs) paints into a tao Window
+# through softbuffer, which speaks raw-window-handle 0.6 — tao implements
+# it behind this feature.
+tao = { version = "0.30", features = ["rwh_06"] }
+# The Quick Connect popup: a plain pixel surface on a tao window (no toolkit,
+# no GPU). default-features off drops the KMS/DRM backend everywhere and lets
+# each OS pick only its native blit path below — Windows = GDI via the
+# windows-sys we already carry, macOS = CoreGraphics via objc2 siblings of
+# what tray-icon already links, Linux = X11/Wayland DLOPENED (never hard-
+# linked; the NEEDED-set assert in CI stays satisfied).
+softbuffer = { version = "0.4", default-features = false }
+# QR encoder for the pairing code — the Rust port of the same Nayuki library
+# the web modal uses (webapp/assets/js/lib/qr.js), so both faces render an
+# identical symbol. Zero dependencies.
+qrcodegen = "1.8"
 # Login-item registration: HKCU Run key (Windows), LaunchAgent plist (macOS,
 # see set_use_launch_agent below — the AppleScript default would tie us to
 # System Events), XDG autostart .desktop (Linux). The launcher registers
@@ -47,6 +61,9 @@ windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_System_Console",
   "Win32_UI_WindowsAndMessaging",
+  # GetAsyncKeyState for the Quick Connect popup's click-outside dismiss
+  # (qr_popup.rs) — a tray-spawned window never gets focus on Windows.
+  "Win32_UI_Input_KeyboardAndMouse",
 ] }
 
 [build-dependencies]
@@ -61,6 +78,12 @@ serde_json = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+# softbuffer needs a display backend on Linux; the -dlopen variants load
+# libX11/libwayland-client at RUNTIME, so a machine missing one still runs
+# and — the part CI polices — the shipped binary gains no NEEDED entry.
+softbuffer = { version = "0.4", default-features = false, features = ["x11", "x11-dlopen", "wayland", "wayland-dlopen"] }
 
 [profile.release]
 strip = true

--- a/rust-launcher/src/main.rs
+++ b/rust-launcher/src/main.rs
@@ -18,6 +18,7 @@
 mod autostart;
 mod paths;
 mod platform;
+mod qr_popup;
 mod server;
 mod tray_app;
 

--- a/rust-launcher/src/qr_popup.rs
+++ b/rust-launcher/src/qr_popup.rs
@@ -1,0 +1,436 @@
+// The Quick Connect popup: left-click the tray icon and a small always-on-top
+// window appears next to it holding the pairing-code QR — scan it with the
+// mStream app and you're connected. No browser, no web UI to learn first.
+// (Right-click keeps the native menu, whose "Quick Connect" item still opens
+// the web modal for the copy-the-code path.)
+//
+// Why a hand-painted window and not a native menu item: every native menu
+// clamps item images to check-mark size (muda: 18px mac / 16px gtk; and
+// Win32 scales hbmpItem to SM_CXMENUCHECK — measured), and a v13 QR is 69
+// modules across. So it's a real window, painted as raw pixels through
+// softbuffer: no toolkit, no GPU, no font stack — a QR is squares, and the
+// two caption lines use a tiny embedded 5x7 bitmap font. The launcher's
+// dependency graph stays small on purpose (see Cargo.toml).
+//
+// Where the code comes from: GET /api/v1/iroh/code on the server's loopback
+// address — the SAME call the web modal makes. mayShareCode (src/api/iroh.js)
+// deliberately lets a loopback caller on a fresh accountless desktop install
+// have the code ("the owner's own browser, opened from the tray"); the tray
+// process is that same trust position. Zero new auth surface.
+use std::num::NonZeroU32;
+use std::rc::Rc;
+use tao::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
+use tao::event_loop::EventLoopWindowTarget;
+use tao::window::{Window, WindowBuilder};
+
+/// What the popup shows. Fetched fresh on every open — the code can change
+/// (config edit + restart) and Quick Connect can be off/unavailable.
+pub enum Content {
+    /// A pairing code to render as a QR.
+    Code(String),
+    /// Quick Connect is enabled but the tunnel isn't up (yet).
+    NotReady,
+    /// Quick Connect is disabled in the server config.
+    Disabled,
+    /// The server didn't answer (still booting, or stopped).
+    NoServer,
+}
+
+/// Fetch the pairing code from the running server. Plain HTTP/1.1 over a
+/// std TcpStream, same shape as server.rs's health probe — no HTTP crate.
+/// Bounded: 1.5s per phase, so a wedged server can't freeze the tray.
+pub fn fetch_content(ep: &crate::paths::Endpoint) -> Content {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+    // ep.ip is already the PROBE address (paths.rs: a pinned interface, else
+    // loopback for the wildcard default) — the same one the health prober
+    // uses, so the same mayShareCode loopback trust applies.
+    let addr = std::net::SocketAddr::new(ep.ip, ep.port);
+    let Ok(mut s) = TcpStream::connect_timeout(&addr, Duration::from_millis(1500)) else {
+        return Content::NoServer;
+    };
+    let _ = s.set_read_timeout(Some(Duration::from_millis(1500)));
+    let _ = s.set_write_timeout(Some(Duration::from_millis(1500)));
+    let req = format!(
+        "GET /api/v1/iroh/code HTTP/1.1\r\nHost: {addr}\r\nAccept: application/json\r\nConnection: close\r\n\r\n"
+    );
+    if s.write_all(req.as_bytes()).is_err() {
+        return Content::NoServer;
+    }
+    let mut buf = Vec::with_capacity(4096);
+    let _ = s.read_to_end(&mut buf);
+    let text = String::from_utf8_lossy(&buf);
+    let Some((head, body)) = text.split_once("\r\n\r\n") else {
+        return Content::NoServer;
+    };
+    if !head.lines().next().is_some_and(|l| l.contains(" 200")) {
+        return Content::NoServer;
+    }
+    // Chunked bodies (Express default for JSON) come with hex length lines
+    // — serde tolerates none of that, so trim to the outer braces.
+    let json = match (body.find('{'), body.rfind('}')) {
+        (Some(a), Some(b)) if b >= a => &body[a..=b],
+        _ => return Content::NoServer,
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Content::NoServer;
+    };
+    if v.get("enabled").and_then(|e| e.as_bool()) != Some(true) {
+        return Content::Disabled;
+    }
+    match v.get("code").and_then(|c| c.as_str()) {
+        Some(code) if !code.is_empty() => Content::Code(code.to_string()),
+        _ => Content::NotReady,
+    }
+}
+
+// ── Layout (logical pixels; painted at physical size via the scale factor).
+const QUIET: i32 = 3; // quiet-zone modules around the symbol
+const QR_TARGET_PX: u32 = 260; // logical px the symbol+quiet zone should span
+const PAD: u32 = 16;
+const HEADER_H: u32 = 30;
+const CAPTION_H: u32 = 44;
+const BG: u32 = 0x00_FF_FF_FF;
+const FG: u32 = 0x00_1A_1A_1A;
+const MUTED: u32 = 0x00_6B_6B_6B;
+const ACCENT: u32 = 0x00_E0_8A_00; // mStream orange
+
+pub struct Popup {
+    window: Rc<Window>,
+    surface: softbuffer::Surface<Rc<Window>, Rc<Window>>,
+    content: Content,
+    qr: Option<qrcodegen::QrCode>,
+    /// Windows click-outside detector state: set once the mouse button has
+    /// been released after the opening click (see clicked_outside).
+    #[cfg(windows)]
+    armed: bool,
+}
+
+impl Popup {
+    /// Build the window flush against the tray icon and paint it once.
+    /// `icon_rect` is the tray icon's screen rectangle in PHYSICAL pixels
+    /// (tray-icon's Click event carries it); `scale` converts to logical.
+    pub fn open<T: 'static>(
+        target: &EventLoopWindowTarget<T>,
+        content: Content,
+        icon_rect: Option<(PhysicalPosition<f64>, PhysicalSize<u32>)>,
+    ) -> Result<Popup, String> {
+        let qr = match &content {
+            Content::Code(c) => qrcodegen::QrCode::encode_text(c, qrcodegen::QrCodeEcc::Medium).ok(),
+            _ => None,
+        };
+        let (w, h) = (QR_TARGET_PX + 2 * PAD, HEADER_H + QR_TARGET_PX + CAPTION_H + PAD);
+        let mut b = WindowBuilder::new()
+            .with_title("mStream - Quick Connect")
+            .with_inner_size(LogicalSize::new(w as f64, h as f64))
+            .with_resizable(false)
+            .with_always_on_top(true)
+            .with_decorations(true);
+        #[cfg(target_os = "macos")]
+        {
+            // Menu-bar-extra manners: appear without yanking focus from the
+            // frontmost app or bouncing anything in the Dock.
+            use tao::platform::macos::WindowBuilderExtMacOS;
+            b = b.with_titlebar_transparent(false).with_title_hidden(false);
+        }
+        // Position: hug the tray icon, centered on it horizontally, and on
+        // whichever side of it has room — the OS does NOT clamp an explicit
+        // position for us (measured: a "below the icon" placement from a
+        // bottom taskbar put the whole body off-screen). Below when the bar
+        // is at the top (macOS menu bar, top-docked taskbars), above when
+        // it's at the bottom (Windows/most Linux panels); then clamp the x
+        // edges into the monitor. Physical-pixel math throughout, converted
+        // to logical only for the builder.
+        if let Some((pos, size)) = icon_rect {
+            let mon = target
+                .available_monitors()
+                .find(|m| {
+                    let p = m.position();
+                    let s = m.size();
+                    pos.x >= p.x as f64
+                        && pos.x < (p.x as f64 + s.width as f64)
+                        && pos.y >= p.y as f64
+                        && pos.y < (p.y as f64 + s.height as f64)
+                })
+                .or_else(|| target.primary_monitor());
+            let scale = mon.as_ref().map(|m| m.scale_factor()).unwrap_or(1.0);
+            let (mon_x, mon_y, mon_w, mon_h) = mon
+                .as_ref()
+                .map(|m| (m.position().x as f64, m.position().y as f64, m.size().width as f64, m.size().height as f64))
+                .unwrap_or((0.0, 0.0, f64::MAX, f64::MAX));
+            let (pw, ph) = ((w as f64) * scale, (h as f64) * scale); // popup, physical
+            let gap = 8.0 * scale;
+            let icon_cx = pos.x + size.width as f64 / 2.0;
+            let icon_bottom = pos.y + size.height as f64;
+            let below_fits = icon_bottom + gap + ph <= mon_y + mon_h;
+            let y = if below_fits { icon_bottom + gap } else { (pos.y - gap - ph).max(mon_y) };
+            let x = (icon_cx - pw / 2.0).clamp(mon_x, (mon_x + mon_w - pw).max(mon_x));
+            b = b.with_position(LogicalPosition::new(x / scale, y / scale));
+        }
+        let window = Rc::new(b.build(target).map_err(|e| format!("popup window: {e}"))?);
+        let context = softbuffer::Context::new(window.clone()).map_err(|e| format!("popup context: {e}"))?;
+        let surface =
+            softbuffer::Surface::new(&context, window.clone()).map_err(|e| format!("popup surface: {e}"))?;
+        // Take focus so that clicking anywhere else fires Focused(false) and
+        // dismisses us like a real flyout. Without this a tray-spawned window
+        // on Windows never becomes foreground (measured: clicks elsewhere left
+        // it up); we're allowed to claim it here because this runs inside the
+        // user's own click on our tray icon.
+        window.set_focus();
+        let mut p = Popup {
+            window,
+            surface,
+            content,
+            qr,
+            #[cfg(windows)]
+            armed: false,
+        };
+        p.paint();
+        Ok(p)
+    }
+
+    /// Windows-only click-outside detection. A tray-spawned window never
+    /// becomes foreground there (Windows' foreground lock refuses
+    /// SetForegroundWindow while Explorer owns the click — measured: no
+    /// Focused event ever arrives), so the mac/Linux "dismiss on
+    /// Focused(false)" path is unreachable. Do what the OS's own flyouts do:
+    /// while the popup is up, notice a primary-button press whose cursor is
+    /// outside our frame. Polled from the event loop at ~50ms ONLY while a
+    /// popup exists — zero cost the rest of the time.
+    #[cfg(windows)]
+    pub fn clicked_outside(&mut self) -> bool {
+        use windows_sys::Win32::Foundation::POINT;
+        use windows_sys::Win32::UI::Input::KeyboardAndMouse::{GetAsyncKeyState, VK_LBUTTON, VK_RBUTTON};
+        use windows_sys::Win32::UI::WindowsAndMessaging::GetCursorPos;
+        // GetAsyncKeyState: high bit = down right now; LOW bit = "was
+        // pressed since the last call" — a latch, so a click shorter than
+        // our 50ms poll interval can't slip between two polls (a fast click
+        // is down for ~10ms; measured: the pure high-bit test missed some).
+        let l = unsafe { GetAsyncKeyState(VK_LBUTTON as i32) } as u16;
+        let r = unsafe { GetAsyncKeyState(VK_RBUTTON as i32) } as u16;
+        let down_now = (l | r) & 0x8000 != 0;
+        let pressed_since = (l | r) & 0x0001 != 0;
+        // The click that OPENED us is itself "outside" (it's on the tray
+        // icon), and its press may still be latched/held on our first poll:
+        // arm only once we've observed the button fully released, and drain
+        // the latch as we do so.
+        if !self.armed {
+            if !down_now {
+                self.armed = true;
+            }
+            return false;
+        }
+        if !down_now && !pressed_since {
+            return false;
+        }
+        let mut pt = POINT { x: 0, y: 0 };
+        if unsafe { GetCursorPos(&mut pt) } == 0 {
+            return false;
+        }
+        let (Ok(pos), size) = (self.window.outer_position(), self.window.outer_size()) else {
+            return false;
+        };
+        let inside = pt.x >= pos.x
+            && pt.x < pos.x + size.width as i32
+            && pt.y >= pos.y
+            && pt.y < pos.y + size.height as i32;
+        !inside
+    }
+
+    pub fn window_id(&self) -> tao::window::WindowId {
+        self.window.id()
+    }
+
+    pub fn request_redraw(&self) {
+        self.window.request_redraw();
+    }
+
+    /// Paint the whole surface. Everything is integer pixel math on a flat
+    /// 0RGB buffer — deliberately dumb and dependency-free.
+    pub fn paint(&mut self) {
+        let size = self.window.inner_size();
+        let (pw, ph) = (size.width as usize, size.height as usize);
+        let (Some(nw), Some(nh)) = (NonZeroU32::new(pw as u32), NonZeroU32::new(ph as u32)) else {
+            return;
+        };
+        if self.surface.resize(nw, nh).is_err() {
+            return;
+        }
+        let Ok(mut buf) = self.surface.buffer_mut() else { return };
+        let scale = self.window.scale_factor();
+        let px = |logical: u32| ((logical as f64) * scale).round() as usize;
+        let mut c = Canvas { buf: &mut buf, w: pw, h: ph };
+        c.fill(BG);
+
+        // Header: accent rule + title.
+        c.rect(0, 0, pw, px(3), ACCENT);
+        let title_scale = if scale >= 1.5 { 3 } else { 2 };
+        c.text_centered(pw, px(9), "mStream Quick Connect", FG, title_scale);
+
+        let qr_top = px(HEADER_H);
+        let qr_left = px(PAD);
+        let qr_side = px(QR_TARGET_PX);
+        match (&self.content, &self.qr) {
+            (Content::Code(_), Some(qr)) => {
+                let modules = qr.size() + 2 * QUIET;
+                let cell = (qr_side / modules as usize).max(1);
+                let drawn = cell * modules as usize;
+                let off = (qr_side.saturating_sub(drawn)) / 2; // center the integer-cell symbol
+                for my in -QUIET..(qr.size() + QUIET) {
+                    for mx in -QUIET..(qr.size() + QUIET) {
+                        if qr.get_module(mx, my) {
+                            let x = qr_left + off + ((mx + QUIET) as usize) * cell;
+                            let y = qr_top + off + ((my + QUIET) as usize) * cell;
+                            c.rect(x, y, cell, cell, FG);
+                        }
+                    }
+                }
+                let cap_y = qr_top + qr_side + px(10);
+                c.text_centered(pw, cap_y, "Scan with the mStream app", FG, 2);
+                c.text_centered(pw, cap_y + px(18), "Right-click icon for menu", MUTED, 1);
+            }
+            _ => {
+                // State card in place of the symbol.
+                c.rect_outline(qr_left, qr_top, qr_side, qr_side, MUTED);
+                // Lines sized to fit the 260px card at 2x/1x (5x7 font, 6px
+                // advance): <= 21 chars at 2x, <= 42 at 1x.
+                let (l1, l2, l3) = match self.content {
+                    Content::NotReady => ("Quick Connect starting", "The tunnel isn't up yet.", "Try again in a moment."),
+                    Content::Disabled => ("Quick Connect is off", "Turn it on in the admin panel", "or scan the LAN in the app."),
+                    Content::NoServer | Content::Code(_) => ("Server not answering", "It may still be starting.", "See View logs in the menu."),
+                };
+                let mid = qr_top + qr_side / 2;
+                c.text_centered(pw, mid - px(18), l1, FG, 2);
+                c.text_centered(pw, mid + px(4), l2, MUTED, 1);
+                c.text_centered(pw, mid + px(14), l3, MUTED, 1);
+            }
+        }
+        let _ = buf.present();
+    }
+}
+
+/// Minimal raster helpers over the softbuffer pixel slice.
+struct Canvas<'a> {
+    buf: &'a mut [u32],
+    w: usize,
+    h: usize,
+}
+
+impl Canvas<'_> {
+    fn fill(&mut self, color: u32) {
+        self.buf.fill(color);
+    }
+    fn rect(&mut self, x: usize, y: usize, w: usize, h: usize, color: u32) {
+        for yy in y..(y + h).min(self.h) {
+            let row = yy * self.w;
+            for xx in x..(x + w).min(self.w) {
+                self.buf[row + xx] = color;
+            }
+        }
+    }
+    fn rect_outline(&mut self, x: usize, y: usize, w: usize, h: usize, color: u32) {
+        self.rect(x, y, w, 1, color);
+        self.rect(x, y + h - 1, w, 1, color);
+        self.rect(x, y, 1, h, color);
+        self.rect(x + w - 1, y, 1, h, color);
+    }
+    /// Text centered horizontally in a `width`-px row.
+    fn text_centered(&mut self, width: usize, y: usize, s: &str, color: u32, scale: usize) {
+        let text_w = s.chars().count() * 6 * scale;
+        let x = width.saturating_sub(text_w) / 2;
+        self.text(x, y, s, color, scale);
+    }
+    /// 5x7 bitmap text at an integer scale; unknown chars render as space.
+    fn text(&mut self, x: usize, y: usize, s: &str, color: u32, scale: usize) {
+        let mut cx = x;
+        for ch in s.chars() {
+            let glyph = font5x7(ch);
+            for (row, bits) in glyph.iter().enumerate() {
+                for col in 0..5 {
+                    if bits & (0b10000 >> col) != 0 {
+                        self.rect(cx + col * scale, y + row * scale, scale, scale, color);
+                    }
+                }
+            }
+            cx += 6 * scale;
+        }
+    }
+}
+
+/// A 5x7 font for the handful of caption strings above. Each glyph is seven
+/// rows of five bits, MSB = leftmost column. Printable ASCII subset that the
+/// captions use; anything else is a blank cell. (Classic public-domain
+/// 5x7 shapes as used by countless LCD/LED libraries.)
+fn font5x7(ch: char) -> [u8; 7] {
+    match ch {
+        'A' => [0x0E, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11],
+        'B' => [0x1E, 0x11, 0x11, 0x1E, 0x11, 0x11, 0x1E],
+        'C' => [0x0E, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0E],
+        'D' => [0x1E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1E],
+        'E' => [0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x1F],
+        'F' => [0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x10],
+        'G' => [0x0E, 0x11, 0x10, 0x17, 0x11, 0x11, 0x0F],
+        'H' => [0x11, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11],
+        'I' => [0x0E, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0E],
+        'J' => [0x07, 0x02, 0x02, 0x02, 0x02, 0x12, 0x0C],
+        'K' => [0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11],
+        'L' => [0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1F],
+        'M' => [0x11, 0x1B, 0x15, 0x15, 0x11, 0x11, 0x11],
+        'N' => [0x11, 0x11, 0x19, 0x15, 0x13, 0x11, 0x11],
+        'O' => [0x0E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E],
+        'P' => [0x1E, 0x11, 0x11, 0x1E, 0x10, 0x10, 0x10],
+        'Q' => [0x0E, 0x11, 0x11, 0x11, 0x15, 0x12, 0x0D],
+        'R' => [0x1E, 0x11, 0x11, 0x1E, 0x14, 0x12, 0x11],
+        'S' => [0x0F, 0x10, 0x10, 0x0E, 0x01, 0x01, 0x1E],
+        'T' => [0x1F, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04],
+        'U' => [0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E],
+        'V' => [0x11, 0x11, 0x11, 0x11, 0x11, 0x0A, 0x04],
+        'W' => [0x11, 0x11, 0x11, 0x15, 0x15, 0x15, 0x0A],
+        'X' => [0x11, 0x11, 0x0A, 0x04, 0x0A, 0x11, 0x11],
+        'Y' => [0x11, 0x11, 0x11, 0x0A, 0x04, 0x04, 0x04],
+        'Z' => [0x1F, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1F],
+        'a' => [0x00, 0x00, 0x0E, 0x01, 0x0F, 0x11, 0x0F],
+        'b' => [0x10, 0x10, 0x16, 0x19, 0x11, 0x11, 0x1E],
+        'c' => [0x00, 0x00, 0x0E, 0x10, 0x10, 0x11, 0x0E],
+        'd' => [0x01, 0x01, 0x0D, 0x13, 0x11, 0x11, 0x0F],
+        'e' => [0x00, 0x00, 0x0E, 0x11, 0x1F, 0x10, 0x0E],
+        'f' => [0x06, 0x09, 0x08, 0x1C, 0x08, 0x08, 0x08],
+        'g' => [0x00, 0x0F, 0x11, 0x11, 0x0F, 0x01, 0x0E],
+        'h' => [0x10, 0x10, 0x16, 0x19, 0x11, 0x11, 0x11],
+        'i' => [0x04, 0x00, 0x0C, 0x04, 0x04, 0x04, 0x0E],
+        'j' => [0x02, 0x00, 0x06, 0x02, 0x02, 0x12, 0x0C],
+        'k' => [0x10, 0x10, 0x12, 0x14, 0x18, 0x14, 0x12],
+        'l' => [0x0C, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0E],
+        'm' => [0x00, 0x00, 0x1A, 0x15, 0x15, 0x11, 0x11],
+        'n' => [0x00, 0x00, 0x16, 0x19, 0x11, 0x11, 0x11],
+        'o' => [0x00, 0x00, 0x0E, 0x11, 0x11, 0x11, 0x0E],
+        'p' => [0x00, 0x00, 0x1E, 0x11, 0x1E, 0x10, 0x10],
+        'q' => [0x00, 0x00, 0x0D, 0x13, 0x0F, 0x01, 0x01],
+        'r' => [0x00, 0x00, 0x16, 0x19, 0x10, 0x10, 0x10],
+        's' => [0x00, 0x00, 0x0E, 0x10, 0x0E, 0x01, 0x1E],
+        't' => [0x08, 0x08, 0x1C, 0x08, 0x08, 0x09, 0x06],
+        'u' => [0x00, 0x00, 0x11, 0x11, 0x11, 0x13, 0x0D],
+        'v' => [0x00, 0x00, 0x11, 0x11, 0x11, 0x0A, 0x04],
+        'w' => [0x00, 0x00, 0x11, 0x11, 0x15, 0x15, 0x0A],
+        'x' => [0x00, 0x00, 0x11, 0x0A, 0x04, 0x0A, 0x11],
+        'y' => [0x00, 0x00, 0x11, 0x11, 0x0F, 0x01, 0x0E],
+        'z' => [0x00, 0x00, 0x1F, 0x02, 0x04, 0x08, 0x1F],
+        '0' => [0x0E, 0x11, 0x13, 0x15, 0x19, 0x11, 0x0E],
+        '1' => [0x04, 0x0C, 0x04, 0x04, 0x04, 0x04, 0x0E],
+        '2' => [0x0E, 0x11, 0x01, 0x02, 0x04, 0x08, 0x1F],
+        '3' => [0x1F, 0x02, 0x04, 0x02, 0x01, 0x11, 0x0E],
+        '4' => [0x02, 0x06, 0x0A, 0x12, 0x1F, 0x02, 0x02],
+        '5' => [0x1F, 0x10, 0x1E, 0x01, 0x01, 0x11, 0x0E],
+        '6' => [0x06, 0x08, 0x10, 0x1E, 0x11, 0x11, 0x0E],
+        '7' => [0x1F, 0x01, 0x02, 0x04, 0x08, 0x08, 0x08],
+        '8' => [0x0E, 0x11, 0x11, 0x0E, 0x11, 0x11, 0x0E],
+        '9' => [0x0E, 0x11, 0x11, 0x0F, 0x01, 0x02, 0x0C],
+        '-' => [0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00],
+        '\'' => [0x0C, 0x04, 0x08, 0x00, 0x00, 0x00, 0x00],
+        ',' => [0x00, 0x00, 0x00, 0x00, 0x0C, 0x04, 0x08],
+        '.' => [0x00, 0x00, 0x00, 0x00, 0x00, 0x0C, 0x0C],
+        '>' => [0x08, 0x04, 0x02, 0x01, 0x02, 0x04, 0x08],
+        _ => [0; 7],
+    }
+}

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -7,16 +7,16 @@
 // the EventLoopProxy. The server child lives in an Arc<Mutex<...>> shared
 // with the watcher; a generation counter keeps a stale watcher (from before
 // a restart) from reporting the new child's state.
-use crate::{autostart, paths, platform, server, LauncherArgs};
+use crate::{autostart, paths, platform, qr_popup, server, LauncherArgs};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tao::event::{Event, StartCause};
+use tao::event::{Event, StartCause, WindowEvent};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
 use tray_icon::menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem};
-use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
+use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 
 const STOP_GRACE: Duration = Duration::from_secs(8);
 const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
@@ -24,6 +24,8 @@ const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
 #[derive(Debug)]
 enum AppEvent {
     Menu(String),
+    /// Left-click on the tray icon (physical-pixel icon rect: position, size).
+    TrayClick(tao::dpi::PhysicalPosition<f64>, tao::dpi::PhysicalSize<u32>),
     ServerUp(u64),
     ServerExited(u64),
 }
@@ -161,6 +163,20 @@ pub fn run(args: LauncherArgs) -> ! {
             let _ = proxy.send_event(AppEvent::Menu(event.id().0.clone()));
         }));
     }
+    {
+        // Left-click = the Quick Connect popup (qr_popup.rs); the native menu
+        // stays on right-click (with_menu_on_left_click(false) below). Only
+        // the release edge, so a click doesn't fire twice; the icon rect
+        // rides along so the popup can hug the icon.
+        let proxy = proxy.clone();
+        TrayIconEvent::set_event_handler(Some(move |event: TrayIconEvent| {
+            if let TrayIconEvent::Click { button: MouseButton::Left, button_state: MouseButtonState::Up, rect, .. } =
+                event
+            {
+                let _ = proxy.send_event(AppEvent::TrayClick(rect.position, rect.size));
+            }
+        }));
+    }
 
     match spawn_generation(&shared, &bin, &args.server_args, &server_log, ep, &proxy, &log) {
         Ok(()) => {}
@@ -177,6 +193,9 @@ pub fn run(args: LauncherArgs) -> ! {
     // State owned by the loop closure.
     let mut tray: Option<TrayIcon> = None;
     let mut autostart_item: Option<CheckMenuItem> = None;
+    // The Quick Connect popup, while one is showing. At most one; a second
+    // left-click while it's up closes it (toggle), like every OS flyout.
+    let mut popup: Option<qr_popup::Popup> = None;
     let mut ever_up = false;
     let mut opened = false;
     let url = paths::server_url(&ep);
@@ -189,8 +208,22 @@ pub fn run(args: LauncherArgs) -> ! {
     // end), the player once music is configured.
     let config_loop = config.clone();
 
-    event_loop.run(move |event, _target, control_flow| {
+    event_loop.run(move |event, target, control_flow| {
         *control_flow = ControlFlow::Wait;
+        // Windows: while the Quick Connect popup is up, tick every 50ms to
+        // catch a click outside it (see Popup::clicked_outside for why the
+        // Focused(false) path can't do this there). Wait (no ticks) the
+        // moment it closes.
+        #[cfg(windows)]
+        if let Some(p) = popup.as_mut() {
+            if p.clicked_outside() {
+                log.line("tray click: quick connect popup dismissed (click outside)");
+                popup = None;
+            } else {
+                *control_flow =
+                    ControlFlow::WaitUntil(std::time::Instant::now() + Duration::from_millis(50));
+            }
+        }
         match event {
             // Tray creation belongs HERE, not before run(): on Linux the
             // tray needs the gtk main context tao initializes, and on macOS
@@ -226,6 +259,11 @@ pub fn run(args: LauncherArgs) -> ! {
                     TrayIconBuilder::new()
                         .with_tooltip("mStream Server")
                         .with_menu(Box::new(menu))
+                        // Left-click opens the Quick Connect popup instead of
+                        // the menu — the flyout convention (Wi-Fi/volume on
+                        // Windows, every menu-bar extra on macOS). Right-
+                        // click still gets the full native menu.
+                        .with_menu_on_left_click(false)
                         .with_icon(load_icon())
                         .build()
                 }));
@@ -296,11 +334,39 @@ pub fn run(args: LauncherArgs) -> ! {
                         log.line("menu: quit");
                         shared_loop.quitting.store(true, Ordering::SeqCst);
                         stop_current(&shared_loop);
+                        popup.take();
                         tray.take(); // remove the icon before the process exits
                         *control_flow = ControlFlow::Exit;
                     }
                     _ => {}
                 },
+                AppEvent::TrayClick(pos, size) => {
+                    if popup.take().is_some() {
+                        // Toggle: clicking the icon while the popup is up
+                        // dismisses it (dropping the Popup closes its window).
+                        log.line("tray click: quick connect popup closed");
+                    } else {
+                        let content = qr_popup::fetch_content(&ep);
+                        log.line(&format!(
+                            "tray click: quick connect popup ({})",
+                            match content {
+                                qr_popup::Content::Code(_) => "code ready",
+                                qr_popup::Content::NotReady => "tunnel not ready",
+                                qr_popup::Content::Disabled => "quick connect disabled",
+                                qr_popup::Content::NoServer => "server not answering",
+                            }
+                        ));
+                        match qr_popup::Popup::open(target, content, Some((pos, size))) {
+                            Ok(p) => popup = Some(p),
+                            Err(e) => {
+                                // No window (weird display stack): fall back
+                                // to what the menu item does — the web modal.
+                                log.line(&format!("popup unavailable ({e}) - opening the web modal instead"));
+                                let _ = open::that_detached(format!("{url}/#quick-connect"));
+                            }
+                        }
+                    }
+                }
                 AppEvent::ServerUp(generation) => {
                     // The probe proved SOMETHING on the port speaks mStream —
                     // make sure it's OUR child and not a foreign instance the
@@ -350,6 +416,41 @@ pub fn run(args: LauncherArgs) -> ! {
                     }
                 }
             },
+            // The popup's window events. It is the only window this process
+            // ever creates, so any WindowEvent is its; the id check is a
+            // guard against a stale event for a popup already dropped.
+            Event::WindowEvent { window_id, event: we, .. }
+                if popup.as_ref().is_some_and(|p| p.window_id() == window_id) =>
+            {
+                match we {
+                    WindowEvent::CloseRequested | WindowEvent::Destroyed => {
+                        popup = None;
+                    }
+                    // Flyout manners: clicking anywhere else dismisses it.
+                    // (macOS/Linux — the popup does receive focus there. On
+                    // Windows it never does; the poll above covers it.)
+                    WindowEvent::Focused(false) => {
+                        popup = None;
+                    }
+                    WindowEvent::KeyboardInput { event, .. }
+                        if event.logical_key == tao::keyboard::Key::Escape =>
+                    {
+                        popup = None;
+                    }
+                    // Repaint on OS request (expose, DPI change, first show).
+                    WindowEvent::ScaleFactorChanged { .. } => {
+                        if let Some(p) = popup.as_mut() {
+                            p.request_redraw();
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Event::RedrawRequested(id) if popup.as_ref().is_some_and(|p| p.window_id() == id) => {
+                if let Some(p) = popup.as_mut() {
+                    p.paint();
+                }
+            }
             // macOS: re-clicking the running .app arrives as a reopen
             // AppleEvent (applicationShouldHandleReopen), never as a second
             // process — the single-instance lock never sees it, and the


### PR DESCRIPTION
## The onboarding moment

**Left-click the tray icon → the pairing-code QR appears right there.** Scan with the mStream app, done. No browser, no web UI to learn first. Right-click keeps the full native menu (its *Quick Connect* item still opens the web modal for the copy-the-code path).

Windows/macOS were the target audience for this (Linux gets it too, but wasn't the design driver).

## Why a painted window, not a menu item

Measured, not assumed: every native menu clamps item images to check-mark size — muda hard-caps at 18 px (mac) / 16 px (gtk), and on Windows muda passes the full bitmap via `hbmpItem` but Win32 scales it to `SM_CXMENUCHECK` anyway (I prototyped a 220 px QR item; it rendered as a 16 px icon). A v13 QR is 69 modules across. So: a tao window painted as raw pixels through **softbuffer** (no toolkit, no GPU, no font stack — captions via an embedded 5×7 bitmap font) with **qrcodegen** (the Rust port of the same Nayuki library the web modal uses, so both faces render the identical symbol; zero deps).

## Trust

The code comes from `GET /api/v1/iroh/code` on **loopback** — the same call the web modal makes. `mayShareCode` already grants loopback callers on a fresh accountless desktop install (its own comment: *"the owner's own browser, opened from the tray"*); the tray process is that same trust position. **Zero new auth surface.**

## Behavior — all measured on Windows against my live install
- Placed flush against the tray icon, on whichever side has room, clamped to the monitor. (Gotcha found: the OS does *not* clamp an explicit position — the naive "below the icon" put the whole body off-screen from a bottom taskbar.)
- **Toggle**: click the icon again to close · ✕ closes · Escape closes
- **Click-outside dismisses.** mac/Linux: `Focused(false)`. Windows: a tray-spawned window **never** gets focus (foreground lock — measured: `set_focus()` refused, no `Focused` event ever arrives), so a 50 ms poll — running *only* while the popup is up, zero cost otherwise — reads `GetAsyncKeyState`'s pressed-since latch + `GetCursorPos`, armed after the opening click's release. The latch matters: a plain "is the button down" test missed fast clicks that fell between polls (measured coin-flip); the latch made it 100%.
- **State cards** instead of a QR when the tunnel isn't up / Quick Connect is off / the server isn't answering (verified the last one live by killing the server under an open popup — launcher survived, card rendered on reopen). Window-creation failure falls back to the web modal.
- Survives the server dying/restarting underneath it.

## Deps
softbuffer with default features off — Windows = GDI via the windows-sys we already carry (+1 feature flag), mac = objc2 siblings of what tray-icon already links, Linux = X11/Wayland **dlopened**. Verified in a Debian container: **NEEDED set unchanged (glibc + GTK3 only)** — CI's assert stays satisfied. qrcodegen has zero deps. Lockfile grows by 38 entries, most of them softbuffer's Linux backends plus wasm-target crates that never compile for our targets. Binary +~350 KB.

## Verification
- Windows: build + clippy `-D warnings` + 11/11 tests; full interactive matrix above on the live install
- Linux: builds clean in a Debian container, NEEDED audited (clippy runs in CI's ubuntu leg)
- **macOS**: needs the mac agent's hardware for two things I could not test — that the popup gets/loses focus normally as an `LSUIElement` accessory app (so `Focused(false)` dismisses), and Retina rendering (`paint` uses physical px via `inner_size`, so it should be crisp). Placement below the menu bar is the same code path as Windows-above-taskbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)