### PR TITLE
reboot: keep the listening socket on same-bind reboots (fixes win-x64 smoke flake + mid-scan reboot death); single-flight ffmpeg install

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -543,6 +543,21 @@ jobs:
               echo "FAIL: no re-serve observed (boot lines ${BOOTS_BEFORE} -> ${BOOTS_AFTER}) — the reboot never happened"
               REBOOT_OK=0
             fi
+            # A same-bind reboot must KEEP the listening socket, never
+            # close()+listen() it. On Windows a live child (here: the ffmpeg
+            # download's PowerShell extractor, alive at this point on a fast
+            # runner) holds an inherited handle to the old listen socket under
+            # Bun <= 1.3.14 (oven-sh/bun#36936), so a relisten sits in
+            # EADDRINUSE until that child exits — this exact step used to die
+            # of it intermittently. Positive proof, not just survival.
+            if ! grep -q "keeping the listening socket" "$RUN/boot.log"; then
+              echo "FAIL: the same-bind reboot did not keep the listening socket (see boot.log)"
+              REBOOT_OK=0
+            fi
+            if grep -q "retrying listen" "$RUN/boot.log"; then
+              echo "FAIL: the same-bind reboot relistened (retrying listen seen) — the socket should never have been released"
+              REBOOT_OK=0
+            fi
 
             # (5) overlapping reboots must not kill the process. Two rapid admin
             # saves used to start two serveIt()s racing for the port; the loser
@@ -568,23 +583,35 @@ jobs:
               sleep 1
               if curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping"; then CONCURRENT_OK=1; break; fi
             done
-            # Must outlive a losing sibling's FULL relisten budget (20 x 250ms):
-            # the process.exit lands ~5s in, and a shorter wait passes against
-            # the very bug this guards.
+            # Must outlive the window in which a losing sibling used to
+            # process.exit() (its 5 s relisten budget — since replaced by an
+            # open-ended, backed-off retry, but a shorter wait would still pass
+            # against a regression of the coalescing itself). Note this step
+            # CHANGES the bind (address), so it exercises the recycle path: a
+            # relisten here — and, on Windows/Bun <= 1.3.14, a few EADDRINUSE
+            # retries while a child still holds the old socket — is expected.
             sleep 10
             curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || CONCURRENT_OK=0
             kill -0 "$SRV" 2>/dev/null || CONCURRENT_OK=0
-            # Fail closed on the TRIGGERS, not just on survival: both requests
+            # Fail closed on the TRIGGERS, not just on survival: the requests
             # must have been accepted, and the server must actually have come
             # back up again afterwards. Without these, "nothing happened" is
-            # indistinguishable from "handled two overlapping reboots".
+            # indistinguishable from "handled two overlapping reboots". At
+            # least one POST must be a 200 (it triggered a reboot); the other
+            # is a 200 (sequential or coalesced) OR a 503 — the reboot window's
+            # own answer, meaning it arrived while the first reboot was already
+            # tearing down (the listener stays bound and says "restarting"
+            # instead of refusing the connection). Anything else — a 400 from a
+            # renamed key, a 404 from a moved route, 000 — is a real failure.
             POST1=$(cat "$RUN/post1.code" 2>/dev/null)
             POST2=$(cat "$RUN/post2.code" 2>/dev/null)
             CONCURRENT_BOOTS_AFTER=$(grep -c "Access mStream locally" "$RUN/boot.log")
-            if [ "$POST1" != "200" ] || [ "$POST2" != "200" ]; then
-              echo "FAIL: reboot triggers were not accepted (HTTP $POST1 / $POST2) — this step would otherwise pass having rebooted NOTHING"
-              CONCURRENT_OK=0
-            fi
+            case "$POST1/$POST2" in
+              200/200|200/503|503/200) ;;
+              *)
+                echo "FAIL: reboot triggers were not accepted (HTTP ${POST1:-000} / ${POST2:-000}) — this step would otherwise pass having rebooted NOTHING"
+                CONCURRENT_OK=0 ;;
+            esac
             if [ "$CONCURRENT_BOOTS_AFTER" -le "$CONCURRENT_BOOTS_BEFORE" ]; then
               echo "FAIL: no additional boot after the overlapping reboots (before=$CONCURRENT_BOOTS_BEFORE after=$CONCURRENT_BOOTS_AFTER) — the server never actually restarted"
               CONCURRENT_OK=0
@@ -594,7 +621,7 @@ jobs:
             # timing-dependent, so a miss is reported, not fatal.
             grep -q "Reboot already in progress" "$RUN/boot.log" \
               && echo "ok: the duplicate reboot request was coalesced" \
-              || echo "note: no coalescing line — the two reboots did not overlap on this runner"
+              || echo "note: no coalescing line — the two reboots did not overlap on this runner (HTTP $POST1 / $POST2)"
           fi
           kill "$SRV" 2>/dev/null
 

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ import { compression } from './util/compression.js';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import https from 'https';
+import crypto from 'crypto';
 import { dataRoot, usingFallbackDataRoot } from './util/esm-helpers.js';
 
 import * as dbApi from './api/db.js';
@@ -62,32 +63,71 @@ import packageJson from '../package.json' with { type: 'json' };
 
 let mstream;
 let server;
-// Live sockets of the CURRENT server, for reboot()'s forced drain. Tracked by
+// Live sockets of the CURRENT listener, for reboot()'s forced drain. Tracked by
 // hand because closeAllConnections() is unusable under Bun: its shim nulls the
 // internal handle synchronously inside close(), so any sweep scheduled after
 // close() early-returns and does nothing (Node's, by contrast, still destroys
 // sockets). Without a working sweep a reboot during an active transfer — a
 // transcode, a big download — never fires its close callback and the server
-// never comes back. 'connection' fires on both runtimes, so this does.
+// never comes back. 'connection' fires on both runtimes, so this does. The set
+// lives as long as the listening socket does (it is NOT per serveIt(): a
+// same-bind reboot keeps the socket and swaps only the app — see below).
 let liveSockets = new Set();
-// True from the start of a reboot until its re-served instance is listening.
+// Identity of the CURRENT listener: { port, address, ssl, fingerprint }. Set
+// once a listen succeeds; reboot() hands it to the re-serve as `relisten` so
+// serveIt() can tell "same socket, keep it" from "bind changed, recycle it".
+let currentBind = null;
+// True from the start of a reboot until its re-served instance is serving.
 // Guards against overlapping reboots (two quick admin saves, two admin tabs):
-// a second server.close() on an already-closing server still runs its callback,
-// which would start a SECOND serveIt racing the first for the port — and the
-// loser would exhaust the relisten budget and process.exit() the whole process,
-// killing the healthy winner with it.
+// two serveIt()s racing for the same port would have the loser exhaust its
+// relisten budget and process.exit() the whole process, killing the healthy
+// winner with it.
 let rebootInFlight = false;
 
