### PR TITLE
chore(deps): @number0/iroh 1.0.0 → 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^4.2.0",
-        "@number0/iroh": "^1.0.0",
+        "@number0/iroh": "^1.1.0",
         "onnxruntime-node": "^1.24.3"
       }
     },
@@ -1259,32 +1259,32 @@
       }
     },
     "node_modules/@number0/iroh": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh/-/iroh-1.0.0.tgz",
-      "integrity": "sha512-QeuRYxfLPm8HGbWKYpZZA//hCn8J+WO8hVrEAU2VQG0BLnfHTX9tcqGbQJLzcePFdtFVVXVIkm3IkSAUWajOXg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh/-/iroh-1.1.0.tgz",
+      "integrity": "sha512-DlrJ4Sza5MiI+WwQg63lg+7eSbxlfQR2Bd+wVDjo7XTqenALD2OCRoSfPTuD12IhcvDbVHr4l7qH48DilocqYA==",
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">= 20.3.0"
       },
       "optionalDependencies": {
-        "@number0/iroh-android-arm-eabi": "1.0.0",
-        "@number0/iroh-android-arm64": "1.0.0",
-        "@number0/iroh-darwin-arm64": "1.0.0",
-        "@number0/iroh-linux-arm-gnueabihf": "1.0.0",
-        "@number0/iroh-linux-arm-musleabihf": "1.0.0",
-        "@number0/iroh-linux-arm64-gnu": "1.0.0",
-        "@number0/iroh-linux-arm64-musl": "1.0.0",
-        "@number0/iroh-linux-x64-gnu": "1.0.0",
-        "@number0/iroh-linux-x64-musl": "1.0.0",
-        "@number0/iroh-win32-arm64-msvc": "1.0.0",
-        "@number0/iroh-win32-x64-msvc": "1.0.0"
+        "@number0/iroh-android-arm-eabi": "1.1.0",
+        "@number0/iroh-android-arm64": "1.1.0",
+        "@number0/iroh-darwin-arm64": "1.1.0",
+        "@number0/iroh-linux-arm-gnueabihf": "1.1.0",
+        "@number0/iroh-linux-arm-musleabihf": "1.1.0",
+        "@number0/iroh-linux-arm64-gnu": "1.1.0",
+        "@number0/iroh-linux-arm64-musl": "1.1.0",
+        "@number0/iroh-linux-x64-gnu": "1.1.0",
+        "@number0/iroh-linux-x64-musl": "1.1.0",
+        "@number0/iroh-win32-arm64-msvc": "1.1.0",
+        "@number0/iroh-win32-x64-msvc": "1.1.0"
       }
     },
     "node_modules/@number0/iroh-android-arm-eabi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-android-arm-eabi/-/iroh-android-arm-eabi-1.0.0.tgz",
-      "integrity": "sha512-AkrdmoQ2YhC+X0JgD14SNE+KOSGLKC8z5HSWnPY5tvSXrASPbwCtvWFCVmyPKWj2kQHv0blMI5lBGeGFe+v54w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-android-arm-eabi/-/iroh-android-arm-eabi-1.1.0.tgz",
+      "integrity": "sha512-PcrwZUGdqEnR0/tus0ehulEa68wVrJRJzFjZN5iBV1Jjhgy00oQ5hKtRdCam1lYAQp3jWmRGktLHF2ejj0xAMg==",
       "cpu": [
         "arm"
       ],
@@ -1298,9 +1298,9 @@
       }
     },
     "node_modules/@number0/iroh-android-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-android-arm64/-/iroh-android-arm64-1.0.0.tgz",
-      "integrity": "sha512-EkZh6hl5XJ1JQlWWANc2yDdScP5yGbi9IlF9bttd4DuUelAI8yqEMzXq4YdPB0kQqPlmPk8nEGLEtPWbVCNTLg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-android-arm64/-/iroh-android-arm64-1.1.0.tgz",
+      "integrity": "sha512-wmnWLRNIHYARAecXbXPwZwduoFkmI+Bt75RSa+NZ3mdXiU+hBwWbHt7x0OEDtG8sMOgGgM22nqWemeU9r+UPqA==",
       "cpu": [
         "arm64"
       ],
