### PR TITLE
ci: pin Bun to 1.4.1 (was latest)

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -411,7 +411,21 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          # Pinned: this IS the runtime embedded in every shipped binary, so
+          # `latest` made releases float onto whatever Bun shipped that week:
+          # every tag from v6.22.0 (2026-08-20) on embedded 1.4.0 — the first
+          # release of Bun's Rust rewrite — the day it landed, sight unseen,
+          # and rebuilding a tag could embed a different runtime than the
+          # tag's first build. Bump deliberately: a PR editing this file runs
+          # the full matrix + smokes as the validation. Keep test.yml's pin
+          # in step (its supervision bun legs assert behavior the shipped
+          # binaries rely on). 1.4.0 is the first release with the
+          # #36936/#36938 Windows socket-inheritance fixes the smoke
+          # tolerances below reference; 1.4.1 (2026-09-04) is the rewrite's
+          # first patch release (202 fixes, among them 1.4.0 regressions in
+          # node:http server/socket lifecycle and the darwin-arm64
+          # `--compile` codesign failure on macOS 27, oven-sh/bun#39764).
+          bun-version: 1.4.1
 
       - name: Install production dependencies
         run: npm ci --omit=dev
@@ -1494,7 +1508,7 @@ jobs:
             # close()+listen() it. On Windows a live child (here: the ffmpeg
             # download's PowerShell extractor, alive at this point on a fast
             # runner) holds an inherited handle to the old listen socket under
-            # Bun <= 1.3.14 (oven-sh/bun#36936), so a relisten sits in
+            # Bun <= 1.3.14 (oven-sh/bun#36936; fixed in 1.4.0), so a relisten sits in
             # EADDRINUSE until that child exits — this exact step used to die
             # of it intermittently. Positive proof, not just survival.
             if ! grep -q "keeping the listening socket" "$RUN/boot.log"; then
@@ -1543,7 +1557,7 @@ jobs:
             # open-ended, backed-off retry, but a shorter wait would still pass
             # against a regression of the coalescing itself). Note this step
             # CHANGES the bind (address), so it exercises the recycle path: a
-            # relisten here — and, on Windows/Bun <= 1.3.14, a few EADDRINUSE
+            # relisten here — and, on Windows/Bun <= 1.3.14 (fixed in 1.4.0), a few EADDRINUSE
             # retries while a child still holds the old socket — is expected.
             sleep 10
             curl -sf --max-time 5 -o /dev/null "http://127.0.0.1:3399/api/v1/ping" || CONCURRENT_OK=0
@@ -1621,7 +1635,8 @@ jobs:
               fi
               # The OLD bind must be gone. Refused or timed out both pass —
               # under Bun <= 1.3.14 on Windows an inherited handle can leave
-              # the old socket accepting-but-unanswered (oven-sh/bun#36936);
+              # the old socket accepting-but-unanswered (oven-sh/bun#36936,
+              # fixed in 1.4.0);
               # only a live HTTP 200 means two servers, which is the failure.
               OLD6=$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' "http://127.0.0.1:3399/api/v1/ping" 2>/dev/null)
               if [ "$OLD6" = "200" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,13 @@ jobs:
       # Bun runtime, for the supervision suite's bun legs — the shipped
       # standalone binaries are Bun builds, so the lost-supervision behavior
       # (test/integration/supervision-shutdown.test.mjs) is asserted on that
-      # runtime too. Those legs skip wherever bun is absent.
+      # runtime too. Those legs skip wherever bun is absent. Pinned to the
+      # version build-bun.yml compiles releases with, so the legs assert the
+      # runtime users actually get — bump the two pins together.
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.1
 
       # ffmpeg sources differ per OS: version-pinned, checksum-verified static
       # builds fetched from GitHub-CDN mirrors on Linux (BtbN) and Windows

--- a/src/server.js
+++ b/src/server.js
@@ -178,7 +178,7 @@ function sameBind(a, b) {
 // on Windows, a listen socket is a kernel object shared with every child that
 // inherited a handle to it, and under Bun <= 1.3.14 EVERY spawned child does
 // (uSockets created inheritable handles; fixed upstream in oven-sh/bun#36938,
-// unreleased as of Aug 2026). So close() in the parent releases nothing while a
+// first released in Bun 1.4.0). So close() in the parent releases nothing while a
 // scanner, transcode, ffmpeg download or enrichment worker is alive — the port
 // stays LISTENING (and even completes TCP handshakes that then hang) until the
 // last such child exits, which for a scan or a backfill can be an hour. A
@@ -1021,7 +1021,8 @@ export async function serveIt(configFile, { relisten = null } = {}) {
           `Port ${bind.port} still held ${Math.round(waitedMs / 1000)}s after reboot — retrying until it frees ` +
           '(mStream is unreachable meanwhile). A child process that was alive during the reboot — a scan, ' +
           'transcode, ffmpeg download or enrichment worker — can hold the old listening socket until it ' +
-          'exits: under Bun <= 1.3.14 on Windows spawned children inherit it (oven-sh/bun#36936).');
+          'exits: under Bun <= 1.3.14 on Windows spawned children inherit it (oven-sh/bun#36936, ' +
+          'fixed in Bun 1.4.0).');
         relistenDiagnosed = true;
         relistenLastLoggedAt = Date.now();
       }

