### PR TITLE
fix(webapp): local search rewrote row filepaths outside the file explorer

### DIFF
--- a/test/unit/webapp-local-search.test.mjs
+++ b/test/unit/webapp-local-search.test.mjs
@@ -1,0 +1,422 @@
+/**
+ * runLocalSearch() in webapp/alpha/m.js — the local filter bar above the
+ * browse column.
+ *
+ * The filter does not hide rows, it RE-RENDERS them from
+ * `currentBrowsingList`. That only works if the entries each panel pushes
+ * carry everything the row needs. They didn't: the DB-driven panels pushed
+ * `{ type: 'file', name }` and nothing else, so the re-render fell back to
+ * `getFileExplorerPath() + x.name` — a rule that only ever held for the file
+ * explorer. Inside an album view a row went from
+ *
+ *     music/The Wall/CD1/01 In the Flesh.flac      (unfiltered)
+ *     music/In the Flesh                           (after typing one char)
+ *
+ * and clicking or queueing it played nothing. Back-navigation replays the
+ * saved filter (`previousSearch` + a synthetic keyup), so the corruption also
+ * hit rows you never typed over.
+ *
+ * The invariant pinned here: for every panel, filtering is *lossless* — a row
+ * that survives the filter is byte-identical to the row the panel drew. That
+ * covers the reported data-file_location bug and the quieter losses in the
+ * same code path (album art, star rating, artist subtitle, album year).
+ *
+ * webapp/ has no browser test harness, so rather than re-typing the
+ * implementation this slices the real functions out of m.js and runs them
+ * against stub globals. If they are renamed or restructured the slice fails
+ * loudly rather than silently testing nothing.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const M_PATH = path.resolve(__dirname, '..', '..', 'webapp', 'alpha', 'm.js');
+const SRC = fs.readFileSync(M_PATH, 'utf8');
+
+// ── source slicing ──────────────────────────────────────────────────
+// Brace-match from a `function NAME(` / `async function NAME(` header to
+// its closing brace. Naive on braces inside strings, which is fine for
+// these functions: every one of them ends at column 0.
+function sliceFn(name) {
+  const lines = SRC.split(/\r?\n/);
+  // m.js writes both `function name (` and `function name(`.
+  const header = (l) => l.split(' (').join('(');
+  const start = lines.findIndex((l) =>
+    header(l).startsWith(`function ${name}(`) ||
+    header(l).startsWith(`async function ${name}(`));
+  assert.ok(start >= 0, `m.js no longer defines ${name}() at top level — update this test`);
+
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i] === '}') return lines.slice(start, i + 1).join('\n');
+  }
+  throw new Error(`could not find the end of ${name}()`);
+}
+
+function sliceConst(name) {
+  const lines = SRC.split(/\r?\n/);
+  const start = lines.findIndex((l) => l.startsWith(`const ${name} = `));
+  assert.ok(start >= 0, `m.js no longer defines const ${name} — update this test`);
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i] === '};') return lines.slice(start, i + 1).join('\n');
+  }
+  throw new Error(`could not find the end of const ${name}`);
+}
+
+const RENDERERS = ['escapeHtml', 'renderAlbum', 'renderArtist', 'renderGenre',
+  'renderFileWithMetadataHtml', 'createMusicFileHtml', 'renderDirHtml',
+  'createFileplaylistHtml', 'renderPlaylist'];
+
+const PANELS = ['setBrowserRootPanel', 'getFileExplorerPath', 'printdir',
+  'getAllGenres', 'getGenreSongs', 'getAllAlbums', 'getArtistsAlbums',
+  'getAlbumSongs', 'getRatedSongs', 'redoRecentlyPlayed', 'redoMostPlayed',
+  'redoRecentlyAdded', 'runLocalSearch'];
+
+// The federation plumbing the panels and renderers read ambiently: which
+// server the app points at (peerContext), the row marker (peerAttr), the
+// routed browse call (browseApi) and the peer-aware art URL (artImgAttr).
+const HELPERS = ['peerAttr', 'browseApi', 'localIgnoreVPaths', 'artUrl', 'artImgAttr'];
+
+const EXPORTS = [...RENDERERS, ...PANELS].join(', ');
+
+// ── sandbox ─────────────────────────────────────────────────────────
+// Only ids m.js actually touches resolve to an element. Everything else
+// is null on purpose — notably `db-search`, whose presence makes
+// runLocalSearch bail out early.
+const KNOWN_IDS = ['filelist', 'localSearchBar', 'directoryName', 'directory_bar',
+  'local_search_btn', 'upload_btn', 'mkdir_btn', 'recently-added-limit',
+  'recently-played-limit', 'most-played-limit'];
+
+function makeSandbox(api) {
+  const els = new Map();
+  for (const id of KNOWN_IDS) {
+    els.set(id, {
+      innerHTML: '', value: id.endsWith('-limit') ? '100' : '', scrollTop: 0,
+      style: {}, disabled: false,
+      classList: { add() {}, remove() {}, contains: () => false },
+      dispatchEvent() {},
+    });
+  }
+
+  const globals = {
+    document: {
+      getElementById: (id) => els.get(id) ?? null,
+      getElementsByClassName: () => [],
+    },
+    MSTREAMAPI: { currentServer: { host: 'http://host/', token: 'TOK' }, ...api },
+    MSTREAMPLAYER: { ignoreVPaths: {} },
+    VUEPLAYERCORE: { altLayout: { compressArt: false }, playlists: [] },
+    t: (k) => k,
+    getLoadingSvg: () => '',
+    boilerplateFailure: (err) => { throw err; },
+  };
+
+  const body = `
+    'use strict';
+    let currentBrowsingList = [];
+    let programState = [];
+    let fileExplorerArray = [];
+    let peerContext = null;
+    let browseGeneration = 0;
+    ${sliceConst('entityMap')}
+    ${HELPERS.map(sliceFn).join('\n\n')}
+    ${RENDERERS.map(sliceFn).join('\n\n')}
+    ${PANELS.map(sliceFn).join('\n\n')}
+    return {
+      ${EXPORTS},
+      setFileExplorerArray(a) { fileExplorerArray = a; },
+      setProgramState(p) { programState = p; },
+      setPeerContext(p) { peerContext = p; },
+      html: () => __els.get('filelist').innerHTML,
+      filter: (value) => { runLocalSearch({ value }); return __els.get('filelist').innerHTML; },
+    };
+  `;
+
+  const names = [...Object.keys(globals), '__els'];
+  const factory = new Function(...names, body);
+  return factory(...names.map((n) => (n === '__els' ? els : globals[n])));
+}
+
+// ── assertions on rendered rows ─────────────────────────────────────
+const WRAPPERS = [
+  ['<ul class="collection">', '</ul>'],
+  ['<div class="album-grid">', '</div>'],
+];
+
+function rows(html) {
+  // Panels wrap their rows in a container; runLocalSearch re-renders the
+  // rows on their own. Drop the wrapper so rows compare like for like.
+  let h = html;
+  for (const [open, close] of WRAPPERS) {
+    if (!h.startsWith(open)) continue;
+    h = h.slice(open.length);
+    if (h.endsWith(close)) h = h.slice(0, -close.length);
+    break;
+  }
+
+  return h
+    .split(/(?=<li |<div class="album-grid-card")/)
+    .filter((chunk) => /data-file_location=|album-grid-card|data-genre=/.test(chunk))
+    .map((chunk) => chunk.trim());
+}
+
+function fileLocations(html) {
+  return rows(html).map((r) => (r.match(/data-file_location="([^"]*)"/) ?? [])[1]);
+}
+
+// ── fixtures ────────────────────────────────────────────────────────
+const canned = (value) => () => Promise.resolve(value);
+
+const ALBUM_SONGS = [
+  { filepath: 'music/The Wall/CD1/01 In the Flesh.flac',
+    metadata: { title: 'In the Flesh?', artist: 'Pink Floyd', filename: '01 In the Flesh.flac' } },
+  { filepath: 'music/The Wall/CD1/02 The Thin Ice.flac',
+    metadata: { title: 'The Thin Ice', artist: 'Pink Floyd', filename: '02 The Thin Ice.flac' } },
+];
+
+const GENRE_SONGS = [
+  { filepath: 'music/Kind of Blue/01 So What.flac',
+    metadata: { title: 'So What', artist: 'Miles Davis' } },
+  { filepath: 'music/Kind of Blue/02 Freddie Freeloader.flac',
+    metadata: { title: 'Freddie Freeloader', artist: 'Miles Davis' } },
+];
+
+const RATED = [
+  { filepath: 'music/The Wall/CD1/01 In the Flesh.flac',
+    metadata: { title: 'In the Flesh?', artist: 'Pink Floyd', rating: 10, 'album-art': 'wall.jpg' } },
+  { filepath: 'music/Kind of Blue/01 So What.flac',
+    metadata: { title: 'So What', artist: 'Miles Davis', rating: 7 } },
+];
+
+const PLAYED = [
+  { filepath: 'music/The Wall/CD1/01 In the Flesh.flac',
+    metadata: { title: 'In the Flesh?', artist: 'Pink Floyd', 'album-art': 'wall.jpg', 'play-count': 4 } },
+  { filepath: 'music/Kind of Blue/01 So What.flac',
+    metadata: { title: 'So What', artist: 'Miles Davis', 'play-count': 9 } },
+];
+
+const DIR_RESPONSE = {
+  path: 'music/The Wall/CD1/',
+  directories: [],
+  files: [
+    { type: 'file', name: '01 In the Flesh.flac' },
+    { type: 'file', name: '02 The Thin Ice.flac' },
+  ],
+};
+
+// Every panel: load it, snapshot the rows, filter, and require each
+// surviving row to be byte-identical to the one the panel drew.
+const CASES = [
+  { name: 'album songs',
+    api: { albumSongs: canned(ALBUM_SONGS) },
+    run: (S) => S.getAlbumSongs('The Wall', 'Pink Floyd', '1979'),
+    needle: 'flesh', total: 2, kept: 1 },
+
+  { name: 'genre songs',
+    api: { genreSongs: canned(GENRE_SONGS) },
+    state: [{ state: 'genre', name: 'Jazz' }],
+    run: (S) => S.getGenreSongs('Jazz'),
+    needle: 'freddie', total: 2, kept: 1 },
+
+  { name: 'starred / rated',
+    api: { getRated: canned(RATED) },
+    run: (S) => S.getRatedSongs(),
+    needle: 'pink floyd', total: 2, kept: 1 },
+
+  { name: 'recently played',
+    api: { getRecentlyPlayed: canned(PLAYED) },
+    run: (S) => S.redoRecentlyPlayed(),
+    needle: 'miles', total: 2, kept: 1 },
+
+  { name: 'most played',
+    api: { getMostPlayed: canned(PLAYED) },
+    run: (S) => S.redoMostPlayed(),
+    needle: 'miles', total: 2, kept: 1 },
+
+  { name: 'recently added',
+    api: { getRecentlyAdded: canned(PLAYED) },
+    run: (S) => S.redoRecentlyAdded(),
+    needle: 'miles', total: 2, kept: 1 },
+
+  { name: 'file explorer',
+    api: {},
+    state: [{ state: 'fileExplorer' }],
+    run: (S) => { S.setFileExplorerArray(['music', 'The Wall', 'CD1']); S.printdir(DIR_RESPONSE); },
+    needle: 'thin', total: 2, kept: 1 },
+];
+
+// ── tests ───────────────────────────────────────────────────────────
+describe('runLocalSearch — filtering is lossless', () => {
+  for (const c of CASES) {
+    test(`${c.name}: surviving rows are byte-identical to the unfiltered ones`, async () => {
+      const S = makeSandbox(c.api);
+      if (c.state) S.setProgramState(c.state);
+      await c.run(S);
+
+      const before = rows(S.html());
+      assert.equal(before.length, c.total, 'panel did not render the expected rows');
+      assert.ok(before.every((r) => /data-file_location="[^"]+"/.test(r)),
+        'panel drew a file row with no path');
+
+      const after = rows(S.filter(c.needle));
+      assert.equal(after.length, c.kept, 'filter matched the wrong number of rows');
+      for (const row of after) {
+        assert.ok(before.includes(row),
+          `filtered row differs from the row the panel drew:\n${row}`);
+      }
+    });
+  }
+});
+
+describe('runLocalSearch — data-file_location', () => {
+  test('album view keeps the real filepath instead of rebuilding it from the file explorer', async () => {
+    const S = makeSandbox({ albumSongs: canned(ALBUM_SONGS) });
+    // A leftover file-explorer position is exactly what the old fallback
+    // (`getFileExplorerPath() + x.name`) reached for from inside an album.
+    S.setFileExplorerArray(['music']);
+    await S.getAlbumSongs('The Wall', 'Pink Floyd', '1979');
+
+    assert.deepEqual(fileLocations(S.html()), [
+      'music&#x2F;The Wall&#x2F;CD1&#x2F;01 In the Flesh.flac',
+      'music&#x2F;The Wall&#x2F;CD1&#x2F;02 The Thin Ice.flac',
+    ]);
+
+    // Was: ['music&#x2F;In the Flesh?'] — a path that does not exist, so
+    // clicking or queueing the row played nothing.
+    assert.deepEqual(fileLocations(S.filter('flesh')),
+      ['music&#x2F;The Wall&#x2F;CD1&#x2F;01 In the Flesh.flac']);
+  });
+
+  test('every filtered panel row points at a path the panel itself produced', async () => {
+    for (const c of CASES) {
+      const S = makeSandbox(c.api);
+      if (c.state) S.setProgramState(c.state);
+      await c.run(S);
+
+      const before = new Set(fileLocations(S.html()));
+      for (const loc of fileLocations(S.filter(c.needle))) {
+        assert.ok(before.has(loc), `${c.name}: filter invented the path ${loc}`);
+      }
+    }
+  });
+});
+
+describe('runLocalSearch — non-file panels', () => {
+  test('genre rows stay genre rows instead of becoming playable file rows', async () => {
+    const S = makeSandbox({
+      genres: canned({ genres: [
+        { name: 'Rock', track_count: 12 },
+        { name: 'Jazz', track_count: 3 },
+      ] }),
+    });
+    await S.getAllGenres();
+
+    const before = rows(S.html());
+    assert.equal(before.length, 2);
+
+    const after = rows(S.filter('jazz'));
+    assert.equal(after.length, 1);
+    assert.ok(after[0].includes('data-genre="Jazz"'));
+    assert.ok(!after[0].includes('data-file_location'),
+      'genre was re-rendered as a file row — clicking it would try to play the genre name');
+    assert.ok(before.includes(after[0]));
+  });
+
+  test('album cards keep the year that getAlbumsOnClick reads back', async () => {
+    const S = makeSandbox({
+      albums: canned({ albums: [
+        { name: 'The Wall', album_art_file: 'wall.jpg', year: 1979 },
+        { name: 'Animals', album_art_file: 'animals.jpg', year: 1977 },
+      ] }),
+    });
+    await S.getAllAlbums();
+
+    const before = rows(S.html());
+    assert.equal(before.length, 2);
+
+    const after = rows(S.filter('wall'));
+    assert.equal(after.length, 1);
+    // Dropping data-year sends getAlbumSongs(album, artist, undefined),
+    // which can resolve to a different album of the same name.
+    assert.ok(after[0].includes('data-year="1979"'), 'album year lost on filter');
+    assert.ok(before.includes(after[0]));
+  });
+
+  test('artist albums keep their year too', async () => {
+    const S = makeSandbox({
+      artistAlbums: canned({ albums: [
+        { name: 'The Wall', album_art_file: 'wall.jpg', year: 1979 },
+        { name: 'Animals', album_art_file: 'animals.jpg', year: 1977 },
+      ] }),
+    });
+    S.setProgramState([{ state: 'artist', name: 'Pink Floyd' }]);
+    await S.getArtistsAlbums('Pink Floyd');
+
+    const after = rows(S.filter('animals'));
+    assert.equal(after.length, 1);
+    assert.ok(after[0].includes('data-year="1977"'));
+  });
+});
+
+// The app can point at a federated peer (peerContext). Rows drawn there carry
+// `data-peer` — the click handlers read it to stay on / return to that peer —
+// and album art goes through the peer proxy. The filter replays the panel's
+// own render args under the same ambient context, so both must survive; the
+// extracted renderGenre() and the hoisted `aa` values are where they could
+// silently be lost.
+describe('runLocalSearch — on a federated peer', () => {
+  const PEER = { id: 7, name: 'Peer Seven' };
+  const peerApi = () => ({
+    peer: {
+      albumSongs: () => Promise.resolve(ALBUM_SONGS),
+      genres: () => Promise.resolve({ genres: [
+        { name: 'Rock', track_count: 12 },
+        { name: 'Jazz', track_count: 3 },
+      ] }),
+      recentlyAdded: () => Promise.resolve(PLAYED),
+    },
+    peerArtUrl: (id, art, compress) => `http://host/api/v1/federation/peers/${id}/art/${art}?compress=${compress}`,
+  });
+
+  test('song rows keep data-peer and the peer art proxy URL through the filter', async () => {
+    const S = makeSandbox(peerApi());
+    S.setPeerContext(PEER);
+    await S.redoRecentlyAdded();
+
+    const before = rows(S.html());
+    assert.equal(before.length, 2);
+    assert.ok(before.every((r) => r.includes('data-peer="7"')), 'peer rows must carry data-peer');
+    assert.ok(before[0].includes('federation/peers/7/art/wall.jpg'), 'art must go through the peer proxy');
+
+    const after = rows(S.filter('flesh'));
+    assert.equal(after.length, 1);
+    assert.ok(after[0].includes('data-peer="7"'), 'data-peer lost on filter');
+    assert.ok(after[0].includes('federation/peers/7/art/wall.jpg'), 'peer art URL lost on filter');
+    assert.ok(before.includes(after[0]));
+  });
+
+  test('album songs and genre rows on a peer survive the filter unchanged', async () => {
+    const S = makeSandbox(peerApi());
+    S.setPeerContext(PEER);
+
+    await S.getAlbumSongs('The Wall', 'Pink Floyd', '1979');
+    const songsBefore = rows(S.html());
+    assert.equal(songsBefore.length, 2);
+    assert.ok(songsBefore.every((r) => r.includes('data-peer="7"')));
+    const songsAfter = rows(S.filter('thin'));
+    assert.equal(songsAfter.length, 1);
+    assert.ok(songsBefore.includes(songsAfter[0]));
+
+    await S.getAllGenres();
+    const genresBefore = rows(S.html());
+    assert.equal(genresBefore.length, 2);
+    assert.ok(genresBefore.every((r) => r.includes('data-peer="7"')), 'genre rows must carry data-peer (renderGenre)');
+    const genresAfter = rows(S.filter('jazz'));
+    assert.equal(genresAfter.length, 1);
+    assert.ok(genresAfter[0].includes('data-genre="Jazz"'));
+    assert.ok(genresBefore.includes(genresAfter[0]));
+  });
+});

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -281,6 +281,14 @@ function renderArtist(artist) {
     </li>`;
 }
 
+function renderGenre(genre, trackCount) {
+  return `<li class="collection-item">
+    <div data-genre="${escapeHtml(genre)}"${peerAttr()} class="artistz" onclick="getGenreSongsList(this)">
+      ${escapeHtml(genre)} <span style="color:#888;font-size:13px;">(${escapeHtml(trackCount)})</span>
+    </div>
+  </li>`;
+}
+
 function renderFileWithMetadataHtml(filepath, lokiId, metadata) {
   return `<li data-lokiid="${lokiId}" class="collection-item">
     <div data-file_location="${escapeHtml(filepath)}" class="filez flex" onclick="onFileClick(this);">
@@ -464,12 +472,13 @@ function printdir(response) {
     // wrapper to load, queue, or download one — skip them on a peer rather than
     // render rows whose handlers would call local APIs with a peer path.
     if (file.type === 'm3u' && peerContext) { continue; }
-    currentBrowsingList.push({ type: file.type, name: file.name })
+    const filePath = file.path || response.path + file.name;
+    const title = file.artist != null || file.title != null ? file.artist + ' - ' + file.title : file.name;
+    currentBrowsingList.push({ type: file.type, name: file.name, path: filePath, title });
     if (file.type === 'm3u') {
       filelist += createFileplaylistHtml(file.name);
     } else {
-      const title = file.artist != null || file.title != null ? file.artist + ' - ' + file.title : file.name;
-      filelist += createMusicFileHtml(file.path || response.path + file.name, title);
+      filelist += createMusicFileHtml(filePath, title);
     }
   }
 
@@ -3148,7 +3157,7 @@ async function getArtistsAlbums(artist) {
     response.albums.forEach(value => {
       const albumString = value.name ? value.name : 'SINGLES';
       albums += renderAlbum(value.name, value.name === null ? artist : null, albumString, value.album_art_file, value.year);
-      currentBrowsingList.push({ type: 'album', name: value.name, artist: artist, album_art_file: value.album_art_file })
+      currentBrowsingList.push({ type: 'album', name: value.name, artist: artist, album_art_file: value.album_art_file, year: value.year })
     });
     albums += '</div>';
 
@@ -3172,12 +3181,8 @@ async function getAllGenres() {
 
     let html = '<ul class="collection">';
     response.genres.forEach(value => {
-      html += `<li class="collection-item">
-        <div data-genre="${escapeHtml(value.name)}"${peerAttr()} class="artistz" onclick="getGenreSongsList(this)">
-          ${escapeHtml(value.name)} <span style="color:#888;font-size:13px;">(${escapeHtml(value.track_count)})</span>
-        </div>
-      </li>`;
-      currentBrowsingList.push({ type: 'genre', name: value.name });
+      html += renderGenre(value.name, value.track_count);
+      currentBrowsingList.push({ type: 'genre', name: value.name, track_count: value.track_count });
     });
     html += '</ul>';
 
@@ -3211,14 +3216,11 @@ async function getGenreSongs(genre) {
 
     let songs = '<ul class="collection">';
     response.forEach(song => {
-      currentBrowsingList.push({ type: 'file', name: song.metadata.title ? song.metadata.title : song.filepath.split('/').pop() });
-      songs += createMusicFileHtml(
-        song.filepath,
-        song.metadata.title ? song.metadata.title : song.filepath.split('/').pop(),
-        undefined,
-        undefined,
-        song.metadata.artist ? song.metadata.artist : undefined
-      );
+      const title = song.metadata.title ? song.metadata.title : song.filepath.split('/').pop();
+      const subtitle = song.metadata.artist ? song.metadata.artist : undefined;
+
+      currentBrowsingList.push({ type: 'file', name: title, path: song.filepath, title, subtitle });
+      songs += createMusicFileHtml(song.filepath, title, undefined, undefined, subtitle);
     });
     songs += '</ul>';
 
@@ -3245,7 +3247,8 @@ async function getAllAlbums() {
       currentBrowsingList.push({
         type: 'album',
         name: value.name,
-        'album_art_file': value.album_art_file
+        'album_art_file': value.album_art_file,
+        year: value.year
       });
 
       albums += renderAlbum(value.name, undefined, value.name, value.album_art_file, value.year);
@@ -3296,8 +3299,11 @@ async function getAlbumSongs(album, artist, year) {
     //parse through the json array and make an array of corresponding divs
     let files = '<ul class="collection">';
     response.forEach(song => {
-      currentBrowsingList.push({ type: 'file', name: song.metadata.title ? song.metadata.title : song.metadata.filename });
-      files += createMusicFileHtml(song.filepath, song.metadata.title ? song.metadata.title : song.metadata.filename, undefined, undefined, song.metadata.artist ? song.metadata.artist : undefined);
+      const title = song.metadata.title ? song.metadata.title : song.metadata.filename;
+      const subtitle = song.metadata.artist ? song.metadata.artist : undefined;
+
+      currentBrowsingList.push({ type: 'file', name: title, path: song.filepath, title, subtitle });
+      files += createMusicFileHtml(song.filepath, title, undefined, undefined, subtitle);
     });
     files += '</ul>';
 
@@ -3330,17 +3336,19 @@ async function getRatedSongs() {
         rating = rating.toFixed(1);
       }
 
+      const title = value.metadata.title ? value.metadata.title : value.filepath.split('/').pop();
+      const aa = artImgAttr(value.metadata['album-art'], 's');
+      const subtitle = value.metadata.artist ? value.metadata.artist : '';
+
       currentBrowsingList.push({
         type: 'file',
         name: value.metadata.artist ? value.metadata.artist + ' - ' + value.metadata.title : value.filepath,
-        metadata: value.metadata
+        metadata: value.metadata,
+        path: value.filepath,
+        title, aa, rating, subtitle
       });
 
-      files += createMusicFileHtml(value.filepath,
-        value.metadata.title ? value.metadata.title : value.filepath.split('/').pop(),
-        artImgAttr(value.metadata['album-art'], 's'),
-        rating,
-        value.metadata.artist ? value.metadata.artist : '');
+      files += createMusicFileHtml(value.filepath, title, aa, rating, subtitle);
     });
 
     document.getElementById('filelist').innerHTML = files;
@@ -3375,16 +3383,18 @@ async function redoRecentlyPlayed() {
     //parse through the json array and make an array of corresponding divs
     let filelist = '<ul class="collection">';
     response.forEach(el => {
+      const title = el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop();
+      const aa = artImgAttr(el.metadata['album-art'], 's');
+      const subtitle = el.metadata.artist ? el.metadata.artist : '';
+
       currentBrowsingList.push({
         type: 'file',
-        name: el.metadata.title ? el.metadata.artist + ' - ' + el.metadata.title : el.filepath.split("/").pop()
+        name: el.metadata.title ? el.metadata.artist + ' - ' + el.metadata.title : el.filepath.split("/").pop(),
+        path: el.filepath,
+        title, aa, subtitle
       });
 
-      filelist += createMusicFileHtml(el.filepath,
-        el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop(),
-        artImgAttr(el.metadata['album-art'], 's'),
-        undefined,
-        el.metadata.artist ? el.metadata.artist : '');
+      filelist += createMusicFileHtml(el.filepath, title, aa, undefined, subtitle);
     });
 
     filelist += '</ul>'
@@ -3427,16 +3437,18 @@ async function redoMostPlayed() {
     //parse through the json array and make an array of corresponding divs
     let filelist = '<ul class="collection">';
     response.forEach(el => {
+      const title = el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop();
+      const aa = artImgAttr(el.metadata['album-art'], 's');
+      const subtitle = el.metadata.artist ? `${el.metadata.artist} [${el.metadata['play-count']} plays]` : `[${el.metadata['play-count']} plays]`;
+
       currentBrowsingList.push({
         type: 'file',
-        name: el.metadata.title ? el.metadata.artist + ' - ' + el.metadata.title : el.filepath.split("/").pop()
+        name: el.metadata.title ? el.metadata.artist + ' - ' + el.metadata.title : el.filepath.split("/").pop(),
+        path: el.filepath,
+        title, aa, subtitle
       });
 
-      filelist += createMusicFileHtml(el.filepath,
-        el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop(),
-        artImgAttr(el.metadata['album-art'], 's'),
-        undefined,
-        el.metadata.artist ? `${el.metadata.artist} [${el.metadata['play-count']} plays]` : `[${el.metadata['play-count']} plays]`);
+      filelist += createMusicFileHtml(el.filepath, title, aa, undefined, subtitle);
     });
 
     filelist += '</ul>'
@@ -3478,16 +3490,18 @@ async function redoRecentlyAdded() {
     //parse through the json array and make an array of corresponding divs
     let filelist = '<ul class="collection">';
     response.forEach(el => {
+      const title = el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop();
+      const aa = artImgAttr(el.metadata['album-art'], 's');
+      const subtitle = el.metadata.artist ? el.metadata.artist : '';
+
       currentBrowsingList.push({
         type: 'file',
-        name: el.metadata.title ? el.metadata.artist + ' - ' + el.metadata.title : el.filepath.split("/").pop()
+        name: el.metadata.title ? el.metadata.artist + ' - ' + el.metadata.title : el.filepath.split("/").pop(),
+        path: el.filepath,
+        title, aa, subtitle
       });
 
-      filelist += createMusicFileHtml(el.filepath,
-        el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop(),
-        artImgAttr(el.metadata['album-art'], 's'),
-        undefined,
-        el.metadata.artist ? el.metadata.artist : '');
+      filelist += createMusicFileHtml(el.filepath, title, aa, undefined, subtitle);
     });
 
     filelist += '</ul>'
@@ -5213,18 +5227,22 @@ function runLocalSearch(el) {
         filelist += renderPlaylist(x.name);
       } else if (x.type === 'album') {
         const albumString = x.name  ? x.name  : 'SINGLES';
-        filelist += renderAlbum(x.name, x.name === null ? x.artist : null, albumString, x.album_art_file);
+        filelist += renderAlbum(x.name, x.name === null ? x.artist : null, albumString, x.album_art_file, x.year);
       } else if (x.type === 'artist') {
         filelist += renderArtist(x.name);
+      } else if (x.type === 'genre') {
+        filelist += renderGenre(x.name, x.track_count);
       } else {
         if (programState[programState.length - 1].state === 'playlist') {
           filelist += renderFileWithMetadataHtml(x.filepath, x.lokiId, x.metadata);
         } else if (x.type == "m3u") {
           filelist += createFileplaylistHtml(x.name);
         } else {
-          const fileLocation = x.path || getFileExplorerPath() + x.name;
-          const title = x.artist != null || x.title != null ? x.artist + ' - ' + x.title : x.name;
-          filelist += createMusicFileHtml(fileLocation, title);
+          // Replay the args the panel itself passed to createMusicFileHtml.
+          // Deriving the path here (getFileExplorerPath() + x.name) only ever
+          // held for the file explorer, and silently rewrote every DB-panel
+          // row's data-file_location to a path that does not exist.
+          filelist += createMusicFileHtml(x.path, x.title, x.aa, x.rating, x.subtitle);
         }
       }
     }


### PR DESCRIPTION
## The bug

The default UI's local search bar doesn't hide rows when you type — it **re-renders** the list from `currentBrowsingList`. That only works if each browse panel pushed enough data to redraw its own rows, and the DB-driven panels pushed `{ type: 'file', name }` and nothing else. So `runLocalSearch` fell back to reconstructing the path:

```js
const fileLocation = x.path || getFileExplorerPath() + x.name;
```

That rule only ever held for the file explorer. Inside an album view it rewrote every row's `data-file_location` from the real path to a stale explorer dir plus the song title:

```
music/The Wall/CD1/01 In the Flesh.flac   →   music/In the Flesh
```

Clicking or queueing a filtered row then 404'd and played nothing. Back-navigation replays the saved filter (`previousSearch` + a synthetic `keyup`), so it also corrupted rows the user never typed over.

## The fix

Invert the contract. Each panel pushes the exact arguments it passed to the renderer, and `runLocalSearch` replays them verbatim:

```js
filelist += createMusicFileHtml(x.path, x.title, x.aa, x.rating, x.subtitle);
```

The filtered render now calls the same function with the same values as the original render, so the two can't drift — this is a structural fix rather than a per-panel patch.

## What the audit turned up beyond the reported bug

Auditing every panel that pushes `{ type: 'file' }` found the missing path was one symptom of a broader omission:

| Panel | Was losing on filter |
|---|---|
| `getAlbumSongs`, `getGenreSongs` | path (the reported bug) |
| `getRatedSongs` | path, **album art, star rating**, artist subtitle |
| `redoRecentlyPlayed` / `redoMostPlayed` / `redoRecentlyAdded` | path, **album art**, artist subtitle |
| `printdir` (file explorer) | dropped the server's authoritative `file.path`; never pushed `artist`/`title`, so `Artist - Title` labels collapsed to the filename |
| `getAllGenres` | **no branch existed** — genres fell through to the file-row `else` and rendered as playable rows pointing at the genre name |
| `getAllAlbums`, `getArtistsAlbums` | `data-year`, which `getAlbumsOnClick` reads back — a filtered album could open a *different* album of the same name |

`renderGenre()` was extracted so the genre list has one renderer, matching `renderArtist`/`renderAlbum`.

## Testing

**Automated — 12 new tests.** `webapp/` has no browser harness, so these follow the existing `webapp-waveform-cache.test.mjs` pattern: slice the real functions out of `m.js` and run them against stub globals, rather than re-typing the implementation where it could drift from what ships. They pin a stronger invariant than "the path survives" — **a row that survives the filter must be byte-identical to the row the panel drew** — which also catches the art/rating/subtitle losses. All 12 fail on `master`.

Reverting *only* the `runLocalSearch` fallback (keeping `renderGenre` and the fixed producers) reproduces the exact reported corruption, confirming the tests bite for the right reason:

```
+ actual - expected
+   'music&#x2F;In the Flesh?'
-   'music&#x2F;The Wall&#x2F;CD1&#x2F;01 In the Flesh.flac'
```

**Live end-to-end with a negative control.** Real `keyup`, real `.click()` on the filtered row, real range request against the queued URL:

| | filtered row's path | server response |
|---|---|---|
| Old code | `music/Here Comes the Sun` | **404** `text/html` |
| Fixed | `music/The Beatles/Abbey Road/07 - Here Comes the Sun.flac` | **206** `audio/x-flac` |

Also driven live: genre filter stays a genre row; back-navigation replay (drilled into a genre, hit back → search bar restored, rows still genre rows); recently-added filter with album art and subtitle intact.

**Suite:** 536/539 unit tests pass, 0 failures. New test file lints clean (`webapp/` is eslint-ignored).

## Reviewer notes

- **Not covered:** 5 of 8 `runLocalSearch` branches (`directory`, `playlist`, `artist`, playlist-state rows, `m3u`) — the fixture has `directories: []` and no m3u entries. None of those five were changed behaviorally.
- **Not run:** full `npm test`. Unit suite only; the change is webapp-only and touches no server code. Worth the `full-ci` label.
- Starred/rated, most-played, file-explorer and album-grid filters rest on the unit tests — the preview library has zero rated songs, so that panel wasn't exercised live.
- No coverage for null album names (the `SINGLES` path), missing `metadata.title`, or filepaths containing `#`/`?`/`%`.
- **Velvet is deliberately untouched:** `webapp/velvet/alpha/m.js:1588` and `webapp/velvet/assets/js/mstream.js:1198` still carry the old fallback, but velvet's live UI is `index.html` → `/app.js`, which has no `runLocalSearch` or `currentBrowsingList` at all. Those copies are reachable only via `old.html` — dead code, and velvet is slated for removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
