### PR TITLE
fix(build): ship the ffmpeg + p2p-sidecar pin manifests in every bundle

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -620,6 +620,43 @@ jobs:
           esac
           echo "OK: embedded installer present for ${{ matrix.key }}"
 
+      # Same story for the runtime-fetch pin manifests: the ffmpeg bootstrap
+      # reads bin/ffmpeg/manifest.json from the bundle at runtime, and a
+      # bundle without it downloads nothing, forever, with only a boot-time
+      # warning to say why (observed on the first post-pin bundle). Assert
+      # presence, valid JSON, and — for ffmpeg — a pin for this leg's own
+      # platform. The p2p-sidecar manifest backs its runtime-fetch fallback
+      # rung; presence + JSON is enough (musl legs ship manifest-musl.json).
+      - name: Assert the pin manifests shipped
+        shell: bash
+        run: |
+          D=$(ls -d dist/stage/mStream-*-${{ matrix.key }})
+          case "${{ matrix.key }}" in
+            darwin-*) B="$D/mStream.app/Contents/MacOS/bin" ;;
+            *)        B="$D/bin" ;;
+          esac
+          case "${{ matrix.key }}" in
+            *-musl) SC_MANIFEST="manifest-musl.json" ;;
+            *)      SC_MANIFEST="manifest.json" ;;
+          esac
+          case "${{ matrix.key }}" in
+            win-x64)      FKEY="win32-x64" ;;
+            linux-arm64*) FKEY="linux-arm64" ;;
+            linux-x64*)   FKEY="linux-x64" ;;
+            *)            FKEY="${{ matrix.key }}" ;;
+          esac
+          node -e "
+            const fs = require('fs');
+            const read = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+            const fm = read(process.argv[1] + '/ffmpeg/manifest.json');
+            if (!fm.assets || !fm.assets[process.argv[2]]) {
+              console.error('::error::bin/ffmpeg/manifest.json in the bundle has no pin for ' + process.argv[2]);
+              process.exit(1);
+            }
+            read(process.argv[1] + '/p2p-sidecar/' + process.argv[3]);
+          " "$B" "$FKEY" "$SC_MANIFEST" || { echo "::error::pin manifest missing or invalid in the bundle"; exit 1; }
+          echo "OK: pin manifests present for ${{ matrix.key }} (ffmpeg key $FKEY, sidecar $SC_MANIFEST)"
+
       - name: Assert Windows VersionInfo on every shipped PE (win-x64)
         if: matrix.key == 'win-x64'
         shell: pwsh
@@ -1673,10 +1710,14 @@ jobs:
           $stage = Join-Path $env:RUNNER_TEMP 'installer-stage'
           if (-not (Test-Path $stage)) { Write-Host '::error::pristine payload snapshot missing - was the snapshot step reordered?'; exit 1 }
           # Belt for future reordering: smoke residue in the SNAPSHOT means
-          # it was taken too late, and the installer must not ship.
-          foreach ($bad in 'boot.log','default-boot.log','portable-boot.log','smoke-config.json','post1.code','post2.code','bin\ffmpeg') {
+          # it was taken too late, and the installer must not ship. bin\ffmpeg
+          # itself is legitimate now (the pin manifest ships there), so the
+          # sentinel is the smoke's DOWNLOADED binaries, not the directory.
+          foreach ($bad in 'boot.log','default-boot.log','portable-boot.log','smoke-config.json','post1.code','post2.code','bin\ffmpeg\ffmpeg.exe','bin\ffmpeg\ffprobe.exe') {
             if (Test-Path (Join-Path $stage $bad)) { Write-Host "::error::smoke residue '$bad' inside the installer payload snapshot"; exit 1 }
           }
+          $ffx = Get-ChildItem (Join-Path $stage 'bin\ffmpeg') -File | Where-Object { $_.Name -ne 'manifest.json' }
+          if ($ffx) { Write-Host "::error::unexpected files beside the manifest in bin\ffmpeg: $($ffx.Name -join ', ')"; exit 1 }
           $out = Join-Path $PWD 'dist/installer'
           & $iscc "/DAppVersion=$ver" "/DAppVersion4=$ver4" "/DStageDir=$stage" "/O$out" 'build/windows-installer.iss'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -355,6 +355,38 @@ for (const [dir, file] of sidecars) {
   }
 }
 
