### PR TITLE
feat(release): manifest.json + one-line install scripts (P3 trust, part 2)

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -801,6 +801,47 @@ jobs:
           path: bundles
           merge-multiple: true
 
+      # manifest.json: the release's own inventory — version + sha256 per zip.
+      # install.sh / install.ps1 read it FIRST (to learn the exact asset name
+      # for their platform, then to verify the download), and the future
+      # launcher auto-updater will read the same file. Same shape as
+      # mstream-terminal-player's, so tooling that understands one
+      # understands both: {name, version, apiVersion, assets:[{file,sha256}]}.
+      # Bump apiVersion only on a breaking change to this shape.
+      - name: Generate sha256 manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd bundles
+          version="${GITHUB_REF_NAME#v}"
+          {
+            echo '{'
+            echo '  "name": "mstream",'
+            echo "  \"version\": \"${version}\","
+            echo '  "apiVersion": 1,'
+            echo '  "assets": ['
+            first=true
+            for f in mStream-*.zip; do
+              sum=$(sha256sum "$f" | cut -d' ' -f1)
+              $first || echo ','
+              first=false
+              printf '    {"file": "%s", "sha256": "%s"}' "$f" "$sum"
+            done
+            echo ''
+            echo '  ]'
+            echo '}'
+          } > manifest.json
+          cat manifest.json
+          # Every asset name must carry THIS version: the installers derive
+          # the filename from manifest.version, so a bundle built from a
+          # package.json that lags the tag would be un-installable.
+          for f in mStream-*.zip; do
+            case "$f" in
+              "mStream-${version}-"*) ;;
+              *) echo "::error::$f does not match tag version ${version} - package.json and the tag disagree"; exit 1 ;;
+            esac
+          done
+
       - name: Attach bundles to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -814,4 +855,4 @@ jobs:
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes --draft
           fi
