### PR TITLE
feat(discovery): sidecar memory watchdog — planned restart before the OOM killer chooses a victim

### DIFF
--- a/src/state/config.js
+++ b/src/state/config.js
@@ -471,6 +471,17 @@ const discoveryP2pOptions = Joi.object({
   autoFetch: Joi.boolean().default(true),
   autoFetchCount: Joi.number().integer().min(0).max(50).default(6),
   maxPeerDbStorageMb: Joi.number().integer().min(10).max(100000).default(500),
+  // Sidecar memory watchdog: when the p2p-sidecar's resident set exceeds
+  // this many MB, the mesh-health watch kills it and lets crash recovery
+  // replay the stack — a planned ~6s blip with a loud log line, instead of
+  // the container's OOM killer choosing a victim hours later (the #880
+  // outage: a leaking sidecar quietly out-grew the entire server on a
+  // ~102-hour fuse). A healthy sidecar sits at 20–30MB, so the default is
+  // ~10x headroom. 0 disables the watchdog (rotationDays' 0=off
+  // convention). Deliberately no minimum above that: tests force a breach
+  // by setting it to 1, and an operator picking a too-small ceiling gets a
+  // visible restart-per-watch-tick, not a silent failure.
+  sidecarMaxRssMb: Joi.number().integer().min(0).max(100000).default(256),
   // Rotation: once a full shelf's snapshot has been held this many days,
   // the hourly pass may SWAP it (never just drop it) for a catalog peer we
   // don't hold yet, so network suggestions cycle instead of freezing on

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -27,7 +27,7 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 import { EventEmitter } from 'events';
-import { spawn } from 'child_process';
+import { spawn, execFile } from 'child_process';
 import winston from 'winston';
 import { appRoot } from '../util/esm-helpers.js';
 import * as sidecarBootstrap from '../util/p2p-sidecar-bootstrap.js';
@@ -129,6 +129,50 @@ export function getEndpointId() { return endpointId; }
 // The sidecar's own endpoint ticket — what another operator pastes into
 // their bootstrapPeers to befriend this server.
 export function getEndpointTicket() { return endpointTicket; }
+
+export function getPid() { return proc ? proc.pid : null; }
+
+// Resident-set size of the live sidecar in MB, or null when it can't be
+// read (no child, unsupported platform, a race with an exit). Linux reads
+// /proc/<pid>/status VmRSS — reported in kB, so no page-size dependence;
+// darwin shells out to ps (dev machines). Best-effort by design: the
+// watchdog stands down on null rather than guessing.
+export async function sidecarRssMb() {
+  if (!proc || !proc.pid) { return null; }
+  const pid = proc.pid;
+  try {
+    if (process.platform === 'linux') {
+      const status = await fs.promises.readFile(`/proc/${pid}/status`, 'utf8');
+      const m = status.match(/^VmRSS:\s+(\d+)\s+kB/m);
+      return m ? Number(m[1]) / 1024 : null;
+    }
+    if (process.platform === 'darwin') {
+      const kb = await new Promise((resolve) => {
+        execFile('ps', ['-o', 'rss=', '-p', String(pid)], (err, stdout) => {
+          resolve(err ? null : Number(String(stdout).trim()));
+        });
+      });
+      return Number.isFinite(kb) && kb > 0 ? kb / 1024 : null;
+    }
+  } catch (_err) { /* fall through to null */ }
+  return null;
+}
+
+// Watchdog kill: end the child WITHOUT bumping the stop generation, so the
+// exit classifies as unexpected and the stack's crash recovery replays
+// everything — subscribe, spawn, join, announce, holds — on its tested
+// ladder. SIGKILL rather than the graceful shutdown RPC, on purpose: the
+// watchdog fires precisely when the process is unhealthy (bloated, or
+// wedged enough that an RPC may never be answered), and nothing durable
+// depends on the polite goodbye — the identity key and the blob store live
+// on disk, and the store is transactional. The caller logs the why; this
+// logs nothing so the exit handler's warn stays the single source of truth
+// about the death itself.
+export function killSidecarForRestart() {
+  if (!proc) { return false; }
+  try { proc.kill('SIGKILL'); } catch (_err) { return false; }
+  return true;
+}
 
 // Acquire a binary to spawn. A dev build or an operator-placed prebuilt wins
 // untouched; otherwise the bootstrap fetches (or refreshes) the managed

--- a/src/state/discovery-seeds.js
+++ b/src/state/discovery-seeds.js
@@ -88,8 +88,20 @@ const MAX_SEEDS = 20;            // sanity cap on a fetched list
 const MAX_TICKET_LEN = 4096;
 // Mesh-health watch: if we're joined but have heard nobody for this long,
 // re-resolve (fresh remote fetch) and re-join — covers seed rotation that
-// happened after this release shipped.
-const HEALTH_INTERVAL_MS = 5 * 60 * 1000;
+// happened after this release shipped. The same tick carries the sidecar
+// memory watchdog below. Env override mirrors MSTREAM_TEST_DISCOVERY_ROTATE_MS.
+const HEALTH_INTERVAL_MS =
+  Number(process.env.MSTREAM_TEST_DISCOVERY_HEALTH_MS) || 5 * 60 * 1000;
+
+// Sidecar memory watchdog state, surfaced for the p2p status route. The
+// counter is per-process (not persisted): it exists so a RECURRING breach
+// reads as a pattern in the admin panel instead of a mystery of repeating
+// one-off log lines.
+let watchdogRestarts = 0;
+let lastSidecarRssMb = null;
+export function getWatchdogState() {
+  return { restarts: watchdogRestarts, lastRssMb: lastSidecarRssMb };
+}
 
 function cachePath() {
   return path.join(config.program.storage.dbDirectory, 'discovery-p2p', 'seeds-cache.json');
@@ -220,6 +232,27 @@ export function startMeshHealthWatch() {
   watchTimer = setInterval(async () => {
     try {
       if (!discoveryP2p.isRunning()) { return; }
+      // Memory watchdog FIRST — it must run on every tick, and the mesh
+      // checks below early-return on a healthy mesh (a mesh-healthy sidecar
+      // can still be a bloating one; that combination was exactly the #880
+      // outage's first 102 hours). On breach: kill and stand back — the
+      // exit classifies as unexpected, crash recovery replays the whole
+      // stack, and this watch's next ticks see a fresh sidecar. Ceiling 0
+      // disables. A null reading (unsupported platform, exit race) stands
+      // down rather than guessing.
+      const ceiling = config.program.discoveryP2p.sidecarMaxRssMb;
+      if (ceiling > 0) {
+        const rss = await discoveryP2p.sidecarRssMb();
+        lastSidecarRssMb = rss;
+        if (rss !== null && rss > ceiling) {
+          watchdogRestarts += 1;
+          winston.warn(`[discovery-seeds] sidecar RSS ${Math.round(rss)}MB exceeds the `
+            + `${ceiling}MB ceiling (discoveryP2p.sidecarMaxRssMb) — killing it so crash `
+            + `recovery replays the stack (watchdog restart #${watchdogRestarts})`);
+          discoveryP2p.killSidecarForRestart();
+          return;
+        }
+      }
       const s = await discoveryP2p.status();
       if (s.joined && s.neighbors > 0) { return; }
       const bootstrap = await resolveBootstrap({ forceRefresh: true });

--- a/test/integration/discovery-p2p-watchdog.test.mjs
+++ b/test/integration/discovery-p2p-watchdog.test.mjs
@@ -1,0 +1,160 @@
+/**
+ * The sidecar memory watchdog, end to end against a real binary.
+ *
+ * WHY IT EXISTS. The #880 outage's root cause was a sidecar whose RSS
+ * climbed ~2-3MB/h (a connection leak in iroh-gossip) until, at ~102 hours
+ * of uptime, it out-grew the entire Node server and the container's OOM
+ * killer SIGKILLed it. The leak itself is fixed in sidecar v1.0.2, but the
+ * CLASS must never reach an outage again: whatever leaks next — an upstream
+ * regression, a different crate — the watchdog converts it into a planned
+ * restart with a loud log line, long before the kernel starts choosing
+ * victims. It also protects the SERVER: on a host with a big library, Node
+ * out-weighs the sidecar and the next OOM kill would take the whole thing.
+ *
+ * MECHANISM UNDER TEST. The mesh-health watch reads the sidecar's RSS each
+ * tick and, over the discoveryP2p.sidecarMaxRssMb ceiling, kills the child
+ * WITHOUT bumping the stop generation — so the exit classifies as
+ * unexpected and #880's crash recovery replays the whole stack (spawn,
+ * join, announce). The suite forces a breach by setting the ceiling to 1MB
+ * (any real sidecar is ~20MB), which also means the watchdog keeps firing
+ * on every later tick — assertions poll for the up-windows in that cycle
+ * rather than assuming a settled end state.
+ *
+ * Needs a real sidecar binary and a POSIX ps, like the crash-recovery
+ * suite; skips in CI where neither exists.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { startServer } from '../helpers/server.mjs';
+import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
+
+const SIDECAR_BIN = resolveSidecarBinary();
+const SKIP = process.platform === 'win32'
+  ? 'needs a POSIX ps to observe the sidecar grandchild'
+  : (SIDECAR_BIN ? false : 'no p2p-sidecar binary on this machine');
+
+function sidecarPids(dataDir) {
+  const out = execFileSync('ps', ['-axo', 'pid=,args='], { encoding: 'utf8' });
+  return out.split('\n')
+    .filter((line) => line.includes('p2p-sidecar') && line.includes(dataDir))
+    .map((line) => Number(line.trim().split(/\s+/)[0]))
+    .filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+async function pollUntil(fn, { timeoutMs = 60000, everyMs = 200, what = 'condition' } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn();
+    if (value) { return value; }
+    if (Date.now() > deadline) { throw new Error(`timed out waiting for ${what}`); }
+    await new Promise((r) => setTimeout(r, everyMs));
+  }
+}
+
+describe('discovery p2p watchdog: an over-ceiling sidecar is restarted through crash recovery', { skip: SKIP }, () => {
+  let server;
+  let statusOf;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: false,
+      // Ceiling of 1MB: every real sidecar breaches on the first watch tick.
+      // The 4s tick (vs 5min in production) keeps the whole cycle inside the
+      // test budget while leaving a wide-enough up-window between recovery
+      // completing (~5.5s after a kill) and the next tick to observe it.
+      extraConfig: {
+        discoveryP2p: { enabled: true, useCommunitySeeds: false, sidecarMaxRssMb: 1 },
+      },
+      env: { MSTREAM_TEST_DISCOVERY_HEALTH_MS: '4000' },
+    });
+    statusOf = async () =>
+      (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+  });
+
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('breach → watchdog kill → recovery replays the stack, identity kept', async () => {
+    const dataDir = path.join(server.tmpDir, 'db', 'discovery-p2p');
+
+    const healthy = await pollUntil(
+      async () => { const s = await statusOf(); return s.running && s.joined ? s : null; },
+      { what: 'the boot stack to come up' },
+    );
+    const [bootPid] = sidecarPids(dataDir);
+    assert.ok(bootPid, 'a sidecar should be running after boot');
+
+    // The first watch tick (≤4s) reads RSS ≈20MB against the 1MB ceiling and
+    // kills the child; the server notices before recovery replays.
+    await pollUntil(
+      async () => (await statusOf()).running === false,
+      { timeoutMs: 15000, what: 'the watchdog to kill the over-ceiling sidecar' },
+    );
+
+    // Crash recovery must bring back a NEW process, joined, same identity —
+    // the whole #880 contract, triggered by the watchdog instead of an OOM.
+    const recovered = await pollUntil(async () => {
+      const s = await statusOf();
+      if (!s.running || !s.joined) { return null; }
+      const pids = sidecarPids(dataDir);
+      return pids.length === 1 && pids[0] !== bootPid ? { s, pid: pids[0] } : null;
+    }, { what: 'recovery to replay the stack with a fresh sidecar' });
+
+    assert.equal(recovered.s.endpointId, healthy.endpointId,
+      'a watchdog restart must keep the persisted endpoint identity');
+  });
+
+  test('the cycle repeats without orphan accumulation', async () => {
+    const dataDir = path.join(server.tmpDir, 'db', 'discovery-p2p');
+    // With the ceiling still at 1MB the kill/recover loop is ongoing. Sample
+    // through one more full cycle: never more than one sidecar process, and
+    // the server itself stays healthy throughout.
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline) {
+      assert.ok(sidecarPids(dataDir).length <= 1, 'never more than one sidecar, even mid-cycle');
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    const ping = await fetch(`${server.baseUrl}/api/v1/ping`);
+    assert.equal(ping.status, 200, 'the music server must ride through watchdog cycles untouched');
+  });
+});
+
+describe('discovery p2p watchdog: the default ceiling never fires on a healthy sidecar', { skip: SKIP }, () => {
+  let server;
+  let statusOf;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: false,
+      // Default sidecarMaxRssMb (256MB) — a ~20MB sidecar sits far under it.
+      // A 1s tick packs many watchdog evaluations into the observation window.
+      extraConfig: { discoveryP2p: { enabled: true, useCommunitySeeds: false } },
+      env: { MSTREAM_TEST_DISCOVERY_HEALTH_MS: '1000' },
+    });
+    statusOf = async () =>
+      (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+  });
+
+  after(async () => { if (server) { await server.stop(); } });
+
+  test('no false positives: pid stable across many watch ticks', async () => {
+    const dataDir = path.join(server.tmpDir, 'db', 'discovery-p2p');
+    await pollUntil(
+      async () => { const s = await statusOf(); return s.running && s.joined ? s : null; },
+      { what: 'the boot stack to come up' },
+    );
+    const [pid] = sidecarPids(dataDir);
+    assert.ok(pid, 'a sidecar should be running');
+
+    await new Promise((r) => setTimeout(r, 5000)); // ~5 watchdog evaluations
+    const s = await statusOf();
+    assert.equal(s.running, true, 'still running');
+    assert.equal(s.joined, true, 'still joined');
+    const pids = sidecarPids(dataDir);
+    assert.deepEqual(pids, [pid], 'same single sidecar process — the watchdog never fired');
+  });
+});


### PR DESCRIPTION
Phase 2 (part A) of the #880 follow-up plan: whatever leaks next — an upstream regression, a different crate — must become a planned ~6s restart with a loud log line, never another 4¼-day fuse ending in the kernel picking a victim. On hosts with big libraries Node out-weighs the sidecar, so the next container OOM would take the **server**, not the sidecar.

## Mechanism

- The existing 5-minute mesh-health watch reads the sidecar's RSS each tick (Linux `/proc/<pid>/status` VmRSS — kB, no page-size dependence; darwin `ps` fallback; other platforms stand down on null rather than guess). It runs **before** the mesh-health early-return: a mesh-healthy sidecar can still be a bloating one — that combination was the outage's first 102 hours.
- Over the ceiling — `discoveryP2p.sidecarMaxRssMb`, default 256MB (≈10× the healthy 20–30MB baseline), `0` = off — it warns with the measured number and kills the child **without bumping the stop generation**, so the exit classifies as unexpected and #880's crash-recovery ladder replays the whole stack. No new restart orchestration: the watchdog reuses the battle-tested path, config gate (#881) included.
- Deliberately SIGKILL, not the graceful shutdown RPC: the watchdog fires precisely when the process is unhealthy enough that an RPC may never be answered; identity and blob store are on disk and transactional.
- Restart count + last RSS reading are kept for the status route / admin panel (Phase 2 part B) via `getWatchdogState()`.

## Tests

New real-binary integration suite (`discovery-p2p-watchdog.test.mjs`, hermetic, skips in CI like its siblings):
- ceiling forced to 1MB → watchdog kills, recovery replays with a fresh pid and the **persisted identity kept**;
- the kill/recover cycle repeats without orphan accumulation and the music server rides through untouched;
- default ceiling → pid stable across many accelerated ticks (no false positives).

`HEALTH_INTERVAL_MS` gains the same `MSTREAM_TEST_*` env override pattern the rotate interval already has.

Local verification: new suite 3/3 · discovery p2p integration 65/65 · unit 544/544 · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)