### PR TITLE
fix(server): routine rejections are not server errors — honest severity in the terminal error handler

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -57,7 +57,7 @@ import * as lyricsLrclib from './api/lyrics-cache.js';
 import * as backupApi from './api/backup.js';
 import * as backupManager from './backup/manager.js';
 // Velvet UI modules — dynamically imported only when ui='velvet' is active
-import WebError from './util/web-error.js';
+import { classifyError } from './util/web-error.js';
 import { isAdminAllowed } from './util/admin-network.js';
 import { writeJsonAtomic, completedWrites } from './util/atomic-json.js';
 import * as updateCheck from './util/update-check.js';
@@ -684,21 +684,37 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     return handler(req, res, next);
   });
 
-  // error handling
+  // Error handling — the terminal translator from thrown errors to HTTP
+  // responses, and the last place log severity gets decided (the policy
+  // itself is classifyError in util/web-error.js, unit-pinned). Handled
+  // rejections log as rejections at warn with ip + user-agent, so a
+  // misbehaving client names itself in the log line (attributing the /ping
+  // one took router logs; never again). Error level + a stack are reserved
+  // for what they imply: genuine server failures.
   mstream.use((error, req, res, _next) => {
-    winston.error(`Server error on route ${req.originalUrl}`, { stack: error });
+    const from = `${req.ip} ${String(req.headers['user-agent'] || '-').slice(0, 80)}`;
 
     // Schema validation failures are malformed-request errors: the client
     // sent a body/params we can't accept. That's 400 Bad Request, not 403
     // Forbidden (which means "authenticated but not permitted").
     if (error instanceof Joi.ValidationError) {
+      winston.warn(`Rejected ${req.method} ${req.originalUrl} (${from}) — 400: ${error.message}`);
       return res.status(400).json({ error: error.message });
     }
 
-    if (error instanceof WebError) {
-      return res.status(error.status).json({ error: error.message });
+    const c = classifyError(error);
+    if (c.kind === 'web') {
+      if (c.level === 'error') {
+        winston.error(`Request failed: ${req.method} ${req.originalUrl} (${from}) — ${c.status}: ${error.message}`);
+      } else {
+        winston.warn(`Rejected ${req.method} ${req.originalUrl} (${from}) — ${c.status}: ${error.message}`);
+      }
+      return res.status(c.status).json({ error: error.message });
     }
 
+    // Unchanged wording + stack metadata on purpose: this line now MEANS
+    // something again — anyone grepping for it finds only real crashes.
+    winston.error(`Server error on route ${req.originalUrl}`, { stack: error });
     res.status(500).json({ error: 'Server Error' });
   });
 

--- a/src/util/web-error.js
+++ b/src/util/web-error.js
@@ -19,3 +19,34 @@ class WebError extends Error {
 }
 
 export default WebError;
+
+// How the terminal error handler (src/server.js) treats one error: the HTTP
+// status to answer with, the log level the event deserves, and whether the
+// stack belongs in the log. Pure — this classification IS the severity
+// policy, so it's pinned by unit tests (test/unit/web-error.test.mjs)
+// instead of living implicitly in the handler.
+//
+//   WebError 4xx   a deliberately thrown, handled "no" to the client —
+//                  routine traffic, logged as a rejection (warn). It used to
+//                  be logged as error-level "Server error on route …", which
+//                  manufactured phantom incidents: one credential-less
+//                  client polling /api/v1/ping put ~100 "Server error" lines
+//                  a day into a production log, and any real 500 drowned in
+//                  them (mStream #880's investigation tripped over exactly
+//                  that).
+//   WebError 5xx   server-side trouble the throw site CHOSE — error level,
+//                  but no stack: the message is the story, the trace is
+//                  noise pointing at the throw statement.
+//   anything else  a genuine unhandled crash: error level, stack attached,
+//                  answered as a plain 500.
+export function classifyError(error) {
+  if (error instanceof WebError) {
+    return {
+      kind: 'web',
+      status: error.status,
+      level: error.status >= 500 ? 'error' : 'warn',
+      stack: false,
+    };
+  }
+  return { kind: 'unhandled', status: 500, level: 'error', stack: true };
+}

--- a/test/unit/web-error.test.mjs
+++ b/test/unit/web-error.test.mjs
@@ -26,3 +26,34 @@ test('WebError carries the message and is a real Error', () => {
   assert.equal(e.message, 'boom');
   assert.equal(e.name, 'WebError');
 });
+
+// ── classifyError: the terminal handler's severity policy ────────────────────
+// The contract that keeps routine rejections OUT of error-level logs: a
+// production server once collected ~100 error-level "Server error" lines a
+// day from one credential-less client being correctly told 401, burying the
+// signal a real 500 would need.
+import { classifyError } from '../../src/util/web-error.js';
+
+test('a 4xx WebError is a handled rejection: warn, no stack, its own status', () => {
+  assert.deepEqual(classifyError(new WebError('Authentication Error', 401)),
+    { kind: 'web', status: 401, level: 'warn', stack: false });
+  assert.deepEqual(classifyError(new WebError('nope', 404)),
+    { kind: 'web', status: 404, level: 'warn', stack: false });
+});
+
+test('a 5xx WebError is chosen server trouble: error level, but message-only', () => {
+  assert.deepEqual(classifyError(new WebError('announce failed', 500)),
+    { kind: 'web', status: 500, level: 'error', stack: false });
+  assert.deepEqual(classifyError(new WebError('binary missing', 503)),
+    { kind: 'web', status: 503, level: 'error', stack: false });
+});
+
+test('anything else is an unhandled crash: error level, stack attached, plain 500', () => {
+  for (const e of [new TypeError('x is not a function'), new Error('boom'), 'a thrown string']) {
+    assert.deepEqual(classifyError(e), { kind: 'unhandled', status: 500, level: 'error', stack: true });
+  }
+});
+
+test('the code-less WebError default (400) classifies as a rejection', () => {
+  assert.equal(classifyError(new WebError('bad input')).level, 'warn');
+});


### PR DESCRIPTION
Phase 3 item 2 from the #880 follow-up plan, reframed by investigation: the `/api/v1/ping?__lt=…` noise (~100/day on a production server) was **never a 500**. The auth wall correctly answers 401 — but the terminal error handler logged *every* error it translated, including routine handled rejections, as error-level `Server error on route …` with a stack, before returning the right status. That manufactured a phantom incident, sent the #880 investigation chasing a crash that didn't exist, and would drown any real 500 in 4xx noise.

## The change

Severity policy extracted to a pure, unit-pinned `classifyError` (util/web-error.js); the handler becomes a thin translator:

| error | response | log |
|---|---|---|
| `WebError` 4xx | its status (unchanged) | `warn: Rejected GET /api/v1/ping?… (ip user-agent) — 401: Authentication Error` |
| `WebError` 5xx | its status (unchanged) | error level, message only — the throw site chose the status; the trace is noise |
| `Joi.ValidationError` | 400 (unchanged) | warn, same rejection shape |
| anything else | 500 (unchanged) | **verbatim** old line + stack — `Server error on route` now greps to only real crashes |

Rejection lines carry ip + truncated user-agent so the next confused client names itself (attributing this one took out-of-band knowledge). **Response statuses and bodies are byte-identical on every path** — this PR changes only what the log says.

## Verification

- Live repro of the exact production request, before/after on the same server config: before → `error: Server error on route /api/v1/ping?__lt=…`; after → `warn: Rejected GET /api/v1/ping?__lt=… (127.0.0.1 node) — 401: Authentication Error`, same 401 body.
- `web-error` unit suite 8/8 (4 new classifier contracts).
- **Full test suite: 2375 pass / 0 fail.** The 26 `waveform` cancellations seen mid-run were a stale month-old local `rust-parser` build in the working tree tripping the suite's deliberate generation-drift assertion — removed, suites re-run standalone 26/26. Unrelated to this change.
- eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)