### PR TITLE
ci: assert launcher VERSION at tag time (fixes the 6.20.1 FileVersion=6.20.0 bug); delete the signing keychain right after codesign

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -253,22 +253,36 @@ jobs:
 
           # Tag builds ship the COMMITTED binaries (the linux one carries the
           # debian:11 glibc floor an in-job rebuild here couldn't reproduce),
-          # so a tag must prove those binaries match its own launcher source.
-          # The stamp is written by build-rust-launcher's commit job; a tag
-          # cut inside the rebuild window — or before the stamp ever landed —
-          # fails here instead of shipping a stale launcher green.
+          # so a tag must prove those binaries match its own launcher source
+          # AND its own version: build.rs bakes package.json's version into
+          # the Windows exe's VersionInfo, and `npm version` tags the bump
+          # commit itself — before build-rust-launcher has rebuilt — so a
+          # tree-only check let v6.20.1 ship an mStream.exe reporting 6.20.0.
+          # The two-line stamp (tree, version) is written by
+          # build-rust-launcher's commit job; a tag cut inside the rebuild
+          # window — or before the stamp ever landed — fails here instead of
+          # shipping a stale launcher green.
           if [ "${{ github.ref_type }}" = "tag" ]; then
-            WANT=$(git rev-parse HEAD:rust-launcher)
+            WANT_TREE=$(git rev-parse HEAD:rust-launcher)
+            # node, not jq: this leg runs on all three OSes and setup-node ran
+            # above; jq's presence on the Windows leg's git-bash is a runner-
+            # image detail not worth depending on.
+            WANT_VER=$(node -pe "require('./package.json').version")
             if [ ! -f bin/rust-launcher/.source-tree ]; then
               echo "::error::no launcher provenance stamp (bin/rust-launcher/.source-tree) — wait for build-rust-launcher's commit on master, then re-tag"
               exit 1
             fi
-            HAVE=$(cat bin/rust-launcher/.source-tree)
-            if [ "$WANT" != "$HAVE" ]; then
-              echo "::error::committed launcher binaries were built from rust-launcher tree $HAVE but this tag's tree is $WANT — wait for build-rust-launcher's commit (or re-run it), then re-tag"
+            HAVE_TREE=$(sed -n '1p' bin/rust-launcher/.source-tree)
+            HAVE_VER=$(sed -n '2p' bin/rust-launcher/.source-tree)
+            if [ "$WANT_TREE" != "$HAVE_TREE" ]; then
+              echo "::error::committed launcher binaries were built from rust-launcher tree $HAVE_TREE but this tag's tree is $WANT_TREE — wait for build-rust-launcher's commit (or re-run it), then re-tag"
               exit 1
             fi
-            echo "launcher provenance ok: $WANT"
+            if [ "$WANT_VER" != "$HAVE_VER" ]; then
+              echo "::error::committed launcher binaries were built for version '${HAVE_VER:-<unstamped>}' but this tag is $WANT_VER — their VersionInfo would be wrong. Bump with \`npm version --no-git-tag-version\`, push, wait for build-rust-launcher's 'ci: update pre-built' commit, then tag THAT commit"
+              exit 1
+            fi
+            echo "launcher provenance ok: tree $WANT_TREE, version $WANT_VER"
           fi
 
           REBUILD=0
@@ -460,6 +474,23 @@ jobs:
           # Gatekeeper's own spctl assessment after stapling, below.
           codesign --verify --strict --verbose=2 "$APP"
 
+          # The signing key's job is done: everything from here on —
+          # notarytool (submits the already-signed app), stapler, spctl, the
+          # re-zip — reads the signature or talks to Apple; none of it needs
+          # the private key. Take the keychain out of the search list and
+          # delete it NOW, not at job end: the smoke steps that follow run the
+          # freshly built server plus every prod dependency on this same
+          # runner, and an unlocked, codesign-authorized Developer ID keychain
+          # sitting in the search list for that whole time is an exfiltration
+          # window (a validly signed Mach-O under our identity is the prize;
+          # Apple revoking the cert would Gatekeeper-fail every shipped
+          # release). Ephemeral runners make it a small window; there is no
+          # reason to leave it open at all. The `if: always()` step below
+          # covers a failure that exits this script before this line.
+          security list-keychains -d user -s login.keychain
+          security delete-keychain "$keychain"
+          echo "signing keychain removed"
+
           if [ "$FULL_NOTARIZE" = "true" ]; then
             echo "$ASC_API_KEY" > "$RUNNER_TEMP/asc.p8"
             ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/notarize.zip"