-          gh release upload "$TAG" bundles/*.zip --clobber --repo "$REPO"
+          gh release upload "$TAG" bundles/*.zip bundles/manifest.json --clobber --repo "$REPO"

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -27,6 +27,11 @@ on:
       # to codesign. An entitlements-only PR without this filter would merge
       # with zero CI and first run on the release tag.
       - 'build/**'
+      # The install scripts + manifest generator have their own PR-time
+      # contract check (installer-contract job below).
+      - 'install.sh'
+      - 'install.ps1'
+      - 'scripts/release-manifest.sh'
   workflow_dispatch:
     inputs:
       notarize:
@@ -35,6 +40,123 @@ on:
         default: false
 
 jobs:
+  # ── The installers' contract with the manifest, checked on every PR. ─────
+  # The real manifest step only runs on tag builds, and install.sh parses the
+  # manifest with grep (no jq on a fresh box) — so a harmless-looking change
+  # to either side (pretty-printing the JSON, renaming a key, a shell
+  # portability slip) would ship broken and be found by users. This job
+  # builds fake bundles of the real SHAPE, generates a manifest with the real
+  # script, serves it locally, and runs each installer end to end against it:
+  # fetch → verify → extract → link → post-install proof. Fast (no bun build).
+  installer-contract:
+    name: installer contract (${{ matrix.os }})
+    if: github.event_name != 'push'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build fake bundles + real manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          sh -n install.sh
+          mkdir -p rel
+          # A fake bundle: the folder shape the installers expect, with a
+          # mstream-server that answers -V (the post-install proof) and a
+          # README. Every key, so the linux AND windows installer find theirs.
+          for key in win-x64 linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl darwin-x64 darwin-arm64; do
+            b="mStream-9.9.9-$key"; mkdir -p "rel/$b"
+            case "$key" in
+              win-*)  # a .cmd is not an .exe; the windows leg's proof runs a real tiny exe below
+                      printf 'fake' > "rel/$b/mstream-server.exe"; printf 'fake' > "rel/$b/mStream.exe" ;;
+              darwin-*) mkdir -p "rel/$b/mStream.app/Contents/MacOS"
+                      printf '#!/bin/sh\n[ "$1" = -V ] && echo 9.9.9\n' > "rel/$b/mStream.app/Contents/MacOS/mstream-server"; chmod +x "rel/$b/mStream.app/Contents/MacOS/mstream-server" ;;
+              *)      printf '#!/bin/sh\n[ "$1" = -V ] && echo 9.9.9\n' > "rel/$b/mstream-server"; chmod +x "rel/$b/mstream-server"
+                      printf '[Desktop Entry]\nExec=%%INSTALL_DIR%%/mstream-desktop\n' > "rel/$b/mStream.desktop" ;;
+            esac
+            echo "fake bundle" > "rel/$b/README.txt"
+            (cd rel && zip -qr "$b.zip" "$b" && rm -rf "$b")
+          done
+          sh scripts/release-manifest.sh 9.9.9 rel
+          # The manifest must be valid JSON with every asset — and the
+          # generator must REFUSE a zip whose name doesn't match the version.
+          node -e "const m=JSON.parse(require('fs').readFileSync('rel/manifest.json','utf8')); if(m.version!=='9.9.9'||m.assets.length!==7) process.exit(1); console.log('manifest ok:', m.assets.length, 'assets')"
+          cp rel/mStream-9.9.9-win-x64.zip rel/mStream-9.9.9-beta.1-win-x64.zip
+          if sh scripts/release-manifest.sh 9.9.9 rel 2>/dev/null; then echo "::error::generator accepted a prerelease-named zip for 9.9.9"; exit 1; fi
+          rm rel/mStream-9.9.9-beta.1-win-x64.zip
+          sh scripts/release-manifest.sh 9.9.9 rel
+
+      - name: Serve the fake release
+        shell: bash
+        run: |
+          (cd rel && python3 -m http.server 8765 --bind 127.0.0.1 >/dev/null 2>&1 &)
+          for i in $(seq 1 20); do curl -sf http://127.0.0.1:8765/manifest.json >/dev/null && break; sleep 0.5; done
+          curl -sf http://127.0.0.1:8765/manifest.json | head -3
+
+      - name: install.sh end to end (linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          export MSTREAM_RELEASE_BASE=http://127.0.0.1:8765
+          export MSTREAM_INSTALL_DIR="$RUNNER_TEMP/app" MSTREAM_BIN_DIR="$RUNNER_TEMP/bin"
+          export MSTREAM_NO_DESKTOP=1
+          sh install.sh | tee out.log
+          grep -q "mstream-server 9.9.9 runs" out.log
+          [ "$(readlink "$RUNNER_TEMP/app/current")" = "$RUNNER_TEMP/app/mStream-9.9.9-linux-x64" ]
+          [ -x "$RUNNER_TEMP/bin/mstream-server" ]
+          # same-version re-run: keep + short-circuit
+          echo keep > "$RUNNER_TEMP/app/mStream-9.9.9-linux-x64/STATE"
+          sh install.sh | grep -q "already installed"
+          [ -f "$RUNNER_TEMP/app/mStream-9.9.9-linux-x64/STATE" ]
+          # tampered manifest must refuse
+          sed -i 's/"sha256": "[0-9a-f]*"/"sha256": "0000000000000000000000000000000000000000000000000000000000000000"/' rel/manifest.json
+          if MSTREAM_FORCE=1 sh install.sh >/dev/null 2>&1; then echo "::error::installed despite bad hash"; exit 1; fi
+          # uninstall removes what was installed and nothing else
+          git checkout -- . 2>/dev/null || true
+          sh scripts/release-manifest.sh 9.9.9 rel
+          MSTREAM_UNINSTALL=1 sh install.sh | tee un.log
+          [ ! -e "$RUNNER_TEMP/app" ] && [ ! -e "$RUNNER_TEMP/bin/mstream-server" ]
+          grep -q "left in place" un.log
+          echo "install.sh contract OK"
+
+      - name: install.ps1 end to end (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'
+          # The fake win bundle needs a real exe for the -V proof: reuse the
+          # runner's own tiny "cmd /c" via a wrapper is not an exe either —
+          # so accept the proof warning path here and assert on the layout.
+          $env:MSTREAM_RELEASE_BASE = 'http://127.0.0.1:8765'
+          $env:MSTREAM_INSTALL_DIR = "$env:RUNNER_TEMP\app"
+          $env:MSTREAM_NO_DESKTOP = '1'; $env:MSTREAM_NO_PATH = '1'
+          & .\install.ps1 *>&1 | Tee-Object -Variable out
+          if (-not (Test-Path "$env:RUNNER_TEMP\app\mStream-9.9.9-win-x64\README.txt")) { throw "no install" }
+          $j = Get-Item "$env:RUNNER_TEMP\app\current" -Force
+          if (-not ($j.Attributes -band [IO.FileAttributes]::ReparsePoint)) { throw "current is not a junction" }
+          # same-version re-run keeps + short-circuits
+          Set-Content "$env:RUNNER_TEMP\app\mStream-9.9.9-win-x64\STATE" keep
+          $out2 = & .\install.ps1 *>&1 | Out-String
+          if ($out2 -notmatch 'already installed') { throw "no short-circuit" }
+          if (-not (Test-Path "$env:RUNNER_TEMP\app\mStream-9.9.9-win-x64\STATE")) { throw "state deleted on re-run" }
+          # tampered manifest refused
+          (Get-Content rel\manifest.json -Raw) -replace '"sha256": "[0-9a-f]*"', ('"sha256": "' + ('0' * 64) + '"') | Set-Content rel\manifest.json -NoNewline
+          $env:MSTREAM_FORCE = '1'
+          try { & .\install.ps1 *>&1 | Out-Null; throw "installed despite bad hash" } catch { if ("$_" -notmatch 'sha256 mismatch') { throw } }
+          $env:MSTREAM_FORCE = $null
+          # uninstall
+          $env:MSTREAM_UNINSTALL = '1'
+          & .\install.ps1 *>&1 | Tee-Object -Variable un
+          if (Test-Path "$env:RUNNER_TEMP\app") { throw "app root survived uninstall" }
+          if (($un | Out-String) -notmatch 'left in place') { throw "no data-home note" }
+          Write-Host "install.ps1 contract OK"
+
   build:
     name: ${{ matrix.key }}
     runs-on: ${{ matrix.os }}
@@ -801,46 +923,24 @@ jobs:
           path: bundles
           merge-multiple: true
 
-      # manifest.json: the release's own inventory — version + sha256 per zip.
-      # install.sh / install.ps1 read it FIRST (to learn the exact asset name
-      # for their platform, then to verify the download), and the future
-      # launcher auto-updater will read the same file. Same shape as
-      # mstream-terminal-player's, so tooling that understands one
-      # understands both: {name, version, apiVersion, assets:[{file,sha256}]}.
-      # Bump apiVersion only on a breaking change to this shape.
+      # manifest.json: the release's own inventory (scripts/release-manifest.sh
+      # — the SAME script the PR-time `installer-contract` job below runs, so
+      # the generator and the installers' parser cannot drift apart). It
+      # refuses unless every zip is exactly mStream-<tag-version>-<key>.zip:
+      # a lagging or prerelease package.json would otherwise ship bundles no
+      # installer can name.
+      - name: Check out (for scripts/release-manifest.sh)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: scripts/release-manifest.sh
+          sparse-checkout-cone-mode: false
+          path: src
+
       - name: Generate sha256 manifest
         shell: bash
         run: |
-          set -euo pipefail
-          cd bundles
-          version="${GITHUB_REF_NAME#v}"
-          {
-            echo '{'
-            echo '  "name": "mstream",'
-            echo "  \"version\": \"${version}\","
-            echo '  "apiVersion": 1,'
-            echo '  "assets": ['
-            first=true
-            for f in mStream-*.zip; do
-              sum=$(sha256sum "$f" | cut -d' ' -f1)
-              $first || echo ','
-              first=false
-              printf '    {"file": "%s", "sha256": "%s"}' "$f" "$sum"
-            done
-            echo ''
-            echo '  ]'
-            echo '}'
-          } > manifest.json
-          cat manifest.json
-          # Every asset name must carry THIS version: the installers derive
-          # the filename from manifest.version, so a bundle built from a
-          # package.json that lags the tag would be un-installable.
-          for f in mStream-*.zip; do
-            case "$f" in
-              "mStream-${version}-"*) ;;
-              *) echo "::error::$f does not match tag version ${version} - package.json and the tag disagree"; exit 1 ;;
-            esac
-          done
+          sh src/scripts/release-manifest.sh "${GITHUB_REF_NAME#v}" bundles
+          cat bundles/manifest.json
 
       - name: Attach bundles to the release
         env:
@@ -851,8 +951,20 @@ jobs:
         # can be reviewed and PUBLISHED manually (publishing is what fires the
         # downstream npm-publish / deploy-demo jobs), idempotent on same-tag
         # re-runs, then upload the bundles. A genuine create failure fails the job.
+        #
+        # Never touch a PUBLISHED release: a re-run of the tag workflow (Re-run
+        # all jobs, or a dispatch on the tag) would --clobber the zips and the
+        # manifest piecemeal — builds aren't byte-reproducible (fresh
+        # notarization ticket, zip mtimes), so for the ~5s window users mid-
+        # `curl | sh` get a sha256 mismatch, and if a leg failed the release is
+        # left half-new. Publishing is the point of no return; a genuine
+        # re-ship of a published version is a new patch tag.
         run: |
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes --draft
+          fi
+          if [ "$(gh release view "$TAG" --repo "$REPO" --json isDraft --jq .isDraft)" != "true" ]; then
+            echo "::error::release $TAG is already PUBLISHED - refusing to overwrite its assets. Ship a new patch version instead."
+            exit 1
           fi
           gh release upload "$TAG" bundles/*.zip bundles/manifest.json --clobber --repo "$REPO"

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -80,7 +80,12 @@ jobs:
                       printf '[Desktop Entry]\nExec=%%INSTALL_DIR%%/mstream-desktop\n' > "rel/$b/mStream.desktop" ;;
             esac
             echo "fake bundle" > "rel/$b/README.txt"
-            (cd rel && zip -qr "$b.zip" "$b" && rm -rf "$b")
+            # python's zipfile, not `zip`: the Windows runner's git-bash has
+            # no Info-ZIP, and python3 is on every runner. Unix mode bits
+            # don't survive this route, which is fine — install.sh chmods
+            # the binaries it knows about, exactly as it must for real
+            # bundles that crossed a mode-stripping hop.
+            (cd rel && python3 -m zipfile -c "$b.zip" "$b" && rm -rf "$b")
           done
           sh scripts/release-manifest.sh 9.9.9 rel
           # The manifest must be valid JSON with every asset — and the
@@ -110,9 +115,13 @@ jobs:
           grep -q "mstream-server 9.9.9 runs" out.log
           [ "$(readlink "$RUNNER_TEMP/app/current")" = "$RUNNER_TEMP/app/mStream-9.9.9-linux-x64" ]
           [ -x "$RUNNER_TEMP/bin/mstream-server" ]
-          # same-version re-run: keep + short-circuit
+          # same-version re-run: keep + short-circuit. Capture to a file, then
+          # grep: `sh install.sh | grep -q` closes the pipe on first match and
+          # the installer's later echo dies of EPIPE under set -e (measured:
+          # "echo: I/O error", a false failure).
           echo keep > "$RUNNER_TEMP/app/mStream-9.9.9-linux-x64/STATE"
-          sh install.sh | grep -q "already installed"
+          sh install.sh > rerun.log 2>&1
+          grep -q "already installed" rerun.log
           [ -f "$RUNNER_TEMP/app/mStream-9.9.9-linux-x64/STATE" ]
           # tampered manifest must refuse
           sed -i 's/"sha256": "[0-9a-f]*"/"sha256": "0000000000000000000000000000000000000000000000000000000000000000"/' rel/manifest.json

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,6 +10,38 @@ A bundle is a **folder**, not a single file: the desktop launcher, the server
 binary (`mstream-server`), `webapp/` (the UI), and `bin/` (sidecar binaries).
 Keep them together; the bundle itself can live anywhere.
 
+## Install with one command
+
+The install scripts pick the right bundle for your machine (OS, CPU, and on
+Linux glibc-vs-musl), verify its sha256 against the release's `manifest.json`,
+extract it into a versioned folder, and wire up a `mstream-server` command
+plus an app-menu / Start Menu / `~/Applications` entry. Re-running upgrades in
+place; your data is never inside the app folder, so it is never touched.
+
+```shell
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.ps1 | iex
+```
+
+Where things land: the app folders under `~/.local/share/mstream/app/`
+(Linux), `~/Library/Application Support/mStream/app/` (macOS), or
+`%LOCALAPPDATA%\Programs\mStream\` (Windows), with `current` pointing at the
+active version; the `mstream-server` command in `~/.local/bin` (Linux/macOS) or
+via the user PATH (Windows). Optional knobs, all environment variables:
+`MSTREAM_VERSION` (a tag like `v6.20.0`; default latest), `MSTREAM_INSTALL_DIR`,
+`MSTREAM_BIN_DIR` (unix), `MSTREAM_NO_PATH` (Windows), `MSTREAM_NO_DESKTOP`,
+and `MSTREAM_RELEASE_BASE` (a URL serving `manifest.json` + the zips, for
+internal mirrors). Older versions are kept beside `current` for rollback —
+delete them whenever you like.
+
+Prefer to do it by hand? Every release also lists the zips directly, with
+`manifest.json` holding their sha256s:
+
 **Just double-click it.** The desktop face of the bundle — `mStream.exe` on
 Windows, `mStream.app` on macOS, `mstream-desktop` on Linux — starts the
 server in the background, puts an mStream icon in your tray / menu bar

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,14 +33,23 @@ Where things land: the app folders under `~/.local/share/mstream/app/`
 `%LOCALAPPDATA%\Programs\mStream\` (Windows), with `current` pointing at the
 active version; the `mstream-server` command in `~/.local/bin` (Linux/macOS) or
 via the user PATH (Windows). Optional knobs, all environment variables:
-`MSTREAM_VERSION` (a tag like `v6.20.0`; default latest), `MSTREAM_INSTALL_DIR`,
-`MSTREAM_BIN_DIR` (unix), `MSTREAM_NO_PATH` (Windows), `MSTREAM_NO_DESKTOP`,
-and `MSTREAM_RELEASE_BASE` (a URL serving `manifest.json` + the zips, for
-internal mirrors). Older versions are kept beside `current` for rollback —
-delete them whenever you like.
+`MSTREAM_VERSION` (a tag; default latest — releases from v6.20.2 on carry the
+`manifest.json` the script needs), `MSTREAM_INSTALL_DIR`, `MSTREAM_BIN_DIR`
+(unix), `MSTREAM_NO_PATH` (Windows), `MSTREAM_NO_DESKTOP`, `MSTREAM_KEY` (unix:
+force a bundle key when auto-detection is wrong), `MSTREAM_FORCE` (replace an
+already-installed copy of the same version; the old one is moved aside), and
+`MSTREAM_RELEASE_BASE` (a URL serving `manifest.json` + the zips, for internal
+mirrors). Older versions are kept beside `current` for rollback — once mStream
+is no longer running from one, delete it whenever you like.
 
-Prefer to do it by hand? Every release also lists the zips directly, with
-`manifest.json` holding their sha256s:
+Re-running to upgrade re-points the app-menu / Start Menu entry and the
+login item at the new version, but never stops a running mStream: Quit it
+from the tray icon and start it again to switch. A copy you extracted by hand
+somewhere else (or run with `--portable`) is left untouched — the script only
+manages its own folder.
+
+Prefer to do it by hand? Every release from v6.20.2 on also lists the zips
+directly, with `manifest.json` holding their sha256s:
 
 **Just double-click it.** The desktop face of the bundle — `mStream.exe` on
 Windows, `mStream.app` on macOS, `mstream-desktop` on Linux — starts the

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,6 +48,11 @@ from the tray icon and start it again to switch. A copy you extracted by hand
 somewhere else (or run with `--portable`) is left untouched — the script only
 manages its own folder.
 
+To uninstall, run the same one-liner with `MSTREAM_UNINSTALL=1` set: it
+removes the app folders, the `mstream-server` command, the menu / Start Menu /
+`~/Applications` entry, and the login item — and leaves your library, config,
+and database in the data directory for you to keep or delete.
+
 Prefer to do it by hand? Every release from v6.20.2 on also lists the zips
 directly, with `manifest.json` holding their sha256s:
 

--- a/install.ps1
+++ b/install.ps1
@@ -17,6 +17,9 @@
 #                         GitHub release) - for internal mirrors and testing
 #   MSTREAM_FORCE         set to 1 to replace an already-installed copy of
 #                         the same version (the old one is moved aside)
+#   MSTREAM_UNINSTALL     set to 1 to remove everything this script installed
+#                         (app folders, PATH entry, Start Menu shortcut,
+#                         login item). Your data is left in place.
 #
 # The bundle is a folder (mStream.exe tray launcher + mstream-server.exe +
 # webapp\ + bin\ sidecars). Data lives in %LOCALAPPDATA%\mStream, outside
@@ -30,6 +33,10 @@
 $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor 3072
 
+# Everything below runs from Main, called on the LAST line: PowerShell parses
+# the whole function before executing any of it, so an `irm | iex` whose
+# stream is cut short fails to parse instead of running half an install.
+function Main {
 $repo = 'IrosTheBeggar/mStream'
 $key = 'win-x64'
 if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') {
@@ -48,6 +55,43 @@ $base = if ($env:MSTREAM_RELEASE_BASE) {
     "https://github.com/$repo/releases/latest/download"
 } else {
     "https://github.com/$repo/releases/download/$version"
+}
+
+# -- Uninstall: MSTREAM_UNINSTALL=1 removes everything this script created -
+# the app folders + junction, the PATH entry, the Start Menu shortcut, and
+# the login item - and nothing else. Your library, config, and database in
+# %LOCALAPPDATA%\mStream stay put; the last line says where.
+if ($env:MSTREAM_UNINSTALL) {
+    $running = @(Get-Process mStream, mstream-server -ErrorAction SilentlyContinue | Where-Object { $_.Path -like "$root\*" })
+    if ($running) { throw "mStream is running from $root - Quit it from the tray icon first, then re-run" }
+    $current = Join-Path $root 'current'
+    $launcher = Join-Path $current 'mStream.exe'
+    if (Test-Path $launcher) {
+        # Login item first, while a launcher still exists to remove it.
+        & $launcher --autostart=disable 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) { Write-Host "removed the login item" }
+    }
+    $lnk = Join-Path ([Environment]::GetFolderPath('Programs')) 'mStream.lnk'
+    if (Test-Path $lnk) { Remove-Item $lnk -Force; Write-Host "removed the Start Menu shortcut" }
+    $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+    try {
+        $rawPath = [string]$envKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $parts = @($rawPath -split ';' | Where-Object { $_ -and $_ -ne $current })
+        if (($rawPath -split ';') -contains $current) {
+            $envKey.SetValue('Path', ($parts -join ';'), [Microsoft.Win32.RegistryValueKind]::ExpandString)
+            Write-Host "removed $current from your user PATH"
+        }
+    } finally { $envKey.Close() }
+    if (Test-Path $current) {
+        # A junction: delete the link only, never the target's contents.
+        $item = Get-Item $current -Force
+        if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) { $item.Delete() }
+    }
+    if (Test-Path $root) { Remove-Item -Recurse -Force $root; Write-Host "removed $root" }
+    Write-Host "mStream is uninstalled. Your library, config, and database were left in place:"
+    Write-Host "  $env:LOCALAPPDATA\mStream"
+    Write-Host "  (delete that folder yourself if you want them gone too)"
+    return
 }
 
 $tmp = Join-Path $env:TEMP "mstream-install-$PID"
@@ -208,3 +252,6 @@ try {
 } finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }
+}
+
+Main

--- a/install.ps1
+++ b/install.ps1
@@ -33,6 +33,23 @@
 $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor 3072
 
+# Where the login item points right now, if anywhere. The launcher registers
+# ONE per-user login item by app name (HKCU\...\Run\mStream), so a second
+# copy of mStream on the machine - one the user extracted by hand, a
+# developer's checkout - shares the slot. This script only ever re-points
+# or removes a login item that points at a copy IT manages (under $root);
+# anything else is the user's and is left alone, and they are told so.
+function Get-LoginItemTarget {
+    $v = (Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name mStream -ErrorAction SilentlyContinue).mStream
+    if (-not $v) { return $null }
+    # The value is `"C:\path\mStream.exe" --autostarted`; take the quoted path.
+    if ($v -match '^"([^"]+)"') { return $Matches[1] } else { return ($v -split ' ')[0] }
+}
+function Test-LoginItemIsOurs([string]$root) {
+    $t = Get-LoginItemTarget
+    return [bool]($t -and $t.StartsWith("$root\", [StringComparison]::OrdinalIgnoreCase))
+}
+
 # Everything below runs from Main, called on the LAST line: PowerShell parses
 # the whole function before executing any of it, so an `irm | iex` whose
 # stream is cut short fails to parse instead of running half an install.
@@ -66,13 +83,17 @@ if ($env:MSTREAM_UNINSTALL) {
     if ($running) { throw "mStream is running from $root - Quit it from the tray icon first, then re-run" }
     $current = Join-Path $root 'current'
     $launcher = Join-Path $current 'mStream.exe'
-    if (Test-Path $launcher) {
-        # Login item first, while a launcher still exists to remove it.
-        # Best-effort: an exe that cannot start must not block the uninstall.
+    $rootAbs = if (Test-Path $root) { (Resolve-Path $root).Path } else { $root }
+    if ((Test-Path $launcher) -and (Test-LoginItemIsOurs $rootAbs)) {
+        # Login item first, while a launcher still exists to remove it -
+        # only if it points at a copy this script manages. Best-effort: an
+        # exe that cannot start must not block the uninstall.
         try {
             & $launcher --autostart=disable 2>$null | Out-Null
             if ($LASTEXITCODE -eq 0) { Write-Host "removed the login item" }
         } catch { Write-Warning "could not run the launcher to remove the login item ($($_.Exception.Message))" }
+    } elseif (Get-LoginItemTarget) {
+        Write-Host "left the login item alone - it points at $(Get-LoginItemTarget), which this script did not install"
     }
     $lnk = Join-Path ([Environment]::GetFolderPath('Programs')) 'mStream.lnk'
     if (Test-Path $lnk) { Remove-Item $lnk -Force; Write-Host "removed the Start Menu shortcut" }
@@ -201,9 +222,16 @@ try {
         try {
             $status = (& $launcher --autostart=status 2>$null | Out-String).Trim()
             if ($status -eq 'enabled') {
-                & $launcher --autostart=enable 2>$null | Out-Null
-                if ($LASTEXITCODE -eq 0) { Write-Host "  login item re-pointed at $ver" }
-                else { Write-Warning "could not re-point the login item - open mStream once to fix it" }
+                if (Test-LoginItemIsOurs $root) {
+                    & $launcher --autostart=enable 2>$null | Out-Null
+                    if ($LASTEXITCODE -eq 0) { Write-Host "  login item re-pointed at $ver" }
+                    else { Write-Warning "could not re-point the login item - open mStream once to fix it" }
+                } else {
+                    # Enabled, but for a copy we don't manage (hand-extracted, a
+                    # dev checkout). Its owner decides; the launcher's own logic
+                    # takes over the moment they open THIS copy and toggle it.
+                    Write-Warning "the login item points at $(Get-LoginItemTarget) (not managed by this script) - left as is; open the new mStream and toggle 'Start at login' to move it"
+                }
             }
         } catch {
             Write-Warning "could not run the launcher to re-point the login item ($($_.Exception.Message)) - open mStream once to fix it"

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,136 @@
+# Installs mStream on Windows.
+#
+#   irm https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.ps1 | iex
+#
+# Fetches the Windows bundle from the release, checks its sha256 against
+# the release's manifest.json, extracts it into a versioned folder under
+# %LOCALAPPDATA%\Programs\mStream, points a `current` junction at it, adds
+# a Start Menu shortcut, and puts the folder on the user PATH so
+# `mstream-server` works in any terminal. Configuration, all optional, via
+# environment variables (the pipe-to-iex form cannot take parameters):
+#
+#   MSTREAM_VERSION       a tag like v6.20.0 (default: latest)
+#   MSTREAM_INSTALL_DIR   root for the app folders
+#   MSTREAM_NO_PATH       set to 1 to leave PATH alone
+#   MSTREAM_NO_DESKTOP    set to 1 to skip the Start Menu shortcut
+#   MSTREAM_RELEASE_BASE  URL serving manifest.json + the zips (default: the
+#                         GitHub release) - for internal mirrors and testing
+#
+# The bundle is a folder (mStream.exe tray launcher + mstream-server.exe +
+# webapp\ + bin\ sidecars). Data lives in %LOCALAPPDATA%\mStream, outside
+# the app folder, so re-running this to upgrade never touches your library.
+#
+# Windows PowerShell 5.1 is the floor. That is why TLS 1.2 is asked for by
+# hand (5.1 predates it being the default), and why this file is pure
+# ASCII: without a BOM, 5.1 reads UTF-8 as the ANSI codepage, where the
+# last byte of an em dash turns into a curly quote that PowerShell will
+# happily treat as a string terminator.
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor 3072
+
+$repo = 'IrosTheBeggar/mStream'
+$key = 'win-x64'
+if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') {
+    throw "no prebuilt bundle for $env:PROCESSOR_ARCHITECTURE - x64 only for now"
+}
+
+$version = if ($env:MSTREAM_VERSION) { $env:MSTREAM_VERSION } else { 'latest' }
+$root = if ($env:MSTREAM_INSTALL_DIR) {
+    $env:MSTREAM_INSTALL_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA 'Programs\mStream'
+}
+$base = if ($env:MSTREAM_RELEASE_BASE) {
+    $env:MSTREAM_RELEASE_BASE.TrimEnd('/')
+} elseif ($version -eq 'latest') {
+    "https://github.com/$repo/releases/latest/download"
+} else {
+    "https://github.com/$repo/releases/download/$version"
+}
+
+$tmp = Join-Path $env:TEMP "mstream-install-$PID"
+New-Item -ItemType Directory -Force $tmp | Out-Null
+try {
+    # The manifest first: it names the exact zip for this version, so the
+    # script never guesses the version number embedded in the filename.
+    Write-Host "fetching manifest ($version)..."
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/manifest.json" -OutFile (Join-Path $tmp 'manifest.json')
+    $manifest = Get-Content (Join-Path $tmp 'manifest.json') -Raw | ConvertFrom-Json
+    if (-not $manifest.version) { throw 'manifest.json is missing a version - refusing to install' }
+    $ver = $manifest.version
+    $bundle = "mStream-$ver-$key"
+    $asset = "$bundle.zip"
+    $expected = ($manifest.assets | Where-Object file -eq $asset).sha256
+    if (-not $expected) {
+        throw "manifest.json has no entry for $asset - this release has no Windows bundle"
+    }
+
+    Write-Host "fetching $asset..."
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/$asset" -OutFile (Join-Path $tmp $asset)
+    $actual = (Get-FileHash -Algorithm SHA256 (Join-Path $tmp $asset)).Hash.ToLower()
+    if ($actual -ne $expected) {
+        throw "sha256 mismatch for $asset - download corrupted, not installing (expected $expected, got $actual)"
+    }
+
+    # Extract beside the final location, then rename into place: a killed
+    # install leaves a stray .partial folder, never a half-written `current`.
+    New-Item -ItemType Directory -Force $root | Out-Null
+    $partial = Join-Path $root "$bundle.partial"
+    $final = Join-Path $root $bundle
+    if (Test-Path $partial) { Remove-Item -Recurse -Force $partial }
+    Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $partial -Force
+    if (Test-Path $final) {
+        # A running launcher holds files open; stopping it is the user's
+        # call (tray > Quit), so say why instead of a cryptic access error.
+        try { Remove-Item -Recurse -Force $final } catch {
+            throw "could not replace $final - if mStream is running, Quit it from the tray icon and re-run"
+        }
+    }
+    Move-Item (Join-Path $partial $bundle) $final
+    Remove-Item -Recurse -Force $partial
+
+    # `current` as a junction (no admin needed, unlike a symlink), so a
+    # shortcut and the PATH entry keep working across upgrades.
+    $current = Join-Path $root 'current'
+    if (Test-Path $current) { (Get-Item $current).Delete() }
+    New-Item -ItemType Junction -Path $current -Target $final | Out-Null
+
+    Write-Host "installed mStream $ver to $final"
+    # Proof the binary execs here: commander's -V is instant and boots nothing.
+    try {
+        $v = & (Join-Path $final 'mstream-server.exe') -V 2>&1
+        if ($LASTEXITCODE -eq 0 -and $v) { Write-Host "  mstream-server $v runs" }
+        else { Write-Warning "the server did not run cleanly ($v) - see $final\README.txt" }
+    } catch { Write-Warning "the server did not run: $($_.Exception.Message)" }
+
+    if (-not $env:MSTREAM_NO_DESKTOP) {
+        # Start Menu shortcut to the tray launcher (mStream.exe), which is
+        # the double-click experience: background server + tray + browser.
+        $programs = [Environment]::GetFolderPath('Programs')
+        $shell = New-Object -ComObject WScript.Shell
+        $lnk = $shell.CreateShortcut((Join-Path $programs 'mStream.lnk'))
+        $lnk.TargetPath = Join-Path $current 'mStream.exe'
+        $lnk.WorkingDirectory = $current
+        $lnk.Description = 'mStream music server'
+        $lnk.Save()
+        Write-Host "  Start Menu: mStream (tray icon; Quick Connect on)"
+    }
+    Write-Host "  headless: mstream-server   (data lives in $env:LOCALAPPDATA\mStream, not the app folder)"
+
+    if (-not $env:MSTREAM_NO_PATH) {
+        # The user PATH in the registry, not this session's: an installer
+        # that edits $env:PATH improves exactly one window's life.
+        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        if (($userPath -split ';') -notcontains $current) {
+            [Environment]::SetEnvironmentVariable('Path', "$userPath;$current", 'User')
+            Write-Host "  added $current to your user PATH - new terminals will see mstream-server"
+        }
+    }
+
+    $others = Get-ChildItem $root -Directory | Where-Object { $_.Name -like "mStream-*-$key" -and $_.Name -ne $bundle }
+    if ($others) {
+        Write-Host "  older versions kept under $root - safe to delete any that aren't 'current'"
+    }
+} finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/install.ps1
+++ b/install.ps1
@@ -15,6 +15,8 @@
 #   MSTREAM_NO_DESKTOP    set to 1 to skip the Start Menu shortcut
 #   MSTREAM_RELEASE_BASE  URL serving manifest.json + the zips (default: the
 #                         GitHub release) - for internal mirrors and testing
+#   MSTREAM_FORCE         set to 1 to replace an already-installed copy of
+#                         the same version (the old one is moved aside)
 #
 # The bundle is a folder (mStream.exe tray launcher + mstream-server.exe +
 # webapp\ + bin\ sidecars). Data lives in %LOCALAPPDATA%\mStream, outside
@@ -54,10 +56,20 @@ try {
     # The manifest first: it names the exact zip for this version, so the
     # script never guesses the version number embedded in the filename.
     Write-Host "fetching manifest ($version)..."
-    Invoke-WebRequest -UseBasicParsing -Uri "$base/manifest.json" -OutFile (Join-Path $tmp 'manifest.json')
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri "$base/manifest.json" -OutFile (Join-Path $tmp 'manifest.json')
+    } catch {
+        throw ("could not fetch $base/manifest.json ($($_.Exception.Message)). " +
+               "Releases published before the installer existed have no manifest.json - " +
+               "pick a newer MSTREAM_VERSION, or download a bundle by hand from " +
+               "https://github.com/$repo/releases (see docs/install.md).")
+    }
     $manifest = Get-Content (Join-Path $tmp 'manifest.json') -Raw | ConvertFrom-Json
     if (-not $manifest.version) { throw 'manifest.json is missing a version - refusing to install' }
-    $ver = $manifest.version
+    $ver = [string]$manifest.version
+    # The version becomes a path component below: keep it to what a release
+    # tag can contain, so a bad manifest can't steer Remove-Item anywhere.
+    if ($ver -notmatch '^[0-9A-Za-z.\-]+$') { throw "manifest.json version '$ver' is not a plain version string - refusing" }
     $bundle = "mStream-$ver-$key"
     $asset = "$bundle.zip"
     $expected = ($manifest.assets | Where-Object file -eq $asset).sha256
@@ -72,30 +84,75 @@ try {
         throw "sha256 mismatch for $asset - download corrupted, not installing (expected $expected, got $actual)"
     }
 
-    # Extract beside the final location, then rename into place: a killed
-    # install leaves a stray .partial folder, never a half-written `current`.
     New-Item -ItemType Directory -Force $root | Out-Null
+    $root = (Resolve-Path $root).Path   # a relative MSTREAM_INSTALL_DIR would bake into the junction + PATH
     $partial = Join-Path $root "$bundle.partial"
     $final = Join-Path $root $bundle
-    if (Test-Path $partial) { Remove-Item -Recurse -Force $partial }
-    Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $partial -Force
-    if (Test-Path $final) {
-        # A running launcher holds files open; stopping it is the user's
-        # call (tray > Quit), so say why instead of a cryptic access error.
-        try { Remove-Item -Recurse -Force $final } catch {
-            throw "could not replace $final - if mStream is running, Quit it from the tray icon and re-run"
+    $current = Join-Path $root 'current'
+
+    # Which mStream is running right now, if any? Never stop it (that is the
+    # user's call, tray > Quit) - but never delete files under it either:
+    # Remove-Item -Recurse tears through bin\ and webapp\ before it reaches
+    # the locked exe, leaving a live server without its UI or sidecars. And
+    # after an upgrade, that instance keeps running the OLD version until
+    # restarted, which the summary must say plainly.
+    $runningFrom = @(Get-Process mStream, mstream-server -ErrorAction SilentlyContinue |
+        Where-Object { $_.Path } | ForEach-Object { Split-Path $_.Path } | Sort-Object -Unique)
+
+    $installedFresh = $false
+    if ((Test-Path $final) -and -not $env:MSTREAM_FORCE) {
+        # Same version already installed: leave it ALONE (it may be live,
+        # and under --portable it holds the user's config and database).
+        # Re-point the links and shortcuts, nothing more.
+        Write-Host "mStream $ver is already installed at $final - keeping it (set MSTREAM_FORCE=1 to replace)"
+    } else {
+        if ($runningFrom -contains $final) {
+            throw "mStream is running from $final - Quit it from the tray icon and re-run to replace this version"
         }
+        # Extract beside the final location, then rename into place: a killed
+        # install leaves a stray .partial folder, never a half-written `current`.
+        if (Test-Path $partial) { Remove-Item -Recurse -Force $partial }
+        Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $partial -Force
+        if (Test-Path $final) {
+            # Forced replace: MOVE the old copy aside (never rm), so
+            # whatever state it held survives at a findable name.
+            $aside = "$final.replaced-$(Get-Date -Format yyyyMMddHHmmss)"
+            Move-Item $final $aside
+            Write-Host "  previous copy moved to $aside"
+        }
+        Move-Item (Join-Path $partial $bundle) $final
+        Remove-Item -Recurse -Force $partial
+        $installedFresh = $true
     }
-    Move-Item (Join-Path $partial $bundle) $final
-    Remove-Item -Recurse -Force $partial
 
     # `current` as a junction (no admin needed, unlike a symlink), so a
-    # shortcut and the PATH entry keep working across upgrades.
-    $current = Join-Path $root 'current'
-    if (Test-Path $current) { (Get-Item $current).Delete() }
+    # shortcut and the PATH entry keep working across upgrades. A REAL
+    # directory named current (older manual layout) is moved aside, not
+    # nested into. Deleting a junction removes only the link, never the
+    # target's contents.
+    if (Test-Path $current) {
+        $item = Get-Item $current -Force
+        if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) { $item.Delete() }
+        else { Move-Item $current "$current.was-a-directory-$(Get-Date -Format yyyyMMddHHmmss)" }
+    }
     New-Item -ItemType Junction -Path $current -Target $final | Out-Null
 
-    Write-Host "installed mStream $ver to $final"
+    if ($installedFresh) { Write-Host "installed mStream $ver to $final" }
+
+    # The launcher registers ITSELF as the login item (HKCU Run) by absolute
+    # path - the VERSIONED folder, not current - so an upgrade would never
+    # reach the login item: next boot silently starts the OLD version. Ask
+    # the NEW launcher to re-register (its --autostart CLI runs with no
+    # tray/window/server), only if the user has it enabled.
+    $launcher = Join-Path $current 'mStream.exe'
+    if ($installedFresh -and (Test-Path $launcher)) {
+        $status = (& $launcher --autostart=status 2>$null | Out-String).Trim()
+        if ($status -eq 'enabled') {
+            & $launcher --autostart=enable 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) { Write-Host "  login item re-pointed at $ver" }
+            else { Write-Warning "could not re-point the login item - open mStream once to fix it" }
+        }
+    }
     # Proof the binary execs here: commander's -V is instant and boots nothing.
     try {
         $v = & (Join-Path $final 'mstream-server.exe') -V 2>&1
@@ -119,17 +176,34 @@ try {
 
     if (-not $env:MSTREAM_NO_PATH) {
         # The user PATH in the registry, not this session's: an installer
-        # that edits $env:PATH improves exactly one window's life.
-        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-        if (($userPath -split ';') -notcontains $current) {
-            [Environment]::SetEnvironmentVariable('Path', "$userPath;$current", 'User')
-            Write-Host "  added $current to your user PATH - new terminals will see mstream-server"
-        }
+        # that edits $env:PATH improves exactly one window's life. Read the
+        # RAW value and write it back as REG_EXPAND_SZ: the .NET
+        # GetEnvironmentVariable/SetEnvironmentVariable pair returns the
+        # EXPANDED string and writes REG_SZ, which would bake every %VAR%
+        # entry other tools rely on (nvm's %NVM_HOME%, %JAVA_HOME%\bin) into
+        # frozen literals.
+        $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+        try {
+            $rawPath = [string]$envKey.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            if (($rawPath -split ';') -notcontains $current) {
+                $newPath = if ($rawPath) { "$rawPath;$current" } else { $current }
+                $envKey.SetValue('Path', $newPath, [Microsoft.Win32.RegistryValueKind]::ExpandString)
+                Write-Host "  added $current to your user PATH - new terminals will see mstream-server"
+            }
+        } finally { $envKey.Close() }
     }
 
+    # An instance running from somewhere else stays on its own version until
+    # it is restarted - the script never kills a user's server. Say so, with
+    # the exact path, instead of letting "installed" imply "upgraded".
+    $elsewhere = @($runningFrom | Where-Object { $_ -ne $final -and $_ -ne $current })
+    if ($elsewhere) {
+        Write-Warning ("mStream is currently running from $($elsewhere -join ', ') - it keeps running that version " +
+                       "until you Quit it (tray icon) and start the new one; the Start Menu entry now points at $ver.")
+    }
     $others = Get-ChildItem $root -Directory | Where-Object { $_.Name -like "mStream-*-$key" -and $_.Name -ne $bundle }
     if ($others) {
-        Write-Host "  older versions kept under $root - safe to delete any that aren't 'current'"
+        Write-Host "  older versions kept under $root - once mStream is not running from one, it is safe to delete"
     }
 } finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue

--- a/install.ps1
+++ b/install.ps1
@@ -68,8 +68,11 @@ if ($env:MSTREAM_UNINSTALL) {
     $launcher = Join-Path $current 'mStream.exe'
     if (Test-Path $launcher) {
         # Login item first, while a launcher still exists to remove it.
-        & $launcher --autostart=disable 2>$null | Out-Null
-        if ($LASTEXITCODE -eq 0) { Write-Host "removed the login item" }
+        # Best-effort: an exe that cannot start must not block the uninstall.
+        try {
+            & $launcher --autostart=disable 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) { Write-Host "removed the login item" }
+        } catch { Write-Warning "could not run the launcher to remove the login item ($($_.Exception.Message))" }
     }
     $lnk = Join-Path ([Environment]::GetFolderPath('Programs')) 'mStream.lnk'
     if (Test-Path $lnk) { Remove-Item $lnk -Force; Write-Host "removed the Start Menu shortcut" }
@@ -188,13 +191,22 @@ try {
     # reach the login item: next boot silently starts the OLD version. Ask
     # the NEW launcher to re-register (its --autostart CLI runs with no
     # tray/window/server), only if the user has it enabled.
+    # Best-effort from here on: the install already succeeded, so nothing
+    # below may fail it. Under $ErrorActionPreference='Stop', a launcher that
+    # cannot start at all ("not a valid application for this OS platform" -
+    # a foreign-arch or corrupt exe) throws from `&` itself, not just a
+    # nonzero exit; catch it and say what happened.
     $launcher = Join-Path $current 'mStream.exe'
     if ($installedFresh -and (Test-Path $launcher)) {
-        $status = (& $launcher --autostart=status 2>$null | Out-String).Trim()
-        if ($status -eq 'enabled') {
-            & $launcher --autostart=enable 2>$null | Out-Null
-            if ($LASTEXITCODE -eq 0) { Write-Host "  login item re-pointed at $ver" }
-            else { Write-Warning "could not re-point the login item - open mStream once to fix it" }
+        try {
+            $status = (& $launcher --autostart=status 2>$null | Out-String).Trim()
+            if ($status -eq 'enabled') {
+                & $launcher --autostart=enable 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) { Write-Host "  login item re-pointed at $ver" }
+                else { Write-Warning "could not re-point the login item - open mStream once to fix it" }
+            }
+        } catch {
+            Write-Warning "could not run the launcher to re-point the login item ($($_.Exception.Message)) - open mStream once to fix it"
         }
     }
     # Proof the binary execs here: commander's -V is instant and boots nothing.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+# Installs mStream on Linux and macOS.
+#
+#   curl -fsSL https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.sh | sh
+#
+# Picks the release bundle for this machine, checks its sha256 against the
+# release's manifest.json, extracts it into a versioned folder, and points a
+# `current` link + a `mstream-server` command at it. Configuration, all
+# optional, via environment variables (the pipe-to-sh form takes no args):
+#
+#   MSTREAM_VERSION       a tag like v6.20.0 (default: latest)
+#   MSTREAM_INSTALL_DIR   root for the app folders (default: per-OS user data
+#                         home, next to where the server keeps its own data)
+#   MSTREAM_BIN_DIR       where the `mstream-server` command goes
+#                         (default: ~/.local/bin)
+#   MSTREAM_NO_DESKTOP    set to 1 to skip the app-menu entry (Linux) /
+#                         ~/Applications link (macOS)
+#   MSTREAM_RELEASE_BASE  URL serving manifest.json + the zips (default: the
+#                         GitHub release) - for internal mirrors and testing
+#
+# The bundle is a folder, not one binary: mstream-server + webapp/ + bin/
+# sidecars, plus the desktop launcher (mstream-desktop / mStream.app) on the
+# targets that ship one. Data (config, db, caches) lives OUTSIDE the install
+# folder in the server's data home, so re-running this to upgrade never
+# touches your library.
+#
+# POSIX sh on purpose: NAS boxes and minimal images do not all carry bash.
+set -eu
+
+REPO="IrosTheBeggar/mStream"
+VERSION="${MSTREAM_VERSION:-latest}"
+BIN_DIR="${MSTREAM_BIN_DIR:-$HOME/.local/bin}"
+
+os=$(uname -s)
+arch=$(uname -m)
+case "$os" in
+    Darwin) platform=darwin ;;
+    Linux) platform=linux ;;
+    *)
+        echo "unsupported OS: $os - on Windows, use install.ps1" >&2
+        exit 1
+        ;;
+esac
+
+# Linux: glibc or musl? The glibc bundles cannot exec on Alpine/musl; the
+# static musl bundles run anywhere but ship no desktop launcher and no
+# server-audio sidecar, so they are only picked when they are the ones that
+# will actually run. ldd's own banner is the most portable tell.
+libc=""
+if [ "$platform" = linux ]; then
+    if ldd --version 2>&1 | grep -qi musl; then
+        libc="-musl"
+    elif [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]; then
+        libc="-musl"
+    fi
+fi
+
+case "$platform-$arch" in
+    darwin-x86_64) key="darwin-x64" ;;
+    darwin-arm64) key="darwin-arm64" ;;
+    linux-x86_64 | linux-amd64) key="linux-x64$libc" ;;
+    linux-aarch64 | linux-arm64) key="linux-arm64$libc" ;;
+    linux-armv7l | linux-armv6l)
+        echo "no 32-bit ARM build - mStream needs a 64-bit OS on this Pi (or run from source with Node)" >&2
+        exit 1
+        ;;
+    *)
+        echo "no prebuilt bundle for $os/$arch - run from source: https://github.com/$REPO/blob/master/docs/install.md" >&2
+        exit 1
+        ;;
+esac
+
+# Where the app folders live: beside the server's own data home so one
+# `du` shows all of mStream, and so a future in-app updater and this script
+# agree on the layout ($ROOT/<bundle>/ + $ROOT/current -> <bundle>).
+if [ -n "${MSTREAM_INSTALL_DIR:-}" ]; then
+    ROOT="$MSTREAM_INSTALL_DIR"
+elif [ "$platform" = darwin ]; then
+    ROOT="$HOME/Library/Application Support/mStream/app"
+else
+    ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/mstream/app"
+fi
+
+if [ -n "${MSTREAM_RELEASE_BASE:-}" ]; then
+    base="${MSTREAM_RELEASE_BASE%/}"
+elif [ "$VERSION" = latest ]; then
+    base="https://github.com/$REPO/releases/latest/download"
+else
+    base="https://github.com/$REPO/releases/download/$VERSION"
+fi
+
+fetch() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$2" "$1"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$2" "$1"
+    else
+        echo "this installer needs curl or wget" >&2
+        exit 1
+    fi
+}
+command -v unzip >/dev/null 2>&1 || {
+    echo "this installer needs unzip (debian/ubuntu: sudo apt install unzip; alpine: apk add unzip)" >&2
+    exit 1
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# The manifest first: it names the exact zip for this version, so the
+# script never has to guess the version number embedded in the filename.
+echo "fetching manifest ($VERSION)..."
+fetch "$base/manifest.json" "$tmp/manifest.json"
+version=$(grep -o '"version": *"[^"]*"' "$tmp/manifest.json" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+[ -n "$version" ] || { echo "manifest.json is missing a version - refusing to install" >&2; exit 1; }
+asset="mStream-$version-$key.zip"
+
+# The hash for this asset, out of the manifest published beside it. No jq
+# on a fresh box, so the line is picked apart with the tools sh always has.
+expected=$(grep -o "\"file\": *\"$asset\", *\"sha256\": *\"[0-9a-f]*\"" "$tmp/manifest.json" \
+    | grep -o '[0-9a-f]\{64\}' || true)
+if [ -z "$expected" ]; then
+    echo "manifest.json has no entry for $asset - this release has no bundle for $key" >&2
+    exit 1
+fi
+
+echo "fetching $asset..."
+fetch "$base/$asset" "$tmp/$asset"
+if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$tmp/$asset" | cut -d' ' -f1)
+else
+    actual=$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)
+fi
+if [ "$actual" != "$expected" ]; then
+    echo "sha256 mismatch for $asset - download corrupted, not installing" >&2
+    echo "  expected $expected" >&2
+    echo "  got      $actual" >&2
+    exit 1
+fi
+
+# Extract beside the final location, then rename into place: a killed
+# install leaves a stray .partial folder, never a half-written `current`.
+bundle="mStream-$version-$key"
+mkdir -p "$ROOT"
+rm -rf "$ROOT/$bundle.partial"
+unzip -q "$tmp/$asset" -d "$ROOT/$bundle.partial"
+rm -rf "$ROOT/$bundle"
+mv "$ROOT/$bundle.partial/$bundle" "$ROOT/$bundle"
+rmdir "$ROOT/$bundle.partial"
+# Zip mode bits are usually preserved (Info-ZIP records them), but a bundle
+# that went through a mode-stripping hop must still run.
+chmod 755 "$ROOT/$bundle/mstream-server" 2>/dev/null || true
+chmod 755 "$ROOT/$bundle/mstream-desktop" 2>/dev/null || true
+chmod 755 "$ROOT/$bundle/mStream.app/Contents/MacOS/"* 2>/dev/null || true
+chmod 755 "$ROOT/$bundle"/bin/*/* 2>/dev/null || true
+ln -sfn "$ROOT/$bundle" "$ROOT/current"
+
+# The command: a symlink, so `mstream-server` on PATH always means `current`
+# and an upgrade is one link flip. Data lives in the server's data home,
+# never here.
+if [ "$platform" = darwin ]; then
+    server="$ROOT/current/mStream.app/Contents/MacOS/mstream-server"
+else
+    server="$ROOT/current/mstream-server"
+fi
+mkdir -p "$BIN_DIR"
+ln -sfn "$server" "$BIN_DIR/mstream-server"
+
+# Desktop integration where a launcher shipped: the app-menu entry (Linux)
+# gets the bundle's own .desktop with its %INSTALL_DIR% placeholder filled;
+# macOS gets a link in ~/Applications so Spotlight and Launchpad find it.
+desktop_note=""
+if [ -z "${MSTREAM_NO_DESKTOP:-}" ]; then
+    if [ "$platform" = linux ] && [ -f "$ROOT/$bundle/mStream.desktop" ]; then
+        apps="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+        mkdir -p "$apps"
+        sed "s|%INSTALL_DIR%|$ROOT/current|g" "$ROOT/$bundle/mStream.desktop" > "$apps/mstream.desktop"
+        chmod 644 "$apps/mstream.desktop"
+        command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$apps" 2>/dev/null || true
+        desktop_note="app menu: mStream (or run: $ROOT/current/mstream-desktop)"
+    elif [ "$platform" = darwin ] && [ -d "$ROOT/$bundle/mStream.app" ]; then
+        mkdir -p "$HOME/Applications"
+        ln -sfn "$ROOT/current/mStream.app" "$HOME/Applications/mStream.app"
+        desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
+    fi
+fi
+
+echo "installed mStream $version to $ROOT/$bundle"
+[ -n "$desktop_note" ] && echo "  $desktop_note"
+
+# Does the binary actually exec here? `-V` is commander's version print -
+# instant, no server boot, no side effects - so it doubles as the proof of
+# a working install. Catch a missing runtime library NOW, with the fix,
+# instead of at the user's first run. Known case: the musl bundle (Bun's
+# musl build) links libstdc++/libgcc dynamically, and a minimal Alpine has
+# neither (measured on alpine:3.20 - a wall of "Error relocating" from the
+# loader).
+if v=$("$server" -V 2>/dev/null) && [ -n "$v" ]; then
+    echo "  mstream-server $v runs"
+else
+    err=$("$server" -V 2>&1 | head -3)
+    case "$err" in
+        *"libstdc++"*|*"libgcc"*|*"Error relocating"*|*"Error loading shared library"*)
+            echo "  NOTE: the server needs the C++ runtime, which this system lacks:" >&2
+            if command -v apk >/dev/null 2>&1; then
+                echo "        apk add libstdc++ libgcc" >&2
+            else
+                echo "        install libstdc++ / libgcc via your package manager" >&2
+            fi
+            ;;
+        *)
+            echo "  NOTE: the server did not run - see $ROOT/current/README.txt and try: $server" >&2
+            ;;
+    esac
+fi
+echo "  headless: mstream-server   (data lives in the mStream data home, not the app folder)"
+case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;
+    *) echo "  note: $BIN_DIR is not on your PATH" ;;
+esac
+# Old versions are left in place on purpose (rollback = re-point `current`);
+# say so once there is more than one, so they don't accumulate unnoticed.
+count=$(ls -d "$ROOT"/mStream-*-"$key" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$count" -gt 1 ]; then
+    echo "  older versions kept under $ROOT - safe to delete any that aren't 'current'"
+fi

--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,7 @@ login_item_is_ours() {
 # Does this script own ~/Applications/mStream.app? The ownership marker is a
 # SIBLING file, never inside the bundle: writing anything into Contents/
 # invalidates the notarization seal, and the hardened-runtime launcher in a
-# seal-broken bundle is SIGKILLed by the kernel at exec — the installed app
+# seal-broken bundle is SIGKILLed by the kernel at exec - the installed app
 # would be dead on arrival (measured; the very bug this marker placement
 # once caused). The legacy inner marker is still honored read-only so a copy
 # installed by the broken version is recognized as ours and healed by the

--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,14 @@ fi
 login_item_target() {
     if [ "$platform" = darwin ]; then
         f="$HOME/Library/LaunchAgents/mStream.plist"
-        [ -f "$f" ] && sed -n 's/^[[:space:]]*<string>\(\/[^<]*\)<\/string>.*/\1/p' "$f" | head -1
+        # First absolute-path <string> in the plist, WHEREVER it sits: the
+        # launcher's auto-launch crate writes ProgramArguments as ONE line
+        # (<array><string>/path</string><string>--autostarted</string>...),
+        # so a ^-anchored per-line match never fires and every login item
+        # would read as "not ours" - upgrades would silently never re-point
+        # (measured). Splitting on '<' handles one-line and pretty-printed
+        # plists alike, and greedy-match order can't pick a later argument.
+        [ -f "$f" ] && tr '<' '\n' < "$f" | sed -n 's/^string>\(\/.*\)/\1/p' | head -1
     else
         f="$HOME/.config/autostart/mStream.desktop"
         [ -f "$f" ] && sed -n 's/^Exec="\{0,1\}\([^" ]*\).*/\1/p' "$f" | head -1
@@ -144,8 +151,22 @@ login_item_is_ours() {
     [ -z "$t" ] && return 1
     case "$t" in
         "$ROOT/"*) return 0 ;;
-        "$HOME/Applications/mStream.app/"*) [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ] && return 0 ;;
+        "$HOME/Applications/mStream.app/"*) apps_copy_is_ours && return 0 ;;
     esac
+    return 1
+}
+# Does this script own ~/Applications/mStream.app? The ownership marker is a
+# SIBLING file, never inside the bundle: writing anything into Contents/
+# invalidates the notarization seal, and the hardened-runtime launcher in a
+# seal-broken bundle is SIGKILLed by the kernel at exec — the installed app
+# would be dead on arrival (measured; the very bug this marker placement
+# once caused). The legacy inner marker is still honored read-only so a copy
+# installed by the broken version is recognized as ours and healed by the
+# next install run.
+apps_marker="$HOME/Applications/.mstream-installer"
+apps_copy_is_ours() {
+    [ -f "$apps_marker" ] && return 0
+    [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ] && return 0
     return 1
 }
 
