### PR TITLE
install.sh: fix mac login-item ownership check; never delete a running app's tree

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
 
@@ -173,6 +173,98 @@ jobs:
           if (Test-Path "$env:RUNNER_TEMP\app") { throw "app root survived uninstall" }
           if (($un | Out-String) -notmatch 'left in place') { throw "no data-home note" }
           Write-Host "install.ps1 contract OK"
+
+      # The darwin-only paths: ~/Applications copy + sibling ownership marker,
+      # login-item re-pointing through the RIGHT launcher, and the
+      # refresh-while-running rules. Self-contained: rebuilds the fake darwin
+      # bundle with an instrumented launcher stub (records which binary ran
+      # --autostart=enable, writes the same one-line plist the auto-launch
+      # crate writes) and a server stub, then walks fresh install -> enabled
+      # upgrade -> running upgrade -> idle upgrade -> uninstall. HOME is
+      # redirected so the runner's real ~/Applications is never touched.
+      - name: install.sh end to end (macos)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/home"
+          mkdir -p "$HOME/Applications" "$HOME/Library/LaunchAgents"
+          export MSTREAM_STUB_DIR="$RUNNER_TEMP/stub"; mkdir -p "$MSTREAM_STUB_DIR"
+          export MSTREAM_RELEASE_BASE=http://127.0.0.1:8765
+          DKEY="darwin-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"
+          DEST="$HOME/Applications/mStream.app"
+          ROOT="$HOME/Library/Application Support/mStream/app"
+          cat > "$RUNNER_TEMP/stub-launcher" <<'STUB'
+          #!/bin/sh
+          d="$MSTREAM_STUB_DIR"
+          case "$1" in
+            --autostart=status) cat "$d/state" 2>/dev/null || echo disabled ;;
+            --autostart=enable)
+              echo enabled > "$d/state"
+              printf '%s\n' "$0" >> "$d/enable-calls"
+              printf '<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict><key>Label</key><string>mStream</string><key>ProgramArguments</key><array><string>%s</string><string>--autostarted</string></array><key>RunAtLoad</key><true/></dict></plist>' "$0" > "$HOME/Library/LaunchAgents/mStream.plist"
+              ;;
+            --autostart=disable) echo disabled > "$d/state"; rm -f "$HOME/Library/LaunchAgents/mStream.plist" ;;
+          esac
+          exit 0
+          STUB
+          mkrel() {
+            rm -f rel/mStream-*.zip rel/manifest.json
+            b="mStream-$1-$DKEY"; mkdir -p "rel/$b/mStream.app/Contents/MacOS"
+            printf '%s\n' "$1" > "rel/$b/mStream.app/Contents/VERSION"
+            printf '#!/bin/sh\n[ "$1" = -V ] && echo %s\nexit 0\n' "$1" > "rel/$b/mStream.app/Contents/MacOS/mstream-server"
+            cp "$RUNNER_TEMP/stub-launcher" "rel/$b/mStream.app/Contents/MacOS/mStream"
+            chmod +x "rel/$b/mStream.app/Contents/MacOS/mstream-server" "rel/$b/mStream.app/Contents/MacOS/mStream"
+            echo "fake bundle" > "rel/$b/README.txt"
+            (cd rel && python3 -m zipfile -c "$b.zip" "$b" && rm -rf "$b")
+            sh scripts/release-manifest.sh "$1" rel >/dev/null
+          }
+          # A: fresh install - copy, sibling marker, untouched login item
+          mkrel 9.9.9
+          sh install.sh > a.log 2>&1 || { cat a.log; exit 1; }
+          [ "$(readlink "$ROOT/current")" = "$ROOT/mStream-9.9.9-$DKEY" ]
+          [ "$(cat "$DEST/Contents/VERSION")" = 9.9.9 ]
+          [ "$(cat "$HOME/Applications/.mstream-installer")" = 9.9.9 ]
+          [ ! -f "$MSTREAM_STUB_DIR/enable-calls" ]
+          # B: with the login item enabled, an upgrade re-points it - and the
+          # enable must run through the ~/APPLICATIONS launcher (the stable
+          # path), not $ROOT/current: the sibling-marker ownership check.
+          "$DEST/Contents/MacOS/mStream" --autostart=enable
+          : > "$MSTREAM_STUB_DIR/enable-calls"
+          mkrel 9.9.10
+          sh install.sh > b.log 2>&1 || { cat b.log; exit 1; }
+          grep -q "login item re-pointed at 9.9.10" b.log
+          [ "$(tail -1 "$MSTREAM_STUB_DIR/enable-calls")" = "$DEST/Contents/MacOS/mStream" ]
+          [ "$(cat "$HOME/Applications/.mstream-installer")" = 9.9.10 ]
+          # C: upgrade while mStream runs from ~/Applications - the old tree
+          # is moved aside INTACT (a live process reads webapp/sidecars from
+          # it), never rm -rf'd; the running-instance note is printed.
+          bash -c "exec -a '$DEST/Contents/MacOS/mstream-server' sleep 600" &
+          HANG=$!
+          sleep 1
+          pgrep -f "^$DEST/" >/dev/null
+          mkrel 9.9.11
+          sh install.sh > c.log 2>&1 || { cat c.log; exit 1; }
+          [ "$(cat "$DEST/Contents/VERSION")" = 9.9.11 ]
+          [ "$(ls -d "$DEST".old.* | wc -l | tr -d ' ')" = 1 ]
+          olddir=$(ls -d "$DEST".old.*)
+          [ "$(cat "$olddir/Contents/VERSION")" = 9.9.10 ]
+          [ -x "$olddir/Contents/MacOS/mstream-server" ]
+          kill -0 "$HANG"
+          grep -q "currently running from" c.log
+          # D: once idle, the next upgrade sweeps the aside
+          kill "$HANG"; wait "$HANG" 2>/dev/null || true
+          mkrel 9.9.12
+          sh install.sh > d.log 2>&1 || { cat d.log; exit 1; }
+          [ "$(cat "$DEST/Contents/VERSION")" = 9.9.12 ]
+          if ls -d "$DEST".old.* 2>/dev/null; then echo "::error::stale aside survived an idle upgrade"; exit 1; fi
+          # E: uninstall removes copy, marker, login item, root - keeps data
+          MSTREAM_UNINSTALL=1 sh install.sh > e.log 2>&1 || { cat e.log; exit 1; }
+          [ ! -e "$ROOT" ] && [ ! -e "$DEST" ]
+          [ ! -e "$HOME/Applications/.mstream-installer" ]
+          [ ! -e "$HOME/Library/LaunchAgents/mStream.plist" ]
+          grep -q "left in place" e.log
+          echo "install.sh darwin contract OK"
 
   build:
     name: ${{ matrix.key }}