@@ -1314,9 +1314,9 @@
       }
     },
     "node_modules/@number0/iroh-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-darwin-arm64/-/iroh-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-zmf9CE1l6TWy9zDlNs3EvcxPxHfVQKvkod7wuF6llkGi/2WaSRc+x1vaaMEfpguaxnRfP4NNvIKyy8Ni4imIQg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-darwin-arm64/-/iroh-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-CM6gaQ+6r9K0HRswc2gOKeGL8XYUHUbz7ESkgOltBFin9OsYKmIo+JVYFxlahH8C7ypGEKq1ybU22Ifcf2kXnQ==",
       "cpu": [
         "arm64"
       ],
@@ -1330,9 +1330,9 @@
       }
     },
     "node_modules/@number0/iroh-linux-arm-gnueabihf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm-gnueabihf/-/iroh-linux-arm-gnueabihf-1.0.0.tgz",
-      "integrity": "sha512-obp3eZIJrOGD0rUL1Y0SSCFUNa6NQAsZS+z2khmurqD/rOIIjzvVNYakS4+MEWQLzF1acuUvN7aprHAceUkiuQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm-gnueabihf/-/iroh-linux-arm-gnueabihf-1.1.0.tgz",
+      "integrity": "sha512-5K4Kaz4gzyPo5s5LLAFO0zLXc2F0EZ3BXeMKzQc5zuPaeHQt4XqdwxozXVtn0/3EiUYqFNH1JIowagpwahxAlw==",
       "cpu": [
         "arm"
       ],
@@ -1346,9 +1346,9 @@
       }
     },
     "node_modules/@number0/iroh-linux-arm-musleabihf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm-musleabihf/-/iroh-linux-arm-musleabihf-1.0.0.tgz",
-      "integrity": "sha512-5OXTzmdej7CPaQCReg3vf0/jDCRdVgiOsbC0gcyoPBOdNPs7tZgSoXRBQsod7ioObrjegPM2UfvdF+bIyGst4Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm-musleabihf/-/iroh-linux-arm-musleabihf-1.1.0.tgz",
+      "integrity": "sha512-Bz/vWWauI9t96imq8Jq1a2La4u5K9jVTjuCgm6gjpcFIp7wivfv4syZ4HlbgVD61C3Aqjb89lnlhzMd5qE/w0w==",
       "cpu": [
         "arm"
       ],
@@ -1362,9 +1362,9 @@
       }
     },
     "node_modules/@number0/iroh-linux-arm64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm64-gnu/-/iroh-linux-arm64-gnu-1.0.0.tgz",
-      "integrity": "sha512-whQ36eFP+9aYRJxpZn/Q35EVlvEJm45AFSO2mfctVYvZFJKC/YjZWue4p60VWuW4/yBdjBTErwUum5mMppoeLQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm64-gnu/-/iroh-linux-arm64-gnu-1.1.0.tgz",
+      "integrity": "sha512-AZHpCKQEcJdXya9llNld5u+S2Cz+ehWgGzILtpEJ1qljNYJAClDovzA+5ehUVaXEc+P7ZUNQ+pIjMcWXM0cAug==",
       "cpu": [
         "arm64"
       ],
@@ -1378,9 +1378,9 @@
       }
     },
     "node_modules/@number0/iroh-linux-arm64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm64-musl/-/iroh-linux-arm64-musl-1.0.0.tgz",
