### PR TITLE
fix(discovery): recover the p2p sidecar when it dies, and rejoin the topic

### DIFF
--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -18,6 +18,55 @@ let stopping = null;
 
 export function isStackRunning() { return running; }
 
+// Recovery backoff after an unexpected sidecar death. Short first — the
+// common cause is a one-off OOM kill, and seconds off the mesh cost nothing
+// — then widening, so a sidecar that CANNOT stay up (bad binary, wedged data
+// dir, a memory limit it will always hit) settles at ~12 attempts an hour
+// instead of hot-looping. It never gives up: the failure this fixes is a
+// server quietly staying off the network forever, and a recovery loop that
+// exhausts itself would just reintroduce it with extra steps.
+const RECOVERY_DELAYS_MS = [5000, 15000, 60000, 300000];
+let recoveryTimer = null;
+let recoveryAttempts = 0;
+
+function cancelRecovery() {
+  if (recoveryTimer) { clearTimeout(recoveryTimer); recoveryTimer = null; }
+  recoveryAttempts = 0;
+}
+
+// Called by discovery-p2p.js when the child died without us asking. Replays
+// the ENTIRE stack — subscribe, spawn, join, re-announce, holds — because
+// everything the sidecar knew about the mesh died with the process.
+function scheduleRecovery(why) {
+  // `running` is the feature's INTENT. A crash leaves it true (that is the
+  // stale flag this module also repairs below), so this reads "we are
+  // supposed to be on the network"; a deliberate stop clears it first and
+  // therefore silences recovery, which is exactly right.
+  if (!running || recoveryTimer) { return; }
+  const delay = RECOVERY_DELAYS_MS[Math.min(recoveryAttempts, RECOVERY_DELAYS_MS.length - 1)];
+  recoveryAttempts += 1;
+  winston.warn(`[discovery-p2p] sidecar ${why} — replaying the stack in `
+    + `${Math.round(delay / 1000)}s (attempt ${recoveryAttempts})`);
+  recoveryTimer = setTimeout(() => {
+    recoveryTimer = null;
+    if (!running) { return; }
+    // Clear the dead sidecar's stale intent HERE so the start below does the
+    // real work instead of tripping the "already running" guard.
+    running = false;
+    startDiscoveryP2pStack()
+      .then(() => winston.info('[discovery-p2p] sidecar recovered — rejoined the catalog topic'))
+      .catch((err) => {
+        winston.warn(`[discovery-p2p] sidecar recovery failed: ${err.message}`);
+        // Re-arm: startDiscoveryP2pStack() left `running` false on failure,
+        // and scheduleRecovery reads it as "give up". The intent has not
+        // changed — the config still says enabled — so restore it.
+        running = true;
+        scheduleRecovery('recovery failed');
+      });
+  }, delay);
+  if (recoveryTimer.unref) { recoveryTimer.unref(); }
+}
+
 export async function startDiscoveryP2pStack() {
   // Serialize behind an in-flight stop. A soft reboot stops the stack and then
   // re-serves, and stopping the sidecar can take up to ~10s (a shutdown RPC
@@ -30,13 +79,28 @@ export async function startDiscoveryP2pStack() {
   if (stopping) {
     try { await stopping; } catch (_err) { /* stop's own caller logs it */ }
   }
-  if (running) { return; }
+  if (running) {
+    // `running` records that a start COMPLETED — never that the sidecar is
+    // still alive. An OOM kill or a crash leaves it stale, and this is the
+    // route the admin "enable the network" button lands on: it answered 200
+    // {"enabled":true} while repairing precisely nothing, which is the worst
+    // possible reply to an operator trying to fix an outage. Ask the sidecar
+    // itself, and if it is gone treat THIS call as the repair it looks like.
+    // The import is free here: a true `running` means the module is resident.
+    const p2p = await import('./discovery-p2p.js');
+    if (p2p.isRunning()) { return; }
+    winston.warn('[discovery-p2p] the stack is marked running but the sidecar is gone — replaying the start');
+    running = false;
+  }
   if (starting) { return starting; }
   starting = (async () => {
     const p2p = await import('./discovery-p2p.js');
     const catalog = await import('./discovery-catalog.js');
     const seeds = await import('./discovery-seeds.js');
     catalog.subscribe();
+    // Armed BEFORE the spawn, so a sidecar that dies seconds into its life
+    // is covered too. Idempotent — re-registering just replaces the slot.
+    p2p.setUnexpectedExitHandler(scheduleRecovery);
     await p2p.start();
     // Two-phase bootstrap. Phase one joins the topic IMMEDIATELY with
     // what's known locally (baked seeds + cached list + the operator's
@@ -71,6 +135,10 @@ export async function startDiscoveryP2pStack() {
     // whose snapshot we hold stays listed however long it's been silent.
     catalog.startPruning(() => new Set(peerDbs.list().map((e) => e.endpointId)));
     running = true;
+    // We are on the network again: retire any pending retry and reset the
+    // backoff, so the NEXT crash starts from 5s rather than wherever this
+    // one's ladder left off.
+    cancelRecovery();
   })();
   try { await starting; } finally { starting = null; }
 }
@@ -86,6 +154,10 @@ export async function stopDiscoveryP2pStack() {
   // resolved was the bug — the window is seconds wide, and a reboot lands
   // squarely inside it.
   running = false;
+  // A pending retry outlives the flag it reads, so drop it here as well —
+  // otherwise a crash landing just before an operator disables the feature
+  // would resurrect the sidecar seconds after they turned it off.
+  cancelRecovery();
   stopping = (async () => {
     const seeds = await import('./discovery-seeds.js');
     const peerDbs = await import('./discovery-peer-dbs.js');
@@ -94,6 +166,10 @@ export async function stopDiscoveryP2pStack() {
     peerDbs.stopAutoFetch();
     catalog.stopPruning();
     const p2p = await import('./discovery-p2p.js');
+    // Nothing to recover from a shutdown we asked for. (stop() also bumps
+    // its generation counter, so the exit is classified as expected anyway —
+    // this is the belt to that suspenders.)
+    p2p.setUnexpectedExitHandler(null);
     await p2p.stop();
   })();
   try { await stopping; } finally { stopping = null; }

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -40,6 +40,29 @@ import * as config from './config.js';
 // The catalog module (discovery-catalog.js) is the main subscriber.
 export const events = new EventEmitter();
 
+// Unexpected-death hook, set by the stack (discovery-p2p-stack.js).
+//
+// The sidecar is a child process, so an OOM kill, a panic, or an operator's
+// `kill` takes it down with nobody asking — and NOTHING used to put it back:
+// start() has exactly one real caller (the stack's boot), and the two
+// periodic passes that could have noticed (the mesh-health watch, the
+// catalog prune) both return early on `!isRunning()`. A server therefore sat
+// off the network, config still saying "enabled", until someone restarted it
+// by hand.
+//
+// Deliberately NOT routed through `events` above: that emitter re-emits
+// whatever the child names in its `event` field, so a buggy sidecar could
+// synthesize its own resurrection. This is a private channel the child
+// cannot reach.
+//
+// The handler gets the whole stack replayed, not a bare respawn — the topic
+// subscription, the announce payload and the holds beacon all live in the
+// sidecar's memory and die with it. A respawn without them yields the worst
+// state of all: a process that reports `running: true` while being just as
+// invisible to the network as no process at all.
+let unexpectedExitHandler = null;
+export function setUnexpectedExitHandler(fn) { unexpectedExitHandler = fn; }
+
 const ext = process.platform === 'win32' ? '.exe' : '';
 // musl detection mirrors task-queue.js's rust-parser resolution.
 const isMusl = process.platform === 'linux' && !process.report?.getReport()?.header?.glibcVersionRuntime;
@@ -152,6 +175,25 @@ export function start() {
     const child = spawn(bin, ['--data-dir', dataDir()], { stdio: ['pipe', 'pipe', 'pipe'] });
     proc = child;
 
+    // Pipe errors must never be fatal. An rpc() that lands in the window
+    // between the child dying and Node delivering its 'exit' event writes
+    // into a broken pipe: EPIPE. The write callback in rpc() already turns
+    // that into a rejected request — but a Writable ALSO emits 'error', and
+    // an unhandled 'error' on a stream is an uncaught exception, i.e. the
+    // whole music server going down because a status poll lost a race with
+    // an OOM kill. The status route polls exactly there, so this is a
+    // reachable crash, not a theoretical one. Same reasoning for the read
+    // side, where a mid-line destroy surfaces on the readline source.
+    child.stdin.on('error', (err) => {
+      winston.debug(`[p2p-sidecar] stdin: ${err.message}`);
+    });
+    child.stdout.on('error', (err) => {
+      winston.debug(`[p2p-sidecar] stdout: ${err.message}`);
+    });
+    child.stderr.on('error', (err) => {
+      winston.debug(`[p2p-sidecar] stderr: ${err.message}`);
+    });
+
     const readyTimer = setTimeout(() => {
       reject(new Error('p2p-sidecar did not become ready in time'));
       try { child.kill(); } catch (_err) { /* already gone */ }
@@ -195,11 +237,21 @@ export function start() {
     child.on('exit', (code, signal) => {
       clearTimeout(readyTimer);
       const why = `exited (code=${code} signal=${signal})`;
-      // Unexpected death after ready: log at warn — an admin action will
-      // surface the failure on its next rpc() call, and start() can respawn.
-      if (endpointId) { winston.warn(`[p2p-sidecar] ${why}`); }
+      // Was this death ASKED FOR? stop() bumps startGen before it touches
+      // anything else, so a generation mismatch means the shutdown is ours —
+      // no warn, and above all no recovery racing the teardown. Computed
+      // before teardown(), which clears endpointId.
+      const unexpected = endpointId !== null && gen === startGen;
+      if (unexpected) { winston.warn(`[p2p-sidecar] ${why}`); }
       teardown(why);
       reject(new Error(`p2p-sidecar ${why}`));
+      // Last, so the module is already back to a clean stopped state by the
+      // time the stack tries to start a replacement.
+      if (unexpected && unexpectedExitHandler) {
+        try { unexpectedExitHandler(why); } catch (err) {
+          winston.warn(`[p2p-sidecar] unexpected-exit handler threw: ${err.message}`);
+        }
+      }
     });
   })).finally(() => {
     // Only OUR slot: stop() may already have detached this chain so a fresh

--- a/src/state/discovery-seeds.js
+++ b/src/state/discovery-seeds.js
@@ -201,10 +201,19 @@ export async function resolveBootstrap(opts = {}) {
   );
 }
 
-// Watch the mesh after boot: joined-but-zero-neighbors for a full interval
-// means our bootstrap set is stale or the peers are gone — re-resolve with a
-// forced list refresh and join again (join_peers is idempotent, so this can
-// never hurt an already-healthy mesh). Idempotent across server reboot()s.
+// Watch the mesh after boot: a running sidecar that is off the topic, or on
+// it with zero neighbors for a full interval, means our bootstrap set is
+// stale or the peers are gone — re-resolve with a forced list refresh and
+// join again (join_peers is idempotent, so this can never hurt an
+// already-healthy mesh). Idempotent across server reboot()s.
+//
+// NOTE the un-joined case is included deliberately. It used to be excluded
+// (`if (!s.joined || ...) return`), which skipped the single most broken
+// state a live sidecar can be in — and that state is reachable, because
+// publish/fetch/announce all lazily start() the sidecar WITHOUT joining it.
+// A rotation fetch respawning a crashed sidecar therefore left the server
+// permanently silent: process up, topic un-subscribed, and the one watch
+// that could have noticed bailing on the very condition it should repair.
 let watchTimer = null;
 export function startMeshHealthWatch() {
   if (watchTimer) { return; }
@@ -212,10 +221,11 @@ export function startMeshHealthWatch() {
     try {
       if (!discoveryP2p.isRunning()) { return; }
       const s = await discoveryP2p.status();
-      if (!s.joined || s.neighbors > 0) { return; }
+      if (s.joined && s.neighbors > 0) { return; }
       const bootstrap = await resolveBootstrap({ forceRefresh: true });
       if (bootstrap.length === 0) { return; } // nothing to join with — nothing to do
-      winston.info(`[discovery-seeds] no mesh neighbors — re-joining with ${bootstrap.length} bootstrap peer(s)`);
+      winston.info(`[discovery-seeds] ${s.joined ? 'no mesh neighbors' : 'sidecar is not on the catalog topic'} `
+        + `— re-joining with ${bootstrap.length} bootstrap peer(s)`);
       await discoveryP2p.join(bootstrap);
     } catch (err) {
       winston.warn(`[discovery-seeds] mesh health check failed: ${err.message}`);

--- a/test/integration/discovery-p2p-crash-recovery.test.mjs
+++ b/test/integration/discovery-p2p-crash-recovery.test.mjs
@@ -1,0 +1,188 @@
+/**
+ * The sidecar crash-recovery loop, end to end against a real binary.
+ *
+ * THE OUTAGE THIS COVERS. The p2p-sidecar is a child process, so an OOM kill
+ * takes it down with nobody asking. Before this, nothing put it back:
+ * p2p.start() had exactly one real caller (the stack's boot), and both
+ * periodic passes that could have noticed — the mesh-health watch and the
+ * catalog prune — returned early on `!isRunning()`. A server ran on for hours
+ * with the config saying "enabled" and nothing on the network.
+ *
+ * Worse, recovery DID sometimes happen by accident, and left a state that
+ * looked healthier while being just as broken: publish/fetch/announce all
+ * lazily start() the sidecar, so an hourly rotation fetch would respawn the
+ * process WITHOUT rejoining the gossip topic — `running: true`, `joined:
+ * false`, invisible forever, and the health watch skipping it because its
+ * guard excluded the un-joined case outright.
+ *
+ * So `joined` is the assertion that matters here, not `running`. A bare
+ * respawn satisfies `running`; only a full stack replay — subscribe, spawn,
+ * join, re-announce, holds — satisfies `joined`. The sidecar reports
+ * joined:true on an empty bootstrap set (it subscribes to the topic whether
+ * or not anyone else is there), which is what lets this suite prove the
+ * property with no network, no seeds and no peers at all.
+ *
+ * Needs a real sidecar binary (dev build in p2p-sidecar/target/release, or an
+ * operator prebuilt in bin/p2p-sidecar/). CI usually has neither — the
+ * binaries left git when the sidecar moved to its own repo — so this skips
+ * there, exactly like the gossip layers of discovery-p2p.test.mjs.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { startServer } from '../helpers/server.mjs';
+import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
+
+const SIDECAR_BIN = resolveSidecarBinary();
+// Killing a specific grandchild by pid needs a POSIX `ps`; the recovery logic
+// itself is platform-independent and is unit-covered in
+// test/unit/discovery-p2p-crash-recovery.test.mjs.
+const SKIP = process.platform === 'win32'
+  ? 'needs a POSIX ps to find the sidecar grandchild'
+  : (SIDECAR_BIN ? false : 'no p2p-sidecar binary on this machine');
+
+// The sidecar is a GRANDCHILD (test → server → sidecar), so there is no
+// handle to it here. Match on the per-test data dir, which is a unique tmp
+// path — never on the binary name alone, or a developer's own mStream
+// running in the background would be a candidate.
+function sidecarPids(dataDir) {
+  const out = execFileSync('ps', ['-axo', 'pid=,args='], { encoding: 'utf8' });
+  return out.split('\n')
+    .filter((line) => line.includes('p2p-sidecar') && line.includes(dataDir))
+    .map((line) => Number(line.trim().split(/\s+/)[0]))
+    .filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+async function pollUntil(fn, { timeoutMs = 30000, everyMs = 250, what = 'condition' } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn();
+    if (value) { return value; }
+    if (Date.now() > deadline) { throw new Error(`timed out waiting for ${what}`); }
+    await new Promise((r) => setTimeout(r, everyMs));
+  }
+}
+
+describe('discovery p2p: an unexpectedly killed sidecar rejoins by itself', { skip: SKIP }, () => {
+  let server;
+  let statusOf;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: false,
+      extraConfig: {
+        discoveryP2p: {
+          enabled: true,
+          // Friend-to-friend mode with no friends: the topic still gets
+          // joined, so `joined` stays a clean signal while the suite stays
+          // hermetic. (startServer also empties the baked seeds.)
+          useCommunitySeeds: false,
+        },
+      },
+    });
+    statusOf = async () =>
+      (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+  });
+
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('SIGKILL → the stack replays itself, topic subscription included', async () => {
+    const dataDir = path.join(server.tmpDir, 'db', 'discovery-p2p');
+
+    const healthy = await pollUntil(
+      async () => { const s = await statusOf(); return s.running && s.joined ? s : null; },
+      { what: 'the boot stack to spawn the sidecar and join the topic' },
+    );
+
+    const before2 = sidecarPids(dataDir);
+    assert.equal(before2.length, 1, 'exactly one sidecar should belong to this server');
+
+    // The OOM killer's signal — uncatchable, so the sidecar gets no chance to
+    // shut down tidily. This is the real-world failure, not a polite stop.
+    process.kill(before2[0], 'SIGKILL');
+
+    await pollUntil(
+      async () => (await statusOf()).running === false,
+      { what: 'the server to notice the sidecar died' },
+    );
+
+    // First backoff rung is 5s, then the spawn + join round trip.
+    const recovered = await pollUntil(
+      async () => { const s = await statusOf(); return s.running && s.joined ? s : null; },
+      { timeoutMs: 60000, what: 'the stack to replay itself after the crash' },
+    );
+
+    assert.equal(recovered.joined, true,
+      'a bare respawn would leave joined:false — recovery must replay the whole stack');
+
+    const after2 = sidecarPids(dataDir);
+    assert.equal(after2.length, 1, 'exactly one sidecar after recovery — no orphan left behind');
+    assert.notEqual(after2[0], before2[0], 'the recovered sidecar must be a genuinely new process');
+
+    // The identity key is persisted under the data dir, so the server keeps
+    // the endpoint id its peers already know. A recovery that changed it
+    // would strand every catalog entry pointing at this server.
+    assert.equal(recovered.endpointId, healthy.endpointId,
+      'recovery must keep the persisted endpoint identity');
+  });
+
+  test('re-enabling a stack whose sidecar is gone repairs it instead of answering 200 to nothing', async () => {
+    const dataDir = path.join(server.tmpDir, 'db', 'discovery-p2p');
+    const [pid] = sidecarPids(dataDir);
+    assert.ok(pid, 'previous test should have left a live sidecar');
+
+    process.kill(pid, 'SIGKILL');
+    await pollUntil(
+      async () => (await statusOf()).running === false,
+      { what: 'the server to notice the second kill' },
+    );
+
+    // What an operator does when the panel says the network is down. This
+    // used to return {"enabled":true} while the stack's stale `running` flag
+    // turned the call into a silent no-op.
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/enabled`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: true }),
+    });
+    assert.equal(r.status, 200);
+
+    const s = await statusOf();
+    assert.equal(s.running, true, 're-enable must actually respawn the sidecar');
+    assert.equal(s.joined, true, 're-enable must put it back on the catalog topic');
+  });
+
+  test('an RPC that loses the race with the kill fails the request, not the server', async () => {
+    // Found by this suite, and far worse than the outage it was written for:
+    // between the child dying and Node delivering 'exit', `proc` is still set
+    // and its stdin is a broken pipe. rpc() writes anyway, EPIPE lands on the
+    // stream, and an unhandled 'error' on a stream is an uncaught exception —
+    // the entire music server, library and all, going down because a status
+    // poll arrived at the wrong millisecond. The status route polls exactly
+    // there, so an admin watching their Discovery page during an OOM kill was
+    // the trigger.
+    const dataDir = path.join(server.tmpDir, 'db', 'discovery-p2p');
+    await pollUntil(
+      async () => { const s = await statusOf(); return s.running && s.joined ? s : null; },
+      { timeoutMs: 60000, what: 'a live sidecar to race against' },
+    );
+    const [pid] = sidecarPids(dataDir);
+    assert.ok(pid, 'need a live sidecar to kill');
+
+    // Fire a burst of status RPCs and kill underneath them: some land before
+    // the death, some inside the window, some after. Any of them may fail —
+    // that is the contract, requests fail — but the process must survive.
+    const burst = Promise.allSettled(
+      Array.from({ length: 40 }, () => statusOf().catch(() => null)),
+    );
+    process.kill(pid, 'SIGKILL');
+    await burst;
+
+    const ping = await fetch(`${server.baseUrl}/api/v1/ping`);
+    assert.equal(ping.status, 200,
+      'a broken sidecar pipe must never take the whole server down');
+  });
+});

--- a/test/unit/discovery-p2p-crash-recovery.test.mjs
+++ b/test/unit/discovery-p2p-crash-recovery.test.mjs
@@ -1,0 +1,235 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// The silent outage: a sidecar that died on its own and never came back.
+//
+// The sidecar is a child process — an OOM kill takes it down with nobody
+// asking. p2p.start() had exactly ONE real caller (the stack's boot), and the
+// two periodic passes that could have noticed (the mesh-health watch, the
+// catalog prune) both returned early on `!isRunning()`. So the process stayed
+// dead, the config kept saying "enabled", and the only trace was a single
+// warn line at the moment of death.
+//
+// There was a second, nastier half. publish/fetch/announce all lazily
+// start() the sidecar, so unrelated background work — an hourly rotation
+// fetch — would respawn the PROCESS without rejoining the TOPIC. That state
+// reports `running: true` while being just as invisible as no process at
+// all, and the health watch skipped it too (`if (!s.joined ...) return`).
+// Hence the contract below is about `joined`, not `running`: recovery must
+// replay the whole start sequence, because the topic subscription, the
+// announce payload and the holds beacon all live in the sidecar's memory.
+//
+// These model the flag/timer logic directly. The real module dynamically
+// imports the entire p2p world (sidecar spawn included), which a unit test
+// cannot stand up — the same reason discovery-p2p-stack-race.test.mjs models
+// its contract — and the end-to-end proof against a real binary lives in
+// test/integration/discovery-p2p-crash-recovery.test.mjs. makeLegacyStack is
+// the negative control: it reproduces the previous implementation and must
+// FAIL every contract the fixed one upholds.
+
+const RECOVERY_DELAYS_MS = [5, 15, 60, 300]; // shape of the real ladder, scaled down
+
+// Current implementation: the child's death is reported to the stack, which
+// replays the whole start; `running` is intent, and a start that finds the
+// sidecar gone treats itself as the repair.
+function makeFixedStack({ spawnFails = 0 } = {}) {
+  let running = false;
+  let sidecarAlive = false;
+  let joined = false;
+  let recoveryTimer = null;
+  let recoveryAttempts = 0;
+  let failuresLeft = spawnFails;
+  const delaysUsed = [];
+  let starts = 0;
+
+  function cancelRecovery() {
+    if (recoveryTimer) { clearTimeout(recoveryTimer); recoveryTimer = null; }
+    recoveryAttempts = 0;
+  }
+
+  async function start() {
+    if (running) {
+      if (sidecarAlive) { return; }   // genuinely up: nothing to do
+      running = false;                // stale flag — this call IS the repair
+    }
+    starts += 1;
+    if (failuresLeft > 0) { failuresLeft -= 1; throw new Error('spawn failed'); }
+    sidecarAlive = true;
+    joined = true;                    // the full sequence: spawn AND join
+    running = true;
+    cancelRecovery();
+  }
+
+  async function stop() {
+    running = false;
+    cancelRecovery();
+    sidecarAlive = false;
+    joined = false;
+  }
+
+  // What discovery-p2p.js calls when the child died without us asking.
+  function onUnexpectedExit() {
+    sidecarAlive = false;
+    joined = false;
+    scheduleRecovery();
+  }
+
+  function scheduleRecovery() {
+    if (!running || recoveryTimer) { return; }
+    const delay = RECOVERY_DELAYS_MS[Math.min(recoveryAttempts, RECOVERY_DELAYS_MS.length - 1)];
+    delaysUsed.push(delay);
+    recoveryAttempts += 1;
+    recoveryTimer = setTimeout(() => {
+      recoveryTimer = null;
+      if (!running) { return; }
+      running = false;
+      start().catch(() => { running = true; scheduleRecovery(); });
+    }, delay);
+    // The real timer is unref'd too; without it a stack still walking its
+    // ladder would hold the test runner's event loop open.
+    if (recoveryTimer.unref) { recoveryTimer.unref(); }
+  }
+
+  // A lazy start(), as publish/fetch/announce perform it: the process comes
+  // back, the topic subscription does NOT.
+  function lazyStartSidecarOnly() { sidecarAlive = true; }
+
+  return {
+    start, stop, onUnexpectedExit, lazyStartSidecarOnly,
+    // Arm the NEXT n respawns to fail, so a test can drive the ladder. Has
+    // to reach the closure's own start(); a monkeypatched .start property
+    // would never be seen by scheduleRecovery.
+    failNext: (n) => { failuresLeft = n; },
+    state: () => ({ running, sidecarAlive, joined, starts }),
+    delaysUsed: () => [...delaysUsed],
+  };
+}
+
+// The PREVIOUS implementation, verbatim in shape: no death notification at
+// all, and a start that returns early on the stale flag. Nothing here may be
+// borrowed from the fixed version.
+function makeLegacyStack() {
+  let running = false;
+  let sidecarAlive = false;
+  let joined = false;
+  let starts = 0;
+
+  async function start() {
+    if (running) { return; }          // stale `true` after a crash => no-op
+    starts += 1;
+    sidecarAlive = true;
+    joined = true;
+    running = true;
+  }
+  async function stop() { running = false; sidecarAlive = false; joined = false; }
+  function onUnexpectedExit() { sidecarAlive = false; joined = false; }  // nobody listening
+  function lazyStartSidecarOnly() { sidecarAlive = true; }
+
+  return {
+    start, stop, onUnexpectedExit, lazyStartSidecarOnly,
+    state: () => ({ running, sidecarAlive, joined, starts }),
+  };
+}
+
+const settle = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('a crashed sidecar is brought back AND put on the topic again', async () => {
+  const stack = makeFixedStack();
+  await stack.start();
+  assert.deepEqual(stack.state(), { running: true, sidecarAlive: true, joined: true, starts: 1 });
+
+  stack.onUnexpectedExit();                       // the OOM kill
+  assert.equal(stack.state().sidecarAlive, false);
+
+  await settle(40);                               // first rung is 5ms here
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, true, 'the sidecar must be respawned');
+  assert.equal(s.joined, true, 'and rejoined — a bare respawn is not recovery');
+});
+
+test('NEGATIVE CONTROL: with no death hook the crash is permanent', async () => {
+  const stack = makeLegacyStack();
+  await stack.start();
+
+  stack.onUnexpectedExit();
+  await settle(40);
+
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, false, 'old logic: nothing ever respawned it');
+  assert.equal(s.running, true, 'old logic: the config-level flag still claims enabled');
+});
+
+test('a lazy start (rotation fetch) leaves it un-joined — recovery must not be satisfied by that', async () => {
+  const stack = makeLegacyStack();
+  await stack.start();
+  stack.onUnexpectedExit();
+  stack.lazyStartSidecarOnly();       // what an hourly rotation fetch did
+
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, true, 'the process is back...');
+  assert.equal(s.joined, false, '...but off the topic: running:true, invisible to the network');
+});
+
+test('re-enabling after a crash repairs the stack instead of no-oping on the stale flag', async () => {
+  const stack = makeFixedStack();
+  await stack.start();
+  stack.onUnexpectedExit();
+
+  await stack.start();                // the admin enable route
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, true, 'the operator asked for the network; they must get it');
+  assert.equal(s.joined, true);
+  assert.equal(s.starts, 2, 'a real second start, not an early return');
+});
+
+test('NEGATIVE CONTROL: the old guard answered success and did nothing', async () => {
+  const stack = makeLegacyStack();
+  await stack.start();
+  stack.onUnexpectedExit();
+
+  await stack.start();                // returns without error — and without effect
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, false, 'old logic: silent no-op behind a 200');
+  assert.equal(s.starts, 1, 'old logic: the second start never ran');
+});
+
+test('a deliberate stop cancels recovery — a disabled feature stays disabled', async () => {
+  const stack = makeFixedStack();
+  await stack.start();
+
+  stack.onUnexpectedExit();           // crash lands...
+  await stack.stop();                 // ...just before the operator disables it
+  await settle(40);
+
+  assert.deepEqual(stack.state(), { running: false, sidecarAlive: false, joined: false, starts: 1 },
+    'recovery must not resurrect a sidecar the operator just turned off');
+});
+
+test('a sidecar that keeps dying widens the backoff instead of hot-looping', async () => {
+  const stack = makeFixedStack();
+  await stack.start();
+  stack.failNext(3);                  // the next three respawns fail
+  stack.onUnexpectedExit();
+  await settle(600);                  // 5 + 15 + 60 + 300 (the rung that works)
+
+  const used = stack.delaysUsed();
+  assert.ok(used.length >= 3, `expected the ladder to be walked, saw ${used.join(',') || 'nothing'}`);
+  for (let i = 1; i < used.length; i++) {
+    assert.ok(used[i] >= used[i - 1], `backoff must never shrink: ${used.join(',')}`);
+  }
+  assert.ok(used.at(-1) <= RECOVERY_DELAYS_MS.at(-1), 'and must cap at the ceiling');
+  assert.equal(stack.state().joined, true, 'and it must still get back on the topic in the end');
+});
+
+test('a recovery that keeps failing never gives up', async () => {
+  // The failure being fixed is a server silently off the network forever, so
+  // a recovery loop that exhausts itself would just reintroduce it.
+  const stack = makeFixedStack();
+  await stack.start();
+  stack.failNext(99);
+  stack.onUnexpectedExit();
+  await settle(300);
+
+  assert.ok(stack.delaysUsed().length >= 3, 'must keep retrying');
+  assert.equal(stack.state().sidecarAlive, false, 'still down — but still trying');
+});


### PR DESCRIPTION
> **Handoff:** full investigation record, verification status, reproduction steps and open items are in [this comment](https://github.com/IrosTheBeggar/mStream/pull/880#issuecomment-5398359448). **CI on this PR is build-only** — `test.yml` runs only on the `full-ci` label or `workflow_dispatch`, so the suite results below are local.

## What happened

A live server's p2p-sidecar was `SIGKILL`ed at `09:08:48Z` and the server spent the next **6h45m off the discovery network** with the config still saying `enabled`. Diagnosed from operator logs, then reproduced locally end to end.

The network itself was healthy throughout — a fresh node joins in ~3s, reaches neighbours, and pulls snapshots normally. This was entirely a local failure to recover.

```
09:08:48Z  warn  [p2p-sidecar] exited (code=null signal=SIGKILL)
09:21:14Z  info  [p2p-sidecar] ready — endpointId=99e4fd0beb32…   ← respawned by an hourly
09:21:18Z  warn  [discovery-peer-dbs] rotation fetch … failed        rotation fetch, 3.7s earlier
```

That respawn is the trap. `publish`/`fetch`/`announce` all lazily `start()` the sidecar **without joining the topic**, so the rotation fetch brought the *process* back as a bare process — `running: true`, `joined: false`, invisible. Strictly worse than staying down: it looks healthier while being just as disconnected. The same pattern had already happened once on 08-16.

## Three defects

**1. Nothing put a dead sidecar back.** `p2p.start()` has exactly one real caller (the stack's boot), and both periodic passes that could have noticed — the mesh-health watch and the catalog prune — return early on `!isRunning()`. The child now reports its own unexpected death through a private hook, and the stack **replays itself** on a 5s/15s/60s/5min ladder that never gives up. A replay, not a respawn: the topic subscription, announce payload and holds beacon all live in the sidecar's memory. Deliberate stops are classified via the existing `startGen` counter and never trigger recovery.

**2. The admin enable route answered `200` and did nothing.** `running` recorded that a start *completed*, never that the sidecar was *alive*, so re-enabling after a crash hit `if (running) return` — the exact button an operator presses to fix an outage, replying success while repairing nothing. Verified against the running server before the fix:

```
POST /api/v1/admin/discovery/p2p/enabled {"enabled":true}
→ {"enabled":true,"collectForced":false}      # success…
→ status: {"running":true,"joined":false,"neighbors":0}   # …and still off the network
```

Same bug class as M3 in ddcf03ca, which fixed the reboot race but not this one.

**3. An RPC racing the kill took down the whole server.** Between the child dying and Node delivering `'exit'`, `proc` is still set and its stdin is a broken pipe. `rpc()` writes, `EPIPE` lands on the stream, and an unhandled `'error'` on a stream is an uncaught exception. **The status route polls exactly there** — so an admin watching their Discovery page during an OOM kill lost their music server, library and all. Found by the new test suite, not by inspection.

The mesh-health watch also stops skipping the un-joined case (`if (!s.joined || …) return`) — the single most broken state a live sidecar can be in, and the one the reported server was stuck in.

## Tests

- `test/unit/discovery-p2p-crash-recovery.test.mjs` — models the flag/timer contract with **negative controls** that reproduce the previous implementation and fail it (the precedent set by `discovery-p2p-stack-race.test.mjs`). Always runs.
- `test/integration/discovery-p2p-crash-recovery.test.mjs` — kills a **real** sidecar and asserts it comes back **joined**, keeps its persisted endpoint identity, leaves no orphan, and that a burst of RPCs racing the kill fails the requests rather than the process. Hermetic (no network, no seeds, no peers: the sidecar reports `joined:true` on an empty bootstrap set). Skips where no sidecar binary exists, like the gossip layers of the existing suite.

Negative-controlled: with the stdin handler removed, all three integration tests fail with the server dead.

```
unit                     542 pass / 0 fail
discovery integration     44 pass  +  3 new pass
lint                      unchanged (80 pre-existing errors on HEAD, 0 added)
```

## Not in this PR

Two things I found and deliberately left out of scope:

- **Hourly rotation churn.** 333 warnings since 08-10, alternating between the same two unreachable peers (`cannot reach the blob's origin: No addressing information available`). The per-peer backoff caps at 60min while rotation runs hourly, so it has always expired by the next pass — it retries forever. Harmless, but it was the *only* p2p line in the logs, so the real failure landed in noise that looks exactly like business as usual.
- **The admin panel renders a dead sidecar as healthy-ish.** `meshSearching` is true whenever `!running || !joined || neighbors === 0`, so the panel shows "not joined yet" over a *"searching for peers"* progress bar — indistinguishable from normal startup, indefinitely.

Happy to take either as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
