### PR TITLE
feat(discovery): a failed boot start retries on the recovery ladder

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -816,7 +816,17 @@ export async function serveIt(configFile, { relisten = null } = {}) {
           const stack = await import('./state/discovery-p2p-stack.js');
           await stack.startDiscoveryP2pStack();
         } catch (err) {
-          winston.error(`[discovery-p2p] catalog unavailable — feature disabled this boot: ${err.message}`);
+          // Not "disabled this boot" any more: the config says enabled, so
+          // the stack's crash-recovery ladder takes over — 5s/15s/60s/5min,
+          // never giving up, config-gated so a runtime disable still wins.
+          // The likely causes are transient (a flaky first-install sidecar
+          // download, a busy data dir, a slow relay handshake), and the ones
+          // that aren't stay loudly visible: one warn per attempt, and the
+          // admin panel shows "reconnecting" instead of an ambiguous
+          // "not joined yet".
+          winston.error(`[discovery-p2p] catalog unavailable at boot — retrying on the recovery ladder: ${err.message}`);
+          const stack = await import('./state/discovery-p2p-stack.js');
+          stack.armBootRetry('boot start failed');
         }
       })();
     }

--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -93,6 +93,27 @@ function scheduleRecovery(why) {
   if (recoveryTimer.unref) { recoveryTimer.unref(); }
 }
 
