### PR TITLE
feat(api): report discovery readiness on GET /api/

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -957,9 +957,31 @@ paths:
                   apiVersions:
                     type: array
                     items: { type: string }
+                  features:
+                    type: object
+                    description: >
+                      Capability flags a client can gate UI on without an extra
+                      round-trip.
+                    properties:
+                      subsonic:
+                        type: boolean
+                        description: Whether the Subsonic API surface is mounted.
+                      discoveryReady:
+                        type: boolean
+                        description: >
+                          Whether a sonic-similarity query would find anything
+                          right now. Distinct from the ping's `discovery` flag,
+                          which reports only that the feature is enabled: a
+                          server can have discovery on with an unfinished scan,
+                          in which case similarity queries fail against an empty
+                          pool. A boolean rather than a count because this
+                          endpoint is public.
               example:
-                server: "6.4.2"
+                server: "6.22.0"
                 apiVersions: ["1"]
+                features:
+                  subsonic: false
+                  discoveryReady: true
 
   /api/v1/ping:
     get:

--- a/src/db/discovery-similarity.js
+++ b/src/db/discovery-similarity.js
@@ -77,6 +77,34 @@ function l2normalize(v) {
  *   artists: Map<artistName, { vec, analyzedCount, topTags }>,
  * }
  */
+/// Cheapest possible "would a similarity query find anything?" — one indexed
+/// existence check, no vector decode, no index build.
+///
+/// Deliberately NOT getIndex(): that rebuilds the in-memory index whenever the
+/// cache is stale, and the only caller of this is the PUBLIC /api/ endpoint.
+/// Letting an unauthenticated request force an index build would be a free
+/// amplification vector on a large library.
+///
+/// Returns false when discovery is switched off, the DB has never been
+/// created, or nothing has been embedded yet for the configured model — which
+/// are the three ways a client asking "can I use sonic similarity" gets the
+/// same practical answer: not right now.
+export function hasEmbeddings() {
+  if (config.program.scanOptions.collectDiscoveryData !== true) { return false; }
+  try {
+    const ddb = discoveryDb.openDiscoveryDbIfExists();
+    if (!ddb) { return false; }
+    const row = ddb.prepare(
+      'SELECT 1 FROM discovery_tracks WHERE embedding IS NOT NULL AND model_id = ? LIMIT 1'
+    ).get(config.program.scanOptions.discoveryModel);
+    return row !== undefined;
+  } catch (err) {
+    // Never let a capability probe take down the endpoint that reports it.
+    winston.warn(`[discovery] readiness check failed: ${err.message}`);
+    return false;
+  }
+}
+
 export function getIndex() {
   const ddb = discoveryDb.openDiscoveryDbIfExists();
   if (!ddb) { return null; }

--- a/src/server.js
+++ b/src/server.js
@@ -34,6 +34,7 @@ import * as dbManager from './db/manager.js';
 import * as discoveryDb from './db/discovery-db.js';
 import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // scanner.js removed — parser now writes directly to SQLite
+import * as sim from './db/discovery-similarity.js';
 import * as federationApi from './api/federation.js';
 import * as federationDiscoveryApi from './api/federation-discovery.js';
 import * as federationLimitsApi from './api/federation-limits.js';
@@ -641,6 +642,17 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     apiVersions: ["1"],
     features: {
       subsonic: config.program.subsonic.mode !== 'disabled',
+      // Whether a sonic-similarity query would find anything RIGHT NOW.
+      // Distinct from the ping's `discovery` flag, which says the feature is
+      // switched on: a server can have it on with an unfinished scan, and
+      // that combination is exactly what makes clients look broken. Auto DJ
+      // sends similarTo/minSimilarity, every pick 400s on the empty pool, and
+      // the queue silently stops advancing.
+      //
+      // A boolean, not a count: this endpoint is public, and how many tracks
+      // are analysed is library-size information. Clients only need to know
+      // whether to offer the feature.
+      discoveryReady: sim.hasEmbeddings(),
     },
   }));
 

