### PR TITLE
feat(discovery): surface watchdog + recovery state — a dead sidecar must not render as 'searching for peers'

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -18,6 +18,8 @@ import { EMBEDDING_MODELS } from '../db/discovery-features-lib.js';
 import * as discoveryP2p from '../state/discovery-p2p.js';
 import * as sidecarBootstrap from '../util/p2p-sidecar-bootstrap.js';
 import * as discoveryCatalog from '../state/discovery-catalog.js';
+import * as discoverySeeds from '../state/discovery-seeds.js';
+import * as discoveryStack from '../state/discovery-p2p-stack.js';
 import * as discoveryPeerDbs from '../state/discovery-peer-dbs.js';
 import * as logger from '../logger.js';
 import { joiValidate } from '../util/validation.js';
@@ -568,6 +570,19 @@ export function setup(mstream) {
       ticket: discoveryP2p.getEndpointTicket(),
       joined,
       neighbors,
+      // Sidecar memory + watchdog posture (#885): lastRssMb is the
+      // mesh-health watch's most recent reading (null before the first
+      // tick or where RSS can't be read), restarts counts watchdog kills
+      // this process lifetime, maxRssMb echoes the ceiling (0 = off).
+      watchdog: {
+        ...discoverySeeds.getWatchdogState(),
+        maxRssMb: config.program.discoveryP2p.sidecarMaxRssMb,
+      },
+      // Crash-recovery posture: attempts > 0 = recovery owns the sidecar
+      // right now (it zeroes on success/stop); retryPending = a ladder
+      // timer is armed. Lets the panel say "reconnecting, attempt N"
+      // instead of rendering a dead sidecar as "searching for peers".
+      recovery: discoveryStack.getRecoveryState(),
       knownPeers: discoveryCatalog.size(),
       communitySeeds: config.program.discoveryP2p.useCommunitySeeds,
       serverName: config.program.discoveryP2p.serverName,

--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -19,6 +19,14 @@ let stopping = null;
 
 export function isStackRunning() { return running; }
 
+// Crash-recovery state for the status route / admin panel. `attempts` spans
+// crash -> recovered (cancelRecovery zeroes it on success, stop, or
+// disable), so attempts > 0 reads as "recovery owns the sidecar right now";
+// retryPending narrows that to "a timer is armed" (false mid-attempt).
+export function getRecoveryState() {
+  return { attempts: recoveryAttempts, retryPending: recoveryTimer !== null };
+}
+
 // Recovery backoff after an unexpected sidecar death. Short first — the
 // common cause is a one-off OOM kill, and seconds off the mesh cost nothing
 // — then widening, so a sidecar that CANNOT stay up (bad binary, wedged data

--- a/test/integration/discovery-p2p-watchdog.test.mjs
+++ b/test/integration/discovery-p2p-watchdog.test.mjs
@@ -94,6 +94,14 @@ describe('discovery p2p watchdog: an over-ceiling sidecar is restarted through c
       { timeoutMs: 15000, what: 'the watchdog to kill the over-ceiling sidecar' },
     );
 
+    // While the sidecar is down, the status route must SAY that recovery
+    // owns it — the field the panel renders as "reconnecting, attempt N".
+    await pollUntil(async () => {
+      const st = await statusOf();
+      if (st.running) { return true; } // recovery already won the race — fine
+      return st.recovery && (st.recovery.attempts >= 1 || st.recovery.retryPending) ? true : null;
+    }, { timeoutMs: 10000, what: 'the status route to report recovery in progress' });
+
     // Crash recovery must bring back a NEW process, joined, same identity —
     // the whole #880 contract, triggered by the watchdog instead of an OOM.
     const recovered = await pollUntil(async () => {
@@ -105,6 +113,12 @@ describe('discovery p2p watchdog: an over-ceiling sidecar is restarted through c
 
     assert.equal(recovered.s.endpointId, healthy.endpointId,
       'a watchdog restart must keep the persisted endpoint identity');
+
+    // The breach is a countable event, not just a log line.
+    const st = await statusOf();
+    assert.ok(st.watchdog.restarts >= 1,
+      `the status route must count watchdog restarts (saw ${st.watchdog.restarts})`);
+    assert.equal(st.watchdog.maxRssMb, 1, 'the route echoes the configured ceiling');
   });
 
   test('the cycle repeats without orphan accumulation', async () => {
@@ -156,5 +170,15 @@ describe('discovery p2p watchdog: the default ceiling never fires on a healthy s
     assert.equal(s.joined, true, 'still joined');
     const pids = sidecarPids(dataDir);
     assert.deepEqual(pids, [pid], 'same single sidecar process — the watchdog never fired');
+
+    // Observability contract: a real reading was taken and surfaced (this
+    // doubles as the platform RSS-reader proof — null would mean the reader
+    // stood down), nothing was restarted, and the default ceiling is echoed.
+    assert.ok(typeof s.watchdog.lastRssMb === 'number' && s.watchdog.lastRssMb > 1,
+      `expected a real RSS reading, saw ${JSON.stringify(s.watchdog)}`);
+    assert.equal(s.watchdog.restarts, 0, 'no watchdog restarts on a healthy sidecar');
+    assert.equal(s.watchdog.maxRssMb, 256, 'default ceiling echoed');
+    assert.deepEqual(s.recovery, { attempts: 0, retryPending: false },
+      'recovery idle on a healthy stack');
   });
 });

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -7597,13 +7597,24 @@ const discoveryView = Vue.component('discovery-view', {
                   <p><b>Network:</b>
                     <span v-if="discoveryP2p.status.neighbors > 0" style="color: #2e7d32;">connected
                       — {{ discoveryP2p.status.neighbors }} mesh neighbor{{ discoveryP2p.status.neighbors === 1 ? '' : 's' }}</span>
+                    <span v-else-if="meshRecovering" style="color: #c62828;">reconnecting — the sidecar died and
+                      is being replayed automatically (attempt {{ discoveryP2p.status.recovery.attempts }})</span>
                     <span v-else-if="discoveryP2p.status.joined" style="color: #e65100;">joined, waiting for
                       neighbors — the mesh weaves in within a minute or two of another server coming online</span>
                     <span v-else>not joined yet</span>
                   </p>
+                  <p v-if="discoveryP2p.status.watchdog && discoveryP2p.status.watchdog.lastRssMb !== null"><b>Sidecar memory:</b>
+                    {{ discoveryP2p.status.watchdog.lastRssMb.toFixed(0) }} MB resident<span
+                      v-if="discoveryP2p.status.watchdog.maxRssMb > 0"> — auto-restarts over {{ discoveryP2p.status.watchdog.maxRssMb }} MB</span><span
+                      v-else style="color: #e65100;"> — memory watchdog off</span><span
+                      v-if="discoveryP2p.status.watchdog.restarts > 0" style="color: #e65100;"> ·
+                      {{ discoveryP2p.status.watchdog.restarts }} watchdog restart{{ discoveryP2p.status.watchdog.restarts === 1 ? '' : 's' }} since boot</span>
+                  </p>
                   <div v-if="meshSearching" style="max-width: 480px;">
                     <div class="progress" style="margin: 4px 0 6px 0;"><div class="indeterminate"></div></div>
-                    <span style="color: #757575; font-size: 0.85em;">searching for peers — this page updates itself every few seconds</span>
+                    <span style="color: #757575; font-size: 0.85em;">{{ meshRecovering
+                      ? 'reconnecting — crash recovery replays the stack on a widening ladder; no action needed'
+                      : 'searching for peers — this page updates itself every few seconds' }}</span>
                   </div>
                   <p v-if="discoveryP2p.status.ticket" style="margin-bottom: 4px;"><b>Your ticket</b> — a friend pastes this
                   into the box below on <i>their</i> Discovery page to befriend this server:<br>
@@ -7699,6 +7710,18 @@ const discoveryView = Vue.component('discovery-view', {
       const s = this.discoveryP2p.status;
       return !!(s && s.enabled === true
         && (!s.running || !s.joined || (s.neighbors || 0) === 0));
+    },
+    // Narrower than meshSearching: crash recovery currently owns the
+    // sidecar (#880's replay ladder — attempts zero on success). Rendered
+    // as its own state so a dead sidecar reads "reconnecting, attempt N"
+    // instead of masquerading as the indistinguishable-from-startup
+    // "searching for peers" (the 6h45m outage was invisible for exactly
+    // that reason).
+    meshRecovering: function() {
+      const s = this.discoveryP2p.status;
+      return !!(s && s.enabled === true && s.recovery
+        && (s.recovery.attempts > 0 || s.recovery.retryPending)
+        && (s.neighbors || 0) === 0);
     },
     // Case-insensitive substring match over what the operator can see
     // (name, description) plus the endpoint id for exactness. Preserves


### PR DESCRIPTION
Part B of the Phase-2 observability work (#885 shipped the watchdog; this makes it visible). Closes the follow-up noted in #880's review: the admin panel rendered a crashed sidecar identically to normal startup — *"searching for peers"* over an indeterminate bar, indefinitely — which is exactly why the 6h45m production outage was invisible.

## Status route (`GET /api/v1/admin/discovery/p2p/status`)

Two additive objects:

- `watchdog: { lastRssMb, restarts, maxRssMb }` — the mesh-health watch's most recent RSS reading (null before the first tick / unreadable platform), watchdog kills this process lifetime, and the configured ceiling (0 = off).
- `recovery: { attempts, retryPending }` — from a new `getRecoveryState()` export on the stack. `attempts` spans crash → recovered (zeroing on success/stop/disable), so `attempts > 0` reads as *recovery owns the sidecar right now*; `retryPending` narrows to *a ladder timer is armed*.

## Admin panel

- **Network** line gains a distinct red state: *reconnecting — the sidecar died and is being replayed automatically (attempt N)* — ranked above the joined/not-joined text; the progress-bar caption goes state-aware to match.
- New **Sidecar memory** line: last RSS reading, the auto-restart ceiling (or *memory watchdog off* for 0), and the restart count when nonzero. This is also the post-deploy verification surface for the v1.0.2 leak fix: RSS parked flat at 20–30 MB vs the old 2–3 MB/h climb toward a ~4¼-day OOM.

## Tests

Assertions ride the real-binary watchdog suite: during the breach down-window the route must report recovery-in-progress; after recovery it must count the restart and echo the ceiling; on a healthy sidecar it must surface a real numeric RSS reading (doubling as the platform reader proof) with recovery idle. Suite 3/3 · crash-recovery suite green · unit 544/544 · eslint clean (the one warning is the repo's webapp ignore pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)