@@ -159,7 +180,7 @@ if [ -n "${MSTREAM_UNINSTALL:-}" ]; then
         exit 1
     fi
     launcher="$ROOT/current/$launcher_rel"
-    [ "$platform" = darwin ] && [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ] \
+    [ "$platform" = darwin ] && apps_copy_is_ours \
         && launcher="$HOME/Applications/mStream.app/Contents/MacOS/mStream"
     # Login item first, while a launcher still exists to remove it - but
     # only if it points at a copy this script manages.
@@ -175,9 +196,10 @@ if [ -n "${MSTREAM_UNINSTALL:-}" ]; then
     else
         d="$HOME/Applications/mStream.app"
         if [ -L "$d" ]; then rm -f "$d" && echo "removed ~/Applications/mStream.app (link)"
-        elif [ -f "$d/Contents/.mstream-installer" ]; then rm -rf "$d" && echo "removed ~/Applications/mStream.app"
+        elif [ -e "$d" ] && apps_copy_is_ours; then rm -rf "$d" && echo "removed ~/Applications/mStream.app"
         elif [ -e "$d" ]; then echo "left ~/Applications/mStream.app alone (not installed by this script)"
         fi
+        rm -f "$apps_marker"
     fi
     if [ -d "$ROOT" ]; then rm -rf "$ROOT" && echo "removed $ROOT"; fi
     echo "mStream is uninstalled. Your library, config, and database were left in place:"
