### PR TITLE
feat(packages): Linux deb + rpm from the glibc bundles (P3.4b — native installers)

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1318,9 +1318,228 @@ jobs:
           path: dist/installer/mStream-*-win-x64-setup.exe
           if-no-files-found: error
 
+  # ── Linux native packages (P3.4b) ─────────────────────────────────────────
+  # deb + rpm for the glibc bundles, built with pinned nfpm from the exact
+  # zips the build job produced (musl targets use apk-based distros — no
+  # deb/rpm for them). amd64 is the full desktop package: /opt/mstream tree,
+  # /usr/bin symlinks for both faces, a system .desktop entry + hicolor icon.
+  # arm64 bundles are server-only BY DESIGN (no launcher), so their packages
+  # are too. Server hard-deps stay minimal (the server is pure glibc — the
+  # bare-Debian-11 dep audit); the desktop/audio libraries ride Recommends,
+  # so a headless `--no-install-recommends` install never drags GTK in.
+  # The amd64 deb is installed and BOOTED on this runner; the rpm proves
+  # itself in a Fedora container; arm64 can't exec here, so its packages get
+  # content asserts.
+  linux-packages:
+    name: Linux deb/rpm packages
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download linux-x64 bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: mStream-linux-x64
+          path: zips
+      - name: Download linux-arm64 bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: mStream-linux-arm64
+          path: zips
+
+      - name: Install nfpm (pinned)
+        run: |
+          set -euo pipefail
+          # Pinned + hashed like every other fetched build tool in this repo
+          # (see the sidecar workflows' cross pin). Bump version and sha256
+          # together.
+          curl -fsSL -o nfpm.tar.gz "https://github.com/goreleaser/nfpm/releases/download/v2.47.0/nfpm_2.47.0_Linux_x86_64.tar.gz"
+          echo "0660ca602b2d2d2ae4781a06c692b3eeb9d437ffea05b831d76e41f4a3188783  nfpm.tar.gz" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"
+          tar xzf nfpm.tar.gz -C "$HOME/.local/bin" nfpm
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Build deb + rpm packages
+        run: |
+          set -euo pipefail
+          VER=$(node -pe "require('./package.json').version")
+          mkdir -p pkg dist/packages
+          for key in linux-x64 linux-arm64; do
+            unzip -q "zips/mStream-$VER-$key.zip" -d "pkg/$key"
+            tree=$(ls -d "pkg/$key"/mStream-*)
+            # Belt over the zip's unix attrs: the spawn paths need +x.
+            chmod +x "$tree/mstream-server" 2>/dev/null || true
+            chmod +x "$tree/mstream-desktop" 2>/dev/null || true
+            chmod +x "$tree"/bin/rust-parser/* "$tree"/bin/rust-server-audio/* 2>/dev/null || true
+            mv "$tree" "pkg/tree-$key"
+          done
+          test -x pkg/tree-linux-x64/mstream-desktop || { echo "::error::linux-x64 bundle has no launcher — the desktop package would be a lie"; exit 1; }
+
+          cat > pkg/mstream.desktop <<'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=mStream
+          Comment=Personal music streaming server
+          Exec=/opt/mstream/mstream-desktop
+          TryExec=/opt/mstream/mstream-desktop
+          Icon=mstream
+          Terminal=false
+          Categories=AudioVideo;Audio;Player;
+          EOF
+          cat > pkg/postinstall.sh <<'EOF'
+          #!/bin/sh
+          update-desktop-database -q /usr/share/applications 2>/dev/null || true
+          gtk-update-icon-cache -q /usr/share/icons/hicolor 2>/dev/null || true
+          exit 0
+          EOF
+          cp pkg/postinstall.sh pkg/postremove.sh
+
+          # amd64: full desktop package.
+          cat > pkg/nfpm-amd64.yaml <<EOF
+          name: mstream
+          arch: amd64
+          platform: linux
+          version: "$VER"
+          maintainer: "Paul Sori <paul@mstream.io>"
+          description: |
+            Personal music streaming server with a desktop tray launcher.
+            Stream your music collection to any browser or mobile device.
+          homepage: https://mstream.io
+          license: GPL-3.0
+          contents:
+            - src: ./pkg/tree-linux-x64
+              dst: /opt/mstream
+              type: tree
+            - src: /opt/mstream/mstream-server
+              dst: /usr/bin/mstream-server
+              type: symlink
+            - src: /opt/mstream/mstream-desktop
+              dst: /usr/bin/mstream-desktop
+              type: symlink
+            - src: ./pkg/mstream.desktop
+              dst: /usr/share/applications/mstream.desktop
+            - src: ./pkg/tree-linux-x64/mStream.png
+              dst: /usr/share/icons/hicolor/512x512/apps/mstream.png
+          scripts:
+            postinstall: ./pkg/postinstall.sh
+            postremove: ./pkg/postremove.sh
+          overrides:
+            deb:
+              depends: [libc6]
+              recommends: [libgtk-3-0, libayatana-appindicator3-1, libasound2]
+            rpm:
+              depends: [glibc]
+              recommends: [gtk3, libayatana-appindicator-gtk3, alsa-lib]
+          EOF
+
+          # arm64: server-only (the bundle ships no launcher by design).
+          cat > pkg/nfpm-arm64.yaml <<EOF
+          name: mstream
+          arch: arm64
+          platform: linux
+          version: "$VER"
+          maintainer: "Paul Sori <paul@mstream.io>"
+          description: |
+            Personal music streaming server (headless).
+            Stream your music collection to any browser or mobile device.
+          homepage: https://mstream.io
+          license: GPL-3.0
+          contents:
+            - src: ./pkg/tree-linux-arm64
+              dst: /opt/mstream
+              type: tree
+            - src: /opt/mstream/mstream-server
+              dst: /usr/bin/mstream-server
+              type: symlink
+          overrides:
+            deb:
+              depends: [libc6]
+              recommends: [libasound2]
+            rpm:
+              depends: [glibc]
+              recommends: [alsa-lib]
+          EOF
+
+          for a in amd64 arm64; do
+            nfpm pkg --config "pkg/nfpm-$a.yaml" --packager deb --target dist/packages/
+            nfpm pkg --config "pkg/nfpm-$a.yaml" --packager rpm --target dist/packages/
+          done
+          ls -l dist/packages/
+
+      - name: Smoke the amd64 deb on this runner (install, boot, remove)
+        run: |
+          set -euo pipefail
+          VER=$(node -pe "require('./package.json').version")
+          sudo apt-get install -y ./dist/packages/mstream_"$VER"_amd64.deb desktop-file-utils
+          test -x /opt/mstream/mstream-server
+          test -x /opt/mstream/mstream-desktop
+          test -L /usr/bin/mstream-server
+          desktop-file-validate /usr/share/applications/mstream.desktop
+          V_OUT=$(/usr/bin/mstream-server -V)
+          echo "mstream-server -V -> $V_OUT"
+          echo "$V_OUT" | grep -qF "$VER" || { echo "::error::installed server reports the wrong version"; exit 1; }
+          # Boot through the /usr/bin symlink and serve — the package layout
+          # must actually run, not just exist.
+          printf '{"port":3555,"address":"127.0.0.1"}\n' > /tmp/pkg-smoke.json
+          /usr/bin/mstream-server -j /tmp/pkg-smoke.json > /tmp/pkg-boot.log 2>&1 &
+          SRV=$!
+          UP=0
+          for i in $(seq 1 30); do
+            sleep 1
+            if curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3555/api/v1/ping"; then UP=1; break; fi
+          done
+          kill "$SRV" 2>/dev/null; wait "$SRV" 2>/dev/null || true
+          [ "$UP" = "1" ] || { echo "::error::installed server never served /api/v1/ping"; tail -30 /tmp/pkg-boot.log; exit 1; }
+          echo "installed server served 200 on :3555"
+          sudo apt-get remove -y mstream
+          [ ! -e /opt/mstream ] || { echo "::error::/opt/mstream survived apt remove"; exit 1; }
+          echo "deb install/boot/remove: OK"
+
+      - name: Smoke the x86_64 rpm in a Fedora container
+        run: |
+          set -euo pipefail
+          VER=$(node -pe "require('./package.json').version")
+          docker run --rm -v "$PWD/dist/packages:/pkg:ro" fedora:41 bash -c "
+            set -e
+            dnf install -y -q /pkg/mstream-$VER-1.x86_64.rpm
+            test -x /opt/mstream/mstream-server
+            out=\$(/usr/bin/mstream-server -V)
+            echo \"mstream-server -V -> \$out\"
+            echo \"\$out\" | grep -qF '$VER'
+            rpm -e mstream
+            [ ! -e /opt/mstream ]
+            echo 'rpm install/exec/remove: OK'
+          "
+
+      - name: Content-assert the arm64 packages (cannot exec on x64)
+        run: |
+          set -euo pipefail
+          VER=$(node -pe "require('./package.json').version")
+          deb="dist/packages/mstream_${VER}_arm64.deb"
+          # List once into a file: `dpkg-deb -c | grep -q` under pipefail
+          # SIGPIPEs dpkg-deb on the first match and fails the pipeline
+          # BECAUSE it matched.
+          dpkg-deb -c "$deb" > arm64-contents.txt
+          grep -q './opt/mstream/mstream-server' arm64-contents.txt || { echo "::error::arm64 deb lacks the server"; exit 1; }
+          if grep -q 'mstream-desktop' arm64-contents.txt; then echo "::error::arm64 deb unexpectedly ships a launcher"; exit 1; fi
+          rpm=$(ls dist/packages/mstream-"$VER"-*.aarch64.rpm)
+          docker run --rm -v "$PWD/dist/packages:/pkg:ro" fedora:41 bash -c "rpm -qlp /pkg/$(basename "$rpm") > /tmp/l && grep -q '/opt/mstream/mstream-server' /tmp/l"
+          echo "arm64 package contents: OK"
+
+      - name: Upload packages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mStream-linux-packages
+          path: dist/packages/*
+          if-no-files-found: error
+
   release:
     name: Attach bundles to release
-    needs: build
+    # linux-packages too: its deb/rpm artifacts ride the same merged
+    # download below — without the dependency a tag's attach step races the
+    # packaging job and globs at nothing.
+    needs: [build, linux-packages]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -1376,8 +1595,13 @@ jobs:
             echo "::error::release $TAG is already PUBLISHED - refusing to overwrite its assets. Ship a new patch version instead."
             exit 1
           fi
-          # The Windows setup.exe rides the same artifact download into
-          # bundles/ (manifest.json stays zips-only by design — the install
-          # scripts and the future auto-updater consume zips; the installer
-          # is a direct-download asset).
-          gh release upload "$TAG" bundles/*.zip bundles/manifest.json bundles/mStream-*-win-x64-setup.exe --clobber --repo "$REPO"
+          # The Windows setup.exe and the Linux deb/rpm packages ride the
+          # same artifact download into bundles/ (manifest.json stays
+          # zips-only by design — the install scripts and the future
+          # auto-updater consume zips; native installers are direct-download
+          # assets, and the manifest generator's mStream-*.zip glob never
+          # sees them).
+          gh release upload "$TAG" bundles/*.zip bundles/manifest.json \
+            bundles/mStream-*-win-x64-setup.exe \
+            bundles/mstream_*.deb bundles/mstream-*.rpm \
+            --clobber --repo "$REPO"


### PR DESCRIPTION
Second leg of P3.4, stacked on #845 (GitHub retargets to master when it merges; only the packages commit is this PR's diff).

## What ships
Four packages per release, built with **pinned nfpm** (sha256-verified, like every fetched build tool here) from the exact zips the build job produced:
- `mstream_<ver>_amd64.deb` / `mstream-<ver>-1.x86_64.rpm` — **full desktop package**: `/opt/mstream` tree, `/usr/bin/mstream-server` + `/usr/bin/mstream-desktop` symlinks, system `.desktop` entry + 512×512 hicolor icon, desktop-db/icon-cache post scripts.
- `mstream_<ver>_arm64.deb` / `mstream-<ver>-1.aarch64.rpm` — **server-only**, matching their bundle (linux-arm64 ships no launcher by design).

Dependency posture: hard deps stay minimal (`libc6`/`glibc` — the server is pure glibc per the bare-Debian-11 audit); GTK3/appindicator/ALSA ride **Recommends**, so a headless `--no-install-recommends` install never drags a desktop stack in. musl targets are deliberately excluded (Alpine uses apk).

`manifest.json` stays zips-only (its consumers eat zips; the generator's `mStream-*.zip` glob never sees the packages). The release job gains `needs: linux-packages` — without it a tag's attach step races the packaging job — and uploads the deb/rpm set next to the zips.

## CI proof on every run
- amd64 deb: installed on the runner, `desktop-file-validate`, **booted through the `/usr/bin` symlink to a 200 ping**, clean `apt remove`.
- x86_64 rpm: installed + exec'd in a `fedora:41` container.
- arm64 packages: content asserts (server present; deb must NOT ship a launcher).

## Local E2E already done (real v6.20.2 zips, ubuntu:24.04 + fedora:41 containers)
- All 4 packages build; amd64 deb installs, validates, **boots as a non-root user and serves 200 in ~2s**, removes cleanly (`/opt/mstream` gone); fedora rpm installs/execs/removes cleanly; arm64 content asserts pass.
- Trap fixes proven along the way, baked into the workflow: `dpkg-deb -c | grep -q` under pipefail SIGPIPE-fails **because** it matches (list to a file first); desktop-entry Categories with two main categories (now `AudioVideo;Audio;Player;`).

## Flagged for follow-up (not this PR)
Running the packaged server **as root** parks runtime data inside `/opt/mstream` (the dataRoot ladder treats any writable appRoot as portable) — leftovers then survive an `apt remove`, which is dpkg-correct but untidy. Non-root runs (the normal case, and what CI smokes) use `~/.local/share/mstream` properly. A task chip proposes teaching boot-config to skip the appRoot rung under system prefixes (`/opt`, `/usr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)