### PR TITLE
build: one Windows VersionInfo contract for every PE the win-x64 bundle ships

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -225,6 +225,18 @@ jobs:
           "BUN_COMPILE_EXEC_PATH=$exe" | Add-Content -Path $env:GITHUB_ENV
           Write-Host "runtime: $exe"
 
+      # The bundler stamps Windows VersionInfo onto the staged rust sidecars
+      # with resedit (scripts/win-versioninfo.mjs). It's a devDependency, and
+      # this job installs prod-only, so add JUST that package under
+      # scripts/node_modules — a plain `npm install --no-save resedit` would
+      # reconcile the whole tree and drag every devDependency (eslint,
+      # redocly, ...) in with it; `--omit=dev` would then skip resedit itself.
+      # The bundler resolves it from scripts/ (its own directory) first.
+      # Version pinned to match package.json's devDependency — bump both.
+      - name: Install the VersionInfo stamper (win-x64)
+        if: matrix.key == 'win-x64'
+        run: npm install --prefix scripts --no-save --no-audit --no-fund resedit@3.0.2
+
       # Desktop tray launcher: the bundler stages bin/rust-launcher/<name> as
       # the bundle's double-click face (mStream.exe / .app executable /
       # mstream-desktop). Those binaries are CI-committed on master pushes
@@ -319,6 +331,47 @@ jobs:
 
       - name: Build + bundle (${{ matrix.key }})
         run: bun scripts/build-bun.mjs --target=${{ matrix.key }} --bundle
+
+      # ── Windows VersionInfo contract (win-x64) ──────────────────────────
+      # Every PE the zip ships must carry the same ProductName / version /
+      # company / copyright, read back through the Win32 version API — what
+      # Explorer, Task Manager, and (next) code-signing metadata restrictions
+      # see. Three sources feed it: Bun's --windows-* flags (server), the
+      # launcher's build.rs (baked at its CI build), and the bundler's
+      # resedit stamp (sidecars). Strict on tags; on PR builds a version-only
+      # mismatch on the committed launcher is a warning (see the script).
+      # Any PE the script doesn't know fails the build: no binary may ship
+      # blank — and later unsigned — by omission.
+      #
+      # rust-server-audio is stamped here but exercised by no other smoke
+      # (server-playback is opt-in), so prove the stamped exe still runs:
+      # start it, GET /status, stop it. rust-parser and the launcher run
+      # stamped/baked in the smoke steps below.
+      - name: Assert Windows VersionInfo on every shipped PE (win-x64)
+        if: matrix.key == 'win-x64'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'
+          $D = (Get-Item dist/stage/mStream-*-win-x64).FullName
+          $strict = '${{ github.ref_type }}' -eq 'tag'
+          & ./scripts/check-win-versioninfo.ps1 -BundleDir $D -Strict:$strict
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $sa = Join-Path $D 'bin/rust-server-audio/rust-server-audio-win32-x64.exe'
+          $p = Start-Process -FilePath $sa -ArgumentList '--port','3391' -PassThru -WindowStyle Hidden -RedirectStandardOutput sa.out -RedirectStandardError sa.err
+          $ok = $false
+          for ($i = 0; $i -lt 20 -and -not $ok; $i++) {
+            Start-Sleep -Milliseconds 250
+            try { $ok = (Invoke-WebRequest -UseBasicParsing 'http://127.0.0.1:3391/status' -TimeoutSec 2).StatusCode -eq 200 } catch { $ok = $false }
+            if ($p.HasExited) { break }
+          }
+          Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+          if (-not $ok) {
+            Write-Host "::error::stamped rust-server-audio did not serve /status (exited=$($p.HasExited))"
+            Get-Content sa.out, sa.err -ErrorAction SilentlyContinue | Select-Object -Last 10
+            exit 1
+          }
+          Write-Host 'stamped rust-server-audio serves /status -> 200'
 
       # ── Developer ID signing + notarization (darwin legs only) ──────────
       # Ported from mstream-terminal-player's release.yml, adapted from a

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -677,7 +677,15 @@ jobs:
           MUSIC="$WS/smoke-music"
           mkdir -p "$MUSIC"
           ffmpeg -hide_banner -loglevel error -f lavfi -i "sine=frequency=440:duration=1" -metadata title=Smoke -metadata artist=CI "$MUSIC/smoke.mp3" -y || echo "ffmpeg unavailable; scanning an empty library"
-          printf '{"port":3399,"folders":{"music":{"root":"%s"}}}\n' "$MUSIC" > "$RUN/smoke-config.json"
+          # address is pinned to 127.0.0.1 ON PURPOSE: step (5) reboots via
+          # POST /config/address {"address":"127.0.0.1"}, and that must be a
+          # SAME-bind reboot (keep-socket path). Unset, the server binds [::]
+          # and the same POST becomes a bind CHANGE — which recycles the
+          # listener by design (#833), leaving a real ~40 ms refused window
+          # that the second concurrent trigger sometimes lands in (000 on
+          # darwin-arm64, run 32170210445). That was the "listener down for a
+          # beat" #832 retried around, not the pre-#833 socket drop.
+          printf '{"port":3399,"address":"127.0.0.1","folders":{"music":{"root":"%s"}}}\n' "$MUSIC" > "$RUN/smoke-config.json"
           "$BIN" -j "$RUN/smoke-config.json" > "$RUN/boot.log" 2>&1 &
           SRV=$!
           UP=0
@@ -703,14 +711,18 @@ jobs:
           #
           # The trigger POSTs below are plain, single-shot curls ON PURPOSE:
           # a connection-level failure (curl code 000) is a real finding, not
-          # noise. Once (#832) they retried 000s, because the old reboot
-          # dropped the listener for a beat and a trigger racing that window
-          # got connection-refused. Since #833 a same-bind reboot never gives
-          # the socket up — a request landing in the window gets an honest
-          # 503, never a dead connection — so a 000 here would mean that
-          # guarantee regressed, which is precisely what steps (4)/(5) exist
-          # to catch. A retry would re-fire after the dust settled and turn
-          # that regression back into a green run.
+          # noise. Once (#832) they retried 000s, because a trigger racing a
+          # reboot window got connection-refused. Since #833 a SAME-bind
+          # reboot never gives the socket up — a request landing in the window
+          # gets an honest 503, never a dead connection — so a 000 here would
+          # mean that guarantee regressed, which is precisely what steps
+          # (4)/(5) exist to catch. A retry would re-fire after the dust
+          # settled and turn that regression back into a green run. Both
+          # triggers are therefore same-bind by construction: trust-proxy
+          # doesn't touch the bind, and the smoke config above pins address to
+          # the very value step (5) posts. (A bind-CHANGING save recycles the
+          # listener on purpose and does have a refused window; that path is
+          # not what these steps assert.)
 
           REBOOT_OK=0
           if [ "$CODE" = "200" ]; then
