### PR TITLE
chore(deps): update packages, clearing 3 of 5 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,24 +17,24 @@
         "essentia.js": "^0.1.3",
         "express": "^5.0.1",
         "jimp": "^1.6.0",
-        "joi": "^18.2.3",
+        "joi": "^18.2.5",
         "jsonwebtoken": "^9.0.3",
         "m3u8-parser": "^7.2.0",
         "mime-types": "^3.0.2",
-        "music-metadata": "^11.13.0",
+        "music-metadata": "^11.15.0",
         "nanoid": "^5.1.16",
         "tree-kill": "^1.2.2",
         "winston": "^3.19.0",
-        "ws": "^8.21.0"
+        "ws": "^8.21.3"
       },
       "bin": {
         "mstream": "cli-boot-wrapper.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@redocly/cli": "^2.35.1",
-        "eslint": "^10.6.0",
-        "globals": "^17.7.0",
+        "@redocly/cli": "^2.47.0",
+        "eslint": "^10.8.1",
+        "globals": "^17.11.0",
         "resedit": "3.0.2"
       },
       "engines": {
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1524,9 +1524,9 @@
       "optional": true
     },
     "node_modules/@redocly/cli": {
-      "version": "2.35.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.35.1.tgz",
-      "integrity": "sha512-8XcUIR6bCI4KmVg6RJyzL3peZhld/tu7oO8WGVaHp43byhcds6ProHlfqEFa+dZA+qA+dUMebgRELVOe5AW4Lg==",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.47.0.tgz",
+      "integrity": "sha512-4sv638LZxiUSsNGqfWPzA2hrNM4KrNRc9jOaH9igqDJlZimiGCYliVpbdrWvfL/YlaSnIBpJE1O1CveXDYTTWw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1882,21 +1882,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1930,15 +1943,15 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -2444,9 +2457,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2457,7 +2470,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -2481,7 +2494,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2977,9 +2990,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3238,9 +3251,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.2.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
-      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
+      "version": "18.2.5",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.5.tgz",
+      "integrity": "sha512-+gEA7rLfaNWx9JzawWPrPetSZwT16NUqHtECDgjyAJreXcs4TM7tx2Pa+VVJJK0YHM83ybrVdaT6UekHH50FJQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -3589,9 +3602,9 @@
       "license": "MIT"
     },
     "node_modules/music-metadata": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.13.0.tgz",
-      "integrity": "sha512-uXRaov9dfjSpQufXIU7sMxVZnh+FilCQv2mXn+K5EJ/decP3dTWrgvPYa5r6MtRbieNSCE708Da4J0u1UGfQIw==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.15.0.tgz",
+      "integrity": "sha512-TN+kO1/oOc8UzDW5N3vSDncBcv9WyNnQQe/NFMcFWq6G1+zVeYUkGvkYpQ/S8wb8vKtUD7i78dIaY0cv+cmPRA==",
       "funding": [
         {
           "type": "github",
@@ -3606,7 +3619,7 @@
       "dependencies": {
         "@borewit/text-codec": "^0.2.2",
         "@tokenizer/token": "^0.3.0",
-        "content-type": "^2.0.0",
+        "content-type": "^2.1.0",
         "debug": "^4.4.3",
         "file-type": "^21.3.4",
         "media-typer": "^2.0.0",
@@ -3620,9 +3633,9 @@
       }
     },
     "node_modules/music-metadata/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3996,9 +4009,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -4661,17 +4674,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/uint8array-extras": {
@@ -4823,9 +4853,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -61,15 +61,15 @@
     "essentia.js": "^0.1.3",
     "express": "^5.0.1",
     "jimp": "^1.6.0",
-    "joi": "^18.2.3",
+    "joi": "^18.2.5",
     "jsonwebtoken": "^9.0.3",
     "m3u8-parser": "^7.2.0",
     "mime-types": "^3.0.2",
-    "music-metadata": "^11.13.0",
+    "music-metadata": "^11.15.0",
     "nanoid": "^5.1.16",
     "tree-kill": "^1.2.2",
     "winston": "^3.19.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.3"
   },
   "optionalDependencies": {
     "@huggingface/transformers": "^4.2.0",
@@ -78,9 +78,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@redocly/cli": "^2.35.1",
-    "eslint": "^10.6.0",
-    "globals": "^17.7.0",
+    "@redocly/cli": "^2.47.0",
+    "eslint": "^10.8.1",
+    "globals": "^17.11.0",
     "resedit": "3.0.2"
   }
 }


