### PR TITLE
Auto-update: server-side check, verify, and stage; apply on restart

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1806,11 +1806,12 @@ jobs:
             exit 1
           fi
           # The Windows setup.exe and the Linux deb/rpm packages ride the
-          # same artifact download into bundles/ (manifest.json stays
-          # zips-only by design — the install scripts and the future
-          # auto-updater consume zips; native installers are direct-download
-          # assets, and the manifest generator's mStream-*.zip glob never
-          # sees them).
+          # same artifact download into bundles/. manifest.json lists the
+          # zips (what the install scripts and the updater's managed staging
+          # consume) PLUS the setup.exe/.pkg installers — the in-app updater
+          # verifies those hashes before offering/launching them on Inno and
+          # pkg installs. deb/rpm stay unlisted: their integrity story is the
+          # package manager's.
           gh release upload "$TAG" bundles/*.zip bundles/manifest.json \
             bundles/mStream-*-win-x64-setup.exe \
             bundles/mstream_*.deb bundles/mstream-*.rpm \

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -134,9 +134,24 @@ jobs:
           # tampered manifest must refuse
           sed -i 's/"sha256": "[0-9a-f]*"/"sha256": "0000000000000000000000000000000000000000000000000000000000000000"/' rel/manifest.json
           if MSTREAM_FORCE=1 sh install.sh >/dev/null 2>&1; then echo "::error::installed despite bad hash"; exit 1; fi
-          # uninstall removes what was installed and nothing else
+          # a bundle whose binary cannot exec here must never take over
+          # `current`: probe-before-flip refuses, exits nonzero, keeps the
+          # working install (the in-app updater treats that exit as a failed
+          # stage instead of arming a landmine for the next restart)
+          bb="mStream-9.9.10-linux-x64"; mkdir -p "rel/$bb"
+          printf '#!/bin/sh\nexit 1\n' > "rel/$bb/mstream-server"; chmod +x "rel/$bb/mstream-server"
+          echo broken > "rel/$bb/README.txt"
+          rm -f rel/mStream-*.zip rel/manifest.json
+          (cd rel && python3 -m zipfile -c "$bb.zip" "$bb" && rm -rf "$bb")
+          sh scripts/release-manifest.sh 9.9.10 rel
+          if sh install.sh > broken.log 2>&1; then echo "::error::installed a bundle that cannot exec"; exit 1; fi
+          grep -q "does not run on this system" broken.log
+          [ "$(readlink "$RUNNER_TEMP/app/current")" = "$RUNNER_TEMP/app/mStream-9.9.9-linux-x64" ]
+          # uninstall removes what was installed and nothing else. The
+          # uninstall path exits before any feed fetch, so the (now 9.9.10-
+          # only) rel dir needs no rebuilding; checkout restores install.sh
+          # from the tamper-test's sed.
           git checkout -- . 2>/dev/null || true
-          sh scripts/release-manifest.sh 9.9.9 rel
           MSTREAM_UNINSTALL=1 sh install.sh | tee un.log
           [ ! -e "$RUNNER_TEMP/app" ] && [ ! -e "$RUNNER_TEMP/bin/mstream-server" ]
           grep -q "left in place" un.log
@@ -167,6 +182,26 @@ jobs:
           $env:MSTREAM_FORCE = '1'
           try { & .\install.ps1 *>&1 | Out-Null; throw "installed despite bad hash" } catch { if ("$_" -notmatch 'sha256 mismatch') { throw } }
           $env:MSTREAM_FORCE = $null
+          # a bundle whose binary cannot exec must never take over `current`:
+          # probe-before-flip refuses (throws, nonzero exit) and keeps the
+          # working install. The fake 9.9.9 exe is already non-executable,
+          # which is exactly the probe-failure shape; only the presence of a
+          # working-or-first-install current decides advisory vs refusal.
+          $bb = 'mStream-9.9.10-win-x64'
+          Remove-Item rel\mStream-*.zip, rel\manifest.json -Force
+          # zip from INSIDE rel so entries carry no rel\ prefix
+          Push-Location rel
+          New-Item -ItemType Directory -Force $bb | Out-Null
+          Set-Content "$bb\mstream-server.exe" 'broken'
+          Set-Content "$bb\README.txt" 'broken'
+          python3 -m zipfile -c "$bb.zip" $bb
+          Remove-Item -Recurse -Force $bb
+          Pop-Location
+          # bash, not sh: git-bash's bash.exe is on the runner PATH for pwsh
+          bash scripts/release-manifest.sh 9.9.10 rel
+          try { & .\install.ps1 *>&1 | Out-Null; throw "installed a bundle that cannot exec" } catch { if ("$_" -notmatch 'does not run on this system') { throw } }
+          $j2 = Get-Item "$env:RUNNER_TEMP\app\current" -Force
+          if (($j2.Target | Select-Object -First 1) -notmatch 'mStream-9\.9\.9-win-x64$') { throw "current moved off 9.9.9: $($j2.Target)" }
           # uninstall
           $env:MSTREAM_UNINSTALL = '1'
           & .\install.ps1 *>&1 | Tee-Object -Variable un
@@ -224,7 +259,7 @@ jobs:
           sh install.sh > a.log 2>&1 || { cat a.log; exit 1; }
           [ "$(readlink "$ROOT/current")" = "$ROOT/mStream-9.9.9-$DKEY" ]
           [ "$(cat "$DEST/Contents/VERSION")" = 9.9.9 ]
-          [ "$(cat "$HOME/Applications/.mstream-installer")" = 9.9.9 ]
+          [ "$(head -1 "$HOME/Applications/.mstream-installer")" = 9.9.9 ]
           [ ! -f "$MSTREAM_STUB_DIR/enable-calls" ]
           # B: with the login item enabled, an upgrade re-points it - and the
           # enable must run through the ~/APPLICATIONS launcher (the stable
@@ -235,7 +270,7 @@ jobs:
           sh install.sh > b.log 2>&1 || { cat b.log; exit 1; }
           grep -q "login item re-pointed at 9.9.10" b.log
           [ "$(tail -1 "$MSTREAM_STUB_DIR/enable-calls")" = "$DEST/Contents/MacOS/mStream" ]
-          [ "$(cat "$HOME/Applications/.mstream-installer")" = 9.9.10 ]
+          [ "$(head -1 "$HOME/Applications/.mstream-installer")" = 9.9.10 ]
           # C: upgrade while mStream runs from ~/Applications - the old tree
           # is moved aside INTACT (a live process reads webapp/sidecars from
           # it), never rm -rf'd; the running-instance note is printed.

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,6 +48,30 @@ from the tray icon and start it again to switch. A copy you extracted by hand
 somewhere else (or run with `--portable`) is left untouched — the script only
 manages its own folder.
 
+## Automatic updates
+
+mStream checks the release feed once a day (plus once shortly after boot)
+and, by default, **downloads new versions in the background and applies them
+on the next restart**: installs made by the one-liner stage the new version
+beside the running one and flip `current`, so any restart — the tray menu,
+a reboot, a service restart — lands on it. Windows `setup.exe` installs
+download the verified installer; applying it is one click. The admin panel's
+About page shows the state and holds the controls:
+
+- `updates.mode` — `notify` (report only, download nothing), `stage`
+  (the default, described above), or `auto` (additionally restart into the
+  update once the server is idle — no active streams, no scan running).
+  On a headless install, `auto` exits with code 0 after staging and expects
+  a process supervisor (systemd, pm2) configured to start mStream again.
+- `updates.check` — set `false` and mStream never phones home; the admin
+  panel's "check now" button still works on demand.
+
+The check and the downloads honor `MSTREAM_RELEASE_BASE` for mirrors, verify
+every download against the release's `manifest.json` sha256s, and only ever
+stage into layouts the installer owns: package-manager installs (deb/rpm,
+the macOS `.pkg`), Docker, npm, and hand-extracted copies are told about
+updates but never touched.
+
 To uninstall, run the same one-liner with `MSTREAM_UNINSTALL=1` set: it
 removes the app folders, the `mstream-server` command, the menu / Start Menu /
 `~/Applications` entry, and the login item — and leaves your library, config,

--- a/docs/install.md
+++ b/docs/install.md
@@ -72,6 +72,13 @@ stage into layouts the installer owns: package-manager installs (deb/rpm,
 the macOS `.pkg`), Docker, npm, and hand-extracted copies are told about
 updates but never touched.
 
+Rolling back? Re-run the installer with `MSTREAM_VERSION=<old tag>`, restart,
+and then **skip the bad release** (the admin panel's skip link, or
+`updates.skipVersion` in the config) — otherwise the next daily check
+re-stages the very version you just backed out of. A staged version that
+gets skipped is un-staged on the spot: `current` returns to the running
+version. The skip clears itself the moment a newer release ships.
+
 To uninstall, run the same one-liner with `MSTREAM_UNINSTALL=1` set: it
 removes the app folders, the `mstream-server` command, the menu / Start Menu /
 `~/Applications` entry, and the login item — and leaves your library, config,

--- a/docs/json_config.md
+++ b/docs/json_config.md
@@ -188,7 +188,8 @@ Controls the daily release-update check and what happens when one is found
 ```json
   "updates": {
     "check": true,
-    "mode": "stage"
+    "mode": "stage",
+    "skipVersion": ""
   },
 ```
 
@@ -198,8 +199,12 @@ Controls the daily release-update check and what happens when one is found
   background; applying takes a restart or a click), or `"auto"` (also
   restart into the update when the server is idle; headless installs need a
   process supervisor that restarts mStream after it exits).
+* `skipVersion`: hold one version back — never download or restart into it.
+  Set it (from the admin panel's skip link, or by hand) after rolling back a
+  bad release, or the next daily check would silently re-stage it. Clear
+  with `""`; a newer release supersedes it naturally.
 
-Both are editable live from the admin panel's About page — no reboot needed.
+All of these are editable live from the admin panel's About page — no reboot needed.
 
 ## Secret
 

--- a/docs/json_config.md
+++ b/docs/json_config.md
@@ -64,6 +64,10 @@ A heavily edited config would look like:
     "defaultBitrate": "128k",
     "autoUpdate": true
   },
+  "updates": {
+    "check": true,
+    "mode": "stage"
+  },
   "ssl": {
     "key": "/path/to/key.pem",
     "cert": "/path/to/cert.pem"
@@ -175,6 +179,27 @@ uses them as-is and never auto-updates them.
 
 Note: older configs may contain `"enabled": true` here — that key is ignored;
 transcoding no longer has an on/off switch.
+
+## Updates
+
+Controls the daily release-update check and what happens when one is found
+(see the "Automatic updates" section of `install.md` for the full story):
+
+```json
+  "updates": {
+    "check": true,
+    "mode": "stage"
+  },
+```
+
+* `check`: (boolean, default `true`) poll the release feed once a day. Set
+  `false` to never phone home — the admin panel's "check now" still works.
+* `mode`: `"notify"` (report only), `"stage"` (default — download in the
+  background; applying takes a restart or a click), or `"auto"` (also
+  restart into the update when the server is idle; headless installs need a
+  process supervisor that restarts mStream after it exits).
+
+Both are editable live from the admin panel's About page — no reboot needed.
 
 ## Secret
 

--- a/install.ps1
+++ b/install.ps1
@@ -11,8 +11,11 @@
 #
 #   MSTREAM_VERSION       a tag like v6.20.0 (default: latest)
 #   MSTREAM_INSTALL_DIR   root for the app folders
-#   MSTREAM_NO_PATH       set to 1 to leave PATH alone
-#   MSTREAM_NO_DESKTOP    set to 1 to skip the Start Menu shortcut
+#   MSTREAM_NO_PATH       set to 1 to leave PATH alone. Persisted: scheduled
+#                         re-runs (the in-app updater) keep the choice; set 0
+#                         to re-enable and clear the persisted opt-out
+#   MSTREAM_NO_DESKTOP    set to 1 to skip the Start Menu shortcut (persisted
+#                         the same way; 0 re-enables)
 #   MSTREAM_RELEASE_BASE  URL serving manifest.json + the zips (default: the
 #                         GitHub release) - for internal mirrors and testing
 #   MSTREAM_FORCE         set to 1 to replace an already-installed copy of
@@ -66,6 +69,21 @@ $root = if ($env:MSTREAM_INSTALL_DIR) {
 } else {
     Join-Path $env:LOCALAPPDATA 'Programs\mStream'
 }
+# Choices persisted by an earlier run rule later ones: the in-app updater
+# re-runs this script on a schedule with a bare environment, and "I opted
+# out of the Start Menu shortcut / PATH edit" must survive that. Env wins
+# when set; the literal '0' explicitly re-enables (and un-persists).
+$optFile = Join-Path $root '.install-options'
+if ((-not $env:MSTREAM_UNINSTALL) -and (Test-Path $optFile)) {
+    foreach ($line in Get-Content $optFile -ErrorAction SilentlyContinue) {
+        $k, $v = $line -split '=', 2
+        if ($k -eq 'no_desktop' -and -not $env:MSTREAM_NO_DESKTOP) { $env:MSTREAM_NO_DESKTOP = '1' }
+        if ($k -eq 'no_path' -and -not $env:MSTREAM_NO_PATH) { $env:MSTREAM_NO_PATH = '1' }
+    }
+}
+if ($env:MSTREAM_NO_DESKTOP -eq '0') { $env:MSTREAM_NO_DESKTOP = '' }
+if ($env:MSTREAM_NO_PATH -eq '0') { $env:MSTREAM_NO_PATH = '' }
+
 $base = if ($env:MSTREAM_RELEASE_BASE) {
     $env:MSTREAM_RELEASE_BASE.TrimEnd('/')
 } elseif ($version -eq 'latest') {
@@ -138,6 +156,12 @@ try {
     # The version becomes a path component below: keep it to what a release
     # tag can contain, so a bad manifest can't steer Remove-Item anywhere.
     if ($ver -notmatch '^[0-9A-Za-z.\-]+$') { throw "manifest.json version '$ver' is not a plain version string - refusing" }
+    # apiVersion gates the layout contract; this copy may be YEARS old when
+    # it runs (it rides inside every bundle for the in-app updater). A bump
+    # means: do not guess at a layout you predate.
+    if ($manifest.apiVersion -and $manifest.apiVersion -ne 1) {
+        throw "this release uses a newer install layout (apiVersion $($manifest.apiVersion)) than this script understands - re-run the current installer (see docs/install.md)"
+    }
     $bundle = "mStream-$ver-$key"
     $asset = "$bundle.zip"
     $expected = ($manifest.assets | Where-Object file -eq $asset).sha256
@@ -154,6 +178,7 @@ try {
 
     New-Item -ItemType Directory -Force $root | Out-Null
     $root = (Resolve-Path $root).Path   # a relative MSTREAM_INSTALL_DIR would bake into the junction + PATH
+    $optFile = Join-Path $root '.install-options'  # re-anchor now that $root is absolute
     $partial = Join-Path $root "$bundle.partial"
     $final = Join-Path $root $bundle
     $current = Join-Path $root 'current'
@@ -193,6 +218,29 @@ try {
         $installedFresh = $true
     }
 
+    # Does the NEW binary actually exec here? Probe BEFORE `current` moves:
+    # a bundle this host cannot run must never take over a working install -
+    # the in-app updater drives this script on a schedule, and a silent flip
+    # here IS the next restart's outage. With a working `current` pointing
+    # at a DIFFERENT version, refuse and throw (nonzero exit = failed stage);
+    # a first install or same-version re-run keeps the diagnostic-only path.
+    $newServerV = $null
+    try {
+        $probeOut = & (Join-Path $final 'mstream-server.exe') -V 2>&1
+        if ($LASTEXITCODE -eq 0 -and $probeOut) { $newServerV = ($probeOut | Out-String).Trim() }
+    } catch { }
+    if (-not $newServerV) {
+        $curTarget = $null
+        if (Test-Path $current) {
+            $curItem = Get-Item $current -Force
+            if ($curItem.Attributes -band [IO.FileAttributes]::ReparsePoint) { $curTarget = $curItem.Target | Select-Object -First 1 }
+        }
+        if ($curTarget -and (Test-Path $curTarget) -and ((Resolve-Path $curTarget).Path -ne $final)) {
+            throw ("the new mstream-server ($ver) does not run on this system - keeping the existing install " +
+                   "(current stays at $curTarget; the new copy is at $final)")
+        }
+    }
+
     # `current` as a junction (no admin needed, unlike a symlink), so a
     # shortcut and the PATH entry keep working across upgrades. A REAL
     # directory named current (older manual layout) is moved aside, not
@@ -206,6 +254,13 @@ try {
     New-Item -ItemType Junction -Path $current -Target $final | Out-Null
 
     if ($installedFresh) { Write-Host "installed mStream $ver to $final" }
+
+    # The choices this run actually used, for the next (possibly scheduled
+    # and env-bare) run - see the read side near the top.
+    $opts = @()
+    if ($env:MSTREAM_NO_DESKTOP) { $opts += 'no_desktop=1' }
+    if ($env:MSTREAM_NO_PATH) { $opts += 'no_path=1' }
+    Set-Content -Path $optFile -Value ($opts -join "`n") -ErrorAction SilentlyContinue
 
     # The launcher registers ITSELF as the login item (HKCU Run) by absolute
     # path - the VERSIONED folder, not current - so an upgrade would never
@@ -237,12 +292,11 @@ try {
             Write-Warning "could not run the launcher to re-point the login item ($($_.Exception.Message)) - open mStream once to fix it"
         }
     }
-    # Proof the binary execs here: commander's -V is instant and boots nothing.
-    try {
-        $v = & (Join-Path $final 'mstream-server.exe') -V 2>&1
-        if ($LASTEXITCODE -eq 0 -and $v) { Write-Host "  mstream-server $v runs" }
-        else { Write-Warning "the server did not run cleanly ($v) - see $final\README.txt" }
-    } catch { Write-Warning "the server did not run: $($_.Exception.Message)" }
+    # Report the exec probe taken BEFORE the junction flip. Empty here means
+    # a first install or same-version re-run (nothing working was displaced),
+    # so it stays a diagnostic.
+    if ($newServerV) { Write-Host "  mstream-server $newServerV runs" }
+    else { Write-Warning "the server did not run cleanly - see $final\README.txt" }
 
     if (-not $env:MSTREAM_NO_DESKTOP) {
         # Start Menu shortcut to the tray launcher (mStream.exe), which is

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,9 @@
 #   MSTREAM_BIN_DIR       where the `mstream-server` command goes
 #                         (default: ~/.local/bin)
 #   MSTREAM_NO_DESKTOP    set to 1 to skip the app-menu entry (Linux) /
-#                         ~/Applications copy (macOS)
+#                         ~/Applications copy (macOS). Persisted: scheduled
+#                         re-runs (the in-app updater) keep the choice.
+#                         Set to 0 to re-enable and clear the persisted opt-out.
 #   MSTREAM_UNINSTALL     set to 1 to remove everything this script installed
 #                         (app folders, command, menu entry / ~/Applications
 #                         copy, login item). Your data is left in place.
@@ -22,7 +24,11 @@
 #                         GitHub release) - for internal mirrors and testing
 #   MSTREAM_KEY           force a bundle key (linux-x64, linux-x64-musl,
 #                         linux-arm64, linux-arm64-musl, darwin-x64,
-#                         darwin-arm64) when auto-detection gets it wrong
+#                         darwin-arm64) when auto-detection gets it wrong.
+#                         The key actually installed is persisted and rules
+#                         later runs, so host-probe drift (e.g. gcompat
+#                         adding a glibc loader on musl) never switches
+#                         bundle families on an existing install
 #   MSTREAM_FORCE         set to 1 to replace an already-installed copy of
 #                         the same version (the old one is moved aside)
 #
@@ -109,9 +115,37 @@ else
 fi
 # Both dirs become symlink TARGETS below; a relative value would be stored
 # literally and dangle from wherever the link lives. Canonicalize.
-mkdir -p "$ROOT" "$BIN_DIR"
+mkdir -p "$ROOT"
 ROOT=$(cd "$ROOT" && pwd -P)
+
+# Choices persisted by an earlier run rule later ones: the in-app updater
+# re-runs this script on a schedule with a bare environment, and "I opted
+# out of the app-menu entry" or a custom command dir must survive that.
+# Env still wins when set; MSTREAM_NO_DESKTOP=0 explicitly re-enables (and
+# un-persists) the integration.
+if [ -f "$ROOT/.install-options" ]; then
+    while IFS='=' read -r optk optv; do
+        case "$optk" in
+            no_desktop) [ -z "${MSTREAM_NO_DESKTOP:-}" ] && MSTREAM_NO_DESKTOP=1 ;;
+            bin_dir) [ -z "${MSTREAM_BIN_DIR:-}" ] && [ -n "$optv" ] && BIN_DIR="$optv" ;;
+        esac
+    done < "$ROOT/.install-options"
+fi
+[ "${MSTREAM_NO_DESKTOP:-}" = 0 ] && MSTREAM_NO_DESKTOP=""
+mkdir -p "$BIN_DIR"
 BIN_DIR=$(cd "$BIN_DIR" && pwd -P)
+
+# The bundle key chosen at FIRST install rules later runs too: the host
+# probes above can drift (installing gcompat drops a glibc loader on a musl
+# box and flips the detection), and a scheduled re-run must never switch
+# bundle families on a live install because of that. An explicit
+# MSTREAM_KEY still overrides - and updates the persisted choice below.
+if [ -z "${MSTREAM_KEY:-}" ] && [ -f "$ROOT/.bundle-key" ]; then
+    saved_key=$(head -1 "$ROOT/.bundle-key" | tr -cd 'a-z0-9-')
+    case " win-x64 linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl darwin-x64 darwin-arm64 " in
+        *" $saved_key "*) key="$saved_key" ;;
+    esac
+fi
 
 # Per-platform names inside a bundle, and where the server keeps its data
 # (which this script never touches - not on install, not on uninstall).
@@ -249,6 +283,16 @@ if ! fetch "$base/manifest.json" "$tmp/manifest.json"; then
 fi
 version=$(grep -o '"version": *"[^"]*"' "$tmp/manifest.json" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 [ -n "$version" ] || { echo "manifest.json is missing a version - refusing to install" >&2; exit 1; }
+# apiVersion gates the layout contract between this script and the release.
+# This copy may be YEARS old by the time it runs (it rides inside every
+# bundle for the in-app updater), so a bumped apiVersion means: do not
+# guess at a layout you predate - fetch the current installer instead.
+api=$(grep -o '"apiVersion": *[0-9]*' "$tmp/manifest.json" | grep -o '[0-9]*$' || true)
+if [ -n "$api" ] && [ "$api" != 1 ]; then
+    echo "this release uses a newer install layout (apiVersion $api) than this script understands" >&2
+    echo "  re-run the current one-line installer from https://github.com/$REPO (see docs/install.md)" >&2
+    exit 1
+fi
 # The version becomes a path component below: keep it to what a release
 # tag can contain, so a bad manifest can't steer rm/mv anywhere.
 case "$version" in
@@ -359,12 +403,40 @@ if command -v ps >/dev/null 2>&1; then
     done
 fi
 
+# Does the NEW binary actually exec here? Probe it BEFORE `current` moves:
+# a bundle this host cannot run (missing runtime library, a raised OS/libc
+# floor, a bundle family the box cannot exec) must never take over a
+# working install - the in-app updater drives this script on a schedule,
+# and a silent flip here IS the next restart's outage. When there is a
+# working install to keep, refuse and exit nonzero so the updater reports
+# a failed stage instead of a staged landmine. A first install (nothing to
+# keep) still proceeds and gets the diagnostic at the end.
+new_server_v=$("$ROOT/$bundle/$server_rel" -V 2>/dev/null) || new_server_v=""
+if [ -z "$new_server_v" ] && [ -L "$ROOT/current" ] && [ -e "$ROOT/current" ] \
+    && [ "$(readlink "$ROOT/current")" != "$ROOT/$bundle" ]; then
+    echo "the new mstream-server ($version) does not run on this system - keeping the existing install" >&2
+    "$ROOT/$bundle/$server_rel" -V 2>&1 | head -3 | sed 's/^/    /' >&2
+    echo "  current stays at $(readlink "$ROOT/current"); the new copy is at $ROOT/$bundle" >&2
+    echo "  (missing runtime library? wrong bundle for this machine? see docs/install.md; MSTREAM_KEY forces a bundle)" >&2
+    exit 1
+fi
+
 # `current` -> this version. If a previous manual layout left a REAL
 # directory named current, move it aside rather than nest into it.
 if [ -e "$ROOT/current" ] && [ ! -L "$ROOT/current" ]; then
     mv "$ROOT/current" "$ROOT/current.was-a-directory-$(date +%Y%m%d%H%M%S)"
 fi
 link "$ROOT/$bundle" "$ROOT/current"
+
+# The choices this run actually used, for the next (possibly scheduled and
+# env-bare) run - see the read side at the top. Written only once the new
+# version is in place.
+printf '%s\n' "$key" > "$ROOT/.bundle-key"
+{
+    [ -n "${MSTREAM_NO_DESKTOP:-}" ] && echo "no_desktop=1"
+    [ "$BIN_DIR" != "$HOME/.local/bin" ] && printf 'bin_dir=%s\n' "$BIN_DIR"
+    :
+} > "$ROOT/.install-options"
 
 # The command: a symlink, so `mstream-server` on PATH always means `current`
 # and an upgrade is one link flip. Data lives in the server's data home,
@@ -439,8 +511,11 @@ if [ -z "${MSTREAM_NO_DESKTOP:-}" ]; then
                 # Marker AFTER the copy is in place, and OUTSIDE the bundle.
                 # (This also heals a copy from the old installer, which wrote
                 # the marker inside Contents/ and broke the seal - the fresh
-                # ditto above replaced it wholesale.)
-                printf '%s\n' "$version" > "$apps_marker"
+                # ditto above replaced it wholesale.) Line 2 = the install
+                # ROOT, so the in-app updater's method detection can find a
+                # CUSTOM root from a launcher running out of ~/Applications;
+                # single-line markers from older runs read as version-only.
+                printf '%s\n%s\n' "$version" "$ROOT" > "$apps_marker"
                 desktop_note="app: ~/Applications/mStream.app (menu-bar icon; Quick Connect on)"
             else
                 rm -rf "$dest.installing"
@@ -499,15 +574,15 @@ if [ -n "$running_from" ]; then
     echo "        the new one - the app menu / Start Menu entry now points at $version." >&2
 fi
 
-# Does the binary actually exec here? `-V` is commander's version print -
-# instant, no server boot, no side effects - so it doubles as the proof of
-# a working install. Catch a missing runtime library NOW, with the fix,
-# instead of at the user's first run. Known case: the musl bundle (Bun's
-# musl build) links libstdc++/libgcc dynamically, and a minimal Alpine has
-# neither (measured on alpine:3.20 - a wall of "Error relocating" from the
-# loader).
-if v=$("$server" -V 2>/dev/null) && [ -n "$v" ]; then
-    echo "  mstream-server $v runs"
+# Report the exec probe (taken BEFORE the `current` flip above). An empty
+# result down here means a first install or a same-version re-run of a
+# binary that cannot exec - nothing working was displaced, so this stays a
+# diagnostic with the fix, exactly as before. Known case: the musl bundle
+# (Bun's musl build) links libstdc++/libgcc dynamically, and a minimal
+# Alpine has neither (measured on alpine:3.20 - a wall of "Error
+# relocating" from the loader).
+if [ -n "$new_server_v" ]; then
+    echo "  mstream-server $new_server_v runs"
 else
     err=$("$server" -V 2>&1 | head -3)
     case "$err" in

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -387,6 +387,21 @@ if (isMac) {
 // bare server box, so the box can't explain itself — this file has to.
 writeFileSync(join(stageDir, 'README.txt'), bundleReadme(pkg.version, t, launcherStaged, serverName));
 
+// The installer script travels WITH the bundle: the in-app updater
+// (src/util/update-check.js) stages a new version by running exactly the
+// code that installed this one, pinned at build time and covered by the
+// bundle's own sha256 — never a fetch of a mutable script URL at update
+// time. macOS: Contents/Resources — it is a data file, and codesign's
+// nested-code scan rejects loose scripts under Contents/MacOS (same rule
+// that put webapp/ in Resources above).
+if (t.plat === 'win32') {
+  cpSync(join(root, 'install.ps1'), join(contentRoot, 'install.ps1'));
+} else if (isMac) {
+  cpSync(join(root, 'install.sh'), join(stageDir, 'mStream.app', 'Contents', 'Resources', 'install.sh'));
+} else {
+  cpSync(join(root, 'install.sh'), join(contentRoot, 'install.sh'));
+}
+
 const archivePath = join(root, 'dist', `${bundleName}.zip`);
 rmSync(archivePath, { force: true });
 console.log(`Bundling -> dist/${bundleName}.zip`);

--- a/scripts/release-manifest.sh
+++ b/scripts/release-manifest.sh
@@ -19,6 +19,11 @@
 #     (install.sh greps that shape; it has no jq)
 #   - "version" is the bare tag version (no leading v)
 #   - assets are named mStream-<version>-<key>.zip
+#   - native-installer assets (the win-x64 setup.exe and the darwin .pkgs)
+#     appear as EXTRA lines of the same shape when present in the dir. The
+#     install scripts grep by their own exact zip name, so extra lines are
+#     invisible to them; the in-app updater (src/util/update-check.js) reads
+#     these to verify the installer it downloads for Inno/pkg installs.
 #
 # Refuses (exit 1) when a zip's name does not carry EXACTLY this version
 # followed by a known bundle key: the installers derive filenames from
@@ -33,6 +38,10 @@ case "$version" in
 esac
 cd "$dir"
 keys="win-x64 linux-x64 linux-arm64 linux-x64-musl linux-arm64-musl darwin-x64 darwin-arm64"
+# Native installers whose hashes the in-app updater verifies. Exact names
+# only, same version-strictness as the zips; absent files are simply not
+# listed (releases build them independently of the bundles).
+installers="mStream-$version-win-x64-setup.exe mStream-$version-darwin-x64.pkg mStream-$version-darwin-arm64.pkg"
 found=0
 for f in mStream-*.zip; do
     [ -e "$f" ] || { echo "release-manifest: no mStream-*.zip in $dir" >&2; exit 1; }
@@ -44,7 +53,19 @@ for f in mStream-*.zip; do
         echo "release-manifest: $f is not mStream-$version-<key>.zip for a known key - package.json and the tag disagree, or an unknown bundle" >&2
         exit 1
     fi
-    found=$((found + 1))
+done
+# A setup.exe / .pkg for the WRONG version in the release dir is the same
+# class of bug as a mismatched zip: refuse rather than list or skip it.
+for f in mStream-*-setup.exe mStream-*.pkg; do
+    [ -e "$f" ] || continue
+    ok=""
+    for i in $installers; do
+        [ "$f" = "$i" ] && ok=1
+    done
+    if [ -z "$ok" ]; then
+        echo "release-manifest: $f does not match mStream-$version-<target> for a known installer - refusing" >&2
+        exit 1
+    fi
 done
 {
     echo '{'
@@ -53,7 +74,8 @@ done
     echo '  "apiVersion": 1,'
     echo '  "assets": ['
     first=true
-    for f in mStream-*.zip; do
+    for f in mStream-*.zip $installers; do
+        [ -e "$f" ] || continue
         if command -v sha256sum >/dev/null 2>&1; then
             sum=$(sha256sum "$f" | cut -d' ' -f1)
         else
@@ -61,6 +83,7 @@ done
         fi
         $first || echo ','
         first=false
+        found=$((found + 1))
         printf '    {"file": "%s", "sha256": "%s"}' "$f" "$sum"
     done
     echo ''

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1634,11 +1634,13 @@ export function setup(mstream) {
     const schema = Joi.object({
       check: Joi.boolean(),
       mode: Joi.string().valid('notify', 'stage', 'auto'),
-    }).or('check', 'mode');
+      skipVersion: Joi.string().pattern(/^\d+\.\d+\.\d+$/).allow(''),
+    }).or('check', 'mode', 'skipVersion');
     joiValidate(schema, req.body);
 
     if (req.body.check !== undefined) { await admin.editUpdatesCheck(req.body.check); }
     if (req.body.mode !== undefined) { await admin.editUpdatesMode(req.body.mode); }
+    if (req.body.skipVersion !== undefined) { await admin.editUpdatesSkipVersion(req.body.skipVersion); }
     updateCheck.onSettingsChanged();
     res.json({});
   });

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -10,6 +10,7 @@ import * as config from '../state/config.js';
 import * as dbQueue from '../db/task-queue.js';
 import * as imageCompress from '../db/image-compress-manager.js';
 import * as transcode from './transcode.js';
+import * as updateCheck from '../util/update-check.js';
 import * as db from '../db/manager.js';
 import * as discoveryDb from '../db/discovery-db.js';
 import * as discoveryExport from '../db/discovery-export.js';
@@ -1601,6 +1602,44 @@ export function setup(mstream) {
 
   mstream.post("/api/v1/admin/transcode/download", async (req, res) => {
     await transcode.downloadedFFmpeg();
+    res.json({});
+  });
+
+  // ── Release updates (util/update-check.js) ──────────────────────────────
+  // Status is in-memory state, instant; check hits the release feed and
+  // waits; download kicks staging off and returns - a bundle is minutes on
+  // a slow link, so the card polls GET status instead of hanging a POST.
+
+  mstream.get("/api/v1/admin/update", (req, res) => {
+    res.json(updateCheck.getStatus());
+  });
+
+  mstream.post("/api/v1/admin/update/check", async (req, res) => {
+    res.json(await updateCheck.checkNow(true));
+  });
+
+  mstream.post("/api/v1/admin/update/download", (req, res) => {
+    const r = updateCheck.stageNow();
+    if (r.error) { return res.status(409).json(r); }
+    res.json(r);
+  });
+
+  mstream.post("/api/v1/admin/update/apply", async (req, res) => {
+    const r = await updateCheck.requestApply();
+    if (r.error) { return res.status(409).json(r); }
+    res.json(r);
+  });
+
+  mstream.post("/api/v1/admin/update/settings", async (req, res) => {
+    const schema = Joi.object({
+      check: Joi.boolean(),
+      mode: Joi.string().valid('notify', 'stage', 'auto'),
+    }).or('check', 'mode');
+    joiValidate(schema, req.body);
+
+    if (req.body.check !== undefined) { await admin.editUpdatesCheck(req.body.check); }
+    if (req.body.mode !== undefined) { await admin.editUpdatesMode(req.body.mode); }
+    updateCheck.onSettingsChanged();
     res.json({});
   });
 

--- a/src/server.js
+++ b/src/server.js
@@ -60,6 +60,7 @@ import * as backupManager from './backup/manager.js';
 import WebError from './util/web-error.js';
 import { isAdminAllowed } from './util/admin-network.js';
 import { writeJsonAtomic, completedWrites } from './util/atomic-json.js';
+import * as updateCheck from './util/update-check.js';
 
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -97,6 +98,10 @@ let rebootInFlight = false;
 // just cost another tunnel/listener cycle.
 let rebootPending = false;
 let configWritesAtRead = 0;
+// Set by onListening's lazy import; update-check's idle test reads it (null
+// = "not fully booted yet", which idle() treats as busy — auto-apply never
+// fires into a half-started server).
+let taskQueueMod = null;
 // Bumped by every reboot(); each request tags its socket with the generation
 // serving it, so reboot()'s grace-period sweep can tell "still busy with an
 // OLD-app response" (destroy: that handler must not live on) from "idle
@@ -565,6 +570,16 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   downloadApi.setup(mstream);
   fileExplorerApi.setup(mstream);
   transcode.setup(mstream);
+  updateCheck.setup(mstream, {
+    // Idle = safe to restart into a staged update: no socket carrying an
+    // in-flight response (the same tagging reboot()'s drain sweep uses) and
+    // no scan running. Conservative before boot completes.
+    hasBusySockets: () => {
+      for (const s of liveSockets) { if (s._mstreamBusy) { return true; } }
+      return false;
+    },
+    isScanning: () => (taskQueueMod ? taskQueueMod.isScanning() : true),
+  });
   scrobblerApi.setup(mstream);
   remoteApi.setupAfterAuth(mstream, server);
   sharedApi.setupAfterSecurity(mstream);
@@ -709,6 +724,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     }
 
     const taskQueue = await import('./db/task-queue.js');
+    taskQueueMod = taskQueue;
     taskQueue.runAfterBoot();
 
     // Torrent completion-watcher (V42-adjacent). Polls the active

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -350,6 +350,11 @@ const updatesOptions = Joi.object({
   //   staged version; headless by exiting 0, which expects a process
   //   supervisor (systemd/pm2) configured to start mStream again.
   mode: Joi.string().valid('notify', 'stage', 'auto').default('stage'),
+  // Hold one version back: report it, never stage or apply it. The
+  // companion of a manual rollback (docs/install.md) — without it the next
+  // daily check would silently re-stage the very release the operator just
+  // backed out of. Cleared (set '') to resume normal updates.
+  skipVersion: Joi.string().pattern(/^\d+\.\d+\.\d+$/).allow('').default(''),
 });
 
 const rpnOptions = Joi.object({

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -335,6 +335,23 @@ const transcodeOptions = Joi.object({
   autoUpdate: Joi.boolean().default(true)
 });
 
+const updatesOptions = Joi.object({
+  // Daily poll of the release feed (manifest.json on the latest GitHub
+  // release; MSTREAM_RELEASE_BASE overrides it, exactly as for the install
+  // scripts). false = never phone home - the admin "Check now" button still
+  // works, it is only the schedule that stops.
+  check: Joi.boolean().default(true),
+  // notify: report only, download nothing until a human clicks.
+  // stage (default): background-download the new version - managed installs
+  //   stage it behind $ROOT/current, Windows setup.exe installs download the
+  //   verified installer - but applying still takes a restart or a click.
+  // auto: additionally apply when the server is idle (no busy connections,
+  //   no scan): under the tray launcher by asking it to restart into the
+  //   staged version; headless by exiting 0, which expects a process
+  //   supervisor (systemd/pm2) configured to start mStream again.
+  mode: Joi.string().valid('notify', 'stage', 'auto').default('stage'),
+});
+
 const rpnOptions = Joi.object({
   iniFile: Joi.string().default(path.join(appRoot, 'bin/rpn/frps.ini')),
   apiUrl: Joi.string().default('https://api.mstream.io'),
@@ -680,6 +697,7 @@ const schema = Joi.object({
   webAppDirectory: Joi.string().default(path.join(appRoot, 'webapp')),
   rpn: rpnOptions.default(rpnOptions.validate({}).value),
   transcode: transcodeOptions.default(transcodeOptions.validate({}).value),
+  updates: updatesOptions.default(updatesOptions.validate({}).value),
   lyrics: lyricsOptions.default(lyricsOptions.validate({}).value),
   secret: Joi.string().optional(),
   // Separate secret used to derive the AES-256-GCM key for the

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -911,22 +911,29 @@ export async function editAutoUpdate(val) {
 
 // Release auto-update settings (util/update-check.js). Same live-effect
 // contract as editAutoUpdate above: the checker reads config.program.updates
-// at each firing, so neither needs a reboot.
-export async function editUpdatesCheck(val) {
-  const loadConfig = await loadFile(config.configFile);
-  if (!loadConfig.updates) { loadConfig.updates = {}; }
-  loadConfig.updates.check = val;
-  await saveFile(loadConfig, config.configFile);
-  config.program.updates.check = val;
+// at each firing, so no reboot is needed. Written through updateJsonAtomic —
+// the read and the write are ONE serialized step, so a settings POST racing
+// any other config save can't resurrect the document it read before that
+// save landed (the plain load-then-save shape loses that race).
+async function editUpdatesField(field, val) {
+  await updateJsonAtomic(config.configFile, (doc) => {
+    // updateJsonAtomic hands us null for ANY read failure — absent file,
+    // but also a transiently locked or momentarily unparsable one. The
+    // config file always exists on a booted server, so null here means
+    // "could not read it": throwing 500s the settings POST and leaves the
+    // file intact, instead of replacing the operator's whole config with
+    // just an updates block.
+    if (doc === null) { throw new Error('config file unreadable - not overwriting it'); }
+    if (!doc.updates) { doc.updates = {}; }
+    doc.updates[field] = val;
+    return doc;
+  });
+  config.program.updates[field] = val;
 }
 
-export async function editUpdatesMode(val) {
-  const loadConfig = await loadFile(config.configFile);
-  if (!loadConfig.updates) { loadConfig.updates = {}; }
-  loadConfig.updates.mode = val;
-  await saveFile(loadConfig, config.configFile);
-  config.program.updates.mode = val;
-}
+export function editUpdatesCheck(val) { return editUpdatesField('check', val); }
+export function editUpdatesMode(val) { return editUpdatesField('mode', val); }
+export function editUpdatesSkipVersion(val) { return editUpdatesField('skipVersion', val); }
 
 // Set the SQLite synchronous mode for the main DB connection (FULL | NORMAL).
 // Persisted to config and applied to the live connection immediately —

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -909,6 +909,25 @@ export async function editAutoUpdate(val) {
   config.program.transcode.autoUpdate = val;
 }
 
+// Release auto-update settings (util/update-check.js). Same live-effect
+// contract as editAutoUpdate above: the checker reads config.program.updates
+// at each firing, so neither needs a reboot.
+export async function editUpdatesCheck(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.updates) { loadConfig.updates = {}; }
+  loadConfig.updates.check = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.updates.check = val;
+}
+
+export async function editUpdatesMode(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.updates) { loadConfig.updates = {}; }
+  loadConfig.updates.mode = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.updates.mode = val;
+}
+
 // Set the SQLite synchronous mode for the main DB connection (FULL | NORMAL).
 // Persisted to config and applied to the live connection immediately —
 // PRAGMA synchronous is per-connection and takes effect on the next

--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -1,0 +1,633 @@
+// Release update checker + stager — the server-side brain of auto-update.
+//
+// The server owns check/verify/download/stage because it is the one component
+// present in EVERY install shape (the tray launcher ships only on four of the
+// seven bundle targets, and not at all for npm/source/Docker), and because the
+// hardened download transport already lives here (ffmpeg-bootstrap). The
+// launcher's whole role is the two things only it can do: show a tray item and
+// restart into the staged version — it learns both from the status file this
+// module writes (update-status.json in userDataHome(), the same directory that
+// holds its launcher.lock; NOT esm-helpers' dataRoot, which equals appRoot on
+// writable installs — inside the versioned bundle folder, or worse, inside the
+// ~/Applications .app where any write breaks the notarization seal).
+//
+// What "an update" means: the WHOLE bundle folder, never the server binary
+// alone. webapp/, rust-parser (hash-generation gated), rust-server-audio, and
+// the p2p sidecar all ship inside the zip and must move together — a lone
+// binary swap leaves a stale UI and sidecars that can never self-heal (the
+// bundle's sidecar sits on the "operator property" rung of discovery-p2p's
+// resolution). So managed staging runs the BUNDLE-EMBEDDED installer script —
+// exactly the code that installed this copy, contract-tested in CI, fetched
+// from nowhere at update time — which downloads the zip, verifies its sha256
+// against the release manifest, extracts a versioned folder beside the running
+// one, and flips $ROOT/current. The running server keeps serving the old
+// version until something restarts it.
+//
+// Modes (config: updates.mode, live-read so admin toggles need no reboot):
+//   notify - check only; every download/install is user-initiated
+//   stage  - (default) background-stage for managed installs and
+//            background-download the Windows installer; applying still takes
+//            a restart / a click
+//   auto   - additionally apply when idle: under the launcher, by flagging
+//            applyRequested in the status file (the launcher restarts into
+//            the staged version); headless, by exiting 0 — documented as
+//            "auto expects a process supervisor" (systemd/pm2 restart lands
+//            on the new version via the flipped `current` link)
+import fs from 'fs';
+import fsp from 'fs/promises';
+import path from 'path';
+import { spawn } from 'child_process';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import { writeJsonAtomic } from './atomic-json.js';
+import { downloadToFile, computeFileChecksum } from './ffmpeg-bootstrap.js';
+import { appRoot, isBunStandalone, userDataHome, underSystemPrefix } from './esm-helpers.js';
+import packageJson from '../../package.json' with { type: 'json' };
+
+const REPO = 'IrosTheBeggar/mStream';
+const LATEST_BASE = `https://github.com/${REPO}/releases/latest/download`;
+const RELEASES_PAGE = `https://github.com/${REPO}/releases/latest`;
+// manifest.json is ~15 lines; anything past this is not our manifest.
+const MANIFEST_MAX_BYTES = 64 * 1024;
+// setup.exe is ~45 MB, a .pkg ~150 MB. A pinned size is not in the release
+// manifest (yet), so cap at "clearly wrong" instead.
+const INSTALLER_MAX_BYTES = 500 * 1024 * 1024;
+const STAGE_TIMEOUT_MS = 30 * 60 * 1000; // a bundle download on a slow link
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // daily
+const BOOT_CHECK_DELAY_MS = 30 * 1000;
+const AUTO_APPLY_POLL_MS = 15 * 60 * 1000;
+
+// ── Pure helpers (unit-tested with injected fs) ─────────────────────────────
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+// Strict numeric-triple compare. Returns <0, 0, >0 — or null when either
+// side is not a plain X.Y.Z (prerelease-shaped strings are refused on
+// purpose: releases are always bare triples, so anything else in a manifest
+// is not a version to act on).
+export function compareVersions(a, b) {
+  const ma = VERSION_RE.exec(a);
+  const mb = VERSION_RE.exec(b);
+  if (!ma || !mb) { return null; }
+  for (let i = 1; i <= 3; i++) {
+    const d = Number(ma[i]) - Number(mb[i]);
+    if (d !== 0) { return d; }
+  }
+  return 0;
+}
+
+// The release manifest contract (scripts/release-manifest.sh). `name` guards
+// against a non-mStream release capturing the GitHub "latest" pointer (the
+// repo also hosts asset-store releases); apiVersion gates layout changes —
+// a manifest from the future downgrades this updater to notify-only rather
+// than letting it run an install flow it no longer understands.
+export function validateManifest(m) {
+  if (!m || typeof m !== 'object') { return { ok: false, reason: 'not an object' }; }
+  if (m.name !== 'mstream') { return { ok: false, reason: `manifest name is ${JSON.stringify(m.name)}, not "mstream"` }; }
+  if (m.apiVersion !== 1) { return { ok: false, reason: `manifest apiVersion ${m.apiVersion} is newer than this server understands`, apiMismatch: true }; }
+  if (typeof m.version !== 'string' || !VERSION_RE.test(m.version)) {
+    return { ok: false, reason: `manifest version ${JSON.stringify(m.version)} is not a plain X.Y.Z` };
+  }
+  if (!Array.isArray(m.assets) || !m.assets.every(a => a && typeof a.file === 'string' && /^[0-9a-f]{64}$/.test(a.sha256 || ''))) {
+    return { ok: false, reason: 'manifest assets are malformed' };
+  }
+  return { ok: true };
+}
+
+// mStream-<version>-<key>[.zip] -> { version, key }, or null.
+export function parseBundleName(name) {
+  const m = /^mStream-(\d+\.\d+\.\d+)-((?:darwin|linux|win)-[a-z0-9]+(?:-musl)?)(?:\.zip)?$/.exec(name);
+  return m ? { version: m[1], key: m[2] } : null;
+}
+
+// Where and how is this server installed? Decides what an update can DO:
+// only the script-managed layout ($ROOT/<bundle>/ + $ROOT/current) is staged
+// in place; everything else gets told, not touched. Pure and injected so the
+// decision table is unit-testable; production wiring is detectInstall()
+// below. Detection is by GEOMETRY (walk up from the real executable path
+// looking for the `current` link that points back at our own tree), not env:
+// the server never inherits the installer's MSTREAM_INSTALL_DIR, and
+// geometry follows custom roots for free.
+export function detectInstallMethod({
+  execPath,
+  platform = process.platform,
+  env = process.env,
+  standalone = isBunStandalone,
+  fsx = fs,
+  homedir = undefined,
+} = {}) {
+  const home = userDataHome(platform, env, ...(homedir ? [homedir] : []));
+  // Test / escape hatch: trust the operator, skip geometry.
+  if (env.MSTREAM_UPDATE_ROOT) { return { method: 'managed', root: env.MSTREAM_UPDATE_ROOT }; }
+  if (!standalone) { return { method: 'npm-source' }; }
+  if (platform === 'linux') {
+    try { fsx.accessSync('/.dockerenv'); return { method: 'docker' }; } catch { /* not docker */ }
+  }
+  let real = execPath;
+  try { real = fsx.realpathSync(execPath); } catch { /* keep the literal path */ }
+  const realDir = path.dirname(real);
+
+  // macOS ~/Applications copy: the installer's ditto copy plus its SIBLING
+  // ownership marker. The versioned root is the per-OS default (the marker
+  // is only ever written by an install into that default layout).
+  if (platform === 'darwin') {
+    const hd = homedir ? homedir() : path.dirname(path.dirname(path.dirname(home)));
+    const appsCopy = path.join(hd, 'Applications', 'mStream.app');
+    if ((real.startsWith(appsCopy + path.sep)) && fsx.existsSync(path.join(hd, 'Applications', '.mstream-installer'))) {
+      const root = path.join(home, 'app');
+      if (fsx.existsSync(path.join(root, 'current'))) { return { method: 'managed', root }; }
+    }
+  }
+
+  // deb/rpm (/opt, /usr) and the macOS .pkg (/Applications) live in
+  // package-manager territory — never staged by us.
+  if (underSystemPrefix(realDir + '/', platform)) {
+    return { method: platform === 'darwin' ? 'pkg' : 'deb-rpm' };
+  }
+
+  // The managed layout: some ancestor holds `current`, and a versioned
+  // bundle dir sits on the path between them.
+  let dir = realDir;
+  for (let i = 0; i < 8; i++) {
+    const parent = path.dirname(dir);
+    if (parent === dir) { break; }
+    if (parseBundleName(path.basename(dir)) && fsx.existsSync(path.join(parent, 'current'))) {
+      return { method: 'managed', root: parent };
+    }
+    dir = parent;
+  }
+
+  // Windows Inno install: flat files at %LOCALAPPDATA%\Programs\mStream,
+  // same root install.ps1 uses but with no versioned dir and no junction.
+  if (platform === 'win32') {
+    const innoDir = path.join(env.LOCALAPPDATA || '', 'Programs', 'mStream');
+    if (env.LOCALAPPDATA && path.resolve(realDir).toLowerCase() === path.resolve(innoDir).toLowerCase()
+        && !fsx.existsSync(path.join(realDir, 'current'))) {
+      return { method: 'inno' };
+    }
+  }
+
+  // A hand-extracted bundle, --portable, or anything else we don't own.
+  return { method: 'portable' };
+}
+
+// ── Module state ────────────────────────────────────────────────────────────
+
+let _install = null;        // { method, root? } — detected once per process
+let _hooks = { hasBusySockets: () => false, isScanning: () => false };
+let _bootTimer = null;
+let _checkTimer = null;
+let _applyTimer = null;
+let _staging = null;        // single-flight staging promise; never cleared by reboot
+let _exiting = false;
+
+const state = {
+  schema: 1,
+  current: packageJson.version,
+  latest: null,
+  available: false,
+  method: null,
+  mode: null,               // mirrored at write time for observability
+  staged: false,
+  stagedVersion: null,
+  downloading: false,
+  applyRequested: false,
+  installerPath: null,      // inno/pkg: the verified installer the launcher may spawn
+  downloadUrl: null,        // non-managed: where a human gets the update
+  lastCheckAt: null,
+  error: null,
+  notifyOnly: false,        // apiVersion from the future: check works, staging refused
+};
+
+function updatesConfig() {
+  return config.program?.updates || { check: true, mode: 'stage' };
+}
+
+function supervisedByLauncher() {
+  return process.argv.includes('--supervised');
+}
+
+export function statusFilePath() {
+  return path.join(userDataHome(), 'update-status.json');
+}
+
+export function getStatus() {
+  return { ...state, check: updatesConfig().check, mode: updatesConfig().mode };
+}
+
+async function writeStatus() {
+  const doc = { ...getStatus(), writtenAt: new Date().toISOString() };
+  try {
+    await fsp.mkdir(userDataHome(), { recursive: true });
+    await writeJsonAtomic(statusFilePath(), doc);
+  } catch (err) {
+    winston.warn(`[update] Could not write ${statusFilePath()}: ${err.message}`);
+  }
+}
+
+function releaseBase() {
+  const rb = process.env.MSTREAM_RELEASE_BASE;
+  return rb ? rb.replace(/\/+$/, '') : LATEST_BASE;
+}
+
+// Tag-pinned asset URL: after a check said "latest is X", downloads must be
+// X's bytes even if the "latest" pointer moves meanwhile. A mirror
+// (MSTREAM_RELEASE_BASE) serves one flat version — pinning is impossible
+// there by construction, and the sha256 check catches a rotated mirror.
+function assetUrl(version, file) {
+  const rb = process.env.MSTREAM_RELEASE_BASE;
+  if (rb) { return `${rb.replace(/\/+$/, '')}/${file}`; }
+  return `https://github.com/${REPO}/releases/download/v${version}/${file}`;
+}
+
+function installerAssetName(version) {
+  if (process.platform === 'win32') { return `mStream-${version}-win-x64-setup.exe`; }
+  if (process.platform === 'darwin') {
+    return `mStream-${version}-darwin-${process.arch === 'arm64' ? 'arm64' : 'x64'}.pkg`;
+  }
+  return null;
+}
+
+// The installer script that shipped INSIDE this bundle. macOS: Resources
+// (a data file; under Contents/MacOS the codesign nested-code scan would
+// reject it), which the appRoot (= Contents/MacOS) reaches as a sibling.
+function embeddedInstallerPath() {
+  if (process.platform === 'win32') { return path.join(appRoot, 'install.ps1'); }
+  if (process.platform === 'darwin' && appRoot.includes(`.app${path.sep}`)) {
+    return path.join(appRoot, '..', 'Resources', 'install.sh');
+  }
+  return path.join(appRoot, 'install.sh');
+}
+
+function detectInstall() {
+  if (!_install) {
+    _install = detectInstallMethod({ execPath: process.execPath });
+    state.method = _install.method;
+  }
+  return _install;
+}
+
+// ── Checking ────────────────────────────────────────────────────────────────
+
+async function fetchManifest() {
+  const dir = userDataHome();
+  await fsp.mkdir(dir, { recursive: true });
+  const tmp = path.join(dir, `.update-manifest-${process.pid}.json`);
+  try {
+    await downloadToFile(`${releaseBase()}/manifest.json`, tmp, { maxBytes: MANIFEST_MAX_BYTES });
+    return JSON.parse(await fsp.readFile(tmp, 'utf8'));
+  } finally {
+    fsp.unlink(tmp).catch(() => { /* scratch file */ });
+  }
+}
+
+// Check the release feed. `force` is a human clicking "Check now" — it works
+// even with the periodic check switched off. Never throws; failures land in
+// state.error and the previous knowledge stays put.
+export async function checkNow(force = false) {
+  const cfg = updatesConfig();
+  if (!cfg.check && !force) { return getStatus(); }
+  detectInstall();
+  try {
+    const manifest = await fetchManifest();
+    const v = validateManifest(manifest);
+    state.lastCheckAt = new Date().toISOString();
+    if (!v.ok) {
+      state.notifyOnly = !!v.apiMismatch;
+      state.error = v.apiMismatch
+        ? 'A newer release changed the update format - update by re-running the install command'
+        : `Release feed rejected: ${v.reason}`;
+      if (v.apiMismatch) {
+        // The version itself is still trustworthy enough to announce.
+        if (typeof manifest.version === 'string' && VERSION_RE.test(manifest.version)) {
+          state.latest = manifest.version;
+          state.available = compareVersions(manifest.version, state.current) > 0;
+          state.downloadUrl = RELEASES_PAGE;
+        }
+        await writeStatus();
+      }
+      winston.warn(`[update] ${state.error}`);
+      return getStatus();
+    }
+    state.error = null;
+    state.notifyOnly = false;
+    state.latest = manifest.version;
+    state.available = compareVersions(manifest.version, state.current) > 0;
+    if (!state.available) {
+      state.downloadUrl = null;
+    } else {
+      const m = detectInstall();
+      state.downloadUrl = downloadUrlFor(m.method, manifest);
+      winston.info(`[update] mStream ${manifest.version} is available (running ${state.current}, install: ${m.method})`);
+      const mode = updatesConfig().mode;
+      if (mode !== 'notify' && !state.notifyOnly
+          && (m.method === 'managed' || m.method === 'inno')
+          && (!state.staged || state.stagedVersion !== manifest.version)) {
+        stageNow(manifest); // async, single-flight; errors land in state
+      }
+    }
+    await writeStatus();
+    maybeAutoApply();
+  } catch (err) {
+    state.error = `Update check failed: ${err.message}`;
+    winston.warn(`[update] ${state.error}`);
+  }
+  return getStatus();
+}
+
+function downloadUrlFor(method, manifest) {
+  const name = installerAssetName(manifest.version);
+  if ((method === 'inno' || method === 'pkg') && name
+      && manifest.assets.some(a => a.file === name)) {
+    return assetUrl(manifest.version, name);
+  }
+  return RELEASES_PAGE;
+}
+
+// ── Staging ─────────────────────────────────────────────────────────────────
+
+// Managed installs: run the embedded installer script against the checked
+// version. Returns immediately with {started:true} (the admin card polls
+// GET status); the download itself is minutes on a slow link. Single-flight:
+// a second call while one runs joins it.
+export function stageNow(manifest = null) {
+  const m = detectInstall();
+  if (state.notifyOnly) { return { error: 'update format changed - re-run the install command' }; }
+  if (m.method === 'inno' || m.method === 'pkg') {
+    if (!state.latest || !state.available) { return { error: 'no update available' }; }
+    if (!_staging) {
+      _staging = stageInstaller(manifest).finally(() => { _staging = null; });
+    }
+    return { started: true };
+  }
+  if (m.method !== 'managed') { return { error: `this install (${m.method}) updates through its own channel` }; }
+  if (!state.latest || !state.available) { return { error: 'no update available' }; }
+  if (_staging) { return { started: true }; }
+  const target = state.latest;
+  _staging = runInstallerScript(target, m.root)
+    .then(async () => {
+      const landed = await stagedVersionFromRoot(m.root);
+      if (!landed) {
+        throw new Error('installer finished but $ROOT/current does not name a bundle');
+      }
+      if (compareVersions(landed, state.current) <= 0) {
+        // A mirror can only serve what it serves (MSTREAM_VERSION is
+        // decorative when MSTREAM_RELEASE_BASE is set) — report what
+        // actually landed rather than pretending.
+        throw new Error(`installer staged ${landed}, which is not newer than ${state.current}`);
+      }
+      state.staged = true;
+      state.stagedVersion = landed;
+      state.error = null;
+      winston.info(`[update] mStream ${landed} is staged - it takes over on the next restart`);
+      await pruneOldVersions(m.root);
+      await writeStatus();
+      maybeAutoApply();
+    })
+    .catch(async (err) => {
+      state.error = `Staging failed: ${err.message}`;
+      winston.warn(`[update] ${state.error}`);
+      await writeStatus();
+    })
+    .finally(() => { _staging = null; });
+  return { started: true };
+}
+
+function runInstallerScript(targetVersion, root) {
+  return new Promise((resolve, reject) => {
+    const script = embeddedInstallerPath();
+    if (!fs.existsSync(script)) {
+      return reject(new Error(`no embedded installer at ${script}`));
+    }
+    const env = {
+      ...process.env,
+      MSTREAM_VERSION: `v${targetVersion}`,
+      MSTREAM_INSTALL_DIR: root,
+    };
+    const [cmd, args] = process.platform === 'win32'
+      ? ['powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', script]]
+      : ['/bin/sh', [script]];
+    winston.info(`[update] Staging mStream ${targetVersion} via ${path.basename(script)}...`);
+    const child = spawn(cmd, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    const tail = [];
+    const keep = (chunk) => {
+      for (const line of chunk.toString().split('\n')) {
+        const t = line.trimEnd();
+        if (!t) { continue; }
+        winston.info(`[update] installer: ${t}`);
+        tail.push(t);
+        if (tail.length > 40) { tail.shift(); }
+      }
+    };
+    child.stdout.on('data', keep);
+    child.stderr.on('data', keep);
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error('installer timed out'));
+    }, STAGE_TIMEOUT_MS);
+    if (timer.unref) { timer.unref(); }
+    child.on('error', (err) => { clearTimeout(timer); reject(err); });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0) { resolve(); }
+      else { reject(new Error(`installer exited ${code}: ${tail.slice(-6).join(' | ')}`)); }
+    });
+  });
+}
+
+async function stagedVersionFromRoot(root) {
+  try {
+    const target = await fsp.readlink(path.join(root, 'current'));
+    return parseBundleName(path.basename(target))?.version || null;
+  } catch {
+    return null;
+  }
+}
+
+// Windows installer / macOS .pkg: download + verify into our own updates/
+// dir. The launcher (or the user) runs it from there; verification is the
+// manifest's sha256, same trust chain as the bundles.
+async function stageInstaller(manifest) {
+  try {
+    if (!manifest) { manifest = await fetchManifest(); }
+    const v = validateManifest(manifest);
+    if (!v.ok) { throw new Error(v.reason); }
+    const name = installerAssetName(manifest.version);
+    const entry = name && manifest.assets.find(a => a.file === name);
+    if (!entry) { throw new Error(`this release has no ${name || 'installer'} (releases before the updater carry none)`); }
+    const dir = path.join(userDataHome(), 'updates');
+    await fsp.mkdir(dir, { recursive: true });
+    const dest = path.join(dir, name);
+    const already = fs.existsSync(dest) && (await computeFileChecksum(dest)) === entry.sha256;
+    if (!already) {
+      state.downloading = true;
+      await writeStatus();
+      await downloadToFile(assetUrl(manifest.version, name), dest, { maxBytes: INSTALLER_MAX_BYTES });
+      const sum = await computeFileChecksum(dest);
+      if (sum !== entry.sha256) {
+        await fsp.unlink(dest).catch(() => {});
+        throw new Error(`sha256 mismatch for ${name}`);
+      }
+    }
+    // One installer at a time: sweep siblings from older checks.
+    for (const f of await fsp.readdir(dir)) {
+      if (f !== name) { await fsp.rm(path.join(dir, f), { force: true }).catch(() => {}); }
+    }
+    state.staged = true;
+    state.stagedVersion = manifest.version;
+    state.installerPath = dest;
+    state.error = null;
+    winston.info(`[update] ${name} is downloaded and verified`);
+  } catch (err) {
+    state.error = `Installer download failed: ${err.message}`;
+    winston.warn(`[update] ${state.error}`);
+  } finally {
+    state.downloading = false;
+    await writeStatus();
+    maybeAutoApply();
+  }
+}
+
+// Old versioned folders accumulate under daily staging (install.sh never
+// prunes by design — a human runs it rarely; we run it on a schedule). Keep
+// the current target, the tree the running server lives in, and the single
+// newest other version (the manual-rollback candidate); delete the rest.
+async function pruneOldVersions(root) {
+  try {
+    const protect = new Set();
+    try { protect.add(await fsp.realpath(path.join(root, 'current'))); } catch { /* no current */ }
+    try {
+      let dir = path.dirname(await fsp.realpath(process.execPath));
+      for (let i = 0; i < 8 && dir !== path.dirname(dir); i++) {
+        if (parseBundleName(path.basename(dir))) { protect.add(dir); break; }
+        dir = path.dirname(dir);
+      }
+    } catch { /* keep going */ }
+    const candidates = [];
+    for (const entry of await fsp.readdir(root)) {
+      if (!parseBundleName(entry)) { continue; }
+      const full = path.join(root, entry);
+      let real = full;
+      try { real = await fsp.realpath(full); } catch { continue; }
+      if (protect.has(real)) { continue; }
+      const st = await fsp.stat(full).catch(() => null);
+      if (st && st.isDirectory()) { candidates.push({ full, mtime: st.mtimeMs }); }
+    }
+    candidates.sort((a, b) => b.mtime - a.mtime);
+    for (const c of candidates.slice(1)) {
+      winston.info(`[update] Pruning old version ${path.basename(c.full)}`);
+      await fsp.rm(c.full, { recursive: true, force: true }).catch(() => {});
+    }
+  } catch (err) {
+    winston.warn(`[update] Prune skipped: ${err.message}`);
+  }
+}
+
+// ── Applying ────────────────────────────────────────────────────────────────
+
+function idle() {
+  try { return !_hooks.hasBusySockets() && !_hooks.isScanning(); }
+  catch { return false; }
+}
+
+// The human clicked "restart to update" in the webapp. Managed under the
+// launcher / inno: raise applyRequested — the launcher reads the status file
+// every minute and performs the restart (the <=1 min lag is in the UI copy).
+// pkg: open the verified installer now (Installer.app takes it from there).
+// Managed headless: exit once the response has gone out; the supervisor
+// restart lands on the flipped `current`.
+export async function requestApply() {
+  const m = detectInstall();
+  if (!state.staged) { return { error: 'nothing is staged yet' }; }
+  if (m.method === 'pkg') {
+    if (!state.installerPath || !fs.existsSync(state.installerPath)) { return { error: 'installer not downloaded yet' }; }
+    spawn('open', [state.installerPath], { detached: true, stdio: 'ignore' }).unref();
+    return { opened: true };
+  }
+  state.applyRequested = true;
+  await writeStatus();
+  if (m.method === 'managed' && !supervisedByLauncher()) {
+    scheduleHeadlessExit('an admin requested the update');
+    return { exiting: true };
+  }
+  return { requested: true };
+}
+
+function scheduleHeadlessExit(why) {
+  if (_exiting) { return; }
+  _exiting = true;
+  winston.info(`[update] Restarting into mStream ${state.stagedVersion}: ${why}. `
+    + 'Exiting 0 - the process supervisor is expected to start mStream again.');
+  // Give the HTTP response and log writes a beat to flush.
+  const t = setTimeout(() => { process.exit(0); }, 1500);
+  if (t.unref) { t.unref(); }
+}
+
+// auto mode: apply on our own once nothing is streaming and no scan runs.
+function maybeAutoApply() {
+  if (updatesConfig().mode !== 'auto' || !state.staged || state.applyRequested) { return; }
+  const m = detectInstall();
+  if (m.method !== 'managed' && m.method !== 'inno') { return; }
+  if (!idle()) { return; }
+  if (m.method === 'managed' && !supervisedByLauncher()) {
+    scheduleHeadlessExit('auto mode, server idle');
+    return;
+  }
+  // Launcher-supervised (managed restart, or inno silent install): flag it;
+  // the launcher acts within a minute.
+  state.applyRequested = true;
+  writeStatus().catch(() => {});
+}
+
+// Admin toggles (mode/check) changed: re-evaluate posture and re-publish.
+export function onSettingsChanged() {
+  writeStatus().catch(() => {});
+  maybeAutoApply();
+  const cfg = updatesConfig();
+  if (cfg.check && cfg.mode !== 'notify' && state.available && !state.staged) {
+    // e.g. notify -> stage: start the download the old mode withheld.
+    checkNow(true).catch(() => {});
+  }
+}
+
+// ── Wiring ──────────────────────────────────────────────────────────────────
+
+// Called from serveIt() on every (re)boot. Idempotent across soft reboots —
+// the timers survive reboot() untouched (it is not in any reset list), and
+// the boot-time status write is what lets the launcher's "restart to update"
+// item self-correct the moment the staged version actually boots.
+export function setup(mstream, hooks = {}) {
+  _hooks = { ..._hooks, ...hooks };
+  detectInstall();
+  // A staged flag from a PREVIOUS process run: if we ARE that version now,
+  // clear it; if not (the restart didn't land on it), re-checking will
+  // re-discover it within a day, or instantly via the boot check.
+  if (state.stagedVersion && compareVersions(state.stagedVersion, state.current) <= 0) {
+    state.staged = false;
+    state.stagedVersion = null;
+    state.applyRequested = false;
+  }
+  writeStatus().catch(() => {});
+  if (_bootTimer || _checkTimer) { return; }
+  _bootTimer = setTimeout(() => {
+    _bootTimer = null;
+    checkNow().catch(() => {});
+  }, BOOT_CHECK_DELAY_MS);
+  if (_bootTimer.unref) { _bootTimer.unref(); }
+  _checkTimer = setInterval(() => { checkNow().catch(() => {}); }, CHECK_INTERVAL_MS);
+  if (_checkTimer.unref) { _checkTimer.unref(); }
+  _applyTimer = setInterval(() => { maybeAutoApply(); }, AUTO_APPLY_POLL_MS);
+  if (_applyTimer.unref) { _applyTimer.unref(); }
+}
+
+// Test hook: stop timers and forget detection.
+export function stopForTests() {
+  for (const t of [_bootTimer, _checkTimer, _applyTimer]) { if (t) { clearTimeout(t); clearInterval(t); } }
+  _bootTimer = _checkTimer = _applyTimer = null;
+  _install = null;
+  _exiting = false;
+  state.latest = null; state.available = false; state.staged = false;
+  state.stagedVersion = null; state.applyRequested = false; state.error = null;
+  state.installerPath = null; state.downloadUrl = null; state.notifyOnly = false;
+  state.downloading = false; state.method = null; state.lastCheckAt = null;
+}

