### PR TITLE
chore(discovery): pin p2p-sidecar v1.0.2 — the iroh-gossip connection-leak fix

### DIFF
--- a/bin/p2p-sidecar/manifest-musl.json
+++ b/bin/p2p-sidecar/manifest-musl.json
@@ -2,24 +2,24 @@
   "family": "p2p-sidecar",
   "schema": 2,
   "repo": "IrosTheBeggar/mstream-p2p-sidecar",
-  "tag": "v1.0.1",
-  "builtFrom": "6503af188c42add3663e72456cd278ed9830437b",
-  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/32279710667",
+  "tag": "v1.0.2",
+  "builtFrom": "a5cf970ad434d443fec8b2c3d48343eb9b6c424b",
+  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/32772968454",
   "assets": {
     "p2p-sidecar-linux-x64-musl": {
       "file": "p2p-sidecar-linux-x64-musl",
-      "sha256": "abd0d899c69bbe6c89e7695871412ef652c39c0a7361f560c457e998ccd8b2cd",
-      "size": 8631136
+      "sha256": "05bca884aeb74d13b27a70540097c21fb634ec3b76e8cfd8fd3b0e194e96ce3b",
+      "size": 8635232
     },
     "p2p-sidecar-linux-arm64-musl": {
       "file": "p2p-sidecar-linux-arm64-musl",
-      "sha256": "c4021fefc6da3fb32d86fd8d1735a3f9164d1a06c48d897c7bef5182424361cb",
-      "size": 7258304
+      "sha256": "639821c52b420385c32da19885fa478c10a5afebb600308ce92e36b99c190da9",
+      "size": 7274696
     },
     "p2p-sidecar-linux-arm-musl": {
       "file": "p2p-sidecar-linux-arm-musl",
-      "sha256": "8f52c35b9fc6e141be5fd30ffd429ef5006baf757d3691a61d57ea9f4eccc13b",
-      "size": 7230820
+      "sha256": "488cac16a55a4d7960193b6eacfbd79adcae43059323bd58553bcfe095d90c0c",
+      "size": 7226724
     }
   }
 }

--- a/bin/p2p-sidecar/manifest.json
+++ b/bin/p2p-sidecar/manifest.json
@@ -2,39 +2,39 @@
   "family": "p2p-sidecar",
   "schema": 2,
   "repo": "IrosTheBeggar/mstream-p2p-sidecar",
-  "tag": "v1.0.1",
-  "builtFrom": "6503af188c42add3663e72456cd278ed9830437b",
-  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/32279710706",
+  "tag": "v1.0.2",
+  "builtFrom": "a5cf970ad434d443fec8b2c3d48343eb9b6c424b",
+  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/32772968463",
   "assets": {
     "p2p-sidecar-win32-x64.exe": {
       "file": "p2p-sidecar-win32-x64.exe",
-      "sha256": "ed5652eedcdaa6f41045fbb461cdc9dcaf0e2f0c082d5364daff081e2bcc09cf",
-      "size": 7008768
+      "sha256": "555505d5bbbb62be74261c9b0c6c0bb668aae1892f5261c87bc00a16d91c742c",
+      "size": 7019520
     },
     "p2p-sidecar-darwin-x64": {
       "file": "p2p-sidecar-darwin-x64",
-      "sha256": "5897b7bcec43b52286ea3d45e2950f3f4eef71d70dc38d14938684e6804bc77a",
-      "size": 7341804
+      "sha256": "85ee86ba832b2cee1b1cca1743149aad144faa0dc6d5bcab8a830efdc6475313",
+      "size": 7354552
     },
     "p2p-sidecar-darwin-arm64": {
       "file": "p2p-sidecar-darwin-arm64",
-      "sha256": "825792d6c26c496bb41f03a86ac791c6a2c8f7521e6f66bfec16825cd7005afe",
-      "size": 6262960
+      "sha256": "de9565677a4ad8c5247a52f6855aed36f20dfdf308a0d3c9b791f256eebef513",
+      "size": 6262992
     },
     "p2p-sidecar-linux-x64": {
       "file": "p2p-sidecar-linux-x64",
-      "sha256": "93e6eddb12333b6b7bf88f8020e71fa2cd7bdd6e667a0d29b5755df91788dfb6",
-      "size": 8508224
+      "sha256": "62fa038f28fca8d3d58a4bffec70317b39682a03e3b63583d8e82ad73ef92841",
+      "size": 8527120
     },
     "p2p-sidecar-linux-arm64": {
       "file": "p2p-sidecar-linux-arm64",
-      "sha256": "5c122b99965256fabb3c06761ac24239058ebcec1c8b6a9bda834a56e50b7c44",
-      "size": 7492520
+      "sha256": "c5131612be86958d2182f94f9e847bae12decaf9205a98bc8b16f5c4c1abc9a9",
+      "size": 7513008
     },
     "p2p-sidecar-linux-arm": {
       "file": "p2p-sidecar-linux-arm",
-      "sha256": "6791ef8e1d2bcc6c64434f17818f4d25a383d6a5351170cb2509a7a1b16ca6ff",
-      "size": 7288664
+      "sha256": "af60c634e6b63dc3f5428048ee844fde061b985c88ea41ee8dabbed06cb519b9",
+      "size": 7292768
     }
   }
 }


### PR DESCRIPTION
The manifest half of the leak fix — merging this is what rolls the fleet. Managed installs refresh their sha256-pinned binary on the next discovery start (including PR #880's recovery restarts); operator prebuilts and dev builds stay untouched.

## What v1.0.2 carries ([release](https://github.com/IrosTheBeggar/mstream-p2p-sidecar/releases/tag/v1.0.2), builtFrom `a5cf970`)

1. **iroh-gossip from the [leakfix fork](https://github.com/IrosTheBeggar/iroh-gossip)**, tag `v0.101.0-leakfix.1` = upstream v0.101.0 + [upstream PR #154](https://github.com/n0-computer/iroh-gossip/pull/154) (open, unmerged). Without it, every superseded or dropped peer link between two live processes leaks a kept-alive QUIC connection (~110 KB, ≈ one per hyparview shuffle interval per node) — the ~102-hour OOM fuse diagnosed in [#880's investigation](https://github.com/IrosTheBeggar/mStream/pull/880#issuecomment-5399205924). Exact-pin philosophy unchanged: a tag, never a branch; re-pin to crates.io when upstream ships the fix.
2. **`last_accepted` flood-guard bound**: TTL sweep + hard cap on the per-origin map that previously grew forever (identities are free to mint). Safe because rollback protection is Node-side — discovery-catalog keeps the highest snapshotSeq per origin.

## Verification ladder

- Fork tree byte-identical to the A/B-validated patch; crate suite 25/25 (incl. PR #154's regression test) re-run in the fork checkout before tagging.
- Sidecar v1.0.2: cargo tests 14+1 (3 new sweep tests); mStream discovery p2p integration **65/65** (incl. #880's crash-recovery suite) against a local build of the same commit.
- Both release workflows green; fragments spot-checked (family/schema/tag, 6 glibc/darwin/win + 3 musl assets, `linux-x64-musl` — the affected production platform — included).
- Draft-release binary downloaded, sha256 + size verified against the fragment, executed on darwin-arm64; release then published.
- `scripts/fetch-p2p-sidecar.mjs` run against **these exact manifests**: download → checksum verify → exec, green.

Post-deploy check for the affected server: sidecar RSS should hold flat at ~20–30 MB instead of climbing ~2–3 MB/h toward a ~4¼-day OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)