### PR TITLE
feat(bundle): bake the p2p-sidecar into every release bundle (Phase D)

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -959,6 +959,19 @@ jobs:
           echo "$OUT" | grep -q dbPath || { echo "FAIL: worker self-dispatch"; echo "$OUT"; exit 1; }
           echo "ok: worker self-dispatch"
 
+          # (1b) the baked-in p2p-sidecar: staged from the pinned release
+          # assets (sha-verified at bundle time) and actually EXECUTABLE on
+          # this leg — --print-id is the sidecar's own identity self-test.
+          # Bundle installs' discovery P2P depends on exactly this file (the
+          # resolver's appRoot rung); on darwin this also proves the SIGNED
+          # copy still runs (the sign walk covers it as a generic Mach-O).
+          SC=$(ls "$RUN"/bin/p2p-sidecar/p2p-sidecar-* 2>/dev/null | head -1)
+          [ -n "$SC" ] || { echo "FAIL: no p2p-sidecar staged in the bundle (bin/p2p-sidecar empty)"; exit 1; }
+          SCOUT=$("$SC" --print-id --data-dir "$RUN/sc-selftest" 2>/dev/null)
+          echo "$SCOUT" | grep -Eq '^[0-9a-f]{64}$' || { echo "FAIL: staged p2p-sidecar --print-id produced no/invalid output"; echo "$SCOUT"; exit 1; }
+          rm -rf "$RUN/sc-selftest"
+          echo "ok: baked-in p2p-sidecar executes ($(basename "$SC"))"
+
           # (2) default-path boot (no -j) — the double-click invocation. A fresh
           # standalone install is the DESKTOP profile: the config resolves to the
           # per-OS user data home and is generated with Quick Connect on

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -236,12 +236,11 @@ if (t.plat === 'linux' && !t.musl) {
 //
 // THREE LISTS MOVE TOGETHER: the `sidecars` array above, this description
 // map, and $known in scripts/check-win-versioninfo.ps1 (which fails the
-// win-x64 leg on any PE it doesn't know). Staging a new Windows sidecar —
-// e.g. the p2p-sidecar exe, deliberately NOT staged (Bun bundles ship
-// without a baked-in discovery-P2P binary; since the move to fetch-on-use
-// the server can download it into its data root at runtime instead) — means
-// updating all three in the same change, or the leg goes red with
-// "unknown PE".
+// win-x64 leg on any PE it doesn't know). Staging a new Windows sidecar
+// means updating all three in the same change, or the leg goes red with
+// "unknown PE". (The p2p-sidecar is staged separately below — it comes from
+// the pinned release assets, not from bin/ — but its Windows copy joins the
+// same stamped set and the same $known list.)
 const sidecarDescription = {
   'rust-parser':       'mStream Library Scanner',
   'rust-server-audio': 'mStream Server Audio',
@@ -268,6 +267,91 @@ for (const [dir, file] of sidecars) {
     }
   } else {
     console.warn(`  sidecar not found, skipping: bin/${dir}/${file}`);
+  }
+}
+
+// p2p-sidecar (discovery network): the crate lives in its own repo
+// (IrosTheBeggar/mstream-p2p-sidecar) and the binaries left git — bundles
+// BAKE the target's binary in at build time, fetched from the release
+// assets the committed manifests pin (fetch → sha256+size verify → stage;
+// one download in CI instead of one per user machine). The runtime
+// resolver (src/state/discovery-p2p.js resolveSidecarBinary) finds it at
+// appRoot/bin/p2p-sidecar/<name> — its "prebuilt" rung — so bundle
+// installs never fetch; npm/source/Docker installs keep fetch-on-first-use.
+// The Windows copy is VersionInfo-stamped like the other sidecars (the
+// staged bytes then legitimately differ from the manifest sha — verify
+// happens BEFORE the stamp) and gets Authenticode-signed with the PE set.
+// CI without the asset = a broken release, fail loud (launcher precedent);
+// local/offline builds warn and ship without — the runtime fetch is the
+// fallback. MSTREAM_SIDECAR_BASE mirrors apply here too (pins still hold).
+{
+  const scName = `p2p-sidecar-${t.plat}-${t.arch}${libc}${t.ext}`;
+  const manifestFile = join(root, 'bin', 'p2p-sidecar', t.musl ? 'manifest-musl.json' : 'manifest.json');
+  const skip = (why) => {
+    if (process.env.CI && !process.env.MSTREAM_ALLOW_MISSING_SIDECAR) {
+      console.error(`  FATAL: p2p-sidecar staging failed for ${key}: ${why} (set MSTREAM_ALLOW_MISSING_SIDECAR=1 to bundle without it on purpose)`);
+      process.exit(1);
+    }
+    console.warn(`  p2p-sidecar not staged (${why}) — bundle falls back to runtime fetch`);
+  };
+  let entry = null;
+  try {
+    const m = JSON.parse(readFileSync(manifestFile, 'utf8'));
+    entry = m.assets?.[scName] ? { ...m.assets[scName], repo: m.repo, tag: m.tag } : null;
+  } catch (err) {
+    entry = null;
+  }
+  if (!entry) {
+    skip(`no manifest entry for ${scName}`);
+  } else {
+    // Same URL shape the runtime fetch uses — one derivation, no drift.
+    const { deriveAssetUrl } = await import('../src/util/p2p-sidecar-bootstrap.js');
+    const base = (process.env.MSTREAM_SIDECAR_BASE || '').replace(/\/+$/, '');
+    const url = base ? `${base}/${entry.file}` : deriveAssetUrl(entry);
+    const cacheDir = join(root, 'dist', 'sidecar-cache');
+    mkdirSync(cacheDir, { recursive: true });
+    const cached = join(cacheDir, `${entry.sha256.slice(0, 12)}-${scName}`);
+    let bytes = null;
+    if (existsSync(cached)) {
+      bytes = readFileSync(cached);
+      if (createHash('sha256').update(bytes).digest('hex') !== entry.sha256) { bytes = null; }
+    }
+    if (!bytes) {
+      console.log(`  fetching p2p-sidecar: ${url}`);
+      try {
+        const res = await fetch(url, { redirect: 'follow' });
+        if (!res.ok) { throw new Error(`HTTP ${res.status}`); }
+        bytes = Buffer.from(await res.arrayBuffer());
+      } catch (err) {
+        bytes = null;
+        skip(`download failed: ${err.message}`);
+      }
+    }
+    if (bytes) {
+      const gotSha = createHash('sha256').update(bytes).digest('hex');
+      if (gotSha !== entry.sha256 || bytes.length !== entry.size) {
+        // A hash mismatch is NEVER skippable — wrong bytes must not ship,
+        // and must not poison the cache.
+        console.error(`  FATAL: p2p-sidecar ${scName} failed verification (sha ${gotSha.slice(0, 12)}… vs pinned ${entry.sha256.slice(0, 12)}…, ${bytes.length} vs ${entry.size} bytes)`);
+        process.exit(1);
+      }
+      writeFileSync(cached, bytes);
+      mkdirSync(join(contentRoot, 'bin', 'p2p-sidecar'), { recursive: true });
+      const dest = join(contentRoot, 'bin', 'p2p-sidecar', scName);
+      writeFileSync(dest, bytes);
+      if (t.plat !== 'win32') { chmodSync(dest, 0o755); }
+      console.log(`  staged p2p-sidecar ${entry.tag}: bin/p2p-sidecar/${scName} (${(entry.size / 1048576).toFixed(1)} MB, sha verified)`);
+      if (t.plat === 'win32') {
+        try {
+          await stampWindowsVersionInfo(dest, { ...winMeta, fileDescription: 'mStream P2P Sidecar' });
+          console.log(`  stamped VersionInfo: bin/p2p-sidecar/${scName} (${winMeta.productName} ${winMeta.version})`);
+        } catch (err) {
+          const msg = `VersionInfo stamp failed for bin/p2p-sidecar/${scName}: ${err.message}`;
+          if (process.env.CI) { console.error(`  FATAL: ${msg}`); process.exit(1); }
+          console.warn(`  WARN: ${msg}`);
+        }
+      }
+    }
   }
 }
 

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -298,8 +298,8 @@ for (const [dir, file] of sidecars) {
   try {
     const m = JSON.parse(readFileSync(manifestFile, 'utf8'));
     entry = m.assets?.[scName] ? { ...m.assets[scName], repo: m.repo, tag: m.tag } : null;
-  } catch (err) {
-    entry = null;
+  } catch (_err) {
+    // unreadable/absent manifest = the same no-entry skip below
   }
   if (!entry) {
     skip(`no manifest entry for ${scName}`);

--- a/scripts/check-win-versioninfo.ps1
+++ b/scripts/check-win-versioninfo.ps1
@@ -66,6 +66,12 @@ $known = @(
   @{ path = 'mstream-server.exe';                                   lenient = $false; optional = $false }
   @{ path = 'bin\rust-parser\rust-parser-win32-x64.exe';            lenient = $false; optional = $false }
   @{ path = 'bin\rust-server-audio\rust-server-audio-win32-x64.exe'; lenient = $false; optional = $false }
+  # Fetched from the pinned release assets at bundle time and stamped like
+  # the other sidecars (build-bun.mjs). optional: a local/offline build
+  # legitimately ships without it (runtime fetch is the fallback); in CI
+  # the bundler itself is fatal on a missing asset, so absence here can
+  # only mean a deliberate MSTREAM_ALLOW_MISSING_SIDECAR build.
+  @{ path = 'bin\p2p-sidecar\p2p-sidecar-win32-x64.exe';            lenient = $false; optional = $true  }
 )
 $upstream = @('bin\iroh\iroh.win32-x64-msvc.node')
 # The server's ffmpeg-bootstrap downloads ffmpeg/ffprobe into <appRoot>/bin/ffmpeg


### PR DESCRIPTION
The plan's R1: bundles ship the sidecar built in, so discovery P2P works on binary installs — with the Windows copy positioned to be Authenticode-signed alongside the PE set.

## How it works
- `build-bun.mjs` stages the target's sidecar from the **pinned release assets** (the same committed manifests the runtime fetch uses; URL derivation imported from `p2p-sidecar-bootstrap` — one implementation, no drift): fetch → **sha256+size verify** → stage → **VersionInfo stamp** on Windows (`mStream P2P Sidecar`, full product contract). Cache under `dist/sidecar-cache/` keyed by pin.
- The runtime resolver's existing `appRoot/bin/p2p-sidecar/<name>` rung picks it up — **bundle installs never fetch**; npm/source/Docker behavior unchanged.
- musl bundles stage the `-musl` assets from `manifest-musl.json`.
- **Posture** (launcher precedent): CI missing-asset = loud failure (`MSTREAM_ALLOW_MISSING_SIDECAR=1` = deliberate); local/offline = warn + ship without (runtime fetch fallback); **hash mismatch = fatal everywhere, never skippable, never cached**. `MSTREAM_SIDECAR_BASE` mirrors honored, pins still enforced.
- `check-win-versioninfo.ps1` $known gains the sidecar as a **stamped, full-contract** entry (optional-when-absent covers deliberate/offline builds; CI absence is already fatal upstream).
- **Smoke (1b)** on every smoking leg: the staged binary must exist AND execute (`--print-id`) — on darwin that exercises the **signed** copy (the codesign walk covers it as a generic Mach-O automatically; no sign-step changes needed).

## Verified locally (win-x64, real assets)
Fetched v1.0.1 from the actual public release URL → sha verified (6.7 MB) → staged → stamped → **stamped PE executes** (`--print-id`) → zip carries it → **strict VersionInfo contract 5/5** including the new row.

## Coordination
- The SignPath branch (#851) gets the matching update (6th `pe-file` in `win-bundle-pes`, **with** product restrictions now that it's stamped, + the collect/apply steps) — pushed separately; the UI config to paste is the 6-entry version.
- Bundle size cost: ~+3 MB compressed per bundle (the #853-optimized builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)