### PR TITLE
perf(p2p-sidecar): size-tuned release profile — 67% smaller binaries

### DIFF
--- a/p2p-sidecar/Cargo.toml
+++ b/p2p-sidecar/Cargo.toml
@@ -27,3 +27,24 @@ tokio-stream = "0.1"
 
 [profile.release]
 strip = true
+# Size-tuned (2026-08-19): the sidecar ships in every release bundle and is
+# runtime-fetched by npm installs, so bytes matter more than the last few
+# percent of throughput (payloads are announcements, DMs, and catalog blobs
+# — not the QC media tunnel, which lives in-process via @number0/iroh).
+# Measured on this dep tree (baseline = the previous strip-only profile):
+#   win32-x64:  20.5 MB -> 6.7 MB (-67%)
+#   linux-x64:  21.2 MB -> 8.1 MB (-62%); opt-level "z" = 7.6 MB (-64%)
+# The bulk is fat LTO + 1 codegen unit deduplicating iroh's generic-heavy
+# async code, plus panic=abort shedding unwind tables. "z" buys only ~7%
+# over "s" — kept at "s" for optimizer headroom; flip to "z" if bytes ever
+# matter more. Feature audit found nothing to trim: pkarr/swarm-discovery
+# already absent, hickory-resolver is the dial-by-endpointId path, metrics
+# is the exporter-less form. NO packers/UPX ever — AV/SmartApp heuristics.
+# panic = "abort": no catch_unwind anywhere in main.rs (prod code is all
+# anyhow Results; the only panic!s are test asserts), and the Node side
+# (discovery-p2p.js) already treats child exit as a respawn signal — a loud
+# abort beats a half-dead sidecar with one crashed tokio task.
+lto = "fat"
+codegen-units = 1
+opt-level = "s"
+panic = "abort"


### PR DESCRIPTION
Phase A of the sidecar plan (bundle-ready sizes before anything downstream ships them).

## Measured (baseline = the previous strip-only profile)
| target | baseline | new (`opt-level=s`) | `z` variant |
|---|---|---|---|
| win32-x64 | 20.5 MB | **6.7 MB (−67%)** | — |
| linux-x64 glibc | 21.2 MB | **8.1 MB (−62%)** | 7.6 MB (−64%) |

The win is fat LTO + `codegen-units=1` deduplicating iroh's generic-heavy async code, plus `panic=abort` shedding unwind tables. `z` buys only ~7% over `s` — kept at `s` for optimizer headroom, delta documented in the profile comment for trivial flipping.

## Safety
- **`panic=abort` is semantics-improving here**: no `catch_unwind` anywhere; prod code is all `anyhow` Results (the only `panic!`s are test asserts); and `discovery-p2p.js` already treats child exit as a respawn signal — a loud abort beats a half-dead sidecar with one crashed tokio task.
- **Verified on real runs**: win build passes `--print-id` ×2 (identity persistence) + the real-run smoke (endpoint bound, `ready` emitted — the same gate that caught the musl noq-udp SIGABRT in production). The glibc `z` build passes both in Docker. Every CI leg additionally re-proves its own binary via the existing self-test + real-run workflow gates.
- **Feature audit: nothing to trim** — `pkarr`/`swarm-discovery` were never compiled in, `hickory-resolver` is the dial-by-endpointId path the catalog needs, metrics is the exporter-less form. Explicit anti-goal: no UPX/packers (AV + Smart App Control heuristic magnets).

## Ripples
Whole 9-binary set: ~172 MB → ~60 MB. Bundle staging (Phase D) gains ~3 MB compressed per bundle instead of 8. The npm/Docker runtime fetch drops to ~7–8 MB per platform. The new-repo extraction (Phase B, in flight) picks the crate up from this branch so the first release is born at these sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)