### PR TITLE
fix(scanner,db): album view was alphabetical — "N/total" tags dropped, NULLs sorted first

### DIFF
--- a/rust-parser/src/main.rs
+++ b/rust-parser/src/main.rs
@@ -2960,6 +2960,29 @@ fn extract_track(
                 disc_num = tag.disk().map(|d| d as i64);
                 track_total = tag.track_total().map(|t| t as i64);
                 disc_total = tag.disk_total().map(|d| d as i64);
+                // The typed accessors above return None when a tag format
+                // lofty doesn't split for stores the combined "N/total" form
+                // — Vorbis `DISCNUMBER=1/2` (FLAC/OGG/Opus) and RIFF INFO's
+                // ITRK are the two that bite in the wild. Re-read the raw
+                // string and split it ourselves so those tracks keep their
+                // numbers instead of landing in the DB as NULL, which drops
+                // the album view back to alphabetical filepath order and
+                // interleaves the discs of a multi-disc set. See
+                // parse_num_of.
+                if track_num.is_none() || track_total.is_none() {
+                    if let Some(raw) = tag.get_string(&ItemKey::TrackNumber) {
+                        let (num, total) = parse_num_of(raw);
+                        if track_num.is_none() { track_num = num; }
+                        if track_total.is_none() { track_total = total; }
+                    }
+                }
+                if disc_num.is_none() || disc_total.is_none() {
+                    if let Some(raw) = tag.get_string(&ItemKey::DiscNumber) {
+                        let (num, total) = parse_num_of(raw);
+                        if disc_num.is_none() { disc_num = num; }
+                        if disc_total.is_none() { disc_total = total; }
+                    }
+                }
                 genre = tag.genre().map(|s| s.to_string());
 
                 rg_track_db = tag.get(&ItemKey::ReplayGainTrackGain).and_then(|item| {
@@ -6312,4 +6335,30 @@ fn hex_lower(bytes: impl AsRef<[u8]>) -> String {
 fn parse_replaygain_db(s: &str) -> Option<f64> {
     let s = s.trim().trim_end_matches("dB").trim_end_matches("db").trim();
     s.parse::<f64>().ok()
+}
+
+// Split a raw track/disc tag value written in the combined "N/total" form
+// (e.g. "7/12") into its two numbers. Returns (number, total); either half is
+// None when it isn't a plain non-negative integer, so "A1" (vinyl side
+// numbering) and "" simply yield (None, None) rather than a bogus value.
+//
+// lofty's typed accessors already split this form for ID3v2 (TRCK/TPOS), MP4
+// (trkn/disk) and Vorbis TRACKNUMBER — but NOT for Vorbis DISCNUMBER or RIFF
+// INFO's ITRK, where a combined value makes `Accessor::disk()` /
+// `Accessor::track()` return None outright. music-metadata (the JS scanner)
+// parses every one of them, so without this the two scanners disagree and a
+// FLAC set tagged `DISCNUMBER=1/2` lands in the DB with no disc number at all.
+//
+// Parsed as u32 — the same domain lofty's accessors return — so this fallback
+// can't admit a value (a negative number) the primary path would have refused.
+// Widened to i64 only because that's what the DB columns take.
+fn parse_num_of(s: &str) -> (Option<i64>, Option<i64>) {
+    let (num, total) = match s.split_once('/') {
+        Some((num, total)) => (num, Some(total)),
+        None => (s, None),
+    };
+    (
+        num.trim().parse::<u32>().ok().map(i64::from),
+        total.and_then(|t| t.trim().parse::<u32>().ok()).map(i64::from),
+    )
 }

--- a/src/api/db.js
+++ b/src/api/db.js
@@ -5,6 +5,7 @@ import * as dbQueue from '../db/task-queue.js';
 import * as db from '../db/manager.js';
 import { joiValidate, dualId } from '../util/validation.js';
 import WebError from '../util/web-error.js';
+import { ALBUM_TRACK_ORDER } from '../db/track-order.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -692,7 +693,7 @@ export function setup(mstream) {
       ${trackQuery(req.user?.id, { includeGenres: false })}
       JOIN track_genres tg ON tg.track_id = t.id AND tg.genre_id IN (${idPh})
       WHERE ${filter.clause}
-      ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, t.disc_number, t.track_number
+      ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, ${ALBUM_TRACK_ORDER}
       ${pageSql}
     `).all(...allParams, ...pageParams);
 
@@ -729,7 +730,7 @@ export function setup(mstream) {
     const rows = d().prepare(`
       ${trackQuery(req.user?.id, { includeGenres: false })}
       WHERE ${conditions.join(' AND ')}
-      ORDER BY t.disc_number, t.track_number, t.filepath
+      ORDER BY ${ALBUM_TRACK_ORDER}, t.filepath
     `).all(...allParams);
 
     res.json(enrichRowsWithGenres(d(), rows).map(renderMetadataObj));

--- a/src/api/dlna.js
+++ b/src/api/dlna.js
@@ -7,6 +7,7 @@ import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
 import { getBaseUrl } from '../dlna/ssdp.js';
 import { timeSeekMiddleware } from '../dlna/time-seek.js';
+import { ALBUM_TRACK_ORDER } from '../db/track-order.js';
 
 // ── Mutable state ────────────────────────────────────────────────────────────
 
@@ -522,7 +523,7 @@ function getLibraryTrackCount(libraryId) {
   });
 }
 
-function getLibraryTracks(libraryId, start, count, orderBy = 'al.name, t.disc_number, t.track_number, t.title') {
+function getLibraryTracks(libraryId, start, count, orderBy = `al.name, ${ALBUM_TRACK_ORDER}, t.title`) {
   const limit = count > 0 ? count : -1; // SQLite: -1 = no limit
   return db.getDB().prepare(`
     SELECT t.id, t.filepath, t.title, t.track_number, t.duration, t.format,
@@ -644,7 +645,7 @@ function getAlbumTracks(libraryId, albumId) {
       LEFT JOIN artists a  ON t.artist_id = a.id
       LEFT JOIN albums  al ON t.album_id  = al.id
       WHERE t.library_id = ? AND t.album_id IS NULL
-      ORDER BY t.disc_number, t.track_number, t.title
+      ORDER BY ${ALBUM_TRACK_ORDER}, t.title
     `).all(libraryId);
   }
   return db.getDB().prepare(`
@@ -655,7 +656,7 @@ function getAlbumTracks(libraryId, albumId) {
     LEFT JOIN artists a  ON t.artist_id = a.id
     LEFT JOIN albums  al ON t.album_id  = al.id
     WHERE t.library_id = ? AND t.album_id = ?
-    ORDER BY t.disc_number, t.track_number, t.title
+    ORDER BY ${ALBUM_TRACK_ORDER}, t.title
   `).all(libraryId, albumId);
 }
 
@@ -981,7 +982,7 @@ function getFavoriteTracks(start, count) {
     LEFT JOIN albums  al ON t.album_id  = al.id
     GROUP BY t.id
     HAVING top_rating >= 4
-    ORDER BY top_rating DESC, a.name, al.name, t.disc_number, t.track_number
+    ORDER BY top_rating DESC, a.name, al.name, ${ALBUM_TRACK_ORDER}
     LIMIT ? OFFSET ?
   `).all(limit, start);
 }
@@ -1032,7 +1033,7 @@ function getYearTracks(year, start, count) {
     LEFT JOIN artists a  ON t.artist_id = a.id
     LEFT JOIN albums  al ON t.album_id  = al.id
     WHERE t.year = ?
-    ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, t.disc_number, t.track_number, t.title
+    ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, ${ALBUM_TRACK_ORDER}, t.title
     LIMIT ? OFFSET ?
   `).all(year, limit, start);
 }
@@ -1518,7 +1519,7 @@ function handleBrowse(body, res) {
       return sendBrowseResponse(res, didlWrapper(viewContainer(libId, 'tracks', total)), 1, 1);
     }
 
-    const orderBy = buildOrderBy(sortTerms, 'al.name, t.disc_number, t.track_number, t.title');
+    const orderBy = buildOrderBy(sortTerms, `al.name, ${ALBUM_TRACK_ORDER}, t.title`);
     const tracks = getLibraryTracks(libId, startIdx, reqCount, orderBy);
     return sendBrowseResponse(res, didlWrapper(tracks.map(t => trackItem(t, lib, objectId)).join('')), tracks.length, total);
   }

--- a/src/api/subsonic/handlers.js
+++ b/src/api/subsonic/handlers.js
@@ -26,6 +26,7 @@ import * as dbQueue from '../../db/task-queue.js';
 import * as adminUtil from '../../util/admin.js';
 import { ffmpegBin, getResolvedSource } from '../../util/ffmpeg-bootstrap.js';
 import { serveAlbumArtFile } from '../album-art.js';
+import { ALBUM_TRACK_ORDER } from '../../db/track-order.js';
 import { getSystemUpdateID } from '../dlna.js';
 import * as serverPlayback from '../server-playback.js';
 import { sendOk, sendError, SubErr } from './response.js';
@@ -781,7 +782,7 @@ export function getAlbum(req, res) {
     LEFT JOIN artists a ON a.id = t.artist_id
     LEFT JOIN albums  al ON al.id = t.album_id
     WHERE t.album_id = ? AND ${clause}
-    ORDER BY t.disc_number, t.track_number, t.title
+    ORDER BY ${ALBUM_TRACK_ORDER}, t.title
   `).all(id, ...params);
 
   const albumStars = albumStarMap(req.user.id, [album.id]);
@@ -948,7 +949,7 @@ export function getMusicDirectory(req, res) {
       LEFT JOIN artists a ON a.id = t.artist_id
       LEFT JOIN albums  al ON al.id = t.album_id
       WHERE t.album_id = ? AND ${clause}
-      ORDER BY t.disc_number, t.track_number, t.title
+      ORDER BY ${ALBUM_TRACK_ORDER}, t.title
     `).all(album.id, ...params);
     return sendOk(req, res, {
       directory: {
@@ -2249,7 +2250,7 @@ export function getSongsByGenre(req, res) {
     LEFT JOIN artists a  ON a.id = t.artist_id
     LEFT JOIN albums  al ON al.id = t.album_id
     WHERE ${where.join(' AND ')}
-    ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, t.disc_number, t.track_number
+    ORDER BY a.name COLLATE NOCASE, al.name COLLATE NOCASE, ${ALBUM_TRACK_ORDER}
     LIMIT ? OFFSET ?
   `).all(...args, count, offset);
 

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -81,7 +81,7 @@ import { HASH_GENERATION } from './audio-hash.js';
 // V63 indexes cue_points.library_id and play_events.library_id so the
 // library-delete cascade seeks instead of scanning. See SCHEMA_V63.
 // V64 indexes tracks.year so the DLNA By-Year browse seeks. See SCHEMA_V64.
-export const SCHEMA_VERSION = 65;
+export const SCHEMA_VERSION = 66;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2373,6 +2373,25 @@ export const SCHEMA_V65 = `
   CREATE INDEX IF NOT EXISTS idx_play_events_user_time ON play_events(user_id, started_at);
 `;
 
+// V66: rescan marker only — no schema change, same shape as V49.
+//
+// The Rust scanner used to drop track/disc numbers written in the combined
+// "N/total" form wherever lofty's typed accessors don't split it: Vorbis
+// DISCNUMBER (FLAC/OGG/Opus) and RIFF INFO's ITRK (WAV). It now parses those
+// itself (parse_num_of in rust-parser/src/main.rs) — but only when a file is
+// actually re-parsed, and unchanged files ride the mtime fast-path. Without a
+// forced re-parse, every library scanned by an older build keeps its NULLs:
+// a multi-disc FLAC set stays interleaved and a WAV album stays in
+// alphabetical order in the album view, until the user guesses at a manual
+// force-rescan. rescanRequired writes the .rescan-pending marker so the next
+// boot runs the resumable migration rescan and repairs them automatically.
+//
+// SELECT 1 because the runner unconditionally exec()s migration SQL inside
+// its transaction — a trivial statement keeps that path uniform.
+export const SCHEMA_V66 = `
+  SELECT 1;
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2753,4 +2772,9 @@ export const MIGRATIONS = [
   // V65 indexes play_events(user_id, started_at) for the wrapped-stats
   // period windows. Index-only, no rescan. See SCHEMA_V65.
   { version: 65, sql: SCHEMA_V65 },
+  // V66 is a rescan marker with no schema change: rust-parser now reads
+  // track/disc numbers written as "N/total" in Vorbis DISCNUMBER and RIFF
+  // INFO, and only a re-parse can backfill the NULLs older builds left.
+  // See SCHEMA_V66.
+  { version: 66, sql: SCHEMA_V66, rescanRequired: true },
 ];

--- a/src/db/track-order.js
+++ b/src/db/track-order.js
@@ -1,0 +1,35 @@
+// Canonical "in album order" SQL sort for a set of tracks, shared by every
+// listing that shows an album's tracks — the webapp album view
+// (/api/v1/db/album-songs), genre songs, the Subsonic album/directory
+// browsers and the DLNA content directory — so they can't drift apart.
+//
+// Lives in its own dependency-free module rather than in src/api/db.js
+// because src/api/dlna.js needs it too, and db.js already reaches dlna.js
+// through src/db/task-queue.js — importing it from there would close an
+// import cycle.
+//
+// Assumes the tracks table is aliased `t`.
+//
+// The two guards exist because SQLite sorts NULL FIRST, so a plain
+// `t.disc_number, t.track_number` hoists every untagged track ABOVE the
+// tagged ones instead of leaving it at the end:
+//
+//   COALESCE(t.disc_number, 1)
+//     A single-disc rip usually carries no TPOS / DISCNUMBER at all, so "no
+//     disc tag" means disc 1, not disc zero. Without this, an album where
+//     only SOME files carry a disc tag lists the untagged ones first; with
+//     it they interleave with disc 1 by track number, and a real disc 2
+//     still sorts after them.
+//
+//   t.track_number IS NULL
+//     Sorts false(0) before true(1), so tracks with no track number fall to
+//     the bottom of their disc rather than jumping to the top.
+//
+// Callers append their own last-resort tiebreak (filepath or title) for
+// tracks that carry no numbering at all. That tiebreak is alphabetical —
+// the best guess available with no numbers to go on, but a fallback, not
+// the intended order. A whole album landing there is a symptom worth
+// chasing: it usually means the scanner failed to read the track numbers
+// (see parse_num_of in rust-parser/src/main.rs).
+export const ALBUM_TRACK_ORDER =
+  'COALESCE(t.disc_number, 1), t.track_number IS NULL, t.track_number';

--- a/test/integration/album-track-order-surfaces.test.mjs
+++ b/test/integration/album-track-order-surfaces.test.mjs
@@ -1,0 +1,228 @@
+/**
+ * Album track ordering on the OTHER surfaces — Subsonic and DLNA.
+ *
+ * test/integration/album-track-order.test.mjs covers the webapp album view
+ * (/api/v1/db/album-songs). The same ALBUM_TRACK_ORDER fragment
+ * (src/db/track-order.js) also drives the Subsonic album/directory browsers
+ * and the DLNA content directory, and those had no ordering coverage at all:
+ * the shared fixture library is entirely `disc: 1` with no NULLs, so every
+ * existing Subsonic/DLNA test would pass just as happily with the discs
+ * interleaved or the untagged tracks hoisted to the top.
+ *
+ * Three albums, covering two different jobs:
+ *   - "Order Half Tagged" and "Order Partly Numbered" are the cases that
+ *     actually broke — SQLite sorts NULL FIRST, so a track missing its disc
+ *     or track number used to be hoisted above the properly tagged ones.
+ *     Both fail on every surface here against the pre-fix ordering (6 of
+ *     these 9 assertions do).
+ *   - "Order Two Disc" is fully tagged, so the old and new orderings agree
+ *     on it and it is NOT a regression guard for that fix. It is here to
+ *     pin disc separation itself: a two-disc set whose track numbers restart
+ *     at 1 must not interleave, which is what a future refactor dropping the
+ *     disc term would do.
+ *
+ * Titles are deliberately anti-alphabetical, so a regression to alphabetical
+ * — or to raw filepath order, since the files are named after their titles —
+ * shows up as a wrong result rather than an accidental pass.
+ *
+ * Tags are written BARE (`disc: 1`, not `1/2`) on purpose. The combined
+ * "N/total" form is the subject of test/scanner/scanner-track-disc-numbers
+ * .test.mjs and depends on which rust-parser binary is on disk; this suite is
+ * about ORDERING, so it uses the tag shape every scanner build reads
+ * identically and stays deterministic either way.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { startServer } from '../helpers/server.mjs';
+import { generateLibrary, mkSpec } from '../helpers/library-gen.mjs';
+
+const VPATH = 'ordersurf';
+
+// [album, title, track, disc]. disc === null means the file carries no disc
+// tag at all — the case that used to sort first.
+const TRACKS = [
+  ['Order Two Disc',      'Zulu',     1, 1],
+  ['Order Two Disc',      'Yankee',   2, 1],
+  ['Order Two Disc',      'Alpha',    1, 2],
+  ['Order Two Disc',      'Bravo',    2, 2],
+
+  ['Order Half Tagged',   'Zulu',     1, 1],
+  ['Order Half Tagged',   'Yankee',   2, null],
+  ['Order Half Tagged',   'Xray',     3, 1],
+  ['Order Half Tagged',   'Whiskey',  4, null],
+
+  ['Order Partly Numbered', 'Zulu',     1,    1],
+  ['Order Partly Numbered', 'Yankee',   2,    1],
+  ['Order Partly Numbered', 'Alpha',    null, 1],
+  ['Order Partly Numbered', 'Bravo',    null, 1],
+];
+
+// What each album must look like, top to bottom.
+const EXPECTED = {
+  // Disc 2 follows disc 1 even though its track numbers restart at 1.
+  // Alphabetical would be Alpha, Bravo, Yankee, Zulu; disc-blind track order
+  // would interleave as Zulu, Alpha, Yankee, Bravo.
+  'Order Two Disc': ['Zulu', 'Yankee', 'Alpha', 'Bravo'],
+  // The untagged-disc tracks belong WITH disc 1 (COALESCE(disc_number, 1)),
+  // interleaved by track number — not stacked on top as NULL-first gave.
+  'Order Half Tagged': ['Zulu', 'Yankee', 'Xray', 'Whiskey'],
+  // Unnumbered tracks fall to the bottom and tie-break on title, which is
+  // what both the Subsonic and DLNA queries use as their last sort key.
+  'Order Partly Numbered': ['Zulu', 'Yankee', 'Alpha', 'Bravo'],
+};
+
+const USER = { username: 'order-admin', password: 'passw0rd-order' };
+
+let server;
+let tmpLib;
+let apiKey;
+
+before(async () => {
+  tmpLib = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-ordersurf-'));
+  await generateLibrary({
+    outputDir: tmpLib,
+    cleanFirst: true,
+    specs: TRACKS.map(([album, title, track, disc], i) => mkSpec({
+      // Named after the title, so filename order == alphabetical title order.
+      // Any fallback to filepath ordering is therefore indistinguishable from
+      // "sorted alphabetically" — exactly the regression being guarded.
+      filepath: `${album}/${title}.mp3`,
+      title,
+      artist: 'Order Artist',
+      album,
+      year: 2001,
+      ...(track != null ? { track } : {}),
+      ...(disc  != null ? { disc }  : {}),
+      toneFreq: 200 + i,
+    })),
+  });
+
+  server = await startServer({
+    // The helper grants ['testlib'] by default; without the curated vpath the
+    // user can't see it and every library-scoped query filters it away.
+    users: [{ ...USER, admin: true, vpaths: ['testlib', VPATH] }],
+    extraFolders: { [VPATH]: tmpLib },
+    dlnaMode: 'same-port',
+    subsonicMode: 'same-port',
+  });
+
+  const login = await fetch(`${server.baseUrl}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(USER),
+  });
+  const { token } = await login.json();
+  const keyResp = await fetch(`${server.baseUrl}/api/v1/user/api-keys`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-access-token': token },
+    body: JSON.stringify({ name: 'order-surfaces' }),
+  });
+  apiKey = (await keyResp.json()).key;
+  assert.ok(apiKey, 'expected an API key');
+});
+
+after(async () => {
+  if (server) { await server.stop(); }
+  if (tmpLib) { await fs.rm(tmpLib, { recursive: true, force: true }).catch(() => {}); }
+});
+
+// ── Subsonic ────────────────────────────────────────────────────────────────
+
+async function sub(method, params = {}) {
+  const q = new URLSearchParams({ f: 'json', apiKey, ...params });
+  const r = await fetch(`${server.baseUrl}/rest/${method}?${q}`);
+  const body = await r.json();
+  const env = body['subsonic-response'];
+  assert.equal(env.status, 'ok', `${method}: ${JSON.stringify(env.error || {})}`);
+  return env;
+}
+
+// Subsonic ids are opaque/encoded — resolve them by name rather than guessing.
+async function subsonicAlbumId(name) {
+  const env = await sub('getAlbumList2', { type: 'alphabeticalByName', size: 500 });
+  const hit = (env.albumList2?.album || []).find((a) => a.name === name);
+  assert.ok(hit, `album "${name}" missing from getAlbumList2`);
+  return hit.id;
+}
+
+describe('Subsonic album track ordering', () => {
+  for (const album of Object.keys(EXPECTED)) {
+    test(`getAlbum("${album}") is in disc/track order`, async () => {
+      const env = await sub('getAlbum', { id: await subsonicAlbumId(album) });
+      assert.deepEqual((env.album.song || []).map((s) => s.title), EXPECTED[album]);
+    });
+
+    test(`getMusicDirectory("${album}") is in disc/track order`, async () => {
+      const env = await sub('getMusicDirectory', { id: await subsonicAlbumId(album) });
+      assert.deepEqual((env.directory.child || []).map((c) => c.title), EXPECTED[album]);
+    });
+  }
+});
+
+// ── DLNA ────────────────────────────────────────────────────────────────────
+
+function soapBody(action, fields) {
+  const inner = Object.entries(fields).map(([k, v]) => `<${k}>${v}</${k}>`).join('');
+  return '<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+    + `<s:Body><u:${action} xmlns:u="urn:schemas-upnp-org:service:ContentDirectory:1">${inner}`
+    + `</u:${action}></s:Body></s:Envelope>`;
+}
+
+async function browse(objectId) {
+  const r = await fetch(`${server.baseUrl}/dlna/control/content-directory`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/xml',
+      SOAPACTION: '"urn:schemas-upnp-org:service:ContentDirectory:1#Browse"',
+    },
+    body: soapBody('Browse', {
+      ObjectID: objectId, BrowseFlag: 'BrowseDirectChildren', Filter: '*',
+      StartingIndex: 0, RequestedCount: 0, SortCriteria: '',
+    }),
+  });
+  assert.equal(r.status, 200, `Browse ${objectId} returned ${r.status}`);
+  return r.text();
+}
+
+// The DIDL payload is XML-escaped inside the SOAP envelope, so ids and titles
+// come back as &lt;container id=&quot;…&quot;&gt; / &lt;dc:title&gt;…
+const titlesOf = (xml) => [...xml.matchAll(/&lt;dc:title&gt;(.*?)&lt;\/dc:title&gt;/g)].map((m) => m[1]);
+
+function containerIdFor(xml, title) {
+  // Each container element carries its id before its title, so pair them up
+  // by walking the elements rather than matching across the whole document.
+  for (const el of xml.split('&lt;container ').slice(1)) {
+    const id = (el.match(/id=&quot;([^&]*)&quot;/) || [])[1];
+    const name = (el.match(/&lt;dc:title&gt;(.*?)&lt;\/dc:title&gt;/) || [])[1];
+    if (name === title) { return id; }
+  }
+  return null;
+}
+
+describe('DLNA album track ordering', () => {
+  let albumsContainerId;
+
+  before(async () => {
+    // root → "Music" → the library container for our curated vpath → Albums.
+    const root = await browse('0');
+    const musicId = containerIdFor(root, 'Music');
+    assert.ok(musicId, 'Music container not found in the DLNA root');
+    const libId = containerIdFor(await browse(musicId), VPATH);
+    assert.ok(libId, `library container "${VPATH}" not found under Music`);
+    albumsContainerId = containerIdFor(await browse(libId), 'Albums');
+    assert.ok(albumsContainerId, 'Albums view container not found under the library');
+  });
+
+  for (const album of Object.keys(EXPECTED)) {
+    test(`browsing "${album}" lists tracks in disc/track order`, async () => {
+      const albums = await browse(albumsContainerId);
+      const albumId = containerIdFor(albums, album);
+      assert.ok(albumId, `album container "${album}" not found`);
+      assert.deepEqual(titlesOf(await browse(albumId)), EXPECTED[album]);
+    });
+  }
+});