+// Boot's catch calls this when the FIRST start of the session failed. The
+// ladder normally arms only after a start has succeeded (`running` = intent
+// was established), which left a transient boot failure — a flaky sidecar
+// download on a fresh install, a briefly wedged data dir, a slow relay
+// handshake past the ready timeout — disabling the feature for the whole
+// session: the last remaining path to "config says enabled, nothing
+// running, nothing retrying" (#880's open item 1). The config IS the
+// operator's intent at boot, so when it says enabled, a failed boot start
+// deserves the same never-give-up walk a crash gets. Setting `running`
+// before scheduling is honest under #881's semantics (running = intent) and
+// lets every existing guard do its job: the config gate vetoes if the
+// operator disables meanwhile, cancelRecovery clears on stop, and the
+// status route reports "reconnecting, attempt N" instead of the ambiguous
+// "not joined yet".
+export function armBootRetry(why) {
+  if (running || starting || stopping) { return; } // a later start beat us — nothing to arm
+  if (config.program.discoveryP2p.enabled !== true) { return; }
+  running = true;
+  scheduleRecovery(why);
+}
+
 export async function startDiscoveryP2pStack() {
   // Serialize behind an in-flight stop. A soft reboot stops the stack and then
   // re-serves, and stopping the sidecar can take up to ~10s (a shutdown RPC

--- a/test/integration/discovery-p2p-boot-retry.test.mjs
+++ b/test/integration/discovery-p2p-boot-retry.test.mjs
@@ -29,7 +29,12 @@ import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
 const SIDECAR_BIN = resolveSidecarBinary();
 const SKIP = process.platform === 'win32'
   ? 'needs POSIX directory permissions to fake the wedged data dir'
-  : (SIDECAR_BIN ? false : 'no p2p-sidecar binary on this machine');
+  : process.getuid?.() === 0
+    // Root writes straight through a 000 directory, so the wedge never
+    // wedges and phase 1 would time out confusingly instead of failing
+    // honestly — common when running the suite inside a container as root.
+    ? 'mode-000 does not block root — run as a regular user'
+    : (SIDECAR_BIN ? false : 'no p2p-sidecar binary on this machine');
 
 async function pollUntil(fn, { timeoutMs = 60000, everyMs = 250, what = 'condition' } = {}) {
   const deadline = Date.now() + timeoutMs;

--- a/test/integration/discovery-p2p-boot-retry.test.mjs
+++ b/test/integration/discovery-p2p-boot-retry.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Boot-start retry, end to end against a real binary: a TRANSIENT failure
+ * during the boot-time stack start must not disable discovery for the whole
+ * session.
+ *
+ * Before this, the recovery ladder armed only after a start had SUCCEEDED —
+ * so a flaky first-install sidecar download or a briefly wedged data dir
+ * left the feature off with the config saying enabled, until a restart or a
+ * manual admin re-enable: the last remaining path to the #880 silent-outage
+ * shape. Now server.js's boot catch arms the same ladder a crash gets
+ * (config-gated per #881, surfaced as "reconnecting" per #886).
+ *
+ * The transient fault here is a data directory the sidecar cannot write
+ * (mode 000): the spawned child dies on the identity file, the boot start
+ * rejects, the ladder arms — and the moment the directory heals, the next
+ * rung brings the stack up joined. Deterministic, hermetic, no download
+ * games. Needs a real sidecar binary and POSIX permissions; skips in CI and
+ * on Windows like its sibling suites.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { startServer } from '../helpers/server.mjs';
+import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
+
+const SIDECAR_BIN = resolveSidecarBinary();
+const SKIP = process.platform === 'win32'
+  ? 'needs POSIX directory permissions to fake the wedged data dir'
+  : (SIDECAR_BIN ? false : 'no p2p-sidecar binary on this machine');
+
+async function pollUntil(fn, { timeoutMs = 60000, everyMs = 250, what = 'condition' } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn();
+    if (value) { return value; }
+    if (Date.now() > deadline) { throw new Error(`timed out waiting for ${what}`); }
+    await new Promise((r) => setTimeout(r, everyMs));
+  }
+}
+
+describe('discovery p2p: a failed boot start retries on the ladder', { skip: SKIP }, () => {
+  let server;
+  let dir;
+  let wedgedDir;
+  let statusOf;
+
+  before(async () => {
+    // Pre-seeded storage (the rotation suite's technique) so the sidecar
+    // data dir exists BEFORE boot — wedged shut. mkdirSync(recursive) on an
+    // existing dir succeeds, so the server's own setup sails past it; the
+    // spawned sidecar then dies on the unwritable identity file.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-boot-retry-'));
+    const stateDir = path.join(dir, 'state');
+    const dbDir = path.join(stateDir, 'db');
+    wedgedDir = path.join(dbDir, 'discovery-p2p');
+    fs.mkdirSync(wedgedDir, { recursive: true });
+    fs.chmodSync(wedgedDir, 0o000);
+
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: false,
+      extraConfig: {
+        storage: {
+          albumArtDirectory: path.join(stateDir, 'image-cache'),
+          dbDirectory: dbDir,
+          logsDirectory: path.join(stateDir, 'logs'),
+          syncConfigDirectory: path.join(stateDir, 'sync'),
+          waveformCacheDirectory: path.join(stateDir, 'waveform-cache'),
+        },
+        discoveryP2p: { enabled: true, useCommunitySeeds: false },
+      },
+    });
+    statusOf = async () =>
+      (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+  });
+
+  after(async () => {
+    if (wedgedDir) { try { fs.chmodSync(wedgedDir, 0o755); } catch { /* healed in-test */ } }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('the failure is armed, visible, and heals the moment the fault clears', async () => {
+    // Phase 1 — the boot start failed and the ladder owns it. The status
+    // route must SAY so (the #886 field the panel renders as
+    // "reconnecting, attempt N"), not the ambiguous nothing of old.
+    const armed = await pollUntil(async () => {
+      const s = await statusOf();
+      return !s.running && s.recovery
+        && (s.recovery.attempts >= 1 || s.recovery.retryPending) ? s : null;
+    }, { timeoutMs: 30000, what: 'the boot failure to arm the recovery ladder' });
+    assert.equal(armed.running, false, 'nothing is running yet — the data dir is wedged');
+
+    // Phase 2 — the transient clears; the next rung must bring the whole
+    // stack up: spawn AND join, identity persisted into the healed dir.
+    fs.chmodSync(wedgedDir, 0o755);
+    const up = await pollUntil(async () => {
+      const s = await statusOf();
+      return s.running && s.joined ? s : null;
+    }, { timeoutMs: 60000, what: 'the ladder to bring the stack up after the dir healed' });
+    assert.ok(up.endpointId, 'a live endpoint identity');
+    assert.ok(fs.existsSync(path.join(wedgedDir, 'identity.key')),
+      'the identity landed in the healed data dir');
+  });
+});

--- a/test/unit/discovery-p2p-crash-recovery.test.mjs
+++ b/test/unit/discovery-p2p-crash-recovery.test.mjs
@@ -97,6 +97,17 @@ function makeFixedStack({ spawnFails = 0 } = {}) {
     scheduleRecovery();
   }
 
+  // What server.js's boot catch calls when the FIRST start of the session
+  // failed: config intent is on, so establish the running intent and walk
+  // the same ladder a crash gets. No-ops when a later start already won or
+  // the operator's flag is off.
+  function armBootRetry() {
+    if (running) { return; }
+    if (!configEnabled) { return; }
+    running = true;
+    scheduleRecovery();
+  }
+
   function scheduleRecovery() {
     if (!running || recoveryTimer) { return; }
     const delay = RECOVERY_DELAYS_MS[Math.min(recoveryAttempts, RECOVERY_DELAYS_MS.length - 1)];
@@ -124,7 +135,7 @@ function makeFixedStack({ spawnFails = 0 } = {}) {
   function lazyStartSidecarOnly() { sidecarAlive = true; }
 
   return {
-    start, stop, disable, onUnexpectedExit, lazyStartSidecarOnly,
+    start, stop, disable, onUnexpectedExit, armBootRetry, lazyStartSidecarOnly,
     // Arm the NEXT n respawns to fail, so a test can drive the ladder. Has
     // to reach the closure's own start(); a monkeypatched .start property
     // would never be seen by scheduleRecovery.
@@ -379,4 +390,50 @@ test('NEGATIVE CONTROL: an ungated re-arm resurrects a stack the operator disabl
   assert.equal(s.sidecarAlive, true,
     'ungated: the failed attempt re-armed and the next rung brought it back — config off, stack on');
   assert.equal(s.configEnabled, false, 'while the operator-facing flag still says disabled');
+});
+
+
+// The boot-failure flavor: the ladder used to arm only after a SUCCESSFUL
+// start, so a transient failure during the boot start (a flaky first-install
+// sidecar download, a briefly wedged data dir) disabled the feature for the
+// whole session — the last remaining "config enabled, nothing running,
+// nothing retrying" path.
+test('a failed boot start walks the ladder instead of disabling the feature for the session', async () => {
+  const stack = makeFixedStack({ spawnFails: 1 });   // the boot attempt fails...
+  await stack.start().catch(() => stack.armBootRetry()); // ...and the boot catch arms the ladder
+  assert.equal(stack.state().sidecarAlive, false, 'boot attempt genuinely failed');
+
+  await settle(40);                                  // first rung (5ms here) retries
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, true, 'the ladder must bring the stack up');
+  assert.equal(s.joined, true, 'fully — spawn AND join, not a bare respawn');
+});
+
+test('NEGATIVE CONTROL: without the boot arm, a boot failure is a session-long outage', async () => {
+  const stack = makeLegacyStack();
+  // Legacy shape: boot catch only logged. Model the failed boot as "never
+  // started" — nothing is armed, nothing ever retries.
+  await settle(40);
+  const s = stack.state();
+  assert.equal(s.sidecarAlive, false, 'old logic: off for the whole session');
+  assert.equal(s.starts, 0);
+});
+
+test('the boot arm respects the config: a disabled feature is not resurrected', async () => {
+  const stack = makeFixedStack({ spawnFails: 1 });
+  await stack.disable();                             // operator's flag is off
+  await stack.start().catch(() => stack.armBootRetry());
+  await settle(60);
+  assert.equal(stack.state().sidecarAlive, false, 'no ladder for a feature the config says is off');
+  assert.equal(stack.state().running, false);
+});
+
+test('the boot arm is a no-op when a later start already won the race', async () => {
+  const stack = makeFixedStack();
+  await stack.start();                               // e.g. the admin enable route got there first
+  stack.armBootRetry();
+  await settle(40);
+  const s = stack.state();
+  assert.equal(s.starts, 1, 'no second start, no timer churn');
+  assert.equal(s.sidecarAlive, true);
 });


### PR DESCRIPTION
Phase 3 item 3 — closes #880's open item 1, the last remaining path to "config says enabled, nothing running, nothing retrying".

## Before / after

A transient failure during the boot-time stack start (flaky first-install sidecar download, briefly wedged data dir, slow relay handshake) logged `catalog unavailable — feature disabled this boot` and gave up for the session. Every *other* death already self-heals (#880 crash ladder, #885 watchdog); boot was the asymmetry. It was also the last #886 panel blind spot: `recovery.attempts` stayed 0, so boot failures rendered as the ambiguous "not joined yet" forever.

Now the boot catch arms the same ladder a crash gets, via a small `armBootRetry()` on the stack: under #881's semantics `running` is *intent*, and at boot the config **is** the operator's intent — so the arm sets it and calls the existing `scheduleRecovery`. Everything comes free and unchanged: 5s→15s→60s→5min never-give-up walk, the #881 config gate (runtime disable still wins — unit-tested), stop cancellation, backoff reset on success, and "reconnecting — attempt N" in the status route and panel. The arm no-ops if a later start already won or the config is off.

Timing note: the fleet is about to perform the exact triggering download — the first discovery start on v6.23.0 fetches sidecar v1.0.2 on every runtime-fetch install ([linuxserver/docker-mstream#37](https://github.com/linuxserver/docker-mstream/pull/37) removes that download for baked images; this covers everyone else, and every non-download transient).

## Tests

- Unit model (house negative-control convention): failed boot → ladder recovers fully (spawn AND join); **negative control reproduces the session-long outage**; config veto keeps a disabled feature down; lost-race arm is a no-op.
- Real-binary integration (`discovery-p2p-boot-retry.test.mjs`): wedges the data dir shut (`chmod 000`) before boot → asserts the failure is **armed and visible** (`recovery.retryPending`/`attempts` via the status route) → heals the dir → the next rung brings the stack up joined, identity persisted. 8.6s, hermetic, deterministic.
- Sweep: unit 556/556 · all four discovery p2p integration suites green · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)