-      "integrity": "sha512-Xb4Yy9I2MXlv2SeZZcEIkJIgG1do+5F4R5GkXb4L0if/5vTuuKj7KGQE/ehaIJjNcv+TE+KIOhUvGCxO02l7Nw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-arm64-musl/-/iroh-linux-arm64-musl-1.1.0.tgz",
+      "integrity": "sha512-4ZS/U2L4+zk2E5cn5WmxxuUDTkdwWiyxRq0NFArRQNFbuH7mjtQok2aDIbOIFOIrTTB4x1hwb4Gt0OJw4om4SQ==",
       "cpu": [
         "arm64"
       ],
@@ -1394,9 +1394,9 @@
       }
     },
     "node_modules/@number0/iroh-linux-x64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-x64-gnu/-/iroh-linux-x64-gnu-1.0.0.tgz",
-      "integrity": "sha512-ZOOWURPAWhnBmj5ElLaB/wCjoWNdrjOblaOs0YViW+dlTc5qwInSGJdYEDRdSoZ61MIP0gI2H9EwENe8UYWRcg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-x64-gnu/-/iroh-linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-P2mo734gUjrfJgwbma1fHAyfeWqtY5IHTx53b1peei2/05JKZ2JJ4LS/YzI4qYW20mVtLKD9GS0T3q/iFYVC9Q==",
       "cpu": [
         "x64"
       ],
@@ -1410,9 +1410,9 @@
       }
     },
     "node_modules/@number0/iroh-linux-x64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-x64-musl/-/iroh-linux-x64-musl-1.0.0.tgz",
-      "integrity": "sha512-sJzuehJ9BnuZe4lnP6cWA1wDedC+rbOiI/Hu4V9BGTUE50Z/s28rXDQFJCqVWz1qseXCqHYQ/Jt3U1XdX+Gmtw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-linux-x64-musl/-/iroh-linux-x64-musl-1.1.0.tgz",
+      "integrity": "sha512-GTnr8v59AeS5iGmXLyqcgLCsTAFW2w6tdfDzjyyCYr6iO3h4vZuBv9HG3CwaVU+vOzzig9ojDzauDLgl96nniw==",
       "cpu": [
         "x64"
       ],
@@ -1426,9 +1426,9 @@
       }
     },
     "node_modules/@number0/iroh-win32-arm64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-win32-arm64-msvc/-/iroh-win32-arm64-msvc-1.0.0.tgz",
-      "integrity": "sha512-7KgpUvinndcJnQgbYdV0zs7nGTxKi9zZDBxyTX9PRlQm/9TfTDZhSkur+sZYW2xca2P31XGkjZYZ78yAjYviqQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-win32-arm64-msvc/-/iroh-win32-arm64-msvc-1.1.0.tgz",
+      "integrity": "sha512-LvG4Vcw8D7tFAxZpuZsh6rmyW1YmtS3McDIQjEUNhf9VNBFzQ7WHyEIxdr1GAg/HvC8rmPJ1MQBM24RCDbdUew==",
       "cpu": [
         "arm64"
       ],
@@ -1442,9 +1442,9 @@
       }
     },
     "node_modules/@number0/iroh-win32-x64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@number0/iroh-win32-x64-msvc/-/iroh-win32-x64-msvc-1.0.0.tgz",
-      "integrity": "sha512-mNgHds9US3IWfrvZn+yBuyE/kjrM//jSFpWn1llu3aiNgGq8Rf7yW2TJWvmrFT+eeTi2osOsh1nJfykXTe9xYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@number0/iroh-win32-x64-msvc/-/iroh-win32-x64-msvc-1.1.0.tgz",
+      "integrity": "sha512-1eSztLtesLu2tHdAgr9KNPBsSVdiz2+MDHNvCVDtH+UQAN8F+21YqAAbRJB0ctBvB5zcGeTwYawGaqVMTyRVJg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "optionalDependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "@number0/iroh": "^1.0.0",
+    "@number0/iroh": "^1.1.0",
     "onnxruntime-node": "^1.24.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Despite the minor-version jump, this is a **native-binary refresh, not a code change**. I unpacked both tarballs rather than trusting the release notes, which describe only CI workflow tweaks.