--- a/src/util/kept-listener.js
+++ b/src/util/kept-listener.js
@@ -6,8 +6,9 @@
 // reboot precisely because, on Windows under Bun <= 1.3.14, every spawned
 // child (scanner, transcode, ffmpeg download, enrichment worker) inherits a
 // handle to every listen socket in the process, and close() in the parent
-// releases nothing until that child exits (oven-sh/bun#36938). The separate-
-// port servers were still doing close()+listen() on every reboot: their
+// releases nothing until that child exits (oven-sh/bun#36938; fix first
+// released in Bun 1.4.0). The separate-port servers were still doing
+// close()+listen() on every reboot: their
 // re-listen hit EADDRINUSE mid-scan, their 'error' handler nulled the module
 // reference, and the Subsonic API (every mobile client) stayed silently dead
 // until the next restart while the tray said Running. Keeping the server
@@ -64,7 +65,8 @@ export function createKeptListener(name) {
           winston.warn(
             `[${name}] Port ${port} still held ${Math.round(waitedMs / 1000)}s after reboot — retrying until it frees ` +
             '(the separate server is unreachable meanwhile). A child process alive during the reboot can hold the ' +
-            'old listening socket until it exits (Bun <= 1.3.14 on Windows: oven-sh/bun#36938).');
+            'old listening socket until it exits (Bun <= 1.3.14 on Windows: oven-sh/bun#36938, ' +
+            'fixed in Bun 1.4.0).');
           diagnosed = true;
           lastLoggedAt = Date.now();
         }

--- a/test/integration/reboot-keeps-listener.test.mjs
+++ b/test/integration/reboot-keeps-listener.test.mjs
@@ -5,7 +5,7 @@
  * Why this matters: on Windows a listen socket is shared with every child
  * process holding an inherited handle to it, and under Bun <= 1.3.14 every
  * spawned child does (uSockets created inheritable handles — fixed upstream
- * in oven-sh/bun#36938, unreleased as of Aug 2026). A close()+listen() reboot
+ * in oven-sh/bun#36938, first released in Bun 1.4.0). A close()+listen() reboot
  * therefore got EADDRINUSE for as long as a scanner / transcode / ffmpeg
  * download / enrichment worker lived, and the old 5 s relisten budget then
  * took the whole process down. The reboot path now keeps the socket bound


### PR DESCRIPTION
Both workflows floated on setup-bun's `latest`, so Bun 1.4.0 — the first release of Bun's Rust rewrite — reached release tags sight unseen: every tag from v6.22.0 (2026-08-20) through v6.25.0 embedded it (confirmed from the release builds' "Install Bun" step logs), and rebuilding a tag could embed a different runtime than the tag's first build. Pin the exact version in build-bun.yml (the runtime embedded in every shipped binary) and test.yml (the supervision suite's bun legs), to be bumped together deliberately: a PR editing build-bun.yml runs the full matrix + smokes as the validation.

**Why 1.4.1 (2026-09-04), not 1.4.0.** It is the rewrite's first patch release: 202 fixes, among them 1.4.0 regressions in the node:http server/socket lifecycle and the darwin-arm64 `--compile` codesign failure on macOS 27 (oven-sh/bun#39764 — the day-one issue the original 1.4.0 pin flagged as "re-check before the first 1.4-built tag"). With master on `latest`, the next tag would embed 1.4.1 anyway; this makes that deliberate and reproducible.

Checked and **not** applicable to this codebase: the 1.4.0 fetch()-timeout regression (our `signal: AbortSignal.timeout(n)` shape completes fine on 1.4.0 — verified against a delayed local server), the Windows extra-stdio-pipe handle bug (we spawn with the standard three stdio), and the listen(port, cb)-after-EADDRINUSE bug (our relisten path uses the `listening` event, no callback). Known open 1.4.x issue worth knowing about, unchanged between 1.4.0 and 1.4.1: oven-sh/bun#41133 — an `http.request` with a queued body never arms its timeout while the SYN is silently dropped (firewalled host); in this codebase that is Last.fm scrobble POSTs and DLNA SOAP control calls to a vanished renderer, a hang instead of a timeout, not a crash.

1.4.0 is the first release carrying the fixes for the Windows socket-handle-inheritance bugs (oven-sh/bun#36936 / #36938, merged 2026-08-05 and an ancestor of the bun-v1.4.0 tag; no 1.3.15 exists) that the keep-listener reboot design works around, so refresh the "unreleased as of Aug 2026" notes and the version-qualified operator diagnostics. Every workaround and smoke tolerance stays: harmless on 1.4, load-bearing for binaries built on <= 1.3.14.

**Validated locally with 1.4.1** (win-x64 baseline runtime pre-fetched the way CI does it):
- Inheritance probe (listen, spawn a 20 s child, close, re-listen on the same port): Bun 1.3.14 sat in EADDRINUSE for 12 s / 45 attempts; 1.4.0 and 1.4.1 re-listened on the first attempt (2–3 ms), like Node. The runtime cause of "a reboot mid-scan kills the Windows server" is gone.
- `bun build --compile` (1005 modules) + the staged win-x64 bundle: boot, Rust scan, jukebox WebSocket, same-bind reboot keeping the socket (40 requests through the window, all 200, no relisten), two overlapping reboots, port-change recycle — smoke steps (3)–(6) replayed locally.
- test/integration/reboot-keeps-listener + reboot-keeps-services, Node and Bun 1.4.1 legs: 14/14.
- linux-x64 cross-compiled bundle in a debian:12 container (glibc 2.36, native Rust scanner): the same smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
