### PR TITLE
fix(discovery): rotation stops dialing the dead — fetchability gate + a real backoff cap

### DIFF
--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -438,8 +438,16 @@ export function readEmbeddings(endpointId, modelId) {
 // Exponential per-peer cooldown, reset by any success (including a manual
 // admin fetch, which deliberately bypasses the backoff). In-memory only:
 // a reboot retrying immediately is fine.
+//
+// The cap must sit WELL ABOVE the hourly rotation interval. It used to be
+// exactly 60min — equal to ROTATE_INTERVAL_MS — so a failing peer's backoff
+// had always just expired when the next rotation pass ran: the "backoff"
+// retried every hour forever (333 warns in two weeks on one production
+// server, the noise floor that buried the #880 outage). At 24h, a peer that
+// keeps failing walks the ladder to roughly one attempt a day; any success,
+// or a reboot, starts it fresh.
 const FETCH_BACKOFF_BASE_MS = 2 * 60 * 1000;
-const FETCH_BACKOFF_MAX_MS = 60 * 60 * 1000;
+const FETCH_BACKOFF_MAX_MS = 24 * 60 * 60 * 1000;
 const fetchFailures = new Map(); // endpointId -> { failures, nextTryMs }
 
 function recordFetchFailure(endpointId) {

--- a/src/state/discovery-peer-rotation.js
+++ b/src/state/discovery-peer-rotation.js
@@ -17,6 +17,13 @@
 // (gentle, self-limiting on small catalogs), never touches pinned entries,
 // and prefers to evict what's least useful (long-offline, longest-held) in
 // favor of what's most novel (never held before, model-compatible, online).
+//
+// Novelty never outranks REACHABILITY: a candidate must be fetchable right
+// now — origin online, or a live holds beacon offering its snapshot — or it
+// is not a candidate at all. Without that gate, the never-held-first order
+// kept picking the same two long-offline peers every hour for two weeks on a
+// production server: each pass a guaranteed dead dial and a warn line, noise
+// that ended up masking a real outage (mStream #880).
 
 // A peer is "online" when we heard a re-announcement recently. Announcers
 // re-broadcast every ~15s; 90s tolerates a few missed rounds.
@@ -124,8 +131,15 @@ export function planRotation({
   if (eligible.length === 0) { return null; }
 
   const held = new Set(shelf.map((e) => e.endpointId));
+  // Fetchable = someone can actually serve the snapshot right now: the
+  // origin announced within the online window, or a live (TTL-pruned) holds
+  // beacon lists the hash — the swarm path fetches from any live holder, so
+  // an offline origin with live seeders is still a perfectly good pick.
+  const fetchable = (c) => now - ts(c.updatedAt) < ONLINE_WINDOW_MS
+    || seederCountOf(c.payload.hash || '') > 0;
   const candidates = catalog
-    .filter((c) => !held.has(c.from) && !isBlocked(c.from) && !inBackoff(c.from))
+    .filter((c) => !held.has(c.from) && !isBlocked(c.from) && !inBackoff(c.from)
+      && fetchable(c))
     .sort(rotationCandidateOrder(ledger, localModel, now));
   if (candidates.length === 0) { return null; }
 

--- a/test/unit/discovery-peer-rotation.test.mjs
+++ b/test/unit/discovery-peer-rotation.test.mjs
@@ -12,6 +12,8 @@
  *     prefer entries other seeders still hold
  *   - candidate order: never-held first (ledger), then the shared
  *     usefulness order (model-compatible -> online -> biggest)
+ *   - candidate fetchability: offline origins with no live seeders are not
+ *     candidates at all — novelty never outranks reachability
  *   - capacity: the incoming snapshot must fit AFTER the eviction;
  *     evictFirst signals when it only fits because of it
  */
@@ -204,6 +206,39 @@ describe('planRotation — candidate choice', () => {
         cat('d', { modelId: 'other-model', rowCount: 99999 }),
         cat('e', { modelId: 'model-x', rowCount: 1 }),
       ],
+    }));
+    assert.equal(plan.fetchId, id('e'));
+  });
+});
+
+describe('planRotation — candidate fetchability', () => {
+  test('an offline candidate with no live seeders is not a candidate', () => {
+    assert.equal(planRotation(inputs({
+      catalog: [cat('d', { silentMs: DAY })],
+    })), null, 'a guaranteed-dead dial must not be planned');
+  });
+
+  test('an offline candidate WITH live seeders is fetchable via the swarm', () => {
+    const plan = planRotation(inputs({
+      catalog: [cat('d', { silentMs: DAY })],
+      seederCountOf: (hash) => (hash === id('d') ? 2 : 0),
+    }));
+    assert.equal(plan.fetchId, id('d'),
+      'live holders make an offline origin a perfectly good pick');
+  });
+
+  test('the production pathology: only dead candidates -> no plan, no hourly churn', () => {
+    // Two long-offline peers, no seeders — the exact shape that produced a
+    // guaranteed-failure dial (and a warn line) every hour for two weeks.
+    assert.equal(planRotation(inputs({
+      catalog: [cat('d', { silentMs: 7 * DAY }), cat('e', { silentMs: 30 * DAY })],
+    })), null);
+  });
+
+  test('novelty no longer outranks reachability: a dead never-held loses to a live past-evictee', () => {
+    const plan = planRotation(inputs({
+      catalog: [cat('d', { silentMs: DAY }), cat('e')], // d never held but dead; e alive
+      ledger: { [id('e')]: iso(2 * DAY) },              // e was rotated out recently
     }));
     assert.equal(plan.fetchId, id('e'));
   });


### PR DESCRIPTION
Phase 3 item 1 from the #880 follow-up plan: the hourly rotation churn — 333 warnings in two weeks, the noise floor that made a 6h45m outage look like business as usual. Two defects, both diagnosed during the investigation:

## 1. Novelty outranked reachability

`rotationCandidateOrder` puts never-held / longest-evicted candidates first and only tiebreaks on online-ness — so the same two long-offline peers were picked alternately every hour, each pass a guaranteed `cannot reach the blob's origin` dial. `planRotation` now gates candidates on **fetchability**: origin announced within the online window, **or** a live (TTL-pruned) holds beacon lists the snapshot — the existing swarm fetch serves from any live holder, so an offline origin with live seeders stays a valid pick. When only dead candidates remain, there is **no plan at all**: zero churn, zero warns — the production scenario goes silent for the right reason.

## 2. The backoff cap equaled the rotation interval

`FETCH_BACKOFF_MAX_MS` was exactly 60 min against the hourly `ROTATE_INTERVAL_MS`, so a failing peer's backoff had *always just expired* by the next pass — an exponential ladder that retried hourly forever. Raised to 24 h: a fetchable-but-broken peer (invalid snapshot, flaky holder) decays to ~one attempt a day; any success or a reboot resets it.

## Tests

Four new cases in the pure-policy suite, following its negative-control convention — **3 fail against the ungated policy (27/30), all pass with it (30/30)**: offline + no seeders → not a candidate; offline + live seeders → fetchable via swarm; only-dead-candidates → no plan (the production replay); dead never-held loses to a live past-evictee.

Sweep: unit 548/548 · discovery p2p integration suites (real sidecar) green · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)