+// Runtime-fetch pin manifests travel WITH the bundle. The ffmpeg bootstrap
+// (src/util/ffmpeg-bootstrap.js) deliberately downloads on first use — the
+// binaries are ~60-130 MB of GPL code we don't redistribute — and reads its
+// pin set from appRoot/bin/ffmpeg/manifest.json at runtime, so a bundle
+// without the file boots with ffmpeg permanently unavailable ("No pinned
+// ffmpeg build for <platform>", observed on the first post-pin bundle).
+// The p2p-sidecar manifest backs that family's runtime-fetch rung for
+// bundles built without the baked binary (MSTREAM_ALLOW_MISSING_SIDECAR /
+// offline local builds) — the "falls back to runtime fetch" promise above
+// holds only if the pins ship. macOS: real file in Contents/Resources,
+// relative symlink from MacOS/bin/<family>/ — codesign's nested-code scan
+// rejects loose non-Mach-O files under MacOS (the same rule that put
+// webapp/ and install.sh in Resources), a symlink is sealed as a symlink,
+// and the runtime's appRoot-relative read resolves through it unchanged.
+for (const m of [
+  { family: 'ffmpeg', file: 'manifest.json' },
+  { family: 'p2p-sidecar', file: t.musl ? 'manifest-musl.json' : 'manifest.json' },
+]) {
+  const src = join(root, 'bin', m.family, m.file);
+  const destDir = join(contentRoot, 'bin', m.family);
+  mkdirSync(destDir, { recursive: true });
+  if (isMac) {
+    const resRoot = join(stageDir, 'mStream.app', 'Contents', 'Resources');
+    const resName = `${m.family}-${m.file}`;
+    mkdirSync(resRoot, { recursive: true });
+    cpSync(src, join(resRoot, resName));
+    symlinkSync(join('..', '..', '..', 'Resources', resName), join(destDir, m.file));
+  } else {
+    cpSync(src, join(destDir, m.file));
+  }
+}
+
 // Iroh remote-access tunnel: @number0/iroh ships as a NAPI-RS *native addon*
 // (prebuilt .node), not a spawned exe like the rust sidecars. A Bun standalone
 // binary can't resolve it from node_modules, so we stage the target's .node next

--- a/src/util/ffmpeg-bootstrap.js
+++ b/src/util/ffmpeg-bootstrap.js
@@ -143,7 +143,10 @@ async function pathExists(p) {
 // The committed pin set. Lives under appRoot (shipped with the code, like
 // bin/p2p-sidecar/manifest.json), while downloads land in getFfmpegDir()
 // (dataRoot-based) — same split as the sidecar: pins travel with the code
-// they were reviewed with, binaries live somewhere writable.
+// they were reviewed with, binaries live somewhere writable. Standalone
+// bundles ship it too — scripts/build-bun.mjs stages it at bin/ffmpeg/
+// (a Resources-backed symlink on macOS); a bundle without it has no pins
+// and boots with ffmpeg permanently unavailable.
 const MANIFEST_DIR = path.join(appRoot, 'bin', 'ffmpeg');
 
 // Everything that goes into a URL is validated as a plain token first: the


### PR DESCRIPTION
## The bug

[fb9c0966](https://github.com/IrosTheBeggar/mStream/commit/fb9c0966) (pin ffmpeg downloads for better Windows builds) made the ffmpeg bootstrap read its pin set from `bin/ffmpeg/manifest.json` **at runtime** — but `scripts/build-bun.mjs` was never taught to ship that file. Every standalone bundle built since boots with:

```
warn: [ffmpeg-bootstrap] No pinned ffmpeg build for darwin/arm64 in bin/ffmpeg/manifest.json. ...
error: [ffmpeg-bootstrap] No working ffmpeg found (download failed and no system binary on PATH)
```

and transcoding / album-art embedding / waveforms / yt-dlp stay dead on any machine without a cached or system ffmpeg. No released bundle carries the bug — it was caught on a locally built bundle (the staged-update demo) before the first post-pin release.

## The fix

- **build-bun.mjs** stages `bin/ffmpeg/manifest.json` into every bundle. On macOS the real file lands in `Contents/Resources` with a relative symlink from `MacOS/bin/ffmpeg/` — codesign's nested-code scan rejects loose non-Mach-O files under `MacOS/` (the same rule that put `webapp/` and `install.sh` in Resources), a symlink is sealed as a symlink, and the runtime's appRoot-relative read resolves through it unchanged.
- Same treatment for `bin/p2p-sidecar/manifest[-musl].json`: the build's documented *"bundle falls back to runtime fetch"* path (sidecar-less bundles via `MSTREAM_ALLOW_MISSING_SIDECAR` / offline local builds) was a no-op for exactly the same reason.
- **New per-leg CI assert** ("Assert the pin manifests shipped"): presence, valid JSON, and an ffmpeg pin for the leg's own platform key — so this regression class can't ship silently again.
- The win-x64 installer **residue tripwire** listed bare `bin\ffmpeg` as a smoke-residue sentinel; the staged manifest makes that dir legitimately present, which would have turned every win-x64 leg red before ISCC. Sentinel moved to the downloaded binaries (`ffmpeg.exe`/`ffprobe.exe`), plus a stricter check that nothing but `manifest.json` sits in the snapshot's `bin\ffmpeg`. (Found by the adversarial verification pass over this fix.)

## Verification

- darwin-arm64 bundle built from this branch; `MacOS/bin/ffmpeg/manifest.json` symlink resolves before and after a `zip -y` → `unzip` round-trip.
- End-to-end: fresh sandbox HOME, bare `PATH` (no system ffmpeg), booted the bundle — it resolved the manifest, downloaded the pinned martin-riedl 9.0.1 build, sha-verified it, `ffmpeg ready` in 41s.
- `test/unit/ffmpeg-bootstrap.test.mjs` + `test/unit/ffmpeg-manifest-pins.test.mjs`: 12/12 pass.
- Adversarial verification workflow over the diff + a sibling-gap sweep (other runtime-read assets missing from bundles): sweep came back clean; the one confirmed finding (the residue tripwire above) is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)