@@ -753,7 +765,9 @@ jobs:
             # winner. /config/address is the right trigger: unlike trust-proxy
             # and most others it has NO unchanged-value short-circuit, so both
             # POSTs really do reboot (with a no-op second POST this test passes
-            # against the bug). Bind stays reachable at 127.0.0.1.
+            # against the bug). The posted address EQUALS the smoke config's
+            # bind, so this is the keep-socket path: the reboot log line must
+            # read "bind unchanged", not "recycling the listener".
             # Capture each POST's status. Previously these were `curl -s` with
             # no -f and their exit codes discarded by `wait`, so if the endpoint
             # ever 400s or moves (a renamed Joi key, a moved route) NO reboot
@@ -816,6 +830,15 @@ jobs:
             grep -q "Reboot already in progress" "$RUN/boot.log" \
               && echo "ok: the duplicate reboot request was coalesced" \
               || echo "note: no coalescing line — the two reboots did not overlap on this runner (HTTP $POST1 / $POST2)"
+            # The 000-is-a-regression rule above only holds if this reboot
+            # kept the socket. Enforce it: if the address save recycled the
+            # listener, the smoke config's address and the posted one have
+            # drifted apart, and a 000 here would be the by-design refused
+            # window, not a finding — fail loudly instead of guessing.
+            if grep -q "recycling the listener" "$RUN/boot.log"; then
+              echo "FAIL: the step-(5) address save recycled the listener — the posted address must equal the smoke config's bind (same-bind = keep-socket) for the 000 rule to mean anything"
+              CONCURRENT_OK=0
+            fi
           fi
           kill "$SRV" 2>/dev/null
 

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -16,7 +16,15 @@ on:
       - 'bin/**'
       - 'cli-boot-wrapper.js'
       - 'scripts/build-bun.mjs'
+      # Imported by build-bun.mjs on EVERY target (a broken stamper breaks
+      # bundling everywhere) / the win-x64 VersionInfo gate — a change to
+      # either must run the legs before merge, not first on the release tag.
+      - 'scripts/win-versioninfo.mjs'
+      - 'scripts/check-win-versioninfo.ps1'
+      # A lockfile-only dependency refresh changes what `npm ci` + `bun build
+      # --compile` embed in the shipped binaries just as much as package.json.
       - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/build-bun.yml'
       # Launcher source changes must run the integrated bundle smokes BEFORE
       # merge (the launcher step below builds them fresh for such PRs) — the
@@ -232,10 +240,39 @@ jobs:
       # reconcile the whole tree and drag every devDependency (eslint,
       # redocly, ...) in with it; `--omit=dev` would then skip resedit itself.
       # The bundler resolves it from scripts/ (its own directory) first.
-      # Version pinned to match package.json's devDependency — bump both.
+      #
+      # This install does NOT consult package-lock.json (verified: it happily
+      # installs with a corrupted root lock), and the code it fetches rewrites
+      # two PEs that ship — and will be code-signed. So: pin BOTH packages
+      # (resedit's `pe-library ^2.0.1` would otherwise float to whatever the
+      # registry serves that minute), run no lifecycle scripts, and then bind
+      # the result to the reviewed lockfile: npm records resolved+integrity of
+      # what it installed in scripts/node_modules/.package-lock.json; both
+      # entries must equal the root package-lock.json's. Any drift — a new
+      # publish, a registry substitution, a stale pin here vs the lock — is a
+      # red step, not a silently different stamper. Bump the pins together
+      # with the lockfile.
       - name: Install the VersionInfo stamper (win-x64)
         if: matrix.key == 'win-x64'
-        run: npm install --prefix scripts --no-save --no-audit --no-fund resedit@3.0.2
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --prefix scripts --no-save --no-audit --no-fund --ignore-scripts resedit@3.0.2 pe-library@2.0.1
+          node -e '
+            const want = require("./package-lock.json").packages;
+            const got = require("./scripts/node_modules/.package-lock.json").packages;
+            let bad = 0;
+            for (const name of ["node_modules/resedit", "node_modules/pe-library"]) {
+              const w = want[name], g = got[name];
+              if (!w || !g || w.version !== g.version || w.integrity !== g.integrity || w.resolved !== g.resolved) {
+                console.error(`::error::stamper dependency ${name} differs from package-lock.json: installed ${g && g.version} ${g && g.integrity} vs lock ${w && w.version} ${w && w.integrity} — bump the pins in this step together with the lockfile`);
+                bad = 1;
+              } else {
+                console.log(`ok ${name}@${g.version} matches package-lock.json (${g.integrity.slice(0, 20)}...)`);
+              }
+            }
+            process.exit(bad);
+          '
 
       # Desktop tray launcher: the bundler stages bin/rust-launcher/<name> as
       # the bundle's double-click face (mStream.exe / .app executable /
@@ -328,6 +365,10 @@ jobs:
           mkdir -p bin/rust-launcher
           cp "$SRC" "bin/rust-launcher/$NAME"
           echo "built: bin/rust-launcher/$NAME"
+          # Tell the VersionInfo assert below that mStream.exe is THIS PR's
+          # own build: a version mismatch there can only mean build.rs is
+          # broken, so it must fail, not get the committed-launcher leniency.
+          echo "LAUNCHER_REBUILT=1" >> "$GITHUB_ENV"
 
       - name: Build + bundle (${{ matrix.key }})
         run: bun scripts/build-bun.mjs --target=${{ matrix.key }} --bundle
@@ -338,10 +379,13 @@ jobs:
       # Explorer, Task Manager, and (next) code-signing metadata restrictions
       # see. Three sources feed it: Bun's --windows-* flags (server), the
       # launcher's build.rs (baked at its CI build), and the bundler's
-      # resedit stamp (sidecars). Strict on tags; on PR builds a version-only
-      # mismatch on the committed launcher is a warning (see the script).
-      # Any PE the script doesn't know fails the build: no binary may ship
-      # blank — and later unsigned — by omission.
+      # resedit stamp (sidecars). Strict on tags AND whenever the launcher
+      # step above rebuilt mStream.exe from this very tree (LAUNCHER_REBUILT):
+      # a fresh build has no excuse. Only a PR that stages the COMMITTED
+      # launcher gets the leniency (package.json-derived fields may lag until
+      # build-rust-launcher recommits — see the script). Any PE the script
+      # doesn't know fails the build: no binary may ship blank — and later
+      # unsigned — by omission.
       #
       # rust-server-audio is stamped here but exercised by no other smoke
       # (server-playback is opt-in), so prove the stamped exe still LOADS
@@ -359,7 +403,8 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'
           $D = (Get-Item dist/stage/mStream-*-win-x64).FullName
