### PR TITLE
Auto-update: launcher notify + one-click apply (takeover relaunch)

### DIFF
--- a/build/windows-installer.iss
+++ b/build/windows-installer.iss
@@ -96,7 +96,10 @@ Filename: "{app}\mStream.exe"; Description: "Launch mStream"; Flags: nowait post
 ; /MSTREAMRELAUNCH=1 after gracefully stopping mStream and exiting itself.
 ; skipifsilent above would leave the user trayless at the end of a silent
 ; update, so this param-gated twin relaunches exactly (and only) then.
-Filename: "{app}\mStream.exe"; Flags: nowait; Check: WantsRelaunch
+; --takeover: a relaunch mid-update is never a first run — without it the
+; tray would announce (pop the user's browser open) after every silent
+; update, at whatever moment the update happened to land.
+Filename: "{app}\mStream.exe"; Parameters: "--takeover"; Flags: nowait; Check: WantsRelaunch
 
 [Code]
 const

--- a/build/windows-installer.iss
+++ b/build/windows-installer.iss
@@ -92,10 +92,22 @@ Name: "{userdesktop}\mStream"; Filename: "{app}\mStream.exe"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\mStream.exe"; Description: "Launch mStream"; Flags: nowait postinstall skipifsilent
+; The tray launcher's one-click update runs this installer /VERYSILENT with
+; /MSTREAMRELAUNCH=1 after gracefully stopping mStream and exiting itself.
+; skipifsilent above would leave the user trayless at the end of a silent
+; update, so this param-gated twin relaunches exactly (and only) then.
+Filename: "{app}\mStream.exe"; Flags: nowait; Check: WantsRelaunch
 
 [Code]
 const
   RunKey = 'Software\Microsoft\Windows\CurrentVersion\Run';
+
+{ True only for the launcher-driven silent update (/MSTREAMRELAUNCH=1) —
+  see the param-gated [Run] entry above. }
+function WantsRelaunch(): Boolean;
+begin
+  Result := ExpandConstant('{param:MSTREAMRELAUNCH|0}') = '1';
+end;
 
 function AppPrefix(): string;
 begin

--- a/rust-launcher/build.rs
+++ b/rust-launcher/build.rs
@@ -22,16 +22,23 @@
 // winresource for non-windows targets built on a Windows host. No-op for
 // every non-Windows TARGET.
 fn main() {
-    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
-        return;
-    }
-    println!("cargo:rerun-if-changed=../build/mstream-logo-cut.ico");
     println!("cargo:rerun-if-changed=../package.json");
     let pkg: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string("../package.json").expect("read ../package.json"),
     )
     .expect("parse package.json");
     let version = pkg["version"].as_str().unwrap_or("0.0.0");
+    // Compile-time bundle version for EVERY target (the Windows VersionInfo
+    // below stamps only PEs): the tray's status line shows the server version
+    // from update-status.json once the server writes it, and this stamp is
+    // the before-first-boot fallback. Launcher binaries are rebuilt each
+    // release (deploy.md step 2), so the stamp always matches the bundle.
+    println!("cargo:rustc-env=MSTREAM_BUNDLE_VERSION={version}");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+    println!("cargo:rerun-if-changed=../build/mstream-logo-cut.ico");
     let author = pkg["author"]["name"].as_str().unwrap_or("");
     let license = pkg["license"].as_str().unwrap_or("");
 

--- a/rust-launcher/src/main.rs
+++ b/rust-launcher/src/main.rs
@@ -31,6 +31,10 @@ pub struct LauncherArgs {
     pub autostarted: bool,
     /// Never open the browser (`--no-open`; smokes and scripts).
     pub no_open: bool,
+    /// Apply-update handoff (`--takeover`): the previous launcher spawned us
+    /// and is exiting — retry its single-instance lock briefly instead of
+    /// yielding, and skip first-run behavior (no browser announce).
+    pub takeover: bool,
     /// Server binary override (`--server-bin <p>` / MSTREAM_SERVER_BIN).
     pub server_bin: Option<PathBuf>,
     /// Everything not launcher-specific, forwarded to the server verbatim
@@ -50,6 +54,7 @@ fn parse_cli(argv: impl Iterator<Item = String>) -> (LauncherArgs, Option<String
         tray: false,
         autostarted: false,
         no_open: false,
+        takeover: false,
         server_bin: std::env::var_os("MSTREAM_SERVER_BIN").map(PathBuf::from),
         server_args: Vec::new(),
     };
@@ -61,6 +66,10 @@ fn parse_cli(argv: impl Iterator<Item = String>) -> (LauncherArgs, Option<String
             "--tray" => args.tray = true,
             "--autostarted" => args.autostarted = true,
             "--no-open" => args.no_open = true,
+            // Ours, never the server's: without this arm the fall-through
+            // would forward --takeover to mstream-server, which exits on
+            // unknown options — the relaunched update would die at boot.
+            "--takeover" => args.takeover = true,
             "--server-bin" => {
                 if let Some(p) = it.next() {
                     args.server_bin = Some(PathBuf::from(p));
@@ -106,8 +115,12 @@ fn main() {
         std::process::exit(autostart::run_cli(&cmd));
     }
 
-    // Terminal face: hand the whole invocation to the server.
-    if has_console && !args.tray {
+    // Terminal face: hand the whole invocation to the server. A --takeover
+    // relaunch is always the tray taking over from a previous tray — even
+    // when it inherited a tty-shaped stdio from the session that spawned it,
+    // the console face would be wrong (measured: the update handoff became a
+    // bare pass-through server and the tray vanished).
+    if has_console && !args.tray && !args.takeover {
         platform::run_console_passthrough(&args);
         // (only returns on spawn failure, which it has already reported)
         std::process::exit(1);
@@ -144,5 +157,16 @@ mod tests {
         assert_eq!(args.server_bin.as_deref(), Some(std::path::Path::new("/x/srv")));
         assert_eq!(args.server_args, vec!["--portable"]);
         assert_eq!(cmd, None);
+    }
+
+    #[test]
+    fn takeover_is_ours_and_never_reaches_the_server() {
+        let (args, _) = parse(&["--takeover"]);
+        assert!(args.takeover);
+        assert!(args.server_args.is_empty(), "--takeover must not leak into server argv");
+        // ...except when it's a -j VALUE, which belongs to the server verbatim.
+        let (args, _) = parse(&["-j", "--takeover"]);
+        assert!(!args.takeover);
+        assert_eq!(args.server_args, vec!["-j", "--takeover"]);
     }
 }

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -207,6 +207,150 @@ pub fn browse_target(config: &Path, ep: &Endpoint) -> String {
     }
 }
 
+/// The status file the server's update checker writes
+/// (src/util/update-check.js) — same data home that holds launcher.lock, by
+/// the same byte-identical derivation on both sides.
+pub fn update_status_file() -> PathBuf {
+    data_home().join("update-status.json")
+}
+
+/// What the tray needs from update-status.json. Everything here is DATA from
+/// a file another process writes: versions are shape-checked before display,
+/// paths are validated against expectations before use, and nothing else is
+/// trusted at all (no URLs, no commands).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct UpdateStatus {
+    /// The running server's own version, as it reported it at boot.
+    pub current: Option<String>,
+    pub latest: Option<String>,
+    pub available: bool,
+    pub method: Option<String>,
+    pub staged: bool,
+    pub staged_version: Option<String>,
+    pub downloading: bool,
+    /// auto mode / a webapp "restart to update" click: the server asks the
+    /// launcher to apply on its next tick.
+    pub apply_requested: bool,
+    /// inno/pkg: the verified installer the server downloaded. Validated
+    /// (location + name shape) before the launcher will touch it.
+    pub installer_path: Option<PathBuf>,
+}
+
+/// A display-safe version: bare digits-and-dots triple, bounded length —
+/// anything else in the file renders as if absent, so a corrupted or
+/// malicious status file can't put arbitrary text in the menu.
+pub fn sanitize_version(s: &str) -> Option<String> {
+    if s.len() > 24 || s.is_empty() {
+        return None;
+    }
+    let mut dots = 0;
+    for c in s.chars() {
+        match c {
+            '0'..='9' => {}
+            '.' => dots += 1,
+            _ => return None,
+        }
+    }
+    (dots == 2 && !s.starts_with('.') && !s.ends_with('.')).then(|| s.to_string())
+}
+
+/// Tolerant read of the status file: absent, unreadable, or garbage all come
+/// back as None; unknown fields are ignored (the server may write a newer
+/// schema than this launcher knows).
+pub fn read_update_status() -> Option<UpdateStatus> {
+    parse_update_status(&std::fs::read_to_string(update_status_file()).ok()?)
+}
+
+/// The parsing half, split out so tests can feed it documents directly.
+pub fn parse_update_status(doc: &str) -> Option<UpdateStatus> {
+    let v = serde_json::from_str::<serde_json::Value>(doc).ok()?;
+    let ver = |key: &str| v.get(key).and_then(|x| x.as_str()).and_then(sanitize_version);
+    let flag = |key: &str| v.get(key).and_then(|x| x.as_bool()).unwrap_or(false);
+    Some(UpdateStatus {
+        current: ver("current"),
+        latest: ver("latest"),
+        available: flag("available"),
+        method: v
+            .get("method")
+            .and_then(|x| x.as_str())
+            .filter(|s| s.len() <= 16 && s.chars().all(|c| c.is_ascii_lowercase() || c == '-'))
+            .map(str::to_string),
+        staged: flag("staged"),
+        staged_version: ver("stagedVersion"),
+        downloading: flag("downloading"),
+        apply_requested: flag("applyRequested"),
+        installer_path: v.get("installerPath").and_then(|x| x.as_str()).map(PathBuf::from),
+    })
+}
+
+/// The bundle-dir naming the installers create: mStream-<X.Y.Z>-<key>.
+/// Mirrors parseBundleName in src/util/update-check.js closely enough for
+/// target derivation (the final existence check is the real gate).
+pub fn is_bundle_dir_name(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("mStream-") else { return false };
+    let Some(dash) = rest.find(|c: char| !(c.is_ascii_digit() || c == '.')) else { return false };
+    if dash == 0 || !rest[dash..].starts_with('-') {
+        return false;
+    }
+    if sanitize_version(&rest[..dash]).is_none() {
+        return false;
+    }
+    let key = &rest[dash + 1..];
+    ["darwin-", "linux-", "win-"].iter().any(|p| key.starts_with(p))
+        && key.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !key.ends_with('-')
+}
+
+/// The launcher face's path inside a bundle, per platform.
+fn launcher_rel() -> &'static str {
+    if cfg!(windows) {
+        "mStream.exe"
+    } else if cfg!(target_os = "macos") {
+        "mStream.app/Contents/MacOS/mStream"
+    } else {
+        "mstream-desktop"
+    }
+}
+
+/// Where "restart into the staged update" should exec from — derived from
+/// OUR OWN location, never from the status file:
+///
+///   - running from the ~/Applications copy (macOS): our own exe path — the
+///     path is stable across upgrades and the installer refreshed its
+///     CONTENTS when it staged;
+///   - running from a managed versioned dir: `<root>/current/<face>`, which
+///     the flip already points at the new version;
+///   - anything else (portable, dev): None — the menu item stays inert.
+///
+/// `exe` is the REAL path of the running launcher (caller passes
+/// current_exe(); tests pass fabricated layouts).
+pub fn derive_relaunch_target(exe: &Path) -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let apps_copy = home_dir().join("Applications").join("mStream.app");
+        if exe.starts_with(&apps_copy) && exe.exists() {
+            return Some(exe.to_path_buf());
+        }
+    }
+    let mut dir = exe.parent()?;
+    for _ in 0..8 {
+        let parent = dir.parent()?;
+        if dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(is_bundle_dir_name)
+        {
+            let target = parent.join("current").join(launcher_rel());
+            if target.exists() {
+                return Some(target);
+            }
+            return None;
+        }
+        dir = parent;
+    }
+    None
+}
+
 /// Locate the server binary: explicit override (--server-bin /
 /// MSTREAM_SERVER_BIN), else the `mstream-server` sibling the bundles stage
 /// next to the launcher (phase 1c renames the shipped binaries to this).