--- a/test/integration/album-track-order.test.mjs
+++ b/test/integration/album-track-order.test.mjs
@@ -1,0 +1,211 @@
+/**
+ * Album-view track ordering — /api/v1/db/album-songs.
+ *
+ * The webapp's album view renders this endpoint's rows in the order it
+ * receives them (webapp/alpha/m.js getAlbumSongs — no client-side sort), so
+ * this response IS the order the user sees.
+ *
+ * The ordering used to be a plain `t.disc_number, t.track_number, t.filepath`,
+ * and SQLite sorts NULL FIRST. Any track whose disc or track number was
+ * missing therefore jumped ABOVE the properly tagged ones, and an album with
+ * no track numbers at all fell through to the filepath tiebreak — i.e. showed
+ * up in alphabetical order. ALBUM_TRACK_ORDER (src/db/track-order.js) fixes
+ * both: a missing disc number means disc 1, and a missing track number sorts
+ * to the end of its disc.
+ *
+ * The upstream half of the same bug — the Rust scanner dropping track/disc
+ * numbers written in the "N/total" form — is covered by
+ * test/scanner/scanner-track-disc-numbers.test.mjs.
+ *
+ * Pattern mirrors test/integration/genre-agg-endpoints.test.mjs: boot a real
+ * mStream in public/no-users mode, seed the DB directly, hit the HTTP API.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForReady(baseUrl, timeoutMs = 30_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(`${baseUrl}/api/`);
+      if (r.status < 500) return;
+    } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+
+async function bootMstream(tmpDir, musicDir) {
+  const port = await findFreePort();
+  const config = {
+    port, address: '127.0.0.1', ui: 'default',
+    dlna:     { mode: 'disabled' },
+    subsonic: { mode: 'disabled' },
+    folders:  { testlib: { root: musicDir } },
+    storage: {
+      albumArtDirectory:   path.join(tmpDir, 'image-cache'),
+      dbDirectory:         path.join(tmpDir, 'db'),
+      logsDirectory:       path.join(tmpDir, 'logs'),
+    },
+    scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+  };
+  for (const dir of Object.values(config.storage)) {
+    await fs.mkdir(dir, { recursive: true });
+  }
+  const configPath = path.join(tmpDir, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2));
+  const proc = spawn(
+    process.execPath,
+    ['cli-boot-wrapper.js', '-j', configPath],
+    { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } },
+  );
+  proc.stdout.on('data', () => {});
+  proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    // Don't leak the child on a ready-timeout — a live orphan's stdio keeps
+    // this file's event loop open and the run hangs at exit instead of
+    // reporting the timeout.
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
+  return { proc, baseUrl, port };
+}
+
+async function killProc(proc) {
+  if (proc.exitCode != null || proc.signalCode != null) return;
+  proc.kill('SIGKILL');
+  await new Promise(r => proc.once('exit', r));
+}
+
+// Four albums, each isolating one ordering rule. Titles and filenames are
+// deliberately NOT in track order, so any fallback to alphabetical shows up
+// as a wrong result rather than an accidental pass.
+function seedDB(dbPath) {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA foreign_keys = ON');
+
+  const lib = db.prepare("SELECT id FROM libraries WHERE name = 'testlib'").get().id;
+  const artist = Number(db.prepare("INSERT INTO artists (name) VALUES ('Order Artist')").run().lastInsertRowid);
+  const insAlbum = db.prepare('INSERT INTO albums (name, artist_id, year) VALUES (?, ?, 2001)');
+  const insTrack = db.prepare(`
+    INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, track_number,
+                        disc_number, year, format, duration, file_hash, audio_hash, modified, scan_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 2001, 'flac', 180, ?, ?, 1700000000000, 'seed')
+  `);
+  let n = 0;
+  const album = (name, tracks) => {
+    const id = Number(insAlbum.run(name, artist).lastInsertRowid);
+    for (const [title, track, disc] of tracks) {
+      n += 1;
+      insTrack.run(`${name}/${title}.flac`, lib, title, artist, id, track, disc, `h${n}`, `a${n}`);
+    }
+  };
+
+  // The plain case: fully tagged, single disc. Alphabetical order would be
+  // Apple, Banana, Mango, Zebra — the exact symptom the fix is about.
+  album('Tagged Album', [
+    ['Zebra', 1, 1], ['Mango', 2, 1], ['Banana', 3, 1], ['Apple', 4, 1],
+  ]);
+
+  // Only SOME files carry a disc tag — the common case after a partial
+  // re-tag, or (before the scanner fix) a mixed-format album. The untagged
+  // ones must interleave with disc 1, not stack on top of it.
+  album('Half Disc Tagged', [
+    ['Zebra', 1, 1], ['Mango', 2, null], ['Banana', 3, 1], ['Apple', 4, null],
+  ]);
+
+  // Genuine two-disc set: disc 2 must follow disc 1 even though its track
+  // numbers restart at 1.
+  album('Two Disc Set', [
+    ['Zebra', 1, 1], ['Mango', 2, 1], ['Apple', 1, 2], ['Banana', 2, 2],
+  ]);
+
+  // Tracks with no number at all belong at the BOTTOM of the album, ordered
+  // by filepath among themselves — not hoisted above the numbered ones.
+  album('Partly Numbered', [
+    ['Zebra', 1, 1], ['Mango', 2, 1], ['Apple', null, 1], ['Banana', null, null],
+  ]);
+
+  db.close();
+}
+
+async function albumSongs(baseUrl, album) {
+  const r = await fetch(`${baseUrl}/api/v1/db/album-songs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ album }),
+  });
+  assert.equal(r.status, 200, `album-songs ${album} returned ${r.status}`);
+  return (await r.json()).map(x => x.metadata.title);
+}
+
+describe('album view track ordering', () => {
+  let tmpDir;
+  let server;
+
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-albumorder-'));
+    const musicDir = path.join(tmpDir, 'music');
+    await fs.mkdir(musicDir, { recursive: true });
+    server = await bootMstream(tmpDir, musicDir);
+    await killProc(server.proc);
+    await sleep(200);
+    seedDB(path.join(tmpDir, 'db', 'mstream.db'));
+    server = await bootMstream(tmpDir, musicDir);
+  });
+
+  after(async () => {
+    if (server?.proc) await killProc(server.proc);
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('a fully tagged album comes back in track order, not alphabetical', async () => {
+    assert.deepEqual(await albumSongs(server.baseUrl, 'Tagged Album'),
+      ['Zebra', 'Mango', 'Banana', 'Apple']);
+  });
+
+  test('tracks with no disc tag interleave with disc 1 instead of jumping above it', async () => {
+    assert.deepEqual(await albumSongs(server.baseUrl, 'Half Disc Tagged'),
+      ['Zebra', 'Mango', 'Banana', 'Apple']);
+  });
+
+  test('disc 2 follows disc 1 even though its track numbers restart', async () => {
+    assert.deepEqual(await albumSongs(server.baseUrl, 'Two Disc Set'),
+      ['Zebra', 'Mango', 'Apple', 'Banana']);
+  });
+
+  test('tracks with no track number sort to the end, not the start', async () => {
+    // Apple and Banana are unnumbered, so they land last and fall back to
+    // filepath order between themselves.
+    assert.deepEqual(await albumSongs(server.baseUrl, 'Partly Numbered'),
+      ['Zebra', 'Mango', 'Apple', 'Banana']);
+  });
+});

--- a/test/scanner/scanner-track-disc-numbers.test.mjs
+++ b/test/scanner/scanner-track-disc-numbers.test.mjs
@@ -1,0 +1,160 @@
+/**
+ * Track / disc number ingestion — both-scanner parity.
+ *
+ * Taggers write these two numbers either bare (`3`) or in the combined
+ * "N of total" form (`3/9`). lofty's typed accessors split the combined form
+ * for ID3v2 (TRCK/TPOS) and MP4 (trkn/disk), and for Vorbis TRACKNUMBER — but
+ * NOT for Vorbis DISCNUMBER or RIFF INFO's ITRK, where `Accessor::disk()` /
+ * `Accessor::track()` return None outright. That silently cost the Rust
+ * scanner (the default) the numbers music-metadata reads fine:
+ *
+ *   • a multi-disc FLAC/OGG/Opus set tagged `DISCNUMBER=1/2` landed with
+ *     disc_number NULL on every track, so the album view interleaved the
+ *     discs (disc 1 track 1, disc 2 track 1, disc 1 track 2, …);
+ *   • a WAV album tagged `track=1/4` landed with track_number NULL on every
+ *     track, so the album view fell through to its filepath tiebreak and
+ *     showed the album in alphabetical order.
+ *
+ * rust-parser now re-reads the raw tag string and splits it itself
+ * (parse_num_of). This test locks that in for BOTH engines, so the two can't
+ * drift apart again.
+ *
+ * Skipped when the bundled ffmpeg or a usable rust-parser binary is absent
+ * (same gate as the other scanner-parity tests).
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  findRustParser, FFMPEG, initEmptyDb, buildScanConfig, runScan, runJsScan,
+} from '../helpers/scanner-runner.mjs';
+import { makeAudio } from '../helpers/scanner-fixture.mjs';
+
+const MP3  = ['-c:a', 'libmp3lame', '-b:a', '64k', '-id3v2_version', '3'];
+const FLAC = ['-c:a', 'flac'];
+const OGG  = ['-c:a', 'libvorbis', '-q:a', '2'];
+const WAV  = ['-c:a', 'pcm_s16le'];
+
+// One row per fixture: [title, codec, tags, expected track/disc/totals].
+// `track` / `disc` are written verbatim as ffmpeg -metadata values, so they
+// carry the exact tag shape (bare vs "N/total") each case is about.
+const CASES = [
+  { title: 'Flac Combined', codec: FLAC, ext: 'flac', tags: { track: '1/9', disc: '1/2' },
+    want: { track_number: 1, disc_number: 1, track_total: 9, disc_total: 2 },
+    why: 'Vorbis DISCNUMBER=1/2 — the form lofty\'s disk() cannot split' },
+  { title: 'Flac Bare', codec: FLAC, ext: 'flac', tags: { track: '2', disc: '2' },
+    want: { track_number: 2, disc_number: 2, track_total: null, disc_total: null },
+    why: 'bare Vorbis values — the control that always worked' },
+  { title: 'Ogg Combined', codec: OGG, ext: 'ogg', tags: { track: '3/9', disc: '2/2' },
+    want: { track_number: 3, disc_number: 2, track_total: 9, disc_total: 2 },
+    why: 'Vorbis comments again, different container' },
+  { title: 'Wav Combined', codec: WAV, ext: 'wav', tags: { track: '4/9' },
+    want: { track_number: 4, disc_number: null, track_total: 9, disc_total: null },
+    why: 'RIFF INFO ITRK=4/9 — the form lofty\'s track() cannot split' },
+  { title: 'Mp3 Combined', codec: MP3, ext: 'mp3', tags: { track: '5/9', disc: '1/2' },
+    want: { track_number: 5, disc_number: 1, track_total: 9, disc_total: 2 },
+    why: 'ID3v2 TRCK/TPOS — lofty splits these natively' },
+  { title: 'Vinyl Side', codec: FLAC, ext: 'flac', tags: { track: 'A1' },
+    want: { track_number: null, disc_number: null, track_total: null, disc_total: null },
+    why: 'non-numeric side numbering stays NULL rather than becoming a bogus number' },
+  { title: 'No Numbers', codec: FLAC, ext: 'flac', tags: {},
+    want: { track_number: null, disc_number: null, track_total: null, disc_total: null },
+    why: 'no tag at all' },
+];
+
+let rustBin;
+let workDir;
+let libRoot;
+// Capability probe (the protocol-PR CI rule): a full-ci run tests against
+// MASTER's prebuilt rust-parser, which predates parse_num_of until the
+// post-merge binaries rebuild — the rust leg must skip on an old binary, not
+// fail. The probe scan doubles as the rust leg's actual scan (no double work);
+// the JS leg always covers the ingestion logic either way.
+let rustDbPath = null;
+let rustSplitsCombined = false;
+
+before(async () => {
+  rustBin = findRustParser();
+  if (!rustBin || !fs.existsSync(FFMPEG)) { return; } // tests skip
+
+  workDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'mstream-tracknums-'));
+  libRoot = path.join(workDir, 'library');
+  await fsp.mkdir(libRoot, { recursive: true });
+
+  for (const c of CASES) {
+    await makeAudio(
+      path.join(libRoot, 'Numbered Artist', 'Numbered Album', `${c.title}.${c.ext}`),
+      c.codec,
+      { title: c.title, artist: 'Numbered Artist', album: 'Numbered Album', ...c.tags },
+    );
+  }
+
+  rustDbPath = await scanWith('rust');
+  rustSplitsCombined = trackByTitle(rustDbPath, 'Flac Combined')?.disc_number === 1;
+});
+
+after(async () => {
+  if (workDir) { await fsp.rm(workDir, { recursive: true, force: true }).catch(() => {}); }
+});
+
+// Run one scan with the given engine into a fresh DB and return its path.
+async function scanWith(engine) {
+  const dbPath = path.join(workDir, `db-${engine}.db`);
+  const artDir = path.join(workDir, `art-${engine}`);
+  const wfDir  = path.join(workDir, `wf-${engine}`);
+  await fsp.mkdir(artDir, { recursive: true });
+  await fsp.mkdir(wfDir, { recursive: true });
+  const { libraryId, vpath } = initEmptyDb(dbPath, libRoot, 'testlib');
+  const cfg = buildScanConfig({
+    dbPath, libraryId, vpath, directory: libRoot,
+    albumArtDirectory: artDir, waveformCacheDir: wfDir,
+    scanId: `tracknums-${engine}`,
+  });
+  const runner = engine === 'rust' ? (c => runScan(rustBin, c)) : runJsScan;
+  await runner(cfg);
+  return dbPath;
+}
+
+function trackByTitle(dbPath, title) {
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db.prepare(
+      'SELECT track_number, disc_number, track_total, disc_total FROM tracks WHERE title = ?',
+    ).get(title);
+  } finally {
+    db.close();
+  }
+}
+
+describe('track / disc number ingestion', () => {
+  for (const engine of ['rust', 'js']) {
+    test(`[${engine}] reads bare and "N/total" track + disc tags`, async (t) => {
+      if (!rustBin)               { return t.skip('no rust-parser binary'); }
+      if (!fs.existsSync(FFMPEG)) { return t.skip('no bundled ffmpeg'); }
+      if (engine === 'rust' && !rustSplitsCombined) {
+        return t.skip('rust-parser binary predates the "N/total" tag split '
+          + '(CI prebuilt until the post-merge rebuild) — the JS leg still covers the logic');
+      }
+
+      const dbPath = engine === 'rust' ? rustDbPath : await scanWith(engine);
+
+      for (const c of CASES) {
+        const row = trackByTitle(dbPath, c.title);
+        assert.ok(row, `[${engine}] ${c.title} was scanned`);
+        assert.deepEqual(
+          {
+            track_number: row.track_number, disc_number: row.disc_number,
+            track_total: row.track_total, disc_total: row.disc_total,
+          },
+          c.want,
+          `[${engine}] ${c.title}: ${c.why}`,
+        );
+      }
+    });
+  }
+});


### PR DESCRIPTION
A user reported that the webapp album view ignores track order and lists songs alphabetically. Replicated, and it turned out to be two independent bugs stacked on top of each other.

## Root cause 1 — the Rust scanner drops `N/total` track and disc numbers

lofty's typed accessors split the combined `7/12` form for ID3v2 (TRCK/TPOS) and MP4 (trkn/disk), and for Vorbis `TRACKNUMBER` — but **not** for Vorbis `DISCNUMBER` or RIFF INFO's `ITRK`, where they return `None` outright. music-metadata (the JS fallback scanner) parses all of them, so the two scanners silently disagreed.

Measured with identical fixtures (`track=7/12`, `disc=1/2`):

| format | rust-parser (before) | music-metadata |
|---|---|---|
| mp3, m4a | track 7, disc 1 ✅ | ✅ |
| flac, ogg, opus | track 7, **disc NULL** ❌ | ✅ |
| wav | **track NULL** ❌ | ✅ |

End to end in the album view — a WAV album tagged `1/4` … `4/4`, which is the literal report:

```
1. Apple   2. Banana   3. Mango   4. Zebra      ← alphabetical
```

Every `track_number` was NULL, so the query fell through to its `filepath` tiebreak. The FLAC shape of the same bug is a multi-disc set tagged `DISCNUMBER=1/2`: disc numbers all NULL, discs interleaved (disc1 t1, disc2 t1, disc1 t2…).

`extract_track` now re-reads the raw `ItemKey::TrackNumber` / `ItemKey::DiscNumber` string and splits it itself for whichever half the typed accessor left empty (`parse_num_of`). Parsed as `u32` — the accessors' own domain — so the fallback can't admit a value the primary path would have refused, and `A1`-style vinyl side numbering stays NULL rather than becoming a bogus number.

## Root cause 2 — the album `ORDER BY` sorted NULLs first

`ORDER BY t.disc_number, t.track_number, t.filepath` — SQLite sorts NULL **first**, so any track missing a number jumped *above* the properly tagged ones. An album where only some files carry a disc tag came back `2, 4, 1, 3`.

New `ALBUM_TRACK_ORDER` (`src/db/track-order.js`) replaces it everywhere an album's tracks are listed — the webapp album view, genre songs, the Subsonic album/directory browsers, the DLNA content directory:

```sql
COALESCE(t.disc_number, 1), t.track_number IS NULL, t.track_number
```

No disc tag means disc 1 (single-disc rips usually carry none), so partially tagged albums interleave with disc 1 instead of stacking on top of it, and a real disc 2 still sorts after. No track number sorts to the bottom of its disc instead of the top.

Query plans are unchanged — both forms already used a temp b-tree, and there's no composite index on `(album_id, disc_number, track_number)` to lose. It lives in its own dependency-free module rather than in `src/api/db.js` because `src/api/dlna.js` needs it too, and `db.js` already reaches `dlna.js` through `src/db/task-queue.js` — importing it from there would close a cycle.

## V66 so existing libraries actually heal

The scanner fix only applies when a file is re-parsed, and unchanged files ride the mtime fast-path — every library scanned by an older build would keep its NULLs until the user guessed at a manual force-rescan. V66 is a rescan marker with no schema change (same shape as V49); the next boot runs the resumable migration rescan and repairs them.

Verified the whole upgrade path against a v65 DB carrying the NULLs: boot → `Database schema v65 → v66` → `Rescan pending from migration` → album view correct, no user action.

## Verification

Real dev instance, default UI, before → after:

| album | before | after |
|---|---|---|
| 2-disc FLAC, `DISCNUMBER=1/2` | d1t1, d2t1, d1t2, d2t2, … | d1t1, d1t2, d1t3, d2t1, d2t2, d2t3 |
| WAV album, `track=n/4` | Apple, Banana, Mango, Zebra | Zebra, Apple, Mango, Banana (tracks 1–4) |
| mixed disc tagging | 2, 4, 1, 3 | 1, 2, 3, 4 |

Tests added:

- `test/scanner/scanner-track-disc-numbers.test.mjs` — both engines, seven tag shapes across mp3/flac/ogg/wav (bare, combined, non-numeric, absent). Carries the capability probe the other scanner-parity tests use, so the rust leg skips rather than fails against master's prebuilt binary until the post-merge rebuild.
- `test/integration/album-track-order.test.mjs` — the four ordering rules over the real HTTP endpoint. Two of them fail against the old `ORDER BY`.
- `test/integration/album-track-order-surfaces.test.mjs` — the same rules over **Subsonic** (`getAlbum`, `getMusicDirectory`) and **DLNA** (SOAP album browse), which had no ordering coverage at all: the shared fixture library is entirely `disc: 1` with no NULLs, so every existing test on those surfaces would pass just as happily with the discs interleaved or the untagged tracks hoisted. Builds a curated library through `extraFolders` so both surfaces answer from real scanner-indexed data. 6 of its 9 assertions fail against the old `ORDER BY`.

Full suite locally: **2327 tests, 0 failures** (one heavy suite got cancelled by a 90s timeout under parallel load and passes standalone). `npx eslint` clean on the changed files; `cargo clippy` clean on the new code.

`bin/rust-parser/*` is deliberately untouched — CI rebuilds it on push to master, and the new scanner test skips its rust leg until it does.

## Not in scope

If the reporter actually meant the **File Explorer** panel (browsing album *folders*), that's a different code path: `getDirectoryContents` sorts strictly by filename with `localeCompare`, so `10 - x.mp3` sorts before `2 - x.mp3`. That's #357 and it's untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