@@ -311,13 +333,14 @@ fi
 # told that the running instance stays on the OLD version until they quit
 # it - nothing here can (or should) kill their server under them.
 running_from=""
-if command -v pgrep >/dev/null 2>&1; then
-    # -f matches the full command line; the launcher execs from an
-    # absolute path under $ROOT (or wherever the user extracted it).
-    # Match the EXECUTABLE (argv[0], the 2nd field of `pgrep -a`), not the
-    # whole command line: a shell whose command text merely mentions
+if command -v ps >/dev/null 2>&1; then
+    # `ps -axo pid=,args=`, NOT `pgrep -a`: on macOS/BSD pgrep, -a means
+    # "include ancestors" and prints bare PIDs - no command column, so the
+    # match below silently never fired on Macs (measured). ps args= puts
+    # argv[0] in $2 on both platforms. Match the EXECUTABLE (argv[0]), not
+    # the whole command line: a shell whose command text merely mentions
     # "mstream-server" (a terminal, a script, docker-init) is not mStream.
-    for pid in $(pgrep -a . 2>/dev/null \
+    for pid in $(ps -axo pid=,args= 2>/dev/null \
         | awk '$1 != '"$$"' && ($2 ~ /(^|\/)mstream-server$/ || $2 ~ /(^|\/)mstream-desktop$/ || $2 ~ /\/MacOS\/mStream$/) {print $1}'); do
         # The real path of the running binary where the OS will say
         # (/proc on Linux); argv[0] otherwise (macOS launches by absolute
@@ -367,21 +390,27 @@ if [ -z "${MSTREAM_NO_DESKTOP:-}" ]; then
         # lesson Homebrew Cask learned. ditto preserves the bundle's internal
         # symlink (Contents/MacOS/webapp -> ../Resources/webapp), xattrs,
         # and the notarization staple, so Gatekeeper still sees a sealed,
-        # stapled app. Only THIS installer's copy is ever replaced: a bundle
-        # the user put there by hand (no marker file) is left alone.
+        # stapled app - PROVIDED nothing is ever written inside it: the
+        # ownership marker lives BESIDE the app (see apps_copy_is_ours), and
+        # the copy must land byte-identical to the bundle. Only THIS
+        # installer's copy is ever replaced: a bundle the user put there by
+        # hand (no marker) is left alone.
         mkdir -p "$HOME/Applications"
         dest="$HOME/Applications/mStream.app"
-        marker="$dest/Contents/.mstream-installer"
-        if [ -e "$dest" ] && [ ! -L "$dest" ] && [ ! -f "$marker" ]; then
+        if [ -e "$dest" ] && [ ! -L "$dest" ] && ! apps_copy_is_ours; then
             desktop_note="app: $ROOT/current/mStream.app  (~/Applications/mStream.app is your own copy - replace it with this one when you're ready)"
         elif [ -n "$installed_fresh" ] || [ ! -e "$dest" ]; then
             rm -rf "$dest.installing"
             if ditto "$ROOT/$bundle/mStream.app" "$dest.installing" 2>/dev/null; then
-                printf '%s\n' "$version" > "$dest.installing/Contents/.mstream-installer"
                 # A symlink from an older run of this script gives way too.
                 [ -L "$dest" ] && rm -f "$dest"
                 [ -d "$dest" ] && mv "$dest" "$dest.old.$$" && rm -rf "$dest.old.$$"
                 mv "$dest.installing" "$dest"
+                # Marker AFTER the copy is in place, and OUTSIDE the bundle.
+                # (This also heals a copy from the old installer, which wrote
+                # the marker inside Contents/ and broke the seal - the fresh
+                # ditto above replaced it wholesale.)
+                printf '%s\n' "$version" > "$apps_marker"
                 desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
             else
                 rm -rf "$dest.installing"

--- a/install.sh
+++ b/install.sh
@@ -123,6 +123,32 @@ else
     data_home="${XDG_DATA_HOME:-$HOME/.local/share}/mstream"
 fi
 
+# Where the login item points right now, if anywhere. The launcher registers
+# ONE per-user login item by app name ("mStream"), so a second copy of
+# mStream on the machine - one the user extracted by hand, a developer's
+# checkout - shares the slot. This script only ever re-points or removes
+# a login item that points at a copy IT manages ($ROOT, or the
+# ~/Applications copy on macOS); anything else is the user's and is left
+# alone, and they are told so.
+login_item_target() {
+    if [ "$platform" = darwin ]; then
+        f="$HOME/Library/LaunchAgents/mStream.plist"
+        [ -f "$f" ] && sed -n 's/^[[:space:]]*<string>\(\/[^<]*\)<\/string>.*/\1/p' "$f" | head -1
+    else
+        f="$HOME/.config/autostart/mStream.desktop"
+        [ -f "$f" ] && sed -n 's/^Exec="\{0,1\}\([^" ]*\).*/\1/p' "$f" | head -1
+    fi
+}
+login_item_is_ours() {
+    t=$(login_item_target)
+    [ -z "$t" ] && return 1
+    case "$t" in
+        "$ROOT/"*) return 0 ;;
+        "$HOME/Applications/mStream.app/"*) [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ] && return 0 ;;
+    esac
+    return 1
+}
+
 # -- Uninstall: MSTREAM_UNINSTALL=1 removes everything this script created -
 # the app folders, the command link, the app-menu entry / ~/Applications
 # copy, and the login item - and nothing else. Your library, config, and