--- a/install.sh
+++ b/install.sh
@@ -401,14 +401,40 @@ if [ -z "${MSTREAM_NO_DESKTOP:-}" ]; then
         # hand (no marker) is left alone.
         mkdir -p "$HOME/Applications"
         dest="$HOME/Applications/mStream.app"
+        # Is anything running from under this path? pgrep matches the COMMAND
+        # string (argv), which keeps saying the ORIGINAL path even after the
+        # directory is renamed aside - so a busy $dest also means the .old.*
+        # asides may be live trees, and none of them can be swept this run.
+        apps_busy() { command -v pgrep >/dev/null 2>&1 && pgrep -f "^$1/" >/dev/null 2>&1; }
         if [ -e "$dest" ] && [ ! -L "$dest" ] && ! apps_copy_is_ours; then
             desktop_note="app: $ROOT/current/mStream.app  (~/Applications/mStream.app is your own copy - replace it with this one when you're ready)"
         elif [ -n "$installed_fresh" ] || [ ! -e "$dest" ]; then
+            # Sweep asides left by earlier upgrades that ran while mStream was
+            # live (below) - only once nothing runs from the copy at all.
+            if ! apps_busy "$dest"; then
+                for old in "$dest".old.*; do
+                    [ -e "$old" ] || continue
+                    apps_busy "$old" && continue
+                    rm -rf "$old"
+                done
+            fi
             rm -rf "$dest.installing"
             if ditto "$ROOT/$bundle/mStream.app" "$dest.installing" 2>/dev/null; then
                 # A symlink from an older run of this script gives way too.
                 [ -L "$dest" ] && rm -f "$dest"