| | 1.0.0 vs 1.1.0 |
|---|---|
| `index.d.ts` | **byte-identical** |
| Rust `src/` | **byte-identical** |
| `Cargo.toml` | differs only in its own version string |
| `index.js` | regenerated napi-rs loader boilerplate only |

So there is **zero API surface change**. The entire delta is which crates the prebuilt `.node` binaries link — read out with `strings`, and identical on both the linux-x64-musl and win32-x64 natives:

| crate | 1.0.0 | 1.1.0 |
|---|---|---|
| iroh, iroh-base, iroh-dns, iroh-relay | 1.0.0 | **1.0.2** |
| noq, noq-proto, **noq-udp** | 1.0.0 | **1.0.1** |
| iroh-services, iroh-tickets, iroh-metrics | — | unchanged |

Two things follow:

1. The Node side moves to iroh **1.0.2**, so it now trails the sidecar (1.0.3) by one patch instead of three.
2. **`noq-udp` stays on the 1.0.x line.** The prod musl `SIGABRT` was noq-udp **1.1.0**'s `SO_TIMESTAMPNS` cmsg-alignment abort — these bindings were never exposed to it, and this bump does not move them toward it. That remains a sidecar-only story.

## What we gain

iroh 1.0.1 and 1.0.2 are maintenance releases with **no protocol or wire-format changes**. Most relevant here: a regression test for transient Windows receive errors (Quick Connect runs on Windows desktops), a receive-lane fairness fix, and better relay handling of invalid messages.

## Scope

The Node binding backs **two of the three** iroh personas:

| Persona | Transport | Affected |
|---|---|---|
| Remote-access tunnel — [iroh.js](src/state/iroh.js) | `@number0/iroh` | **yes** |
| Federation endpoint — [federation.js](src/state/federation.js) | `@number0/iroh` | **yes** |
| Discovery network — [discovery-p2p.js](src/state/discovery-p2p.js) | Rust p2p-sidecar | no |

Discovery is untouched — it runs over the sidecar precisely because the NAPI binding exposes neither iroh-blobs nor iroh-gossip.

**Platform coverage is unchanged.** `darwin-x64` has no prebuilt binding in *either* version, so Intel Macs keep degrading exactly as before: `stageIroh` is best-effort and the build still ships, with remote access unavailable. Pre-existing gap, not a regression from this bump.

## Verification

The lesson from the musl abort is that **a load-only check misses socket-path breakage** — `--print-id` passed while the real run aborted in seconds. So the gate here goes past `dlopen`:

| Check | Result |
|---|---|
| iroh + federation suites (39 tests) | tunnel handshake (**a real HTTP request tunnelled through**), federation handshake/dial/e2e, soft-reboot-keeps-Quick-Connect — all pass |
| `stageIroh` into the win-x64 bundle | `staged iroh.win32-x64-msvc.node` |
| CI's exact gate, `--mstream-worker=iroh-selftest` | `IROH_OK exports=26`, loaded from the staged path |
| **Standalone binary booted with `iroh.enabled`** | **`[iroh] tunnel up — endpointId=8ed56344…`** — the QUIC endpoint actually **bound**, no abort |

That last row is the one the musl regression would have failed and the self-test would not.

Plus: full suite **2379 tests, 2369 pass, 0 fail**, 10 skipped. Lint **unchanged at 142**. Lockfile diff is the meta-package plus its 11 platform packages — **no additions, no removals**.

## Still worth a `full-ci` label

My standalone smoke was win-x64 from a Windows host. The legs I can't cover locally are the ones where native bindings have burned us: **linux musl** (where the noq-udp abort landed) and **darwin-arm64**, where the sign step walks `Contents/MacOS` for Mach-Os *including the iroh `.node`* — new bytes to sign, so notarization is the thing to watch.

Independent of #874 (chokidar/nanoid); both branch off master and touch different dependency entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