@@ -135,9 +161,12 @@ if [ -n "${MSTREAM_UNINSTALL:-}" ]; then
     launcher="$ROOT/current/$launcher_rel"
     [ "$platform" = darwin ] && [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ] \
         && launcher="$HOME/Applications/mStream.app/Contents/MacOS/mStream"
-    # Login item first, while a launcher still exists to remove it.
-    if [ -x "$launcher" ]; then
+    # Login item first, while a launcher still exists to remove it - but
+    # only if it points at a copy this script manages.
+    if [ -x "$launcher" ] && login_item_is_ours; then
         "$launcher" --autostart=disable >/dev/null 2>&1 && echo "removed the login item" || true
+    elif [ -n "$(login_item_target)" ]; then
+        echo "left the login item alone - it points at $(login_item_target), which this script did not install"
     fi
     if [ -L "$BIN_DIR/mstream-server" ]; then rm -f "$BIN_DIR/mstream-server"; echo "removed $BIN_DIR/mstream-server"; fi
     if [ "$platform" = linux ]; then
@@ -380,9 +409,17 @@ if [ "$platform" = darwin ] && [ -f "$HOME/Applications/mStream.app/Contents/.ms
 fi
 if [ -x "$launcher" ] && [ -n "$installed_fresh" ]; then
     if [ "$("$launcher" --autostart=status 2>/dev/null)" = enabled ]; then
-        "$launcher" --autostart=enable >/dev/null 2>&1 \
-            && echo "  login item re-pointed at $version" \
-            || echo "  note: could not re-point the login item - open mStream once to fix it" >&2
+        if login_item_is_ours; then
+            "$launcher" --autostart=enable >/dev/null 2>&1 \
+                && echo "  login item re-pointed at $version" \
+                || echo "  note: could not re-point the login item - open mStream once to fix it" >&2
+        else
+            # Enabled, but for a copy we don't manage (hand-extracted, a dev
+            # checkout). Its owner decides; the launcher's own first-run logic
+            # takes over the moment they open THIS copy and toggle it.
+            echo "  note: the login item points at $(login_item_target) (not managed by this script) - left as is;" >&2
+            echo "        open the new mStream and toggle 'Start at login' to move it" >&2
+        fi
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -334,13 +334,17 @@ fi
 # it - nothing here can (or should) kill their server under them.
 running_from=""
 if command -v ps >/dev/null 2>&1; then
-    # `ps -axo pid=,args=`, NOT `pgrep -a`: on macOS/BSD pgrep, -a means
-    # "include ancestors" and prints bare PIDs - no command column, so the
-    # match below silently never fired on Macs (measured). ps args= puts
-    # argv[0] in $2 on both platforms. Match the EXECUTABLE (argv[0]), not
-    # the whole command line: a shell whose command text merely mentions
-    # "mstream-server" (a terminal, a script, docker-init) is not mStream.
-    for pid in $(ps -axo pid=,args= 2>/dev/null \
+    # `ps -A -o pid=,args=` - the POSIX spelling - NOT `pgrep -a` and NOT
+    # `ps -ax`: on macOS/BSD pgrep, -a means "include ancestors" and prints
+    # bare PIDs (no command column - the match silently never fired on
+    # Macs, measured), and busybox ps (Alpine, most NAS firmware) rejects
+    # the BSD -ax flags outright ("unrecognized option: x" - the scan was
+    # silently empty there, measured). -A = every process on busybox,
+    # procps, and BSD alike; args= puts argv[0] in $2 on all three. Match
+    # the EXECUTABLE (argv[0]), not the whole command line: a shell whose
+    # command text merely mentions "mstream-server" (a terminal, a script,
+    # docker-init) is not mStream.
+    for pid in $(ps -A -o pid=,args= 2>/dev/null \
         | awk '$1 != '"$$"' && ($2 ~ /(^|\/)mstream-server$/ || $2 ~ /(^|\/)mstream-desktop$/ || $2 ~ /\/MacOS\/mStream$/) {print $1}'); do
         # The real path of the running binary where the OS will say
         # (/proc on Linux); argv[0] otherwise (macOS launches by absolute

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,11 @@
 #                         ~/Applications link (macOS)
 #   MSTREAM_RELEASE_BASE  URL serving manifest.json + the zips (default: the
 #                         GitHub release) - for internal mirrors and testing
+#   MSTREAM_KEY           force a bundle key (linux-x64, linux-x64-musl,
+#                         linux-arm64, linux-arm64-musl, darwin-x64,
+#                         darwin-arm64) when auto-detection gets it wrong
+#   MSTREAM_FORCE         set to 1 to replace an already-installed copy of
+#                         the same version (the old one is moved aside)
 #
 # The bundle is a folder, not one binary: mstream-server + webapp/ + bin/
 # sidecars, plus the desktop launcher (mstream-desktop / mStream.app) on the
@@ -45,14 +50,26 @@ esac
 # Linux: glibc or musl? The glibc bundles cannot exec on Alpine/musl; the
 # static musl bundles run anywhere but ship no desktop launcher and no
 # server-audio sidecar, so they are only picked when they are the ones that
-# will actually run. ldd's own banner is the most portable tell.
+# will actually run. Decide POSITIVELY for glibc first: a glibc box that has
+# the `musl` package installed (musl-tools for Rust/Go cross builds, Arch's
+# musl) carries /lib/ld-musl-*.so.1 too, and picking musl there installs a
+# server-only bundle whose libstdc++ the musl loader can't even find.
 libc=""
 if [ "$platform" = linux ]; then
-    if ldd --version 2>&1 | grep -qi musl; then
-        libc="-musl"
-    elif [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]; then
+    if [ -e /lib64/ld-linux-x86-64.so.2 ] || [ -e /lib/ld-linux-aarch64.so.1 ] \
+        || ldd --version 2>&1 | grep -qiE 'glibc|GNU libc'; then
+        libc=""
+    elif ldd --version 2>&1 | grep -qi musl \
+        || [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]; then
         libc="-musl"
     fi
+fi
+
+# 64-bit kernel, 32-bit userland: uname -m says aarch64 on a Pi 4/400/CM4
+# running 32-bit Raspberry Pi OS (the default kernel there is 64-bit), but
+# no 64-bit binary can run. Ask the userland, not the kernel.
+if [ "$platform" = linux ] && [ "$(getconf LONG_BIT 2>/dev/null || echo 64)" = 32 ]; then
+    arch="32bit-userland"
 fi
 
 case "$platform-$arch" in
@@ -60,8 +77,8 @@ case "$platform-$arch" in
     darwin-arm64) key="darwin-arm64" ;;
     linux-x86_64 | linux-amd64) key="linux-x64$libc" ;;
     linux-aarch64 | linux-arm64) key="linux-arm64$libc" ;;