-          $strict = '${{ github.ref_type }}' -eq 'tag'
+          $strict = ('${{ github.ref_type }}' -eq 'tag') -or ($env:LAUNCHER_REBUILT -eq '1')
+          if ($env:LAUNCHER_REBUILT -eq '1') { Write-Host 'launcher was rebuilt from this tree -> strict mode' }
           & ./scripts/check-win-versioninfo.ps1 -BundleDir $D -Strict:$strict
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -344,8 +344,14 @@ jobs:
       # blank — and later unsigned — by omission.
       #
       # rust-server-audio is stamped here but exercised by no other smoke
-      # (server-playback is opt-in), so prove the stamped exe still runs:
-      # start it, GET /status, stop it. rust-parser and the launcher run
+      # (server-playback is opt-in), so prove the stamped exe still LOADS
+      # AND RUNS: start it and either see it serve /status, or see it get
+      # as far as its own audio-device probe. The runner has no sound
+      # device, so on CI it panics at startup with "Failed to open audio
+      # output device: NoDevice" — that is Rust code executing past main(),
+      # i.e. the PE loader accepted the re-laid-out file, which is the only
+      # thing the stamp could have broken. Anything else (won't start, no
+      # output, a different failure) fails. rust-parser and the launcher run
       # stamped/baked in the smoke steps below.
       - name: Assert Windows VersionInfo on every shipped PE (win-x64)
         if: matrix.key == 'win-x64'
@@ -366,12 +372,18 @@ jobs:
             if ($p.HasExited) { break }
           }
           Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