-                [ -d "$dest" ] && mv "$dest" "$dest.old.$$" && rm -rf "$dest.old.$$"
+                if [ -d "$dest" ]; then
+                    # Replace the directory ENTRY, but never delete a tree a
+                    # live process runs from: the binary itself survives an
+                    # unlink, but the running app's webapp/ and bin/ sidecars
+                    # are read from disk on demand - rm -rf here kills its UI
+                    # mid-flight. Move the old copy aside instead; a later
+                    # idle run sweeps it (above).
+                    if apps_busy "$dest"; then
+                        mv "$dest" "$dest.old.$(date +%Y%m%d%H%M%S).$$"
+                    else
+                        mv "$dest" "$dest.old.$$" && rm -rf "$dest.old.$$"
+                    fi
+                fi
                 mv "$dest.installing" "$dest"
                 # Marker AFTER the copy is in place, and OUTSIDE the bundle.
                 # (This also heals a copy from the old installer, which wrote
@@ -435,9 +461,13 @@ fi
 # no server, no window. Only when the user has it enabled - never turn it
 # on for them here. Which launcher: the one the user actually opens - the
 # ~/Applications copy on macOS when this installer owns it (a stable path
-# across upgrades), else the one behind `current`.
+# across upgrades), else the one behind `current`. Ownership means
+# apps_copy_is_ours - the SIBLING marker; testing only the legacy inner
+# marker here made every current-installer install re-point the login item
+# at the versioned folder instead, exactly what this step exists to avoid.
 launcher="$ROOT/current/$launcher_rel"
-if [ "$platform" = darwin ] && [ -f "$HOME/Applications/mStream.app/Contents/.mstream-installer" ]; then
+if [ "$platform" = darwin ] && apps_copy_is_ours \
+    && [ -x "$HOME/Applications/mStream.app/Contents/MacOS/mStream" ]; then
     launcher="$HOME/Applications/mStream.app/Contents/MacOS/mStream"
 fi
 if [ -x "$launcher" ] && [ -n "$installed_fresh" ]; then


### PR DESCRIPTION
Two darwin upgrade bugs in `install.sh`, both found while designing the auto-update feature that will run this script on a schedule (plan: server-staged updates drive the installer weekly, so these latent paths become routine). Shipping the fixes first, independently.

## Fix 1 — login item re-pointed through the wrong launcher

The upgrade-time launcher selection tested only the **legacy inner marker** (`Contents/.mstream-installer`), which current installs no longer write. On every current-installer machine the condition was false, so `--autostart=enable` ran through `$ROOT/current/…` — and since the launcher registers `current_exe()` (symlink-resolved), the login item pinned to the **versioned folder**. The next login silently started the old version; the comment right above the code says this step exists to prevent exactly that. Ownership now means `apps_copy_is_ours()` (sibling marker), matching the uninstall path, plus an `-x` guard so a stale marker with a deleted app falls back to `$ROOT/current`.

## Fix 2 — upgrading while running deleted the live app's tree

The `~/Applications` refresh did `mv` aside + `rm -rf` unconditionally. If mStream was **running from that copy**, the running binary survives the unlink, but its `webapp/` and `bin/` sidecars are read from disk on demand — the UI dies at install time. Now:

- while anything runs from the copy, the old tree is **moved aside intact** (`mStream.app.old.<ts>.<pid>`) and the new copy takes its place; the running instance keeps working until restarted (the existing "still running the old version" note covers messaging)
- a later **idle** run sweeps stale asides — and the sweep additionally requires the copy itself to be idle, because a renamed-aside tree keeps its original argv paths: checking only the aside's own path would re-create the bug one rename removed

## CI

`installer-contract` gains a **macos-latest leg** (self-contained; ubuntu/windows legs untouched). An instrumented launcher stub records which binary ran `--autostart=enable` and writes the same one-line plist the auto-launch crate writes, so `login_item_target`/`login_item_is_ours` execute for real; a fake running process (`exec -a`, so argv looks like a Mach-O path under the copy) drives the running-upgrade and idle-sweep scenarios. Sequence: fresh install → enabled upgrade (fix 1 assert) → running upgrade (fix 2 assert) → idle sweep → uninstall.

## Verification

- Full scenario matrix run locally on macOS (arm64): all pass
- **Negative controls**: the same harness against the unfixed script fails exactly at the fix-1 assert (`enable` ran as `$ROOT/current/…/mStream`), and the fix-2 scenario against the unfixed script leaves zero asides — the running process's tree was deleted
- The exact extracted CI step body (post-YAML-strip) executed locally end-to-end: green; workflow YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)