-    linux-armv7l | linux-armv6l)
-        echo "no 32-bit ARM build - mStream needs a 64-bit OS on this Pi (or run from source with Node)" >&2
+    linux-armv7l | linux-armv6l | linux-32bit-userland)
+        echo "no 32-bit build - mStream needs a 64-bit OS (on a Pi: the 64-bit Raspberry Pi OS image), or run from source with Node" >&2
         exit 1
         ;;
     *)
@@ -69,6 +86,8 @@ case "$platform-$arch" in
         exit 1
         ;;
 esac
+# Escape hatch for exotic setups: name the bundle key yourself.
+key="${MSTREAM_KEY:-$key}"
 
 # Where the app folders live: beside the server's own data home so one
 # `du` shows all of mStream, and so a future in-app updater and this script
@@ -80,6 +99,11 @@ elif [ "$platform" = darwin ]; then
 else
     ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/mstream/app"
 fi
+# Both dirs become symlink TARGETS below; a relative value would be stored
+# literally and dangle from wherever the link lives. Canonicalize.
+mkdir -p "$ROOT" "$BIN_DIR"
+ROOT=$(cd "$ROOT" && pwd -P)
+BIN_DIR=$(cd "$BIN_DIR" && pwd -P)
 
 if [ -n "${MSTREAM_RELEASE_BASE:-}" ]; then
     base="${MSTREAM_RELEASE_BASE%/}"
@@ -89,11 +113,14 @@ else
     base="https://github.com/$REPO/releases/download/$VERSION"
 fi
 
