### PR TITLE
feat(discovery)!: retire CLAP, drop @huggingface/transformers, and clear the last npm alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "node": ">=22.5.0"
       },
       "optionalDependencies": {
-        "@huggingface/transformers": "^4.2.0",
         "@number0/iroh": "^1.1.0",
         "onnxruntime-node": "^1.24.3"
       }
@@ -83,16 +82,6 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -271,37 +260,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@huggingface/jinja": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
-      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@huggingface/tokenizers": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
-      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@huggingface/transformers": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
-      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@huggingface/jinja": "^0.5.6",
-        "@huggingface/tokenizers": "^0.1.3",
-        "onnxruntime-node": "1.24.3",
-        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
-        "sharp": "^0.34.5"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -366,472 +324,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jimp/core": {
@@ -1457,72 +949,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
     "node_modules/@redocly/cli": {
       "version": "2.47.0",
       "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.47.0.tgz",
@@ -1597,16 +1023,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "undici-types": "~8.3.0"
-      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -2334,16 +1750,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -2854,13 +2260,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/flatbuffers": {
-      "version": "25.9.23",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
-      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -3030,13 +2429,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
@@ -3485,13 +2877,6 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/m3u8-parser": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz",
@@ -3793,28 +3178,6 @@
         "onnxruntime-common": "1.24.3"
       }
     },
-    "node_modules/onnxruntime-web": {
-      "version": "1.26.0-dev.20260416-b7804b056c",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
-      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "flatbuffers": "^25.1.24",
-        "guid-typescript": "^1.0.9",
-        "long": "^5.2.3",
-        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
-        "platform": "^1.3.6",
-        "protobufjs": "^7.2.4"
-      }
-    },
-    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-      "version": "1.24.0-dev.20251116-b39e144322",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
-      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3967,13 +3330,6 @@
         "node": ">=12.13.0"
       }
     },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/pngjs": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
@@ -4007,30 +3363,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
-    },
-    "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -4335,51 +3667,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4640,13 +3927,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4715,13 +3995,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1094,13 +1094,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/any-base": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "@number0/iroh": "^1.1.0",
     "onnxruntime-node": "^1.24.3"
   },
+  "overrides": {
+    "adm-zip": "^0.6.0"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@redocly/cli": "^2.47.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "ws": "^8.21.3"
   },
   "optionalDependencies": {
-    "@huggingface/transformers": "^4.2.0",
     "@number0/iroh": "^1.1.0",
     "onnxruntime-node": "^1.24.3"
   },

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -72,7 +72,7 @@ const winMeta = canonicalFields(pkg);
 const winVersion = winMeta.version;
 
 const buildArgs = ['build', '--compile', `--target=${t.bun}`];
-// The discovery feature's ML runtimes CANNOT be bundled: onnxruntime-node's
+// The discovery feature's ML runtime CANNOT be bundled: onnxruntime-node's
 // loader requires a per-(platform,arch) native binary that upstream doesn't
 // ship for every target (darwin-x64 has none at all), and Bun folds
 // process.platform/arch to the COMPILE TARGET's constants, so any target
@@ -81,7 +81,7 @@ const buildArgs = ['build', '--compile', `--target=${t.bun}`];
 // and the discovery worker reports the model runtime as unavailable (the
 // dependencyMissing path in src/db/discovery-features-lib.js). Discovery in
 // Bun bundles awaits a sidecar-staging strategy like iroh's below.
