### PR TITLE
ci: asset-store tag guards for release-triggered workflows + pin cross in the musl sidecar build

### DIFF
--- a/.github/workflows/build-p2p-sidecar-musl.yml
+++ b/.github/workflows/build-p2p-sidecar-musl.yml
@@ -65,11 +65,18 @@ jobs:
 
       - name: Install cross
         run: |
-          curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
-            | tar xz -C "$HOME/.cargo/bin"
+          # Pinned + hashed, same as the glibc workflow (and the other
+          # sidecar families since #841): `releases/latest` piped straight
+          # into ~/.cargo/bin meant a new (or hijacked) cross release ran on
+          # the next master push and produced the SHIPPED musl binaries —
+          # this workflow was the last one still floating. Bump the version
+          # and the sha256 together (sha256sum of the release asset).
+          curl -fsSL -o cross.tar.gz "https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz"
+          echo "642375d1bcf3bd88272c32ba90e999f3d983050adf45e66bd2d3887e8e838bad  cross.tar.gz" | sha256sum -c -
+          tar xzf cross.tar.gz -C "$HOME/.cargo/bin" && rm cross.tar.gz
 
       - name: Build
-        run: cross build --release --target ${{ matrix.target }} --manifest-path p2p-sidecar/Cargo.toml
+        run: cross build --release --locked --target ${{ matrix.target }} --manifest-path p2p-sidecar/Cargo.toml
 
       - name: Stage binary
         run: |

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -9,8 +9,12 @@ jobs:
   deploy-demo:
     # Server releases only. The `-DESKTOP_PLAYER` companion
     # release is just binaries for the Electron player; there's
-    # no reason to re-pull the server on the demo host.
-    if: ${{ !endsWith(github.event.release.tag_name, '-DESKTOP_PLAYER') }}
+    # no reason to re-pull the server on the demo host. Same for
+    # asset-store releases (`discovery-models-*`, any future
+    # `p2p-sidecar-*` tag) — machine-managed file shelves that a
+    # human touching in the UI would otherwise redeploy the demo
+    # (see npm-publish.yml for the full rationale).
+    if: ${{ !endsWith(github.event.release.tag_name, '-DESKTOP_PLAYER') && !startsWith(github.event.release.tag_name, 'p2p-sidecar-') && !startsWith(github.event.release.tag_name, 'discovery-models-') }}
     runs-on: ubuntu-latest
     steps:
     - name: pull changes

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,10 +9,17 @@ on:
 
 jobs:
   publish-npm:
-    # Server releases only. The desktop player ships as a separate
-    # release with a `-DESKTOP_PLAYER` tag suffix; publishing its
-    # draft shouldn't republish the server to npm.
-    if: ${{ !endsWith(github.event.release.tag_name, '-DESKTOP_PLAYER') }}
+    # Server releases only, twice over:
+    #  - the desktop player ships as a separate release with a
+    #    `-DESKTOP_PLAYER` tag suffix; publishing its draft shouldn't
+    #    republish the server to npm;
+    #  - asset-store releases (`discovery-models-*` today; any future
+    #    `p2p-sidecar-*` tag) are machine-managed file shelves, not server
+    #    releases. A HUMAN editing or re-publishing one in the UI re-fires
+    #    `release: published` — without this guard that meant an `npm
+    #    publish` of whatever master held (worst case: a version bumped but
+    #    not yet released ships to npm early).
+    if: ${{ !endsWith(github.event.release.tag_name, '-DESKTOP_PLAYER') && !startsWith(github.event.release.tag_name, 'p2p-sidecar-') && !startsWith(github.event.release.tag_name, 'discovery-models-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Split out of the p2p-sidecar distribution rework so these land on master regardless of it — both are wanted today, independent of any migration:

1. **`npm-publish.yml` / `deploy-demo.yml` tag guards.** Both fire on any `release: published`. Asset-store releases (`discovery-models-*` exists today; `p2p-sidecar-*` reserved) are machine-managed file shelves, not server releases — CI-created ones can't trigger workflows (GITHUB_TOKEN events never do), but a **human** editing/re-publishing one in the UI re-fires the event. Without the guard that means `npm publish` of whatever master holds (worst case: a bumped-but-unreleased version ships to npm early) plus a demo redeploy. The guards only narrow the trigger; `v*` server releases behave exactly as before.
2. **`build-p2p-sidecar-musl.yml` supply-chain catch-up.** It was the last binary workflow still piping `cross` from `releases/latest` unverified into `~/.cargo/bin` and building without `--locked` — the glibc sidecar workflow and every other family were pinned+hashed in #841. Now pinned to v0.2.5 with the same sha256, and `--locked` added.

No step logic changed anywhere — the `if:` expressions and the pinned install are the whole diff. All three files parse (checked with PyYAML); the guarded workflows are release-triggered only, so nothing runs differently for the in-flight 6.20.3 flow (this PR is meant to merge after it ships anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)