+# fetch URL DEST: curl or wget, never silent on failure. `wget -q` swallows
+# its own "ERROR 404" so a missing asset used to die with no clue; -nv keeps
+# errors and drops the progress noise. Callers add the WHY on failure.
 fetch() {
     if command -v curl >/dev/null 2>&1; then
         curl -fsSL -o "$2" "$1"
     elif command -v wget >/dev/null 2>&1; then
-        wget -qO "$2" "$1"
+        wget -nv -O "$2" "$1"
     else
         echo "this installer needs curl or wget" >&2
         exit 1
@@ -110,9 +137,20 @@ trap 'rm -rf "$tmp"' EXIT INT TERM
 # The manifest first: it names the exact zip for this version, so the
 # script never has to guess the version number embedded in the filename.
 echo "fetching manifest ($VERSION)..."
-fetch "$base/manifest.json" "$tmp/manifest.json"
+if ! fetch "$base/manifest.json" "$tmp/manifest.json"; then
+    echo "could not fetch $base/manifest.json" >&2
+    echo "  Releases published before the installer existed have no manifest.json." >&2
+    echo "  Pick a newer MSTREAM_VERSION, or download a bundle by hand from" >&2
+    echo "  https://github.com/$REPO/releases and see docs/install.md." >&2
+    exit 1
+fi
 version=$(grep -o '"version": *"[^"]*"' "$tmp/manifest.json" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 [ -n "$version" ] || { echo "manifest.json is missing a version - refusing to install" >&2; exit 1; }
+# The version becomes a path component below: keep it to what a release
+# tag can contain, so a bad manifest can't steer rm/mv anywhere.
+case "$version" in
+    *[!0-9A-Za-z.-]*|"") echo "manifest.json version '$version' is not a plain version string - refusing" >&2; exit 1 ;;
+esac
 asset="mStream-$version-$key.zip"
 
 # The hash for this asset, out of the manifest published beside it. No jq
@@ -125,7 +163,7 @@ if [ -z "$expected" ]; then
 fi
 
 echo "fetching $asset..."
-fetch "$base/$asset" "$tmp/$asset"
+fetch "$base/$asset" "$tmp/$asset" || { echo "download failed: $base/$asset" >&2; exit 1; }
 if command -v sha256sum >/dev/null 2>&1; then
     actual=$(sha256sum "$tmp/$asset" | cut -d' ' -f1)
 else
@@ -138,33 +176,104 @@ if [ "$actual" != "$expected" ]; then
     exit 1
 fi
 
-# Extract beside the final location, then rename into place: a killed
-# install leaves a stray .partial folder, never a half-written `current`.
+# link TARGET DEST: point DEST at TARGET as a symlink. `ln -sfn` alone is a
+# trap here: -n only stops it following an existing SYMLINK; if DEST is a
+# real directory, ln happily creates the link INSIDE it (DEST/<basename>)
+# and exits 0 - a hand-installed ~/Applications/mStream.app would silently
+# keep the old version. So: an existing symlink is replaced; an existing
+# real directory is left alone and reported (never delete a user's own
+# folder); the result is verified.
+link() {
+    if [ -e "$2" ] && [ ! -L "$2" ]; then
+        echo "  note: $2 exists and is not a link - left alone (remove it and re-run to relink)" >&2
+        return 1
+    fi
+    ln -sfn "$1" "$2" && [ "$(readlink "$2")" = "$1" ]
+}
+
 bundle="mStream-$version-$key"
 mkdir -p "$ROOT"
-rm -rf "$ROOT/$bundle.partial"
-unzip -q "$tmp/$asset" -d "$ROOT/$bundle.partial"
-rm -rf "$ROOT/$bundle"
-mv "$ROOT/$bundle.partial/$bundle" "$ROOT/$bundle"
-rmdir "$ROOT/$bundle.partial"
-# Zip mode bits are usually preserved (Info-ZIP records them), but a bundle
-# that went through a mode-stripping hop must still run.
-chmod 755 "$ROOT/$bundle/mstream-server" 2>/dev/null || true
-chmod 755 "$ROOT/$bundle/mstream-desktop" 2>/dev/null || true
-chmod 755 "$ROOT/$bundle/mStream.app/Contents/MacOS/"* 2>/dev/null || true
-chmod 755 "$ROOT/$bundle"/bin/*/* 2>/dev/null || true
-ln -sfn "$ROOT/$bundle" "$ROOT/current"
+
+# Same version already installed? Leave it ALONE. That folder may be live
+# (a running server), and under --portable it holds the user's config and
+# database - an unconditional rm -rf here would delete a library to
+# "upgrade" it to itself. Re-verify against the manifest so a corrupt or
+# tampered copy is still caught, then just re-point the links.
+if [ -d "$ROOT/$bundle" ] && [ -z "${MSTREAM_FORCE:-}" ]; then
+    echo "mStream $version is already installed at $ROOT/$bundle - keeping it (set MSTREAM_FORCE=1 to replace)"
+    installed_fresh=""
+else
+    # A forced replace of the same version moves the old folder aside
+    # (mv, not rm): whatever state it held survives at a findable name.
+    if [ -d "$ROOT/$bundle" ]; then
+        old="$ROOT/$bundle.replaced-$(date +%Y%m%d%H%M%S)"
+        mv "$ROOT/$bundle" "$old"
+        echo "  previous copy moved to $old"
+    fi
+    # Extract beside the final location, then rename into place: a killed
+    # install leaves a stray .partial folder, never a half-written `current`.
+    rm -rf "$ROOT/$bundle.partial"
+    unzip -q "$tmp/$asset" -d "$ROOT/$bundle.partial"
+    mv "$ROOT/$bundle.partial/$bundle" "$ROOT/$bundle"
+    rmdir "$ROOT/$bundle.partial"
+    # Zip mode bits are usually preserved (Info-ZIP records them), but a
+    # bundle that went through a mode-stripping hop must still run.
+    chmod 755 "$ROOT/$bundle/mstream-server" 2>/dev/null || true
+    chmod 755 "$ROOT/$bundle/mstream-desktop" 2>/dev/null || true
+    chmod 755 "$ROOT/$bundle/mStream.app/Contents/MacOS/"* 2>/dev/null || true
+    chmod 755 "$ROOT/$bundle"/bin/*/* 2>/dev/null || true
+    installed_fresh=1
+fi
+
+# Which version is running right now, if any? Needed twice below: the
+# login item must be re-pointed at the NEW launcher, and the user must be
+# told that the running instance stays on the OLD version until they quit
+# it - nothing here can (or should) kill their server under them. Detect by
+# the launcher's single-instance lock in the data home, then find its exe.
+if [ "$platform" = darwin ]; then
+    launcher_rel="mStream.app/Contents/MacOS/mStream"; server_rel="mStream.app/Contents/MacOS/mstream-server"
+    data_home="$HOME/Library/Application Support/mStream"
+else
+    launcher_rel="mstream-desktop"; server_rel="mstream-server"
+    data_home="${XDG_DATA_HOME:-$HOME/.local/share}/mstream"
+fi
+running_from=""
+if command -v pgrep >/dev/null 2>&1; then
+    # -f matches the full command line; the launcher execs from an
+    # absolute path under $ROOT (or wherever the user extracted it).
+    running_from=$(pgrep -fa "mstream-server|mstream-desktop|MacOS/mStream( |$)" 2>/dev/null \
+        | grep -v "$$" | awk '{print $2}' | grep -v "^$ROOT/current/" | head -1 || true)
+fi
+
+# `current` -> this version. If a previous manual layout left a REAL
+# directory named current, move it aside rather than nest into it.
+if [ -e "$ROOT/current" ] && [ ! -L "$ROOT/current" ]; then
+    mv "$ROOT/current" "$ROOT/current.was-a-directory-$(date +%Y%m%d%H%M%S)"
+fi
+link "$ROOT/$bundle" "$ROOT/current"
 
 # The command: a symlink, so `mstream-server` on PATH always means `current`
 # and an upgrade is one link flip. Data lives in the server's data home,
 # never here.
-if [ "$platform" = darwin ]; then
-    server="$ROOT/current/mStream.app/Contents/MacOS/mstream-server"
-else
-    server="$ROOT/current/mstream-server"
+server="$ROOT/current/$server_rel"
+link "$server" "$BIN_DIR/mstream-server" || true
+
+# The launcher registers ITSELF as the login item, by absolute path - which
+# is the VERSIONED folder, not `current`. Without this step an upgrade
+# never reaches the login item: next boot silently starts the OLD version
+# (and once the old folder is deleted, nothing at all, while the tray still
+# says "Start at login" is on). --autostart=enable re-registers using the
+# new binary's own path; the launcher's CLI face does this with no tray,
+# no server, no window. Only when the user has it enabled - never turn it
+# on for them here.
+launcher="$ROOT/current/$launcher_rel"
+if [ -x "$launcher" ] && [ -n "$installed_fresh" ]; then
+    if [ "$("$launcher" --autostart=status 2>/dev/null)" = enabled ]; then
+        "$launcher" --autostart=enable >/dev/null 2>&1 \
+            && echo "  login item re-pointed at $version" \
+            || echo "  note: could not re-point the login item - open mStream once to fix it" >&2
+    fi
 fi
-mkdir -p "$BIN_DIR"
-ln -sfn "$server" "$BIN_DIR/mstream-server"
 
 # Desktop integration where a launcher shipped: the app-menu entry (Linux)
 # gets the bundle's own .desktop with its %INSTALL_DIR% placeholder filled;
@@ -180,13 +289,28 @@ if [ -z "${MSTREAM_NO_DESKTOP:-}" ]; then
         desktop_note="app menu: mStream (or run: $ROOT/current/mstream-desktop)"
     elif [ "$platform" = darwin ] && [ -d "$ROOT/$bundle/mStream.app" ]; then
         mkdir -p "$HOME/Applications"
-        ln -sfn "$ROOT/current/mStream.app" "$HOME/Applications/mStream.app"
-        desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
+        # A REAL mStream.app already there (dragged in by hand) is the
+        # user's; link() refuses to touch it and says so.
+        if link "$ROOT/current/mStream.app" "$HOME/Applications/mStream.app"; then
+            desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
+        else
+            desktop_note="app: $ROOT/current/mStream.app  (~/Applications/mStream.app is a separate copy - replace it with this one when you're ready)"
+        fi
     fi
 fi
 
-echo "installed mStream $version to $ROOT/$bundle"
+if [ -n "$installed_fresh" ]; then
+    echo "installed mStream $version to $ROOT/$bundle"
+fi
 [ -n "$desktop_note" ] && echo "  $desktop_note"
+# An instance running from somewhere else stays on its own version until
+# it is restarted - the script never kills a user's server. Say so, with
+# the exact path, instead of letting "installed" imply "upgraded".
+if [ -n "$running_from" ]; then
+    echo "  NOTE: mStream is currently running from $running_from" >&2
+    echo "        it keeps running that version until you Quit it (tray menu) and start" >&2
+    echo "        the new one - the app menu / Start Menu entry now points at $version." >&2
+fi
 
 # Does the binary actually exec here? `-V` is commander's version print -
 # instant, no server boot, no side effects - so it doubles as the proof of
@@ -220,7 +344,10 @@ case ":$PATH:" in
 esac
 # Old versions are left in place on purpose (rollback = re-point `current`);
 # say so once there is more than one, so they don't accumulate unnoticed.
+# The wording matters: a version that is still RUNNING must not be deleted
+# (its server would lose its UI mid-flight and Restart would fail), and the
+# login item is re-pointed only when this run installed something new.
 count=$(ls -d "$ROOT"/mStream-*-"$key" 2>/dev/null | wc -l | tr -d ' ')
 if [ "$count" -gt 1 ]; then
-    echo "  older versions kept under $ROOT - safe to delete any that aren't 'current'"
+    echo "  older versions kept under $ROOT - once mStream is not running from one, it is safe to delete"
 fi

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,10 @@
 #   MSTREAM_BIN_DIR       where the `mstream-server` command goes
 #                         (default: ~/.local/bin)
 #   MSTREAM_NO_DESKTOP    set to 1 to skip the app-menu entry (Linux) /
-#                         ~/Applications link (macOS)
+#                         ~/Applications copy (macOS)
+#   MSTREAM_UNINSTALL     set to 1 to remove everything this script installed
+#                         (app folders, command, menu entry / ~/Applications
+#                         copy, login item). Your data is left in place.
 #   MSTREAM_RELEASE_BASE  URL serving manifest.json + the zips (default: the
 #                         GitHub release) - for internal mirrors and testing
 #   MSTREAM_KEY           force a bundle key (linux-x64, linux-x64-musl,
@@ -32,6 +35,11 @@
 # POSIX sh on purpose: NAS boxes and minimal images do not all carry bash.
 set -eu
 
+# Everything below runs from main(), called on the LAST line: sh parses the
+# whole function before executing any of it, so a `curl | sh` whose stream
+# is cut short fails to parse instead of running half an install (the
+# rustup / brew / deno installers all do this).
+main() {
 REPO="IrosTheBeggar/mStream"
 VERSION="${MSTREAM_VERSION:-latest}"
 BIN_DIR="${MSTREAM_BIN_DIR:-$HOME/.local/bin}"
@@ -104,6 +112,50 @@ fi
 mkdir -p "$ROOT" "$BIN_DIR"
 ROOT=$(cd "$ROOT" && pwd -P)
 BIN_DIR=$(cd "$BIN_DIR" && pwd -P)
+
+# Per-platform names inside a bundle, and where the server keeps its data
+# (which this script never touches - not on install, not on uninstall).
+if [ "$platform" = darwin ]; then
+    launcher_rel="mStream.app/Contents/MacOS/mStream"; server_rel="mStream.app/Contents/MacOS/mstream-server"
+    data_home="$HOME/Library/Application Support/mStream"
+else
+    launcher_rel="mstream-desktop"; server_rel="mstream-server"
+    data_home="${XDG_DATA_HOME:-$HOME/.local/share}/mstream"
+fi
+
+# -- Uninstall: MSTREAM_UNINSTALL=1 removes everything this script created -
+# the app folders, the command link, the app-menu entry / ~/Applications
+# copy, and the login item - and nothing else. Your library, config, and
+# database in the data home stay put; the last line says where.
+if [ -n "${MSTREAM_UNINSTALL:-}" ]; then
+    if command -v pgrep >/dev/null 2>&1 && pgrep -f "^$ROOT/" >/dev/null 2>&1; then
+        echo "mStream is running from $ROOT - Quit it from the tray icon first, then re-run" >&2
+        exit 1
+    fi
+    launcher="$ROOT/current/$launcher_rel"
+    [ "$platform" = darwin ] && [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ] \
+        && launcher="$HOME/Applications/mStream.app/Contents/MacOS/mStream"
+    # Login item first, while a launcher still exists to remove it.
+    if [ -x "$launcher" ]; then
+        "$launcher" --autostart=disable >/dev/null 2>&1 && echo "removed the login item" || true
+    fi
+    if [ -L "$BIN_DIR/mstream-server" ]; then rm -f "$BIN_DIR/mstream-server"; echo "removed $BIN_DIR/mstream-server"; fi
+    if [ "$platform" = linux ]; then
+        f="${XDG_DATA_HOME:-$HOME/.local/share}/applications/mstream.desktop"
+        if [ -f "$f" ]; then rm -f "$f"; echo "removed the app-menu entry"; fi
+    else
+        d="$HOME/Applications/mStream.app"
+        if [ -L "$d" ]; then rm -f "$d" && echo "removed ~/Applications/mStream.app (link)"
+        elif [ -f "$d/Contents/.mstream-installer" ]; then rm -rf "$d" && echo "removed ~/Applications/mStream.app"
+        elif [ -e "$d" ]; then echo "left ~/Applications/mStream.app alone (not installed by this script)"
+        fi
+    fi
+    if [ -d "$ROOT" ]; then rm -rf "$ROOT" && echo "removed $ROOT"; fi
+    echo "mStream is uninstalled. Your library, config, and database were left in place:"
+    echo "  $data_home"
+    echo "  (delete that folder yourself if you want them gone too)"
+    exit 0
+fi
 
 if [ -n "${MSTREAM_RELEASE_BASE:-}" ]; then
     base="${MSTREAM_RELEASE_BASE%/}"
@@ -228,21 +280,27 @@ fi
 # Which version is running right now, if any? Needed twice below: the
 # login item must be re-pointed at the NEW launcher, and the user must be
 # told that the running instance stays on the OLD version until they quit
-# it - nothing here can (or should) kill their server under them. Detect by
-# the launcher's single-instance lock in the data home, then find its exe.
-if [ "$platform" = darwin ]; then
-    launcher_rel="mStream.app/Contents/MacOS/mStream"; server_rel="mStream.app/Contents/MacOS/mstream-server"
-    data_home="$HOME/Library/Application Support/mStream"
-else
-    launcher_rel="mstream-desktop"; server_rel="mstream-server"
-    data_home="${XDG_DATA_HOME:-$HOME/.local/share}/mstream"
-fi
+# it - nothing here can (or should) kill their server under them.
 running_from=""
 if command -v pgrep >/dev/null 2>&1; then
     # -f matches the full command line; the launcher execs from an
     # absolute path under $ROOT (or wherever the user extracted it).
-    running_from=$(pgrep -fa "mstream-server|mstream-desktop|MacOS/mStream( |$)" 2>/dev/null \
-        | grep -v "$$" | awk '{print $2}' | grep -v "^$ROOT/current/" | head -1 || true)
+    # Match the EXECUTABLE (argv[0], the 2nd field of `pgrep -a`), not the
+    # whole command line: a shell whose command text merely mentions
+    # "mstream-server" (a terminal, a script, docker-init) is not mStream.
+    for pid in $(pgrep -a . 2>/dev/null \
+        | awk '$1 != '"$$"' && ($2 ~ /(^|\/)mstream-server$/ || $2 ~ /(^|\/)mstream-desktop$/ || $2 ~ /\/MacOS\/mStream$/) {print $1}'); do
+        # The real path of the running binary where the OS will say
+        # (/proc on Linux); argv[0] otherwise (macOS launches by absolute
+        # path from LaunchServices, so that is already the full path).
+        exe=$(readlink "/proc/$pid/exe" 2>/dev/null || ps -o comm= -p "$pid" 2>/dev/null || true)
+        # Skip the version this run is installing (a real path never goes
+        # through the `current` symlink, so compare against the bundle dir).
+        case "$exe" in
+            "$ROOT/$bundle/"*|"$ROOT/current/"*|"") ;;
+            *) running_from="$exe"; break ;;
+        esac
+    done
 fi
 
 # `current` -> this version. If a previous manual layout left a REAL
