### PR TITLE
test(discovery-p2p): don't require a running sidecar where CI can never have one

### DIFF
--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -1325,13 +1325,29 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
   after(async () => { if (server) { await server.stop(); } });
 
   test('server boots, joins the topic, and the p2p surface works', async () => {
+    // What "works" means depends on whether a sidecar binary exists here.
+    //
+    // WITH one, the sidecar must actually come up and be joined-or-joinable.
+    // WITHOUT one there is nothing to come up, and that is now the norm in
+    // CI: the binaries left git when the sidecar moved to its own repo
+    // (fetch-on-first-use, pinned per release), and startServer deliberately
+    // pins MSTREAM_SIDECAR_BASE to a dead port so no suite can pull one
+    // mid-test. Waiting on `running` in that case can only ever time out —
+    // which is exactly what it did on every OS once the binaries left, while
+    // still passing for anyone with a local dev build in p2p-sidecar/target.
+    //
+    // Either way the invariant this suite exists for is the same, and it is
+    // the weaker one: an unreachable community-seed list must not wedge the
+    // boot path. So require `running` only when it is achievable, and always
+    // require the status route to answer with the feature enabled.
     const status = await pollUntil(async () => {
       const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      if (!SIDECAR_BIN) { return s; }
       return s.running ? s : null;
-    }, { timeoutMs: 30000, what: 'sidecar up despite dead seed URL' });
-    // With the binary present the sidecar must still be running and joined-
-    // or-joinable; without it the route still answers. Either way the dead
-    // URL must not have prevented the boot path from completing.
+    }, {
+      timeoutMs: 30000,
+      what: SIDECAR_BIN ? 'sidecar up despite dead seed URL' : 'p2p status despite dead seed URL',
+    });
     assert.equal(status.enabled, true);
   });
 });


### PR DESCRIPTION
`discovery seeds — unreachable list degrades gracefully` fails on **every OS** on current master. It's blocking full CI on unrelated PRs — found while looking at the red checks on #861, which doesn't touch any of this.

## Why it can't pass

Two things have to be true at once, and as of `09a209cc` they no longer can be:

1. `startServer` pins `MSTREAM_SIDECAR_BASE` to a dead port **on purpose** ([test/helpers/server.mjs:274](test/helpers/server.mjs)), so no suite can pull the manifest-pinned binary from the real release mid-test.
2. `bin/p2p-sidecar/` no longer ships binaries — the crate moved to `IrosTheBeggar/mstream-p2p-sidecar` and mStream fetches on first use.

No binary on disk, no way to fetch one ⇒ the sidecar cannot start ⇒ polling for `status.running` can only burn its 30s and throw:

```
✖ server boots, joins the topic, and the p2p surface works (30204ms)
  Error: timed out waiting for sidecar up despite dead seed URL
```

It still passes locally for anyone with a dev build in `p2p-sidecar/target/release/`, which is why it went unnoticed: the last green `test.yml` run (2026-08-18 23:15) predates the split, and this is the first full-CI run since.

## The change

Every other sidecar-dependent `describe` in this file is gated on `SIDECAR_BIN`. This one deliberately isn't — its subject is the community-seed list, not the sidecar — and its comment already said *"without it the route still answers"*. The assertion simply didn't match the comment.

So: require `running` only when a binary makes it achievable, and in both cases require what this suite actually exists to prove — an unreachable seed list must not wedge the boot path, and the status route still answers with the feature enabled.

## Verified both ways locally

| condition | before | after |
|---|---|---|
| dev sidecar on disk | 44 pass / 0 fail | 44 pass / 0 fail |
| no binary anywhere (CI's exact state) | 21 pass / **1 fail** | 22 pass / 0 fail |

Confirmed the run stays hermetic — `bin/p2p-sidecar/` is still binary-free afterwards, nothing was downloaded.

## Follow-up, not fixed here

With the dead-base guard in place, **nothing in the suite exercises boot-with-fetch** — the path every fresh install now takes. The fetch machinery itself is fine: `test/unit/p2p-sidecar-fetch.test.mjs` covers it against a loopback store, and a real boot with no binary downloads 6.7 MB, verifies the checksum and is ready in ~4.5s (measured). It's the *integration* between boot and fetch that has no coverage. Worth its own change — a loopback release store in an integration suite would close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
