### PR TITLE
fix(scanner): deflake the Windows orphan-reaper kill test

### DIFF
--- a/src/db/scan-pidfile.js
+++ b/src/db/scan-pidfile.js
@@ -104,21 +104,39 @@ function probeProcess(pid, needCmdline) {
       const line = (r.stdout || '').toString().split(/\r?\n/).find(l => l.startsWith('"'));
       if (!line) { return null; } // tasklist prints an INFO line when no match
       const image = line.split('","')[0].replace(/^"/, '').toLowerCase();
-      // The command line needs a CIM query (tasklist doesn't expose it).
-      // Only required to vet generic images like node.exe; a failure
-      // leaves cmdline null and the caller refuses to kill on it. The
-      // budget is deliberately generous: PowerShell's cold start blew an
-      // 8s cap on a loaded CI runner (2026-08-04), and a timeout here
-      // demotes a real orphan to "unverifiable" — alive until a later
-      // boot manages to inspect it.
+      // The command line needs WMI (tasklist doesn't expose it). Only
+      // required to vet generic images like node.exe; a failure leaves
+      // cmdline null and the caller refuses to kill on it.
+      //
+      // wmic first: it talks to WMI without PowerShell's cold start and
+      // typically answers in well under a second even on a cold machine.
+      // It is deprecated — client 24H2+ and Server 2025 ship without it —
+      // so ANY failure (absent binary, timeout, no output) falls through
+      // to the PowerShell CIM query. That fallback's budget stays
+      // deliberately generous: PowerShell's cold start blew an 8s cap on
+      // a loaded CI runner (2026-08-04) and the raised 30s cap on another
+      // (2026-08-20) — a timeout here demotes a real orphan to
+      // "unverifiable", alive until a later boot manages to inspect it,
+      // which is exactly why callers must treat 'unknown' as retryable.
       let cmdline = null;
       if (needCmdline) {
-        const ps = child.spawnSync('powershell',
-          ['-NoProfile', '-NonInteractive', '-Command',
-            `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CommandLine`],
-          { timeout: 30000 });
-        if (ps.status === 0) {
-          cmdline = (ps.stdout || '').toString().trim() || null;
+        try {
+          const w = child.spawnSync('wmic',
+            ['process', 'where', `processid=${pid}`, 'get', 'commandline', '/format:list'],
+            { timeout: 5000 });
+          if (w.status === 0) {
+            const m = (w.stdout || '').toString().match(/^CommandLine=(.*)$/m);
+            if (m && m[1].trim()) { cmdline = m[1].trim(); }
+          }
+        } catch (_err) { /* absent binary — fall through to CIM */ }
+        if (cmdline === null) {
+          const ps = child.spawnSync('powershell',
+            ['-NoProfile', '-NonInteractive', '-Command',
+              `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CommandLine`],
+            { timeout: 30000 });
+          if (ps.status === 0) {
+            cmdline = (ps.stdout || '').toString().trim() || null;
+          }
         }
       }
       return { image, cmdline };

--- a/test/scanner/scanner-schema-guard.test.mjs
+++ b/test/scanner/scanner-schema-guard.test.mjs
@@ -476,7 +476,7 @@ describe('orphan reaper (scan-pidfile.js)', () => {
     }
   });
 
-  test('live orphaned JS scanner is killed', { timeout: 90000 }, async () => {
+  test('live orphaned JS scanner is killed', { timeout: 150000 }, async () => {
     const tmp = makeTmp('orphan');
     // A real "orphan": a node process running a file named scanner.mjs,
     // which is what the identity check requires before killing a
@@ -484,11 +484,22 @@ describe('orphan reaper (scan-pidfile.js)', () => {
     // is written by hand with a foreign ppid.
     //
     // Timing: reapOrphanedScanner is fully synchronous, and for a js
-    // record on Windows it shells out twice (tasklist ≤5s, then the
-    // PowerShell CIM command-line query ≤30s) — up to ~35s on a loaded
-    // runner before it even decides to kill. Only once it returns can
-    // the event loop deliver the child's exit, so the wait below must be
-    // generous too; the declared timeout has to cover reap + wait.
+    // record on Windows the command-line probe can legitimately blow its
+    // whole budget on a cold, loaded runner (wmic ≤5s, then PowerShell
+    // CIM ≤30s — the 30s cap was itself blown on 2026-08-20 after the 8s
+    // cap fell on 2026-08-04). When that happens the verdict is
+    // 'unknown' and the reaper — BY CONTRACT — keeps the record and
+    // declines to kill: a later boot retries. A single reap call plus a
+    // fixed wait therefore flakes by design pressure, not by bug.
+    //
+    // So model successive boots: reap in a loop. The first attempt
+    // doubles as the WMI/PowerShell warm-up, and a retry against warm
+    // services decides in seconds. The loop still fails if the reaper
+    // never kills what it CAN identify — the behavior under guard — and
+    // the record must be gone once it has. Budget arithmetic for the
+    // declared timeout: worst-case attempt ≈ 40s of shell-out caps
+    // (tasklist 5 + wmic 5 + CIM 30) + 10s wait; new attempts start only
+    // inside the first 90s, so the ceiling is ~140s — 150s covers it.
     const fakeScanner = path.join(tmp, 'scanner.mjs');
     fs.writeFileSync(fakeScanner, 'setInterval(() => {}, 1000);\n');
     const p = child.spawn(process.execPath, [fakeScanner], { stdio: 'ignore' });
@@ -501,9 +512,13 @@ describe('orphan reaper (scan-pidfile.js)', () => {
         marker: fakeScanner,
         startedAt: 'x',
       }));
-      reapOrphanedScanner(tmp);
-      const died = await waitFor(() => p.exitCode !== null || p.signalCode !== null, 45000);
-      assert.ok(died, 'orphaned scanner should be terminated by the reaper');
+      const lastBoot = Date.now() + 90000;
+      let died = false;
+      do {
+        reapOrphanedScanner(tmp);
+        died = await waitFor(() => p.exitCode !== null || p.signalCode !== null, 10000);
+      } while (!died && Date.now() < lastBoot);
+      assert.ok(died, 'orphaned scanner should be terminated by the reaper (retried across simulated boots)');
       assert.ok(!fs.existsSync(path.join(tmp, '.scanner.pid.json')));
     } finally {
       try { p.kill(); } catch (_) { /* already dead */ }


### PR DESCRIPTION
## The flake

`live orphaned JS scanner is killed` failed on the windows 1/3 shard of [run 32429184057](https://github.com/IrosTheBeggar/mStream/actions/runs/32429184057) (PR #869, `864aab55`) at **75.4s**, while the identical commit passed the suite 15 minutes earlier. The number decodes exactly:

- the PowerShell CIM command-line probe blew its **30s cap** on a cold, loaded runner — the second cap to fall there (8s blew on 2026-08-04, per the scar comment in `probeProcess`);
- a blown probe yields verdict `'unknown'`, and the reaper **by contract** keeps the record and declines to kill (never kill blind; retry next boot);
- the test then waited its full 45s for a kill that was never licensed: 30 + 45 ≈ 75s.

So the safety design worked; the test modeled only one boot. Production absorbs this exact situation by retrying at the next boot.

## The fix (no blind timeout raises)

**Reaper** — `probeProcess` (win32) now tries `wmic` for the command line first: it talks to WMI without PowerShell's cold start (typically sub-second; capped 5s). It's deprecated and absent on client 24H2+/Server 2025, so **any** failure falls through to the existing 30s CIM query unchanged. This strictly shrinks the flake window on today's runners and trims the same synchronous stall from real Windows boots. No verdict/safety semantics change.

**Test** — reap now runs in a loop (10s waits, new attempts only within the first 90s), modeling successive boots per the reaper's own documented contract. The first attempt doubles as the WMI/PowerShell warm-up, so a retry decides in seconds. It still fails if the reaper never kills what it *can* identify — the behavior under guard — and still asserts the record is cleared. The 150s declared timeout is budget arithmetic (worst-case ~40s of shell-out caps + wait on a final attempt starting at 90s), documented inline.

All 29 `scanner-schema-guard` tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)