### PR TITLE
reboot: keep Quick Connect, federation, the separate-port listeners and every admin save alive across a soft reboot

### DIFF
--- a/src/dlna/dlna-server.js
+++ b/src/dlna/dlna-server.js
@@ -1,17 +1,17 @@
 import express from 'express';
-import http from 'node:http';
-import winston from 'winston';
 import * as config from '../state/config.js';
 import * as dlnaApi from '../api/dlna.js';
 import { serveAlbumArtFile } from '../api/album-art.js';
 import { timeSeekMiddleware } from './time-seek.js';
 import { resolveLibraryMediaPath } from './media-path.js';
+import { createKeptListener } from '../util/kept-listener.js';
 
-let dlnaServer = null;
+// Kept listener (util/kept-listener.js): start() after a soft reboot keeps
+// the socket when port/address are unchanged and recycles it (with same-port
+// EADDRINUSE patience) when they changed — the main listener's rule.
+const listener = createKeptListener('dlna');
 
-export function start() {
-  if (dlnaServer) { return; }
-
+function buildApp() {
   const app = express();
 
   // Time-seek (TimeSeekRange.dlna.org) handler runs first; it calls next()
@@ -39,29 +39,17 @@ export function start() {
 
   // All DLNA control/description routes — no mode guard needed on this server
   dlnaApi.setup(app, { checkMode: false });
+  return app;
+}
 
-  const s = http.createServer(app);
-  dlnaServer = s;
-
-  s.listen(config.program.dlna.port, config.program.address, () => {
-    winston.info(`[dlna] Separate server listening on port ${config.program.dlna.port}`);
-  });
-
-  s.on('error', (err) => {
-    winston.error(`[dlna] Separate server error: ${err.message}`);
-    // Only clear the module-level reference if it still points at THIS server.
-    // A late error on an already-replaced server must not nullify the new one.
-    if (dlnaServer === s) { dlnaServer = null; }
+export function start() {
+  listener.ensure({
+    port: config.program.dlna.port,
+    address: config.program.address,
+    build: buildApp,
   });
 }
 
-export function stop() {
-  if (!dlnaServer) { return; }
-  const s = dlnaServer;
-  dlnaServer = null;
-  s.close(() => { winston.info('[dlna] Separate server stopped'); });
-}
+export function stop() { listener.stop(); }
 
-export function isRunning() {
-  return dlnaServer !== null;
-}
+export function isRunning() { return listener.isRunning(); }

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ import { compression } from './util/compression.js';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import https from 'https';
+import net from 'net';
 import crypto from 'crypto';
 import { dataRoot, usingFallbackDataRoot } from './util/esm-helpers.js';
 
@@ -58,6 +59,7 @@ import * as backupManager from './backup/manager.js';
 // Velvet UI modules — dynamically imported only when ui='velvet' is active
 import WebError from './util/web-error.js';
 import { isAdminAllowed } from './util/admin-network.js';
+import { writeJsonAtomic, completedWrites } from './util/atomic-json.js';
 
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -83,6 +85,38 @@ let currentBind = null;
 // relisten budget and process.exit() the whole process, killing the healthy
 // winner with it.
 let rebootInFlight = false;
+// A reboot request that arrived while one was in flight. The in-flight reboot
+// re-reads the config from disk, but only ONCE, at its start: a save that
+// lands after that read (two admin tabs, a slow-bodied POST already dispatched
+// to the old app) would otherwise be on disk and never applied — the admin
+// sees "Updated" while the server runs the previous value until the next
+// restart. So a coalesced request re-runs the reboot once the in-flight one
+// has re-served — but only if a config write actually completed after that
+// read (configWritesAtRead vs util/atomic-json's completed-write count);
+// otherwise the in-flight reboot already applied it and a second bounce would
+// just cost another tunnel/listener cycle.
+let rebootPending = false;
+let configWritesAtRead = 0;
+// Bumped by every reboot(); each request tags its socket with the generation
+// serving it, so reboot()'s grace-period sweep can tell "still busy with an
+// OLD-app response" (destroy: that handler must not live on) from "idle
+// keep-alive" or "already carrying a NEW-app response" (leave alone: the kept
+// socket swapped apps ~70 ms in, and destroying those cut audio streams the
+// new app was mid-way through).
+let appGeneration = 0;
+
+// Per-request socket tagging for the sweep above. Registered ONCE per
+// listener alongside the 'connection' tracker; runtimes/servers where
+// req.socket is not the accepted socket (Bun's shim, https' TLSSocket over
+// the raw 'connection' socket) simply leave sockets untagged, and untagged
+// sockets get the pre-existing behaviour (destroyed by the sweep).
+function tagRequestSocket(req, res) {
+  const socket = req.socket;
+  if (!socket) { return; }
+  socket._mstreamGen = appGeneration;
+  socket._mstreamBusy = true;
+  res.once('close', () => { socket._mstreamBusy = false; });
+}
 
 // Placeholder request handler for the reboot window: the listening socket stays
 // bound while the app is torn down and rebuilt, and callers get an honest 503
@@ -92,6 +126,30 @@ function rebootStub(req, res) {
   res.setHeader('Retry-After', '1');
   res.setHeader('Connection', 'close');
   res.end('mStream is restarting');
+}
+
+// Put a rejected bind change back: the previous port/address into the config
+// file (atomically — the admin's own saves go through the same writer), so
+// the next start doesn't fail on the value this one just refused.
+async function revertBindInConfig(configFile, prev) {
+  const doc = JSON.parse(await fs.promises.readFile(configFile, 'utf8'));
+  doc.port = prev.port;
+  doc.address = prev.address;
+  await writeJsonAtomic(configFile, doc);
+}
+
+// Can this machine bind {port, address} right now? A throwaway net.Server —
+// node:net, deliberately: Bun's node:http server reports an address that
+// isn't local as EADDRINUSE ("Is port N in use?"), which the same-port relisten
+// patience would then wait on forever, while its node:net server says
+// EADDRNOTAVAIL like Node does. Port 0 probes the ADDRESS alone.
+function probeBind(port, address) {
+  return new Promise((resolve) => {
+    const probe = net.createServer();
+    const timer = setTimeout(() => { try { probe.close(); } catch (_) { /* never opened */ } resolve({ ok: false, code: 'ETIMEDOUT' }); }, 3000);
+    probe.once('error', (err) => { clearTimeout(timer); resolve({ ok: false, code: err.code || err.message }); });
+    probe.listen(port, address, () => { clearTimeout(timer); probe.close(() => resolve({ ok: true })); });
+  });
 }
 
 function bindLabel(bind) {
@@ -132,6 +190,9 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   mstream = express();
 
   try {
+    // Captured BEFORE the read: any admin save that completes from here on
+    // may have missed this read (see rebootPending).
+    configWritesAtRead = completedWrites(configFile);
     await config.setup(configFile);
   } catch (err) {
     // A permission/read-only failure is NOT a malformed config, and saying so
@@ -193,7 +254,37 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   // Keep the socket when a reboot re-serves the very same bind (the common
   // case: trust proxy, UI switch, request-size limit...). See keepListener's
   // rationale above serveIt.
-  const keepListener = relisten !== null && !!server && server.listening && sameBind(relisten, bind);
+  let keepListener = relisten !== null && !!server && server.listening && sameBind(relisten, bind);
+  if (!keepListener && relisten !== null && server && server.listening &&
+      (relisten.port !== bind.port || relisten.address !== bind.address)) {
+    // The admin moved the port/address. Before giving up a socket that works,
+    // prove the new one is servable AT ALL — an address that isn't this
+    // machine's, a privileged/reserved port, a port another program owns. It
+    // used to be: recycle, fail to listen, exit — and exit again on every
+    // later start, the bad value now being on disk. Now: refuse the change,
+    // put the previous port/address back in the config, keep serving on the
+    // socket we have. A port move probes the exact new bind (that port is one
+    // this process never held, so "in use" is real); an address move on the
+    // same port probes the address alone (port 0) — the exact bind would fail
+    // against our own still-open socket on Linux.
+    const portMoved = relisten.port !== bind.port;
+    const probe = await probeBind(portMoved ? bind.port : 0, bind.address);
+    if (!probe.ok) {
+      const rejected = bindLabel(bind);
+      bind.port = relisten.port;
+      bind.address = relisten.address;
+      config.program.port = relisten.port;
+      config.program.address = relisten.address;
+      winston.error(`The new bind ${rejected} cannot be served (${probe.code}) — keeping ${bindLabel(bind)} and restoring port/address in the config file`);
+      try { fs.writeSync(2, `mStream: bind ${rejected} rejected (${probe.code}); staying on ${bindLabel(bind)}\n`); } catch (_) { /* stderr gone */ }
+      revertBindInConfig(configFile, relisten).catch((revertErr) => {
+        winston.error(`Could not restore the previous port/address in ${configFile}: ${revertErr.message} — edit it by hand or the next start will fail the same way`);
+      });
+      // Nothing about the bind changes now (unless TLS did too, which still
+      // recycles — onto the address we know works).
+      keepListener = sameBind(relisten, bind);
+    }
+  }
   if (!keepListener) {
     // Build the replacement first: an unreadable or malformed cert must fail
     // here, before anything is torn down.
@@ -238,6 +329,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
       mySockets.add(socket);
       socket.on('close', () => mySockets.delete(socket));
     });
+    server.on('request', tagRequestSocket);
   }
 
   // Magic Middleware Things
@@ -602,6 +694,20 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     rebootInFlight = false;   // a reboot's re-serve is complete
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
 
+    // A settings change landed while the reboot above was already past its
+    // config read (see rebootPending): go straight around again rather than
+    // booting the chores below for a config that is already stale. The
+    // re-run re-reads the file, so it applies both changes.
+    if (rebootPending) {
+      rebootPending = false;
+      if (completedWrites(config.configFile) > configWritesAtRead) {
+        winston.info('A settings change landed after this reboot read the config — rebooting once more to apply it');
+        setImmediate(reboot);
+        return;
+      }
+      winston.info('The settings change that arrived during the reboot was already picked up by it');
+    }
+
     const taskQueue = await import('./db/task-queue.js');
     taskQueue.runAfterBoot();
 
@@ -616,11 +722,20 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     if (config.program.dlna.mode !== 'disabled') {
       dlnaSsdp.start();
     }
+    // The separate-port servers are kept listeners (util/kept-listener.js):
+    // reboot() deliberately does NOT stop them, so start() here keeps their
+    // socket when port/address are unchanged and only recycles it when they
+    // are — same rule as the main listener, same Windows/Bun reason. A config
+    // that no longer wants them must therefore stop them HERE.
     if (config.program.dlna.mode === 'separate-port') {
       dlnaServer.start();
+    } else {
+      dlnaServer.stop();
     }
     if (config.program.subsonic.mode === 'separate-port') {
       subsonicServer.start();
+    } else {
+      subsonicServer.stop();
     }
 
     // Iroh P2P remote-access tunnel (opt-in; default off). Lazy-loaded so a
@@ -717,7 +832,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   // until that child exits (see keepListener above). Both end on their own;
   // neither is a reason to take the process down. So retry with backoff for
   // as long as it takes, say why, and let the eventual listen succeed.
-  const samePortRelisten = relisten !== null && relisten.port === bind.port;
+  let samePortRelisten = relisten !== null && relisten.port === bind.port;
   if (relisten !== null && !samePortRelisten) {
     winston.info(`Reboot moved the port ${relisten.port} -> ${bind.port}; a conflict on the new port is real, not a release delay`);
   }
@@ -725,6 +840,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   let relistenAttempts = 0;
   let relistenLastLoggedAt = 0;
   let relistenDiagnosed = false;
+  let rolledBack = false;
   server.on('error', (err) => {
     // Only the CURRENT server may act on its errors. A superseded instance
     // (an overlapping reboot's loser) must never run the exit paths below —
@@ -734,9 +850,53 @@ export async function serveIt(configFile, { relisten = null } = {}) {
       try { thisServer.close(); } catch (_) { /* already closed */ }
       return;
     }
+    // A reboot that CHANGED the bind to something this machine cannot serve
+    // — an address that isn't local (EADDRNOTAVAIL), a privileged or reserved
+    // port (EACCES), a port some other program owns (EADDRINUSE on a MOVED
+    // port, where a conflict is real). The old bind worked a moment ago; going
+    // dark, exiting, and re-exiting on every later boot because the bad value
+    // is now on disk (that was the behaviour) helps nobody. Revert instead:
+    // put the previous port/address back in the config file, say so loudly,
+    // and re-take the bind we just released — with the same-port patience,
+    // since it IS the port this process held.
+    if (relisten !== null && !rolledBack &&
+        (err.code === 'EADDRNOTAVAIL' || err.code === 'EACCES' || err.code === 'EINVAL' ||
+         (err.code === 'EADDRINUSE' && !samePortRelisten))) {
+      rolledBack = true;
+      const rejected = bindLabel(bind);
+      bind.port = relisten.port;
+      bind.address = relisten.address;
+      config.program.port = relisten.port;
+      config.program.address = relisten.address;
+      samePortRelisten = true;
+      winston.error(`The new bind ${rejected} cannot be served (${err.code}${err.message ? `: ${err.message}` : ''}) — reverting to ${bindLabel(bind)} and restoring port/address in the config file`);
+      try { fs.writeSync(2, `mStream: bind ${rejected} rejected (${err.code}); staying on ${bindLabel(bind)}\n`); } catch (_) { /* stderr gone */ }
+      revertBindInConfig(config.configFile, relisten).catch((revertErr) => {
+        winston.error(`Could not restore the previous port/address in ${config.configFile}: ${revertErr.message} — edit it by hand or the next start will fail the same way`);
+      });
+      setTimeout(() => { if (thisServer === server) { thisServer.listen(bind.port, bind.address); } }, 250);
+      return;
+    }
     if (err.code === 'EADDRINUSE' && samePortRelisten) {
       relistenAttempts++;
       const waitedMs = Date.now() - relistenStartedAt;
+      // Same port, MOVED address (e.g. [::] -> 127.0.0.1): "in use" can be our
+      // own child's inherited handle (a wait, as below) or another program on
+      // exactly the new address (permanent — the pre-recycle probe can't see
+      // that one, since on Linux the exact bind fails against our own socket
+      // until we close it). Give it 20 s, then go back to the address that
+      // worked rather than sit dark indefinitely; if THAT is held too it is
+      // the inherited-handle case, and the unbounded patience below applies.
+      if (!rolledBack && relisten.address !== bind.address && waitedMs >= 20000) {
+        rolledBack = true;
+        const rejected = bindLabel(bind);
+        bind.address = relisten.address;
+        config.program.address = relisten.address;
+        winston.error(`Port ${bind.port} still busy 20s after moving to ${rejected} — reverting to ${bindLabel(bind)} and restoring the address in the config file`);
+        revertBindInConfig(config.configFile, relisten).catch((revertErr) => {
+          winston.error(`Could not restore the previous address in ${config.configFile}: ${revertErr.message}`);
+        });
+      }
       // 250 ms for the first two seconds (the ordinary Windows release delay),
       // then 1 s, then every 5 s once it is clearly a held socket.
       const delay = waitedMs < 2000 ? 250 : waitedMs < 30000 ? 1000 : 5000;
@@ -786,13 +946,16 @@ export function reboot() {
     // serveIt()s would both try to take over the listener (or race for the
     // port on a bind change, where the loser exits the process out from under
     // the winner). Two quick admin saves is all it takes. Coalesce instead —
-    // the in-flight reboot already re-reads the config from disk, so it picks
-    // up both changes.
+    // and remember it: the in-flight reboot re-reads the config exactly once,
+    // at its start, so a save landing after that read is applied by ONE more
+    // reboot once this one has re-served (see rebootPending / onListening).
     if (rebootInFlight) {
-      winston.warn('Reboot already in progress — skipping the duplicate request');
+      rebootPending = true;
+      winston.warn('Reboot already in progress — this request will re-run the reboot once it completes');
       return;
     }
     rebootInFlight = true;
+    appGeneration++;
     // The bind we are serving right now, captured BEFORE serveIt's
     // config.setup re-reads the file: the re-serve keeps the socket if the
     // new config binds identically, and only gets the EADDRINUSE patience if
@@ -804,8 +967,13 @@ export function reboot() {
     transcode.reset();
 
     dlnaSsdp.stop();
-    dlnaServer.stop();
-    subsonicServer.stop();
+    // The separate-port DLNA/Subsonic servers are NOT stopped here: they are
+    // kept listeners (util/kept-listener.js) and onListening re-ensures them
+    // against the re-read config — kept when their bind is unchanged, recycled
+    // (with same-port patience) when it isn't, stopped when no longer wanted.
+    // Closing them here made every soft reboot on the Windows Bun bundle
+    // re-listen against a child's inherited handle, and their re-listen has
+    // no second chance: the Subsonic API stayed dead until the next restart.
     mdns.stop();
     serverPlaybackApi.killRustPlayer();
     // Tear down the /remote WebSocket server: it detaches its upgrade/error
@@ -820,39 +988,39 @@ export function reboot() {
     // pending alongside the new ones.
     backupManager.shutdown();
 
-    // Tear down the Iroh tunnel. It binds its own UDP socket independent of the
-    // HTTP server, so it doesn't block server.close(); we stop it to free the
-    // socket + relay connection. Lazy-imported to match the boot path and to
-    // stay a no-op when the native module was never loaded.
-    import('./state/iroh.js').then((m) => m.stop()).catch(() => {});
-    // Same for the federation endpoint — its own UDP socket + relay conn.
-    // Peer bridges (loopback servers + outbound conns) go down with it.
-    import('./state/federation-client.js').then((m) => m.stopAll()).catch(() => {});
-    import('./state/federation.js').then((m) => m.stop()).catch(() => {});
-    // Same for the discovery-network gossip stack: sidecar process, gossip
-    // subscription, mesh-health watch, auto-fetch and pruning timers. Without
-    // it, an operator who DISABLES the feature in the config file and uses the
-    // admin reboot (the documented flow) keeps publishing snapshots and
-    // gossiping their catalog until a full process restart, while the server
-    // reports the feature off.
+    // Tear down the Iroh tunnel, the federation endpoint (+ its peer bridges)
+    // and the discovery-network gossip stack. Each binds its own sockets
+    // independent of the HTTP server; each is lazy-imported to match the boot
+    // path and to stay a no-op when its native module was never loaded.
     //
-    // Unlike the teardowns above this one is SEQUENCED before the re-serve
-    // rather than fired and forgotten, so a reboot that disables the feature
-    // has actually released the sidecar before the new instance boots.
+    // ALL of these are SEQUENCED before the re-serve, not fired and
+    // forgotten. The re-serve now runs tens of milliseconds after this point
+    // (the kept-socket swap), while closing an iroh endpoint takes ~1 s: a
+    // fire-and-forget stop() meant onListening's start() found the endpoint
+    // still set (closing), no-oped, and the late stop then nulled it — Quick
+    // Connect and federation dead after ANY reboot-requiring admin save, no
+    // error logged, until the next process restart. Same for the discovery
+    // stack: an operator who DISABLES it in the config and uses the admin
+    // reboot kept publishing until a full restart.
     //
     // The timeout is a LATENCY bound, not the correctness mechanism: a wedged
     // teardown can delay the restart but never block it. Correctness lives in
-    // the stack itself, which now clears `running` up front and makes a start
-    // wait on the in-flight stop (see startDiscoveryP2pStack). That ordering
-    // matters because a full stop can outlast this timeout — the sidecar gets
-    // a shutdown-RPC grace AND a SIGKILL fallback — and when it does, the
-    // restart lands mid-stop. Before the stack serialized, that combination
-    // silently left the feature dead: the restart no-oped on a stale flag and
-    // the late stop killed the sidecar it was meant to replace.
-    const p2pStopped = Promise.race([
-      import('./state/discovery-p2p-stack.js')
-        .then((m) => m.stopDiscoveryP2pStack())
-        .catch((err) => winston.warn(`[discovery-p2p] stop during reboot failed: ${err.message}`)),
+    // the modules themselves — each keeps an in-flight `stopping` promise,
+    // clears its public state up front, and makes a start() wait on the stop
+    // (state/iroh.js, state/federation.js, state/discovery-p2p-stack.js). That
+    // ordering matters because a full stop can outlast this timeout (the
+    // discovery sidecar gets a shutdown-RPC grace AND a SIGKILL fallback), and
+    // when it does the restart lands mid-stop and must wait rather than no-op.
+    const stopOf = (label, load) => load()
+      .catch((err) => winston.warn(`[${label}] stop during reboot failed: ${err.message}`));
+    const teardowns = Promise.all([
+      stopOf('discovery-p2p', () => import('./state/discovery-p2p-stack.js').then((m) => m.stopDiscoveryP2pStack())),
+      stopOf('iroh', () => import('./state/iroh.js').then((m) => m.stop())),
+      stopOf('federation-client', () => import('./state/federation-client.js').then((m) => m.stopAll())),
+      stopOf('federation', () => import('./state/federation.js').then((m) => m.stop())),
+    ]);
+    const teardownsDone = Promise.race([
+      teardowns,
       new Promise((resolve) => setTimeout(resolve, 5000)),
     ]);
 
@@ -865,17 +1033,25 @@ export function reboot() {
       server.off('request', mstream);
       server.on('request', rebootStub);
     }
-    // Drop the connections that existed at reboot time after a short grace
-    // period, so in-flight writes get a chance to finish but a long transfer
-    // (a transcode, a big download) doesn't keep the old app's handlers alive
-    // indefinitely — and, on a bind change, so Node's close() can settle (it
-    // waits for every connection to drain, and closeAllConnections() is a
-    // guaranteed no-op under Bun once close() has run). Snapshot, not the
-    // live set: connections the kept socket accepts after this moment belong
-    // to the stub and then to the new app.
+    // Drop the OLD app's in-flight connections after a short grace period, so
+    // short writes get a chance to finish but a long transfer (a transcode, a
+    // big download) doesn't keep the old app's handlers alive indefinitely —
+    // and, on a bind change, so Node's close() can settle (serveIt's recycle
+    // path destroys ALL of the old listener's sockets for that; see there).
+    // Snapshot, not the live set: connections the kept socket accepts after
+    // this moment belong to the stub and then to the new app. And on the
+    // kept socket the app swaps ~70 ms in, so by the time this fires an idle
+    // keep-alive connection from before the reboot may already be carrying a
+    // NEW-app response (a browser's pooled connection starting the next
+    // track): destroy only sockets still busy with a response the OLD
+    // generation started; leave idle ones and new-generation ones alone.
+    // Untagged sockets (a runtime where req.socket isn't the accepted socket)
+    // keep the previous behaviour and are destroyed.
     const closingSockets = [...liveSockets];
+    const newGeneration = appGeneration;
     setTimeout(() => {
       for (const socket of closingSockets) {
+        if (socket._mstreamGen !== undefined && (!socket._mstreamBusy || socket._mstreamGen >= newGeneration)) { continue; }
         try { socket.destroy(); } catch (_) { /* already gone */ }
       }
     }, 1000);
@@ -884,9 +1060,10 @@ export function reboot() {
     // cert first fails HERE). Unhandled, that's a raw unhandled rejection
     // with the old app already torn down — the silent death #803 set out to
     // eliminate, just moved to the reboot path.
-    // Gate the re-serve on the discovery-p2p teardown finishing (see above).
-    p2pStopped.then(() => serveIt(config.configFile, { relisten: previousBind })).catch((rebootErr) => {
+    // Gate the re-serve on the endpoint/sidecar teardowns finishing (see above).
+    teardownsDone.then(() => serveIt(config.configFile, { relisten: previousBind })).catch((rebootErr) => {
       rebootInFlight = false;
+      rebootPending = false;
       winston.error('Reboot failed to restart the server', { stack: rebootErr });
       try { fs.writeSync(2, `mStream fatal: reboot failed to restart the server: ${rebootErr.message}\n`); } catch (_) { /* stderr gone */ }
       process.exit(1);

--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -55,6 +55,10 @@ const failedHandshakes = new Map(); // remoteId -> { fails, blockedUntil }
 let irohMod = null;
 let endpoint = null;
 let endpointIdStr = null;
+// In-flight stop(), or null — see state/iroh.js: a soft reboot's re-serve
+// calls start() while the previous endpoint is still closing; start() must
+// wait for that instead of no-oping on the closing endpoint.
+let stopping = null;
 
 // Live authorized connections per key id, so revoking a key can sever its
 // open pipes instead of waiting for the peer to reconnect and fail.
@@ -221,11 +225,11 @@ async function acceptConnection(conn, targetHost, targetPort) {
   }
 }
 
-async function runAcceptLoop(targetHost, targetPort) {
+async function runAcceptLoop(ep, targetHost, targetPort) {
   for (;;) {
     let incoming;
     try {
-      incoming = await endpoint.acceptNext();
+      incoming = await ep.acceptNext();
     } catch (_err) {
       break; // endpoint closing
     }
@@ -277,6 +281,9 @@ async function runAcceptLoop(targetHost, targetPort) {
 //               info (default true).
 // Returns { endpointId }. Throws if the native module can't load.
 export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, awaitOnline = true } = {}) {
+  if (stopping) {
+    try { await stopping; } catch (_err) { /* stop() is best-effort */ }
+  }
   if (endpoint) { return { endpointId: endpointIdStr }; }
   if (!targetPort) { throw new Error('federation.start: targetPort is required'); }
 
@@ -285,14 +292,18 @@ export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, a
 
   const options = { alpns: [FEDERATION_ALPN] };
   if (secretKey) { options.secretKey = Array.from(asBuffer(secretKey)); }
-  endpoint = await Endpoint.bind(options);
-  endpointIdStr = endpoint.id().toString();
+  const ep = await Endpoint.bind(options);
+  endpoint = ep;
+  endpointIdStr = ep.id().toString();
 
   if (awaitOnline) {
-    await Promise.race([endpoint.online().catch(() => {}), delay(8000)]);
+    await Promise.race([ep.online().catch(() => {}), delay(8000)]);
   }
+  // stop() ran while we waited for the relay (see state/iroh.js): ep is
+  // closed and the state cleared — the reboot's own start() takes over.
+  if (endpoint !== ep) { return { endpointId: null }; }
 
-  runAcceptLoop(targetHost, targetPort); // detached; ends when the endpoint closes
+  runAcceptLoop(ep, targetHost, targetPort); // detached; ends when the endpoint closes
   winston.info(`[federation] endpoint up — endpointId=${endpointIdStr} -> ${targetHost}:${targetPort}`);
   return { endpointId: endpointIdStr };
 }
@@ -312,12 +323,17 @@ export function getEndpointTicket() {
 }
 
 export async function stop() {
+  if (stopping) { return stopping; }
   if (!endpoint) { return; }
-  try { await endpoint.close(); } catch (_err) { /* best effort */ }
+  const ep = endpoint;
   endpoint = null;
   endpointIdStr = null;
   liveConns.clear();
   failedHandshakes.clear();
+  stopping = (async () => {
+    try { await ep.close(); } catch (_err) { /* best effort */ }
+  })();
+  try { await stopping; } finally { stopping = null; }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/state/iroh.js
+++ b/src/state/iroh.js
@@ -62,6 +62,12 @@ let irohMod = null;         // the loaded native module (set by start/connectTun
 let endpoint = null;        // the live Iroh endpoint (null when stopped)
 let endpointIdStr = null;   // cached base32 EndpointId string
 let connectSecretBuf = null; // Buffer the handshake compares against
+// In-flight stop(), or null. A start() that lands mid-teardown waits on it:
+// the soft reboot fires stop() and re-serves within tens of milliseconds while
+// endpoint.close() takes ~1 s, so without this the re-serve's start() saw the
+// still-closing endpoint, returned as a no-op, and the tunnel stayed dead
+// until the next process restart (same shape discovery-p2p-stack.js fixed).
+let stopping = null;
 
 // ---------------------------------------------------------------------------
 // Composite ticket (what the QR encodes): EndpointTicket + connectSecret.
@@ -133,11 +139,11 @@ async function acceptConnection(conn, targetHost, targetPort) {
 
 // Top-level accept loop: pull incoming connections, complete the handshake, and
 // hand authorized connections to acceptConnection. Unauthorized peers are closed.
-async function runAcceptLoop(targetHost, targetPort) {
+async function runAcceptLoop(ep, targetHost, targetPort) {
   for (;;) {
     let incoming;
     try {
-      incoming = await endpoint.acceptNext();
+      incoming = await ep.acceptNext();
     } catch (_err) {
       break; // endpoint closing
     }
@@ -172,6 +178,9 @@ async function runAcceptLoop(targetHost, targetPort) {
 //   awaitOnline   wait (bounded) for a home relay so the ticket has relay info (default true).
 // Returns { endpointId }. Throws if the native module can't load (caller handles).
 export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, connectSecret, awaitOnline = true } = {}) {
+  if (stopping) {
+    try { await stopping; } catch (_err) { /* stop() is best-effort */ }
+  }
   if (endpoint) { return { endpointId: endpointIdStr }; }
   if (!targetPort) { throw new Error('iroh.start: targetPort is required'); }
   if (!connectSecret) { throw new Error('iroh.start: connectSecret is required'); }
@@ -182,14 +191,19 @@ export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, c
 
   const options = { alpns: [TUNNEL_ALPN] };
   if (secretKey) { options.secretKey = Array.from(asBuffer(secretKey)); }
-  endpoint = await Endpoint.bind(options);
-  endpointIdStr = endpoint.id().toString();
+  const ep = await Endpoint.bind(options);
+  endpoint = ep;
+  endpointIdStr = ep.id().toString();
 
   if (awaitOnline) {
-    await Promise.race([endpoint.online().catch(() => {}), delay(8000)]);
+    await Promise.race([ep.online().catch(() => {}), delay(8000)]);
   }
+  // stop() ran while we waited for the relay (a soft reboot lands here when
+  // an admin saves right after boot): ep is closed and the state cleared —
+  // nothing to serve, and the reboot's own start() brings the tunnel back.
+  if (endpoint !== ep) { return { endpointId: null }; }
 
-  runAcceptLoop(targetHost, targetPort); // detached; ends when the endpoint closes
+  runAcceptLoop(ep, targetHost, targetPort); // detached; ends when the endpoint closes
   winston.info(`[iroh] tunnel up — endpointId=${endpointIdStr} -> ${targetHost}:${targetPort}`);
   return { endpointId: endpointIdStr };
 }
@@ -213,11 +227,18 @@ export function getTicket() {
 export function getEndpoint() { return endpoint; }
 
 export async function stop() {
+  if (stopping) { return stopping; }
   if (!endpoint) { return; }
-  try { await endpoint.close(); } catch (_err) { /* best effort */ }
+  // Clear the public state FIRST: from here on the tunnel reports stopped and
+  // start() waits on `stopping` rather than seeing a live-looking endpoint.
+  const ep = endpoint;
   endpoint = null;
   endpointIdStr = null;
   connectSecretBuf = null;
+  stopping = (async () => {
+    try { await ep.close(); } catch (_err) { /* best effort */ }
+  })();
+  try { await stopping; } finally { stopping = null; }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/subsonic/subsonic-server.js
+++ b/src/subsonic/subsonic-server.js
@@ -6,46 +6,34 @@
  * independently of the main mStream web UI. Authentication is still handled
  * by the Subsonic layer itself (u/p or apiKey), so this server carries no
  * mStream session cookies.
+ *
+ * The listener is a kept listener (util/kept-listener.js): start() after a
+ * soft reboot KEEPS the socket when port/address are unchanged and only
+ * recycles it (with same-port EADDRINUSE patience) when they changed — the
+ * same rule the main listener follows, for the same Windows/Bun reason.
  */
 
 import express from 'express';
-import http from 'node:http';
-import winston from 'winston';
 import * as config from '../state/config.js';
 import * as subsonicApi from '../api/subsonic/index.js';
+import { createKeptListener } from '../util/kept-listener.js';
 
-let server = null;
+const listener = createKeptListener('subsonic');
 
 export function start() {
-  if (server) { return; }
-
-  const app = express();
-  app.use(express.urlencoded({ extended: true }));
-  app.use(express.json());
-
-  subsonicApi.setup(app);
-
-  const s = http.createServer(app);
-  server = s;
-
-  s.listen(config.program.subsonic.port, config.program.address, () => {
-    winston.info(`[subsonic] Separate server listening on port ${config.program.subsonic.port}`);
-  });
-
-  s.on('error', (err) => {
-    winston.error(`[subsonic] Separate server error: ${err.message}`);
-    // Identity check: only clear the module ref if it still points at THIS
-    // server. A late error on an already-replaced instance mustn't nullify
-    // the new one.
-    if (server === s) { server = null; }
+  listener.ensure({
+    port: config.program.subsonic.port,
+    address: config.program.address,
+    build: () => {
+      const app = express();
+      app.use(express.urlencoded({ extended: true }));
+      app.use(express.json());
+      subsonicApi.setup(app);
+      return app;
+    },
   });
 }
 
-export function stop() {
-  if (!server) { return; }
-  const s = server;
-  server = null;
-  s.close(() => { winston.info('[subsonic] Separate server stopped'); });
-}
+export function stop() { listener.stop(); }
 
-export function isRunning() { return server !== null; }
+export function isRunning() { return listener.isRunning(); }

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -18,17 +18,68 @@ import * as subsonicServer from '../subsonic/subsonic-server.js';
 import { getDirname } from './esm-helpers.js';
 import { launchWorker } from './worker-process.js';
 import { invalidateWhitelistCache } from './admin-network.js';
+import { updateJsonAtomic, completedWrites } from './atomic-json.js';
 
 const __dirname = getDirname(import.meta.url);
 
 // ── Config file helpers (for server-level settings) ─────────────────────────
 
+// Every setting editor below is a read-modify-write: loadFile -> mutate ->
+// saveFile. Two of them in flight together (two admin tabs, two quick saves,
+// the smoke's concurrent POSTs) used to be last-writer-wins on disk — both
+// loaded the same document, and the second save silently threw away the
+// first's change (a trustProxy flip lost under a maxRequestSize save, both
+// answered 200). And the writes were plain fs.writeFile, so the soft reboot's
+// config re-read, now microseconds after the save that triggered it, could
+// see a truncated file and exit the process.
+//
+// So: loadFile remembers the document it handed out (a deep snapshot, keyed by
+// the returned object), and saveFile writes through util/atomic-json.js —
+// atomic (temp + rename: no reader ever sees a partial document), serialized
+// per file, and MERGING when another write landed in between: only the paths
+// the caller actually changed since its load are applied onto the file's
+// current content, so concurrent saves of different settings both survive
+// (same path: the later save wins, as before). Callers need no change.
+const loaded = new WeakMap();   // returned object -> { file, base (deep clone), writes }
+
 export async function loadFile(file) {
-  return JSON.parse(await fs.readFile(file, 'utf-8'));
+  const doc = JSON.parse(await fs.readFile(file, 'utf-8'));
+  if (doc && typeof doc === 'object') {
+    loaded.set(doc, { file: path.resolve(file), base: structuredClone(doc), writes: completedWrites(file) });
+  }
+  return doc;
 }
 
 export function saveFile(saveData, file) {
-  return fs.writeFile(file, JSON.stringify(saveData, null, 2), 'utf8');
+  const origin = (saveData && typeof saveData === 'object') ? loaded.get(saveData) : undefined;
+  return updateJsonAtomic(file, (current) => {
+    // No snapshot (not from loadFile), a different file, nothing landed since
+    // the load, or nothing to merge onto: write the caller's document as is.
+    if (!origin || origin.file !== path.resolve(file) || completedWrites(file) === origin.writes || !current || typeof current !== 'object') {
+      return saveData;
+    }
+    return mergeChanges(current, origin.base, saveData);
+  });
+}
+
+const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+// Apply to `current` every path where `mine` differs from `base` (what this
+// caller loaded); paths the caller didn't touch keep `current`'s value.
+function mergeChanges(current, base, mine) {
+  const out = { ...current };
+  for (const key of new Set([...Object.keys(base || {}), ...Object.keys(mine || {})])) {
+    const inMine = Object.prototype.hasOwnProperty.call(mine, key);
+    const inBase = Object.prototype.hasOwnProperty.call(base || {}, key);
+    if (!inMine && inBase) { delete out[key]; continue; }          // caller deleted it
+    if (!inMine) { continue; }
+    if (isPlainObject(mine[key]) && isPlainObject(base?.[key]) && isPlainObject(out[key])) {
+      out[key] = mergeChanges(out[key], base[key], mine[key]);      // descend: sibling sub-keys survive
+    } else if (!inBase || JSON.stringify(mine[key]) !== JSON.stringify(base[key])) {
+      out[key] = mine[key];                                         // caller changed (or added) it
+    }
+  }
+  return out;
 }
 
 // ── Directory / Library management (now in SQLite) ──────────────────────────

--- a/src/util/atomic-json.js
+++ b/src/util/atomic-json.js
@@ -1,0 +1,83 @@
+// Atomic, per-file-serialized JSON writes for state files other code READS
+// concurrently — the config file above all.
+//
+// Why: `fs.writeFile` is open(O_TRUNC) followed by write(). A reader that
+// lands between the two — and since the soft reboot re-reads the config
+// file within microseconds of the admin save that triggered it (server.js
+// reboot -> serveIt -> config.setup), a second admin save racing the first
+// puts a reader exactly there — sees '' or a prefix, JSON.parse throws, and
+// serveIt exits the process (measured on Windows: 0.2-0.4% of concurrent
+// write/read pairs torn; 2.7-4% of concurrent admin-save pairs killing the
+// server, under both node and bun). Writing to a sibling temp file and
+// rename()ing it over the target makes every reader see either the old
+// document or the new one, never a partial. Serializing writes to the same
+// path keeps two saves from interleaving their temp+rename dance (and keeps
+// the last-issued write the one that lands last).
+//
+// Windows: rename over an open file can fail transiently (EPERM/EBUSY —
+// an AV scanner or an editor holding the target for a moment); a few short
+// retries cover that. The temp file lives next to the target so the rename
+// stays on one filesystem.
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const chains = new Map();   // absolute path -> tail of the write chain
+const completed = new Map(); // absolute path -> number of writes that have landed
+let seq = 0;
+
+// How many writes to `file` have COMPLETED (rename done). A reader that
+// captures this before reading and compares afterwards knows whether a write
+// may have landed after its read — server.js's reboot uses it to decide
+// whether a coalesced reboot request still needs a re-run.
+export function completedWrites(file) {
+  return completed.get(path.resolve(file)) || 0;
+}
+
+const RETRY_CODES = new Set(['EPERM', 'EBUSY', 'EACCES']);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function replaceFile(tmp, file) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await fs.rename(tmp, file);
+      return;
+    } catch (err) {
+      if (!RETRY_CODES.has(err.code) || attempt >= 5) {
+        try { await fs.unlink(tmp); } catch (_) { /* leave nothing behind, best effort */ }
+        throw err;
+      }
+      await sleep(20 * (attempt + 1));
+    }
+  }
+}
+
+// Serialize `data` as pretty JSON and atomically replace `file` with it.
+// Resolves when the new content is durably the file's content; concurrent
+// calls for the same path run in call order.
+export function writeJsonAtomic(file, data) {
+  return updateJsonAtomic(file, () => data);
+}
+
+// Same, but `produce(current)` runs INSIDE the per-file chain — after every
+// earlier write has landed and before any later one starts — with `current`
+// = the file's document as it is at that moment (null when unreadable /
+// absent). Whatever it returns is written. This is the primitive a
+// read-modify-write needs to not clobber a concurrent writer's change: the
+// read and the write are one serialized step.
+export function updateJsonAtomic(file, produce) {
+  const key = path.resolve(file);
+  const prev = chains.get(key) || Promise.resolve();
+  const run = prev.catch(() => {}).then(async () => {
+    let current;
+    try { current = JSON.parse(await fs.readFile(key, 'utf8')); } catch (_) { current = null; }
+    const data = await produce(current);
+    const tmp = `${key}.${process.pid}.${++seq}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(data, null, 2), 'utf8');
+    await replaceFile(tmp, key);
+    completed.set(key, (completed.get(key) || 0) + 1);
+  });
+  chains.set(key, run);
+  const forget = () => { if (chains.get(key) === run) { chains.delete(key); } };
+  run.then(forget, forget);
+  return run;
+}

--- a/src/util/kept-listener.js
+++ b/src/util/kept-listener.js
@@ -1,0 +1,98 @@
+// A secondary HTTP listener (the Subsonic and DLNA separate-port servers)
+// that survives a soft reboot when its bind is unchanged, and recycles with
+// the main listener's same-port patience when it isn't.
+//
+// Why: server.js's reboot keeps the MAIN listening socket across a same-bind
+// reboot precisely because, on Windows under Bun <= 1.3.14, every spawned
+// child (scanner, transcode, ffmpeg download, enrichment worker) inherits a
+// handle to every listen socket in the process, and close() in the parent
+// releases nothing until that child exits (oven-sh/bun#36938). The separate-
+// port servers were still doing close()+listen() on every reboot: their
+// re-listen hit EADDRINUSE mid-scan, their 'error' handler nulled the module
+// reference, and the Subsonic API (every mobile client) stayed silently dead
+// until the next restart while the tray said Running. Keeping the server
+// object across a same-bind reboot sidesteps that on every runtime; a bind
+// change (port/address edit) recycles, retrying EADDRINUSE with backoff when
+// it is re-taking the port it just held (a release delay or a held handle,
+// not a conflict — same reasoning as serveIt's samePortRelisten).
+//
+// The Express app inside is rebuilt on every recycle and REUSED across a keep:
+// both apps read config/db at request time (route setup captures nothing
+// per-boot), so the kept app serves the rebooted config correctly.
+import http from 'node:http';
+import winston from 'winston';
+
+export function createKeptListener(name) {
+  let server = null;   // the live http.Server, or null
+  let bound = null;    // { port, address } it was told to serve
+
+  // Serve `build()` on { port, address }. Keeps the current server when the
+  // bind is unchanged; otherwise closes it and listens afresh.
+  function ensure({ port, address, build }) {
+    const want = { port, address: address ?? null };
+    if (server && bound && bound.port === want.port && bound.address === want.address) {
+      winston.info(`[${name}] Separate server kept across reboot on port ${port}`);
+      return;
+    }
+    // Re-taking the port we just held (address change): EADDRINUSE there is a
+    // release delay / a child's inherited handle, not a conflict — wait it out.
+    const samePortRelisten = !!(server && bound && bound.port === want.port);
+    if (server) {
+      const old = server;
+      server = null; bound = null;
+      old.close(() => { winston.info(`[${name}] Separate server on port ${old._keptPort} recycled`); });
+    }
+
+    const s = http.createServer(build());
+    s._keptPort = want.port;
+    server = s; bound = want;
+    const startedAt = Date.now();
+    let attempts = 0;
+    let lastLoggedAt = 0;
+    let diagnosed = false;
+
+    s.on('error', (err) => {
+      if (server !== s) { return; }   // superseded by a later ensure()/stop()
+      if (err.code === 'EADDRINUSE' && samePortRelisten) {
+        attempts++;
+        const waitedMs = Date.now() - startedAt;
+        const delay = waitedMs < 2000 ? 250 : waitedMs < 30000 ? 1000 : 5000;
+        if (attempts === 1) {
+          winston.warn(`[${name}] Port ${port} not released yet after reboot — retrying listen`);
+          lastLoggedAt = Date.now();
+        } else if (waitedMs >= 5000 && Date.now() - lastLoggedAt >= (diagnosed ? 30000 : 0)) {
+          winston.warn(
+            `[${name}] Port ${port} still held ${Math.round(waitedMs / 1000)}s after reboot — retrying until it frees ` +
+            '(the separate server is unreachable meanwhile). A child process alive during the reboot can hold the ' +
+            'old listening socket until it exits (Bun <= 1.3.14 on Windows: oven-sh/bun#36938).');
+          diagnosed = true;
+          lastLoggedAt = Date.now();
+        }
+        setTimeout(() => { if (server === s) { s.listen(want.port, want.address ?? undefined); } }, delay);
+        return;
+      }
+      winston.error(`[${name}] Separate server error: ${err.message}`);
+      // Only clear the module ref if it still points at THIS server: a late
+      // error on an already-replaced instance must not nullify the new one.
+      if (server === s) { server = null; bound = null; }
+    });
+    s.once('listening', () => {
+      if (attempts > 0) {
+        winston.info(`[${name}] Port ${port} released after ${Math.round((Date.now() - startedAt) / 1000)}s (${attempts} retries)`);
+      }
+      winston.info(`[${name}] Separate server listening on port ${port}`);
+    });
+    s.listen(want.port, want.address ?? undefined);
+  }
+
+  function stop() {
+    if (!server) { return; }
+    const s = server;
+    server = null; bound = null;
+    s.close(() => { winston.info(`[${name}] Separate server stopped`); });
+  }
+
+  function isRunning() { return server !== null; }
+
+  return { ensure, stop, isRunning };
+}

--- a/test/integration/reboot-keeps-services.test.mjs
+++ b/test/integration/reboot-keeps-services.test.mjs
@@ -22,6 +22,7 @@
 import { describe, before, after, test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import http from 'node:http';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { startServer } from '../helpers/server.mjs';
@@ -245,6 +246,52 @@ describe(`overlapping admin saves and rejected binds (${label})`, () => {
     assert.match(text, /Reboot: bind unchanged .* keeping the listening socket/);
     assert.doesNotMatch(text, /recycling the listener|retrying listen/);
     assert.match(text, /Access mStream locally/);
+  });
+});
+
+describe(`the reboot sweep spares kept keep-alive connections (${label})`, () => {
+  let server;
+  let jwt;
+  before(async () => {
+    server = await startServer({ dlnaMode: 'disabled', subsonicMode: 'disabled', users: [{ ...ADMIN, admin: true }], ...startOpts });
+    jwt = await login(server);
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  // One keep-alive connection: reuse it for a request served by the NEW app
+  // shortly after the swap, then keep it alive across the +1 s sweep. It
+  // used to be destroyed at +1 s regardless (it existed at reboot time),
+  // resetting whatever the new app was sending on it - a browser's pooled
+  // connection starting the next track.
+  test('a pre-reboot idle connection reused by the new app is not destroyed at +1 s', async () => {
+    const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+    const get = (p) => new Promise((resolve, reject) => {
+      const req = http.get({ host: '127.0.0.1', port: server.port, path: p, agent, headers: { 'x-access-token': jwt } }, (res) => {
+        res.resume();
+        res.on('end', () => resolve({ status: res.statusCode, reused: req.reusedSocket }));
+      });
+      req.on('error', reject);
+    });
+    // Warm the pooled connection before the reboot, then leave it IDLE.
+    assert.equal((await get('/api/v1/ping')).status, 200);
+    const t0 = Date.now();
+    const r = await adminPost(server, jwt, '/api/v1/admin/config/trust-proxy', { trustProxy: true });
+    assert.equal(r.status, 200);
+    // Wait (on fresh connections) until the NEW app is serving, then send a
+    // request down the idle pooled connection: it is served by the new app -
+    // exactly the "browser starts the next track after the swap" shape...
+    await waitForConfig(server, jwt, (c) => c.trustProxy === true, 'trustProxy=true');
+    const mid = await get('/api/v1/ping');
+    assert.equal(mid.status, 200);
+    assert.equal(mid.reused, true, 'precondition: the pooled socket from before the reboot must be the one reused');
+    // ...and it must survive the +1 s sweep: another request on the SAME
+    // socket after that must not find it reset/closed.
+    const untilSweepPassed = t0 + 1400 - Date.now();
+    if (untilSweepPassed > 0) { await sleep(untilSweepPassed); }
+    const late = await get('/api/v1/ping');
+    assert.equal(late.status, 200);
+    assert.equal(late.reused, true, 'the pooled keep-alive socket should still be the same one - the sweep must not have destroyed it');
+    agent.destroy();
   });
 });
 }

--- a/test/integration/reboot-keeps-services.test.mjs
+++ b/test/integration/reboot-keeps-services.test.mjs
@@ -1,0 +1,255 @@
+/**
+ * What a soft reboot (admin config change) must NOT break — the follow-ups to
+ * the kept-listener reboot (reboot-keeps-listener.test.mjs):
+ *
+ *   - Quick Connect (the iroh tunnel) is up again after the reboot with the
+ *     same endpoint id. reboot() used to fire iroh.stop() and forget it while
+ *     the re-serve ran ~70 ms later: start() found the endpoint still closing,
+ *     no-oped, the late stop nulled it, and the tunnel was dead until the next
+ *     process restart — after ANY reboot-requiring admin save, no error logged.
+ *   - The separate-port Subsonic server keeps serving across the reboot on the
+ *     same socket (kept listener) instead of close()+listen() — the re-listen
+ *     is what dies on the Windows Bun bundle mid-scan.
+ *   - Two admin saves in flight together both end up applied: the coalesced
+ *     one used to be dropped when it landed after the in-flight reboot's
+ *     config read.
+ *   - A bind change to an address this machine cannot serve is reverted: the
+ *     server stays reachable on the previous bind and the config file gets
+ *     the previous port/address back (it used to exit, and exit again on every
+ *     later start because the bad value stayed on disk).
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { startServer } from '../helpers/server.mjs';
+
+// MSTREAM_TEST_BUN_BIN points at a bun executable when `bun` on PATH is not
+// spawnable without a shell (npm's bun.ps1/bun.cmd shim on Windows).
+const BUN_BIN = process.env.MSTREAM_TEST_BUN_BIN || 'bun';
+const bunProbe = spawnSync(BUN_BIN, ['--version'], { encoding: 'utf8' });
+const noBun = (!bunProbe.error && bunProbe.status === 0) ? false : 'bun is not installed on this machine';
+
+const ADMIN = { username: 'admin', password: 'pw-admin' };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let irohAvailable = true;
+try { await import('@number0/iroh'); } catch { irohAvailable = false; }
+
+async function login(server) {
+  const r = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(ADMIN),
+  });
+  assert.equal(r.status, 200);
+  return (await r.json()).token;
+}
+const adminGet = (server, jwt, p) => fetch(`${server.baseUrl}${p}`, { headers: { 'x-access-token': jwt } });
+const adminPost = (server, jwt, p, body) => fetch(`${server.baseUrl}${p}`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json', 'x-access-token': jwt }, body: JSON.stringify(body),
+});
+
+async function recentLogText(server, jwt, sinceSeq = 0) {
+  const r = await adminGet(server, jwt, `/api/v1/admin/logs/recent?since=${sinceSeq}`);
+  assert.equal(r.status, 200);
+  const body = await r.json();
+  return { text: body.entries.map((e) => e.message ?? JSON.stringify(e)).join('\n'), lastSeq: body.lastSeq };
+}
+
+// Poll an admin GET until `pred(json)` holds; tolerates the reboot window.
+async function waitForConfig(server, jwt, pred, what, timeoutMs = 25_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const r = await adminGet(server, jwt, '/api/v1/admin/config');
+      if (r.status === 200 && pred(await r.json())) { return; }
+    } catch { /* mid-reboot */ }
+    if (Date.now() > deadline) { throw new Error(`${what} never observed after reboot`); }
+    await sleep(100);
+  }
+}
+
+// Wait until the API has answered 200 continuously for ~1.5 s (no reboot in
+// flight, no pending re-run about to start one).
+async function settle(server, jwt, timeoutMs = 25_000) {
+  const deadline = Date.now() + timeoutMs;
+  let streak = 0;
+  while (streak < 15) {
+    let ok;
+    try { ok = (await adminGet(server, jwt, '/api/v1/ping')).status === 200; } catch { ok = false; }
+    streak = ok ? streak + 1 : 0;
+    if (Date.now() > deadline) { throw new Error('server never settled'); }
+    await sleep(100);
+  }
+}
+
+async function irohStatus(server, jwt) {
+  const r = await adminGet(server, jwt, '/api/v1/admin/iroh');
+  assert.equal(r.status, 200);
+  return r.json();
+}
+async function waitForTunnel(server, jwt, timeoutMs = 40_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    let s = null;
+    try { s = await irohStatus(server, jwt); } catch { /* mid-reboot */ }
+    if (s && s.running) { return s; }
+    if (s && !s.available) { return s; }
+    if (Date.now() > deadline) { throw new Error('iroh tunnel never came up'); }
+    await sleep(250);
+  }
+}
+
+function suites(label, startOpts) {
+describe(`soft reboot keeps Quick Connect (${label})`, { skip: irohAvailable ? false : 'no @number0/iroh binary for this platform' }, () => {
+  let server;
+  let jwt;
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', subsonicMode: 'disabled', users: [{ ...ADMIN, admin: true }],
+      extraConfig: { iroh: { enabled: true } }, ...startOpts,
+    });
+    jwt = await login(server);
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('the tunnel is up again after a same-bind reboot, same endpoint id', async () => {
+    const beforeStatus = await waitForTunnel(server, jwt);
+    if (!beforeStatus.available) { return; }   // native module missing at runtime: nothing to prove
+    assert.equal(beforeStatus.running, true);
+    assert.ok(beforeStatus.endpointId);
+
+    const { lastSeq } = await recentLogText(server, jwt);
+    const r = await adminPost(server, jwt, '/api/v1/admin/config/trust-proxy', { trustProxy: true });
+    assert.equal(r.status, 200);
+    await waitForConfig(server, jwt, (c) => c.trustProxy === true, 'trustProxy=true');
+
+    // Not merely "still reports running" — a fresh "tunnel up" line proves the
+    // re-serve actually started a new endpoint after the stop finished.
+    const afterStatus = await waitForTunnel(server, jwt, 30_000);
+    assert.equal(afterStatus.running, true, `tunnel dead after the reboot: ${JSON.stringify(afterStatus)}`);
+    assert.equal(afterStatus.endpointId, beforeStatus.endpointId, 'the endpoint identity (secret key) must persist across the reboot');
+    // running:true flips as soon as the new endpoint is BOUND; the "tunnel up"
+    // line follows its bounded relay-online wait (up to 8 s) — poll for it.
+    let text;
+    for (const deadline = Date.now() + 20_000; ; ) {
+      ({ text } = await recentLogText(server, jwt, lastSeq));
+      if (/\[iroh\] tunnel up/.test(text) || Date.now() > deadline) { break; }
+      await sleep(250);
+    }
+    assert.match(text, /Reboot: bind unchanged .* keeping the listening socket/);
+    assert.match(text, /\[iroh\] tunnel up/);
+  });
+});
+
+describe(`soft reboot keeps the separate-port Subsonic listener (${label})`, () => {
+  let server;
+  let jwt;
+  before(async () => {
+    server = await startServer({ dlnaMode: 'disabled', subsonicMode: 'separate-port', users: [{ ...ADMIN, admin: true }], ...startOpts });
+    jwt = await login(server);
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  const ping = () => fetch(`${server.subsonicBaseUrl}/rest/ping.view?u=${ADMIN.username}&p=${ADMIN.password}&v=1.16.1&c=test&f=json`);
+
+  test('the Subsonic port keeps answering through and after the reboot; the socket was kept, not re-listened', async () => {
+    assert.equal((await ping()).status, 200);
+    const { lastSeq } = await recentLogText(server, jwt);
+
+    const r = await adminPost(server, jwt, '/api/v1/admin/config/trust-proxy', { trustProxy: true });
+    assert.equal(r.status, 200);
+    // Hammer the Subsonic port through the reboot window: it must never refuse.
+    const outcomes = [];
+    const until = Date.now() + 1200;
+    while (Date.now() < until) {
+      try { outcomes.push((await ping()).status); } catch (err) { outcomes.push(err.cause?.code || err.message); }
+    }
+    assert.deepEqual(outcomes.filter((o) => o !== 200), [], `Subsonic port faltered during the reboot: ${JSON.stringify(outcomes)}`);
+    await waitForConfig(server, jwt, (c) => c.trustProxy === true, 'trustProxy=true');
+    assert.equal((await ping()).status, 200);
+
+    const { text } = await recentLogText(server, jwt, lastSeq);
+    assert.match(text, /\[subsonic\] Separate server kept across reboot/);
+    assert.doesNotMatch(text, /\[subsonic\] Separate server stopped|\[subsonic\] Separate server error/);
+  });
+});
+
+describe(`overlapping admin saves and rejected binds (${label})`, () => {
+  let server;
+  let jwt;
+  before(async () => {
+    server = await startServer({ dlnaMode: 'disabled', subsonicMode: 'disabled', users: [{ ...ADMIN, admin: true }], ...startOpts });
+    jwt = await login(server);
+  });
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('two reboot-requiring saves in flight together are BOTH applied', async () => {
+    const before = await (await adminGet(server, jwt, '/api/v1/admin/config')).json();
+    const newMax = before.maxRequestSize === '100MB' ? '120MB' : '100MB';
+    // Fire both without waiting: the second lands somewhere inside the first
+    // reboot's window — before or after its config read; either way it must
+    // end up applied (via that reboot, or the pending re-run).
+    const [r1, r2] = await Promise.all([
+      adminPost(server, jwt, '/api/v1/admin/config/trust-proxy', { trustProxy: !before.trustProxy }),
+      adminPost(server, jwt, '/api/v1/admin/config/max-request-size', { maxRequestSize: newMax }),
+    ]);
+    assert.ok([200, 503].includes(r1.status), `first save: ${r1.status}`);
+    assert.ok([200, 503].includes(r2.status), `second save: ${r2.status}`);
+    // A 503 is the reboot stub answering a request that arrived mid-window; the
+    // save then never happened, which is honest — re-issue it once the API is
+    // back so the assertion below is about the coalescing, not the stub.
+    await waitForConfig(server, jwt, () => true, 'API back');
+    if (r1.status === 503) { assert.equal((await adminPost(server, jwt, '/api/v1/admin/config/trust-proxy', { trustProxy: !before.trustProxy })).status, 200); }
+    if (r2.status === 503) { assert.equal((await adminPost(server, jwt, '/api/v1/admin/config/max-request-size', { maxRequestSize: newMax })).status, 200); }
+    await waitForConfig(server, jwt, (c) => c.trustProxy === !before.trustProxy && c.maxRequestSize === newMax, 'both saves applied');
+    // Both are on disk too.
+    const doc = JSON.parse(await fs.readFile(path.join(server.tmpDir, 'config.json'), 'utf8'));
+    assert.equal(doc.trustProxy, !before.trustProxy);
+    assert.equal(doc.maxRequestSize, newMax);
+    // Let any coalesced re-run finish before the next test talks to the server.
+    await settle(server, jwt);
+  });
+
+  test('a bind change to an unservable address is reverted, on disk and live', async () => {
+    const { lastSeq } = await recentLogText(server, jwt);
+    // 203.0.113.7 (TEST-NET-3) is not an address of this machine. Joi accepts
+    // it (valid IP syntax), the save succeeds, and the reboot must refuse the
+    // move without ever giving up the socket it is serving on.
+    const r = await adminPost(server, jwt, '/api/v1/admin/config/address', { address: '203.0.113.7' });
+    assert.equal(r.status, 200);
+    // The address is 127.0.0.1 both before and after, so "config reports
+    // 127.0.0.1" proves nothing by itself — wait for the on-disk revert (the
+    // save had put 203.0.113.7 there; the reboot must put 127.0.0.1 back).
+    const cfgPath = path.join(server.tmpDir, 'config.json');
+    let doc;
+    for (const deadline = Date.now() + 25_000; ; ) {
+      try { doc = JSON.parse(await fs.readFile(cfgPath, 'utf8')); } catch { doc = null; }
+      if (doc && doc.address === '127.0.0.1') { break; }
+      if (Date.now() > deadline) { throw new Error(`config file never reverted: address=${doc && doc.address}`); }
+      await sleep(100);
+    }
+    assert.equal(doc.port, server.port);
+    await waitForConfig(server, jwt, (c) => c.address === '127.0.0.1', 'address reverted to 127.0.0.1');
+    // Refused BEFORE the recycle: the working socket was never given up. The
+    // re-serve's own log lines can land a beat after the file revert.
+    let text;
+    for (const deadline = Date.now() + 10_000; ; ) {
+      try { ({ text } = await recentLogText(server, jwt, lastSeq)); } catch { text = ''; }
+      if (/Access mStream locally/.test(text) && /keeping the listening socket/.test(text)) { break; }
+      if (Date.now() > deadline) { break; }
+      await sleep(100);
+    }
+    assert.match(text, /cannot be served \(EADDRNOTAVAIL\) .* keeping http:\/\/127\.0\.0\.1:/);
+    assert.match(text, /Reboot: bind unchanged .* keeping the listening socket/);
+    assert.doesNotMatch(text, /recycling the listener|retrying listen/);
+    assert.match(text, /Access mStream locally/);
+  });
+});
+}
+
+suites('node', {});
+// Same contract under the standalone-binary runtime (the one that bit
+// hardest); skipped where bun is absent.
+describe('bun', { skip: noBun }, () => { suites('bun', { execPath: BUN_BIN }); });

--- a/test/unit/admin-config-save.test.mjs
+++ b/test/unit/admin-config-save.test.mjs
@@ -1,0 +1,69 @@
+/**
+ * util/admin.js loadFile/saveFile: two settings editors in flight together
+ * must both land. Every editor is loadFile -> mutate -> saveFile; the second
+ * save used to overwrite the file with a document loaded before the first
+ * save (last-writer-wins: a trustProxy flip silently lost under a
+ * maxRequestSize save, both answered 200). saveFile now merges only the paths
+ * the caller changed since its load onto the file's current content when
+ * another write landed in between.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { loadFile, saveFile } from '../../src/util/admin.js';
+
+describe('admin config saves merge instead of clobbering', () => {
+  let dir;
+  let file;
+  before(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-cfg-'));
+    file = path.join(dir, 'config.json');
+  });
+  after(async () => { await fs.rm(dir, { recursive: true, force: true }); });
+
+  const read = async () => JSON.parse(await fs.readFile(file, 'utf8'));
+
+  test('two editors that loaded the same document both keep their change', async () => {
+    await fs.writeFile(file, JSON.stringify({ port: 3000, trustProxy: false, maxRequestSize: '1MB', subsonic: { mode: 'disabled', port: 4040 } }));
+    const a = await loadFile(file);   // editTrustProxy
+    const b = await loadFile(file);   // editMaxRequestSize, loaded BEFORE a saved
+    a.trustProxy = true;
+    await saveFile(a, file);
+    b.maxRequestSize = '120MB';
+    await saveFile(b, file);          // used to write b's stale trustProxy:false
+    assert.deepEqual(await read(), { port: 3000, trustProxy: true, maxRequestSize: '120MB', subsonic: { mode: 'disabled', port: 4040 } });
+  });
+
+  test('nested sibling keys survive; the same path is last-writer-wins; deletions apply', async () => {
+    await fs.writeFile(file, JSON.stringify({ port: 3000, subsonic: { mode: 'disabled', port: 4040 }, ssl: { cert: 'c', key: 'k' } }));
+    const a = await loadFile(file);
+    const b = await loadFile(file);
+    const c = await loadFile(file);
+    a.subsonic.mode = 'separate-port';
+    await saveFile(a, file);
+    b.subsonic.port = 4041;             // sibling of a's change
+    delete b.ssl;                       // removeSSL-style deletion
+    await saveFile(b, file);
+    c.port = 3001;
+    c.subsonic.mode = 'same-port';      // same path as a: later save wins
+    await saveFile(c, file);
+    assert.deepEqual(await read(), { port: 3001, subsonic: { mode: 'same-port', port: 4041 } });
+  });
+
+  test('a document not obtained from loadFile is written as is', async () => {
+    await fs.writeFile(file, JSON.stringify({ a: 1, b: 2 }));
+    await saveFile({ z: 9 }, file);
+    assert.deepEqual(await read(), { z: 9 });
+  });
+
+  test('concurrent saves from independent loads all land', async () => {
+    await fs.writeFile(file, JSON.stringify({ k0: 0 }));
+    const docs = await Promise.all(Array.from({ length: 12 }, () => loadFile(file)));
+    await Promise.all(docs.map((d, i) => { d[`k${i + 1}`] = i + 1; return saveFile(d, file); }));
+    const doc = await read();
+    for (let i = 0; i <= 12; i++) { assert.equal(doc[`k${i}`], i, `k${i} missing after concurrent saves`); }
+  });
+});

--- a/test/unit/atomic-json.test.mjs
+++ b/test/unit/atomic-json.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * util/atomic-json.js: the config-file writer behind every admin save.
+ *
+ * The soft reboot re-reads the config file within microseconds of the save
+ * that triggered it, so a second save racing the first must never let that
+ * read see a truncated document (a torn JSON.parse there exits the process).
+ * These tests hammer concurrent write/read pairs and assert every read parses
+ * to a complete document, that concurrent writes land in call order, and that
+ * no temp files are left behind.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { writeJsonAtomic } from '../../src/util/atomic-json.js';
+
+describe('writeJsonAtomic', () => {
+  let dir;
+  before(async () => { dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-atomic-')); });
+  after(async () => { await fs.rm(dir, { recursive: true, force: true }); });
+
+  test('a reader racing concurrent writers always sees a whole document', async () => {
+    const file = path.join(dir, 'config.json');
+    const big = { pad: 'x'.repeat(20_000), users: Object.fromEntries(Array.from({ length: 50 }, (_, i) => [`u${i}`, { admin: i % 2 === 0 }])) };
+    await writeJsonAtomic(file, { ...big, n: 0 });
+    let torn = 0;
+    let reads = 0;
+    for (let i = 1; i <= 300; i++) {
+      // Two writers and a reader, all in flight at once — the exact shape of
+      // "two admin saves + the reboot's config re-read".
+      const w1 = writeJsonAtomic(file, { ...big, n: i, w: 1 });
+      const w2 = writeJsonAtomic(file, { ...big, n: i, w: 2 });
+      const r = fs.readFile(file, 'utf8').then((txt) => {
+        reads++;
+        try { const doc = JSON.parse(txt); assert.equal(typeof doc.n, 'number'); } catch { torn++; }
+      });
+      await Promise.all([w1, w2, r]);
+    }
+    assert.equal(reads, 300);
+    assert.equal(torn, 0, `${torn} torn reads out of ${reads}`);
+  });
+
+  test('concurrent writes to one file land in call order', async () => {
+    const file = path.join(dir, 'order.json');
+    const writes = [];
+    for (let i = 0; i < 25; i++) { writes.push(writeJsonAtomic(file, { i })); }
+    await Promise.all(writes);
+    assert.deepEqual(JSON.parse(await fs.readFile(file, 'utf8')), { i: 24 });
+  });
+
+  test('leaves no temp files next to the target', async () => {
+    const names = await fs.readdir(dir);
+    assert.deepEqual(names.filter((n) => n.endsWith('.tmp')), []);
+  });
+
+  test('a write to a missing directory rejects and does not hang the chain', async () => {
+    const file = path.join(dir, 'nope', 'x.json');
+    await assert.rejects(writeJsonAtomic(file, { a: 1 }));
+    // The chain for that path is not poisoned: a later valid write works.
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await writeJsonAtomic(file, { a: 2 });
+    assert.deepEqual(JSON.parse(await fs.readFile(file, 'utf8')), { a: 2 });
+  });
+});

--- a/test/unit/kept-listener.test.mjs
+++ b/test/unit/kept-listener.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * util/kept-listener.js: the separate-port Subsonic/DLNA servers' listener.
+ *
+ * Contract: ensure() with an unchanged bind KEEPS the socket (no close, no
+ * re-listen — the Windows/Bun inherited-handle reason lives in server.js);
+ * a changed bind recycles it; a same-port recycle retries EADDRINUSE with
+ * backoff instead of dying (the main listener's samePortRelisten rule); a
+ * conflict on a NEW port is reported once and not retried.
+ */
+
+import { describe, test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import net from 'node:net';
+import { EventEmitter } from 'node:events';
+import express from 'express';
+import { createKeptListener } from '../../src/util/kept-listener.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const freePort = () => new Promise((resolve, reject) => {
+  const s = net.createServer();
+  s.listen(0, '127.0.0.1', () => { const { port } = s.address(); s.close(() => resolve(port)); });
+  s.on('error', reject);
+});
+async function get(port, path) {
+  const r = await fetch(`http://127.0.0.1:${port}${path}`);
+  return { status: r.status, text: await r.text() };
+}
+async function waitFor(fn, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try { if (await fn()) { return; } } catch { /* not yet */ }
+    if (Date.now() > deadline) { throw new Error('condition not met in time'); }
+    await sleep(25);
+  }
+}
+
+describe('kept listener (real sockets)', () => {
+  const listeners = [];
+  after(() => { for (const l of listeners) { l.stop(); } });
+
+  test('same bind: the app and socket are kept, a changed port recycles', async () => {
+    const port = await freePort();
+    let builds = 0;
+    const build = () => { builds++; const app = express(); const gen = builds; app.get('/who', (req, res) => res.send(`gen${gen}`)); return app; };
+    const l = createKeptListener('test');
+    listeners.push(l);
+
+    l.ensure({ port, address: '127.0.0.1', build });
+    await waitFor(async () => (await get(port, '/who')).status === 200);
+    assert.equal((await get(port, '/who')).text, 'gen1');
+    assert.equal(l.isRunning(), true);
+
+    // Same bind again (what onListening does after a soft reboot): kept.
+    l.ensure({ port, address: '127.0.0.1', build });
+    await sleep(50);
+    assert.equal(builds, 1, 'build() must not run again for an unchanged bind');
+    assert.equal((await get(port, '/who')).text, 'gen1');
+
+    // Port change: recycled onto the new port, old port closed.
+    const port2 = await freePort();
+    l.ensure({ port: port2, address: '127.0.0.1', build });
+    await waitFor(async () => (await get(port2, '/who')).status === 200);
+    assert.equal(builds, 2);
+    assert.equal((await get(port2, '/who')).text, 'gen2');
+    await waitFor(() => new Promise((resolve) => {
+      const s = net.connect({ port, host: '127.0.0.1' });
+      s.on('error', () => resolve(true));
+      s.on('connect', () => { s.destroy(); resolve(false); });
+    }));
+
+    l.stop();
+    assert.equal(l.isRunning(), false);
+    await waitFor(() => new Promise((resolve) => {
+      const s = net.connect({ port: port2, host: '127.0.0.1' });
+      s.on('error', () => resolve(true));
+      s.on('connect', () => { s.destroy(); resolve(false); });
+    }));
+  });
+});
+
+// The retry logic, driven deterministically through a fake http.Server:
+// listen() fails with EADDRINUSE N times, then succeeds.
+describe('kept listener (retry logic)', () => {
+  const realCreateServer = http.createServer;
+  after(() => { http.createServer = realCreateServer; });
+
+  function fakeServerFactory(script) {
+    // script: array per created server of how many EADDRINUSE errors to emit
+    // before 'listening'; missing entry = succeed immediately.
+    const created = [];
+    http.createServer = () => {
+      const s = new EventEmitter();
+      const idx = created.length;
+      created.push(s);
+      let failuresLeft = script[idx] ?? 0;
+      s.listenCalls = 0;
+      s.listen = () => {
+        s.listenCalls++;
+        setImmediate(() => {
+          if (failuresLeft > 0) { failuresLeft--; const e = new Error('in use'); e.code = 'EADDRINUSE'; s.emit('error', e); }
+          else { s.listening = true; s.emit('listening'); }
+        });
+      };
+      s.close = (cb) => { s.listening = false; if (cb) { setImmediate(cb); } };
+      return s;
+    };
+    return created;
+  }
+
+  test('a same-port recycle retries EADDRINUSE until it binds', async () => {
+    const created = fakeServerFactory([0, 3]);   // first server binds; the recycle fails 3x
+    const l = createKeptListener('retry');
+    l.ensure({ port: 4000, address: '127.0.0.1', build: () => (() => {}) });
+    await waitFor(() => created[0]?.listening);
+    l.ensure({ port: 4000, address: '10.0.0.1', build: () => (() => {}) });   // same port, new address
+    await waitFor(() => created[1]?.listening, 4000);
+    assert.equal(created[1].listenCalls, 4, '3 failures + the successful attempt');
+    assert.equal(l.isRunning(), true);
+    l.stop();
+  });
+
+  test('a conflict on a NEW port is not retried', async () => {
+    const created = fakeServerFactory([0, 5]);
+    const l = createKeptListener('conflict');
+    l.ensure({ port: 4000, address: '127.0.0.1', build: () => (() => {}) });
+    await waitFor(() => created[0]?.listening);
+    l.ensure({ port: 4001, address: '127.0.0.1', build: () => (() => {}) });   // moved port
+    await sleep(300);
+    assert.equal(created[1].listenCalls, 1, 'no retry on a real conflict');
+    assert.equal(l.isRunning(), false, 'the failed listener is not reported as running');
+  });
+});


### PR DESCRIPTION
Batch B of the 2026-08-18 adversarial review (findings 1–6, all confirmed 3/3 with reproductions). Server code only; every fix has a test on **node and bun**, plus a smoke on the compiled Windows Bun bundle with a live scanner child.

## 1 · HIGH — a soft reboot silently killed Quick Connect (and federation)
`reboot()` fired `iroh.stop()` / `federation.stop()` fire-and-forget while the #833 kept-socket re-serve now runs ~70 ms later; `endpoint.close()` takes ~1 s, so `onListening → start()` found `endpoint` still set, no-oped, and the late stop nulled it. After **any** reboot-requiring admin save, the tunnel was dead until the next process restart, no error logged (reproduced end-to-end by the review, and by the new test before the fix). Now every endpoint/sidecar teardown is sequenced into the re-serve gate (5 s latency bound), and `iroh.js`/`federation.js` keep an in-flight `stopping` promise, clear their public state up front, and make `start()` wait on it — the pattern `discovery-p2p-stack.js` already used.

## 2 · MED — concurrent admin saves could exit the process, and lost each other's changes
`saveFile` was a plain `fs.writeFile` racing the reboot's config re-read (2.7–4 % of concurrent save pairs killed the server) — and every editor is `loadFile → mutate → saveFile`, so the second save overwrote the file with a document loaded before the first (a `trustProxy` flip lost under a `maxRequestSize` save, both answered 200 — the new test caught this before the fix). New [`util/atomic-json.js`](src/util/atomic-json.js): temp+rename writes, serialized per file, `updateJsonAtomic()` for read-modify-write as one step. `loadFile` snapshots what it hands out; `saveFile` merges only the caller's changed paths onto the current file when another write landed in between. 72 call sites, zero changes to them.

## 3 · MED — separate-port Subsonic/DLNA died on the Windows Bun bundle mid-scan
They still `close()+listen()`ed on every reboot; the re-listen hit EADDRINUSE against the scanner child's inherited handle and the module ref was nulled — Subsonic dead for every mobile client while the tray said Running. New [`util/kept-listener.js`](src/util/kept-listener.js): keeps the socket when port/address are unchanged, recycles with the main listener's same-port patience otherwise; `reboot()` no longer stops them, `onListening` stops them when no longer wanted.

## 4 · LOW — coalesced reboot dropped a late save
Remembered and re-run once — only if a config write actually completed after the in-flight reboot's read, so an already-applied save doesn't cost a second bounce.

## 5 · LOW — unservable bind change exited the process (and every later start)
`serveIt` now **probes** the new bind before giving up the working socket (exact bind for a port move, address-only for a same-port move; `node:net`, because Bun's `node:http` reports a non-local address as EADDRINUSE while its `node:net` says EADDRNOTAVAIL like Node). On failure the change is refused: previous port/address restored in the config file, kept socket keeps serving, zero downtime. Residual races roll back to the previous bind instead of exiting or spinning.

## 6 · LOW — the +1 s sweep cut new-app responses on kept keep-alive sockets
Requests tag their socket with the app generation; the sweep destroys only sockets still busy with an old-generation response.

## Verification
- New unit tests: atomic-json (torn reads/ordering/tmp cleanup), kept-listener (keep/recycle + deterministic retry logic via a fake server), loadFile/saveFile merge semantics.
- New [`reboot-keeps-services.test.mjs`](test/integration/reboot-keeps-services.test.mjs) on **node + bun**: tunnel up again with the same endpoint id; Subsonic port never falters and logs `kept`; two overlapping saves both applied on disk and live; unservable address refused before the recycle, file reverted. Run 3× under concurrent load, stable.
- Existing `reboot-keeps-listener` suite green on both runtimes; full suite 2285/2292 (rest skipped / pre-existing).
- **Compiled Windows Bun bundle**, 30k-file scan child alive, Subsonic separate port + QC on, admin save mid-scan: main `200×37 503×3`, Subsonic `200×40` (`Separate server kept across reboot`), iroh back with the same endpoint id, process alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
