### PR TITLE
fix(pkg): pin BundleIsRelocatable=false so the installer can't relocate onto the build stage

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -790,8 +790,20 @@ jobs:
           mkdir -p dist/installer pkgwork
           PKG="dist/installer/mStream-$VER-$KEY.pkg"
 
-          pkgbuild --component "$APP" --install-location /Applications \
-            --identifier io.mstream.server --version "$VER" pkgwork/component.pkg
+          # BundleIsRelocatable=false, explicitly: with the default (true),
+          # macOS installer lets Spotlight pick the install target - and when
+          # it has indexed the STAGED mStream.app sitting in this very
+          # workspace, "Upgrading at base path /" relocates the payload onto
+          # the stage copy instead of /Applications (bit the v6.21.1 tag build
+          # on the arm64 leg; a Spotlight-indexing race, so earlier runs
+          # passed). Users keep a fixed /Applications install path too.
+          # Needs the --root + --component-plist form (--component accepts no
+          # plist); ditto preserves the signed bundle bit-exactly.
+          rm -rf pkgwork/root && mkdir -p pkgwork/root
+          ditto "$APP" pkgwork/root/mStream.app
+          pkgbuild --analyze --root pkgwork/root pkgwork/component.plist
+          /usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" pkgwork/component.plist
+          pkgbuild --root pkgwork/root --component-plist pkgwork/component.plist --install-location /Applications --identifier io.mstream.server --version "$VER" pkgwork/component.pkg
           case "$KEY" in
             darwin-arm64) ARCHS="arm64" ;;
             *)            ARCHS="x86_64,arm64" ;;   # x64 payload runs under Rosetta


### PR DESCRIPTION
The v6.21.1 tag build failed on darwin-arm64's pkg install smoke: `installer: Upgrading at base path /` on a fresh runner, then no `/Applications/mStream.app`.

**Root cause — the macOS relocation trap.** `pkgbuild --component` defaults to `BundleIsRelocatable=true`, which lets the installer ask Spotlight where the bundle currently lives. When Spotlight has indexed the **staged** `mStream.app` inside the build workspace, the installer "upgrades" that copy in place instead of installing to /Applications — so the smoke's check fails. It's an indexing race: darwin-x64 passed the *same run*, and 6.20.3/6.21.0 both sailed through.

**Fix**: `pkgbuild --analyze` → `PlistBuddy Set :0:BundleIsRelocatable false` → `pkgbuild --root + --component-plist` (the `--component` form accepts no plist; `ditto` copies the signed bundle bit-exactly, preserving the codesign seal). Bonus for users: upgrades always land in /Applications even if they moved a copy elsewhere.

The failed leg was also re-run as-is in parallel — if the race passes, v6.21.1 ships and this fix covers the future; if not, this merges and the next tag carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)