### PR TITLE
test(helpers): sample the scan-complete gate sequentially, not concurrently

### DIFF
--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -74,30 +74,59 @@ async function waitForReady(baseUrl, { timeoutMs = 90_000, getExitError = () => 
 // guard (from /db/status, as before) covers the window before the boot scan
 // is enqueued at all (scanOptions.bootScanDelay), when the queue is exactly
 // as empty as when everything finished.
+//
+// ORDER MATTERS, and the two facts must NOT be sampled concurrently. The
+// return condition ANDs an observation from /db/status (count > 0) with one
+// from /api/v1/scan/status (queue idle). Issued together via Promise.all,
+// those are two independent round-trips whose SERVICE times can diverge by
+// far more than the 50ms poll: /db/status runs COUNT(*) over tracks, which
+// blocks behind the scanner's SQLite write lock (busy_timeout 5000), while
+// /scan/status answers from in-memory queue state plus a TTL-cached
+// coverage read. Skews of 300ms were measured locally on an idle box; a
+// contended Windows CI runner is worse. Concurrent sampling can therefore
+// satisfy the condition with two observations that were never true at the
+// same moment -- queue read as idle during the bootScanDelay window, count
+// read seconds later once rows had landed -- and return a half-scanned
+// fixture. Sampling SEQUENTIALLY, count first and queue second, makes the
+// pair a sound proof instead: count > 0 means scanning had already begun,
+// so every boot scan task was already enqueued; an idle queue observed
+// strictly AFTER that means all of them have since finished.
 async function waitForScanComplete(baseUrl, timeoutMs = 90_000) {
   const start = Date.now();
+  let last = null;
   while (Date.now() - start < timeoutMs) {
     try {
-      const [statusR, queueR] = await Promise.all([
-        fetch(`${baseUrl}/api/v1/db/status`),
-        fetch(`${baseUrl}/api/v1/scan/status`),
-      ]);
-      if (statusR.ok && queueR.ok) {
+      // Count FIRST -- see the ordering note above; do not merge these two
+      // awaits back into a Promise.all.
+      const statusR = await fetch(`${baseUrl}/api/v1/db/status`);
+      if (statusR.ok) {
         const status = await statusR.json();
-        const { queue } = await queueR.json();
-        // queue.scanning covers an active scan OR backup (the old `locked`
-        // bit); the two kind checks close the between-tasks and not-yet-
-        // dispatched gaps that bit can't see.
-        const pending = queue.scanning
-          || queue.activeTask === 'scan'
-          || queue.queued.includes('scan');
-        if (!pending && status.totalFileCount > 0) { return status.totalFileCount; }
+        if (status.totalFileCount > 0) {
+          const queueR = await fetch(`${baseUrl}/api/v1/scan/status`);
+          if (queueR.ok) {
+            const { queue } = await queueR.json();
+            // queue.scanning covers an active scan OR backup (the old
+            // `locked` bit); the two kind checks close the between-tasks
+            // and not-yet-dispatched gaps that bit can't see.
+            const pending = queue.scanning
+              || queue.activeTask === 'scan'
+              || queue.queued.includes('scan');
+            last = { totalFileCount: status.totalFileCount, queue };
+            if (!pending) { return status.totalFileCount; }
+          }
+        } else {
+          last = { totalFileCount: status.totalFileCount, queue: null };
+        }
       }
-    } catch { /* retry */ }
+    } catch (err) { last = { error: err.message }; }
     await sleep(50);
   }
-  throw new Error(`initial scan did not complete within ${timeoutMs}ms`);
+  // Surface what the poll last saw -- a bare timeout tells the next person
+  // nothing about WHICH half of the condition never came true.
+  throw new Error(
+    `initial scan did not complete within ${timeoutMs}ms; last seen: ${JSON.stringify(last)}`);
 }
+
 
 /**
  * Start an mStream instance. Returns { baseUrl, port, stop }.


### PR DESCRIPTION
Fixes the intermittent windows-latest failure in `discovery-similarity` (seen on #874, run 32483197786). **The hypothesis I was chasing turned out to be wrong** — the real defect is elsewhere, and three candidate theories are refuted below so nobody re-runs them.

## The defect

`waitForScanComplete` ANDs two facts fetched with **`Promise.all`**:

```js
const [statusR, queueR] = await Promise.all([
  fetch(`${baseUrl}/api/v1/db/status`),    // totalFileCount > 0
  fetch(`${baseUrl}/api/v1/scan/status`),  // queue idle
]);
```

Those are two independent round-trips whose **service** times diverge. `/db/status` runs `COUNT(*)` over `tracks` and blocks behind the scanner's SQLite write lock (`busy_timeout` 5000); `/scan/status` answers from in-memory queue state plus a TTL-cached coverage read. I measured skew of **up to 300 ms on an idle box** — a contended Windows runner is worse.

So the return condition can be satisfied by two observations **that were never true at the same moment**: the queue read as idle during the 3-second `bootScanDelay` window, the count read seconds later once rows had landed. The helper then hands a **half-scanned fixture** to the caller.

That matches the symptom exactly. The failing `before` hook asserts a fixture track exists and got `actual: undefined` — and I verified that means the row was genuinely *absent*, not merely unhashed, since node:sqlite returns `null` for a NULL column and `undefined` only for a missing row.

## The fix

Sample **sequentially, count first**. That turns the pair into a sound proof instead of two unrelated samples:

- `count > 0` ⟹ scanning had already begun ⟹ every boot scan task was already enqueued (`scanAll()` enqueues one per library in a single loop).
- An idle queue observed **strictly after** that ⟹ all of them have since finished.

The safe ordering was previously *incidental* — `/scan/status` merely happens to be the slower endpoint most of the time — and is now guaranteed. No retry loop, no sleep, no weakened assertion.

Also: the timeout error now carries the last observation. A bare `did not complete within 90000ms` says nothing about which half of the condition never came true.

## Ruled out — recorded so nobody re-runs these

| Theory | Verdict |
|---|---|
| **Read-only WAL visibility** (the original hypothesis) | **Refuted.** A `readOnly: true` connection read all 501 rows with **2 MB uncheckpointed in the `-wal`** and only 4 KB in the main db file — writer open *and* after close. The `{ readOnly: true }` reads here and in nine other suites are fine; no change needed. |
| **The between-libraries queue gap** | **Refuted.** `nextTask()` shifts and dispatches with no `await` between, and `onScanClose` nulls `activeTask` then calls `nextTask()` across 86 lines containing no `await`/`setTimeout`/`.then`. Both atomic w.r.t. the event loop, so no HTTP handler can observe the gap. |
| **Port collision** | **Refuted.** `findFreePort` *is* a bind-0-close-reuse TOCTOU and this suite boots two servers concurrently — but 3000 concurrent trials gave **0 collisions**, and Windows rejects the double-bind with `EADDRINUSE`. |

## Honest limit

**I did not reproduce the original failure.** ~26 runs of the affected file (6 of them under 10-way CPU saturation) and 10 targeted two-library boots all passed. Locally the natural skew runs in the *safe* direction. This fixes a provable defect that matches the symptom — it is not a defect I caught in the act, and I can't promise the flake is gone until CI runs it a few dozen times.

## Verification

Full suite **2379 tests, 2369 pass, 0 fail**, 10 skipped. `npx eslint test/helpers/server.mjs` clean (tree-wide debt stays at its pre-existing 142).

One earlier full run showed 3 failures in `dlna-surface`, `discovery-p2p` and `reboot-keeps-listener` — all connection-level (`ECONNRESET`/`ECONNREFUSED`/`server not ready`), all from my own CPU-saturation testing still loading the box. Re-run in isolation: **66/66 pass**, and the clean full run above is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