--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -128,25 +128,28 @@ export function detectInstallMethod({
   const realDir = path.dirname(real);
 
   // macOS ~/Applications copy: the installer's ditto copy plus its SIBLING
-  // ownership marker. The versioned root is the per-OS default (the marker
-  // is only ever written by an install into that default layout).
+  // ownership marker. The marker's second line names the install ROOT (a
+  // custom MSTREAM_INSTALL_DIR is invisible from here otherwise); markers
+  // from older installers are version-only, so fall back to the per-OS
+  // default root. Whatever it names must actually hold a `current` link.
   if (platform === 'darwin') {
     const hd = homedir ? homedir() : path.dirname(path.dirname(path.dirname(home)));
     const appsCopy = path.join(hd, 'Applications', 'mStream.app');
-    if ((real.startsWith(appsCopy + path.sep)) && fsx.existsSync(path.join(hd, 'Applications', '.mstream-installer'))) {
-      const root = path.join(home, 'app');
+    const marker = path.join(hd, 'Applications', '.mstream-installer');
+    if ((real.startsWith(appsCopy + path.sep)) && fsx.existsSync(marker)) {
+      let root = path.join(home, 'app');
+      try {
+        const markedRoot = String(fsx.readFileSync(marker, 'utf8')).split('\n')[1];
+        if (markedRoot && path.isAbsolute(markedRoot.trim())) { root = markedRoot.trim(); }
+      } catch { /* version-only marker */ }
       if (fsx.existsSync(path.join(root, 'current'))) { return { method: 'managed', root }; }
     }
   }
 
-  // deb/rpm (/opt, /usr) and the macOS .pkg (/Applications) live in
-  // package-manager territory — never staged by us.
-  if (underSystemPrefix(realDir + '/', platform)) {
-    return { method: platform === 'darwin' ? 'pkg' : 'deb-rpm' };
-  }
-
   // The managed layout: some ancestor holds `current`, and a versioned
-  // bundle dir sits on the path between them.
+  // bundle dir sits on the path between them. This runs BEFORE the
+  // system-prefix classification: a script-managed install under a custom
+  // root in /opt or /usr/local is still managed — geometry outranks prefix.
   let dir = realDir;
   for (let i = 0; i < 8; i++) {
     const parent = path.dirname(dir);
@@ -155,6 +158,12 @@ export function detectInstallMethod({
       return { method: 'managed', root: parent };
     }
     dir = parent;
+  }
+
+  // deb/rpm (/opt, /usr) and the macOS .pkg (/Applications) live in
+  // package-manager territory — never staged by us.
+  if (underSystemPrefix(realDir + '/', platform)) {
+    return { method: platform === 'darwin' ? 'pkg' : 'deb-rpm' };
   }
 
   // Windows Inno install: flat files at %LOCALAPPDATA%\Programs\mStream,
@@ -179,6 +188,8 @@ let _bootTimer = null;
 let _checkTimer = null;
 let _applyTimer = null;
 let _staging = null;        // single-flight staging promise; never cleared by reboot
+let _checking = null;       // single-flight check promise (timer + POST can overlap)
+let _tmpSeq = 0;            // unique manifest scratch names (two checks, one pid)
 let _exiting = false;
 
 const state = {
@@ -197,10 +208,19 @@ const state = {
   lastCheckAt: null,
   error: null,
   notifyOnly: false,        // apiVersion from the future: check works, staging refused
+  skipped: false,           // latest === updates.skipVersion: report, never act
 };
 
 function updatesConfig() {
-  return config.program?.updates || { check: true, mode: 'stage' };
+  return config.program?.updates || { check: true, mode: 'stage', skipVersion: '' };
+}
+
+// The operator held this version back (updates.skipVersion — the companion
+// of the documented manual rollback: without it, the next daily check would
+// silently re-stage the very release the human just backed out of).
+function isSkipped(version) {
+  const skip = updatesConfig().skipVersion;
+  return !!skip && !!version && skip === version;
 }
 
 function supervisedByLauncher() {
@@ -212,10 +232,16 @@ export function statusFilePath() {
 }
 
 export function getStatus() {
-  return { ...state, check: updatesConfig().check, mode: updatesConfig().mode };
+  const cfg = updatesConfig();
+  return { ...state, check: cfg.check, mode: cfg.mode, skipVersion: cfg.skipVersion || '' };
 }
 
 async function writeStatus() {
+  // The file exists FOR the tray launcher, and the data home is shared by
+  // every instance this user runs (a docker exec, an npm dev server, a
+  // second --portable copy). Only the launcher-supervised instance may
+  // write, or an unrelated instance clobbers the tray's state.
+  if (!supervisedByLauncher()) { return; }
   const doc = { ...getStatus(), writtenAt: new Date().toISOString() };
   try {
     await fsp.mkdir(userDataHome(), { recursive: true });
@@ -272,7 +298,10 @@ function detectInstall() {
 async function fetchManifest() {
   const dir = userDataHome();
   await fsp.mkdir(dir, { recursive: true });
-  const tmp = path.join(dir, `.update-manifest-${process.pid}.json`);
+  // pid + sequence: two concurrent checks in ONE process (the daily timer
+  // racing a POST) must not share a scratch path — downloadToFile stages
+  // via `<dest>.tmp`, so a fixed name collides at both files.
+  const tmp = path.join(dir, `.update-manifest-${process.pid}-${++_tmpSeq}.json`);
   try {
     await downloadToFile(`${releaseBase()}/manifest.json`, tmp, { maxBytes: MANIFEST_MAX_BYTES });
     return JSON.parse(await fsp.readFile(tmp, 'utf8'));
@@ -283,8 +312,16 @@ async function fetchManifest() {
 
 // Check the release feed. `force` is a human clicking "Check now" — it works
 // even with the periodic check switched off. Never throws; failures land in
-// state.error and the previous knowledge stays put.
-export async function checkNow(force = false) {
+// state.error and the previous knowledge stays put. Single-flight: a POST
+// landing while the daily timer's check is in the air joins it instead of
+// racing it over the same state.
+export function checkNow(force = false) {
+  if (_checking) { return _checking; }
+  _checking = doCheck(force).finally(() => { _checking = null; });
+  return _checking;
+}
+
+async function doCheck(force) {
   const cfg = updatesConfig();
   if (!cfg.check && !force) { return getStatus(); }
   detectInstall();
@@ -313,19 +350,21 @@ export async function checkNow(force = false) {
     state.notifyOnly = false;
     state.latest = manifest.version;
     state.available = compareVersions(manifest.version, state.current) > 0;
+    state.skipped = state.available && isSkipped(manifest.version);
     if (!state.available) {
       state.downloadUrl = null;
     } else {
       const m = detectInstall();
       state.downloadUrl = downloadUrlFor(m.method, manifest);
-      winston.info(`[update] mStream ${manifest.version} is available (running ${state.current}, install: ${m.method})`);
+      winston.info(`[update] mStream ${manifest.version} is available (running ${state.current}, install: ${m.method}${state.skipped ? ', SKIPPED by updates.skipVersion' : ''})`);
       const mode = updatesConfig().mode;
-      if (mode !== 'notify' && !state.notifyOnly
+      if (mode !== 'notify' && !state.notifyOnly && !state.skipped
           && (m.method === 'managed' || m.method === 'inno')
           && (!state.staged || state.stagedVersion !== manifest.version)) {
         stageNow(manifest); // async, single-flight; errors land in state
       }
     }
+    await enforceSkip();   // a hand-edited skipVersion counts too
     await writeStatus();
     maybeAutoApply();
   } catch (err) {
@@ -353,6 +392,9 @@ function downloadUrlFor(method, manifest) {
 export function stageNow(manifest = null) {
   const m = detectInstall();
   if (state.notifyOnly) { return { error: 'update format changed - re-run the install command' }; }
+  if (state.latest && isSkipped(state.latest)) {
+    return { error: `version ${state.latest} is held back by updates.skipVersion` };
+  }
   if (m.method === 'inno' || m.method === 'pkg') {
     if (!state.latest || !state.available) { return { error: 'no update available' }; }
     if (!_staging) {
@@ -364,6 +406,11 @@ export function stageNow(manifest = null) {
   if (!state.latest || !state.available) { return { error: 'no update available' }; }
   if (_staging) { return { started: true }; }
   const target = state.latest;
+  // The managed download is minutes on a slow link and runs inside the
+  // spawned installer — surface it, exactly as the inno path does, so the
+  // card and the tray don't report "not downloaded" mid-download.
+  state.downloading = true;
+  writeStatus().catch(() => {});
   _staging = runInstallerScript(target, m.root)
     .then(async () => {
       const landed = await stagedVersionFromRoot(m.root);
@@ -381,6 +428,10 @@ export function stageNow(manifest = null) {
       state.error = null;
       winston.info(`[update] mStream ${landed} is staged - it takes over on the next restart`);
       await pruneOldVersions(m.root);
+      // A skip that landed WHILE this stage was downloading was a no-op in
+      // enforceSkip (nothing was staged yet) — honor it now, before the
+      // status file advertises the held-back version as armed.
+      await enforceSkip();
       await writeStatus();
       maybeAutoApply();
     })
@@ -389,7 +440,11 @@ export function stageNow(manifest = null) {
       winston.warn(`[update] ${state.error}`);
       await writeStatus();
     })
-    .finally(() => { _staging = null; });
+    .finally(() => {
+      state.downloading = false;
+      _staging = null;
+      writeStatus().catch(() => {});
+    });
   return { started: true };
 }
 
@@ -404,11 +459,24 @@ function runInstallerScript(targetVersion, root) {
       MSTREAM_VERSION: `v${targetVersion}`,
       MSTREAM_INSTALL_DIR: root,
     };
+    // Never let catastrophic installer modes ride in from the server's own
+    // environment: MSTREAM_UNINSTALL would rm -rf the install root,
+    // MSTREAM_FORCE would displace the live version's folder. The rest
+    // (MSTREAM_RELEASE_BASE above all) passes through on purpose.
+    delete env.MSTREAM_UNINSTALL;
+    delete env.MSTREAM_FORCE;
     const [cmd, args] = process.platform === 'win32'
       ? ['powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', script]]
       : ['/bin/sh', [script]];
     winston.info(`[update] Staging mStream ${targetVersion} via ${path.basename(script)}...`);
-    const child = spawn(cmd, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    // detached (posix): the script's own process group, so the timeout can
+    // kill the WHOLE tree — child.kill() alone reaps the shell and orphans
+    // a mid-flight curl/unzip that could race a retried stage.
+    const child = spawn(cmd, args, {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+    });
     const tail = [];
     const keep = (chunk) => {
       for (const line of chunk.toString().split('\n')) {
@@ -422,8 +490,19 @@ function runInstallerScript(targetVersion, root) {
     child.stdout.on('data', keep);
     child.stderr.on('data', keep);
     const timer = setTimeout(() => {
-      child.kill();
-      reject(new Error('installer timed out'));
+      if (process.platform === 'win32') {
+        // powershell's children (curl/Expand-Archive) are a tree of their
+        // own; /T fells all of it. Reject only after taskkill has RUN —
+        // rejecting first would clear the single-flight while the orphaned
+        // tree could still flip `current` behind a "failed" stage.
+        const tk = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+        const done = () => reject(new Error('installer timed out'));
+        tk.on('close', done);
+        tk.on('error', () => { child.kill(); done(); });
+      } else {
+        try { process.kill(-child.pid, 'SIGKILL'); } catch { child.kill(); }
+        reject(new Error('installer timed out'));
+      }
     }, STAGE_TIMEOUT_MS);
     if (timer.unref) { timer.unref(); }
     child.on('error', (err) => { clearTimeout(timer); reject(err); });
@@ -473,11 +552,20 @@ async function stageInstaller(manifest) {
     for (const f of await fsp.readdir(dir)) {
       if (f !== name) { await fsp.rm(path.join(dir, f), { force: true }).catch(() => {}); }
     }
-    state.staged = true;
-    state.stagedVersion = manifest.version;
-    state.installerPath = dest;
-    state.error = null;
-    winston.info(`[update] ${name} is downloaded and verified`);
+    if (isSkipped(manifest.version)) {
+      // Skipped mid-download: never arm the installer for the launcher.
+      await fsp.unlink(dest).catch(() => {});
+      state.staged = false;
+      state.stagedVersion = null;
+      state.installerPath = null;
+      winston.info(`[update] ${name} discarded - version is held back by updates.skipVersion`);
+    } else {
+      state.staged = true;
+      state.stagedVersion = manifest.version;
+      state.installerPath = dest;
+      state.error = null;
+      winston.info(`[update] ${name} is downloaded and verified`);
+    }
   } catch (err) {
     state.error = `Installer download failed: ${err.message}`;
     winston.warn(`[update] ${state.error}`);
@@ -539,6 +627,9 @@ function idle() {
 export async function requestApply() {
   const m = detectInstall();
   if (!state.staged) { return { error: 'nothing is staged yet' }; }
+  if (isSkipped(state.stagedVersion)) {
+    return { error: `version ${state.stagedVersion} is held back by updates.skipVersion` };
+  }
   if (m.method === 'pkg') {
     if (!state.installerPath || !fs.existsSync(state.installerPath)) { return { error: 'installer not downloaded yet' }; }
     spawn('open', [state.installerPath], { detached: true, stdio: 'ignore' }).unref();
@@ -566,6 +657,7 @@ function scheduleHeadlessExit(why) {
 // auto mode: apply on our own once nothing is streaming and no scan runs.
 function maybeAutoApply() {
   if (updatesConfig().mode !== 'auto' || !state.staged || state.applyRequested) { return; }
+  if (isSkipped(state.stagedVersion)) { return; }
   const m = detectInstall();
   if (m.method !== 'managed' && m.method !== 'inno') { return; }
   if (!idle()) { return; }
@@ -579,15 +671,169 @@ function maybeAutoApply() {
   writeStatus().catch(() => {});
 }
 
-// Admin toggles (mode/check) changed: re-evaluate posture and re-publish.
-export function onSettingsChanged() {
-  writeStatus().catch(() => {});
-  maybeAutoApply();
-  const cfg = updatesConfig();
-  if (cfg.check && cfg.mode !== 'notify' && state.available && !state.staged) {
-    // e.g. notify -> stage: start the download the old mode withheld.
-    checkNow(true).catch(() => {});
+// Replace `link` with a symlink/junction to `target` as atomically as the
+// platform allows: build a temp link, rename it over the old one (POSIX
+// rename replaces a symlink atomically — a crash never leaves the install
+// with no `current` at all). Windows can refuse to rename onto a junction;
+// there the unlink+create fallback keeps the pre-existing exposure.
+async function replaceLink(target, link) {
+  const tmp = `${link}.tmp-${process.pid}`;
+  const kind = process.platform === 'win32' ? 'junction' : 'dir';
+  await fsp.rm(tmp, { force: true }).catch(() => {});
+  await fsp.symlink(target, tmp, kind);
+  try {
+    await fsp.rename(tmp, link);
+  } catch {
+    await fsp.rm(tmp, { force: true }).catch(() => {});
+    await fsp.unlink(link).catch(() => {});
+    await fsp.symlink(target, link, kind);
   }
+}
+
+// `<bin> -V`, bounded: the version the binary answers with, or null.
+function probeVersion(bin) {
+  return new Promise((resolve) => {
+    if (!fs.existsSync(bin)) { return resolve(null); }
+    let out = '';
+    const child = spawn(bin, ['-V'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const t = setTimeout(() => { child.kill(); resolve(null); }, 10000);
+    if (t.unref) { t.unref(); }
+    child.stdout.on('data', (d) => { out += d; });
+    child.on('error', () => { clearTimeout(t); resolve(null); });
+    child.on('close', () => { clearTimeout(t); resolve(out.trim() || null); });
+  });
+}
+
+// The bundle-named ancestor of the running executable, if any.
+async function runningBundleDir() {
+  try {
+    let dir = path.dirname(await fsp.realpath(process.execPath));
+    for (let i = 0; i < 8 && dir !== path.dirname(dir); i++) {
+      if (parseBundleName(path.basename(dir))) { return dir; }
+      dir = path.dirname(dir);
+    }
+  } catch { /* not resolvable */ }
+  return null;
+}
+
+// Point `current` back at the RUNNING version. Target choice mirrors
+// pruneOldVersions' protection: the running exe's own bundle tree when it
+// lives under root; else a folder matching the running version AND the
+// skipped bundle's key (never a different bundle family — re-pointing at a
+// same-version musl/glibc sibling would trade one broken boot for another).
+async function unstageCurrent(root, held) {
+  try {
+    const link = path.join(root, 'current');
+    const curTarget = await fsp.readlink(link).catch(() => null);
+    const curParsed = curTarget ? parseBundleName(path.basename(curTarget)) : null;
+    if (!curParsed || curParsed.version !== held) { return true; } // not on the skipped version
+    const realRoot = await fsp.realpath(root).catch(() => root);
+    let target = await runningBundleDir();
+    if (!(target && path.dirname(target) === realRoot)) {
+      const entries = await fsp.readdir(root);
+      const found = entries.find((e) => {
+        const p = parseBundleName(e);
+        return p && p.version === state.current && p.key === curParsed.key;
+      });
+      target = found ? path.join(root, found) : null;
+    }
+    if (!target) {
+      winston.warn(`[update] No ${state.current} folder under ${root} to re-point current at`);
+      return false;
+    }
+    await replaceLink(target, link);
+    winston.info(`[update] current re-pointed at ${path.basename(target)}`);
+    return true;
+  } catch (err) {
+    winston.warn(`[update] Could not re-point current off the skipped version: ${err.message}`);
+    return false;
+  }
+}
+
+// macOS: staging also refreshed the ~/Applications copy — the tree the
+// login item, Finder, and the launcher's relaunch actually BOOT — moving
+// the previous copy aside. Re-pointing `current` alone would leave the
+// skipped version in the user's face; restore the newest aside whose
+// server answers -V with the running version. Only ever touches a copy the
+// installer owns (sibling marker), same rule as install.sh.
+async function restoreAppsCopy() {
+  try {
+    const home = path.join(userDataHome(), '..', '..', '..');
+    const apps = path.join(home, 'Applications');
+    const dest = path.join(apps, 'mStream.app');
+    const marker = path.join(apps, '.mstream-installer');
+    if (!fs.existsSync(marker) || !fs.existsSync(dest)) { return true; }
+    const serverIn = (d) => path.join(d, 'Contents', 'MacOS', 'mstream-server');
+    if ((await probeVersion(serverIn(dest))) === state.current) { return true; }
+    const asides = (await fsp.readdir(apps))
+      .filter((e) => e.startsWith('mStream.app.old.'))
+      .sort()
+      .reverse();
+    for (const a of asides) {
+      const cand = path.join(apps, a);
+      if ((await probeVersion(serverIn(cand))) === state.current) {
+        // The displaced skipped copy joins the .old.* family so install.sh's
+        // idle sweep reclaims it later.
+        await fsp.rename(dest, path.join(apps, `mStream.app.old.${Date.now()}.skipped`));
+        await fsp.rename(cand, dest);
+        const m = detectInstall();
+        await fsp.writeFile(marker, `${state.current}\n${m.root || ''}\n`);
+        winston.info('[update] ~/Applications/mStream.app restored to the running version');
+        return true;
+      }
+    }
+    winston.warn(`[update] No aside copy of ${state.current} to restore into ~/Applications`);
+    return false;
+  } catch (err) {
+    winston.warn(`[update] Could not restore ~/Applications: ${err.message}`);
+    return false;
+  }
+}
+
+// A staged version that is now skipped must stop being armed: clear the
+// flags (the launcher applies from the status file without asking the
+// server), point `current` back at the running version, and on macOS
+// restore the ~/Applications copy staging displaced. When any of that
+// fails, the flags are STILL cleared (nothing may keep offering the
+// held-back version) but the failure is loud: state.error carries the
+// manual remediation instead of the card pretending the skip is complete.
+async function enforceSkip() {
+  if (!state.staged || !isSkipped(state.stagedVersion)) { return; }
+  const held = state.stagedVersion;
+  winston.info(`[update] Un-staging skipped version ${held}`);
+  const m = detectInstall();
+  let ok = true;
+  if (m.method === 'managed' && m.root) {
+    ok = await unstageCurrent(m.root, held);
+    if (process.platform === 'darwin') {
+      ok = (await restoreAppsCopy()) && ok;
+    }
+  }
+  state.staged = false;
+  state.stagedVersion = null;
+  state.applyRequested = false;
+  if (!ok) {
+    state.error = `Version ${held} is skipped, but the previous version could not be fully restored - `
+      + `re-run the installer with MSTREAM_VERSION=v${state.current} to finish the rollback`;
+    winston.warn(`[update] ${state.error}`);
+  }
+}
+
+// Admin toggles (mode/check/skipVersion) changed: re-evaluate posture and
+// re-publish.
+export function onSettingsChanged() {
+  state.skipped = state.available && isSkipped(state.latest);
+  enforceSkip()
+    .then(() => writeStatus())
+    .catch(() => {})
+    .then(() => {
+      maybeAutoApply();
+      const cfg = updatesConfig();
+      if (cfg.check && cfg.mode !== 'notify' && state.available && !state.skipped && !state.staged) {
+        // e.g. notify -> stage, or an unskip: start the withheld download.
+        checkNow(true).catch(() => {});
+      }
+    });
 }
 
 // ── Wiring ──────────────────────────────────────────────────────────────────
@@ -625,7 +871,9 @@ export function stopForTests() {
   for (const t of [_bootTimer, _checkTimer, _applyTimer]) { if (t) { clearTimeout(t); clearInterval(t); } }
   _bootTimer = _checkTimer = _applyTimer = null;
   _install = null;
+  _checking = null;
   _exiting = false;
+  state.skipped = false;
   state.latest = null; state.available = false; state.staged = false;
   state.stagedVersion = null; state.applyRequested = false; state.error = null;
   state.installerPath = null; state.downloadUrl = null; state.notifyOnly = false;

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -36,7 +36,7 @@ function hostKey() {
 
 let relDir; let relPort; let relServer; let tmpHome;
 
-function makeBundle(version, key) {
+function makeBundle(version, key, { broken = false } = {}) {
   const b = `mStream-${version}-${key}`;
   const dir = path.join(relDir, b);
   const inner = key.startsWith('darwin')
@@ -44,18 +44,23 @@ function makeBundle(version, key) {
     : dir;
   spawnSync('mkdir', ['-p', inner]);
   const server = path.join(inner, 'mstream-server');
-  spawnSync('bash', ['-c', `printf '#!/bin/sh\\n[ "$1" = -V ] && echo ${version}\\nexit 0\\n' > '${server}' && chmod +x '${server}'`]);
+  // broken = a binary this host "cannot exec": the probe-before-flip in
+  // install.sh must refuse it and the stager must report a failed stage.
+  const stub = broken
+    ? `printf '#!/bin/sh\\nexit 1\\n' > '${server}'`
+    : `printf '#!/bin/sh\\n[ "$1" = -V ] && echo ${version}\\nexit 0\\n' > '${server}'`;
+  spawnSync('bash', ['-c', `${stub} && chmod +x '${server}'`]);
   spawnSync('bash', ['-c', `echo 'fake bundle' > '${dir}/README.txt'`]);
   const zip = spawnSync('python3', ['-m', 'zipfile', '-c', `${b}.zip`, b], { cwd: relDir });
   assert.equal(zip.status, 0, `zip failed: ${zip.stderr}`);
   spawnSync('rm', ['-rf', dir]);
 }
 
-async function publish(version, { tamper = false } = {}) {
+async function publish(version, { tamper = false, broken = false } = {}) {
   for (const f of await fs.readdir(relDir)) {
     if (f.endsWith('.zip') || f === 'manifest.json') { await fs.rm(path.join(relDir, f)); }
   }
-  makeBundle(version, hostKey());
+  makeBundle(version, hostKey(), { broken });
   const gen = spawnSync('sh', [path.join(REPO_ROOT, 'scripts', 'release-manifest.sh'), version, relDir]);
   assert.equal(gen.status, 0, `manifest generation failed: ${gen.stderr}`);
   if (tamper) {
@@ -112,7 +117,13 @@ async function pollStatus(baseUrl, pred, timeoutMs = 60_000) {
 
 test('managed round-trip: check, auto-stage, current flip, tamper refusal, live settings', { skip: posixOnly }, async () => {
   await publish('9.9.9');
-  const srv = await startServer({ waitForScan: false, env: updEnv() });
+  // --supervised + held stdin: the status file is written only by the
+  // launcher-supervised instance (a shared data home must not be clobbered
+  // by unrelated instances), and this test asserts on that file.
+  const srv = await startServer({
+    waitForScan: false, env: updEnv(),
+    extraArgs: ['--supervised'], stdin: 'pipe',
+  });
   try {
     // Boot state: forced-managed, nothing known yet.
     let s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update`)).json();
@@ -150,6 +161,45 @@ test('managed round-trip: check, auto-stage, current flip, tamper refusal, live 
     assert.match(s.error, /Staging failed/);
     assert.equal(path.basename(await fs.readlink(path.join(root, 'current'))), `mStream-9.9.9-${hostKey()}`);
 
+    // A bundle whose binary cannot exec must never take over: install.sh's
+    // probe-before-flip refuses, the stager reports a failed stage, and
+    // `current` stays put.
+    await publish('9.9.11', { broken: true });
+    await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+    // Match the probe's own words, not just 'Staging failed' — the tamper
+    // step above already left that prefix in state.error.
+    s = await pollStatus(srv.baseUrl, (x) => (x.error || '').includes('does not run on this system'));
+    assert.match(s.error, /Staging failed/);
+    assert.equal(path.basename(await fs.readlink(path.join(root, 'current'))), `mStream-9.9.9-${hostKey()}`);
+
+    // Skip round-trip: a good newer release stages; skipping it un-stages
+    // AND re-points current at the running version's folder; unskipping
+    // re-stages it. This is the rollback companion — without it the daily
+    // check silently re-flips onto the release the operator backed out of.
+    await publish('9.9.12');
+    await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+    s = await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.12');
+    // A folder for the RUNNING version so the un-flip has a target (a real
+    // managed install always has one; this server runs from source).
+    const runningDir = path.join(root, `mStream-${packageJson.version}-${hostKey()}`);
+    await fs.mkdir(runningDir, { recursive: true });
+    const skipSet = await fetch(`${srv.baseUrl}/api/v1/admin/update/settings`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ skipVersion: '9.9.12' }),
+    });
+    assert.equal(skipSet.status, 200);
+    s = await pollStatus(srv.baseUrl, (x) => x.skipped && !x.staged);
+    assert.equal(s.stagedVersion, null);
+    assert.equal(await fs.readlink(path.join(root, 'current')), runningDir);
+    const dlSkipped = await fetch(`${srv.baseUrl}/api/v1/admin/update/download`, { method: 'POST' });
+    assert.equal(dlSkipped.status, 409);
+    const unskip = await fetch(`${srv.baseUrl}/api/v1/admin/update/settings`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ skipVersion: '' }),
+    });
+    assert.equal(unskip.status, 200);
+    s = await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.12' && !x.skipped);
+
     // Settings persist to the config file and apply live.
     const set = await fetch(`${srv.baseUrl}/api/v1/admin/update/settings`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -175,6 +225,12 @@ test('non-managed installs refuse staging; apply refuses with nothing staged', {
   await publish('9.9.9');
   const env = updEnv();
   delete env.MSTREAM_UPDATE_ROOT; // source run -> method npm-source
+  // A separate home: this instance is NOT launcher-supervised, so it must
+  // never write a status file at all (a docker/npm instance sharing the
+  // data home would otherwise clobber the tray's state).
+  const soloHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-solo-'));
+  env.HOME = soloHome;
+  env.XDG_DATA_HOME = path.join(soloHome, '.local', 'share');
   const srv = await startServer({ waitForScan: false, env });
   try {
     const check = await (await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' })).json();
@@ -187,7 +243,13 @@ test('non-managed installs refuse staging; apply refuses with nothing staged', {
 
     const ap = await fetch(`${srv.baseUrl}/api/v1/admin/update/apply`, { method: 'POST' });
     assert.equal(ap.status, 409);
+
+    const soloStatus = process.platform === 'darwin'
+      ? path.join(soloHome, 'Library', 'Application Support', 'mStream', 'update-status.json')
+      : path.join(soloHome, '.local', 'share', 'mstream', 'update-status.json');
+    await assert.rejects(fs.access(soloStatus), 'unsupervised instances must not write the status file');
   } finally {
     await srv.stop();
+    await fs.rm(soloHome, { recursive: true, force: true }).catch(() => {});
   }
 });

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -1,0 +1,193 @@
+// End-to-end auto-update round-trip against a LOCAL fake release feed:
+// check -> auto-stage (the embedded-installer path, which for a source run
+// is the repo's own install.sh) -> `current` flipped -> tamper refused ->
+// settings persist without a reboot -> non-managed installs refuse staging.
+//
+// The server is pointed at a scratch "release" over loopback HTTP via
+// MSTREAM_RELEASE_BASE (the same knob the install scripts and CI contract
+// job use) and at a scratch managed root via MSTREAM_UPDATE_ROOT. HOME is
+// redirected so update-status.json and install.sh's side effects land in
+// the test's temp dir, never in the developer's real data home.
+//
+// Windows is covered by the unit decision table + the installer-contract
+// job: this suite's fake-bundle zips and install.sh staging are posix.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { startServer } from '../helpers/server.mjs';
+import packageJson from '../../package.json' with { type: 'json' };
+
+const posixOnly = process.platform === 'win32';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// The bundle key install.sh will derive on this host.
+function hostKey() {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  return process.platform === 'darwin' ? `darwin-${arch}` : `linux-${arch}`;
+}
+
+let relDir; let relPort; let relServer; let tmpHome;
+
+function makeBundle(version, key) {
+  const b = `mStream-${version}-${key}`;
+  const dir = path.join(relDir, b);
+  const inner = key.startsWith('darwin')
+    ? path.join(dir, 'mStream.app', 'Contents', 'MacOS')
+    : dir;
+  spawnSync('mkdir', ['-p', inner]);
+  const server = path.join(inner, 'mstream-server');
+  spawnSync('bash', ['-c', `printf '#!/bin/sh\\n[ "$1" = -V ] && echo ${version}\\nexit 0\\n' > '${server}' && chmod +x '${server}'`]);
+  spawnSync('bash', ['-c', `echo 'fake bundle' > '${dir}/README.txt'`]);
+  const zip = spawnSync('python3', ['-m', 'zipfile', '-c', `${b}.zip`, b], { cwd: relDir });
+  assert.equal(zip.status, 0, `zip failed: ${zip.stderr}`);
+  spawnSync('rm', ['-rf', dir]);
+}
+
+async function publish(version, { tamper = false } = {}) {
+  for (const f of await fs.readdir(relDir)) {
+    if (f.endsWith('.zip') || f === 'manifest.json') { await fs.rm(path.join(relDir, f)); }
+  }
+  makeBundle(version, hostKey());
+  const gen = spawnSync('sh', [path.join(REPO_ROOT, 'scripts', 'release-manifest.sh'), version, relDir]);
+  assert.equal(gen.status, 0, `manifest generation failed: ${gen.stderr}`);
+  if (tamper) {
+    const m = path.join(relDir, 'manifest.json');
+    const doc = await fs.readFile(m, 'utf8');
+    await fs.writeFile(m, doc.replace(/"sha256": "[0-9a-f]*"/, `"sha256": "${'0'.repeat(64)}"`));
+  }
+}
+
+before(async function () {
+  if (posixOnly) { return; }
+  relDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-rel-'));
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-home-'));
+  await fs.mkdir(path.join(tmpHome, 'Applications'), { recursive: true });
+  relServer = http.createServer(async (req, res) => {
+    try {
+      const f = path.join(relDir, path.basename(new URL(req.url, 'http://x').pathname));
+      res.end(await fs.readFile(f));
+    } catch {
+      res.statusCode = 404; res.end('nope');
+    }
+  });
+  await new Promise((resolve) => relServer.listen(0, '127.0.0.1', resolve));
+  relPort = relServer.address().port;
+});
+
+after(async () => {
+  if (relServer) { relServer.close(); }
+  for (const d of [relDir, tmpHome]) {
+    if (d) { await fs.rm(d, { recursive: true, force: true }).catch(() => {}); }
+  }
+});
+
+function updEnv() {
+  return {
+    HOME: tmpHome,
+    XDG_DATA_HOME: path.join(tmpHome, '.local', 'share'),
+    MSTREAM_RELEASE_BASE: `http://127.0.0.1:${relPort}`,
+    MSTREAM_UPDATE_ROOT: path.join(tmpHome, 'app'),
+  };
+}
+
+async function pollStatus(baseUrl, pred, timeoutMs = 60_000) {
+  const start = Date.now();
+  let last = null;
+  while (Date.now() - start < timeoutMs) {
+    const r = await fetch(`${baseUrl}/api/v1/admin/update`);
+    last = await r.json();
+    if (pred(last)) { return last; }
+    await sleep(250);
+  }
+  throw new Error(`status never satisfied predicate; last: ${JSON.stringify(last)}`);
+}
+
+test('managed round-trip: check, auto-stage, current flip, tamper refusal, live settings', { skip: posixOnly }, async () => {
+  await publish('9.9.9');
+  const srv = await startServer({ waitForScan: false, env: updEnv() });
+  try {
+    // Boot state: forced-managed, nothing known yet.
+    let s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update`)).json();
+    assert.equal(s.method, 'managed');
+    assert.equal(s.current, packageJson.version);
+    assert.equal(s.staged, false);
+
+    // Check: finds 9.9.9 and (mode=stage default) starts staging on its own.
+    const check = await (await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' })).json();
+    assert.equal(check.available, true);
+    assert.equal(check.latest, '9.9.9');
+
+    s = await pollStatus(srv.baseUrl, (x) => x.staged || x.error);
+    assert.equal(s.error, null, `staging errored: ${s.error}`);
+    assert.equal(s.staged, true);
+    assert.equal(s.stagedVersion, '9.9.9');
+
+    // The layout agreement: $ROOT/current -> the staged bundle.
+    const root = path.join(tmpHome, 'app');
+    const target = await fs.readlink(path.join(root, 'current'));
+    assert.equal(path.basename(target), `mStream-9.9.9-${hostKey()}`);
+
+    // The status file the launcher reads, in the redirected data home.
+    const statusPath = process.platform === 'darwin'
+      ? path.join(tmpHome, 'Library', 'Application Support', 'mStream', 'update-status.json')
+      : path.join(tmpHome, '.local', 'share', 'mstream', 'update-status.json');
+    const onDisk = JSON.parse(await fs.readFile(statusPath, 'utf8'));
+    assert.equal(onDisk.staged, true);
+    assert.equal(onDisk.stagedVersion, '9.9.9');
+
+    // A tampered release must not replace what is staged.
+    await publish('9.9.10', { tamper: true });
+    await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+    s = await pollStatus(srv.baseUrl, (x) => (x.error || '').includes('Staging failed'));
+    assert.match(s.error, /Staging failed/);
+    assert.equal(path.basename(await fs.readlink(path.join(root, 'current'))), `mStream-9.9.9-${hostKey()}`);
+
+    // Settings persist to the config file and apply live.
+    const set = await fetch(`${srv.baseUrl}/api/v1/admin/update/settings`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'notify', check: false }),
+    });
+    assert.equal(set.status, 200);
+    s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update`)).json();
+    assert.equal(s.mode, 'notify');
+    assert.equal(s.check, false);
+
+    // Garbage settings are refused.
+    const bad = await fetch(`${srv.baseUrl}/api/v1/admin/update/settings`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'yolo' }),
+    });
+    assert.equal(bad.status, 400);
+  } finally {
+    await srv.stop();
+  }
+});
+
+test('non-managed installs refuse staging; apply refuses with nothing staged', { skip: posixOnly }, async () => {
+  await publish('9.9.9');
+  const env = updEnv();
+  delete env.MSTREAM_UPDATE_ROOT; // source run -> method npm-source
+  const srv = await startServer({ waitForScan: false, env });
+  try {
+    const check = await (await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' })).json();
+    assert.equal(check.method, 'npm-source');
+    assert.equal(check.available, true); // told...
+    assert.equal(check.staged, false);   // ...but never touched
+
+    const dl = await fetch(`${srv.baseUrl}/api/v1/admin/update/download`, { method: 'POST' });
+    assert.equal(dl.status, 409);
+
+    const ap = await fetch(`${srv.baseUrl}/api/v1/admin/update/apply`, { method: 'POST' });
+    assert.equal(ap.status, 409);
+  } finally {
+    await srv.stop();
+  }
+});

--- a/test/unit/update-check.test.mjs
+++ b/test/unit/update-check.test.mjs
@@ -85,16 +85,25 @@ test('refuses aside/partial names so pruning never eyes them', () => {
 
 // ── detectInstallMethod ──────────────────────────────────────────────────────
 // The decision table. Fake fs: a Set of paths that exist; realpath is
-// identity. All shapes use posix-style paths so the table runs on any host.
+// identity. Shapes are posix-style; the fake normalizes separators because
+// the production code path.join()s its probe paths with the HOST separator —
+// on a Windows host that means backslashes against these forward-slash keys
+// (this exact mismatch failed the windows CI test shard).
 
 function fakeFs(existing) {
   const set = new Set(existing);
+  const norm = (p) => String(p).replaceAll('\\', '/');
   return {
-    existsSync: (p) => set.has(p),
+    existsSync: (p) => set.has(norm(p)),
     realpathSync: (p) => p,
-    accessSync: (p) => { if (!set.has(p)) { throw new Error('ENOENT'); } },
+    accessSync: (p) => { if (!set.has(norm(p))) { throw new Error('ENOENT'); } },
   };
 }
+
+// The ~/Applications scenario exercises a separator-bound prefix check
+// (host path.sep) that in production only ever runs on a darwin host —
+// skip it on a Windows HOST; the mac and linux CI legs keep it covered.
+const posixHostOnly = { skip: process.platform === 'win32' };
 
 const noEnv = {};
 
@@ -155,7 +164,7 @@ test('managed darwin: the versioned .app under the default root', () => {
   assert.deepEqual(r, { method: 'managed', root });
 });
 
-test('the ~/Applications copy with the sibling marker is managed', () => {
+test('the ~/Applications copy with the sibling marker is managed', posixHostOnly, () => {
   const root = '/Users/u/Library/Application Support/mStream/app';
   const r = detectInstallMethod({
     execPath: '/Users/u/Applications/mStream.app/Contents/MacOS/mstream-server',

--- a/test/unit/update-check.test.mjs
+++ b/test/unit/update-check.test.mjs
@@ -1,0 +1,223 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  compareVersions,
+  validateManifest,
+  parseBundleName,
+  detectInstallMethod,
+} from '../../src/util/update-check.js';
+
+// ── compareVersions ──────────────────────────────────────────────────────────
+// Strict numeric triples only: the release feed always carries bare X.Y.Z,
+// so anything else is refused (null) rather than mis-ordered — a prerelease
+// string sorting "newer" than a release would auto-stage a build the tag
+// pipeline never shipped.
+
+test('orders plain triples numerically, not lexically', () => {
+  assert.ok(compareVersions('6.21.2', '6.21.1') > 0);
+  assert.ok(compareVersions('6.9.0', '6.21.0') < 0); // lexical would say 9 > 21
+  assert.ok(compareVersions('10.0.0', '9.99.99') > 0);
+  assert.equal(compareVersions('6.21.2', '6.21.2'), 0);
+});
+
+test('refuses non-triple shapes outright', () => {
+  assert.equal(compareVersions('6.21.2-beta.1', '6.21.1'), null);
+  assert.equal(compareVersions('6.21', '6.21.1'), null);
+  assert.equal(compareVersions('v6.21.2', '6.21.1'), null);
+  assert.equal(compareVersions('', '6.21.1'), null);
+  assert.equal(compareVersions('6.21.2', 'not-a-version'), null);
+});
+
+// ── validateManifest ─────────────────────────────────────────────────────────
+
+const GOOD = {
+  name: 'mstream',
+  version: '6.22.0',
+  apiVersion: 1,
+  assets: [
+    { file: 'mStream-6.22.0-linux-x64.zip', sha256: 'a'.repeat(64) },
+    { file: 'mStream-6.22.0-win-x64-setup.exe', sha256: 'b'.repeat(64) },
+  ],
+};
+
+test('accepts the generator contract, installers included', () => {
+  assert.equal(validateManifest(GOOD).ok, true);
+});
+
+test('a foreign release capturing the latest pointer is rejected by name', () => {
+  // The repo hosts asset-store releases (discovery-models-*); if one is ever
+  // published non-prerelease it becomes GitHub "Latest" — the name check is
+  // what keeps every updater from acting on it.
+  const v = validateManifest({ ...GOOD, name: 'discovery-models' });
+  assert.equal(v.ok, false);
+  assert.ok(!v.apiMismatch);
+});
+
+test('a manifest from the future downgrades to notify-only, not to a guess', () => {
+  const v = validateManifest({ ...GOOD, apiVersion: 2 });
+  assert.equal(v.ok, false);
+  assert.equal(v.apiMismatch, true);
+});
+
+test('rejects malformed shapes', () => {
+  assert.equal(validateManifest(null).ok, false);
+  assert.equal(validateManifest({ ...GOOD, version: 'v6.22.0' }).ok, false);
+  assert.equal(validateManifest({ ...GOOD, version: '6.22.0-beta.1' }).ok, false);
+  assert.equal(validateManifest({ ...GOOD, assets: [{ file: 'x.zip', sha256: 'nothex' }] }).ok, false);
+  assert.equal(validateManifest({ ...GOOD, assets: 'zips' }).ok, false);
+});
+
+// ── parseBundleName ──────────────────────────────────────────────────────────
+
+test('parses bundle dirs and zips, with and without musl', () => {
+  assert.deepEqual(parseBundleName('mStream-6.21.2-linux-x64'), { version: '6.21.2', key: 'linux-x64' });
+  assert.deepEqual(parseBundleName('mStream-6.21.2-linux-arm64-musl.zip'), { version: '6.21.2', key: 'linux-arm64-musl' });
+  assert.deepEqual(parseBundleName('mStream-6.21.2-darwin-arm64'), { version: '6.21.2', key: 'darwin-arm64' });
+  assert.deepEqual(parseBundleName('mStream-6.21.2-win-x64'), { version: '6.21.2', key: 'win-x64' });
+});
+
+test('refuses aside/partial names so pruning never eyes them', () => {
+  assert.equal(parseBundleName('mStream-6.21.2-linux-x64.partial'), null);
+  assert.equal(parseBundleName('mStream-6.21.2-linux-x64.replaced-20260820'), null);
+  assert.equal(parseBundleName('current'), null);
+  assert.equal(parseBundleName('mStream-6.21.2-beta.1-linux-x64'), null);
+});
+
+// ── detectInstallMethod ──────────────────────────────────────────────────────
+// The decision table. Fake fs: a Set of paths that exist; realpath is
+// identity. All shapes use posix-style paths so the table runs on any host.
+
+function fakeFs(existing) {
+  const set = new Set(existing);
+  return {
+    existsSync: (p) => set.has(p),
+    realpathSync: (p) => p,
+    accessSync: (p) => { if (!set.has(p)) { throw new Error('ENOENT'); } },
+  };
+}
+
+const noEnv = {};
+
+test('MSTREAM_UPDATE_ROOT forces managed with the given root', () => {
+  const r = detectInstallMethod({
+    execPath: '/anything/node',
+    platform: 'linux',
+    env: { MSTREAM_UPDATE_ROOT: '/tmp/app' },
+    standalone: false,
+    fsx: fakeFs([]),
+  });
+  assert.deepEqual(r, { method: 'managed', root: '/tmp/app' });
+});
+
+test('a non-compiled runtime is npm/source', () => {
+  const r = detectInstallMethod({
+    execPath: '/usr/bin/node', platform: 'linux', env: noEnv, standalone: false, fsx: fakeFs([]),
+  });
+  assert.equal(r.method, 'npm-source');
+});
+
+test('docker wins over geometry on linux', () => {
+  const r = detectInstallMethod({
+    execPath: '/opt/mstream/mstream-server', platform: 'linux', env: noEnv, standalone: true,
+    fsx: fakeFs(['/.dockerenv']),
+  });
+  assert.equal(r.method, 'docker');
+});
+
+test('managed linux: versioned dir under a root holding current', () => {
+  const root = '/home/u/.local/share/mstream/app';
+  const r = detectInstallMethod({
+    execPath: `${root}/mStream-6.21.2-linux-x64/mstream-server`,
+    platform: 'linux', env: noEnv, standalone: true,
+    fsx: fakeFs([`${root}/current`]),
+  });
+  assert.deepEqual(r, { method: 'managed', root });
+});
+
+test('managed custom root: geometry needs no env var', () => {
+  const root = '/srv/apps/mstream';
+  const r = detectInstallMethod({
+    execPath: `${root}/mStream-6.21.2-linux-x64/mstream-server`,
+    platform: 'linux', env: noEnv, standalone: true,
+    fsx: fakeFs([`${root}/current`]),
+  });
+  assert.deepEqual(r, { method: 'managed', root });
+});
+
+test('managed darwin: the versioned .app under the default root', () => {
+  const root = '/Users/u/Library/Application Support/mStream/app';
+  const r = detectInstallMethod({
+    execPath: `${root}/mStream-6.21.2-darwin-arm64/mStream.app/Contents/MacOS/mstream-server`,
+    platform: 'darwin', env: noEnv, standalone: true,
+    fsx: fakeFs([`${root}/current`]),
+    homedir: () => '/Users/u',
+  });
+  assert.deepEqual(r, { method: 'managed', root });
+});
+
+test('the ~/Applications copy with the sibling marker is managed', () => {
+  const root = '/Users/u/Library/Application Support/mStream/app';
+  const r = detectInstallMethod({
+    execPath: '/Users/u/Applications/mStream.app/Contents/MacOS/mstream-server',
+    platform: 'darwin', env: noEnv, standalone: true,
+    fsx: fakeFs(['/Users/u/Applications/.mstream-installer', `${root}/current`]),
+    homedir: () => '/Users/u',
+  });
+  assert.deepEqual(r, { method: 'managed', root });
+});
+
+test('the ~/Applications copy WITHOUT the marker is portable (user-owned)', () => {
+  const r = detectInstallMethod({
+    execPath: '/Users/u/Applications/mStream.app/Contents/MacOS/mstream-server',
+    platform: 'darwin', env: noEnv, standalone: true,
+    fsx: fakeFs([]),
+    homedir: () => '/Users/u',
+  });
+  assert.equal(r.method, 'portable');
+});
+
+test('a /Applications install is pkg territory', () => {
+  const r = detectInstallMethod({
+    execPath: '/Applications/mStream.app/Contents/MacOS/mstream-server',
+    platform: 'darwin', env: noEnv, standalone: true,
+    fsx: fakeFs([]),
+    homedir: () => '/Users/u',
+  });
+  assert.equal(r.method, 'pkg');
+});
+
+test('/opt is deb/rpm territory', () => {
+  const r = detectInstallMethod({
+    execPath: '/opt/mstream/mstream-server', platform: 'linux', env: noEnv, standalone: true,
+    fsx: fakeFs([]),
+  });
+  assert.equal(r.method, 'deb-rpm');
+});
+
+test('windows flat install at the Inno dir with no current is inno', () => {
+  const r = detectInstallMethod({
+    execPath: '/win/AppData/Local/Programs/mStream/mstream-server.exe',
+    platform: 'win32', env: { LOCALAPPDATA: '/win/AppData/Local' }, standalone: true,
+    fsx: fakeFs([]),
+  });
+  assert.equal(r.method, 'inno');
+});
+
+test('windows install.ps1 layout (versioned dir + current) is managed, not inno', () => {
+  const root = '/win/AppData/Local/Programs/mStream';
+  const r = detectInstallMethod({
+    execPath: `${root}/mStream-6.21.2-win-x64/mstream-server.exe`,
+    platform: 'win32', env: { LOCALAPPDATA: '/win/AppData/Local' }, standalone: true,
+    fsx: fakeFs([`${root}/current`]),
+  });
+  assert.deepEqual(r, { method: 'managed', root });
+});
+
+test('a hand-extracted bundle with no current anywhere is portable', () => {
+  const r = detectInstallMethod({
+    execPath: '/home/u/Downloads/mStream-6.21.2-linux-x64/mstream-server',
+    platform: 'linux', env: noEnv, standalone: true,
+    fsx: fakeFs([]),
+  });
+  assert.equal(r.method, 'portable');
+});

--- a/test/unit/update-check.test.mjs
+++ b/test/unit/update-check.test.mjs
@@ -90,13 +90,17 @@ test('refuses aside/partial names so pruning never eyes them', () => {
 // on a Windows host that means backslashes against these forward-slash keys
 // (this exact mismatch failed the windows CI test shard).
 
-function fakeFs(existing) {
+function fakeFs(existing, files = {}) {
   const set = new Set(existing);
   const norm = (p) => String(p).replaceAll('\\', '/');
   return {
-    existsSync: (p) => set.has(norm(p)),
+    existsSync: (p) => set.has(norm(p)) || (norm(p) in files),
     realpathSync: (p) => p,
-    accessSync: (p) => { if (!set.has(norm(p))) { throw new Error('ENOENT'); } },
+    accessSync: (p) => { if (!set.has(norm(p)) && !(norm(p) in files)) { throw new Error('ENOENT'); } },
+    readFileSync: (p) => {
+      if (norm(p) in files) { return files[norm(p)]; }
+      throw new Error('ENOENT');
+    },
   };
 }
 
@@ -193,6 +197,29 @@ test('a /Applications install is pkg territory', () => {
     homedir: () => '/Users/u',
   });
   assert.equal(r.method, 'pkg');
+});
+
+test('a managed layout under /opt is still managed: geometry outranks prefix', () => {
+  const root = '/opt/apps/mstream';
+  const r = detectInstallMethod({
+    execPath: `${root}/mStream-6.21.2-linux-x64/mstream-server`,
+    platform: 'linux', env: noEnv, standalone: true,
+    fsx: fakeFs([`${root}/current`]),
+  });
+  assert.deepEqual(r, { method: 'managed', root });
+});
+
+test('the marker names a custom root; detection follows it from ~/Applications', posixHostOnly, () => {
+  const root = '/srv/custom/mstream-root';
+  const r = detectInstallMethod({
+    execPath: '/Users/u/Applications/mStream.app/Contents/MacOS/mstream-server',
+    platform: 'darwin', env: noEnv, standalone: true,
+    fsx: fakeFs([`${root}/current`], {
+      '/Users/u/Applications/.mstream-installer': `9.9.9\n${root}\n`,
+    }),
+    homedir: () => '/Users/u',
+  });
+  assert.deepEqual(r, { method: 'managed', root });
 });
 
 test('/opt is deb/rpm territory', () => {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -3354,8 +3354,10 @@ const infoView = Vue.component('info-view', {
                   <tr v-if="update.s.available">
                     <td><b>Available:</b> v{{update.s.latest}} &mdash; {{updLine()}}</td>
                     <td>
-                      <span v-if="updAction()">[<a v-on:click="updDoAction()">{{updAction()}}</a>]</span>
-                      <a v-else-if="update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank">[downloads page]</a>
+                      <span v-if="updAction()">[<a v-on:click="updDoAction()">{{updAction()}}</a>] </span>
+                      <a v-else-if="!update.s.skipped && update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank" rel="noopener">[downloads page] </a>
+                      <span v-if="update.s.skipped">[<a v-on:click="updSetSkip('')">unskip</a>]</span>
+                      <span v-else title="Hold this version back: never download or restart into it (e.g. after rolling back). Cleared by unskip or the next release.">[<a v-on:click="updSetSkip(update.s.latest)">skip</a>]</span>
                     </td>
                   </tr>
                   <tr v-if="update.s.error">
@@ -3387,10 +3389,12 @@ const infoView = Vue.component('info-view', {
     updLine: function() {
       const s = this.update.s;
       if (s.notifyOnly) { return 'this build is too old to self-update; re-run the install command'; }
+      if (s.skipped) { return 'held back (skipped) - it will not be downloaded or applied'; }
       if (s.downloading) { return 'downloading...'; }
-      if (s.staged && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
-      if (s.staged && s.method === 'inno') { return 'installer downloaded and verified'; }
-      if (s.staged && s.method === 'pkg') { return 'installer downloaded; the running app keeps playing until you restart it after installing'; }
+      const stagedIsLatest = s.staged && s.stagedVersion === s.latest;
+      if (stagedIsLatest && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
+      if (stagedIsLatest && s.method === 'inno') { return 'installer downloaded and verified'; }
+      if (stagedIsLatest && s.method === 'pkg') { return 'installer downloaded; the running app keeps playing until you restart it after installing'; }
       if (s.method === 'managed' || s.method === 'inno') { return 'not downloaded yet'; }
       if (s.method === 'pkg') { return 'download the installer, then run it'; }
       if (s.method === 'deb-rpm') { return 'installed from a deb/rpm package; update it with your package manager'; }
@@ -3400,8 +3404,11 @@ const infoView = Vue.component('info-view', {
     },
     updAction: function() {
       const s = this.update.s;
-      if (s.notifyOnly || s.downloading) { return null; }
-      if (s.staged) {
+      if (s.notifyOnly || s.downloading || s.skipped) { return null; }
+      // Act only on a staged copy of the CURRENT latest: with an older
+      // version staged and a newer one advertised, the click must never
+      // apply the old one while the line names the new one.
+      if (s.staged && s.stagedVersion === s.latest) {
         if (s.method === 'managed') { return 'restart into it'; }
         if (s.method === 'inno') { return 'install now'; }
         if (s.method === 'pkg') { return 'open installer'; }
@@ -3415,7 +3422,11 @@ const infoView = Vue.component('info-view', {
       this.updateBusy = true;
       const s = this.update.s;
       try {
-        if (s.staged) {
+        // Same predicate as updAction(): with an OLDER version staged and a
+        // newer latest advertised, the visible action is "download" — the
+        // click must never fall into the apply branch and restart into the
+        // stale one.
+        if (s.staged && s.stagedVersion === s.latest) {
           const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/apply` });
           iziToast.success({
             title: res.data.exiting ? 'mStream is restarting into the update'
@@ -3438,12 +3449,27 @@ const infoView = Vue.component('info-view', {
       try {
         const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/check` });
         ADMINDATA.updateStatus.s = res.data;
-        iziToast.success({
-          title: res.data.available ? `mStream v${res.data.latest} is available` : 'You are up to date',
-          position: 'topCenter', timeout: 3000
-        });
+        if (res.data.error && !res.data.available) {
+          // Covers both failure classes: transport ('Update check failed:
+          // ...') and validation ('Release feed rejected: ...').
+          iziToast.warning({ title: 'Update check failed', message: String(res.data.error).slice(0, 120), position: 'topCenter', timeout: 4000 });
+        } else {
+          iziToast.success({
+            title: res.data.available ? `mStream v${res.data.latest} is available` : 'You are up to date',
+            position: 'topCenter', timeout: 3000
+          });
+        }
       } catch (err) {
         iziToast.error({ title: 'Update check failed', position: 'topCenter', timeout: 3500 });
+      }
+    },
+    updSetSkip: async function(ver) {
+      try {
+        await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/settings`, data: { skipVersion: ver } });
+        await ADMINDATA.getUpdateStatus();
+        iziToast.success({ title: ver ? `v${ver} will be skipped` : 'Version skip cleared', position: 'topCenter', timeout: 2500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to change skip setting', position: 'topCenter', timeout: 3500 });
       }
     },
     updCycleMode: async function() {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -530,7 +530,20 @@ const ADMINDATA = (() => {
         url: `${API.url()}/api`
       });
       module.version.val = res.data.server;
-    }catch (err) {} 
+    }catch (err) {}
+  }
+
+  // Release-update state (GET /api/v1/admin/update). `s` is the whole status
+  // object; the About view polls it while a download is in flight.
+  module.updateStatus = { s: null };
+  module.getUpdateStatus = async () => {
+    try {
+      const res = await API.axios({
+        method: 'GET',
+        url: `${API.url()}/api/v1/admin/update`
+      });
+      module.updateStatus.s = res.data;
+    }catch (err) {}
   }
 
   module.getWinDrives = async () => {
@@ -3295,7 +3308,9 @@ const rpnView = Vue.component('rpn-view', {
 const infoView = Vue.component('info-view', {
   data() {
     return {
-      version: ADMINDATA.version
+      version: ADMINDATA.version,
+      update: ADMINDATA.updateStatus,
+      updateBusy: false,
     };
   },
   template: `
@@ -3324,7 +3339,135 @@ const infoView = Vue.component('info-view', {
           </div>
         </div>
       </div>
-    </div>`
+      <div class="row">
+        <div class="col s12">
+          <div class="card">
+            <div class="card-content">
+              <span class="card-title">Software Updates</span>
+              <div v-if="!update.s">checking...</div>
+              <table v-else>
+                <tbody>
+                  <tr>
+                    <td><b>Installed:</b> v{{update.s.current}}<span v-if="!update.s.available && update.s.lastCheckAt"> &mdash; up to date</span></td>
+                    <td>[<a v-on:click="updCheckNow()">check now</a>]</td>
+                  </tr>
+                  <tr v-if="update.s.available">
+                    <td><b>Available:</b> v{{update.s.latest}} &mdash; {{updLine()}}</td>
+                    <td>
+                      <span v-if="updAction()">[<a v-on:click="updDoAction()">{{updAction()}}</a>]</span>
+                      <a v-else-if="update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank">[downloads page]</a>
+                    </td>
+                  </tr>
+                  <tr v-if="update.s.error">
+                    <td colspan="2" style="color:#c62828;">{{update.s.error}}</td>
+                  </tr>
+                  <tr>
+                    <td><b title="notify: report only. stage (default): download updates in the background; applying still takes a restart or a click. auto: additionally restart into the update when the server is idle (headless installs need a process supervisor that restarts mStream).">Mode:</b> {{update.s.mode}}</td>
+                    <td>[<a v-on:click="updCycleMode()">change</a>]</td>
+                  </tr>
+                  <tr>
+                    <td><b title="One request a day to the release feed on GitHub. Off = never phones home; 'check now' still works.">Daily check:</b> {{update.s.check ? 'on' : 'off'}}</td>
+                    <td>[<a v-on:click="updToggleCheck()">{{update.s.check ? 'disable' : 'enable'}}</a>]</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>`,
+  mounted: function() {
+    ADMINDATA.getUpdateStatus();
+    this.updPoll = setInterval(() => { ADMINDATA.getUpdateStatus(); }, 5000);
+  },
+  beforeDestroy: function() {
+    clearInterval(this.updPoll);
+  },
+  methods: {
+    updLine: function() {
+      const s = this.update.s;
+      if (s.notifyOnly) { return 'this build is too old to self-update; re-run the install command'; }
+      if (s.downloading) { return 'downloading...'; }
+      if (s.staged && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
+      if (s.staged && s.method === 'inno') { return 'installer downloaded and verified'; }
+      if (s.staged && s.method === 'pkg') { return 'installer downloaded; the running app keeps playing until you restart it after installing'; }
+      if (s.method === 'managed' || s.method === 'inno') { return 'not downloaded yet'; }
+      if (s.method === 'pkg') { return 'download the installer, then run it'; }
+      if (s.method === 'deb-rpm') { return 'installed from a deb/rpm package; update it with your package manager'; }
+      if (s.method === 'docker') { return 'running in Docker; pull the updated image'; }
+      if (s.method === 'npm-source') { return 'running from npm/source; update with npm or git'; }
+      return 'this copy was extracted by hand; download the new bundle or use the one-line installer';
+    },
+    updAction: function() {
+      const s = this.update.s;
+      if (s.notifyOnly || s.downloading) { return null; }
+      if (s.staged) {
+        if (s.method === 'managed') { return 'restart into it'; }
+        if (s.method === 'inno') { return 'install now'; }
+        if (s.method === 'pkg') { return 'open installer'; }
+        return null;
+      }
+      if (s.method === 'managed' || s.method === 'inno' || s.method === 'pkg') { return 'download'; }
+      return null;
+    },
+    updDoAction: async function() {
+      if (this.updateBusy) { return; }
+      this.updateBusy = true;
+      const s = this.update.s;
+      try {
+        if (s.staged) {
+          const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/apply` });
+          iziToast.success({
+            title: res.data.exiting ? 'mStream is restarting into the update'
+              : res.data.opened ? 'Installer opened'
+              : 'Requested - the tray app applies it within a minute',
+            position: 'topCenter', timeout: 4000
+          });
+        } else {
+          await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/download` });
+          iziToast.success({ title: 'Download started', position: 'topCenter', timeout: 2500 });
+        }
+        await ADMINDATA.getUpdateStatus();
+      } catch (err) {
+        iziToast.error({ title: 'Update action failed', position: 'topCenter', timeout: 3500 });
+      } finally {
+        this.updateBusy = false;
+      }
+    },
+    updCheckNow: async function() {
+      try {
+        const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/check` });
+        ADMINDATA.updateStatus.s = res.data;
+        iziToast.success({
+          title: res.data.available ? `mStream v${res.data.latest} is available` : 'You are up to date',
+          position: 'topCenter', timeout: 3000
+        });
+      } catch (err) {
+        iziToast.error({ title: 'Update check failed', position: 'topCenter', timeout: 3500 });
+      }
+    },
+    updCycleMode: async function() {
+      const order = ['notify', 'stage', 'auto'];
+      const next = order[(order.indexOf(this.update.s.mode) + 1) % order.length];
+      try {
+        await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/settings`, data: { mode: next } });
+        Vue.set(ADMINDATA.updateStatus.s, 'mode', next);
+        iziToast.success({ title: `Update mode: ${next}`, position: 'topCenter', timeout: 2500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to change update mode', position: 'topCenter', timeout: 3500 });
+      }
+    },
+    updToggleCheck: async function() {
+      const next = !this.update.s.check;
+      try {
+        await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/settings`, data: { check: next } });
+        Vue.set(ADMINDATA.updateStatus.s, 'check', next);
+        iziToast.success({ title: next ? 'Daily update check enabled' : 'Daily update check disabled', position: 'topCenter', timeout: 2500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to change update check', position: 'topCenter', timeout: 3500 });
+      }
+    },
+  }
 });
 
 const transcodeView = Vue.component('transcode-view', {

--- a/webapp/velvet/admin/index.js
+++ b/webapp/velvet/admin/index.js
@@ -178,7 +178,20 @@ const ADMINDATA = (() => {
         url: `${API.url()}/api`
       });
       module.version.val = res.data.server;
-    }catch (err) {} 
+    }catch (err) {}
+  }
+
+  // Release-update state (GET /api/v1/admin/update). `s` is the whole status
+  // object; the About view polls it while a download is in flight.
+  module.updateStatus = { s: null };
+  module.getUpdateStatus = async () => {
+    try {
+      const res = await API.axios({
+        method: 'GET',
+        url: `${API.url()}/api/v1/admin/update`
+      });
+      module.updateStatus.s = res.data;
+    }catch (err) {}
   }
 
   module.getWinDrives = async () => {
@@ -1846,7 +1859,9 @@ const rpnView = Vue.component('rpn-view', {
 const infoView = Vue.component('info-view', {
   data() {
     return {
-      version: ADMINDATA.version
+      version: ADMINDATA.version,
+      update: ADMINDATA.updateStatus,
+      updateBusy: false,
     };
   },
   template: `
@@ -1875,7 +1890,135 @@ const infoView = Vue.component('info-view', {
           </div>
         </div>
       </div>
-    </div>`
+      <div class="row">
+        <div class="col s12">
+          <div class="card">
+            <div class="card-content">
+              <span class="card-title">Software Updates</span>
+              <div v-if="!update.s">checking...</div>
+              <table v-else>
+                <tbody>
+                  <tr>
+                    <td><b>Installed:</b> v{{update.s.current}}<span v-if="!update.s.available && update.s.lastCheckAt"> &mdash; up to date</span></td>
+                    <td>[<a v-on:click="updCheckNow()">check now</a>]</td>
+                  </tr>
+                  <tr v-if="update.s.available">
+                    <td><b>Available:</b> v{{update.s.latest}} &mdash; {{updLine()}}</td>
+                    <td>
+                      <span v-if="updAction()">[<a v-on:click="updDoAction()">{{updAction()}}</a>]</span>
+                      <a v-else-if="update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank">[downloads page]</a>
+                    </td>
+                  </tr>
+                  <tr v-if="update.s.error">
+                    <td colspan="2" style="color:#c62828;">{{update.s.error}}</td>
+                  </tr>
+                  <tr>
+                    <td><b title="notify: report only. stage (default): download updates in the background; applying still takes a restart or a click. auto: additionally restart into the update when the server is idle (headless installs need a process supervisor that restarts mStream).">Mode:</b> {{update.s.mode}}</td>
+                    <td>[<a v-on:click="updCycleMode()">change</a>]</td>
+                  </tr>
+                  <tr>
+                    <td><b title="One request a day to the release feed on GitHub. Off = never phones home; 'check now' still works.">Daily check:</b> {{update.s.check ? 'on' : 'off'}}</td>
+                    <td>[<a v-on:click="updToggleCheck()">{{update.s.check ? 'disable' : 'enable'}}</a>]</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>`,
+  mounted: function() {
+    ADMINDATA.getUpdateStatus();
+    this.updPoll = setInterval(() => { ADMINDATA.getUpdateStatus(); }, 5000);
+  },
+  beforeDestroy: function() {
+    clearInterval(this.updPoll);
+  },
+  methods: {
+    updLine: function() {
+      const s = this.update.s;
+      if (s.notifyOnly) { return 'this build is too old to self-update; re-run the install command'; }
+      if (s.downloading) { return 'downloading...'; }
+      if (s.staged && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
+      if (s.staged && s.method === 'inno') { return 'installer downloaded and verified'; }
+      if (s.staged && s.method === 'pkg') { return 'installer downloaded; the running app keeps playing until you restart it after installing'; }
+      if (s.method === 'managed' || s.method === 'inno') { return 'not downloaded yet'; }
+      if (s.method === 'pkg') { return 'download the installer, then run it'; }
+      if (s.method === 'deb-rpm') { return 'installed from a deb/rpm package; update it with your package manager'; }
+      if (s.method === 'docker') { return 'running in Docker; pull the updated image'; }
+      if (s.method === 'npm-source') { return 'running from npm/source; update with npm or git'; }
+      return 'this copy was extracted by hand; download the new bundle or use the one-line installer';
+    },
+    updAction: function() {
+      const s = this.update.s;
+      if (s.notifyOnly || s.downloading) { return null; }
+      if (s.staged) {
+        if (s.method === 'managed') { return 'restart into it'; }
+        if (s.method === 'inno') { return 'install now'; }
+        if (s.method === 'pkg') { return 'open installer'; }
+        return null;
+      }
+      if (s.method === 'managed' || s.method === 'inno' || s.method === 'pkg') { return 'download'; }
+      return null;
+    },
+    updDoAction: async function() {
+      if (this.updateBusy) { return; }
+      this.updateBusy = true;
+      const s = this.update.s;
+      try {
+        if (s.staged) {
+          const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/apply` });
+          iziToast.success({
+            title: res.data.exiting ? 'mStream is restarting into the update'
+              : res.data.opened ? 'Installer opened'
+              : 'Requested - the tray app applies it within a minute',
+            position: 'topCenter', timeout: 4000
+          });
+        } else {
+          await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/download` });
+          iziToast.success({ title: 'Download started', position: 'topCenter', timeout: 2500 });
+        }
+        await ADMINDATA.getUpdateStatus();
+      } catch (err) {
+        iziToast.error({ title: 'Update action failed', position: 'topCenter', timeout: 3500 });
+      } finally {
+        this.updateBusy = false;
+      }
+    },
+    updCheckNow: async function() {
+      try {
+        const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/check` });
+        ADMINDATA.updateStatus.s = res.data;
+        iziToast.success({
+          title: res.data.available ? `mStream v${res.data.latest} is available` : 'You are up to date',
+          position: 'topCenter', timeout: 3000
+        });
+      } catch (err) {
+        iziToast.error({ title: 'Update check failed', position: 'topCenter', timeout: 3500 });
+      }
+    },
+    updCycleMode: async function() {
+      const order = ['notify', 'stage', 'auto'];
+      const next = order[(order.indexOf(this.update.s.mode) + 1) % order.length];
+      try {
+        await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/settings`, data: { mode: next } });
+        Vue.set(ADMINDATA.updateStatus.s, 'mode', next);
+        iziToast.success({ title: `Update mode: ${next}`, position: 'topCenter', timeout: 2500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to change update mode', position: 'topCenter', timeout: 3500 });
+      }
+    },
+    updToggleCheck: async function() {
+      const next = !this.update.s.check;
+      try {
+        await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/settings`, data: { check: next } });
+        Vue.set(ADMINDATA.updateStatus.s, 'check', next);
+        iziToast.success({ title: next ? 'Daily update check enabled' : 'Daily update check disabled', position: 'topCenter', timeout: 2500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to change update check', position: 'topCenter', timeout: 3500 });
+      }
+    },
+  }
 });
 
 const transcodeView = Vue.component('transcode-view', {

--- a/webapp/velvet/admin/index.js
+++ b/webapp/velvet/admin/index.js
@@ -1905,8 +1905,10 @@ const infoView = Vue.component('info-view', {
                   <tr v-if="update.s.available">
                     <td><b>Available:</b> v{{update.s.latest}} &mdash; {{updLine()}}</td>
                     <td>
-                      <span v-if="updAction()">[<a v-on:click="updDoAction()">{{updAction()}}</a>]</span>
-                      <a v-else-if="update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank">[downloads page]</a>
+                      <span v-if="updAction()">[<a v-on:click="updDoAction()">{{updAction()}}</a>] </span>
+                      <a v-else-if="!update.s.skipped && update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank" rel="noopener">[downloads page] </a>
+                      <span v-if="update.s.skipped">[<a v-on:click="updSetSkip('')">unskip</a>]</span>
+                      <span v-else title="Hold this version back: never download or restart into it (e.g. after rolling back). Cleared by unskip or the next release.">[<a v-on:click="updSetSkip(update.s.latest)">skip</a>]</span>
                     </td>
                   </tr>
                   <tr v-if="update.s.error">
@@ -1938,10 +1940,12 @@ const infoView = Vue.component('info-view', {
     updLine: function() {
       const s = this.update.s;
       if (s.notifyOnly) { return 'this build is too old to self-update; re-run the install command'; }
+      if (s.skipped) { return 'held back (skipped) - it will not be downloaded or applied'; }
       if (s.downloading) { return 'downloading...'; }
-      if (s.staged && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
-      if (s.staged && s.method === 'inno') { return 'installer downloaded and verified'; }
-      if (s.staged && s.method === 'pkg') { return 'installer downloaded; the running app keeps playing until you restart it after installing'; }
+      const stagedIsLatest = s.staged && s.stagedVersion === s.latest;
+      if (stagedIsLatest && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
+      if (stagedIsLatest && s.method === 'inno') { return 'installer downloaded and verified'; }
+      if (stagedIsLatest && s.method === 'pkg') { return 'installer downloaded; the running app keeps playing until you restart it after installing'; }
       if (s.method === 'managed' || s.method === 'inno') { return 'not downloaded yet'; }
       if (s.method === 'pkg') { return 'download the installer, then run it'; }
       if (s.method === 'deb-rpm') { return 'installed from a deb/rpm package; update it with your package manager'; }
@@ -1951,8 +1955,11 @@ const infoView = Vue.component('info-view', {
     },
     updAction: function() {
       const s = this.update.s;
-      if (s.notifyOnly || s.downloading) { return null; }
-      if (s.staged) {
+      if (s.notifyOnly || s.downloading || s.skipped) { return null; }
+      // Act only on a staged copy of the CURRENT latest: with an older
+      // version staged and a newer one advertised, the click must never
+      // apply the old one while the line names the new one.
+      if (s.staged && s.stagedVersion === s.latest) {
         if (s.method === 'managed') { return 'restart into it'; }
         if (s.method === 'inno') { return 'install now'; }
         if (s.method === 'pkg') { return 'open installer'; }
@@ -1966,7 +1973,11 @@ const infoView = Vue.component('info-view', {
       this.updateBusy = true;
       const s = this.update.s;
       try {
-        if (s.staged) {
+        // Same predicate as updAction(): with an OLDER version staged and a
+        // newer latest advertised, the visible action is "download" — the
+        // click must never fall into the apply branch and restart into the
+        // stale one.
+        if (s.staged && s.stagedVersion === s.latest) {
           const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/apply` });
           iziToast.success({
             title: res.data.exiting ? 'mStream is restarting into the update'
@@ -1989,12 +2000,27 @@ const infoView = Vue.component('info-view', {
       try {
         const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/check` });
         ADMINDATA.updateStatus.s = res.data;
-        iziToast.success({
-          title: res.data.available ? `mStream v${res.data.latest} is available` : 'You are up to date',
-          position: 'topCenter', timeout: 3000
-        });
+        if (res.data.error && !res.data.available) {
+          // Covers both failure classes: transport ('Update check failed:
+          // ...') and validation ('Release feed rejected: ...').
+          iziToast.warning({ title: 'Update check failed', message: String(res.data.error).slice(0, 120), position: 'topCenter', timeout: 4000 });
+        } else {
+          iziToast.success({
+            title: res.data.available ? `mStream v${res.data.latest} is available` : 'You are up to date',
+            position: 'topCenter', timeout: 3000
+          });
+        }
       } catch (err) {
         iziToast.error({ title: 'Update check failed', position: 'topCenter', timeout: 3500 });
+      }
+    },
+    updSetSkip: async function(ver) {
+      try {
+        await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/settings`, data: { skipVersion: ver } });
+        await ADMINDATA.getUpdateStatus();
+        iziToast.success({ title: ver ? `v${ver} will be skipped` : 'Version skip cleared', position: 'topCenter', timeout: 2500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to change skip setting', position: 'topCenter', timeout: 3500 });
       }
     },
     updCycleMode: async function() {


### PR DESCRIPTION
Part 2 of the auto-update feature (plan: server = brain, launcher = notify+apply). This PR makes every install shape update-aware and gives managed installs the full default experience: **new versions download and stage in the background; any restart lands on them**. The launcher work (tray item + one-click restart, PR C) builds on the status file this ships.

## What's here

**The brain — `src/util/update-check.js`**
- Daily check (30s after boot, then every 24h, both `unref`'d; timers survive soft reboots by the same pattern as the ffmpeg bootstrap) of `manifest.json` on the latest release. `MSTREAM_RELEASE_BASE` honored exactly as in the install scripts.
- Strict validation: `name === "mstream"` (guards against an asset-store release ever capturing the GitHub *latest* pointer), `apiVersion` gate (a future manifest format degrades this updater to notify-only instead of letting it run a flow it doesn't understand), bare `X.Y.Z` compare (prerelease-shaped strings refused, never mis-ordered).
- **Install-method detection by geometry**: walk up from the real `execPath` to the root holding `current`. Custom roots work with no env var; the `~/Applications` copy is recognized by its sibling marker; `MSTREAM_UPDATE_ROOT` is the test/escape seam. Inno / pkg / deb-rpm / docker / npm / portable are each classified and **never touched** — they get told, with method-appropriate instructions.
- **Staging = running the bundle-embedded installer script** (`build-bun.mjs` now ships `install.sh` in `Contents/Resources` on mac — a data file, sealed as a resource — and at the bundle root elsewhere; `install.ps1` in the win root). Pinned at build time, covered by the bundle's sha256, contract-tested in CI — no fetch of a mutable script URL at update time. Tag-pinned `MSTREAM_VERSION` closes the check→stage TOCTOU; what actually landed is read back from `readlink(current)`, never trusted from output.
- Pruning keeps `current`'s target + the running tree + one rollback candidate, so daily staging can't accrete gigabytes (the installer itself never prunes by design).
- State published via `writeJsonAtomic` to **`userDataHome()/update-status.json`** — the launcher's own data dir (byte-identical derivation to `data_home()` in the launcher), deliberately NOT esm `dataRoot`, which on writable installs is the versioned dir itself or the seal-protected `.app`. Written at boot, so the "restart to update" flag self-corrects the instant the staged version comes up.

**Modes** (`updates.mode`, default `stage`; `updates.check` default true, `false` = never phones home; both live-editable, no reboot):
| method | notify | stage (default) | auto |
|---|---|---|---|
| managed | banner only | background stage; apply on restart/click | + self-apply when idle (launcher via `applyRequested`; headless via exit 0 for the supervisor) |
| inno | banner; click = download verified setup.exe | background-download verified setup.exe | + silent when idle (launcher-driven, PR C) |
| pkg | click = download verified .pkg, open Installer.app | same | same |
| deb/rpm, docker, npm, portable | instructions + link | same | same |

**Native installers join the manifest**: `release-manifest.sh` lists `mStream-<ver>-win-x64-setup.exe` and both `.pkg`s as extra lines of the same `{file, sha256}` shape (wrong-version installers refused, same strictness as zips). The install scripts grep name-anchored patterns, so existing consumers are unaffected; `apiVersion` stays 1. The release job already merges those artifacts into `bundles/` before generation, so this lights up on the next tag.

**Admin API + UI**: `GET /api/v1/admin/update`, `POST …/check | download | apply | settings` behind the existing admin guard (`GET /api/` untouched — update state never leaks publicly). Both admin UIs (default + velvet) get a *Software Updates* card on the About page.

## Verified

- **21 new unit tests** (compare/validate/parse + the full method decision table) and a **live integration round-trip** (`test/integration/update-check.test.mjs`): check → auto-stage through the real `install.sh` → `current` flip → status file on disk → tampered-sha release refused with the staged version intact → settings persist live → non-managed installs 409 staging/apply.
- Full unit suite **507/507**; `admin-access`, `reboot-keeps-listener`, `reboot-keeps-services`, `supervision-shutdown` integration suites green (server.js wiring touched).
- **Real compiled darwin-arm64 bundle smoke** on this Mac (fake HOME, scratch ports): installed managed via install.sh from a local feed → geometry-detected `managed` → auto-staged a newer release through its embedded installer → `current` flipped, running tree protected from pruning, `~/Applications` copy + marker refreshed → old version kept serving throughout → headless apply exited 0 and the flipped `current` answers `-V` with the new version. Same flow then driven end-to-end from the new admin card in a browser (toast + clean exit observed).

## Notes for review

- Merge-order: independent of #862, but the **embedded** install.sh only gains #862's upgrade fixes once both are in — the first release cut after both carries the fixed script in every bundle.
- Headless `auto` documents its contract: exit 0 after staging when idle, supervisor restarts onto the flipped `current`.
- New admin strings are hard-coded English per the existing transcode-row precedent; i18n debt noted.
- PR C (launcher) adds: tray "Restart to update to X" from the status file, the quit-path+spawn relaunch with `--takeover` lock handoff, `applyRequested` handling, Inno silent flow, and the version in the tray status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)