-buildArgs.push('--external', '@huggingface/transformers', '--external', 'onnxruntime-node');
+buildArgs.push('--external', 'onnxruntime-node');
 if (t.win && process.platform === 'win32') {
   buildArgs.push(
     '--windows-icon=build/mstream-logo-cut.ico',

--- a/src/db/discovery-features-lib.js
+++ b/src/db/discovery-features-lib.js
@@ -11,10 +11,6 @@
 // export snapshot carries a (model_id, model_version) pin, and the worker
 // re-embeds rows whose pin doesn't match the active model. Adding an engine
 // = one registry entry + (if it's a new kind) one embedder factory below.
-// The project may yet trade the current Apache-licensed CLAP for a
-// non-commercial-licensed model with better music quality (MTG Discogs-
-// EffNet / MERT) if the commercial angle is dropped — this registry is what
-// makes that a config change instead of a rewrite.
 //
 // The default engine is MTG's Discogs-EffNet — the strongest music-specific
 // embedding model available, adopted after the project dropped all
@@ -26,8 +22,27 @@
 // silently vanishing off HF. Bonus: the same inference emits 400 Discogs
 // style activations, which become free genre tags per track.
 //
-// LAION-CLAP (music_and_speech, Apache-2.0) stays selectable for operators
-// who want a permissively-licensed dataset or (future) text→audio queries.
+// ⚠ THE NON-COMMERCIAL LICENSE IS NOW THE ONLY OPTION, DELIBERATELY.
+// LAION-CLAP (music_and_speech, Apache-2.0) used to be selectable here as a
+// permissively-licensed alternative, and was removed — nobody ran it, and it
+// was the sole reason `@huggingface/transformers` was a dependency, which
+// dragged in ~174 MB (onnxruntime-web + sharp + protobufjs) and a high-severity
+// sharp CVE that no published parent allowed us to patch. Consequences worth
+// knowing BEFORE you need them:
+//
+//   • Every exported discovery dataset now inherits CC BY-NC-SA 4.0 —
+//     non-commercial AND share-alike. If mStream (or an instance, or a
+//     partner) ever needs commercially-usable discovery data, that is a
+//     MODEL decision, not a licensing footnote: a permissive model has to
+//     come back into this registry first.
+//   • CLAP was also the only text↔audio model here — its shared embedding
+//     space is what natural-language search ("dreamy 80s synth ballad")
+//     would have been built on. Only the audio tower was ever wired up, so
+//     nothing regressed, but the capability left with it.
+//
+// If either need shows up, prefer bringing the runtime back as a Rust
+// sidecar (the rust-parser / p2p-sidecar pattern) rather than re-adding the
+// npm chain — that gets the model without re-importing sharp.
 //
 // All heavy runtimes are OPTIONAL dependencies imported lazily per model
 // kind — a failed native install must never break the music server; the
@@ -97,18 +112,6 @@ export const EMBEDDING_MODELS = {
     tagThreshold: 0.1,
     tagTopK: 5,
   },
-  'clap-music-and-speech': {
-    kind: 'transformers-clap',
-    hfRepo: 'Xenova/larger_clap_music_and_speech',   // base weights: laion/larger_clap_music_and_speech (Apache-2.0, verified 2026-07-01)
-    version: '1',
-    dim: 512,
-    sampleRate: 48000,
-    segmentSeconds: 10,
-    segmentPositions: [0.25, 0.5, 0.75],
-    dtype: 'fp32',
-    license: 'Apache-2.0',
-    attribution: 'LAION-CLAP (larger_clap_music_and_speech), ONNX conversion by Xenova',
-  },
   // Deterministic, dependency-free pseudo-embedder. Exists for two reasons:
   // it lets the whole worker/task-queue/export pipeline be tested without a
   // model download, and it exercises the model-swap path for real (tests
@@ -126,6 +129,20 @@ export const EMBEDDING_MODELS = {
 };
 
 export const DEFAULT_EMBEDDING_MODEL = 'effnet-discogs';
+
+// Registry keys that USED to be valid. `scanOptions.discoveryModel` is
+// validated with Joi .valid(...Object.keys(EMBEDDING_MODELS)) and config
+// validation THROWS, so simply deleting a key would turn any config still
+// naming it into a server that refuses to boot — including an operator who
+// tried the model once and left the line in. src/state/config.js coerces
+// these back to the default (and persists) before validation runs.
+// Keep entries here forever; they cost nothing and the alternative is a
+// dead server on upgrade.
+export const RETIRED_EMBEDDING_MODELS = {
+  'clap-music-and-speech':
+    'the LAION-CLAP engine was removed (it required the @huggingface/transformers '
+    + 'runtime, which carried an unpatchable sharp advisory)',
+};
 
 export function getModelSpec(key) {
   const spec = EMBEDDING_MODELS[key];
@@ -345,48 +362,6 @@ async function createEffnetEmbedder(spec, { modelCacheDir } = {}) {
   };
 }
 
-// LAION-CLAP through transformers.js. The processor computes the model's mel
-// patches from a raw Float32Array directly — no essentia, no wav wrapping.
-// Model files download to `modelCacheDir` on first use (set it — the default
-// cache would land inside node_modules); loading takes ~20 s, so the worker
-// creates ONE embedder per run.
-async function createClapEmbedder(spec, { modelCacheDir } = {}) {
-  let transformers;
-  try {
-    // NOTE for Bun `--compile`: this package (via its onnxruntime-node
-    // dependency) requires per-platform .node binaries that upstream doesn't
-    // ship for every target, so bundling it breaks cross-builds. It is marked
-    // `--external` in scripts/build-bun.mjs — concatenation tricks don't help
-    // here because Bun's bundler constant-folds them. In a standalone binary
-    // this import fails at runtime and lands in the catch below.
-    transformers = await import('@huggingface/transformers');
-  } catch (err) {
-    // Optional dependency absent (install failed / pruned / not bundled).
-    // The worker turns this into a clean fatal event; the music server
-    // itself is unaffected.
-    const e = new Error(`@huggingface/transformers is not installed — the '${spec.hfRepo}' embedding model cannot run (${err.message})`);
-    e.dependencyMissing = true;
-    throw e;
-  }
-  const { AutoProcessor, ClapAudioModelWithProjection, env } = transformers;
-  if (modelCacheDir) { env.cacheDir = modelCacheDir; }
-
-  const processor = await AutoProcessor.from_pretrained(spec.hfRepo);
-  const model = await ClapAudioModelWithProjection.from_pretrained(spec.hfRepo, { dtype: spec.dtype });
-
-  return {
-    async analyzeSignal(signal) {
-      const segEmbeds = [];
-      for (const seg of segments(signal, spec)) {
-        const inputs = await processor(seg);
-        const { audio_embeds: audioEmbeds } = await model(inputs);
-        segEmbeds.push(Float32Array.from(audioEmbeds.data));
-      }
-      return { embedding: l2normalize(meanPool(segEmbeds)), genreTags: null };
-    },
-  };
-}
-
 // Deterministic pseudo-embedder: dim buckets of per-band RMS over the
 // segment. Same audio → same vector, on every platform, no dependencies.
 function createFakeEmbedder(spec) {
@@ -422,7 +397,6 @@ export async function createEmbedder(key, opts = {}) {
   const spec = getModelSpec(key);
   switch (spec.kind) {
     case 'effnet-discogs': return { spec, ...(await createEffnetEmbedder(spec, opts)) };
-    case 'transformers-clap': return { spec, ...(await createClapEmbedder(spec, opts)) };
     case 'fake': return { spec, ...createFakeEmbedder(spec) };
     default: throw new Error(`no embedder factory for model kind '${spec.kind}'`);
   }

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -6,7 +6,8 @@ import winston from 'winston';
 import { appRoot, dataRoot } from '../util/esm-helpers.js';
 import { getTransCodecs, getTransBitrates } from '../api/transcode.js';
 import { CLIENT_TYPE, ENABLED_FOR } from '../torrent/constants.js';
-import { EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL } from '../db/discovery-features-lib.js';
+import { EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL, RETIRED_EMBEDDING_MODELS }
+  from '../db/discovery-features-lib.js';
 
 // Writable state hangs off dataRoot, not appRoot: they are the same directory
 // unless the app itself is read-only (a translocated/quarantined macOS .app —
@@ -40,11 +41,11 @@ const storageJoi = Joi.object({
   dbDirectory: Joi.string().default(DEFAULT_DB_DIRECTORY),
   logsDirectory: Joi.string().default(path.join(dataRoot, 'save/logs')),
   waveformCacheDirectory: Joi.string().default(path.join(dataRoot, 'waveform-cache')),
-  // Where ML model weights download/cache (currently: the discovery
-  // embedding model, ~18 MB EffNet; CLAP is far larger). Deliberately
-  // OUTSIDE node_modules — transformers.js's default cache lands in there
-  // and every update/reinstall would silently re-download. Defaults next to
-  // dbDirectory (see deriveModelCacheDirectory above).
+  // Where ML model weights download/cache (currently just the discovery
+  // embedding model, ~18 MB EffNet). Deliberately OUTSIDE node_modules: the
+  // ML runtimes default to a cache in there, and every update/reinstall
+  // would silently re-download. Defaults next to dbDirectory (see
+  // deriveModelCacheDirectory above).
   modelCacheDirectory: Joi.string().default((parent) => deriveModelCacheDirectory(parent && parent.dbDirectory)),
 });
 
@@ -872,6 +873,25 @@ export async function setup(configFileArg) {
       + 'LRCLib fetch was removed. To keep fetching lyrics, set lyrics.backfill=true '
       + '(a post-scan pass that queries external providers); set lyrics.backfill=false '
       + 'to silence this notice.');
+  }
+
+  // A retired embedding-model id in the config would fail Joi's .valid()
+  // enum and THROW — i.e. an upgrade that silently bricks the server for
+  // anyone who ever tried that model and left the line in. Coerce to the
+  // default and persist, same generate-and-persist shape as the lockAdmin
+  // migration above, so the fix is sticky and the warning appears once.
+  // Vectors already stored under the retired pin are NOT deleted: every row
+  // carries its own (model_id, model_version), so the discovery worker
+  // re-embeds them against the new model on its next pass, exactly as it
+  // does for any deliberate model swap.
+  const retiredModel = programData.scanOptions && programData.scanOptions.discoveryModel;
+  if (retiredModel && Object.hasOwn(RETIRED_EMBEDDING_MODELS, retiredModel)) {
+    winston.warn(`[config] scanOptions.discoveryModel='${retiredModel}' is no longer available — `
+      + `${RETIRED_EMBEDDING_MODELS[retiredModel]}. Falling back to '${DEFAULT_EMBEDDING_MODEL}' `
+      + 'and saving; tracks embedded with the old model will be re-embedded on the next '
+      + 'discovery pass.');
+    programData.scanOptions.discoveryModel = DEFAULT_EMBEDDING_MODEL;
+    await fs.writeFile(configFileArg, JSON.stringify(programData, null, 2), 'utf8');
   }
 
   program = await schema.validateAsync(programData, { allowUnknown: true });

--- a/src/util/image-thumbs.js
+++ b/src/util/image-thumbs.js
@@ -36,10 +36,12 @@
 //     uploads instantly, and ffprobe — a real parser, in a child process —
 //     is the authority that gates the decode.
 //
-// `sharp` is deliberately not used: it is only present transitively via the
-// OPTIONAL @huggingface/transformers dependency, so installs that skipped
-// optional deps (or where its native build failed — musl, small VPSes) would
-// lose album-art processing entirely. ffmpeg is already first-class here.
+// `sharp` is deliberately not used, and is no longer even in the tree: it
+// only ever arrived transitively via the optional @huggingface/transformers
+// dependency, which was removed with the CLAP embedding model. Even when it
+// was present, installs that skipped optional deps (or where its native
+// build failed — musl, small VPSes) would have lost album-art processing
+// entirely. ffmpeg is already first-class here.
 
 import fs from 'fs';
 import path from 'path';

--- a/test/integration/discovery-backfill.test.mjs
+++ b/test/integration/discovery-backfill.test.mjs
@@ -6,7 +6,7 @@
  * library DB whose tracks point at small ffmpeg-synthesized audio files. All
  * runs use the registry's 'test-fake' model — deterministic, dependency-free,
  * no network — so the full decode→embed→discovery.db-write loop runs for
- * real without the ~700 MB CLAP download. Covers:
+ * real without the real model download. Covers:
  *
  *   - embedded: discovery_tracks row with an L2-normalized vector of the
  *     model's dim, model pin per row + in discovery_meta, artist/title/

--- a/test/unit/retired-embedding-model.test.mjs
+++ b/test/unit/retired-embedding-model.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * Retired embedding-model migration (src/state/config.js).
+ *
+ * `scanOptions.discoveryModel` is validated with
+ * Joi.string().valid(...Object.keys(EMBEDDING_MODELS)), and config.setup()
+ * uses validateAsync, which THROWS. So retiring a registry key without a
+ * migration turns any config still naming it into a server that refuses to
+ * boot -- including an operator who tried the model once and left the line
+ * in. These tests pin the coercion, its persistence, and the fact that live
+ * keys are never touched.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as config from '../../src/state/config.js';
+import {
+  EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL, RETIRED_EMBEDDING_MODELS,
+} from '../../src/db/discovery-features-lib.js';
+
+let tmpDir;
+
+function writeConfig(name, obj) {
+  const f = path.join(tmpDir, name);
+  fs.writeFileSync(f, JSON.stringify(obj));
+  return f;
+}
+
+describe('retired embedding models', () => {
+  before(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-retired-model-')); });
+  after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+  test('the retired list and the live registry never overlap', () => {
+    for (const key of Object.keys(RETIRED_EMBEDDING_MODELS)) {
+      assert.ok(!Object.hasOwn(EMBEDDING_MODELS, key),
+        `'${key}' is both retired and live — Joi would accept it and the migration would fight it`);
+    }
+  });
+
+  test('clap-music-and-speech is retired, not merely deleted', () => {
+    assert.ok(Object.hasOwn(RETIRED_EMBEDDING_MODELS, 'clap-music-and-speech'));
+  });
+
+  // The whole point: this config used to boot, and must still boot.
+  test('a retired model id boots and coerces to the default', async () => {
+    const f = writeConfig('retired.json', {
+      storage: { dbDirectory: path.join(tmpDir, 'r', 'db') },
+      scanOptions: { discoveryModel: 'clap-music-and-speech' },
+    });
+    await config.setup(f);
+    assert.equal(config.program.scanOptions.discoveryModel, DEFAULT_EMBEDDING_MODEL);
+  });
+
+  // Sticky, like the lockAdmin -> adminAccess precedent: the operator should
+  // not get the warning on every boot forever.
+  test('the coercion is persisted to the config file', async () => {
+    const f = writeConfig('persist.json', {
+      storage: { dbDirectory: path.join(tmpDir, 'p', 'db') },
+      scanOptions: { discoveryModel: 'clap-music-and-speech' },
+    });
+    await config.setup(f);
+    const onDisk = JSON.parse(fs.readFileSync(f, 'utf8'));
+    assert.equal(onDisk.scanOptions.discoveryModel, DEFAULT_EMBEDDING_MODEL,
+      'the retired id must be rewritten on disk, not just in memory');
+  });
+
+  // setup() rewrites the config file for its own reasons (generating the
+  // secret / subsonicSecret / iroh + federation keys / dlna uuid), so
+  // byte-equality proves nothing here. What must hold is that the migration
+  // leaves a LIVE id untouched, on disk and in memory.
+  test('a live model id is left alone', async () => {
+    const f = writeConfig('live.json', {
+      storage: { dbDirectory: path.join(tmpDir, 'l', 'db') },
+      scanOptions: { discoveryModel: 'test-fake' },
+    });
+    await config.setup(f);
+    assert.equal(config.program.scanOptions.discoveryModel, 'test-fake');
+    assert.equal(JSON.parse(fs.readFileSync(f, 'utf8')).scanOptions.discoveryModel, 'test-fake');
+  });
+
+  test('an unset discoveryModel still defaults, with no migration', async () => {
+    const f = writeConfig('unset.json', {
+      storage: { dbDirectory: path.join(tmpDir, 'u', 'db') },
+    });
+    await config.setup(f);
+    assert.equal(config.program.scanOptions.discoveryModel, DEFAULT_EMBEDDING_MODEL);
+  });
+
+  // A genuinely unknown id is an operator TYPO, not an upgrade artifact --
+  // it must still fail loudly rather than be silently coerced.
+  test('an unknown (never-valid) model id still fails validation', async () => {
+    const f = writeConfig('bogus.json', {
+      storage: { dbDirectory: path.join(tmpDir, 'b', 'db') },
+      scanOptions: { discoveryModel: 'not-a-real-model' },
+    });
+    await assert.rejects(() => config.setup(f), /discoveryModel/);
+  });
+});


### PR DESCRIPTION
Nobody was running `clap-music-and-speech`, and it was the **sole reason** `@huggingface/transformers` was a dependency. That one optional dep pulled in ~174 MB and, with it, Dependabot **#165** — a high-severity `sharp` advisory that *no published parent* allowed us to patch, so the only fix on the table was a permanent `overrides` entry.

**Removing the model removes the alert instead of overriding it.**

| | before | after |
|---|---|---|
| `npm audit` | 4 high | **0 vulnerabilities** |
| `sharp` / `onnxruntime-web` / `protobufjs` / `transformers` | present | **absent from the tree** |
| lockfile | — | **−50 packages**, 0 added, 0 changed |

A second commit clears the last alert too — see **The adm-zip override** below. Together these take the npm alert list to **empty**; only #169 (`glib`, `rust-launcher/Cargo.lock`) remains, and it is upstream-blocked by the unmaintained gtk3 bindings.

## Nothing regressed

The **default** engine — MTG's Discogs-EffNet — never touched transformers. It's an 18 MB sha256-pinned `.onnx` fetched from our own release asset and executed by `onnxruntime-node` directly, fed by the pure-JS mel front-end. CLAP was the only `transformers-clap` kind in the registry, and **only its audio tower was ever wired up** — the text side that would have powered natural-language search was never built.

## The migration — the part that would otherwise brick servers

`scanOptions.discoveryModel` is validated with `Joi.string().valid(...Object.keys(EMBEDDING_MODELS))`, and `config.setup()` uses `validateAsync`, which **throws**. Deleting the key would turn any config still naming it into a server that **refuses to boot** — including an operator who tried the model once and left the line in.

So:

- a new **`RETIRED_EMBEDDING_MODELS`** registry records retired keys forever;
- `config.setup()` **coerces a retired id to the default and persists it** before validation — matching the `lockAdmin → adminAccess` precedent, so the fix is sticky and the warning appears once;
- a genuinely **unknown** id (an operator typo) **still fails loudly**. Those are different failures and deliberately do not share a code path.

Stored vectors are **not** deleted: every row carries its own `(model_id, model_version)` pin, so the worker re-embeds on the next discovery pass exactly as it does for any deliberate model swap.

7 new tests pin all of it — coercion, persistence, live ids untouched, unknown ids still rejected, and an invariant that the retired list and live registry never overlap.

## The licence consequence, recorded rather than lost

Written into the module header so nobody rediscovers it the hard way:

- **CC BY-NC-SA 4.0 is now the only option.** Every exported discovery dataset inherits **non-commercial + share-alike** terms. If mStream, an instance, or a partner ever needs commercially-usable discovery data, that's a *model* decision — a permissive model has to come back into the registry first.
- **CLAP was the only text↔audio model here** — the shared embedding space any future natural-language search would have been built on.

## If CLAP ever comes back, do it as a sidecar

I verified this is feasible rather than asserting it. Xenova publishes the towers **separately**: `onnx/audio_model_quantized.onnx` is a standalone **78 MB** file (fp32 is 282 MB) that `onnxruntime-node` can run directly — no transformers. Its `preprocessor_config.json` has **no `fusion` field**, i.e. the *unfused* variant: a plain 64-bin log-mel at 48 kHz, `n_fft` 1024, `hop_length` 480 — well within the mel machinery already in this file. Apache-2.0 base weights make mirroring lighter than the NC-SA weights we already mirror.

Two cautions for whoever does it: confirm the licence on Xenova's *conversion* (the HF API exposes no licence field on that repo), and gate the feature-extractor port behind a **parity test against a reference vector** — a mel mismatch (HTK vs Slaney, log base, power vs magnitude) degrades similarity *silently* rather than erroring. Note also that the config specifies `truncation: "rand_trunc"`, so our fixed-window slicing would be **more** reproducible than the transformers path was.

## The adm-zip override (second commit)

Removing CLAP took **#165 (sharp)** out of the tree entirely. The remaining alert, **#161** — adm-zip's crafted-ZIP 4 GB allocation, reached through `onnxruntime-node` — needs an override, and an override is the **only** route: no published `onnxruntime-node` has ever moved off the vulnerable pin.

| onnxruntime-node | adm-zip pin |
|---|---|
| 1.24.3 | `^0.5.16` |
| 1.26.0 | `^0.5.16` |
| 1.27.0 (latest) | `^0.5.16` |

**Deliberately override-only — `onnxruntime-node` stays on 1.24.3.** Bumping it is now *possible* (dropping transformers removed the exact `1.24.3` pin that would otherwise have forced a second nested 211 MB copy), but it would change the runtime executing Discogs-EffNet, and embeddings that drift between servers are incomparable across the discovery network. That bump wants an embedding-parity check of its own; it buys currency, not security, and doesn't belong here.

I verified the override's one real hazard rather than assuming it. `adm-zip` is **install-time only**: it appears solely in `script/install-utils.js`, called from onnxruntime-node's `postinstall` to unzip CUDA EP binaries fetched from Microsoft's Nuget feed, and is **absent from `dist/`** — never loaded at runtime. That installer is the sole consumer and makes exactly three calls, all exercised against 0.6.0 with a synthetic `.nupkg` (entry found, file extracted, flatten + overwrite flags unchanged):

```js
new AdmZip(packageFilePath)                            // install-utils:156
zip.getEntry(pathInPackage)                            // install-utils:174
zip.extractEntryTo(zipEntry, extractDir, false, true)  // install-utils:183
```

Worth recording for whoever revisits this: practical exposure was always near zero — the only ZIP reaching adm-zip is one onnxruntime-node downloads from Microsoft, during install, on a CUDA path mStream never requests. This is hygiene (a permanently open high alert trains people to ignore Dependabot), not incident response.

## Also updated

- `image-thumbs.js` — its comment explained why sharp isn't used for album art by citing sharp's presence via transformers, which is now false.
- `scripts/build-bun.mjs` — the `--external` list no longer needs the transformers entry.

## Verification

- Full suite **2386 tests, 2376 pass, 0 fail, 0 cancelled**, 10 skipped (+7 new)
- `npm audit`: **0 vulnerabilities** (7 at the start of this dependency sweep)
- Lint **unchanged at 142**
- `bun build --compile` clean at 998 modules with the external removed

One earlier full run showed a single failure in `backup-api` ("queue slot still held after 20000ms"). It runs in **297 ms** in isolation and lives on a code path unrelated to embeddings — machine contention, and the clean run above is green. Reporting it rather than discarding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