-// `relisten` carries the port THIS process just released, so a reboot's
-// re-serve can tell a Windows port-release delay from a real conflict.
-// Windows doesn't grant the immediate same-process rebind unix does —
-// close()'s callback can fire before the OS frees the port — so retrying
-// EADDRINUSE briefly is right THERE, and only there. It is deliberately not a
-// boolean: an admin who changed the port is re-serving a port this process
-// never owned, where a conflict is permanent, and retrying would spend five
-// seconds blaming a transient OS condition before exiting anyway (and on a
-// mac .app could even probe a DIFFERENT mStream on the new port and exit 0 as
-// "redundant"). First boots never retry for the same reason.
+// Placeholder request handler for the reboot window: the listening socket stays
+// bound while the app is torn down and rebuilt, and callers get an honest 503
+// instead of a connection refused (or, worse, a hang — see keepListener below).
+function rebootStub(req, res) {
+  res.statusCode = 503;
+  res.setHeader('Retry-After', '1');
+  res.setHeader('Connection', 'close');
+  res.end('mStream is restarting');
+}
+
+function bindLabel(bind) {
+  const host = bind.address.includes(':') ? `[${bind.address}]` : bind.address;
+  return `${bind.ssl ? 'https' : 'http'}://${host}:${bind.port}`;
+}
+
+function sameBind(a, b) {
+  return a.port === b.port && a.address === b.address && a.ssl === b.ssl && a.fingerprint === b.fingerprint;
+}
+
+// Why a same-bind reboot keeps the listening socket instead of close()+listen():
+// on Windows, a listen socket is a kernel object shared with every child that
+// inherited a handle to it, and under Bun <= 1.3.14 EVERY spawned child does
+// (uSockets created inheritable handles; fixed upstream in oven-sh/bun#36938,
+// unreleased as of Aug 2026). So close() in the parent releases nothing while a
+// scanner, transcode, ffmpeg download or enrichment worker is alive — the port
+// stays LISTENING (and even completes TCP handshakes that then hang) until the
+// last such child exits, which for a scan or a backfill can be an hour. A
+// close()+listen() reboot therefore meant EADDRINUSE for the child's lifetime;
+// with the old 5 s budget it meant the whole process exiting after any admin
+// save made mid-scan. Never giving the socket up sidesteps all of it, on every
+// runtime: only a changed bind (port, address, http<->https, rotated cert
+// material) recycles the listener.
+//
+// `relisten` carries the bind THIS process is currently serving, so a reboot's
+// re-serve can (a) keep the socket when nothing about the bind changed and
+// (b) when it did change but the PORT is the same, tell a release delay from a
+// real conflict. Windows doesn't grant the immediate same-process rebind unix
+// does — close()'s callback can fire before the OS frees the port — and the
+// inherited-handle hold above is the same symptom lasting longer, so retrying
+// EADDRINUSE is right THERE, and only there. It is deliberately not a boolean:
+// an admin who changed the port is re-serving a port this process never owned,
+// where a conflict is permanent, and retrying would only delay the inevitable
+// exit while blaming a transient OS condition. First boots never retry for the
+// same reason.
 export async function serveIt(configFile, { relisten = null } = {}) {
   mstream = express();
 
@@ -124,21 +164,80 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   }
 
   // Set server
-  if (config.program.ssl && config.program.ssl.cert && config.program.ssl.key) {
+  const wantSsl = !!(config.program.ssl && config.program.ssl.cert && config.program.ssl.key);
+  let sslMaterial = null;
+  if (wantSsl) {
     try {
-      config.setIsHttps(true);
-      server = https.createServer({
+      sslMaterial = {
         key: fs.readFileSync(config.program.ssl.key),
         cert: fs.readFileSync(config.program.ssl.cert),
-      });
+      };
     } catch (error) {
       winston.error('FAILED TO CREATE HTTPS SERVER');
       error.code = 'BAD CERTS';
       throw error;
     }
-  } else {
-    config.setIsHttps(false);
-    server = http.createServer();
+  }
+  config.setIsHttps(wantSsl);
+  const bind = {
+    port: config.program.port,
+    address: config.program.address,
+    ssl: wantSsl,
+    // Identity is the cert MATERIAL, not the file names: a rotated cert under
+    // unchanged paths must still recycle the listener, or the reused socket
+    // would keep serving the old certificate.
+    fingerprint: wantSsl
+      ? crypto.createHash('sha256').update(sslMaterial.key).update(sslMaterial.cert).digest('hex')
+      : null,
+  };
+  // Keep the socket when a reboot re-serves the very same bind (the common
+  // case: trust proxy, UI switch, request-size limit...). See keepListener's
+  // rationale above serveIt.
+  const keepListener = relisten !== null && !!server && server.listening && sameBind(relisten, bind);
+  if (!keepListener) {
+    // Build the replacement first: an unreadable or malformed cert must fail
+    // here, before anything is torn down.
+    let next;
+    try {
+      next = wantSsl ? https.createServer(sslMaterial) : http.createServer();
+    } catch (error) {
+      winston.error('FAILED TO CREATE HTTPS SERVER');
+      error.code = 'BAD CERTS';
+      throw error;
+    }
+    if (relisten !== null && server && server.listening) {
+      // The bind changed: this is a real recycle. Release the old listener
+      // before the new one binds, so a same-port move (address or TLS
+      // change) doesn't compete with itself. Node's close() waits for the
+      // remaining connections; reboot()'s grace-period sweep (already armed)
+      // destroys the stragglers so this settles within ~1 s. Under Bun the
+      // callback fires synchronously.
+      winston.info(`Reboot: bind changed ${bindLabel(relisten)} -> ${bindLabel(bind)}; recycling the listener`);
+      const oldSockets = liveSockets;
+      await new Promise((resolve) => {
+        server.close((err) => {
+          if (err) { winston.warn(`Reboot: closing the previous listener reported ${err.code || err.message}`); }
+          resolve();
+        });
+        // The socket kept accepting (and answering 503) during the teardown,
+        // so connections younger than reboot()'s snapshot exist; a stalled one
+        // must not hold close() — and this reboot — open indefinitely.
+        setTimeout(() => {
+          for (const socket of oldSockets) {
+            try { socket.destroy(); } catch (_) { /* already gone */ }
+          }
+        }, 1000);
+      });
+    }
+    server = next;
+    // Track live sockets for reboot()'s drain (see liveSockets above). Bound
+    // to the socket's lifetime, so registered exactly once per listener.
+    const mySockets = new Set();
+    liveSockets = mySockets;
+    server.on('connection', (socket) => {
+      mySockets.add(socket);
+      socket.on('close', () => mySockets.delete(socket));
+    });
   }
 
   // Magic Middleware Things
@@ -497,56 +596,9 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   });
 
   // Start the server!
-  const protocol = config.program.ssl && config.program.ssl.cert && config.program.ssl.key ? 'https' : 'http';
-  server.on('request', mstream);
-  // Without this handler a failed listen() — port already taken being the
-  // canonical case — dies as an uncaught 'error' event: a raw stack in a
-  // terminal, and under a desktop launch pure silence. Log it properly and
-  // exit non-zero; under the launcher, supervision reports the exit and the
-  // reason lands in server-console.log.
-  // Track live sockets for reboot()'s drain (see liveSockets above).
-  const mySockets = new Set();
-  liveSockets = mySockets;
-  server.on('connection', (socket) => {
-    mySockets.add(socket);
-    socket.on('close', () => mySockets.delete(socket));
-  });
-  const thisServer = server;
-  // Only arm the budget when we are re-taking the SAME port we just released.
-  let relistenRetries = (relisten !== null && relisten === config.program.port) ? 20 : 0;   // 20 × 250ms = 5s
-  if (relisten !== null && relistenRetries === 0) {
-    winston.info(`Reboot moved the port ${relisten} -> ${config.program.port}; a conflict on the new port is real, not a release delay`);
-  }
-  server.on('error', (err) => {
-    // Only the CURRENT server may act on its errors. A superseded instance
-    // (an overlapping reboot's loser) must never run the exit paths below —
-    // it would take the healthy live server down with it.
-    if (thisServer !== server) {
-      winston.warn(`Ignoring '${err.code || err.message}' from a superseded server instance`);
-      try { thisServer.close(); } catch (_) { /* already closed */ }
-      return;
-    }
-    if (err.code === 'EADDRINUSE' && relistenRetries > 0) {
-      relistenRetries--;
-      winston.warn(`Port ${config.program.port} not released yet after reboot — retrying listen (${relistenRetries} left)`);
-      // Bare listen(): the 'listening' handler is registered once below —
-      // passing a callback here would stack one stale once-listener per
-      // failed attempt, all firing together on the eventual success.
-      setTimeout(() => { if (thisServer === server) { thisServer.listen(config.program.port, config.program.address); } }, 250);
-      return;
-    }
-    if (err.code === 'EADDRINUSE') {
-      winston.error(`Unable to start mStream: port ${config.program.port} is already in use`);
-    } else {
-      winston.error(`Server error: ${err.message}`, { stack: err });
-    }
-    // Fatal diagnostics go to fd 2 directly as well: process.exit() below beats
-    // winston's File transport, whose boot-time backlog means the on-disk log
-    // of a writeLogs install otherwise just stops mid-boot with no reason.
-    try { fs.writeSync(2, `mStream fatal: ${err.code === 'EADDRINUSE' ? `port ${config.program.port} already in use` : err.message}\n`); } catch (_) { /* stderr gone too */ }
-    process.exit(1);
-  });
+  const protocol = bind.ssl ? 'https' : 'http';
   const onListening = async () => {
+    currentBind = bind;
     rebootInFlight = false;   // a reboot's re-serve is complete
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
 
@@ -633,26 +685,119 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     // eagerly so the admin endpoint has fresh data by the time it's called.
     serverPlaybackApi.bootRustPlayer().catch(() => {});
   };