@@ -549,6 +580,20 @@ jobs:
           magic=$(head -c 4 "dist/$B.zip" | xxd -p)
           [ "$magic" = "504b0304" ] || { echo "::error::recut dist/$B.zip is not a zip (magic: $magic)"; exit 1; }
           echo "re-zipped dist/$B.zip with the signed bundle"
+
+      # Belt to the sign step's suspenders: if that script exits before its
+      # own keychain removal (a codesign or verify failure), the keychain
+      # must still not survive into the smoke steps / the rest of the job.
+      # Idempotent — a keychain already deleted above is simply not there.
+      - name: Remove signing keychain (always)
+        if: always() && startsWith(matrix.key, 'darwin')
+        run: |
+          security list-keychains -d user -s login.keychain 2>/dev/null || true
+          if [ -f "$RUNNER_TEMP/signing.keychain-db" ]; then
+            security delete-keychain "$RUNNER_TEMP/signing.keychain-db" && echo "signing keychain removed (cleanup step)"
+          else
+            echo "no signing keychain present (already removed, or this build shipped unsigned)"
+          fi
 
       # darwin-x64 is the one shipped artifact whose binaries never execute
       # in CI (smoke: false — it's cross-compiled), which after signing means

--- a/.github/workflows/build-rust-launcher.yml
+++ b/.github/workflows/build-rust-launcher.yml
@@ -26,10 +26,11 @@ on:
     # from it: the release version bump must retrigger the binary build or
     # the shipped mStream.exe reports the PREVIOUS version in Explorer.
     # Cheap for non-release package.json edits — the commit job no-ops when
-    # the binaries come out byte-identical (unix binaries don't embed the
-    # version at all). Release process note: after bumping the version, wait
-    # for this workflow's commit before tagging — build-bun stages whatever
-    # is in bin/rust-launcher/ at tag time.
+    # nothing changed (unix binaries don't embed the version at all, but the
+    # provenance stamp records it, so a version bump always commits).
+    # Release process (docs/deploy.md): bump WITHOUT tagging, wait for this
+    # workflow's commit, tag THAT commit — build-bun's tag build asserts the
+    # stamp's tree AND version against the tag and refuses otherwise.
     paths: ['rust-launcher/**', 'package.json']
   pull_request:
     paths:
@@ -243,13 +244,24 @@ jobs:
           # a later `git pull --rebase` isn't blocked by an unstaged mode
           # change, then force 100755 in the index regardless.
           chmod +x bin/rust-launcher/mstream-launcher-*
-          # Provenance stamp: the rust-launcher source TREE these binaries
-          # were built from — the trigger sha, NOT post-rebase HEAD (the
-          # rebase below can pull in newer launcher source these binaries
-          # don't contain). build-bun's tag build asserts this stamp matches
-          # the tag's own tree, so "tag cut inside the rebuild window ships
-          # a stale launcher, all green" becomes a red run with instructions.
-          git rev-parse "${{ github.sha }}:rust-launcher" > bin/rust-launcher/.source-tree
+          # Provenance stamp, two lines:
+          #   1. the rust-launcher source TREE these binaries were built from
+          #   2. the package.json VERSION they were built from
+          # Both taken from the trigger sha, NOT post-rebase HEAD (the rebase
+          # below can pull in newer source these binaries don't contain).
+          # build-bun's tag build asserts BOTH against the tag's own tree and
+          # version, so "tag cut inside the rebuild window ships a stale
+          # launcher, all green" becomes a red run with instructions. Line 2
+          # exists because build.rs bakes package.json's version into the
+          # Windows exe's VersionInfo: a version bump changes package.json but
+          # not the launcher tree, so a tree-only stamp let v6.20.1 ship an
+          # mStream.exe whose FileVersion still read 6.20.0. `npm version`
+          # tags the bump commit itself, so the tag build can only be honest
+          # if it checks the version the binaries actually carry.
+          {
+            git rev-parse "${{ github.sha }}:rust-launcher"
+            git show "${{ github.sha }}:package.json" | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version"
+          } > bin/rust-launcher/.source-tree
           git add bin/rust-launcher/mstream-launcher-* bin/rust-launcher/.source-tree
           git update-index --chmod=+x bin/rust-launcher/mstream-launcher-*
           if git diff --cached --quiet; then

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,7 +1,40 @@
 # Release Instructions
 
-Getting github actions to properly work requires a specific set of steps
+Getting github actions to properly work requires a specific set of steps.
+The order matters: the release tag must land on a commit whose committed
+launcher binaries were built for THAT version — the tag build asserts it
+and fails otherwise.
 