--- a/test/api-discovery-readiness.test.mjs
+++ b/test/api-discovery-readiness.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * `GET /api/` — features.discoveryReady.
+ *
+ * The public API-discovery endpoint reports whether a sonic-similarity query
+ * would find anything RIGHT NOW. That is a different question from the ping's
+ * `discovery` flag, which only says the feature is switched on: a server can
+ * have discovery enabled with an unfinished scan, and that combination is what
+ * makes clients look broken. Auto DJ sends similarTo/minSimilarity, every pick
+ * 400s on the empty pool, and the queue silently stops advancing.
+ *
+ * These cover the readiness predicate itself (sim.hasEmbeddings), which is
+ * what the endpoint returns. Three properties matter:
+ *
+ *   1. Off in config  → false without touching the database at all. The check
+ *      must short-circuit, because /api/ is unauthenticated.
+ *   2. On, no rows    → false. This is the case the field exists for.
+ *   3. On, rows for a DIFFERENT model → false. A vector in another model's
+ *      space cannot answer a query in this one, so "has rows" is not the same
+ *      as "ready".
+ *
+ * It must also never throw: a capability probe that can 500 would take out the
+ * endpoint that reports it.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import * as config from '../src/state/config.js';
+import * as discoveryDb from '../src/db/discovery-db.js';
+import * as sim from '../src/db/discovery-similarity.js';
+
+const MODEL = 'test-model-1';
+let tmpDir;
+let cfgPath;
+
+function setScanOptions({ collect, model = MODEL }) {
+  config.program.scanOptions = {
+    ...(config.program.scanOptions || {}),
+    collectDiscoveryData: collect,
+    discoveryModel: model,
+  };
+}
+
+describe('GET /api/ -> features.discoveryReady', () => {
+  before(async () => {
+    // Real config.setup(), like mdns.test.mjs: program is undefined until it
+    // runs, and the readiness check reads straight off it.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-discovery-ready-'));
+    cfgPath = path.join(tmpDir, 'config.json');
+    await fsp.writeFile(cfgPath, JSON.stringify({
+      port: 3000,
+      storage: { dbDirectory: tmpDir },
+    }));
+    await config.setup(cfgPath);
+    config.program.storage = { ...(config.program.storage || {}), dbDirectory: tmpDir };
+  });
+
+  after(async () => {
+    try { discoveryDb.closeDiscoveryDb(); } catch { /* not open — nothing to close */ }
+    await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('collectDiscoveryData off -> false, and no DB is opened', () => {
+    setScanOptions({ collect: false });
+    try { discoveryDb.closeDiscoveryDb(); } catch { /* not open — nothing to close */ }
+    assert.equal(sim.hasEmbeddings(), false);
+    // The short-circuit is the point: an unauthenticated caller must not be
+    // able to make this endpoint open (or create) a database.
+    assert.equal(discoveryDb.isDiscoveryDbOpen(), false);
+  });
+
+  test('enabled but nothing embedded -> false', () => {
+    setScanOptions({ collect: true });
+    discoveryDb.initDiscoveryDb(path.join(tmpDir, 'discovery.db'));
+    assert.equal(sim.hasEmbeddings(), false, 'an empty table is not readiness');
+  });
+
+  test('a row with a NULL embedding is still not ready', () => {
+    setScanOptions({ collect: true });
+    const ddb = discoveryDb.getDiscoveryDb();
+    ddb.prepare(
+      `INSERT INTO discovery_tracks
+         (audio_hash, updated_at, export_id, model_id, embedding)
+       VALUES (?, ?, ?, ?, NULL)`
+    ).run('hash-pending', 1, 'anon:pending', MODEL);
+    assert.equal(sim.hasEmbeddings(), false,
+      'analysis queued is not analysis done');
+  });
+
+  test('an embedding for a DIFFERENT model is not ready either', () => {
+    setScanOptions({ collect: true });
+    const ddb = discoveryDb.getDiscoveryDb();
+    ddb.prepare(
+      `INSERT INTO discovery_tracks
+         (audio_hash, updated_at, export_id, model_id, embedding)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('hash-other-model', 2, 'anon:other', 'some-other-model',
+          Buffer.from([1, 2, 3, 4]));
+    assert.equal(sim.hasEmbeddings(), false,
+      "vectors in another model space cannot answer this model's queries");
+  });
+
+  test('one embedding for the configured model -> ready', () => {
+    setScanOptions({ collect: true });
+    const ddb = discoveryDb.getDiscoveryDb();
+    ddb.prepare(
+      `INSERT INTO discovery_tracks
+         (audio_hash, updated_at, export_id, model_id, embedding)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('hash-ready', 3, 'anon:ready', MODEL, Buffer.from([1, 2, 3, 4]));
+    assert.equal(sim.hasEmbeddings(), true);
+  });
+
+  test('never throws when the store is unusable', () => {
+    setScanOptions({ collect: true });
+    try { discoveryDb.closeDiscoveryDb(); } catch { /* not open — nothing to close */ }
+    const good = config.program.storage.dbDirectory;
+    config.program.storage = {
+      ...config.program.storage,
+      dbDirectory: path.join(tmpDir, 'does', 'not', 'exist'),
+    };
+    assert.doesNotThrow(() => sim.hasEmbeddings());
+    assert.equal(sim.hasEmbeddings(), false);
+    config.program.storage = { ...config.program.storage, dbDirectory: good };
+  });
+});


### PR DESCRIPTION
## The gap

The ping's `discovery` flag says the feature is switched **on**. It cannot say whether the scan has produced anything yet — and those are different questions with the same symptom for a client.

A server with discovery enabled and an unfinished scan looks fully capable. The client offers sonic similarity, sends `similarTo` / `minSimilarity` on `random-songs`, and every pick 400s against an empty pool. In the mobile app that means Auto DJ stops advancing the queue with nothing on screen to explain it — the feature was offered, accepted, and then silently did nothing.

`features.discoveryReady` closes that in the call clients already make to learn the server version:

```json
{
  "server": "6.22.0",
  "apiVersions": ["1"],
  "features": { "subsonic": false, "discoveryReady": false }
}
```

Paired with the ping flag it separates the three states cleanly:

| ping `discovery` | `discoveryReady` | Meaning |
|---|---|---|
| `false` | — | Feature off |
| `true` | `false` | **On, nothing analysed — offer nothing yet** |
| `true` | `true` | Usable |

## Two choices driven by this endpoint being public

**A boolean, not a count.** How many tracks are analysed is library-size information, and no client needs it to decide whether to offer the feature.

**A one-row existence check, not `getIndex()`.** `getIndex()` rebuilds the in-memory index whenever its cache is stale, so calling it from an unauthenticated route would let anyone force repeated index builds on a large library. `hasEmbeddings()` short-circuits on `collectDiscoveryData` before touching the database at all, then runs a single `LIMIT 1` lookup, and swallows any error — a capability probe must never be able to 500 the endpoint that reports it.

It also filters on `model_id`: vectors in another model's space cannot answer queries in the configured one, so "has rows" is not the same as "ready".

## Testing

Six tests in `test/api-discovery-readiness.test.mjs` cover the predicate: off-in-config returns false **without opening a database** (the short-circuit is the security-relevant part), empty table, NULL embedding, wrong model, one good row, and an unusable store not throwing.

Verified live against 6.22 with discovery enabled and an unscanned library — ping reports `discovery: true`, `/api/` reports `discoveryReady: false`, which is exactly the case that has been breaking clients.

OpenAPI spec updated.

## Note

I considered `/api/v1/federation/health`, which already exposes `analyzedCount`. Two reasons against it: it only exists from 6.17.2, and it is the one federation route that does **not** check `federation.enabled` while every sibling does — which looks like an oversight rather than a contract, so it is a fragile thing for clients to depend on. Worth a separate look either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)