@@ -347,5 +491,79 @@ mod tests {
         env::set_var(&var, "x");
         assert_eq!(env_dir(&var), Some(OsString::from("x")));
         env::remove_var(&var);
+    }
+
+    #[test]
+    fn versions_are_display_safe_or_absent() {
+        assert_eq!(sanitize_version("6.21.2"), Some("6.21.2".to_string()));
+        assert_eq!(sanitize_version("10.0.999"), Some("10.0.999".to_string()));
+        assert_eq!(sanitize_version("v6.21.2"), None);
+        assert_eq!(sanitize_version("6.21"), None);
+        assert_eq!(sanitize_version("6.21.2-beta.1"), None);
+        assert_eq!(sanitize_version("6.21.2\n<script>"), None);
+        assert_eq!(sanitize_version(""), None);
+        assert_eq!(sanitize_version(&"9".repeat(30)), None, "length-capped");
+        assert_eq!(sanitize_version(".1.2"), None);
+        assert_eq!(sanitize_version("1.2."), None);
+    }
+
+    #[test]
+    fn bundle_dir_names() {
+        assert!(is_bundle_dir_name("mStream-6.21.2-darwin-arm64"));
+        assert!(is_bundle_dir_name("mStream-6.21.2-linux-x64-musl"));
+        assert!(is_bundle_dir_name("mStream-6.21.2-win-x64"));
+        assert!(!is_bundle_dir_name("mStream-6.21.2-darwin-arm64.partial"));
+        assert!(!is_bundle_dir_name("current"));
+        assert!(!is_bundle_dir_name("mStream-latest-linux-x64"));
+        assert!(!is_bundle_dir_name("mStream.app"));
+    }
+
+    #[test]
+    fn status_parsing_is_tolerant_and_untrusting() {
+        assert_eq!(parse_update_status("not json"), None);
+        assert_eq!(parse_update_status(""), None);
+        // Unknown fields ignored; knowns picked out; junk versions dropped.
+        let s = parse_update_status(
+            r#"{"schema": 9, "surprise": [1], "current": "6.21.2", "latest": "not a version",
+                "available": true, "method": "managed", "staged": true,
+                "stagedVersion": "6.22.0", "applyRequested": "yes-as-string"}"#,
+        )
+        .unwrap();
+        assert_eq!(s.current.as_deref(), Some("6.21.2"));
+        assert_eq!(s.latest, None, "garbage version renders as absent");
+        assert!(s.available && s.staged);
+        assert_eq!(s.staged_version.as_deref(), Some("6.22.0"));
+        assert!(!s.apply_requested, "non-bool flag reads as false, never truthy");
+        assert_eq!(s.method.as_deref(), Some("managed"));
+        // A method with unexpected characters is dropped, not displayed.
+        let odd = parse_update_status(r#"{"method": "Managed; rm -rf /"}"#).unwrap();
+        assert_eq!(odd.method, None);
+    }
+
+    #[test]
+    fn relaunch_target_resolves_through_current() {
+        let root = env::temp_dir().join(format!("mstream-relaunch-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let bundle = root.join("mStream-6.21.2-linux-x64");
+        // The launcher "runs" from the versioned dir; current points at a
+        // NEWER bundle whose face exists.
+        let newer = root.join("mStream-6.22.0-linux-x64");
+        std::fs::create_dir_all(&bundle).unwrap();
+        std::fs::create_dir_all(&newer).unwrap();
+        let face = newer.join(launcher_rel());
+        if let Some(p) = face.parent() { std::fs::create_dir_all(p).unwrap(); }
+        std::fs::write(&face, "x").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&newer, root.join("current")).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&newer, root.join("current")).unwrap();
+
+        let exe = bundle.join(launcher_rel());
+        let got = derive_relaunch_target(&exe);
+        assert_eq!(got, Some(root.join("current").join(launcher_rel())));
+
+        // Not under a managed layout: no target, item stays inert.
+        assert_eq!(derive_relaunch_target(Path::new("/tmp/loose/mstream-desktop")), None);
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -211,7 +211,10 @@ pub fn browse_target(config: &Path, ep: &Endpoint) -> String {
 /// patterns built from filesystem paths): a HOME containing '+', '?',
 /// '(' or brackets must match itself — a metacharacter that COMPILES but
 /// narrows the pattern silently under-matches, and for a busy-check that
-/// under-match is a deleted live tree.
+/// under-match is a deleted live tree. Both callers (the aside sweep and
+/// the open-handoff liveness probe) are macOS-only; `test` keeps the
+/// matrix test compiling on every host.
+#[cfg(any(target_os = "macos", test))]
 pub(crate) fn escape_ere(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 8);
     for c in s.chars() {

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -207,6 +207,22 @@ pub fn browse_target(config: &Path, ep: &Endpoint) -> String {
     }
 }
 
+/// Escape a literal string for use inside a POSIX ERE (the pgrep -f
+/// patterns built from filesystem paths): a HOME containing '+', '?',
+/// '(' or brackets must match itself — a metacharacter that COMPILES but
+/// narrows the pattern silently under-matches, and for a busy-check that
+/// under-match is a deleted live tree.
+pub(crate) fn escape_ere(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        if "\\^$.|?*+()[]{}".contains(c) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 /// The status file the server's update checker writes
 /// (src/util/update-check.js) — same data home that holds launcher.lock, by
 /// the same byte-identical derivation on both sides.
@@ -500,6 +516,17 @@ mod tests {
         env::set_var(&var, "x");
         assert_eq!(env_dir(&var), Some(OsString::from("x")));
         env::remove_var(&var);
+    }
+
+    #[test]
+    fn ere_escaping_neutralizes_path_metacharacters() {
+        assert_eq!(escape_ere("/Users/plain/Applications"), "/Users/plain/Applications");
+        assert_eq!(escape_ere("a+b"), "a\\+b");
+        assert_eq!(escape_ere("q?"), "q\\?");
+        assert_eq!(escape_ere("x{1}"), "x\\{1\\}");
+        assert_eq!(escape_ere("(par)[br]"), "\\(par\\)\\[br\\]");
+        assert_eq!(escape_ere("dot.dir"), "dot\\.dir");
+        assert_eq!(escape_ere("back\\slash"), "back\\\\slash");
     }
 
     #[test]

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -231,6 +231,10 @@ pub struct UpdateStatus {
     /// auto mode / a webapp "restart to update" click: the server asks the
     /// launcher to apply on its next tick.
     pub apply_requested: bool,
+    /// Fresh per arm (an ISO timestamp; treated as an opaque token): a
+    /// failed apply is retried only when a NEW request arrives — comparing
+    /// this rules out both same-version retry loops and stale replays.
+    pub apply_requested_at: Option<String>,
     /// inno/pkg: the verified installer the server downloaded. Validated
     /// (location + name shape) before the launcher will touch it.
     pub installer_path: Option<PathBuf>,
@@ -279,6 +283,11 @@ pub fn parse_update_status(doc: &str) -> Option<UpdateStatus> {
         staged_version: ver("stagedVersion"),
         downloading: flag("downloading"),
         apply_requested: flag("applyRequested"),
+        apply_requested_at: v
+            .get("applyRequestedAt")
+            .and_then(|x| x.as_str())
+            .filter(|t| t.len() <= 40 && t.chars().all(|c| c.is_ascii_graphic()))
+            .map(str::to_string),
         installer_path: v.get("installerPath").and_then(|x| x.as_str()).map(PathBuf::from),
     })
 }
@@ -534,6 +543,19 @@ mod tests {
         assert!(s.available && s.staged);
         assert_eq!(s.staged_version.as_deref(), Some("6.22.0"));
         assert!(!s.apply_requested, "non-bool flag reads as false, never truthy");
+        assert_eq!(s.apply_requested_at, None);
+        let armed = parse_update_status(
+            r#"{"applyRequested": true, "applyRequestedAt": "2026-08-20T12:00:00.000Z"}"#,
+        )
+        .unwrap();
+        assert!(armed.apply_requested);
+        assert_eq!(armed.apply_requested_at.as_deref(), Some("2026-08-20T12:00:00.000Z"));
+        // Oversized or non-printable tokens are dropped, not displayed/compared.
+        let junk = parse_update_status(&format!(
+            r#"{{"applyRequestedAt": "{}"}}"#, "x".repeat(60)
+        ))
+        .unwrap();
+        assert_eq!(junk.apply_requested_at, None);
         assert_eq!(s.method.as_deref(), Some("managed"));
         // A method with unexpected characters is dropped, not displayed.
         let odd = parse_update_status(r#"{"method": "Managed; rm -rf /"}"#).unwrap();

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -314,15 +314,23 @@ pub fn relaunch(target: &std::path::Path, server_args: &[String]) -> Result<(), 
             .find(|p| p.extension().is_some_and(|e| e == "app"))
             .filter(|_| !direct);
         if let Some(app) = app_root {
-            return std::process::Command::new("/usr/bin/open")
+            // status(), not spawn(): `open` exits nonzero when LaunchServices
+            // refuses the launch (damaged bundle, Gatekeeper). A fire-and-
+            // forget spawn would report Ok on a launch that never happened,
+            // and the caller — who already stopped the server — would exit
+            // into nothing. `open` returns promptly either way.
+            return match std::process::Command::new("/usr/bin/open")
                 .arg("-n")
                 .arg(app)
                 .arg("--args")
                 .arg("--takeover")
                 .args(server_args)
-                .spawn()
-                .map(|_| ())
-                .map_err(|e| format!("open -n {}: {e}", app.display()));
+                .status()
+            {
+                Ok(st) if st.success() => Ok(()),
+                Ok(st) => Err(format!("open -n {} exited {st}", app.display())),
+                Err(e) => Err(format!("open -n {}: {e}", app.display())),
+            };
         }
     }
     let mut cmd = std::process::Command::new(target);
@@ -349,7 +357,21 @@ pub fn relaunch(target: &std::path::Path, server_args: &[String]) -> Result<(), 
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         cmd.creation_flags(DETACHED_PROCESS);
     }
-    cmd.spawn().map(|_| ()).map_err(|e| format!("spawn {}: {e}", target.display()))
+    match cmd.spawn() {
+        Ok(mut child) => {
+            // A brief liveness check: a takeover that dies within its first
+            // beat (bad interpreter, immediate loader failure) means the
+            // handoff did NOT happen — report it so the caller can recover
+            // instead of exiting into nothing. Past this window the child
+            // owns its own fate (its lock retry outlives us).
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            match child.try_wait() {
+                Ok(Some(st)) => Err(format!("{} exited immediately: {st}", target.display())),
+                _ => Ok(()),
+            }
+        }
+        Err(e) => Err(format!("spawn {}: {e}", target.display())),
+    }
 }
 
 /// Windows: run the verified update installer, detached, and return so the

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -327,7 +327,36 @@ pub fn relaunch(target: &std::path::Path, server_args: &[String]) -> Result<(), 
                 .args(server_args)
                 .status()
             {
-                Ok(st) if st.success() => Ok(()),
+                Ok(st) if st.success() => {
+                    // Exit 0 only proves LaunchServices ACCEPTED the launch:
+                    // a takeover that execs and dies instantly (missing
+                    // server sibling in a bad staged copy, an early panic)
+                    // still reports success — measured with a bundle whose
+                    // executable is `exit 7`. Poll briefly for a live
+                    // process under the app path that is not US (the old
+                    // launcher may share the exact path); the takeover
+                    // stays alive through its ~12s lock retry, so any
+                    // healthy handoff is visible well within this window.
+                    let pat = format!("^{}/", crate::paths::escape_ere(&app.display().to_string()));
+                    let me = std::process::id().to_string();
+                    for _ in 0..8 {
+                        std::thread::sleep(std::time::Duration::from_millis(250));
+                        match std::process::Command::new("/usr/bin/pgrep").arg("-f").arg(&pat).output() {
+                            Ok(out) => {
+                                if String::from_utf8_lossy(&out.stdout)
+                                    .lines()
+                                    .any(|l| !l.trim().is_empty() && l.trim() != me)
+                                {
+                                    return Ok(());
+                                }
+                            }
+                            // pgrep itself failing must not fail a possibly
+                            // healthy handoff.
+                            Err(_) => return Ok(()),
+                        }
+                    }
+                    Err(format!("takeover under {} never appeared after open", app.display()))
+                }
                 Ok(st) => Err(format!("open -n {} exited {st}", app.display())),
                 Err(e) => Err(format!("open -n {}: {e}", app.display())),
             };

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -283,6 +283,93 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
     }
 }
 
