### PR TITLE
fix(boot): system install prefixes (/opt, /usr, /Applications) never become the data root

### DIFF
--- a/src/util/esm-helpers.js
+++ b/src/util/esm-helpers.js
@@ -61,10 +61,33 @@ export function userDataHome(platform = process.platform, env = process.env, hom
 // signing and is lost on upgrade, so the fallback is the correct destination
 // regardless.) Falling back beats failing: the only installs affected are ones
 // that could not have stored anything at appRoot in the first place.
-function resolveDataRoot() {
+// System install locations are never data homes, even when this process CAN
+// write there: W_OK answers yes for root under /opt and /usr (a sudo'd
+// `mstream-server -j …` from a deb/rpm install) and for any admin user under
+// /Applications (the pkg install) — but parking the db inside a
+// package-managed tree pollutes it. dpkg/rpm leave the leftovers behind on
+// remove (observed: `apt remove mstream` keeping /opt/mstream alive after
+// one root boot), a pkg upgrade replaces the tree out from under the
+// library, and on macOS it breaks the bundle's code signature. Ownership,
+// not writability, is the question in these prefixes. Windows deliberately
+// unlisted: our per-user install dir (LOCALAPPDATA\Programs) is user space,
+// and there is no package manager reclaiming it. Exported for tests.
+export function underSystemPrefix(dir, platform = process.platform) {
+  if (platform === 'win32') { return false; }
+  const norm = dir.endsWith('/') ? dir : `${dir}/`;
+  return ['/opt/', '/usr/', '/Applications/'].some(
+    (prefix) => norm === prefix || norm.startsWith(prefix));
+}
+
+// Split from the module-level constant wiring so the decision table is unit
+// testable; production behavior is exactly the constant below.
+export function resolveDataRoot(root = appRoot, platform = process.platform, access = fs.accessSync) {
+  if (underSystemPrefix(root, platform)) {
+    return userDataHome();
+  }
   try {
-    fs.accessSync(appRoot, fs.constants.W_OK);
-    return appRoot;
+    access(root, fs.constants.W_OK);
+    return root;
   } catch (_err) {
     return userDataHome();
   }

--- a/test/unit/dataroot-system-prefix.test.mjs
+++ b/test/unit/dataroot-system-prefix.test.mjs
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { underSystemPrefix, resolveDataRoot, userDataHome } from '../../src/util/esm-helpers.js';
+
+// ── underSystemPrefix ────────────────────────────────────────────────────────
+// System install locations must never become data homes even when writable:
+// root under /opt (a sudo'd `mstream-server -j …` from a deb/rpm) and admin
+// users under /Applications (the pkg) both pass W_OK, and the db then lands
+// inside a package-managed tree — leftovers survive `apt remove`, upgrades
+// clobber the library, and on macOS it breaks the bundle's signature.
+
+test('deb/rpm install roots are system prefixes', () => {
+  assert.equal(underSystemPrefix('/opt/mstream', 'linux'), true);
+  assert.equal(underSystemPrefix('/opt/mstream/', 'linux'), true);
+  assert.equal(underSystemPrefix('/usr/lib/mstream', 'linux'), true);
+  assert.equal(underSystemPrefix('/usr/local/mstream', 'linux'), true);
+});
+
+test('the mac pkg install root is a system prefix', () => {
+  assert.equal(underSystemPrefix('/Applications/mStream.app/Contents/MacOS', 'darwin'), true);
+});
+
+test('user-space roots are not system prefixes', () => {
+  assert.equal(underSystemPrefix('/home/u/mstream', 'linux'), false);
+  assert.equal(underSystemPrefix('/home/u/Downloads/mStream-6.20.3-linux-x64', 'linux'), false);
+  assert.equal(underSystemPrefix('/Users/u/Downloads/mStream.app/Contents/MacOS', 'darwin'), false);
+  // Sibling names must not prefix-match: /optimized is not /opt.
+  assert.equal(underSystemPrefix('/optimized/mstream', 'linux'), false);
+  assert.equal(underSystemPrefix('/usrland/mstream', 'linux'), false);
+});
+
+test('windows never treats a root as a system prefix', () => {
+  // The per-user install dir (LOCALAPPDATA\Programs) is user space, and no
+  // package manager reclaims it — portable-style anchoring stays legal there.
+  assert.equal(underSystemPrefix('C:\\Users\\u\\AppData\\Local\\Programs\\mStream', 'win32'), false);
+  assert.equal(underSystemPrefix('C:\\Program Files\\mStream', 'win32'), false);
+});
+
+// ── resolveDataRoot decision table ───────────────────────────────────────────
+
+const writable = () => {};                                  // accessSync: no throw
+const readOnly = () => { throw new Error('EACCES'); };      // accessSync: throws
+
+test('a system-prefix root diverts to the user data home even when writable', () => {
+  // This is the whole fix: before it, root's W_OK on /opt/mstream won and
+  // runtime state landed in the package tree.
+  assert.equal(resolveDataRoot('/opt/mstream', 'linux', writable), userDataHome());
+  assert.equal(
+    resolveDataRoot('/Applications/mStream.app/Contents/MacOS', 'darwin', writable),
+    userDataHome());
+});
+
+test('a writable user-space root anchors in place (existing installs untouched)', () => {
+  assert.equal(resolveDataRoot('/home/u/mstream', 'linux', writable), '/home/u/mstream');
+});
+
+test('an unwritable root still falls back to the user data home (the #802 flow)', () => {
+  assert.equal(resolveDataRoot('/home/u/mstream', 'linux', readOnly), userDataHome());
+});


### PR DESCRIPTION
Follow-up flagged during the P3.4b linux-packages E2E, promoted from a task chip: running the packaged server **as root** parked runtime state inside `/opt/mstream` — the dataRoot ladder treats any *writable* appRoot as portable, and W_OK is the wrong question for package-managed trees (root writes anywhere; mac admins write /Applications).

## The fix (one choke point)
`resolveDataRoot` in `esm-helpers.js` — every storage default (config, db, logs, caches via `config.js` Joi + `boot-config.js`) flows through it:
- `/opt/`, `/usr/`, `/Applications/` divert to the user data home **before** the writability probe.
- **Windows deliberately exempt** — our per-user install dir is user space, no package manager reclaims it; win32 behavior is byte-identical (short-circuit).
- User-space roots keep the existing ladder: writable anchors in place (existing installs untouched), unwritable falls back (the #802 AppTranslocation flow, unchanged).
- `usingFallbackDataRoot`'s boot log line now also fires on system installs, announcing where state lives.

Blast radius: no-args launches (double-click, menu entry, bare `mstream-server`) already used the desktop profile and were correct; only **explicit `-j` runs from a system install as a privileged user** change destination — from polluting the package tree to the invoker's data home.

## Verification
- New decision-table suite (7): system prefixes divert even when writable (the fix itself), `/optimized`//`usrland` don't prefix-match, win32 exempt, #802 fallback intact.
- boot-config 20/20, eslint clean on touched files.
- Full suite ×2: zero genuine failures. Each run had one load-timeout straggler in a *different* file (backup-api cascade-cancel, then the dlna private boot — 77 'cancelled' were its pending subtests), and each passed solo immediately after (18/18, 77/77) — the known node --test file-concurrency starvation on a busy dev box, nothing dataRoot-shaped.

With this merged, the runway to **6.20.3** is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)