### PR DESCRIPTION
Package updates only. Three of the five open npm Dependabot alerts turn out to need nothing but a version bump — the overrides needed for the other two are being looked at separately.

## Alerts cleared by a plain version bump

Each of these has a parent whose declared range **already admits the patched release**, so the fix is a lockfile move with no permanent `overrides` entry:

| Package | Bump | Alert | Parent range that already allowed it |
|---|---|---|---|
| `brace-expansion` | 5.0.6 → **5.0.9** | #162, #167, #168 (high) | `minimatch ^5.0.5` |
| `protobufjs` | 7.6.4 → **7.6.5** | #163 (medium) | `onnxruntime-web ^7.2.4` |
| `body-parser` | 2.2.2 → **2.3.0** | #164 (low) | `express ^2.2.1` |

Worth flagging for the two open community PRs: #838 and #847 both reached for `overrides`. For `brace-expansion` (#847) that would have been permanent dead weight — minimatch's range accepts the fix on its own, and a stale override silently holds the package back later.

## Routine in-range bumps

`joi` 18.2.3 → 18.2.5 · `music-metadata` 11.13.0 → 11.15.0 · `ws` 8.21.0 → 8.21.3 · `eslint` 10.6.0 → 10.8.1 (dev) · `globals` 17.7.0 → 17.11.0 (dev) · `@redocly/cli` 2.35.1 → 2.47.0 (dev)

## Deliberately held back

- **`onnxruntime-node` 1.24.3 → 1.27.0** — `@huggingface/transformers` pins it to *exactly* `1.24.3`, so raising our `^1.24.3` would install a second nested copy; we also hold the 1.24 line for Alpine musl system-onnxruntime parity. It wouldn't clear the alert regardless, since 1.27.0 still pins `adm-zip ^0.5.16`.
- **`@number0/iroh` 1.0.0 → 1.1.0** — in range, but prebuilt native bindings on the federation/discovery path. Wants its own PR with the two-node discovery smoke, not a drive-by in a dependency sweep.
- **`chokidar` 4→5, `nanoid` 5→6** — majors.

## Still open after this

| Alert | Package | Why it needs an override |
|---|---|---|
| #165 (high) | `sharp` <0.35.0 | `@huggingface/transformers@4.2.0` (latest) still pins `^0.34.5` |
| #161 (high) | `adm-zip` <0.6.0 | `onnxruntime-node` pins `^0.5.16` on **every** line, incl. 1.27.0 |

Separately, #169 (`glib`, medium, `rust-launcher/Cargo.lock`) wants glib ≥ 0.20. It arrives via `tray-icon` → `libappindicator` → the `gtk` crate, whose latest release (0.18.2) is **unmaintained** and caps glib at 0.18. Even `tray-icon` 0.24.2 still routes Linux through gtk3, so there is no version path to 0.20 without leaving the gtk3 tray stack.

## Verification

- Full test suite: **2379 tests, 2369 pass, 0 fail, 10 skipped**
- Lint **unchanged at 142 problems** (81 errors, 61 warnings) — confirmed by running the previous eslint 10.6.0 against the same tree for an identical count, so the eslint bump introduces nothing
- `npm audit` 7 → **4** (the two remaining packages, counted across their dependency chains)
- Lockfile diff is 12 version changes plus two `content-type` dedupe entries, **no removals**; `sharp` and `adm-zip` are untouched and stay hoisted where they were

## Supersedes

#796 and #764 (Dependabot's brace-expansion / body-parser PRs) and the brace-expansion half of #847. #771 is stale — it pinned `brace-expansion` 5.0.8, which two later advisories re-broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
