### PR TITLE
chore(deps): chokidar 4 → 5, nanoid 5 → 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "archiver": "^8.0.0",
         "busboy": "^1.6.0",
-        "chokidar": "^4.0.3",
+        "chokidar": "^5.0.0",
         "command-exists": "^1.2.9",
         "cookie-parser": "^1.4.7",
         "essentia.js": "^0.1.3",
@@ -22,7 +22,7 @@
         "m3u8-parser": "^7.2.0",
         "mime-types": "^3.0.2",
         "music-metadata": "^11.15.0",
-        "nanoid": "^5.1.16",
+        "nanoid": "^6.0.1",
         "tree-kill": "^1.2.2",
         "winston": "^3.19.0",
         "ws": "^8.21.3"
@@ -2043,15 +2043,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
-      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+      "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
       "funding": [
         {
           "type": "github",
@@ -3673,7 +3673,7 @@
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^22 || ^24 || >=26"
       }
     },
     "node_modules/natural-compare": {
@@ -4142,12 +4142,12 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "archiver": "^8.0.0",
     "busboy": "^1.6.0",
-    "chokidar": "^4.0.3",
+    "chokidar": "^5.0.0",
     "command-exists": "^1.2.9",
     "cookie-parser": "^1.4.7",
     "essentia.js": "^0.1.3",
@@ -66,7 +66,7 @@
     "m3u8-parser": "^7.2.0",
     "mime-types": "^3.0.2",
     "music-metadata": "^11.15.0",
-    "nanoid": "^5.1.16",
+    "nanoid": "^6.0.1",
     "tree-kill": "^1.2.2",
     "winston": "^3.19.0",
     "ws": "^8.21.3"


### PR DESCRIPTION
Two majors that turn out to be packaging-only. I diffed the published packages rather than trusting the release notes.

> Was stacked on #873, which has since merged; this is now based directly on `master` and contains only the chokidar/nanoid commit.

## chokidar 4.0.3 → 5.0.0

**The runtime API surface is byte-identical.** Every option [library-watcher.js:209](src/util/library-watcher.js:209) passes — `ignoreInitial`, `followSymlinks`, `awaitWriteFinish`, the function-form `ignored` — and every event it binds is unchanged. The `.d.ts` diff is entirely TypeScript cosmetics: `node:` import prefixes, reordering, and one renamed *type* export (`FSWatcherKnownEventMap` → `FSWatcherEventMap`). We're plain JS, so none of it reaches us.

What actually changed:

| | v4.0.3 | v5.0.0 |
|---|---|---|
| Module format | dual CJS+ESM | **ESM-only** (~150kb → ~80kb) |
| Min Node | 14 | **20.19** |
| `readdirp` | 4.x | **5.x** (also ESM-only) |

Both requirements are already met — we're `"type": "module"` with `engines: >=22.5.0`, and CI runs Node 24.

### One real behavior change, and why it can't reach us

Buried in the release notes as a perf tweak ("re-use double slash regex", upstream #1435): `toUnix` went from a `while` loop to a single global replace, so it no longer fully collapses runs of **three or more** slashes.

```
'a///b'                v4 → 'a/b'              v5 → 'a//b'
'/mnt//media///music'  v4 → '/mnt/media/music' v5 → '/mnt/media//music'
```

Not reachable here, for two independent reasons: library roots pass through `fs.realpathSync.native()` before `chokidar.watch()`, and `relFromRoot()` uses `path.relative()`, which normalizes both operands regardless. UNC roots are also safe — both versions special-case the leading `//` via the same `prepend` flag. Flagging it so the next person who hits a stray double slash knows where it comes from.

## nanoid 5.1.16 → 6.0.1

Sole breaking change is dropping Node 18/20. The `nanoid(size)` signature, default alphabet, and default size are all unchanged, and we only ever call `nanoid(8)` / `nanoid(10)` — so persisted share IDs, remote pairing codes, and task IDs keep the same format and nothing needs migrating. 6.0.0 also made generation ~4× faster.

Its `engines` is `^22 || ^24 || >=26`, which **excludes Node 23 and 25**; ours says `>=22.5.0`, so a user on an odd-numbered Node would see an `EBADENGINE` warning on install. I left our `engines` alone — narrowing what mStream claims to support is a product call, not a dependency one. Say the word if you'd rather tighten it.

## Verification

The suite passing wasn't sufficient here. `scripts/build-bun.mjs` externalizes only `@huggingface/transformers` and `onnxruntime-node`, so **chokidar gets bundled into the standalone binary** — an ESM-only dep is exactly the thing that could break the compiled build while every Node test still passed. So I built and drove it:

| Check | Result |
|---|---|
| `bun build --compile` (win-x64) with ESM-only chokidar 5 + readdirp 5 | 998 modules, clean resolve |
| Compiled binary boots | `Library watcher started for 'music'` |
| File added → event fires | `Queued subtree scan: music/Icarus/New Album` |
| `awaitWriteFinish` 2s stability | queued ~2s after the write, not during |
| Coalescer dedup | `Subtree scan … dropped — same subtree already queued` |
| Directory deleted → `walkUpToExisting` | `Queued subtree scan: music/Icarus` (climbed to surviving parent) |

Plus: full suite **2379 tests, 2369 pass, 0 fail**, 10 skipped. Lint **unchanged at 142** problems. Lockfile diff is **three lines** — `chokidar` 4.0.3→5.0.0, `readdirp` 4.1.2→5.1.1, `nanoid` 5.1.16→6.0.1 — no additions, no removals.

## Worth a `full-ci` label

The Bun smoke above was win-x64 only. The watcher's riskiest paths are platform-specific — Windows 8.3 short-name roots (where the code documents an uncatchable native libuv abort), Linux inotify limits, macOS FSEvents — and `test/unit/library-watcher.test.mjs` plus `test/integration/admin-scan-params.test.mjs` exercise real watchers on all three OSes under the labeled matrix.

Still untouched by this PR: `@number0/iroh` 1.0.0 → 1.1.0 and `onnxruntime-node` 1.24.3 → 1.27.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