@@ -258,6 +316,54 @@ link "$ROOT/$bundle" "$ROOT/current"
 server="$ROOT/current/$server_rel"
 link "$server" "$BIN_DIR/mstream-server" || true
 
+# Desktop integration where a launcher shipped.
+desktop_note=""
+if [ -z "${MSTREAM_NO_DESKTOP:-}" ]; then
+    if [ "$platform" = linux ] && [ -f "$ROOT/$bundle/mStream.desktop" ]; then
+        # The app-menu entry: written with printf, not by sed over the
+        # bundle's template - a ROOT containing '&' or '|' would corrupt or
+        # abort a sed replacement, and Exec= must be quoted per the XDG spec
+        # so a path with a space survives the launcher's word split.
+        apps="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+        mkdir -p "$apps"
+        printf '[Desktop Entry]\nType=Application\nName=mStream\nComment=Self-hosted music streaming server\nExec="%s/current/mstream-desktop"\nTryExec=%s/current/mstream-desktop\nIcon=%s/current/mStream.png\nTerminal=false\nCategories=AudioVideo;Audio;Network;\n' \
+            "$ROOT" "$ROOT" "$ROOT" > "$apps/mstream.desktop"
+        chmod 644 "$apps/mstream.desktop"
+        command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$apps" 2>/dev/null || true
+        desktop_note="app menu: mStream (or run: $ROOT/current/mstream-desktop)"
+    elif [ "$platform" = darwin ] && [ -d "$ROOT/$bundle/mStream.app" ]; then
+        # A real COPY of the .app in ~/Applications, not a symlink: Spotlight
+        # indexes a symlink as a symlink (not an application), Launchpad
+        # skips it, and LaunchServices treats it as second-class - the same
+        # lesson Homebrew Cask learned. ditto preserves the bundle's internal
+        # symlink (Contents/MacOS/webapp -> ../Resources/webapp), xattrs,
+        # and the notarization staple, so Gatekeeper still sees a sealed,
+        # stapled app. Only THIS installer's copy is ever replaced: a bundle
+        # the user put there by hand (no marker file) is left alone.
+        mkdir -p "$HOME/Applications"
+        dest="$HOME/Applications/mStream.app"
+        marker="$dest/Contents/.mstream-installer"
+        if [ -e "$dest" ] && [ ! -L "$dest" ] && [ ! -f "$marker" ]; then
+            desktop_note="app: $ROOT/current/mStream.app  (~/Applications/mStream.app is your own copy - replace it with this one when you're ready)"
+        elif [ -n "$installed_fresh" ] || [ ! -e "$dest" ]; then
+            rm -rf "$dest.installing"
+            if ditto "$ROOT/$bundle/mStream.app" "$dest.installing" 2>/dev/null; then
+                printf '%s\n' "$version" > "$dest.installing/Contents/.mstream-installer"
+                # A symlink from an older run of this script gives way too.
+                [ -L "$dest" ] && rm -f "$dest"
+                [ -d "$dest" ] && mv "$dest" "$dest.old.$$" && rm -rf "$dest.old.$$"
+                mv "$dest.installing" "$dest"
+                desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
+            else
+                rm -rf "$dest.installing"
+                desktop_note="app: $ROOT/current/mStream.app (could not copy into ~/Applications)"
+            fi
+        else
+            desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
+        fi
+    fi
+fi
+
 # The launcher registers ITSELF as the login item, by absolute path - which
 # is the VERSIONED folder, not `current`. Without this step an upgrade
 # never reaches the login item: next boot silently starts the OLD version
@@ -265,37 +371,18 @@ link "$server" "$BIN_DIR/mstream-server" || true
 # says "Start at login" is on). --autostart=enable re-registers using the
 # new binary's own path; the launcher's CLI face does this with no tray,
 # no server, no window. Only when the user has it enabled - never turn it
-# on for them here.
+# on for them here. Which launcher: the one the user actually opens - the
+# ~/Applications copy on macOS when this installer owns it (a stable path
+# across upgrades), else the one behind `current`.
 launcher="$ROOT/current/$launcher_rel"
+if [ "$platform" = darwin ] && [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ]; then
+    launcher="$HOME/Applications/mStream.app/Contents/MacOS/mStream"
+fi
 if [ -x "$launcher" ] && [ -n "$installed_fresh" ]; then
     if [ "$("$launcher" --autostart=status 2>/dev/null)" = enabled ]; then
         "$launcher" --autostart=enable >/dev/null 2>&1 \
             && echo "  login item re-pointed at $version" \
             || echo "  note: could not re-point the login item - open mStream once to fix it" >&2
-    fi
-fi
-
-# Desktop integration where a launcher shipped: the app-menu entry (Linux)
-# gets the bundle's own .desktop with its %INSTALL_DIR% placeholder filled;
-# macOS gets a link in ~/Applications so Spotlight and Launchpad find it.
-desktop_note=""
-if [ -z "${MSTREAM_NO_DESKTOP:-}" ]; then
-    if [ "$platform" = linux ] && [ -f "$ROOT/$bundle/mStream.desktop" ]; then
-        apps="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
-        mkdir -p "$apps"
-        sed "s|%INSTALL_DIR%|$ROOT/current|g" "$ROOT/$bundle/mStream.desktop" > "$apps/mstream.desktop"
-        chmod 644 "$apps/mstream.desktop"
-        command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$apps" 2>/dev/null || true
-        desktop_note="app menu: mStream (or run: $ROOT/current/mstream-desktop)"
-    elif [ "$platform" = darwin ] && [ -d "$ROOT/$bundle/mStream.app" ]; then
-        mkdir -p "$HOME/Applications"
-        # A REAL mStream.app already there (dragged in by hand) is the
-        # user's; link() refuses to touch it and says so.
-        if link "$ROOT/current/mStream.app" "$HOME/Applications/mStream.app"; then
-            desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
-        else
-            desktop_note="app: $ROOT/current/mStream.app  (~/Applications/mStream.app is a separate copy - replace it with this one when you're ready)"
-        fi
     fi
 fi
 
@@ -351,3 +438,6 @@ count=$(ls -d "$ROOT"/mStream-*-"$key" 2>/dev/null | wc -l | tr -d ' ')
 if [ "$count" -gt 1 ]; then
     echo "  older versions kept under $ROOT - once mStream is not running from one, it is safe to delete"
 fi
+}
+
+main "$@"

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -417,6 +417,11 @@ function bundleReadme(version, t, launcherStaged, serverName) {
       ? `Data lives in ${dataDir}. (Do not use --portable with the .app: writing inside a signed app breaks its seal.)`
       : `Data lives in ${dataDir}; pass --portable to keep it next to the binaries.`,
     '',
+    'Upgrading? The install script does it in place and verifies the download:',
+    t.plat === 'win32'
+      ? '  irm https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.ps1 | iex'
+      : '  curl -fsSL https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.sh | sh',
+    '',
     `Docs: https://mstream.io        More flags: ${run}${server} --help`,
   );
   return lines.filter((l) => l !== null).join('\n') + '\n';

--- a/scripts/release-manifest.sh
+++ b/scripts/release-manifest.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Writes manifest.json for a release directory of mStream bundle zips.
+#
+#   scripts/release-manifest.sh <version> <dir-with-zips>
+#
+# The release's own inventory: {name, version, apiVersion, assets:[{file,
+# sha256}]} - the same shape mstream-terminal-player publishes, so tooling
+# that understands one understands both. install.sh / install.ps1 read it
+# FIRST (to learn the exact asset name for their platform, then to verify
+# the download); the launcher auto-updater will read the same file.
+#
+# ONE script for the release job AND the PR-time check (build-bun.yml), so
+# the generator and the installers' parser can never drift apart unnoticed:
+# the check runs install.sh against exactly what this emits.
+#
+# Contract the installers rely on (keep it, or bump apiVersion AND update
+# both installers together):
+#   - one asset per line, exactly:  {"file": "<name>", "sha256": "<hex64>"}
+#     (install.sh greps that shape; it has no jq)
+#   - "version" is the bare tag version (no leading v)
+#   - assets are named mStream-<version>-<key>.zip
+#
+# Refuses (exit 1) when a zip's name does not carry EXACTLY this version
+# followed by a known bundle key: the installers derive filenames from
+# manifest.version, so a bundle built from a lagging or prerelease
+# package.json would be un-installable - and 'prefix' matching would let
+# mStream-6.21.0-beta.1-win-x64.zip pass for version 6.21.0.
+set -eu
+version="${1:?usage: release-manifest.sh <version> <dir>}"
+dir="${2:?usage: release-manifest.sh <version> <dir>}"
+case "$version" in
+    *[!0-9A-Za-z.-]*|"") echo "release-manifest: bad version '$version'" >&2; exit 1 ;;
+esac
+cd "$dir"
+keys="win-x64 linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl darwin-x64 darwin-arm64"
+found=0
+for f in mStream-*.zip; do
+    [ -e "$f" ] || { echo "release-manifest: no mStream-*.zip in $dir" >&2; exit 1; }
+    ok=""
+    for k in $keys; do
+        [ "$f" = "mStream-$version-$k.zip" ] && ok=1
+    done
+    if [ -z "$ok" ]; then
+        echo "release-manifest: $f is not mStream-$version-<key>.zip for a known key - package.json and the tag disagree, or an unknown bundle" >&2
+        exit 1
+    fi
+    found=$((found + 1))
+done
+{
+    echo '{'
+    echo '  "name": "mstream",'
+    echo "  \"version\": \"$version\","
+    echo '  "apiVersion": 1,'
+    echo '  "assets": ['
+    first=true
+    for f in mStream-*.zip; do
+        if command -v sha256sum >/dev/null 2>&1; then
+            sum=$(sha256sum "$f" | cut -d' ' -f1)
+        else
+            sum=$(shasum -a 256 "$f" | cut -d' ' -f1)
+        fi
+        $first || echo ','
+        first=false
+        printf '    {"file": "%s", "sha256": "%s"}' "$f" "$sum"
+    done
+    echo ''
+    echo '  ]'
+    echo '}'
+} > manifest.json
+echo "release-manifest: $found assets -> $dir/manifest.json" >&2


### PR DESCRIPTION
## What ships

**Every release gets a `manifest.json`** — `{name, version, apiVersion, assets:[{file, sha256}]}`, the same shape as mstream-terminal-player's — generated in the release job from the downloaded bundles and uploaded beside them. The job also refuses to publish if any zip's filename doesn't carry the tag's version (the installers derive filenames from `manifest.version`, so a lagging package.json would produce an un-installable release).

**`install.sh`** (Linux/macOS, POSIX sh) and **`install.ps1`** (Windows, PS 5.1 floor, pure ASCII):

```sh
curl -fsSL https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.sh | sh
```
```powershell
irm https://raw.githubusercontent.com/IrosTheBeggar/mStream/master/install.ps1 | iex
```

Both: fetch the manifest **first** → derive the exact asset for this machine (OS + arch + **glibc-vs-musl on Linux**, via ldd's banner / `ld-musl` presence) → download → verify sha256 → extract into a versioned folder under the data-home-adjacent app root → point `current` at it (symlink / junction) → wire a `mstream-server` command (`~/.local/bin` symlink / user PATH) → desktop integration (Linux: the bundle's own `.desktop` with `%INSTALL_DIR%` filled — that placeholder has been waiting for exactly this; mac: `~/Applications/mStream.app` link; Windows: Start Menu shortcut). **Re-run = upgrade in place**; data lives outside the app folder, never touched. Old versions kept beside `current` for rollback. `MSTREAM_RELEASE_BASE` points at an internal mirror (also how this was tested).

**Post-install proof: `mstream-server -V`** (commander — instant, no boot). This caught a real gap: **Bun's musl build dynamically links `libstdc++`/`libgcc`, which a minimal Alpine lacks** — a wall of loader `Error relocating`. The installer now reports it *at install time with the fix* (`apk add libstdc++ libgcc`) instead of at the user's first run. Worth a line in the musl bundle's README too (follow-up).

## Layout
| | app root | command |
|---|---|---|
| Linux | `~/.local/share/mstream/app/<bundle>/` + `current` | `~/.local/bin/mstream-server` |
| macOS | `~/Library/Application Support/mStream/app/` | same |
| Windows | `%LOCALAPPDATA%\Programs\mStream\<bundle>\` + `current` junction | user PATH |

This is also the layout P4's auto-updater will want: versioned folders + one pointer flip.

## Verified against the REAL v6.20.0 assets (local mirror serving them + a generated manifest)
- **Windows**: install · upgrade-in-place (stale file gone, junction valid) · tampered-hash refusal · installed server boots from the install dir (`-j` config on :3998, live :3000 untouched)
- **Debian 12**: 8/8 — picked `linux-x64`, layout, symlinks, boot, upgrade, tamper refusal, desktop entry substituted with the `current` path
- **Alpine 3.20**: picked `linux-x64-musl` (the decisive libc test); bare box → runtime hint printed; after `apk add` → `mstream-server 6.20.0 runs`
- macOS: same code path as Linux minus the `.desktop` arm; the `~/Applications` link + `.app`-internal server path need one real run (mac agent).

Also: `docs/install.md` leads with the one-liners; the bundle README points at the script for upgrades.

Note: the manifest step lands in the release job **downstream** of #826's signing/stapling in the build legs — no overlap. Once #826 merges, the stapled mac zips are what get hashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