-  server.once('listening', onListening);
-  server.listen(config.program.port, config.program.address);
+
+  if (keepListener) {
+    // Same bind: the socket never stopped listening. Swap the rebuilt app in
+    // for the reboot stub — atomically, in one tick, so no request falls into
+    // a gap — and run the post-listen boot chores exactly as a fresh listen
+    // would. The 'error' and 'connection' listeners registered when this
+    // socket was created stay in place; nothing about them is per-app.
+    winston.info(`Reboot: bind unchanged (${bindLabel(bind)}) — keeping the listening socket`);
+    server.off('request', rebootStub);
+    server.on('request', mstream);
+    // Fire-and-forget on purpose: same contract as the 'listening' event
+    // dispatch below (a rejection surfaces the same way in both paths).
+    onListening();
+    return;
+  }
+
+  server.on('request', mstream);
+  const thisServer = server;
+  // Without this handler a failed listen() — port already taken being the
+  // canonical case — dies as an uncaught 'error' event: a raw stack in a
+  // terminal, and under a desktop launch pure silence. Log it properly and
+  // exit non-zero; under the launcher, supervision reports the exit and the
+  // reason lands in server-console.log.
+  //
+  // EXCEPT when we are re-taking the very port this process was serving a
+  // moment ago (a reboot that changed the address or TLS setup but not the
+  // port). There EADDRINUSE is a release delay, not a conflict — Windows can
+  // report the port busy for a moment after close(), and under Bun <= 1.3.14
+  // on Windows a live child that inherited the old listen socket holds it
+  // until that child exits (see keepListener above). Both end on their own;
+  // neither is a reason to take the process down. So retry with backoff for
+  // as long as it takes, say why, and let the eventual listen succeed.
+  const samePortRelisten = relisten !== null && relisten.port === bind.port;
+  if (relisten !== null && !samePortRelisten) {
+    winston.info(`Reboot moved the port ${relisten.port} -> ${bind.port}; a conflict on the new port is real, not a release delay`);
+  }
+  const relistenStartedAt = Date.now();
+  let relistenAttempts = 0;
+  let relistenLastLoggedAt = 0;
+  let relistenDiagnosed = false;
+  server.on('error', (err) => {
+    // Only the CURRENT server may act on its errors. A superseded instance
+    // (an overlapping reboot's loser) must never run the exit paths below —
+    // it would take the healthy live server down with it.
+    if (thisServer !== server) {
+      winston.warn(`Ignoring '${err.code || err.message}' from a superseded server instance`);
+      try { thisServer.close(); } catch (_) { /* already closed */ }
+      return;
+    }
+    if (err.code === 'EADDRINUSE' && samePortRelisten) {
+      relistenAttempts++;
+      const waitedMs = Date.now() - relistenStartedAt;
+      // 250 ms for the first two seconds (the ordinary Windows release delay),
+      // then 1 s, then every 5 s once it is clearly a held socket.
+      const delay = waitedMs < 2000 ? 250 : waitedMs < 30000 ? 1000 : 5000;
+      // One line at once, the diagnosis once it has clearly outlasted a
+      // release delay (~5 s), then a heartbeat every 30 s.
+      if (relistenAttempts === 1) {
+        winston.warn(`Port ${bind.port} not released yet after reboot — retrying listen`);
+        relistenLastLoggedAt = Date.now();
+      } else if (waitedMs >= 5000 && Date.now() - relistenLastLoggedAt >= (relistenDiagnosed ? 30000 : 0)) {
+        winston.warn(
+          `Port ${bind.port} still held ${Math.round(waitedMs / 1000)}s after reboot — retrying until it frees ` +
+          '(mStream is unreachable meanwhile). A child process that was alive during the reboot — a scan, ' +
+          'transcode, ffmpeg download or enrichment worker — can hold the old listening socket until it ' +
+          'exits: under Bun <= 1.3.14 on Windows spawned children inherit it (oven-sh/bun#36936).');
+        relistenDiagnosed = true;
+        relistenLastLoggedAt = Date.now();
+      }
+      // Bare listen(): the 'listening' handler is registered once below —
+      // passing a callback here would stack one stale once-listener per
+      // failed attempt, all firing together on the eventual success.
+      setTimeout(() => { if (thisServer === server) { thisServer.listen(bind.port, bind.address); } }, delay);
+      return;
+    }
+    if (err.code === 'EADDRINUSE') {
+      winston.error(`Unable to start mStream: port ${bind.port} is already in use`);
+    } else {
+      winston.error(`Server error: ${err.message}`, { stack: err });
+    }
+    // Fatal diagnostics go to fd 2 directly as well: process.exit() below beats
+    // winston's File transport, whose boot-time backlog means the on-disk log
+    // of a writeLogs install otherwise just stops mid-boot with no reason.
+    try { fs.writeSync(2, `mStream fatal: ${err.code === 'EADDRINUSE' ? `port ${bind.port} already in use` : err.message}\n`); } catch (_) { /* stderr gone too */ }
+    process.exit(1);
+  });
+  server.once('listening', () => {
+    if (relistenAttempts > 0) {
+      winston.info(`Port ${bind.port} released after ${Math.round((Date.now() - relistenStartedAt) / 1000)}s (${relistenAttempts} retries)`);
+    }
+    onListening();
+  });
+  server.listen(bind.port, bind.address);
 }
 
 export function reboot() {
   try {
-    // Overlapping reboots are a hard outage, not a slow restart: a second
-    // close() on an already-closing server still runs its callback, so two
-    // serveIt()s race for the port and the loser's exhausted relisten budget
-    // exits the process out from under the winner. Two quick admin saves is
-    // all it takes. Coalesce instead — the in-flight reboot already re-reads
-    // the config from disk, so it picks up both changes.
+    // Overlapping reboots are a hard outage, not a slow restart: two
+    // serveIt()s would both try to take over the listener (or race for the
+    // port on a bind change, where the loser exits the process out from under
+    // the winner). Two quick admin saves is all it takes. Coalesce instead —
+    // the in-flight reboot already re-reads the config from disk, so it picks
+    // up both changes.
     if (rebootInFlight) {
       winston.warn('Reboot already in progress — skipping the duplicate request');
       return;
     }
     rebootInFlight = true;
-    // Captured BEFORE serveIt's config.setup re-reads the file: the re-serve
-    // only gets the EADDRINUSE retry budget if it is re-taking this same port.
-    const previousPort = config.program.port;
+    // The bind we are serving right now, captured BEFORE serveIt's
+    // config.setup re-reads the file: the re-serve keeps the socket if the
+    // new config binds identically, and only gets the EADDRINUSE patience if
+    // it is at least re-taking this same port.
+    const previousBind = currentBind;
     winston.info('Rebooting Server');
     logger.reset();
     scrobblerApi.reset();
@@ -663,10 +808,11 @@ export function reboot() {
     subsonicServer.stop();
     mdns.stop();
     serverPlaybackApi.killRustPlayer();
-    // Tear down the /remote WebSocket server — any open WS client
-    // otherwise keeps the HTTP server alive and server.close() below
-    // never fires its callback, leaving the user with "server stopped
-    // but never rebooted".
+    // Tear down the /remote WebSocket server: it detaches its upgrade/error
+    // listeners from the HTTP server (serveIt attaches a fresh one) and closes
+    // its clients — an open WS client would otherwise keep a recycled listener
+    // from ever closing, leaving the user with "server stopped but never
+    // rebooted".
     remoteApi.stop();
     // Pause the backup scheduler's timers (intervals + one-shot boot
     // ticks). serveIt below re-runs backupManager.init(), which re-arms
@@ -710,49 +856,41 @@ export function reboot() {
       new Promise((resolve) => setTimeout(resolve, 5000)),
     ]);
 
-    // Close the server. server.close() waits for every in-flight HTTP
-    // request AND every idle keep-alive socket to drain. The admin
-    // client that just issued the UI-switch POST has an open
-    // keep-alive socket; without closeAllConnections() we'd wait up
-    // to the agent's keep-alive timeout (tens of seconds) before the
-    // callback fires. Force the close after a short grace period so
-    // in-flight writes get a chance to finish but stragglers don't
-    // block the restart.
-    server.close((err) => {
-      // An already-closed server reports ERR_SERVER_NOT_RUNNING here; re-serving
-      // on that would mean two live instances fighting for the port.
-      if (err) {
-        winston.warn(`Reboot: server was already closed (${err.code || err.message}) — not re-serving`);
-        rebootInFlight = false;
-        return;
-      }
-      // serveIt can reject before its listen handler exists (bad SSL certs are
-      // the classic: config.setup re-reads the file every reboot, so a rotated
-      // cert first fails HERE). Unhandled, that's a raw unhandled rejection
-      // with the old server already town down — the silent death this PR set
-      // out to eliminate, just moved to the reboot path.
-      // Gate the re-serve on the discovery-p2p teardown finishing (see above).
-      p2pStopped.then(() => serveIt(config.configFile, { relisten: previousPort })).catch((rebootErr) => {
-        rebootInFlight = false;
-        winston.error('Reboot failed to restart the server', { stack: rebootErr });
-        try { fs.writeSync(2, `mStream fatal: reboot failed to restart the server: ${rebootErr.message}\n`); } catch (_) { /* stderr gone */ }
-        process.exit(1);
-      });
-    });
-    // Force the drain after a grace period. Sweeps the sockets WE tracked
-    // rather than calling closeAllConnections(): under Bun that method is a
-    // guaranteed no-op once close() has run (its shim nulls the internal
-    // handle synchronously inside close()), so an active transfer would hold
-    // the close callback — and therefore the whole restart — open forever.
-    // Destroying the old server's sockets is safe for the new one: `mySockets`
-    // is per-instance, and serveIt rebinds `liveSockets` to the new set.
-    const closingSockets = liveSockets;
+    // Park the listener rather than closing it: the socket stays bound and
+    // answers 503 while the app is rebuilt, and serveIt() either swaps the
+    // new app in (same bind — the usual case) or recycles the socket itself
+    // (bind changed). See keepListener above serveIt for why the socket must
+    // not be given up here.
+    if (server) {
+      server.off('request', mstream);
+      server.on('request', rebootStub);
+    }
+    // Drop the connections that existed at reboot time after a short grace
+    // period, so in-flight writes get a chance to finish but a long transfer
+    // (a transcode, a big download) doesn't keep the old app's handlers alive
+    // indefinitely — and, on a bind change, so Node's close() can settle (it
+    // waits for every connection to drain, and closeAllConnections() is a
+    // guaranteed no-op under Bun once close() has run). Snapshot, not the
+    // live set: connections the kept socket accepts after this moment belong
+    // to the stub and then to the new app.
+    const closingSockets = [...liveSockets];
     setTimeout(() => {
       for (const socket of closingSockets) {
         try { socket.destroy(); } catch (_) { /* already gone */ }
       }
-      closingSockets.clear();
     }, 1000);
+    // serveIt can reject before its listen handler exists (bad SSL certs are
+    // the classic: config.setup re-reads the file every reboot, so a rotated
+    // cert first fails HERE). Unhandled, that's a raw unhandled rejection
+    // with the old app already torn down — the silent death #803 set out to
+    // eliminate, just moved to the reboot path.
+    // Gate the re-serve on the discovery-p2p teardown finishing (see above).
+    p2pStopped.then(() => serveIt(config.configFile, { relisten: previousBind })).catch((rebootErr) => {
+      rebootInFlight = false;
+      winston.error('Reboot failed to restart the server', { stack: rebootErr });
+      try { fs.writeSync(2, `mStream fatal: reboot failed to restart the server: ${rebootErr.message}\n`); } catch (_) { /* stderr gone */ }
+      process.exit(1);
+    });
   } catch (err) {
     rebootInFlight = false;
     winston.error('Reboot Failed', { stack: err });

--- a/src/util/ffmpeg-bootstrap.js
+++ b/src/util/ffmpeg-bootstrap.js
@@ -15,6 +15,7 @@
 
 import fsp from 'node:fs/promises';
 import fs from 'node:fs';
+import http from 'node:http';
 import https from 'node:https';
 import crypto from 'node:crypto';
 import path from 'node:path';
@@ -30,7 +31,14 @@ const binaryExt = process.platform === 'win32' ? '.exe' : '';
 // compared to distinguish our managed install from a user's custom directory.
 const BUNDLED_FFMPEG_DIR = path.join(dataRoot, 'bin/ffmpeg');
 const MIN_FFMPEG_MAJOR = 6;
-const CHECKSUMS_URL = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256';
+// Where the builds come from. MSTREAM_FFMPEG_MIRROR replaces the upstream
+// base for BOTH sources (BtbN archive + checksums.sha256; martin-riedl's
+// per-binary zips + sibling .sha256) — for an internal mirror on an air-gapped
+// host, and for the unit test's loopback server. Layout under the base must
+// match upstream's; the mirror is only trusted over https or loopback http.
+const MIRROR = (process.env.MSTREAM_FFMPEG_MIRROR || '').replace(/\/+$/, '');
+const BTBN_BASE = MIRROR || 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest';
+const CHECKSUMS_URL = `${BTBN_BASE}/checksums.sha256`;
 // Download hardening: cap redirect chains and apply a socket-inactivity
 // timeout so a stalled or looping endpoint can't hang the process forever.
 const MAX_REDIRECTS = 5;
@@ -40,6 +48,18 @@ const HTTP_TIMEOUT_MS = 30000;
 const MAX_BUFFER_BYTES = 1024 * 1024;
 
 let _initPromise = null;
+// Bumped by reset(): a resolution chain started before a reset is stale — it
+// may still finish (its download is shared, see _install), but it must not
+// publish its outcome or touch the chain that superseded it.
+let _generation = 0;
+// The one in-flight install, keyed by its target dir: { dir, promise }.
+// Deliberately NOT cleared by reset(). Before this, a soft reboot mid-download
+// (reset() -> the re-served transcode.init() -> ensureFfmpeg()) started a
+// second download+extract into the SAME .staging dir while the first was still
+// extracting — each rm'ing the other's files, both racing to swap binaries in,
+// and the archive fetched twice per reboot (three times in one CI boot.log).
+// checkForUpdate() shares it, so a weekly check can't overlap a boot install.
+let _install = null;
 let _updateTimer = null;
 let _bootTimer = null;
 
@@ -120,7 +140,7 @@ function releaseInfo() {
   const asset = btbnAsset();
   if (asset) {
     return {
-      url: `https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${asset}`,
+      url: `${BTBN_BASE}/${asset}`,
       asset,
       source: 'btbn'
     };
@@ -134,7 +154,7 @@ function releaseInfo() {
   // stable build (vs `snapshot` = git master). Arch tokens are amd64/arm64.
   if (process.platform === 'darwin') {
     const macArch = process.arch === 'arm64' ? 'arm64' : 'amd64';
-    const base = `https://ffmpeg.martin-riedl.de/redirect/latest/macos/${macArch}/release`;
+    const base = MIRROR || `https://ffmpeg.martin-riedl.de/redirect/latest/macos/${macArch}/release`;
     return {
       url: `${base}/ffmpeg.zip`,
       ffprobeUrl: `${base}/ffprobe.zip`,
@@ -148,12 +168,29 @@ function releaseInfo() {
 
 // ── HTTP download with redirect following ───────────────────────────────────
 
+// Only https may leave the machine — a redirect chain must never downgrade a
+// binary download to cleartext. Plain http is accepted for loopback alone (a
+// same-host mirror, the test harness), where nothing can sit in the path.
+function isAcceptedUrl(u) {
+  if (u.startsWith('https:')) { return true; }
+  try {
+    const { protocol, hostname } = new URL(u);
+    return protocol === 'http:' && ['127.0.0.1', 'localhost', '[::1]'].includes(hostname);
+  } catch {
+    return false;
+  }
+}
+
+function clientFor(u) {
+  return u.startsWith('https:') ? https : http;
+}
+
 function downloadToBuffer(url) {
   return new Promise((resolve, reject) => {
     const follow = (u, redirects = 0) => {
       if (redirects > MAX_REDIRECTS) { return reject(new Error(`Too many redirects for ${url}`)); }
-      if (!u.startsWith('https:')) { return reject(new Error(`Refusing non-HTTPS URL: ${u}`)); }
-      const req = https.get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
+      if (!isAcceptedUrl(u)) { return reject(new Error(`Refusing non-HTTPS URL: ${u}`)); }
+      const req = clientFor(u).get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume();
           // Location may be relative (martin-riedl) — resolve against `u`.
@@ -199,8 +236,8 @@ function downloadToFile(url, destPath) {
   return new Promise((resolve, reject) => {
     const follow = (u, redirects = 0) => {
       if (redirects > MAX_REDIRECTS) { return reject(new Error(`Too many redirects for ${url}`)); }
-      if (!u.startsWith('https:')) { return reject(new Error(`Refusing non-HTTPS URL: ${u}`)); }
-      const req = https.get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
+      if (!isAcceptedUrl(u)) { return reject(new Error(`Refusing non-HTTPS URL: ${u}`)); }
+      const req = clientFor(u).get(u, { headers: { 'User-Agent': 'mstream-ffmpeg-bootstrap/2.0' } }, res => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume();
           return follow(new URL(res.headers.location, u).toString(), redirects + 1);
@@ -467,25 +504,41 @@ function getFfmpegVersion(binPath) {
 
 // ── Core download + verify ──────────────────────────────────────────────────
 
-async function downloadAndInstall() {
+// Single-flight per target dir (see _install). A caller arriving while an
+// install into the same dir is running — the re-served instance after a soft
+// reboot, the post-boot update check, a retry — joins it instead of starting a
+// competing one. A DIFFERENT dir (ffmpegDirectory changed by that reboot) is a
+// separate install with its own staging area, so the two never touch.
+function downloadAndInstall() {
+  const dir = getFfmpegDir();
+  if (_install && _install.dir === dir) { return _install.promise; }
+  const promise = installInto(dir).finally(() => {
+    if (_install && _install.promise === promise) { _install = null; }
+  });
+  _install = { dir, promise };
+  return promise;
+}
+
+async function installInto(dir) {
   const info = releaseInfo();
   if (!info) {
     winston.warn(
       `[ffmpeg-bootstrap] No static build for ${process.platform}/${process.arch}. ` +
-      `Place ffmpeg and ffprobe in ${getFfmpegDir()} manually.`
+      `Place ffmpeg and ffprobe in ${dir} manually.`
     );
     return false;
   }
 
-  const dir = getFfmpegDir();
   await fsp.mkdir(dir, { recursive: true });
 
   // Everything is downloaded, extracted, and verified in a staging dir, then
   // renamed into place as a pair. The live binaries stay untouched (and
   // spawnable) for the whole multi-minute download window, and a broken build
   // (glibc mismatch, truncated extract) is rejected before it ever replaces a
-  // working install. Staging lives INSIDE getFfmpegDir() so the final rename
-  // never crosses filesystems.
+  // working install. Staging lives INSIDE the target dir so the final rename
+  // never crosses filesystems. Only one install per dir runs in this process
+  // (downloadAndInstall's single-flight), so the rm here can only ever hit a
+  // previous run's leftovers, never a live one's.
   const staging = path.join(dir, '.staging');
   await fsp.rm(staging, { recursive: true, force: true }).catch(() => {});
   await fsp.mkdir(staging, { recursive: true });
@@ -497,7 +550,7 @@ async function downloadAndInstall() {
   const stagedFfmpeg = path.join(staging, `ffmpeg${binaryExt}`);
   const stagedFfprobe = path.join(staging, `ffprobe${binaryExt}`);
 
-  winston.info(`[ffmpeg-bootstrap] Downloading ffmpeg for ${process.platform}/${process.arch}...`);
+  winston.info(`[ffmpeg-bootstrap] Downloading ffmpeg for ${process.platform}/${process.arch}...${MIRROR ? ` (mirror: ${MIRROR})` : ''}`);
 
   try {
     let archiveChecksum = null;
@@ -591,12 +644,39 @@ async function downloadAndInstall() {
  *
  * Safe to call multiple times — dedupes via cached promise. On success sets
  * _resolvedFfmpegPath / _resolvedFfprobePath / _resolvedSource.
+ *
+ * A chain that a reset() overtakes (soft reboot mid-resolution) runs to its
+ * end — its download is the shared single-flight one — but as a bystander: it
+ * neither publishes its result nor clears the promise of the chain that
+ * replaced it (that used to be possible, and turned one reboot into a THIRD
+ * download).
  */
 export async function ensureFfmpeg() {
   if (_resolvedFfmpegPath) {
     return { ffmpeg: _resolvedFfmpegPath, ffprobe: _resolvedFfprobePath, source: _resolvedSource };
   }
   if (_initPromise) return _initPromise;
+
+  const gen = _generation;
+  const current = () => gen === _generation;
+  // Publish a resolution — unless a reset() has made this chain stale, in
+  // which case the caller still gets its answer but the module state stays
+  // with the current chain.
+  const resolved = (ffmpeg, ffprobe, source, line) => {
+    if (current()) {
+      _resolvedFfmpegPath = ffmpeg;
+      _resolvedFfprobePath = ffprobe;
+      _resolvedSource = source;
+      winston.info(`[ffmpeg-bootstrap] ${line}`);
+    }
+    return { ffmpeg, ffprobe, source };
+  };
+  // Don't cache a failure — let a later call retry. Only OUR promise, though:
+  // a stale chain must not wipe out its successor's.
+  const failed = () => {
+    if (current()) { _initPromise = null; }
+    return null;
+  };
 
   _initPromise = (async () => {
     const dir = getFfmpegDir();
@@ -611,11 +691,7 @@ export async function ensureFfmpeg() {
       // Subsonic / DLNA paths. Every other resolution path checks both.
       const probe = await getFfmpegVersion(bundledFfprobe);
       if (major >= MIN_FFMPEG_MAJOR && probe.major >= MIN_FFMPEG_MAJOR) {
-        _resolvedFfmpegPath = bundledFfmpeg;
-        _resolvedFfprobePath = bundledFfprobe;
-        _resolvedSource = 'bundled';
-        winston.info(`[ffmpeg-bootstrap] ${versionLine}`);
-        return { ffmpeg: _resolvedFfmpegPath, ffprobe: _resolvedFfprobePath, source: _resolvedSource };
+        return resolved(bundledFfmpeg, bundledFfprobe, 'bundled', versionLine);
       }
       winston.warn(`[ffmpeg-bootstrap] ffmpeg v${major || '?'} / ffprobe v${probe.major || '?'} in ${dir} is unusable, refreshing`);
       await fsp.unlink(bundledFfmpeg).catch(() => {});
@@ -627,15 +703,10 @@ export async function ensureFfmpeg() {
       winston.info('[ffmpeg-bootstrap] musl libc detected, skipping download');
       const sys = await findSystemBinaries();
       if (sys) {
-        _resolvedFfmpegPath = sys.ffmpeg;
-        _resolvedFfprobePath = sys.ffprobe;
-        _resolvedSource = 'system';
-        winston.info(`[ffmpeg-bootstrap] Using system ffmpeg: ${sys.ffmpegVersion}`);
-        return { ffmpeg: _resolvedFfmpegPath, ffprobe: _resolvedFfprobePath, source: _resolvedSource };
+        return resolved(sys.ffmpeg, sys.ffprobe, 'system', `Using system ffmpeg: ${sys.ffmpegVersion}`);
       }
       winston.error('[ffmpeg-bootstrap] No system ffmpeg found. Install with: apk add ffmpeg');
-      _initPromise = null; // don't cache failure — let a later call retry
-      return null;
+      return failed();
     }
 
     // ── Step 3: Download to getFfmpegDir(), verify it executes ───────────
@@ -643,11 +714,7 @@ export async function ensureFfmpeg() {
     if (downloadOk) {
       const { major, versionLine } = await getFfmpegVersion(bundledFfmpeg);
       if (major >= MIN_FFMPEG_MAJOR) {
-        _resolvedFfmpegPath = bundledFfmpeg;
-        _resolvedFfprobePath = bundledFfprobe;
-        _resolvedSource = 'bundled';
-        winston.info(`[ffmpeg-bootstrap] ${versionLine}`);
-        return { ffmpeg: _resolvedFfmpegPath, ffprobe: _resolvedFfprobePath, source: _resolvedSource };
+        return resolved(bundledFfmpeg, bundledFfprobe, 'bundled', versionLine);
       }
       winston.warn(`[ffmpeg-bootstrap] Downloaded ffmpeg won't execute (likely libc mismatch), trying system fallback`);
       await fsp.unlink(bundledFfmpeg).catch(() => {});
@@ -657,21 +724,15 @@ export async function ensureFfmpeg() {
     // ── Step 4: System PATH fallback ─────────────────────────────────────
     const sys = await findSystemBinaries();
     if (sys) {
-      _resolvedFfmpegPath = sys.ffmpeg;
-      _resolvedFfprobePath = sys.ffprobe;
-      _resolvedSource = 'system';
-      winston.info(`[ffmpeg-bootstrap] Using system ffmpeg: ${sys.ffmpegVersion}`);
-      return { ffmpeg: _resolvedFfmpegPath, ffprobe: _resolvedFfprobePath, source: _resolvedSource };
+      return resolved(sys.ffmpeg, sys.ffprobe, 'system', `Using system ffmpeg: ${sys.ffmpegVersion}`);
     }
 
     // ── Step 5: Nothing works ────────────────────────────────────────────
     winston.error('[ffmpeg-bootstrap] No working ffmpeg found (download failed and no system binary on PATH)');
-    _initPromise = null; // don't cache failure — let a later call retry
-    return null;
+    return failed();
   })().catch(e => {
     winston.error(`[ffmpeg-bootstrap] ${e.message}`);
-    _initPromise = null; // allow retry
-    return null;
+    return failed();
   });
 
   return _initPromise;
@@ -690,8 +751,15 @@ export function getResolvedSource() {
 /**
  * Reset all resolved state — used by transcode.reset() on soft reboot so that
  * a changed ffmpegDirectory is picked up by the next ensureFfmpeg() call.
+ *
+ * An install already in flight is left alone on purpose: the next
+ * ensureFfmpeg() re-walks the chain and, if the target dir is unchanged, joins
+ * that install rather than starting a competitor (see _install). The chain
+ * that was running is marked stale (see ensureFfmpeg) so it can't publish over
+ * — or clear the promise of — the one the re-serve starts.
  */
 export function reset() {
+  _generation++;
   _resolvedFfmpegPath = null;
   _resolvedFfprobePath = null;
   _resolvedSource = null;
@@ -722,7 +790,7 @@ export async function checkForUpdate() {
     // BtbN: compare checksums to detect new builds
     const checksumFile = path.join(getFfmpegDir(), '.checksum');
     let stored = null;
-    try { stored = (await fsp.readFile(checksumFile, 'utf8')).trim(); } catch {}
+    try { stored = (await fsp.readFile(checksumFile, 'utf8')).trim(); } catch { /* no baseline yet */ }
 
     // `.checksum` is only ever written by our own installs, so it doubles as
     // a provenance marker. No baseline in a CUSTOM ffmpegDirectory means the

--- a/test/integration/reboot-keeps-listener.test.mjs
+++ b/test/integration/reboot-keeps-listener.test.mjs
@@ -1,0 +1,182 @@
+/**
+ * A soft reboot (admin config change) must not give up the listening socket
+ * when the bind is unchanged, and must recycle it cleanly when it is.
+ *
+ * Why this matters: on Windows a listen socket is shared with every child
+ * process holding an inherited handle to it, and under Bun <= 1.3.14 every
+ * spawned child does (uSockets created inheritable handles — fixed upstream
+ * in oven-sh/bun#36938, unreleased as of Aug 2026). A close()+listen() reboot
+ * therefore got EADDRINUSE for as long as a scanner / transcode / ffmpeg
+ * download / enrichment worker lived, and the old 5 s relisten budget then
+ * took the whole process down. The reboot path now keeps the socket bound
+ * (answering 503 while the app is rebuilt) unless port/address/TLS material
+ * changed, and a same-port recycle retries EADDRINUSE patiently instead of
+ * exiting.
+ *
+ * Covered here (Node always, Bun when installed):
+ *   - same-bind reboot: no connection is ever refused during the window,
+ *     every answer is a 503 or a real one, the new config lands, and the log
+ *     says the socket was kept (no relisten, no retry);
+ *   - bind-changed reboot (address): the listener is recycled and the API
+ *     comes back on the new bind.
+ * The Bun/child-process case itself is exercised end-to-end by the win-x64
+ * leg of build-bun.yml (an ffmpeg download's PowerShell extractor is alive
+ * at the reboot on a fast runner).
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { spawnSync } from 'node:child_process';
+import { startServer } from '../helpers/server.mjs';
+
+// MSTREAM_TEST_BUN_BIN points at a bun executable when `bun` on PATH is not
+// spawnable without a shell (npm's bun.ps1/bun.cmd shim on Windows).
+const BUN_BIN = process.env.MSTREAM_TEST_BUN_BIN || 'bun';
+const bunProbe = spawnSync(BUN_BIN, ['--version'], { encoding: 'utf8' });
+const bunAvailable = !bunProbe.error && bunProbe.status === 0;
+const noBun = bunAvailable ? false : 'bun is not installed on this machine';
+
+const ADMIN = { username: 'admin', password: 'pw-admin' };
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function login(server) {
+  const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(ADMIN),
+  });
+  assert.equal(r.status, 200);
+  return (await r.json()).token;
+}
+
+const adminGet = (server, jwt, p) => fetch(`${server.baseUrl}${p}`, { headers: { 'x-access-token': jwt } });
+const adminPost = (server, jwt, p, body) => fetch(`${server.baseUrl}${p}`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json', 'x-access-token': jwt }, body: JSON.stringify(body),
+});
+
+// The admin panel's live-log ring buffer survives the reboot's logger.reset(),
+// so it is the black-box view of which reboot path ran.
+async function recentLogText(server, jwt, sinceSeq = 0) {
+  const r = await adminGet(server, jwt, `/api/v1/admin/logs/recent?since=${sinceSeq}`);
+  assert.equal(r.status, 200);
+  const body = await r.json();
+  return { text: body.entries.map(e => e.message ?? JSON.stringify(e)).join('\n'), lastSeq: body.lastSeq };
+}
+
+// One raw HTTP/1.1 GET on a fresh TCP connection. Resolves to the status code,
+// or to a string naming the connection-level failure. During a kept-listener
+// reboot the kernel keeps accepting, so a refusal here is the bug.
+function rawGet(port, host, path, jwt) {
+  return new Promise(resolve => {
+    let buf = '';
+    let settled = false;
+    const done = v => { if (!settled) { settled = true; resolve(v); } };
+    const sock = net.connect({ port, host }, () => {
+      sock.write(`GET ${path} HTTP/1.1\r\nHost: ${host}\r\nx-access-token: ${jwt}\r\nConnection: close\r\n\r\n`);
+    });
+    sock.setTimeout(3000, () => { done('timeout'); sock.destroy(); });
+    sock.on('data', d => {
+      buf += d;
+      const m = /^HTTP\/1\.[01] (\d{3})/.exec(buf);
+      if (m) { done(Number(m[1])); sock.destroy(); }
+    });
+    sock.on('error', err => done(err.code || err.message));
+    sock.on('close', () => done(buf ? 'closed-before-status' : 'closed-without-response'));
+  });
+}
+
+async function waitForTrustProxy(server, jwt, expected, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const r = await adminGet(server, jwt, '/api/v1/admin/config');
+      if (r.status === 200 && (await r.json()).trustProxy === expected) { return; }
+    } catch { /* mid-reboot */ }
+    if (Date.now() > deadline) { throw new Error(`trustProxy never became ${expected} after reboot`); }
+    await sleep(100);
+  }
+}
+
+async function waitForApi(baseUrl, jwt, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const r = await fetch(`${baseUrl}/api/v1/ping`, { headers: { 'x-access-token': jwt } });
+      if (r.status === 200) { return; }
+    } catch { /* mid-reboot */ }
+    if (Date.now() > deadline) { throw new Error(`API did not come back at ${baseUrl}`); }
+    await sleep(100);
+  }
+}
+
+function suite(label, startOpts) {
+  describe(`soft reboot keeps the listener (${label})`, () => {
+    let server;
+    let jwt;
+
+    before(async () => {
+      server = await startServer({ dlnaMode: 'disabled', subsonicMode: 'disabled', users: [{ ...ADMIN, admin: true }], ...startOpts });
+      jwt = await login(server);
+    });
+
+    after(async () => { if (server) { await server.stop(); } });
+
+    test('same-bind reboot: nothing is refused, the config lands, the socket was kept', async () => {
+      const { lastSeq } = await recentLogText(server, jwt);
+
+      const r = await adminPost(server, jwt, '/api/v1/admin/config/trust-proxy', { trustProxy: true });
+      assert.equal(r.status, 200);
+
+      // Hammer fresh connections through the reboot window. Every one must be
+      // accepted; every answer must be the reboot stub's 503 or a real reply.
+      const outcomes = [];
+      const until = Date.now() + 1500;
+      while (Date.now() < until) {
+        outcomes.push(await rawGet(server.port, '127.0.0.1', '/api/v1/ping', jwt));
+      }
+      const bad = outcomes.filter(o => o !== 200 && o !== 503);
+      assert.deepEqual(bad, [], `connection-level failures during the reboot window: ${JSON.stringify(outcomes)}`);
+      assert.ok(outcomes.length > 0);
+
+      await waitForTrustProxy(server, jwt, true);
+
+      const { text } = await recentLogText(server, jwt, lastSeq);
+      assert.match(text, /Rebooting Server/);
+      assert.match(text, /Reboot: bind unchanged .* keeping the listening socket/);
+      assert.doesNotMatch(text, /recycling the listener|retrying listen|already in use/);
+      // The post-listen boot chores ran again on the kept socket.
+      assert.match(text, /Access mStream locally/);
+
+      // Leave the server as we found it (a second same-bind reboot).
+      const r2 = await adminPost(server, jwt, '/api/v1/admin/config/trust-proxy', { trustProxy: false });
+      assert.equal(r2.status, 200);
+      await waitForTrustProxy(server, jwt, false);
+    });
+
+    test('bind-changed reboot (address): the listener is recycled and the API returns', async () => {
+      const { lastSeq } = await recentLogText(server, jwt);
+      // 127.0.0.1 -> 0.0.0.0 keeps 127.0.0.1 reachable but is a different bind.
+      const r = await adminPost(server, jwt, '/api/v1/admin/config/address', { address: '0.0.0.0' });
+      assert.equal(r.status, 200);
+      await waitForApi(server.baseUrl, jwt);
+      // Wait for the rebooted instance to report the new address.
+      const deadline = Date.now() + 20_000;
+      for (;;) {
+        try {
+          const c = await adminGet(server, jwt, '/api/v1/admin/config');
+          if (c.status === 200 && (await c.json()).address === '0.0.0.0') { break; }
+        } catch { /* mid-reboot */ }
+        if (Date.now() > deadline) { throw new Error('address never became 0.0.0.0 after reboot'); }
+        await sleep(100);
+      }
+      const { text } = await recentLogText(server, jwt, lastSeq);
+      assert.match(text, /Reboot: bind changed .* recycling the listener/);
+      assert.doesNotMatch(text, /keeping the listening socket|already in use/);
+      assert.match(text, /Access mStream locally/);
+    });
+  });
+}
+
+suite('node', {});
+// Same contract under the standalone-binary runtime. Skipped where bun is
+// absent (the win-x64 CI smoke covers the shipped binary itself).
+describe('bun', { skip: noBun }, () => { suite('bun', { execPath: BUN_BIN }); });

--- a/test/unit/ffmpeg-bootstrap.test.mjs
+++ b/test/unit/ffmpeg-bootstrap.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * ffmpeg-bootstrap: the download+install must be single-flight across a soft
+ * reboot.
+ *
+ * reboot() -> transcode.reset() -> ffmpeg-bootstrap reset() used to null the
+ * cached resolution promise while a download was still in flight; the
+ * re-served instance's transcode.init() then started a SECOND download +
+ * extract into the SAME .staging dir (each rm'ing the other's files, both
+ * racing to swap binaries in) — three "Downloading ffmpeg" lines in one CI
+ * boot.log. Now the in-flight install is shared: a chain that arrives while an
+ * install into the same dir is running joins it; a different dir (the reboot
+ * changed ffmpegDirectory) gets its own.
+ *
+ * Hermetic: MSTREAM_FFMPEG_MIRROR points the bootstrap at a loopback server
+ * that serves a slow fake archive and DELIBERATELY WRONG checksums, so every
+ * download completes, fails verification (no extractor is spawned, nothing is
+ * installed) and the chain falls through to the system-PATH probe. What is
+ * asserted is how many times the archive was fetched. The env var is read at
+ * module import, and config.js imports the bootstrap transitively (via
+ * api/transcode.js), so the server is started and the env set BEFORE the
+ * first src import.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// musl skips the download step by design (no static build) — nothing to test.
+const isMusl = process.platform === 'linux' && !(process.report?.getReport?.()?.header?.glibcVersionRuntime);
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+async function waitFor(cond, what, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) { throw new Error(`timed out waiting for ${what}`); }
+    await sleep(20);
+  }
+}
+
+// How long the fake archive body is held open mid-transfer: the window in
+// which reset() + a second ensureFfmpeg() land while the first download is
+// still in flight. Generous, so a slow CI runner can't slip past it.
+const HOLD_MS = 1500;
+const ZERO_DIGEST = '0'.repeat(64);
+
+let server;
+let baseUrl;
+let tmpDir;
+let config;
+let bootstrap;
+const archiveHits = [];   // request paths of archive fetches, in order
+const pending = new Set(); // held responses, released on teardown
+
+describe('ffmpeg-bootstrap: single-flight install across reset()', { skip: isMusl && 'musl skips the download step' }, () => {
+  before(async () => {
+    server = http.createServer((req, res) => {
+      const { pathname } = new URL(req.url, 'http://x');
+      // checksums.sha256 (BtbN) and <asset>.sha256 (martin-riedl): a digest
+      // that can never match, so a finished download is refused, not installed.
+      if (pathname.endsWith('.sha256')) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end([
+          `${ZERO_DIGEST}  ffmpeg-master-latest-linux64-gpl.tar.xz`,
+          `${ZERO_DIGEST}  ffmpeg-master-latest-linuxarm64-gpl.tar.xz`,
+          `${ZERO_DIGEST}  ffmpeg-master-latest-win64-gpl.zip`,
+          '',
+        ].join('\n'));
+        return;
+      }
+      // The archive: headers + a first chunk now, the rest after HOLD_MS.
+      archiveHits.push(pathname);
+      res.writeHead(200, { 'content-type': 'application/octet-stream' });
+      res.write('not-an-archive-');
+      const timer = setTimeout(() => { pending.delete(timer); res.end('tail'); }, HOLD_MS);
+      pending.add(timer);
+      res.on('close', () => { clearTimeout(timer); pending.delete(timer); });
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+    process.env.MSTREAM_FFMPEG_MIRROR = baseUrl;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-ffmpeg-bootstrap-'));
+    config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    config.program.transcode.ffmpegDirectory = path.join(tmpDir, 'ffmpeg-a');
+    bootstrap = await import('../../src/util/ffmpeg-bootstrap.js');
+  });
+
+  after(async () => {
+    for (const t of pending) { clearTimeout(t); }
+    bootstrap?.reset();
+    await new Promise(resolve => server.close(resolve));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('concurrent callers share one download (baseline, no reset)', async () => {
+    archiveHits.length = 0;
+    const results = await Promise.all([bootstrap.ensureFfmpeg(), bootstrap.ensureFfmpeg(), bootstrap.ensureFfmpeg()]);
+    assert.equal(archiveHits.length, 1, `archive fetched ${archiveHits.length}x: ${archiveHits.join(', ')}`);
+    // Whatever the machine has on PATH, the outcome is one answer for all.
+    assert.equal(results.length, 3);
+    assert.notEqual(bootstrap.getResolvedSource(), 'bundled', 'the fake archive must never install');
+  });
+
+  test('ensureFfmpeg() → reset() → ensureFfmpeg() mid-download issues ONE download', async () => {
+    bootstrap.reset();
+    archiveHits.length = 0;
+
+    const first = bootstrap.ensureFfmpeg();
+    await waitFor(() => archiveHits.length === 1, 'the first archive request');
+
+    // The soft reboot: transcode.reset() -> reset(), then the re-served
+    // instance's init() -> ensureFfmpeg(), while the archive is still coming in.
+    bootstrap.reset();
+    const second = bootstrap.ensureFfmpeg();
+
+    const [r1, r2] = await Promise.all([first, second]);
+    assert.equal(archiveHits.length, 1, `archive fetched ${archiveHits.length}x: ${archiveHits.join(', ')}`);
+    // Both callers got an answer (whatever it is on this machine): the stale
+    // chain finished as a bystander, the new one is the published state.
+    assert.equal(r1 === null || typeof r1 === 'object', true);
+    assert.equal(r2 === null || typeof r2 === 'object', true);
+    assert.notEqual(bootstrap.getResolvedSource(), 'bundled');
+  });
+
+  test('a changed ffmpegDirectory mid-download starts its own install (two downloads, no sharing)', async () => {
+    bootstrap.reset();
+    archiveHits.length = 0;
+    config.program.transcode.ffmpegDirectory = path.join(tmpDir, 'ffmpeg-b');
+
+    const first = bootstrap.ensureFfmpeg();
+    await waitFor(() => archiveHits.length === 1, 'the first archive request');
+
+    bootstrap.reset();
+    config.program.transcode.ffmpegDirectory = path.join(tmpDir, 'ffmpeg-c');
+    const second = bootstrap.ensureFfmpeg();
+    await waitFor(() => archiveHits.length === 2, 'the second archive request (new dir)');
+
+    await Promise.all([first, second]);
+    assert.equal(archiveHits.length, 2);
+    // Each install staged under its own dir and cleaned up after itself.
+    assert.equal(fs.existsSync(path.join(tmpDir, 'ffmpeg-b', '.staging')), false);
+    assert.equal(fs.existsSync(path.join(tmpDir, 'ffmpeg-c', '.staging')), false);
+  });
+
+  test('callers arriving after the reset join the current chain (still one download)', async () => {
+    // Chain 1 downloads into dir D; reset(); chain 2 (same dir) joins the
+    // download and a third caller joins chain 2 — one download for all three.
+    // (The stale-chain guard in ensureFfmpeg — a superseded chain must not
+    // publish or clear its successor's promise — is a race window of
+    // microseconds and is covered by code comment, not asserted here.)
+    bootstrap.reset();
+    archiveHits.length = 0;
+    config.program.transcode.ffmpegDirectory = path.join(tmpDir, 'ffmpeg-d');
+
+    const first = bootstrap.ensureFfmpeg();
+    await waitFor(() => archiveHits.length === 1, 'the first archive request');
+    bootstrap.reset();
+    const second = bootstrap.ensureFfmpeg();
+    const third = bootstrap.ensureFfmpeg();   // joins chain 2's promise
+    await Promise.all([first, second, third]);
+    assert.equal(archiveHits.length, 1, `archive fetched ${archiveHits.length}x: ${archiveHits.join(', ')}`);
+  });
+});


### PR DESCRIPTION
## What

**1. Soft reboots no longer give up the listening socket** (`src/server.js`)
- `reboot()` parks the live listener behind a 503 stub (`Retry-After: 1`) instead of `server.close()`, tears down as before, and hands the current bind (`{port, address, ssl, cert-material sha256}`) to `serveIt()`.
- `serveIt()` **keeps the socket** when the bind is unchanged — swaps the rebuilt app in for the stub, runs the post-listen chores — and only **recycles** the listener when the bind changed (address/port/http↔https/rotated cert). The replacement server is created before the old one is closed, so a bad cert still fails with `BAD CERTS` before anything is torn down.
- A **same-port relisten** (address/TLS change) retries EADDRINUSE with backoff (250 ms → 1 s → 5 s) and logs the diagnosis at ~5 s / every 30 s, instead of `process.exit(1)` after 5 s. First boots and moved ports still exit immediately as before.

**2. ffmpeg-bootstrap: one install per reboot, not one per reboot *plus* one per re-serve** (`src/util/ffmpeg-bootstrap.js`)
- `downloadAndInstall()` is single-flight per target dir (`_install = {dir, promise}`), deliberately not cleared by `reset()`; `checkForUpdate()` shares it. A changed `ffmpegDirectory` mid-download gets its own install.
- `reset()` bumps a generation counter so a superseded resolution chain neither publishes resolved state nor nulls its successor's `_initPromise` (the old code could — one reboot could turn into a *third* download).
- `MSTREAM_FFMPEG_MIRROR` = base URL for the BtbN assets + `checksums.sha256` (and the darwin martin-riedl zips); plain http accepted for **loopback only**, everything else stays https-only. Doubles as an air-gapped-mirror knob and the unit test's seam.

**3. Smoke** (`.github/workflows/build-bun.yml`, win-x64 leg's step 4/5): step (4) now fails closed on `keeping the listening socket` present / `retrying listen` absent (positive proof, not just survival); step (5) accepts a `503` for the *second* of its two concurrent `/config/address` POSTs (it arrived inside the reboot window — under the old code that interleaving was a `000` FAIL nobody had hit yet; all four recent green runs saw sequential reboots) while still requiring one `200` and failing on 400/404/000.

**Tests**: `test/integration/reboot-keeps-listener.test.mjs` (Node + Bun legs; `MSTREAM_TEST_BUN_BIN` for machines where npm's `bun` shim isn't spawnable) hammers fresh connections through the reboot window (master: stream of `ECONNREFUSED`; now: only 503/200), asserts the ring-buffer log lines, and covers the address-change recycle. `test/unit/ffmpeg-bootstrap.test.mjs` is hermetic on all three OSes (loopback mirror serving a slow fake archive with wrong checksums, so nothing is ever installed) — with the single-flight disabled it fails with "archive fetched 2x".

## Why

The win-x64 `build-bun` smoke ([run 32094833102, job 95584019673](https://github.com/IrosTheBeggar/mStream/actions/runs/32094833102/job/95584019673)) failed at step (4): after the trust-proxy POST the relisten got EADDRINUSE for its whole 20×250 ms budget → `Unable to start mStream: port 3399 is already in use` → exit. Root cause: **Bun ≤ 1.3.14 on Windows creates inheritable socket handles**, so every spawned child holds a duplicate of the listen socket and `close()` in the parent releases nothing until that child exits (`netstat` keeps showing the port `LISTENING` under the dead listener; the kernel even completes handshakes that then hang). In the smoke the child was the ffmpeg download's PowerShell extractor — alive at the reboot only when the 130 MB download finished fast, hence intermittent. Fixed upstream in [oven-sh/bun#36938](https://github.com/oven-sh/bun/pull/36938) (merged 2026-08-05) but **not in any release** (1.3.14 = latest); CI's `bun-version: latest` and the shipped 6.20.x Windows binaries carry it.

Production impact was real, not just CI: with the staged binary, **saving any reboot-requiring admin setting during a scan killed the whole server** (the `rust-parser` child held the port → 5 s → exit) — same for a transcode, backfill or enrichment worker alive at that moment. Keeping the socket sidesteps the whole class on every runtime; the patient relisten covers the residual bind-change case; the Bun bump when it ships removes the runtime cause on top.

## Reviewer notes

- Verified with the rebuilt win-x64 bundle: reboot with the extractor alive → 70 ms on the same listener; reboot mid-scan → 95 ms, scan keeps running; address change with a live child → 11 EADDRINUSE retries over 6 s then up (old code would have died at 5 s). The workflow's smoke script run verbatim locally: `SMOKE OK` twice (once coalesced, once the 200/503 interleaving), one "Downloading ffmpeg" per boot across its three reboots (was three).
- Full `npm test`: 2271 pass, 0 cancelled (only failures = a pre-existing untracked local test file for routes not on master; not part of this PR). Lint clean on changed files (one pre-existing `require-await` warning in ffmpeg-bootstrap remains).
- Behavior change to be aware of: during a same-bind reboot, clients now get a **503** with `Retry-After` instead of connection-refused; a WebSocket upgrade attempt inside the window is dropped silently under Bun (no `'upgrade'` listener) — same net effect as before. The admin UI only toasts on reboot-triggering saves (no polling), so nothing there depends on refusals.
- Not done / parked: parking requests during the reboot window and replaying them into the new app instead of answering 503 (would let admin double-saves succeed; needs Bun body-stream validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