+/// Start the NEW launcher for the apply-update handoff, detached, and return
+/// so the caller can exit. Always passes `--takeover`: the new instance
+/// retries the single-instance lock briefly (we still hold it for the last
+/// few milliseconds of our life) and skips first-run behavior like the
+/// browser announce.
+///
+/// macOS .app targets go through `open -n`: a bare exec of the inner binary
+/// works, but LaunchServices activation is what keeps the menu-bar
+/// registration and reopen events behaving like an app the user launched.
+/// This is a spawn+exit handoff, NOT an exec-in-place: AppKit/gtk state does
+/// not survive exec, and PID continuity buys nothing here (nothing
+/// supervises the launcher).
+/// `server_args` are the current session's forwarded server flags (-j, --portable,
+/// ...) — the relaunched instance must serve the SAME config, so they ride
+/// along. (Env-shaped overrides like MSTREAM_SERVER_BIN survive the direct
+/// spawn but not `open -n`, which launches through LaunchServices; argv is
+/// the reliable carrier.)
+pub fn relaunch(target: &std::path::Path, server_args: &[String]) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        // Testing hook (same family as MSTREAM_LAUNCHER_SKIP_AUTOSTART):
+        // smokes run inside a redirected HOME, which `open -n` would discard
+        // — launchd starts apps with the session's real environment. Direct
+        // spawn keeps the sandbox; real usage wants LaunchServices below.
+        let direct = std::env::var_os("MSTREAM_LAUNCHER_DIRECT_RELAUNCH").is_some();
+        // .../mStream.app/Contents/MacOS/mStream -> the .app root.
+        let app_root = target
+            .ancestors()
+            .find(|p| p.extension().is_some_and(|e| e == "app"))
+            .filter(|_| !direct);
+        if let Some(app) = app_root {
+            return std::process::Command::new("/usr/bin/open")
+                .arg("-n")
+                .arg(app)
+                .arg("--args")
+                .arg("--takeover")
+                .args(server_args)
+                .spawn()
+                .map(|_| ())
+                .map_err(|e| format!("open -n {}: {e}", app.display()));
+        }
+    }
+    let mut cmd = std::process::Command::new(target);
+    cmd.arg("--takeover");
+    cmd.args(server_args);
+    // The child must outlive US and our whole session: null stdio (an
+    // inherited pty dies with the old session and would SIGHUP the update —
+    // measured) and, on unix, its own session via setsid (no controlling
+    // terminal at all).
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        cmd.creation_flags(DETACHED_PROCESS);
+    }
+    cmd.spawn().map(|_| ()).map_err(|e| format!("spawn {}: {e}", target.display()))
+}
+
+/// Windows: run the verified update installer, detached, and return so the
+/// tray can exit before the installer's process sweep begins. Silent =
+/// Inno's /VERYSILENT unattended path (a param-gated [Run] entry in the .iss
+/// relaunches the tray afterwards); non-silent shows the familiar wizard.
+#[cfg(windows)]
+pub fn spawn_installer_detached(installer: &std::path::Path, silent: bool) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    let mut cmd = std::process::Command::new(installer);
+    if silent {
+        cmd.args(["/VERYSILENT", "/NORESTART", "/MSTREAMRELAUNCH=1"]);
+    }
+    cmd.creation_flags(DETACHED_PROCESS);
+    cmd.spawn()
+        .map(|_| ())
+        .map_err(|e| format!("spawn {}: {e}", installer.display()))
+}
+
 /// POSIX single-quote a path for embedding in `sh -c` text — the macOS data
 /// home ("Application Support") guarantees a space.
 #[cfg(unix)]

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -117,7 +117,7 @@ pub fn run(args: LauncherArgs) -> ! {
     }
     if !locked {
         log.line("another launcher instance holds the lock - focusing it and exiting");
-        if !args.autostarted && !args.no_open {
+        if !args.autostarted && !args.no_open && !args.takeover {
             let _ = open::that_detached(paths::browse_target(&config, &ep));
         }
         std::process::exit(0);
@@ -267,6 +267,14 @@ pub fn run(args: LauncherArgs) -> ! {
     // a spawn loop, but a NEW request — a later version, or the operator
     // clicking "restart to update" again in the webapp — starts fresh.
     let mut auto_apply_attempted: Option<String> = None;
+    // The token alone cannot bound retries: every failed apply respawns the
+    // server, and the fresh process re-stages and mints a fresh
+    // applyRequestedAt within ~2 minutes — an unbounded stop/fail/respawn
+    // flap on a PERSISTENT relaunch failure. So failures are also counted
+    // per staged VERSION; past the cap, auto-apply stands down for that
+    // version (the tray menu still lets a human retry) until a different
+    // version stages.
+    let mut apply_failures: Option<(String, u32)> = None;
     // Our own REAL location (canonicalized so a start through the `current`
     // symlink still resolves to the versioned tree the walk-up needs).
     let exe_real = std::env::current_exe()
@@ -391,10 +399,25 @@ pub fn run(args: LauncherArgs) -> ! {
                     // starts fresh. And never while quitting: a queued poll
                     // must not resurrect mStream on the way out.
                     let token = upd.as_ref().and_then(auto_apply_token);
+                    let staged_ver = upd.as_ref().and_then(|s| s.staged_version.clone());
                     if !shared_loop.quitting.load(Ordering::SeqCst)
                         && upd.as_ref().is_some_and(|s| s.apply_requested)
                         && token.is_some()
                         && token != auto_apply_attempted
+                        // Never mid-boot: the takeover launcher's first poll
+                        // can land while the new server is still migrating,
+                        // reading a status file the OLD session armed — an
+                        // apply here kills a healthy boot. Once the server
+                        // is up (or the probe gave up on an SSL config) the
+                        // file is fresh again.
+                        && !matches!(phase, Phase::Starting)
+                        // Never into OURSELVES: after a successful handoff
+                        // the stale file still says "apply X" until the new
+                        // server rewrites it — but this launcher shipped IN
+                        // bundle X; applying it again is a kill-loop, not
+                        // an update.
+                        && staged_ver.as_deref() != Some(env!("MSTREAM_BUNDLE_VERSION"))
+                        && !auto_apply_capped(&apply_failures, staged_ver.as_deref())
                         && !matches!(action, UpdateAction::None | UpdateAction::OpenReleases)
                     {
                         auto_apply_attempted = token;
@@ -406,6 +429,7 @@ pub fn run(args: LauncherArgs) -> ! {
                             }
                             Err(e) => {
                                 log.line(&format!("update apply failed: {e}"));
+                                record_apply_failure(&mut apply_failures, staged_ver.as_deref(), &log);
                                 spawned_at = Instant::now();
                                 phase = recover_after_failed_apply(
                                     &shared_loop, &bin, &args.server_args, &server_log_loop, ep, &proxy, &log,
@@ -495,6 +519,11 @@ pub fn run(args: LauncherArgs) -> ! {
                             UpdateAction::None => {}
                             _ => {
                                 log.line("menu: apply update");
+                                // The click consumes any pending server-side
+                                // request too: a failed MANUAL apply must not
+                                // be auto-repeated seconds later by a poll
+                                // reading the still-armed file.
+                                auto_apply_attempted = upd.as_ref().and_then(auto_apply_token);
                                 match perform_apply(&shared_loop, &action, exe_real.as_deref(), &args.server_args, &log) {
                                     Ok(()) => {
                                         tray.take();
@@ -502,6 +531,11 @@ pub fn run(args: LauncherArgs) -> ! {
                                     }
                                     Err(e) => {
                                         log.line(&format!("update apply failed: {e}"));
+                                        record_apply_failure(
+                                            &mut apply_failures,
+                                            upd.as_ref().and_then(|s| s.staged_version.as_deref()),
+                                            &log,
+                                        );
                                         spawned_at = Instant::now();
                                         phase = recover_after_failed_apply(
                                             &shared_loop, &bin, &args.server_args, &server_log_loop, ep, &proxy, &log,
@@ -867,6 +901,33 @@ fn render_update_item(
     action
 }
 
+/// How many failed applies one staged version gets before auto-apply
+/// stands down for it (the tray menu still allows manual retries).
+const MAX_APPLY_FAILURES: u32 = 2;
+
+/// True when auto-apply should stand down: this staged version has already
+/// burned its failure budget. Pure for the tests; None staged never caps.
+fn auto_apply_capped(failures: &Option<(String, u32)>, staged: Option<&str>) -> bool {
+    match (failures, staged) {
+        (Some((v, n)), Some(s)) => v == s && *n >= MAX_APPLY_FAILURES,
+        _ => false,
+    }
+}
+
+fn record_apply_failure(failures: &mut Option<(String, u32)>, staged: Option<&str>, log: &Logger) {
+    let Some(s) = staged else { return };
+    let n = match failures {
+        Some((v, n)) if v == s => *n + 1,
+        _ => 1,
+    };
+    *failures = Some((s.to_string(), n));
+    if n >= MAX_APPLY_FAILURES {
+        log.line(&format!(
+            "update: {n} failed applies for {s} - auto-apply stands down for this version (use the tray menu to retry)"
+        ));
+    }
+}
+
 /// The identity of an apply request: the server's applyRequestedAt stamp,
 /// else (an older server writing no stamp) the staged version. A failed
 /// attempt consumes exactly this token; a fresh request mints a new one.
@@ -890,15 +951,28 @@ fn sweep_apps_asides(log: &Logger) {
             continue;
         }
         let p = e.path();
-        let busy = std::process::Command::new("/usr/bin/pgrep")
+        // Metacharacters in the path (a '+' or brackets in the user name)
+        // must match themselves — an ERE that silently narrows would read
+        // a live tree as idle.
+        let pat = format!("^{}/", crate::paths::escape_ere(&p.display().to_string()));
+        let pgrep_busy = std::process::Command::new("/usr/bin/pgrep")
             .arg("-f")
-            .arg(format!("^{}/", p.display()))
+            .arg(&pat)
             .output()
             // pgrep: 1 = no match; anything else (match, or pgrep itself
             // failing) counts as busy — never delete blind.
             .map(|o| o.status.code() != Some(1))
             .unwrap_or(true);
-        if busy {
+        // lsof sees what argv text cannot: a process whose cwd or open
+        // files live inside the tree (someone cd'd in and ran the server
+        // by relative path). Any output — or lsof failing — is busy.
+        let lsof_busy = std::process::Command::new("/usr/sbin/lsof")
+            .arg("+D")
+            .arg(&p)
+            .output()
+            .map(|o| !o.stdout.is_empty())
+            .unwrap_or(true);
+        if pgrep_busy || lsof_busy {
             continue;
         }
         log.line(&format!("sweeping stale ~/Applications aside {name}"));
@@ -1197,6 +1271,24 @@ mod tests {
         let (t, a) = update_item_view(s.as_ref(), ud, true);
         assert_eq!(t, "Update available (6.22.0)");
         assert_eq!(a, UpdateAction::OpenReleases);
+    }
+
+    #[test]
+    fn failure_cap_is_per_version_and_bounded() {
+        let mut f: Option<(String, u32)> = None;
+        assert!(!auto_apply_capped(&f, Some("6.22.0")));
+        let log = Logger(std::env::temp_dir().join(format!("mstream-cap-test-{}.log", std::process::id())));
+        record_apply_failure(&mut f, Some("6.22.0"), &log);
+        assert!(!auto_apply_capped(&f, Some("6.22.0")), "one failure is not the cap");
+        record_apply_failure(&mut f, Some("6.22.0"), &log);
+        assert!(auto_apply_capped(&f, Some("6.22.0")), "second failure caps");
+        // A DIFFERENT staged version starts fresh — the cap must never leak
+        // across releases.
+        assert!(!auto_apply_capped(&f, Some("6.23.0")));
+        record_apply_failure(&mut f, Some("6.23.0"), &log);
+        assert!(!auto_apply_capped(&f, Some("6.23.0")), "counter reset for the new version");
+        assert!(!auto_apply_capped(&f, None));
+        let _ = std::fs::remove_file(&log.0);
     }
 
     #[test]

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -20,6 +20,14 @@ use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 
 const STOP_GRACE: Duration = Duration::from_secs(8);
 const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
+/// How long a `--takeover` relaunch retries the single-instance lock: the
+/// old launcher holds it for at most its own stop_current (STOP_GRACE) plus
+/// process teardown, so this only needs to comfortably exceed that.
+const TAKEOVER_LOCK_PATIENCE: Duration = Duration::from_secs(12);
+/// Where a click on a non-actionable "update available" lands. Hardcoded on
+/// purpose: the status file is another process's data and never supplies a
+/// URL the launcher would open.
+const RELEASES_URL: &str = "https://github.com/IrosTheBeggar/mStream/releases/latest";
 
 #[derive(Debug)]
 enum AppEvent {
@@ -87,7 +95,22 @@ pub fn run(args: LauncherArgs) -> ! {
             std::process::exit(1);
         }
     };
-    if !lock.try_lock().unwrap_or(false) {
+    let mut locked = lock.try_lock().unwrap_or(false);
+    if !locked && args.takeover {
+        // Apply-update handoff: the previous launcher spawned us and is in
+        // its last milliseconds of teardown, still holding the lock. Wait it
+        // out briefly instead of yielding to it.
+        log.line("takeover: waiting for the previous launcher to release the lock");
+        let deadline = Instant::now() + TAKEOVER_LOCK_PATIENCE;
+        while Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(250));
+            if lock.try_lock().unwrap_or(false) {
+                locked = true;
+                break;
+            }
+        }
+    }
+    if !locked {
         log.line("another launcher instance holds the lock - focusing it and exiting");
         if !args.autostarted && !args.no_open {
             let _ = open::that_detached(paths::browse_target(&config, &ep));
@@ -206,8 +229,20 @@ pub fn run(args: LauncherArgs) -> ! {
     let mut spawned_at = Instant::now();
     let mut ever_up = false;
     let mut opened = false;
+    // Update-awareness: the server's checker writes update-status.json in
+    // the shared data home; the tray re-reads it on every minute tick.
+    let mut update_item: Option<MenuItem> = None;
+    let mut upd: Option<paths::UpdateStatus> = paths::read_update_status();
+    let mut upd_text = String::new();
+    let mut apply_handled = false;
+    // Our own REAL location (canonicalized so a start through the `current`
+    // symlink still resolves to the versioned tree the walk-up needs).
+    let exe_real = std::env::current_exe()
+        .ok()
+        .map(|p| std::fs::canonicalize(&p).unwrap_or(p));
     let url = paths::server_url(&ep);
-    let announce = !args.autostarted && !args.no_open;
+    // A --takeover relaunch is mid-update, not a first run: never announce.
+    let announce = !args.autostarted && !args.no_open && !args.takeover;
     let shared_loop = shared.clone();
     let server_log_loop = server_log.clone();
     // For launcher-initiated opens inside the loop (announce, macOS reopen):
@@ -233,7 +268,15 @@ pub fn run(args: LauncherArgs) -> ! {
                 // Disabled = the greyed, unclickable status line every tray
                 // app leads with (Docker Desktop, Tailscale). Text tracks
                 // `phase` via show_status; the id never fires a MenuEvent.
-                let status = MenuItem::with_id("status", phase.menu_text(), false, None);
+                let status = MenuItem::with_id("status", phase.menu_text(&version_label(upd.as_ref())), false, None);
+                // The update line right under it: disabled "Up to date" most
+                // of its life, an enabled action ("Restart to update to X")
+                // when the server has one staged. Text/enabled track the
+                // status file via refresh below.
+                let (utext, uaction) =
+                    update_item_view(upd.as_ref(), &updates_dir(), relaunch_target_exists(exe_real.as_deref()));
+                let update = MenuItem::with_id("update", utext.clone(), uaction != UpdateAction::None, None);
+                upd_text = utext;
                 let open_item = MenuItem::with_id("open", "Open mStream", true, None);
                 let qc_item = MenuItem::with_id("quick-connect", "Quick Connect", true, None);
                 let auto_item =
@@ -242,6 +285,7 @@ pub fn run(args: LauncherArgs) -> ! {
                 let restart_item = MenuItem::with_id("restart", "Restart server", true, None);
                 let quit_item = MenuItem::with_id("quit", "Quit mStream", true, None);
                 let _ = menu.append(&status);
+                let _ = menu.append(&update);
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&open_item);
                 let _ = menu.append(&qc_item);
@@ -252,6 +296,7 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&restart_item);
                 let _ = menu.append(&quit_item);
                 status_item = Some(status);
+                update_item = Some(update);
                 autostart_item = Some(auto_item);
 
                 // catch_unwind because "no tray" arrives two ways: as a
@@ -283,7 +328,7 @@ pub fn run(args: LauncherArgs) -> ! {
                         log.line(&format!("tray unavailable ({msg}) - server continues without it"));
                     }
                 }
-                show_status(status_item.as_ref(), tray.as_ref(), &phase, &url);
+                show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
             }
             Event::UserEvent(app_event) => match app_event {
                 // The minute tick from the current generation's ticker
@@ -292,13 +337,50 @@ pub fn run(args: LauncherArgs) -> ! {
                 // re-set under a hovering cursor. Stale generations are
                 // ignored outright and the rest is throttled to 1 Hz.
                 AppEvent::Tick(generation) => {
+                    // Update-state refresh rides the minute tick: one small
+                    // file read, then the item re-renders only on change (so
+                    // the text is never re-set under a hovering cursor).
+                    upd = paths::read_update_status();
+                    let action = render_update_item(
+                        update_item.as_ref(),
+                        upd.as_ref(),
+                        &updates_dir(),
+                        relaunch_target_exists(exe_real.as_deref()),
+                        &mut upd_text,
+                    );
+                    // auto mode / a webapp "restart to update" click: the
+                    // server flags applyRequested and this launcher acts on
+                    // its next tick. Once — a failed handoff must not retry
+                    // itself into a spawn loop.
+                    if !apply_handled
+                        && upd.as_ref().is_some_and(|s| s.apply_requested)
+                        && !matches!(action, UpdateAction::None | UpdateAction::OpenReleases)
+                    {
+                        apply_handled = true;
+                        log.line("update: the server requested apply - restarting into the staged version");
+                        match perform_apply(&shared_loop, &action, exe_real.as_deref(), &args.server_args, &log) {
+                            Ok(()) => {
+                                tray.take();
+                                *control_flow = ControlFlow::Exit;
+                                return;
+                            }
+                            Err(e) => {
+                                log.line(&format!("update apply failed: {e}"));
+                                spawned_at = Instant::now();
+                                phase = recover_after_failed_apply(
+                                    &shared_loop, &bin, &args.server_args, &server_log_loop, ep, &proxy, &log,
+                                );
+                                show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                            }
+                        }
+                    }
                     let now = Instant::now();
                     if generation == shared_loop.generation.load(Ordering::SeqCst)
                         && phase.ticks()
                         && status_rendered_at.is_none_or(|t| now.duration_since(t) >= Duration::from_secs(1))
                     {
                         status_rendered_at = Some(now);
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url);
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
                     }
                 }
                 AppEvent::Menu(id) => match id.as_str() {
@@ -351,7 +433,42 @@ pub fn run(args: LauncherArgs) -> ! {
                                 Phase::Stopped
                             }
                         };
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url);
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                    }
+                    "update" => {
+                        // Recompute from the file at click time — the menu
+                        // could have been open across a state change.
+                        upd = paths::read_update_status();
+                        let action = render_update_item(
+                            update_item.as_ref(),
+                            upd.as_ref(),
+                            &updates_dir(),
+                            relaunch_target_exists(exe_real.as_deref()),
+                            &mut upd_text,
+                        );
+                        match action {
+                            UpdateAction::OpenReleases => {
+                                let _ = open::that_detached(RELEASES_URL);
+                            }
+                            UpdateAction::None => {}
+                            _ => {
+                                log.line("menu: apply update");
+                                match perform_apply(&shared_loop, &action, exe_real.as_deref(), &args.server_args, &log) {
+                                    Ok(()) => {
+                                        tray.take();
+                                        *control_flow = ControlFlow::Exit;
+                                    }
+                                    Err(e) => {
+                                        log.line(&format!("update apply failed: {e}"));
+                                        spawned_at = Instant::now();
+                                        phase = recover_after_failed_apply(
+                                            &shared_loop, &bin, &args.server_args, &server_log_loop, ep, &proxy, &log,
+                                        );
+                                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                                    }
+                                }
+                            }
+                        }
                     }
                     "quit" => {
                         log.line("menu: quit");
@@ -378,12 +495,23 @@ pub fn run(args: LauncherArgs) -> ! {
                     if child_alive && generation == shared_loop.generation.load(Ordering::SeqCst) {
                         ever_up = true;
                         log.line("server is up");
+                        // The booting server just rewrote the status file
+                        // (its version, cleared staged flags) — pick that up
+                        // now instead of a minute from now.
+                        upd = paths::read_update_status();
+                        let _ = render_update_item(
+                            update_item.as_ref(),
+                            upd.as_ref(),
+                            &updates_dir(),
+                            relaunch_target_exists(exe_real.as_deref()),
+                            &mut upd_text,
+                        );
                         // Uptime counts from here — "up" means serving, not
                         // spawned. A restart or crash lands back in
                         // Starting/Stopped, so the count resets with it.
                         let since = Instant::now();
                         phase = Phase::Running { since };
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url);
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
                         start_ticker(&shared_loop, generation, since, &proxy);
                         // Logged unconditionally (even under --no-open) so
                         // smokes and support can see the routing decision.
@@ -426,7 +554,7 @@ pub fn run(args: LauncherArgs) -> ! {
                         ));
                         let since = spawned_at;
                         phase = Phase::Unverified { since };
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url);
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
                         start_ticker(&shared_loop, generation, since, &proxy);
                     }
                 }
@@ -435,7 +563,7 @@ pub fn run(args: LauncherArgs) -> ! {
                     if generation == current && !shared_loop.quitting.load(Ordering::SeqCst) {
                         log.line("server exited unexpectedly");
                         phase = Phase::Stopped;
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url);
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
                         if !ever_up {
                             // Died before ever serving = a boot failure the
                             // user would otherwise never see (no console).
@@ -581,6 +709,178 @@ fn stop_current(shared: &Arc<Shared>) {
     }
 }
 
+/// What clicking the update menu item does in its current state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum UpdateAction {
+    None,
+    OpenReleases,
+    /// Managed layout with a staged version: quit-path teardown, then spawn
+    /// the launcher behind `current` with --takeover.
+    Relaunch,
+    /// Windows Inno install with a verified downloaded installer.
+    RunInstaller(PathBuf),
+}
+
+/// Where the server's updater downloads native installers (validated
+/// against, never trusted from the status file alone).
+fn updates_dir() -> PathBuf {
+    paths::data_home().join("updates")
+}
+
+/// The version shown in the status line: the running server's own report
+/// (status file), else the version this launcher was built into the bundle
+/// with (build.rs stamp) — present before the server's first boot.
+fn version_label(s: Option<&paths::UpdateStatus>) -> String {
+    s.and_then(|s| s.current.clone())
+        .unwrap_or_else(|| env!("MSTREAM_BUNDLE_VERSION").to_string())
+}
+
+/// The installer path the launcher will actually run: must live in OUR
+/// updates dir with the expected asset name and exist. Everything else in
+/// the status file's installerPath is ignored — the file is another
+/// process's data, not an instruction stream.
+fn valid_installer(p: Option<&Path>, updates_dir: &Path) -> Option<PathBuf> {
+    let p = p?;
+    if !p.starts_with(updates_dir) {
+        return None;
+    }
+    let name = p.file_name()?.to_str()?;
+    (name.starts_with("mStream-") && name.ends_with("-win-x64-setup.exe") && p.exists())
+        .then(|| p.to_path_buf())
+}
+
+/// The update line's text + action for a given status-file state. Pure so
+/// the matrix is unit-testable; `relaunch_ok` is whether
+/// derive_relaunch_target currently resolves (a staged update on a layout
+/// we can't relaunch from renders informational, not clickable).
+fn update_item_view(
+    s: Option<&paths::UpdateStatus>,
+    updates_dir: &Path,
+    relaunch_ok: bool,
+) -> (String, UpdateAction) {
+    let Some(s) = s else {
+        return (
+            format!("Up to date ({})", env!("MSTREAM_BUNDLE_VERSION")),
+            UpdateAction::None,
+        );
+    };
+    if s.downloading {
+        return ("Downloading update…".to_string(), UpdateAction::None);
+    }
+    if s.staged {
+        if let Some(v) = &s.staged_version {
+            let is_new = s.current.as_ref().is_none_or(|c| c != v);
+            if is_new {
+                match s.method.as_deref() {
+                    Some("managed") if relaunch_ok => {
+                        return (format!("Restart to update to {v}"), UpdateAction::Relaunch);
+                    }
+                    Some("managed") => {
+                        return (
+                            format!("Update {v} staged - restart mStream to finish"),
+                            UpdateAction::None,
+                        );
+                    }
+                    Some("inno") => {
+                        if let Some(p) = valid_installer(s.installer_path.as_deref(), updates_dir) {
+                            return (format!("Install update {v}"), UpdateAction::RunInstaller(p));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if s.available {
+        if let Some(v) = &s.latest {
+            return (format!("Update available ({v})"), UpdateAction::OpenReleases);
+        }
+    }
+    (
+        format!(
+            "Up to date ({})",
+            s.current.as_deref().unwrap_or(env!("MSTREAM_BUNDLE_VERSION"))
+        ),
+        UpdateAction::None,
+    )
+}
+
+/// Push the view into the held menu item — only on change, so the text is
+/// never re-set under a hovering cursor. Returns the action for the caller.
+fn render_update_item(
+    item: Option<&MenuItem>,
+    s: Option<&paths::UpdateStatus>,
+    updates_dir: &Path,
+    relaunch_ok: bool,
+    last_text: &mut String,
+) -> UpdateAction {
+    let (text, action) = update_item_view(s, updates_dir, relaunch_ok);
+    if let Some(i) = item {
+        if text != *last_text {
+            i.set_text(text.clone());
+            i.set_enabled(action != UpdateAction::None);
+            *last_text = text;
+        }
+    }
+    action
+}
+
+fn relaunch_target_exists(exe: Option<&Path>) -> bool {
+    exe.and_then(paths::derive_relaunch_target).is_some()
+}
+
+/// Stop the child, then hand off to the update: spawn the new launcher
+/// (managed) or the verified installer (inno). Ok = a handoff process is
+/// running and the caller must exit the loop NOW; Err = nothing was spawned
+/// and the caller must recover — the server is already stopped.
+fn perform_apply(
+    shared: &Arc<Shared>,
+    action: &UpdateAction,
+    exe_real: Option<&Path>,
+    server_args: &[String],
+    log: &Logger,
+) -> Result<(), String> {
+    shared.quitting.store(true, Ordering::SeqCst);
+    stop_current(shared);
+    match action {
+        UpdateAction::Relaunch => {
+            let target = exe_real
+                .and_then(paths::derive_relaunch_target)
+                .ok_or_else(|| "no relaunch target under a managed layout".to_string())?;
+            log.line(&format!("update: relaunching via {}", target.display()));
+            platform::relaunch(&target, server_args)
+        }
+        #[cfg(windows)]
+        UpdateAction::RunInstaller(p) => {
+            log.line(&format!("update: running installer {}", p.display()));
+            platform::spawn_installer_detached(p, true)
+        }
+        _ => Err("not an applicable update action".to_string()),
+    }
+}
+
+/// A failed handoff left the server stopped: bring it back and say so. The
+/// launcher survives; the update stays offered for a later retry.
+#[allow(clippy::too_many_arguments)]
+fn recover_after_failed_apply(
+    shared: &Arc<Shared>,
+    bin: &Path,
+    server_args: &[String],
+    server_log: &Path,
+    ep: paths::Endpoint,
+    proxy: &tao::event_loop::EventLoopProxy<AppEvent>,
+    log: &Logger,
+) -> Phase {
+    shared.quitting.store(false, Ordering::SeqCst);
+    match spawn_generation(shared, bin, server_args, server_log, ep, proxy, log) {
+        Ok(()) => Phase::Starting,
+        Err(e) => {
+            platform::fatal_alert(&format!("mStream could not restart its server:\n{e}"));
+            Phase::Stopped
+        }
+    }
+}
+
 /// The server's lifecycle as the tray reports it. Running carries the
 /// instant the identity probe first answered (ServerUp), which is what the
 /// uptime counts from; Unverified is a child that outlived the probe's
@@ -596,26 +896,30 @@ enum Phase {
 }
 
 impl Phase {
-    /// The disabled first menu line.
-    fn menu_text(&self) -> String {
+    /// The disabled first menu line. `ver` is the server version the status
+    /// file reports (fallback: the bundle version baked in at build time) —
+    /// on the line so "what version am I running" is one glance at the tray.
+    fn menu_text(&self, ver: &str) -> String {
         match self {
-            Phase::Starting => "Starting…".to_string(),
-            Phase::Running { since } => format!("Running · up {}", format_uptime(since.elapsed())),
-            Phase::Unverified { since } => format!("Running (unverified) · up {}", format_uptime(since.elapsed())),
-            Phase::Stopped => "Stopped · use Restart server".to_string(),
+            Phase::Starting => format!("mStream {ver} · starting…"),
+            Phase::Running { since } => format!("mStream {ver} · up {}", format_uptime(since.elapsed())),
+            Phase::Unverified { since } => {
+                format!("mStream {ver} · up {} (unverified)", format_uptime(since.elapsed()))
+            }
+            Phase::Stopped => format!("mStream {ver} · stopped — use Restart server"),
         }
     }
 
     /// The icon tooltip (Windows/macOS; tray-icon's Linux tooltip is a
     /// no-op, so the menu line is the cross-platform carrier).
-    fn tooltip(&self, url: &str) -> String {
+    fn tooltip(&self, url: &str, ver: &str) -> String {
         match self {
-            Phase::Starting => "mStream Server - starting".to_string(),
-            Phase::Running { since } => format!("mStream Server - {url} (up {})", format_uptime(since.elapsed())),
+            Phase::Starting => format!("mStream {ver} - starting"),
+            Phase::Running { since } => format!("mStream {ver} - {url} (up {})", format_uptime(since.elapsed())),
             Phase::Unverified { since } => {
-                format!("mStream Server - {url} (up {}, not verified by the launcher)", format_uptime(since.elapsed()))
+                format!("mStream {ver} - {url} (up {}, not verified by the launcher)", format_uptime(since.elapsed()))
             }
-            Phase::Stopped => "mStream Server - stopped (use Restart server)".to_string(),
+            Phase::Stopped => format!("mStream {ver} - stopped (use Restart server)"),
         }
     }
 
@@ -629,12 +933,12 @@ impl Phase {
 /// Push the phase into the status line and tooltip. Both handles are
 /// Options because the tray can be degraded away (no StatusNotifier host)
 /// while the loop, and the server, carry on.
-fn show_status(item: Option<&MenuItem>, tray: Option<&TrayIcon>, phase: &Phase, url: &str) {
+fn show_status(item: Option<&MenuItem>, tray: Option<&TrayIcon>, phase: &Phase, url: &str, ver: &str) {
     if let Some(i) = item {
-        i.set_text(phase.menu_text());
+        i.set_text(phase.menu_text(ver));
     }
     if let Some(t) = tray {
-        let _ = t.set_tooltip(Some(phase.tooltip(url)));
+        let _ = t.set_tooltip(Some(phase.tooltip(url, ver)));
     }
 }
 
@@ -738,30 +1042,110 @@ mod tests {
 
     #[test]
     fn phase_texts() {
-        assert_eq!(Phase::Starting.menu_text(), "Starting…");
-        assert_eq!(Phase::Stopped.menu_text(), "Stopped · use Restart server");
-        assert_eq!(Phase::Starting.tooltip("http://localhost:3000"), "mStream Server - starting");
+        let v = "6.21.2";
+        assert_eq!(Phase::Starting.menu_text(v), "mStream 6.21.2 · starting…");
+        assert_eq!(Phase::Stopped.menu_text(v), "mStream 6.21.2 · stopped — use Restart server");
+        assert_eq!(Phase::Starting.tooltip("http://localhost:3000", v), "mStream 6.21.2 - starting");
         assert_eq!(
-            Phase::Stopped.tooltip("http://localhost:3000"),
-            "mStream Server - stopped (use Restart server)"
+            Phase::Stopped.tooltip("http://localhost:3000", v),
+            "mStream 6.21.2 - stopped (use Restart server)"
         );
         // A just-started server (Instant can't be rewound on a freshly
         // booted CI box; the big-number formatting is pinned above).
         let running = Phase::Running { since: Instant::now() };
-        assert_eq!(running.menu_text(), "Running · up <1m");
-        assert_eq!(running.tooltip("http://localhost:3000"), "mStream Server - http://localhost:3000 (up <1m)");
+        assert_eq!(running.menu_text(v), "mStream 6.21.2 · up <1m");
+        assert_eq!(running.tooltip("http://localhost:3000", v), "mStream 6.21.2 - http://localhost:3000 (up <1m)");
         // A child that outlived the probe without answering it: alive,
         // presumably serving, and the tray must say so rather than
         // "Starting…" for the rest of the session.
         let unverified = Phase::Unverified { since: Instant::now() };
-        assert_eq!(unverified.menu_text(), "Running (unverified) · up <1m");
+        assert_eq!(unverified.menu_text(v), "mStream 6.21.2 · up <1m (unverified)");
         assert_eq!(
-            unverified.tooltip("http://localhost:3000"),
-            "mStream Server - http://localhost:3000 (up <1m, not verified by the launcher)"
+            unverified.tooltip("http://localhost:3000", v),
+            "mStream 6.21.2 - http://localhost:3000 (up <1m, not verified by the launcher)"
         );
         assert!(running.ticks());
         assert!(unverified.ticks());
         assert!(!Phase::Starting.ticks(), "no ticks unless an uptime is showing");
         assert!(!Phase::Stopped.ticks());
+    }
+
+    fn status(json: &str) -> Option<crate::paths::UpdateStatus> {
+        crate::paths::parse_update_status(json)
+    }
+
+    #[test]
+    fn update_view_matrix() {
+        let ud = std::path::Path::new("/data/updates");
+        // No file at all: bundle-version fallback, inert.
+        let (t, a) = update_item_view(None, ud, true);
+        assert_eq!(t, format!("Up to date ({})", env!("MSTREAM_BUNDLE_VERSION")));
+        assert_eq!(a, UpdateAction::None);
+        // Up to date per the server.
+        let s = status(r#"{"current":"6.21.2","available":false}"#);
+        let (t, a) = update_item_view(s.as_ref(), ud, true);
+        assert_eq!(t, "Up to date (6.21.2)");
+        assert_eq!(a, UpdateAction::None);
+        // Downloading.
+        let s = status(r#"{"current":"6.21.2","available":true,"latest":"6.22.0","downloading":true}"#);
+        let (t, a) = update_item_view(s.as_ref(), ud, true);
+        assert_eq!(t, "Downloading update…");
+        assert_eq!(a, UpdateAction::None);
+        // Staged on a managed layout with a resolvable relaunch target.
+        let s = status(
+            r#"{"current":"6.21.2","available":true,"latest":"6.22.0","method":"managed",
+                "staged":true,"stagedVersion":"6.22.0"}"#,
+        );
+        let (t, a) = update_item_view(s.as_ref(), ud, true);
+        assert_eq!(t, "Restart to update to 6.22.0");
+        assert_eq!(a, UpdateAction::Relaunch);
+        // Same, but the layout can't be relaunched from: informational only.
+        let (t, a) = update_item_view(s.as_ref(), ud, false);
+        assert_eq!(t, "Update 6.22.0 staged - restart mStream to finish");
+        assert_eq!(a, UpdateAction::None);
+        // Staged version already running (post-apply file lag): up to date.
+        let s = status(
+            r#"{"current":"6.22.0","available":false,"method":"managed",
+                "staged":true,"stagedVersion":"6.22.0"}"#,
+        );
+        let (t, a) = update_item_view(s.as_ref(), ud, true);
+        assert_eq!(t, "Up to date (6.22.0)");
+        assert_eq!(a, UpdateAction::None);
+        // Non-managed with an update: availability + the releases page.
+        let s = status(r#"{"current":"6.21.2","available":true,"latest":"6.22.0","method":"docker"}"#);
+        let (t, a) = update_item_view(s.as_ref(), ud, true);
+        assert_eq!(t, "Update available (6.22.0)");
+        assert_eq!(a, UpdateAction::OpenReleases);
+    }
+
+    #[test]
+    fn installer_paths_are_validated_not_trusted() {
+        let dir = std::env::temp_dir().join(format!("mstream-upd-{}", std::process::id()));
+        let ud = dir.join("updates");
+        std::fs::create_dir_all(&ud).unwrap();
+        let good = ud.join("mStream-6.22.0-win-x64-setup.exe");
+        std::fs::write(&good, "x").unwrap();
+        assert_eq!(valid_installer(Some(&good), &ud), Some(good.clone()));
+        // Wrong directory: refused even with a plausible name.
+        let outside = dir.join("mStream-6.22.0-win-x64-setup.exe");
+        std::fs::write(&outside, "x").unwrap();
+        assert_eq!(valid_installer(Some(&outside), &ud), None);
+        // Wrong name shape inside the right dir: refused.
+        let odd = ud.join("evil.exe");
+        std::fs::write(&odd, "x").unwrap();
+        assert_eq!(valid_installer(Some(&odd), &ud), None);
+        // Missing file: refused.
+        assert_eq!(valid_installer(Some(&ud.join("mStream-9.9.9-win-x64-setup.exe")), &ud), None);
+        assert_eq!(valid_installer(None, &ud), None);
+        // An inno status pointing outside the updates dir renders inert.
+        let s = status(&format!(
+            r#"{{"current":"6.21.2","available":true,"latest":"6.22.0","method":"inno",
+                "staged":true,"stagedVersion":"6.22.0","installerPath":{}}}"#,
+            serde_json::json!(outside.to_string_lossy())
+        ));
+        let (t, a) = update_item_view(s.as_ref(), &ud, true);
+        assert_eq!(a, UpdateAction::OpenReleases, "falls back to availability, never runs the file");
+        assert_eq!(t, "Update available (6.22.0)");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -47,6 +47,11 @@ enum AppEvent {
     /// its device thread woke the loop on mouse motion. A proxy event wakes
     /// all three backends identically.
     Tick(u64),
+    /// The update-surface poll, from its own always-running thread —
+    /// deliberately NOT tied to a server generation: a server that never
+    /// came up (or a restart whose spawn failed) has no ticker, and the
+    /// update menu line must keep tracking the status file regardless.
+    UpdatePoll,
 }
 
 struct Shared {
@@ -117,6 +122,15 @@ pub fn run(args: LauncherArgs) -> ! {
         }
         std::process::exit(0);
     }
+
+    // ── The lock just proved every previous launcher session dead — the
+    // one moment the ~/Applications asides (trees an upgrade moved aside
+    // for a then-running app) are provably reclaimable. Without this,
+    // always-on tray users leak one full .app copy per release: the
+    // installer's own sweep only runs when nothing runs from the copy,
+    // which for them is never.
+    #[cfg(target_os = "macos")]
+    sweep_apps_asides(&log);
 
     // ── Headless Linux (ssh without -t, cron, a misused systemd unit):
     // tao's event-loop build would die inside gtk's initializer with a raw
@@ -198,6 +212,20 @@ pub fn run(args: LauncherArgs) -> ! {
         }));
     }
 
+    // The update-surface poll: ONE always-running thread for the whole
+    // session, deliberately not tied to a server generation (see
+    // AppEvent::UpdatePoll — a Stopped/never-verified server has no ticker,
+    // and the update menu line must keep tracking the status file anyway).
+    {
+        let proxy = proxy.clone();
+        std::thread::spawn(move || loop {
+            std::thread::sleep(Duration::from_secs(60));
+            if proxy.send_event(AppEvent::UpdatePoll).is_err() {
+                return; // the loop is gone
+            }
+        });
+    }
+
     match spawn_generation(&shared, &bin, &args.server_args, &server_log, ep, &proxy, &log) {
         Ok(()) => {}
         Err(e) => {
@@ -234,7 +262,11 @@ pub fn run(args: LauncherArgs) -> ! {
     let mut update_item: Option<MenuItem> = None;
     let mut upd: Option<paths::UpdateStatus> = paths::read_update_status();
     let mut upd_text = String::new();
-    let mut apply_handled = false;
+    // The apply request we last ACTED on (the file's applyRequestedAt, else
+    // the staged version): a failed handoff must not auto-retry itself into
+    // a spawn loop, but a NEW request — a later version, or the operator
+    // clicking "restart to update" again in the webapp — starts fresh.
+    let mut auto_apply_attempted: Option<String> = None;
     // Our own REAL location (canonicalized so a start through the `current`
     // symlink still resolves to the versioned tree the walk-up needs).
     let exe_real = std::env::current_exe()
@@ -336,10 +368,13 @@ pub fn run(args: LauncherArgs) -> ! {
                 // changes — never on unrelated events, so the tooltip isn't
                 // re-set under a hovering cursor. Stale generations are
                 // ignored outright and the rest is throttled to 1 Hz.
-                AppEvent::Tick(generation) => {
-                    // Update-state refresh rides the minute tick: one small
-                    // file read, then the item re-renders only on change (so
-                    // the text is never re-set under a hovering cursor).
+                AppEvent::UpdatePoll => {
+                    // The update surface tracks the status file on its own
+                    // cadence — independent of any server generation, so a
+                    // server that never came up (or a failed restart) still
+                    // has a live update menu. One small file read; the item
+                    // re-renders only on change (never re-set under a
+                    // hovering cursor).
                     upd = paths::read_update_status();
                     let action = render_update_item(
                         update_item.as_ref(),
@@ -350,19 +385,24 @@ pub fn run(args: LauncherArgs) -> ! {
                     );
                     // auto mode / a webapp "restart to update" click: the
                     // server flags applyRequested and this launcher acts on
-                    // its next tick. Once — a failed handoff must not retry
-                    // itself into a spawn loop.
-                    if !apply_handled
+                    // the next poll. Once PER REQUEST TOKEN — a failed
+                    // handoff never retries itself into a spawn loop, but a
+                    // NEW request (a later version, another webapp click)
+                    // starts fresh. And never while quitting: a queued poll
+                    // must not resurrect mStream on the way out.
+                    let token = upd.as_ref().and_then(auto_apply_token);
+                    if !shared_loop.quitting.load(Ordering::SeqCst)
                         && upd.as_ref().is_some_and(|s| s.apply_requested)
+                        && token.is_some()
+                        && token != auto_apply_attempted
                         && !matches!(action, UpdateAction::None | UpdateAction::OpenReleases)
                     {
-                        apply_handled = true;
+                        auto_apply_attempted = token;
                         log.line("update: the server requested apply - restarting into the staged version");
                         match perform_apply(&shared_loop, &action, exe_real.as_deref(), &args.server_args, &log) {
                             Ok(()) => {
                                 tray.take();
                                 *control_flow = ControlFlow::Exit;
-                                return;
                             }
                             Err(e) => {
                                 log.line(&format!("update apply failed: {e}"));
@@ -374,6 +414,8 @@ pub fn run(args: LauncherArgs) -> ! {
                             }
                         }
                     }
+                }
+                AppEvent::Tick(generation) => {
                     let now = Instant::now();
                     if generation == shared_loop.generation.load(Ordering::SeqCst)
                         && phase.ticks()
@@ -825,6 +867,45 @@ fn render_update_item(
     action
 }
 
+/// The identity of an apply request: the server's applyRequestedAt stamp,
+/// else (an older server writing no stamp) the staged version. A failed
+/// attempt consumes exactly this token; a fresh request mints a new one.
+fn auto_apply_token(s: &paths::UpdateStatus) -> Option<String> {
+    s.apply_requested_at.clone().or_else(|| s.staged_version.clone())
+}
+
+/// Reclaim ~/Applications/mStream.app.old.* asides. Called only right after
+/// the single-instance lock is won: previous launcher sessions (whose
+/// processes report the ORIGINAL ~/Applications path even after their tree
+/// was renamed aside) are provably dead, so the only live risk is something
+/// launched directly FROM an aside path — which pgrep sees and spares.
+#[cfg(target_os = "macos")]
+fn sweep_apps_asides(log: &Logger) {
+    let apps = paths::home_dir().join("Applications");
+    let Ok(entries) = std::fs::read_dir(&apps) else { return };
+    for e in entries.flatten() {
+        let name = e.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("mStream.app.old.") {
+            continue;
+        }
+        let p = e.path();
+        let busy = std::process::Command::new("/usr/bin/pgrep")
+            .arg("-f")
+            .arg(format!("^{}/", p.display()))
+            .output()
+            // pgrep: 1 = no match; anything else (match, or pgrep itself
+            // failing) counts as busy — never delete blind.
+            .map(|o| o.status.code() != Some(1))
+            .unwrap_or(true);
+        if busy {
+            continue;
+        }
+        log.line(&format!("sweeping stale ~/Applications aside {name}"));
+        let _ = std::fs::remove_dir_all(&p);
+    }
+}
+
 fn relaunch_target_exists(exe: Option<&Path>) -> bool {
     exe.and_then(paths::derive_relaunch_target).is_some()
 }
@@ -1116,6 +1197,25 @@ mod tests {
         let (t, a) = update_item_view(s.as_ref(), ud, true);
         assert_eq!(t, "Update available (6.22.0)");
         assert_eq!(a, UpdateAction::OpenReleases);
+    }
+
+    #[test]
+    fn apply_tokens_identify_requests() {
+        let s = crate::paths::parse_update_status(
+            r#"{"staged": true, "stagedVersion": "6.22.0",
+                "applyRequestedAt": "2026-08-20T12:00:00.000Z"}"#,
+        )
+        .unwrap();
+        assert_eq!(auto_apply_token(&s).as_deref(), Some("2026-08-20T12:00:00.000Z"));
+        // Older server, no stamp: the staged version stands in — a retry
+        // for the SAME version stays consumed, a newer one starts fresh.
+        let old = crate::paths::parse_update_status(
+            r#"{"staged": true, "stagedVersion": "6.22.0"}"#,
+        )
+        .unwrap();
+        assert_eq!(auto_apply_token(&old).as_deref(), Some("6.22.0"));
+        let none = crate::paths::parse_update_status("{}").unwrap();
+        assert_eq!(auto_apply_token(&none), None);
     }
 
     #[test]

--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -203,6 +203,10 @@ const state = {
   stagedVersion: null,
   downloading: false,
   applyRequested: false,
+  // A fresh token per arm (ISO timestamp): the launcher retries a FAILED
+  // apply only when a NEW request arrives — same-version auto-retry loops
+  // and stale-request replays are both ruled out by comparing this value.
+  applyRequestedAt: null,
   installerPath: null,      // inno/pkg: the verified installer the launcher may spawn
   downloadUrl: null,        // non-managed: where a human gets the update
   lastCheckAt: null,
@@ -636,6 +640,7 @@ export async function requestApply() {
     return { opened: true };
   }
   state.applyRequested = true;
+  state.applyRequestedAt = new Date().toISOString();
   await writeStatus();
   if (m.method === 'managed' && !supervisedByLauncher()) {
     scheduleHeadlessExit('an admin requested the update');
@@ -668,6 +673,7 @@ function maybeAutoApply() {
   // Launcher-supervised (managed restart, or inno silent install): flag it;
   // the launcher acts within a minute.
   state.applyRequested = true;
+  state.applyRequestedAt = new Date().toISOString();
   writeStatus().catch(() => {});
 }
 
@@ -812,6 +818,7 @@ async function enforceSkip() {
   state.staged = false;
   state.stagedVersion = null;
   state.applyRequested = false;
+  state.applyRequestedAt = null;
   if (!ok) {
     state.error = `Version ${held} is skipped, but the previous version could not be fully restored - `
       + `re-run the installer with MSTREAM_VERSION=v${state.current} to finish the rollback`;
@@ -852,6 +859,7 @@ export function setup(mstream, hooks = {}) {
     state.staged = false;
     state.stagedVersion = null;
     state.applyRequested = false;
+    state.applyRequestedAt = null;
   }
   writeStatus().catch(() => {});
   if (_bootTimer || _checkTimer) { return; }
@@ -875,7 +883,7 @@ export function stopForTests() {
   _exiting = false;
   state.skipped = false;
   state.latest = null; state.available = false; state.staged = false;
-  state.stagedVersion = null; state.applyRequested = false; state.error = null;
+  state.stagedVersion = null; state.applyRequested = false; state.applyRequestedAt = null; state.error = null;
   state.installerPath = null; state.downloadUrl = null; state.notifyOnly = false;
   state.downloading = false; state.method = null; state.lastCheckAt = null;
 }

--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -410,12 +410,24 @@ export function stageNow(manifest = null) {
   if (!state.latest || !state.available) { return { error: 'no update available' }; }
   if (_staging) { return { started: true }; }
   const target = state.latest;
-  // The managed download is minutes on a slow link and runs inside the
-  // spawned installer — surface it, exactly as the inno path does, so the
-  // card and the tray don't report "not downloaded" mid-download.
-  state.downloading = true;
-  writeStatus().catch(() => {});
-  _staging = runInstallerScript(target, m.root)
+  _staging = (async () => {
+    // A previous (possibly pre-restart) stage may already sit behind
+    // `current` — re-running the installer would re-download the whole
+    // bundle only to short-circuit into "already installed". Trust the
+    // link: it only ever points at a bundle whose pre-flip exec probe
+    // passed. This also makes a launcher-side failed-apply recovery cycle
+    // cheap instead of a fresh download per attempt.
+    if (await stagedVersionFromRoot(m.root) === target) {
+      winston.info(`[update] mStream ${target} is already staged on disk - skipping the re-download`);
+      return;
+    }
+    // The managed download is minutes on a slow link and runs inside the
+    // spawned installer — surface it, exactly as the inno path does, so the
+    // card and the tray don't report "not downloaded" mid-download.
+    state.downloading = true;
+    writeStatus().catch(() => {});
+    await runInstallerScript(target, m.root);
+  })()
     .then(async () => {
       const landed = await stagedVersionFromRoot(m.root);
       if (!landed) {


### PR DESCRIPTION
Part 3 of the auto-update feature (after #862 installer fixes and #864 server brain). The tray learns about updates and performs the one thing only it can do: restart mStream into the staged version.

## What's here

**Notify — from the status file, never HTTP.** The launcher reads `update-status.json` (written by #864's checker into the shared data home, the same dir as `launcher.lock`) at startup and on the existing minute tick. A new menu line under the status line renders: disabled *"Up to date (vX)"*, *"Downloading update…"*, *"Update available (vX)"* (opens the hardcoded releases page — no URL is ever taken from the file), or the enabled action — **"Restart to update to vX"** (managed) / **"Install update vX"** (Inno). The status line itself now shows the running version: *"mStream 6.21.2 · up 3h 12m"* (server-reported; `build.rs` stamps the bundle version into every target as the pre-first-boot fallback).

**Apply — the Quit path plus one spawn, never exec.** `stop_current()` gracefully ends the child first (stdin drop → supervision exit, 8s grace) so the port is free and Inno's process sweep finds nothing; then the handoff spawns and the loop exits:
- **Managed**: relaunch the launcher behind `$ROOT/current` — target derived from our own canonicalized exe path (walk up to the root holding `current`), never trusted from the file. `~/Applications` copies relaunch themselves (stable path, contents already refreshed) via `open -n` so LaunchServices identity survives. Original server args (`-j`, `--portable`) ride along.
- **Inno**: spawn the sha256-verified `setup.exe` #864 downloaded — accepted only from our own `updates/` dir with the exact asset-name shape — `/VERYSILENT /NORESTART /MSTREAMRELAUNCH=1`; a param-gated `[Run]` entry added to the `.iss` relaunches the tray after a silent update (the existing entry is `skipifsilent`).
- `applyRequested` in the file (auto mode, or a webapp *"restart to update"* click) triggers the same path on the next tick, exactly once; a failed handoff recovers by respawning the old server.

**`--takeover`** on the relaunched instance: retries the single-instance lock ~12s (fslock releases at old-process death), skips the browser announce, and **forces the tray face**. All status-file content is treated as data: versions shape-checked before display, methods charset-checked, installer paths validated, nothing executable or navigable ever read from it.

## Two bugs the live smoke caught (fixed in this PR)

1. A relaunch inheriting tty-shaped stdio routed into the **console pass-through face** — the update handoff became a bare server and the tray vanished. `--takeover` now forces tray.
2. The inherited pty **died with the old session and SIGHUP'd the update** mid-handoff. The spawn now uses null stdio in its own `setsid` session (Windows: `DETACHED_PROCESS`).

## Verified

- **21 cargo tests** (status parse tolerance incl. hostile inputs — non-triple versions, `"Managed; rm -rf /"` methods, out-of-dir installer paths all render inert; the update-line view matrix; relaunch-target derivation through `current`; `--takeover` never leaks into server argv while `-j --takeover` still forwards verbatim); clippy clean.
- **Full live loop on this Mac** (fake HOME, scratch port): fresh-built launcher + the real #864 server binary installed managed → server staged 9.9.9 from a local feed in `auto` mode and flagged `applyRequested` → the launcher tick applied it: graceful server stop, takeover relaunch through `current`, lock handoff, and the new session serving the same port **from the 9.9.9 tree**, clean teardown (supervision reaped everything).

## Notes

- Depends on #864 at runtime only (it reads the file #864 writes; without it the menu shows the build-stamped "Up to date" line and stays inert). Merge #864 first for coherent history.
- The launcher binaries in `bin/rust-launcher/` regenerate via the usual Build Rust Launcher workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)