### PR TITLE
fix(update): status file must not lag the API — write before the prune sweep, poll it in the test

### DIFF
--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -443,12 +443,19 @@ export function stageNow(manifest = null) {
       state.stagedVersion = landed;
       state.error = null;
       winston.info(`[update] mStream ${landed} is staged - it takes over on the next restart`);
-      await pruneOldVersions(m.root);
       // A skip that landed WHILE this stage was downloading was a no-op in
       // enforceSkip (nothing was staged yet) — honor it now, before the
       // status file advertises the held-back version as armed.
       await enforceSkip();
+      // Persist BEFORE the prune sweep. The API above already serves
+      // staged:true the moment the state flips, and the launcher-facing
+      // status file must not lag it by a whole disk pass — a loaded CI
+      // runner read the stale file in exactly that window (full-ci
+      // macos shard, PR #881). Pruning also benefits from running after
+      // enforceSkip settled `current`: its protect set is computed from
+      // the link's final target.
       await writeStatus();
+      await pruneOldVersions(m.root);
       maybeAutoApply();
     })
     .catch(async (err) => {

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -147,10 +147,25 @@ test('managed round-trip: check, auto-stage, current flip, tamper refusal, live 
     assert.equal(path.basename(target), `mStream-9.9.9-${hostKey()}`);
 
     // The status file the launcher reads, in the redirected data home.
+    // POLLED, not read once: the API state and the on-disk file are two
+    // writes, and even with the server persisting immediately after the
+    // flip, asserting on a single read races the fsync on a loaded
+    // runner (this exact assert flaked on a full-ci macos shard).
     const statusPath = process.platform === 'darwin'
       ? path.join(tmpHome, 'Library', 'Application Support', 'mStream', 'update-status.json')
       : path.join(tmpHome, '.local', 'share', 'mstream', 'update-status.json');
-    const onDisk = JSON.parse(await fs.readFile(statusPath, 'utf8'));
+    const onDisk = await (async () => {
+      const start = Date.now();
+      let last = null;
+      while (Date.now() - start < 10_000) {
+        try {
+          last = JSON.parse(await fs.readFile(statusPath, 'utf8'));
+          if (last.staged === true) { return last; }
+        } catch { /* not written yet */ }
+        await sleep(100);
+      }
+      throw new Error(`status file never reported staged:true; last: ${JSON.stringify(last)}`);
+    })();
     assert.equal(onDisk.staged, true);
     assert.equal(onDisk.stagedVersion, '9.9.9');
 


### PR DESCRIPTION
Fixes the CI flake that hit PR #881's full-ci run ([macos-latest · 3/3](https://github.com/IrosTheBeggar/mStream/actions/runs/32767808863/job/97561148589)): `managed round-trip` asserted `update-status.json` said `staged:true` on a single read taken right after the API reported it — and the server only wrote the file after `pruneOldVersions()`, a whole disk pass later. On a loaded runner the read landed inside that gap.

**Server side (the real contract gap):** the launcher-facing status file lagged the API by the prune sweep. Reordered — `enforceSkip()` first (preserving the existing rule: never advertise a held-back version), then `writeStatus()`, then the prune. No double write; the file now lags the in-memory flip only by enforceSkip's usually-instant no-op check. Side benefit: prune's protect set is now computed from `current` *after* any skip rollback settled the link. The inno/pkg path (`stageInstaller`) already writes in its `finally` immediately after its flip; the failure/downloading paths were already immediate — no changes needed there.

**Test side (the belt):** the file assertion now polls for `staged:true` (10s ceiling) instead of assuming one read after the API poll observes the write — even an immediate server-side write is a separate fsync.

Verified: `update-check.test.mjs` 2/2, five consecutive runs green on darwin (the platform that flaked); eslint clean.

Not caused by #881 — the update-check code was last touched 2026-08-20 and the prior green full-ci runs already contained it; the race just needed a slow enough runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)