### PR TITLE
fix(discovery): gate sidecar recovery on the config flag so it can never outvote a disable

### DIFF
--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -11,6 +11,7 @@
 // for the (default) servers that never enable the feature.
 
 import winston from 'winston';
+import * as config from './config.js';
 
 let running = false;
 let starting = null;
@@ -49,7 +50,17 @@ function scheduleRecovery(why) {
     + `${Math.round(delay / 1000)}s (attempt ${recoveryAttempts})`);
   recoveryTimer = setTimeout(() => {
     recoveryTimer = null;
-    if (!running) { return; }
+    // Two vetoes: `running` (a stop cancelled us) and the CONFIG — the
+    // operator's own flag, which recovery must never outvote. The config
+    // check is the backstop for the one ordering `running` alone misses: a
+    // disable landing while a replay attempt is in flight can't cancel a
+    // timer that doesn't exist yet, and the attempt's failure handler below
+    // re-arms AFTER the stop's cancelRecovery already ran. Both disable
+    // paths write the flag before they touch the stack (api/admin.js), so
+    // by the time that plays out it is authoritative. A reboot's teardown
+    // leaves the flag true — recovery racing the boot start there converges
+    // through the starting/stopping guards.
+    if (!running || config.program.discoveryP2p.enabled !== true) { return; }
     // Clear the dead sidecar's stale intent HERE so the start below does the
     // real work instead of tripping the "already running" guard.
     running = false;
@@ -57,6 +68,13 @@ function scheduleRecovery(why) {
       .then(() => winston.info('[discovery-p2p] sidecar recovered — rejoined the catalog topic'))
       .catch((err) => {
         winston.warn(`[discovery-p2p] sidecar recovery failed: ${err.message}`);
+        if (config.program.discoveryP2p.enabled !== true) {
+          // The feature was switched off while the attempt was in flight —
+          // this failure IS the teardown winning. Stand down: leave
+          // `running` false so nothing re-arms against the operator.
+          winston.info('[discovery-p2p] recovery stands down — the feature was disabled mid-attempt');
+          return;
+        }
         // Re-arm: startDiscoveryP2pStack() left `running` false on failure,
         // and scheduleRecovery reads it as "give up". The intent has not
         // changed — the config still says enabled — so restore it.

--- a/test/unit/discovery-p2p-crash-recovery.test.mjs
+++ b/test/unit/discovery-p2p-crash-recovery.test.mjs
@@ -36,9 +36,18 @@ function makeFixedStack({ spawnFails = 0 } = {}) {
   let running = false;
   let sidecarAlive = false;
   let joined = false;
+  // The operator's own flag (config.program.discoveryP2p.enabled). Recovery
+  // reads it as the veto of last resort: `running` can be restored by the
+  // re-arm path, the config cannot. disable() mirrors the admin route's
+  // order — flag first, stack stop second (src/api/admin.js).
+  let configEnabled = true;
   let recoveryTimer = null;
   let recoveryAttempts = 0;
   let failuresLeft = spawnFails;
+  // Bumped by stop(); a start attempt in flight across a stop must fail,
+  // exactly as the real spawn does when the teardown kills its child.
+  let stopGen = 0;
+  let pendingGate = null;
   const delaysUsed = [];
   let starts = 0;
 
@@ -53,6 +62,11 @@ function makeFixedStack({ spawnFails = 0 } = {}) {
       running = false;                // stale flag — this call IS the repair
     }
     starts += 1;
+    const gen = stopGen;
+    // A one-shot gate a test can arm to park an attempt mid-start — the
+    // deterministic stand-in for "spawn + join take real time".
+    if (pendingGate) { const g = pendingGate; pendingGate = null; await g.promise; }
+    if (gen !== stopGen) { throw new Error('torn down mid-start'); }
     if (failuresLeft > 0) { failuresLeft -= 1; throw new Error('spawn failed'); }
     sidecarAlive = true;
     joined = true;                    // the full sequence: spawn AND join
@@ -61,10 +75,19 @@ function makeFixedStack({ spawnFails = 0 } = {}) {
   }
 
   async function stop() {
+    stopGen += 1;
     running = false;
     cancelRecovery();
     sidecarAlive = false;
     joined = false;
+  }
+
+  // The admin disable route, in its real order: the config flag is written
+  // (and live in config.program) BEFORE the stack stop begins — what makes
+  // the recovery gate race-free.
+  async function disable() {
+    configEnabled = false;
+    await stop();
   }
 
   // What discovery-p2p.js calls when the child died without us asking.
@@ -81,9 +104,15 @@ function makeFixedStack({ spawnFails = 0 } = {}) {
     recoveryAttempts += 1;
     recoveryTimer = setTimeout(() => {
       recoveryTimer = null;
-      if (!running) { return; }
+      if (!running || !configEnabled) { return; }
       running = false;
-      start().catch(() => { running = true; scheduleRecovery(); });
+      start().catch(() => {
+        // Disabled while the attempt was in flight: the failure IS the
+        // teardown winning. Stand down instead of re-arming.
+        if (!configEnabled) { return; }
+        running = true;
+        scheduleRecovery();
+      });
     }, delay);
     // The real timer is unref'd too; without it a stack still walking its
     // ladder would hold the test runner's event loop open.
@@ -95,12 +124,20 @@ function makeFixedStack({ spawnFails = 0 } = {}) {
   function lazyStartSidecarOnly() { sidecarAlive = true; }
 
   return {
-    start, stop, onUnexpectedExit, lazyStartSidecarOnly,
+    start, stop, disable, onUnexpectedExit, lazyStartSidecarOnly,
     // Arm the NEXT n respawns to fail, so a test can drive the ladder. Has
     // to reach the closure's own start(); a monkeypatched .start property
     // would never be seen by scheduleRecovery.
     failNext: (n) => { failuresLeft = n; },
-    state: () => ({ running, sidecarAlive, joined, starts }),
+    // Park the NEXT start attempt until the returned release() is called —
+    // how a test holds a recovery attempt "in flight" without racing timers.
+    gateNextStart: () => {
+      let release;
+      const promise = new Promise((r) => { release = r; });
+      pendingGate = { promise };
+      return release;
+    },
+    state: () => ({ running, sidecarAlive, joined, starts, configEnabled }),
     delaysUsed: () => [...delaysUsed],
   };
 }
@@ -136,7 +173,7 @@ const settle = (ms) => new Promise((r) => setTimeout(r, ms));
 test('a crashed sidecar is brought back AND put on the topic again', async () => {
   const stack = makeFixedStack();
   await stack.start();
-  assert.deepEqual(stack.state(), { running: true, sidecarAlive: true, joined: true, starts: 1 });
+  assert.deepEqual(stack.state(), { running: true, sidecarAlive: true, joined: true, starts: 1, configEnabled: true });
 
   stack.onUnexpectedExit();                       // the OOM kill
   assert.equal(stack.state().sidecarAlive, false);
@@ -201,7 +238,7 @@ test('a deliberate stop cancels recovery — a disabled feature stays disabled',
   await stack.stop();                 // ...just before the operator disables it
   await settle(40);
 
-  assert.deepEqual(stack.state(), { running: false, sidecarAlive: false, joined: false, starts: 1 },
+  assert.deepEqual(stack.state(), { running: false, sidecarAlive: false, joined: false, starts: 1, configEnabled: true },
     'recovery must not resurrect a sidecar the operator just turned off');
 });
 
@@ -232,4 +269,114 @@ test('a recovery that keeps failing never gives up', async () => {
 
   assert.ok(stack.delaysUsed().length >= 3, 'must keep retrying');
   assert.equal(stack.state().sidecarAlive, false, 'still down — but still trying');
+});
+
+// The in-flight flavor of the disable race. The "deliberate stop" test above
+// covers a stop that lands BEFORE the timer fires (cancelRecovery catches
+// it); this one lands AFTER — the attempt is already mid-start, so there is
+// no timer to cancel, the attempt fails against the teardown, and only the
+// config gate in the re-arm path stands between the operator and a
+// resurrected sidecar.
+test('a disable landing while a recovery attempt is in flight must not resurrect the stack', async () => {
+  const stack = makeFixedStack();
+  await stack.start();
+  const release = stack.gateNextStart(); // park the upcoming replay mid-start
+  stack.onUnexpectedExit();              // crash → first rung arms (5ms)
+  await settle(40);                      // rung fired; the attempt is now held in flight
+  assert.equal(stack.state().starts, 2, 'the replay attempt must be in flight before the disable');
+
+  await stack.disable();                 // operator turns it off: config first, then the stack stop
+  release();                             // teardown wins; the parked attempt now fails
+  await settle(400);                     // long enough for every rung to fire, had one re-armed
+
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, false, 'recovery must never outvote the operator');
+  assert.equal(s.running, false, 'and must not restore the intent flag of a disabled feature');
+});
+
+// The same choreography against the UNGATED re-arm — the shape that shipped
+// in the original recovery patch (restore `running`, re-schedule,
+// unconditionally). Reproduced here as its own model, borrowing nothing from
+// the fixed one, and it must FAIL the contract: config off, stack back on.
+function makeUngatedRecoveryStack() {
+  let running = false;
+  let sidecarAlive = false;
+  let joined = false;
+  let configEnabled = true;
+  let recoveryTimer = null;
+  let recoveryAttempts = 0;
+  let stopGen = 0;
+  let pendingGate = null;
+  let starts = 0;
+
+  async function start() {
+    if (running) {
+      if (sidecarAlive) { return; }
+      running = false;
+    }
+    starts += 1;
+    const gen = stopGen;
+    if (pendingGate) { const g = pendingGate; pendingGate = null; await g.promise; }
+    if (gen !== stopGen) { throw new Error('torn down mid-start'); }
+    sidecarAlive = true;
+    joined = true;
+    running = true;
+    if (recoveryTimer) { clearTimeout(recoveryTimer); recoveryTimer = null; }
+    recoveryAttempts = 0;
+  }
+
+  async function stop() {
+    stopGen += 1;
+    running = false;
+    if (recoveryTimer) { clearTimeout(recoveryTimer); recoveryTimer = null; }
+    recoveryAttempts = 0;
+    sidecarAlive = false;
+    joined = false;
+  }
+
+  async function disable() { configEnabled = false; await stop(); }
+
+  function onUnexpectedExit() { sidecarAlive = false; joined = false; scheduleRecovery(); }
+
+  function scheduleRecovery() {
+    if (!running || recoveryTimer) { return; }
+    const delay = RECOVERY_DELAYS_MS[Math.min(recoveryAttempts, RECOVERY_DELAYS_MS.length - 1)];
+    recoveryAttempts += 1;
+    recoveryTimer = setTimeout(() => {
+      recoveryTimer = null;
+      if (!running) { return; }              // no config veto here — the gap under test
+      running = false;
+      start().catch(() => { running = true; scheduleRecovery(); });
+    }, delay);
+    if (recoveryTimer.unref) { recoveryTimer.unref(); }
+  }
+
+  return {
+    start, disable, onUnexpectedExit,
+    gateNextStart: () => {
+      let release;
+      const promise = new Promise((r) => { release = r; });
+      pendingGate = { promise };
+      return release;
+    },
+    state: () => ({ running, sidecarAlive, joined, starts, configEnabled }),
+  };
+}
+
+test('NEGATIVE CONTROL: an ungated re-arm resurrects a stack the operator disabled', async () => {
+  const stack = makeUngatedRecoveryStack();
+  await stack.start();
+  const release = stack.gateNextStart();
+  stack.onUnexpectedExit();
+  await settle(40);
+  assert.equal(stack.state().starts, 2, 'the replay attempt must be in flight before the disable');
+
+  await stack.disable();
+  release();
+  await settle(400);
+
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, true,
+    'ungated: the failed attempt re-armed and the next rung brought it back — config off, stack on');
+  assert.equal(s.configEnabled, false, 'while the operator-facing flag still says disabled');
 });


### PR DESCRIPTION
Hardens the recovery ladder merged in #880, closing the race noted in [its pre-merge review](https://github.com/IrosTheBeggar/mStream/pull/880#issuecomment-5399205924).

## The race

A disable landing while a recovery replay attempt is **already in flight** could resurrect the sidecar:

1. Sidecar crashes → recovery timer fires → `startDiscoveryP2pStack()` is mid-start.
2. Operator disables the feature → `stopDiscoveryP2pStack()` runs `cancelRecovery()` — but the timer already fired, so there is nothing to cancel — and tears the stack down.
3. The in-flight attempt fails against the teardown → its `.catch` restores `running = true` and re-arms the ladder.
4. The next rung fires → full stack replay → **sidecar running, config saying disabled.**

## The fix

Gate both the timer body and the re-arm path on `config.program.discoveryP2p.enabled === true` — the operator's own flag, which recovery must never outvote. The gate is race-free because both disable paths write the flag (persisted **and** live in `config.program`, `util/admin.js:editDiscoveryP2pEnabled`) *before* they touch the stack:

- the admin disable route (`api/admin.js`): `editDiscoveryP2pEnabled(false)` → `stopDiscoveryP2pStack()`
- the enable-failure rollback: same order

A reboot's teardown (`server.js`) leaves the flag `true`, so a recovery attempt racing the boot start there still converges through the existing `starting`/`stopping` single-flight guards — reboot semantics unchanged.

## Tests

- New unit test models the **in-flight** flavor with a deterministic one-shot start gate (`gateNextStart()`) — the existing deliberate-stop test only covers a stop landing *before* the timer fires.
- New negative control reproduces the ungated re-arm verbatim in shape and demonstrates the resurrection: `sidecarAlive: true` with `configEnabled: false`.
- Local runs: crash-recovery unit suite 10/10; `discovery-p2p-stack-race` 4/4; discovery p2p integration suites (real sidecar) pass.
- Lint: 0 errors; +1 `require-await` warning on a model function, the same accepted idiom as the sibling suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)