-- Bump the version number of package.json.  Make a commit with the message "vX.X.X"
-- Tag the commit `git tag vX.X.X`
-- run `git push && git push --tags`
+1. Bump the version **without tagging**:
+
+   ```shell
+   npm version X.X.X --no-git-tag-version
+   git commit -am "vX.X.X"
+   git push
+   ```
+
+2. **Wait for the `Build Rust Launcher` workflow to finish and push its
+   `ci: update pre-built mstream-launcher binaries` commit** to master (the
+   package.json bump triggers it; ~5 min). That commit carries launcher
+   binaries whose Windows VersionInfo says X.X.X, and a provenance stamp
+   (`bin/rust-launcher/.source-tree`) recording the launcher source tree AND
+   the version they were built for.
+
+3. Tag **that** commit, not the bump commit:
+
+   ```shell
+   git pull
+   git tag vX.X.X          # on the "ci: update pre-built..." commit
+   git push --tags
+   ```
+
+4. The tag build (`Build Bun Server`) asserts the stamp matches the tag's
+   launcher tree and version — a tag cut on the bump commit itself fails with
+   instructions instead of shipping an mStream.exe that reports the previous
+   version — then attaches the bundles + `manifest.json` to a **draft**
+   release. Review, then publish. Publishing fires the downstream jobs
+   (npm publish, demo deploy, website version stamp).
+
+Why not `npm version` alone: it tags the bump commit in the same breath, and
+at that instant the committed launcher binaries are still the previous
+version's (v6.20.1 shipped that way — its `mStream.exe` reported 6.20.0).


### PR DESCRIPTION
Two findings from the adversarial review of the signing/release CI (#9 and #11 on the list). Workflow-only PR plus the release doc.

## #11 — the tag build now asserts the launcher's **version**, not just its tree

**Bug it fixes:** v6.20.1's `mStream.exe` reports **FileVersion 6.20.0** in Explorer (verified on the committed bytes). `build.rs` bakes `package.json`'s version into the Windows exe, but the tag-time provenance check only compared the `rust-launcher/` **tree** hash — a version bump changes `package.json`, not that tree, so the check passed while the staged binary was the previous release's. And `npm version` tags the bump commit itself, so the documented "wait for CI's re-stamp before tagging" rule was unsatisfiable by that command.

**Change:**
- `build-rust-launcher.yml` commit job writes a **two-line** `bin/rust-launcher/.source-tree`: launcher tree hash + the `package.json` version the binaries were built from (both from the trigger sha, not post-rebase HEAD). The commit gate already diffs the stamp, so a version-only bump commits even when the unix binaries are byte-identical.
- `build-bun.yml` tag build asserts **both** lines against the tag; a mismatch fails with the exact ritual to follow. A legacy one-line stamp fails the same way (it predates the check; "rebuild" is the safe answer).
- `docs/deploy.md` rewritten to the honest sequence: `npm version X --no-git-tag-version` → push → **wait for the `ci: update pre-built mstream-launcher binaries` commit** → tag *that* commit. The old text ("bump, tag the same commit, push both") is exactly the ritual that produced the mismatch.

Version extraction uses `node -pe` (jq isn't on the runners).

## #9 — the Developer ID keychain is deleted right after `codesign --verify`

The sign step created, unlocked, and codesign-authorized a signing keychain in the user search list and **never removed it**; the smoke steps that follow run the freshly built server plus every prod dependency on the same runner. An unlocked signing keychain in scope for that whole time is an exfiltration window (a validly signed Mach-O under our identity is the prize; a revoked cert would Gatekeeper-fail every shipped release). Ephemeral runners make it small; nothing makes it necessary.

- Removed immediately after `codesign --verify` — I checked that nothing downstream needs the private key: notarytool (API-key file auth), stapler, spctl, and the re-zip only read the signature or talk to Apple.
- Plus an `if: always()` "Remove signing keychain" step so a mid-script failure never leaves it behind. Both idempotent.

## Verification
- Both YAMLs lint clean.
- Stamp-writer and assert-reader commands run verbatim locally: writer emits `<tree>\n6.20.1`; reader parses tree/ver and matches the tag's want_ver.
- Assert logic unit-tested against four stamp shapes: two-line match → ok; legacy one-line → fail with instructions; version lags the tag (the 6.20.1 case) → fail; tree mismatch → fail.
- The tag-only assert can't be exercised by PR CI (no tag); the darwin legs of this PR's build **do** run the sign step (same-repo PR → secrets present, no notarize) and therefore the new delete-keychain path.

## Merging
Touches `.github/workflows/*` → `gh pr merge` lacks `workflow` scope; merge via git `--no-ff` push like #833/#834. Also: this is the PR that has to be in before **6.20.2** is cut, since the new ritual is what that release follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