-          if (-not $ok) {
-            Write-Host "::error::stamped rust-server-audio did not serve /status (exited=$($p.HasExited))"
-            Get-Content sa.out, sa.err -ErrorAction SilentlyContinue | Select-Object -Last 10
-            exit 1
+          if ($ok) {
+            Write-Host 'stamped rust-server-audio serves /status -> 200'
+          } else {
+            $err = (Get-Content sa.err -ErrorAction SilentlyContinue) -join "`n"
+            if ($p.HasExited -and $err -match 'Failed to open audio output device') {
+              Write-Host 'stamped rust-server-audio executes (reached its audio-device probe: no sound device on this runner, as expected)'
+            } else {
+              Write-Host "::error::stamped rust-server-audio neither served /status nor reached its audio-device probe (exited=$($p.HasExited))"
+              Get-Content sa.out, sa.err -ErrorAction SilentlyContinue | Select-Object -Last 10
+              exit 1
+            }
           }
-          Write-Host 'stamped rust-server-audio serves /status -> 200'
 
       # ── Developer ID signing + notarization (darwin legs only) ──────────
       # Ported from mstream-terminal-player's release.yml, adapted from a

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/*
+# build-bun.yml installs the VersionInfo stamper (resedit) here on the win-x64 leg
+scripts/node_modules/
 webapp/node_modules/*
 
 image-cache/*

--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,8 @@
 # server DOES spawn those at runtime.
 
 node_modules/*
+# build-bun.yml installs the VersionInfo stamper (resedit) here on the win-x64 leg
+scripts/node_modules/
 webapp/node_modules/*
 
 image-cache/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "@eslint/js": "^10.0.1",
         "@redocly/cli": "^2.35.1",
         "eslint": "^10.6.0",
-        "globals": "^17.7.0"
+        "globals": "^17.7.0",
+        "resedit": "^3.0.2"
       },
       "engines": {
         "node": ">=22.5.0"
@@ -3918,6 +3919,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pe-library": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-2.0.1.tgz",
+      "integrity": "sha512-/qjYFqNSlq59B5DI36am++5/3gMgh02QnzpYigrwrW6s+QpU0mHf09/iA4wjTu21UUxodyV7ZCetV5MiDhaN/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
     "node_modules/pixelmatch": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
@@ -4124,6 +4139,23 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-3.0.2.tgz",
+      "integrity": "sha512-FnqVDJYX4etlEnz2AaJYE1c1FTcgrsHiI2U4DXRxO4CIzbGP7r0jml9uZIMlvzCom2pbBLZjIhF26wj92y1cVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
       }
     },
     "node_modules/roarr": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@redocly/cli": "^2.35.1",
         "eslint": "^10.6.0",
         "globals": "^17.7.0",
-        "resedit": "^3.0.2"
+        "resedit": "3.0.2"
       },
       "engines": {
         "node": ">=22.5.0"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "@redocly/cli": "^2.35.1",
     "eslint": "^10.6.0",
     "globals": "^17.7.0",
-    "resedit": "^3.0.2"
+    "resedit": "3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@eslint/js": "^10.0.1",
     "@redocly/cli": "^2.35.1",
     "eslint": "^10.6.0",
-    "globals": "^17.7.0"
+    "globals": "^17.7.0",
+    "resedit": "^3.0.2"
   }
 }

--- a/rust-launcher/build.rs
+++ b/rust-launcher/build.rs
@@ -2,7 +2,19 @@
 // launcher IS the double-click face of the bundle (staged as mStream.exe by
 // scripts/build-bun.mjs), so it must carry the product icon itself — the
 // server keeps its own via Bun's --windows-icon. Version/product strings are
-// read from the repo's package.json so they can never drift from the release.
+// read from the repo's package.json so they can never drift from the release
+// (and build-bun.yml's tag build asserts the baked version against the tag).
+//
+// VERSIONINFO CONTRACT — identical for every PE the win-x64 bundle ships
+// (server: Bun --windows-* flags; sidecars: stamped at bundle time by
+// scripts/win-versioninfo.mjs; all asserted by
+// scripts/check-win-versioninfo.ps1 on the win-x64 CI leg):
+//   ProductName "mStream" · ProductVersion = FileVersion = package version as
+//   FOUR numeric parts (prerelease suffix dropped) in both the string table
+//   AND the fixed-info numbers · CompanyName = package author ·
+//   LegalCopyright "<author> (<license>)". FileDescription is per file.
+// Keep the four in lockstep: uniform metadata is also what code signing's
+// artifact-configuration restrictions will enforce on each signed file.
 //
 // Keyed off CARGO_CFG_TARGET_OS, not #[cfg(target_os)]: build scripts compile
 // FOR THE HOST, so a cfg here asks "building ON Windows" — which silently
@@ -20,14 +32,40 @@ fn main() {
     )
     .expect("parse package.json");
     let version = pkg["version"].as_str().unwrap_or("0.0.0");
+    let author = pkg["author"]["name"].as_str().unwrap_or("");
+    let license = pkg["license"].as_str().unwrap_or("");
+
+    // "6.21.0-beta.1" -> [6, 21, 0, 0]: same rule as win-versioninfo.mjs.
+    let mut parts: Vec<u64> = version
+        .split('-')
+        .next()
+        .unwrap_or("0")
+        .split('.')
+        .map(|p| p.parse::<u64>().unwrap_or(0))
+        .collect();
+    parts.resize(4, 0);
+    let version4 = format!("{}.{}.{}.{}", parts[0], parts[1], parts[2], parts[3]);
+    // VS_FIXEDFILEINFO packs the four parts into one u64, high word first.
+    // Without this, winresource fills the numeric fields from Cargo.toml's
+    // 0.1.0 while the strings say the real version — Explorer shows the
+    // strings, but signing tools and `VersionInfo.FileVersionRaw` see 0.1.0.0.
+    let packed = (parts[0] << 48) | (parts[1] << 32) | (parts[2] << 16) | parts[3];
 
     let mut res = winresource::WindowsResource::new();
     res.set_icon("../build/mstream-logo-cut.ico");
+    res.set_language(0x0409); // en-US string block (the default is "neutral")
     res.set("ProductName", "mStream");
     res.set("FileDescription", "mStream Desktop");
-    res.set("ProductVersion", version);
-    res.set("FileVersion", version);
-    res.set("LegalCopyright", "Paul Sori (GPL-3.0)");
+    res.set("ProductVersion", &version4);
+    res.set("FileVersion", &version4);
+    res.set("CompanyName", author);
+    res.set("LegalCopyright", &format!("{author} ({license})"));
+    // The crate builds as mstream-launcher but ships as mStream.exe — name
+    // the shipped identity, which is what the bundle (and any signature) carries.
+    res.set("OriginalFilename", "mStream.exe");
+    res.set("InternalName", "mStream");
+    res.set_version_info(winresource::VersionInfo::FILEVERSION, packed);
+    res.set_version_info(winresource::VersionInfo::PRODUCTVERSION, packed);
     // A cross-build host without a Windows resource compiler (rc.exe /
     // llvm-rc / windres) can still produce a WORKING exe — just an iconless,
     // versionless one. Warn instead of failing so `cargo check --target

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -232,6 +232,13 @@ if (t.plat === 'linux' && !t.musl) {
 // product name/version — see scripts/win-versioninfo.mjs for why this happens
 // here and not in each crate's build. FileDescription is what Task Manager
 // shows as the process name.
+//
+// THREE LISTS MOVE TOGETHER: the `sidecars` array above, this description
+// map, and $known in scripts/check-win-versioninfo.ps1 (which fails the
+// win-x64 leg on any PE it doesn't know). Staging a new Windows sidecar —
+// e.g. bin/p2p-sidecar/*.exe, CI-committed today but deliberately NOT staged
+// (Bun bundles ship without discovery-P2P) — means updating all three in the
+// same change, or the leg goes red with "unknown PE".
 const sidecarDescription = {
   'rust-parser':       'mStream Library Scanner',
   'rust-server-audio': 'mStream Server Audio',

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -13,6 +13,7 @@ import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, cpSync, chm
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { canonicalFields, stampWindowsVersionInfo } from './win-versioninfo.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
@@ -62,10 +63,12 @@ if (!t) {
 }
 
 const outPath = join('dist', t.out);
-// --windows-version wants 4 numeric parts; strip any prerelease/build suffix.
-const verParts = String(pkg.version).split('-')[0].split('.').map((n) => String(parseInt(n, 10) || 0));
-while (verParts.length < 4) { verParts.push('0'); }
-const winVersion = verParts.slice(0, 4).join('.');
+// One VersionInfo contract for every Windows PE the bundle ships (server via
+// these Bun flags, launcher via rust-launcher/build.rs, sidecars stamped
+// below) — asserted by scripts/check-win-versioninfo.ps1 on the win-x64 CI
+// leg. --windows-version wants 4 numeric parts (prerelease suffix dropped).
+const winMeta = canonicalFields(pkg);
+const winVersion = winMeta.version;
 
 const buildArgs = ['build', '--compile', `--target=${t.bun}`];
 // The discovery feature's ML runtimes CANNOT be bundled: onnxruntime-node's
@@ -81,11 +84,14 @@ buildArgs.push('--external', '@huggingface/transformers', '--external', 'onnxrun
 if (t.win && process.platform === 'win32') {
   buildArgs.push(
     '--windows-icon=build/mstream-logo-cut.ico',
-    '--windows-title=mStream Server',
-    `--windows-publisher=${pkg.author?.name ?? ''}`,
+    // --windows-title is the ProductName (shared, "mStream" like every other
+    // shipped PE); --windows-description is the FileDescription — the name
+    // Task Manager and the Details tab show for THIS file.
+    `--windows-title=${winMeta.productName}`,
+    `--windows-publisher=${winMeta.companyName}`,
     `--windows-version=${winVersion}`,
-    `--windows-description=${pkg.description ?? ''}`,
-    `--windows-copyright=${pkg.author?.name ?? ''} (${pkg.license ?? ''})`,
+    '--windows-description=mStream Server',
+    `--windows-copyright=${winMeta.legalCopyright}`,
   );
 } else if (t.win) {
   console.warn('NOTE: building for Windows from a non-Windows host - icon/metadata skipped (Bun limitation).');
@@ -220,11 +226,36 @@ const sidecars = [
 if (t.plat === 'linux' && !t.musl) {
   sidecars.push(['rust-parser', `rust-parser-${t.plat}-${t.arch}-musl`]);
 }
+// Windows sidecars leave their CI build with no VersionInfo (they're
+// version-agnostic tools). Stamp the bundle's canonical block onto the STAGED
+// copy (bin/ itself stays CI-managed) so every PE in the zip carries the same
+// product name/version — see scripts/win-versioninfo.mjs for why this happens
+// here and not in each crate's build. FileDescription is what Task Manager
+// shows as the process name.
+const sidecarDescription = {
+  'rust-parser':       'mStream Library Scanner',
+  'rust-server-audio': 'mStream Server Audio',
+};
 for (const [dir, file] of sidecars) {
   const src = join(root, 'bin', dir, file);
   if (existsSync(src)) {
     mkdirSync(join(contentRoot, 'bin', dir), { recursive: true });
-    stageExe(src, join(contentRoot, 'bin', dir, file));
+    const dest = join(contentRoot, 'bin', dir, file);
+    stageExe(src, dest);
+    if (t.plat === 'win32') {
+      try {
+        await stampWindowsVersionInfo(dest, { ...winMeta, fileDescription: sidecarDescription[dir] ?? 'mStream' });
+        console.log(`  stamped VersionInfo: bin/${dir}/${file} (${winMeta.productName} ${winMeta.version})`);
+      } catch (err) {
+        // A Windows bundle whose sidecars carry no VersionInfo is a metadata
+        // regression the CI assert would catch anyway — fail here, at the
+        // cause, in CI. Locally it's a warning: a dev box without the
+        // devDependency still gets a working bundle.
+        const msg = `VersionInfo stamp failed for bin/${dir}/${file}: ${err.message}`;
+        if (process.env.CI) { console.error(`  FATAL: ${msg}`); process.exit(1); }
+        console.warn(`  WARN: ${msg}`);
+      }
+    }
   } else {
     console.warn(`  sidecar not found, skipping: bin/${dir}/${file}`);
   }

--- a/scripts/check-win-versioninfo.ps1
+++ b/scripts/check-win-versioninfo.ps1
@@ -15,25 +15,35 @@
 #   build.rs (baked at its CI build; the tag build proves that build matches
 #   the tag); the rust sidecars <- stamped by the bundler.
 #
-# -Strict (tag builds): every mismatch fails. Without it (PR builds), a
-# version mismatch on mStream.exe ALONE is a warning: a PR that bumps
-# package.json builds against the committed launcher, which was baked for the
-# previous version by design - the release ritual (docs/deploy.md) rebuilds it
-# before the tag, and the tag build asserts strictly. Everything else is
-# produced in this very build and must match regardless.
+# -Strict (tag builds, and PR builds whose launcher was rebuilt from the same
+# tree - build-bun.yml passes it then): every mismatch fails. Without it, a
+# mismatch on mStream.exe ALONE, confined to the fields its build.rs bakes
+# FROM package.json (the version strings/numbers, CompanyName,
+# LegalCopyright), is a warning: a PR that edits package.json builds against
+# the COMMITTED launcher, which was baked from the previous package.json by
+# design - build-rust-launcher recommits it on merge (package.json is one of
+# its triggers) and the tag build asserts strictly. Blank fields, a wrong
+# ProductName/FileDescription, or a mismatch on any OTHER file are never
+# lenient: those are produced in this very build and must match regardless.
 #
 # Any PE in the bundle that this script does not know is a FAILURE: a new
 # binary must be added here (and given metadata) rather than ship blank -
 # and later unsigned - by omission. bin/iroh/*.node is @number0/iroh's own
-# prebuilt (upstream, not ours to relabel): listed, never checked.
+# prebuilt (upstream, not ours to relabel): listed, never checked. If you
+# stage another sidecar in scripts/build-bun.mjs, add it to the stamper's
+# description map there AND to $known here in the same change.
 [CmdletBinding()]
 param(
   [Parameter(Mandatory = $true)][string]$BundleDir,
   [switch]$Strict,
-  [string]$PackageJson = (Join-Path (Split-Path -Parent $PSScriptRoot) 'package.json')
+  [string]$PackageJson
 )
 $ErrorActionPreference = 'Stop'
 $inCi = [bool]$env:GITHUB_ACTIONS
+# Default computed here, not in the param block: under Windows PowerShell 5.1
+# `powershell -File` binds parameters before $PSScriptRoot is populated, and a
+# default that reads it dies with "Split-Path: cannot bind ... empty string".
+if (-not $PackageJson) { $PackageJson = Join-Path (Split-Path -Parent (Split-Path -Parent $PSCommandPath)) 'package.json' }
 
 $BundleDir = (Resolve-Path -LiteralPath $BundleDir).Path
 $pkg = Get-Content -LiteralPath $PackageJson -Raw | ConvertFrom-Json
@@ -58,6 +68,11 @@ $known = @(
   @{ path = 'bin\rust-server-audio\rust-server-audio-win32-x64.exe'; lenient = $false; optional = $false }
 )
 $upstream = @('bin\iroh\iroh.win32-x64-msvc.node')
+# The server's ffmpeg-bootstrap downloads ffmpeg/ffprobe into <appRoot>/bin/ffmpeg
+# at RUNTIME. They are never in the zip (the bundler cuts it before anything
+# runs), but a staged bundle that has been booted locally carries them -
+# upstream binaries, not ours: listed, never checked.
+$runtimeUpstreamPrefix = 'bin\ffmpeg\'
 
 $failures = New-Object System.Collections.Generic.List[string]
 $warnings = New-Object System.Collections.Generic.List[string]
@@ -100,12 +115,16 @@ foreach ($k in $known) {
   }
   if ([string]::IsNullOrWhiteSpace($v.FileDescription)) { $problems += 'FileDescription is empty' }
   if ($problems.Count -eq 0) { continue }
-  # Launcher leniency: ONLY version fields, ONLY when not strict, ONLY if
-  # nothing else is wrong - a blank ProductName or company is a real bug even
-  # on a PR build.
-  $versionOnly = @($problems | Where-Object { $_ -notmatch '^(ProductVersion|FileVersion|FileVersionRaw|ProductVersionRaw)=' }).Count -eq 0
-  if ($k.lenient -and -not $Strict -and $versionOnly) {
-    Report 'warning' ("{0}: baked version differs from package.json ({1}) - expected on a PR that bumps the version; the committed launcher is rebuilt for the release before tagging and the tag build asserts strictly" -f $k.path, ($problems -join '; '))
+  # Launcher leniency: ONLY the fields build.rs bakes from package.json
+  # (versions, CompanyName, LegalCopyright - blank included: a launcher
+  # committed by an older build.rs simply lacks them, which is the same lag),
+  # ONLY when not strict, ONLY if nothing else is wrong. A missing rc.exe or
+  # a broken build.rs blanks ProductName/FileDescription too, and those are
+  # never lenient; a launcher rebuilt from the PR itself runs strict.
+  $pkgDerived = '^(ProductVersion|FileVersion|FileVersionRaw|ProductVersionRaw|CompanyName|LegalCopyright)='
+  $lagOnly = @($problems | Where-Object { $_ -notmatch $pkgDerived }).Count -eq 0
+  if ($k.lenient -and -not $Strict -and $lagOnly) {
+    Report 'warning' ("{0}: package.json-derived fields lag ({1}) - expected on a PR that edits package.json (version/author/license) and stages the COMMITTED launcher; build-rust-launcher recommits it on merge and the tag build asserts strictly" -f $k.path, ($problems -join '; '))
   } else {
     Report 'error' ("{0}: {1}" -f $k.path, ($problems -join '; '))
   }
@@ -117,6 +136,7 @@ foreach ($pe in $allPe) {
   $rel = $pe.FullName.Substring($BundleDir.Length).TrimStart('\', '/')
   if ($known.path -contains $rel) { continue }
   if ($upstream -contains $rel) { Write-Host ("  (upstream, not checked) {0}" -f $rel); continue }
+  if ($rel.StartsWith($runtimeUpstreamPrefix, [System.StringComparison]::OrdinalIgnoreCase)) { Write-Host ("  (upstream runtime download, not in the zip, not checked) {0}" -f $rel); continue }
   Report 'error' ("unknown PE in bundle: {0} - add it to scripts/check-win-versioninfo.ps1 (and give it VersionInfo) instead of shipping it blank" -f $rel)
 }
 

--- a/scripts/check-win-versioninfo.ps1
+++ b/scripts/check-win-versioninfo.ps1
@@ -1,0 +1,130 @@
+# Assert the Windows VersionInfo of every PE the win-x64 bundle ships, as
+# WINDOWS reads it (Get-Item ... .VersionInfo goes through the Win32 version
+# API - the same view Explorer's Details tab, Task Manager, and code-signing
+# metadata restrictions get). Runs on the win-x64 CI leg right after bundling
+# and works locally against any staged bundle:
+#
+#   pwsh scripts/check-win-versioninfo.ps1 -BundleDir dist/stage/mStream-6.20.2-win-x64 [-Strict]
+#
+# The contract (one block for every PE - see scripts/win-versioninfo.mjs):
+#   ProductName "mStream" | ProductVersion = FileVersion = package version as
+#   four numeric parts, in the string table AND the fixed-info numbers |
+#   CompanyName = package author | LegalCopyright "<author> (<license>)" |
+#   FileDescription non-empty (per file). Where each file's block comes from:
+#   mstream-server.exe <- Bun --windows-* flags; mStream.exe <- the launcher's
+#   build.rs (baked at its CI build; the tag build proves that build matches
+#   the tag); the rust sidecars <- stamped by the bundler.
+#
+# -Strict (tag builds): every mismatch fails. Without it (PR builds), a
+# version mismatch on mStream.exe ALONE is a warning: a PR that bumps
+# package.json builds against the committed launcher, which was baked for the
+# previous version by design - the release ritual (docs/deploy.md) rebuilds it
+# before the tag, and the tag build asserts strictly. Everything else is
+# produced in this very build and must match regardless.
+#
+# Any PE in the bundle that this script does not know is a FAILURE: a new
+# binary must be added here (and given metadata) rather than ship blank -
+# and later unsigned - by omission. bin/iroh/*.node is @number0/iroh's own
+# prebuilt (upstream, not ours to relabel): listed, never checked.
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$BundleDir,
+  [switch]$Strict,
+  [string]$PackageJson = (Join-Path (Split-Path -Parent $PSScriptRoot) 'package.json')
+)
+$ErrorActionPreference = 'Stop'
+$inCi = [bool]$env:GITHUB_ACTIONS
+
+$BundleDir = (Resolve-Path -LiteralPath $BundleDir).Path
+$pkg = Get-Content -LiteralPath $PackageJson -Raw | ConvertFrom-Json
+# "6.21.0-beta.1" -> "6.21.0.0" (same rule as win-versioninfo.mjs / Bun's --windows-version)
+$parts = @(([string]$pkg.version).Split('-')[0].Split('.') | ForEach-Object { $n = 0; [void][int]::TryParse($_, [ref]$n); $n })
+while ($parts.Count -lt 4) { $parts += 0 }
+$expectVersion = ($parts[0..3] -join '.')
+$expectAuthor = [string]$pkg.author.name
+$expect = @{
+  ProductName    = 'mStream'
+  ProductVersion = $expectVersion
+  FileVersion    = $expectVersion
+  CompanyName    = $expectAuthor
+  LegalCopyright = ('{0} ({1})' -f $expectAuthor, [string]$pkg.license)
+}
+
+# Known PEs, relative to the bundle root. `lenient` = the launcher rule above.
+$known = @(
+  @{ path = 'mStream.exe';                                          lenient = $true;  optional = $true  }  # absent in a local server-only bundle
+  @{ path = 'mstream-server.exe';                                   lenient = $false; optional = $false }
+  @{ path = 'bin\rust-parser\rust-parser-win32-x64.exe';            lenient = $false; optional = $false }
+  @{ path = 'bin\rust-server-audio\rust-server-audio-win32-x64.exe'; lenient = $false; optional = $false }
+)
+$upstream = @('bin\iroh\iroh.win32-x64-msvc.node')
+
+$failures = New-Object System.Collections.Generic.List[string]
+$warnings = New-Object System.Collections.Generic.List[string]
+function Report([string]$kind, [string]$msg) {
+  if ($kind -eq 'error') {
+    if ($inCi) { Write-Host "::error::$msg" } else { Write-Host "ERROR: $msg" }
+    $failures.Add($msg)
+  } else {
+    if ($inCi) { Write-Host "::warning::$msg" } else { Write-Host "WARNING: $msg" }
+    $warnings.Add($msg)
+  }
+}
+
+Write-Host "VersionInfo contract for $BundleDir"
+Write-Host ("  expect ProductName='{0}' version='{1}' CompanyName='{2}' LegalCopyright='{3}'" -f $expect.ProductName, $expectVersion, $expect.CompanyName, $expect.LegalCopyright)
+Write-Host ("  mode: {0}" -f $(if ($Strict) { 'STRICT (tag build: every mismatch fails)' } else { 'lenient on mStream.exe (PR build)' }))
+Write-Host ''
+
+$rows = @()
+foreach ($k in $known) {
+  $full = Join-Path $BundleDir $k.path
+  if (-not (Test-Path -LiteralPath $full)) {
+    if ($k.optional) { Write-Host ("  (absent, skipped) {0}" -f $k.path); continue }
+    Report 'error' ("missing PE: {0}" -f $k.path); continue
+  }
+  $v = (Get-Item -LiteralPath $full).VersionInfo
+  $raw = @{ FileVersionRaw = $v.FileVersionRaw.ToString(); ProductVersionRaw = $v.ProductVersionRaw.ToString() }
+  $rows += [pscustomobject]@{
+    File = $k.path; ProductName = $v.ProductName; ProductVersion = $v.ProductVersion; FileVersion = $v.FileVersion
+    FileVersionRaw = $raw.FileVersionRaw; ProductVersionRaw = $raw.ProductVersionRaw
+    CompanyName = $v.CompanyName; FileDescription = $v.FileDescription; LegalCopyright = $v.LegalCopyright
+  }
+  $problems = @()
+  foreach ($field in @('ProductName', 'ProductVersion', 'FileVersion', 'CompanyName', 'LegalCopyright')) {
+    $have = [string]$v.$field
+    if ($have -ne $expect[$field]) { $problems += ("{0}='{1}' (want '{2}')" -f $field, $have, $expect[$field]) }
+  }
+  foreach ($field in @('FileVersionRaw', 'ProductVersionRaw')) {
+    if ($raw[$field] -ne $expectVersion) { $problems += ("{0}={1} (want {2})" -f $field, $raw[$field], $expectVersion) }
+  }
+  if ([string]::IsNullOrWhiteSpace($v.FileDescription)) { $problems += 'FileDescription is empty' }
+  if ($problems.Count -eq 0) { continue }
+  # Launcher leniency: ONLY version fields, ONLY when not strict, ONLY if
+  # nothing else is wrong - a blank ProductName or company is a real bug even
+  # on a PR build.
+  $versionOnly = @($problems | Where-Object { $_ -notmatch '^(ProductVersion|FileVersion|FileVersionRaw|ProductVersionRaw)=' }).Count -eq 0
+  if ($k.lenient -and -not $Strict -and $versionOnly) {
+    Report 'warning' ("{0}: baked version differs from package.json ({1}) - expected on a PR that bumps the version; the committed launcher is rebuilt for the release before tagging and the tag build asserts strictly" -f $k.path, ($problems -join '; '))
+  } else {
+    Report 'error' ("{0}: {1}" -f $k.path, ($problems -join '; '))
+  }
+}
+
+# Every other PE in the bundle must be accounted for.
+$allPe = Get-ChildItem -LiteralPath $BundleDir -Recurse -File | Where-Object { $_.Extension -in '.exe', '.dll', '.node' }
+foreach ($pe in $allPe) {
+  $rel = $pe.FullName.Substring($BundleDir.Length).TrimStart('\', '/')
+  if ($known.path -contains $rel) { continue }
+  if ($upstream -contains $rel) { Write-Host ("  (upstream, not checked) {0}" -f $rel); continue }
+  Report 'error' ("unknown PE in bundle: {0} - add it to scripts/check-win-versioninfo.ps1 (and give it VersionInfo) instead of shipping it blank" -f $rel)
+}
+
+Write-Host ''
+$rows | Format-Table -AutoSize -Wrap | Out-String -Width 220 | Write-Host
+if ($failures.Count -gt 0) {
+  Write-Host ("VersionInfo check FAILED: {0} problem(s), {1} warning(s)" -f $failures.Count, $warnings.Count)
+  exit 1
+}
+Write-Host ("VersionInfo check OK: {0} PE(s) match the contract, {1} warning(s)" -f $rows.Count, $warnings.Count)
+exit 0

--- a/scripts/win-versioninfo.mjs
+++ b/scripts/win-versioninfo.mjs
@@ -106,7 +106,11 @@ export async function stampWindowsVersionInfo(file, fields) {
 
 // Read back what a PE carries (resedit's view; check-win-versioninfo.ps1 is
 // the Win32-API truth on Windows). Returns null when the file has no
-// VersionInfo. Handy for a quick look from any host:
+// VersionInfo. Throws for PEs pe-library refuses to parse — notably Bun's
+// compiled mstream-server.exe, whose `.bun` section sits after `.rsrc`
+// ("After Resource section, sections except for relocation are not
+// supported"): read that one with PowerShell. Handy for a quick look from
+// any host:
 //   bun scripts/win-versioninfo.mjs <file.exe> [...]
 export async function readWindowsVersionInfo(file) {
   const R = await loadResedit();
@@ -130,8 +134,15 @@ export async function readWindowsVersionInfo(file) {
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const files = process.argv.slice(2);
   if (!files.length) { console.error('usage: bun scripts/win-versioninfo.mjs <file.exe|.dll|.node> ...'); process.exit(2); }
+  let failed = 0;
   for (const f of files) {
     console.log(f);
-    console.log(await readWindowsVersionInfo(f) ?? '  (no VersionInfo)');
+    try {
+      console.log(await readWindowsVersionInfo(f) ?? '  (no VersionInfo)');
+    } catch (err) {
+      failed += 1;
+      console.log(`  (unreadable by resedit: ${err.message} — on Windows use (Get-Item <file>).VersionInfo or scripts/check-win-versioninfo.ps1)`);
+    }
   }
+  process.exit(failed ? 1 : 0);
 }

--- a/scripts/win-versioninfo.mjs
+++ b/scripts/win-versioninfo.mjs
@@ -1,0 +1,137 @@
+// Windows VersionInfo stamping for the PE files the win-x64 bundle ships.
+//
+// The bundle carries three kinds of Windows binaries and each gets its
+// VersionInfo (the Explorer "Details" tab / Task Manager name / what code
+// signing later vouches for) a different way:
+//   - mstream-server.exe: Bun writes it at compile time (--windows-* flags in
+//     build-bun.mjs).
+//   - mStream.exe (the launcher): rust-launcher/build.rs bakes it via
+//     winresource, and the tag build asserts the baked version matches the
+//     tag (build-bun.yml's provenance check).
+//   - the Rust sidecars (rust-parser, rust-server-audio): CI-committed,
+//     version-agnostic tools that were shipping with NO VersionInfo at all.
+//     They are stamped HERE, at bundle time, from the bundle's package.json —
+//     a release property applied at release-packaging time, so a version
+//     bump can never leave them stale (the way it could a build-time bake in
+//     a CI-committed binary) and no sidecar workflow has to rebuild+commit
+//     five targets just to change a Windows string.
+//
+// One canonical block for all of them (asserted by
+// scripts/check-win-versioninfo.ps1 on the win-x64 CI leg): ProductName
+// "mStream", ProductVersion = FileVersion = the package version as four
+// numeric parts, CompanyName = package author, LegalCopyright =
+// "<author> (<license>)". FileDescription is per file (Task Manager shows it
+// as the process name). Uniform metadata across every shipped PE is also a
+// code-signing precondition (SignPath's artifact-configuration restrictions
+// enforce product name/version on each signed file).
+//
+// resedit (pure JS, MIT) does the PE surgery — it is the same approach Bun
+// uses internally for its --windows-* flags. It is a devDependency; CI's
+// prod-only install adds it under scripts/node_modules (see build-bun.yml).
+// Loaded lazily so non-Windows targets never need it.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// "6.21.0-beta.1" -> "6.21.0.0": Windows wants four numeric parts; prerelease
+// tags don't fit and are dropped (same rule as Bun's --windows-version above).
+export function windowsVersion(pkgVersion) {
+  const parts = String(pkgVersion).split('-')[0].split('.').map((n) => String(parseInt(n, 10) || 0));
+  while (parts.length < 4) { parts.push('0'); }
+  return parts.slice(0, 4).join('.');
+}
+
+// The shared strings every stamped/baked/compiled PE must agree on.
+export function canonicalFields(pkg) {
+  const author = pkg.author?.name ?? '';
+  return {
+    productName: 'mStream',
+    version: windowsVersion(pkg.version),
+    companyName: author,
+    legalCopyright: `${author} (${pkg.license ?? ''})`,
+  };
+}
+
+let resedit = null;
+async function loadResedit() {
+  if (resedit) { return resedit; }
+  try {
+    resedit = await import('resedit');
+  } catch (err) {
+    const e = new Error(
+      'resedit is not installed — Windows VersionInfo cannot be stamped. ' +
+      'Dev checkouts get it from devDependencies (npm install); CI installs it ' +
+      'with `npm install --prefix scripts --no-save resedit@<pinned>`. ' +
+      `(${err.message})`,
+    );
+    e.code = 'RESEDIT_MISSING';
+    throw e;
+  }
+  return resedit;
+}
+
+// Write ONE English (US, Unicode) string table carrying `fields` into `file`,
+// replacing whatever VersionInfo it had (a PE with none gets a resource
+// section created; a PE with tables in other languages loses them, so
+// exactly one canonical block ships and Windows can't pick a stale one).
+// Any other resources (icons, manifests) are preserved.
+export async function stampWindowsVersionInfo(file, fields) {
+  const R = await loadResedit();
+  const buf = readFileSync(file);
+  const exe = R.NtExecutable.from(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength), { ignoreCert: true });
+  const res = R.NtExecutableResource.from(exe, true);
+  const existing = R.Resource.VersionInfo.fromEntries(res.entries);
+  const vi = existing[0] ?? R.Resource.VersionInfo.createEmpty();
+  for (const lang of vi.getAvailableLanguages()) {
+    for (const key of Object.keys(vi.getStringValues(lang))) { vi.removeStringValue(lang, key, true); }
+  }
+  const [maj, min, mic, rev] = fields.version.split('.').map(Number);
+  vi.setFileVersion(maj, min, mic, rev, 1033);
+  vi.setProductVersion(maj, min, mic, rev, 1033);
+  const name = basename(file);
+  vi.setStringValues({ lang: 1033, codepage: 1200 }, {
+    ProductName: fields.productName,
+    ProductVersion: fields.version,
+    FileVersion: fields.version,
+    FileDescription: fields.fileDescription,
+    CompanyName: fields.companyName,
+    LegalCopyright: fields.legalCopyright,
+    OriginalFilename: name,
+    InternalName: name.slice(0, name.length - extname(name).length),
+  });
+  vi.outputToResourceEntries(res.entries);
+  res.outputResource(exe);
+  writeFileSync(file, Buffer.from(exe.generate()));
+}
+
+// Read back what a PE carries (resedit's view; check-win-versioninfo.ps1 is
+// the Win32-API truth on Windows). Returns null when the file has no
+// VersionInfo. Handy for a quick look from any host:
+//   bun scripts/win-versioninfo.mjs <file.exe> [...]
+export async function readWindowsVersionInfo(file) {
+  const R = await loadResedit();
+  const buf = readFileSync(file);
+  const exe = R.NtExecutable.from(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength), { ignoreCert: true });
+  const res = R.NtExecutableResource.from(exe, true);
+  const [vi] = R.Resource.VersionInfo.fromEntries(res.entries);
+  if (!vi) { return null; }
+  const langs = vi.getAvailableLanguages();
+  const strings = langs.length ? vi.getStringValues(langs[0]) : {};
+  const fx = vi.fixedInfo;
+  const fixed = (ms, ls) => `${ms >>> 16}.${ms & 0xffff}.${ls >>> 16}.${ls & 0xffff}`;
+  return {
+    languages: langs.map((l) => `${l.lang}/${l.codepage}`),
+    fileVersionRaw: fixed(fx.fileVersionMS, fx.fileVersionLS),
+    productVersionRaw: fixed(fx.productVersionMS, fx.productVersionLS),
+    ...strings,
+  };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const files = process.argv.slice(2);
+  if (!files.length) { console.error('usage: bun scripts/win-versioninfo.mjs <file.exe|.dll|.node> ...'); process.exit(2); }
+  for (const f of files) {
+    console.log(f);
+    console.log(await readWindowsVersionInfo(f) ?? '  (no VersionInfo)');
+  }
+}


### PR DESCRIPTION
Piece #2 of the SignPath plan — useful with or without signing, and needs no account decisions.

## What was wrong (read from the shipped 6.20.0 zip)

| PE | before |
|---|---|
| `mStream.exe` (launcher) | strings `6.20.0` ✓ but fixed-info **`0.1.0.0`** (winresource's default from Cargo.toml), no CompanyName |
| `mstream-server.exe` (Bun) | ProductName **"mStream Server"**, FileDescription "music streaming server" |
| `bin/rust-parser/…exe` | **no VersionInfo at all** |
| `bin/rust-server-audio/…exe` | **no VersionInfo at all** |
| `bin/iroh/….node` | none — but this is `@number0/iroh`'s own prebuilt (upstream), left alone |

Uniform metadata across shipped binaries is a precondition of the SignPath Foundation route (artifact-configuration restrictions enforce product name/version per signed file) and is what users see in Explorer's Details tab / Task Manager.

## The contract (identical on every PE we build)

ProductName `mStream` · ProductVersion = FileVersion = package version as **four** numeric parts, in the string table **and** the fixed-info numbers · CompanyName = package author · LegalCopyright `<author> (<license>)` · FileDescription per file (Task Manager name).

Three sources, each where it belongs:
- **server** — Bun `--windows-*` flags, now driven by the same `canonicalFields()` the stamper uses ([build-bun.mjs](scripts/build-bun.mjs)).
- **launcher** — [rust-launcher/build.rs](rust-launcher/build.rs): 4-part strings, real fixed-info via `set_version_info`, CompanyName, `OriginalFilename mStream.exe`, en-US block. Its baked version is already asserted against the tag by #835.
- **rust sidecars** — stamped **at bundle time** onto the staged copies by the new [scripts/win-versioninfo.mjs](scripts/win-versioninfo.mjs) (resedit, pure JS — the approach Bun uses internally). Deliberately *not* a `build.rs` per crate: they're CI-committed, version-agnostic tools, and a build-time bake would put them in the exact staleness class #835 just closed for the launcher, plus force four sidecar workflows to rebuild+commit five targets each per release — for a Windows string. `bin/` itself is untouched.

## The assert

[scripts/check-win-versioninfo.ps1](scripts/check-win-versioninfo.ps1) reads every PE **the way Windows does** (`Get-Item ….VersionInfo` = Win32 version API — the view Explorer/Task Manager/signing tools get; resedit's own read-back can agree with itself while Windows shows a different string table, which I hit while prototyping). Strict on tags; on PR builds a version-only mismatch on the committed launcher is a warning (a version-bump PR builds against the launcher baked for the previous version by design). **Any PE the script doesn't know fails the build** — nothing ships blank (and later unsigned) by omission. The win-x64 leg runs it right after bundling, then starts the stamped `rust-server-audio` and GETs `/status` — the one shipped binary no other smoke ever executed.

`resedit` is a devDependency; the prod-only CI install adds just it under `scripts/node_modules` (`npm install --prefix scripts --no-save resedit@3.0.2` — a plain `--no-save` install reconciles the whole tree and pulls every devDependency in; `--omit=dev` skips the named package itself; both verified).

## Verified locally (Windows)

- Launcher rebuilt with the new build.rs → `mStream / 6.20.2.0 / rawFV 6.20.2.0 / Paul Sori / en-US`.
- Full win-x64 bundle: both sidecars stamped; **strict check passes on all four PEs**; the same check **fails on the shipped 6.20.0 bundle** for exactly the defects above (negative control, PS 5.1).
- Stamped `rust-server-audio` serves `/status`, stamped `rust-parser` runs, `mstream-server -V` → 6.20.2, staged launcher `--autostart=status` answers; resedit output verified executable under both node and bun.

CI on this PR: the win-x64 leg builds the launcher fresh (PR touches `rust-launcher/`), stamps, asserts (lenient), and every existing smoke then runs on the stamped/baked bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
