### PR TITLE
feat(discovery): one pinned sidecar everywhere — the manifest pin is law, the dev build is the one override

### DIFF
--- a/bin/p2p-sidecar/README.md
+++ b/bin/p2p-sidecar/README.md
@@ -24,9 +24,18 @@ Binary naming convention: `p2p-sidecar-{platform}-{arch}[-musl][.exe]`,
 matching Node's `process.platform` / `process.arch`, with `-musl` selected
 at runtime on musl-libc hosts.
 
+The pin is enforced, not advisory: where a manifest entry exists for this
+platform, a binary here (or at the managed install path) that does not
+hash to the pin is replaced with the pinned build — whoever put it there.
+The one deliberate override is a dev cargo build at
+`p2p-sidecar/target/release/` (clone the sidecar repo into this checkout
+and `cargo build --release`), which also covers self-built binaries for
+platforms the manifests don't pin.
+
 Release bundles are different: they ship the sidecar staged next to the
-server at build time (and signed on Windows), so bundle installs never hit
-this fetch path. It exists for npm, source-checkout, and Docker installs.
+server at build time (and signed on Windows), verified against the same
+pins their manifest symlink carries. The fetch path exists for npm,
+source-checkout, and Docker installs.
 
 ## Doing it yourself instead
 

--- a/docs/p2p-sidecar-distribution.md
+++ b/docs/p2p-sidecar-distribution.md
@@ -51,13 +51,22 @@ is fetched only when the discovery network is turned on.
    hash or probe deletes the download and the feature degrades with the
    cause in the log. `stop()` during the download window is handled by a
    start-generation gate so an aborted start can never orphan a sidecar.
-4. **Humans always win.** Resolution order: nested-clone dev build
-   (`p2p-sidecar/target/release/`, the directory is gitignored for exactly
-   this) → operator-placed binary in `bin/p2p-sidecar/` → managed install.
-   The fetcher records its own installs in `.fetched.json`; anything
-   without a receipt entry is operator property, never refreshed or
-   replaced. Receipted installs *are* refreshed when the manifest pins a
-   newer release.
+4. **One pinned sidecar everywhere; the dev build is the one override.**
+   Resolution order: nested-clone dev build (`p2p-sidecar/target/release/`,
+   gitignored for exactly this — the development loop, and the self-built
+   path for platforms the manifest doesn't pin) → `bin/p2p-sidecar/` →
+   managed install. Where the manifest pins this platform, whatever sits at
+   the non-dev paths must **hash to the pin**: a drifted binary — stale
+   fetch, hand-copied build, bit rot — is replaced with the pinned build
+   where the path is writable, or bypassed for the managed install where it
+   isn't (a bundle's read-only staging). If the pinned build can't be
+   fetched either, the start fails with the cause rather than running the
+   drifted binary; the boot-retry ladder keeps trying. This is deliberate:
+   provenance used to buy exemption ("operator property, never touched"),
+   which meant different install types could quietly run different sidecar
+   behaviour — and a stale binary could reintroduce a fixed bug. The
+   `.fetched.json` receipt remains as provenance only. Platforms with no
+   manifest entry keep the old behaviour: whatever exists is used untouched.
 5. **Release bundles don't use any of this**: they ship the sidecar staged
    next to the server at bundle-build time (fetched from the same release
    assets, sha256-verified, and Authenticode-signed on Windows along with

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -97,10 +97,18 @@ const pending = new Map(); // id -> { resolve, reject, timer }
 // 10-minute compile inside a request is worse than a clear error. The
 // DOWNLOAD lives in start()'s async path, never here — status routes call
 // this synchronously and must stay side-effect free.
+// The dev cargo build: the ONE deliberate override of the manifest pin —
+// the development loop, and the self-built escape hatch for platforms the
+// manifest doesn't cover. Everything else is pin-enforced in
+// acquireSidecarBinary below.
+function devBuildPath() {
+  return path.join(appRoot, 'p2p-sidecar', 'target', 'release', `p2p-sidecar${ext}`);
+}
+
 export function resolveSidecarBinary() {
   const name = `p2p-sidecar-${process.platform}-${process.arch}${libcSuffix}${ext}`;
   const prebuilt = path.join(appRoot, 'bin', 'p2p-sidecar', name);
-  const localBuild = path.join(appRoot, 'p2p-sidecar', 'target', 'release', `p2p-sidecar${ext}`);
+  const localBuild = devBuildPath();
   // Local build first: the crate lives in its own repo now
   // (IrosTheBeggar/mstream-p2p-sidecar), and the dev loop is cloning it into
   // this checkout as p2p-sidecar/ (gitignored) and `cargo build --release`
@@ -183,17 +191,41 @@ export function killSidecarForRestart() {
 // actionable cause (checksum refused, no build published, download failed).
 async function acquireSidecarBinary() {
   const bin = resolveSidecarBinary();
-  // Local build / operator prebuilt: theirs to manage, never second-guessed.
-  // Only the MANAGED path flows through ensureSidecar(), which also picks up
-  // pinned updates for installs it made itself (receipt-gated).
-  if (bin && bin !== sidecarBootstrap.managedSidecarPath()) { return bin; }
+
+  // The dev build is the one deliberate pin override: the development loop,
+  // and the self-built path for unpinned platforms. Everything else runs
+  // exactly the manifest-pinned build — one pinned sidecar everywhere, so
+  // install types can't drift apart in network behaviour (and a stale
+  // binary can't quietly reintroduce a fixed bug).
+  if (bin && bin === devBuildPath()) {
+    winston.info('[p2p-sidecar] using the dev cargo build — the manifest pin does not apply to it');
+    return bin;
+  }
+
+  // A prebuilt that is NOT the managed path (read-only appRoot: a bundle's
+  // staged binary, a system-prefix install) can't be replaced in place —
+  // verify it against the pin where one exists: a match (the normal bundle
+  // case — staged from the same pinned release at build time) is used
+  // as-is; a mismatch falls through to ensureSidecar, which fetches the
+  // pinned build into the writable managed dir instead.
+  if (bin && bin !== sidecarBootstrap.managedSidecarPath()) {
+    const entry = sidecarBootstrap.manifestEntry();
+    if (!entry) { return bin; } // nothing pinned for this platform — nothing to enforce
+    const actual = await sidecarBootstrap.computeFileChecksum(bin);
+    if (actual === entry.sha256) { return bin; }
+    winston.warn(`[p2p-sidecar] staged binary at ${bin} does not match the manifest pin `
+      + `(${actual.slice(0, 12)}… vs ${entry.sha256.slice(0, 12)}…) — using the managed install instead`);
+  }
+
+  // The managed path: ensureSidecar hash-verifies what exists against the
+  // pin and downloads/replaces as needed (or throws with the cause).
   const ensured = await sidecarBootstrap.ensureSidecar();
   if (ensured) { return ensured; }
   if (bin) { return bin; } // on disk but unmanaged coverage — still spawnable
   throw new Error(
     'p2p-sidecar binary not found and no downloadable build is pinned for this platform — ' +
-    'place a prebuilt at bin/p2p-sidecar/, or clone+build the sidecar repo into this checkout ' +
-    '(see bin/p2p-sidecar/README.md)');
+    'clone+build the sidecar repo into this checkout (the dev build overrides the pin; ' +
+    'see bin/p2p-sidecar/README.md), or publish a build for this platform');
 }
 
 // Start the sidecar (idempotent; concurrent callers await the same spawn).

--- a/src/util/p2p-sidecar-bootstrap.js
+++ b/src/util/p2p-sidecar-bootstrap.js
@@ -23,10 +23,17 @@
  *     asset fail closed regardless.
  *   - A download that does not hash to the manifest's pin is deleted and
  *     refused — no fallback, no retry-with-less-verification.
- *   - Binaries the OPERATOR placed (anything we did not record in our install
- *     receipt) are never overwritten or second-guessed: drop a hand-built
- *     binary into bin/p2p-sidecar/ and it wins. Same for a dev cargo build —
- *     src/state/discovery-p2p.js prefers it before this module is consulted.
+ *   - The pin is law for every binary this module manages, WHOEVER put it
+ *     there: a file at the managed path that does not hash to the manifest
+ *     pin is replaced with the pinned build (or, if that can't be fetched,
+ *     refused with the cause). One pinned sidecar everywhere — a binary
+ *     that drifts from the manifest means different installs run different
+ *     network behaviour, and a stale one can quietly reintroduce a fixed
+ *     bug (the v1.0.1 connection leak being the motivating scar). The ONE
+ *     deliberate override left is the dev cargo build at
+ *     p2p-sidecar/target/release/ — src/state/discovery-p2p.js prefers it
+ *     before this module is consulted — which also covers self-built
+ *     binaries for platforms the manifest doesn't pin.
  *
  * The download transport (https-or-loopback policy, redirect cap, socket
  * timeout) is shared with ffmpeg-bootstrap. MSTREAM_SIDECAR_BASE overrides
@@ -42,6 +49,10 @@ import { spawn } from 'node:child_process';
 import winston from 'winston';
 import { appRoot, dataRoot } from './esm-helpers.js';
 import { downloadToFile, computeFileChecksum } from './ffmpeg-bootstrap.js';
+
+// Re-exported for discovery-p2p.js's read-only-root pin check (a bundle's
+// staged binary can't be replaced in place, so acquire verifies it here).
+export { computeFileChecksum };
 import { writeJsonAtomic } from './atomic-json.js';
 
 const FAMILY = 'p2p-sidecar';
@@ -151,11 +162,11 @@ export function deriveAssetUrl({ repo, tag, file }) {
 // ── Install receipt ──────────────────────────────────────────────────────────
 
 // Records the sha256 of every binary THIS module installed, keyed by
-// filename. Its absence for an existing file is the provenance marker that
-// the OPERATOR put it there (hand-built, baked into a Docker image, or a
-// pre-migration git checkout) — those are never refreshed or replaced, the
-// same hands-off rule ffmpeg-bootstrap applies to custom ffmpegDirectory
-// installs via its .checksum baseline.
+// filename. PROVENANCE ONLY since pin enforcement landed: whether a file is
+// current is decided by hashing it against the manifest pin, never by who
+// installed it (a receipt says who put a file there, not what the file is
+// now). Kept because "did the fetcher or a human install this" is still a
+// useful forensic fact — image bakes write it, hand-copies don't.
 const RECEIPT_FILE = '.fetched.json';
 
 function readReceipt(installDir) {
@@ -220,16 +231,20 @@ let _ensure = null;
 /**
  * Make sure a usable sidecar binary exists at the managed path.
  *
- *   - present + not installed by us (no receipt entry) → returned untouched
- *     (operator-supplied; theirs to manage).
- *   - present + ours + receipt matches the manifest pin → returned as-is.
- *   - present + ours + manifest moved on → the new build is downloaded,
- *     verified, probed, and swapped in (rename-aside dance so a locked or
- *     failing swap can roll back).
+ *   - present + hashes to the manifest pin → returned as-is, whoever
+ *     installed it (the hash IS the check; receipts are provenance only).
+ *   - present + does NOT hash to the pin — stale receipted install,
+ *     operator-placed build, bit rot alike → the pinned build is
+ *     downloaded, verified, probed, and swapped in (rename-aside dance so
+ *     a locked or failing swap can roll back). If the fetch fails, this
+ *     throws rather than running the drifted binary: one pinned sidecar
+ *     everywhere. The dev cargo build is the deliberate escape hatch,
+ *     preferred by discovery-p2p.js before this module is consulted.
  *   - absent + manifest has an entry → downloaded, verified, probed,
  *     installed.
- *   - absent + no manifest entry for this platform → null (callers degrade
- *     with their own actionable error; nothing is fetched unverified).
+ *   - present-or-absent + no manifest entry for this platform → whatever
+ *     exists is returned untouched (nothing to enforce against), else null
+ *     (callers degrade with their own actionable error).
  *
  * Throws on download/verification/probe failures — the caller (discovery-p2p
  * start(), which the admin route and boot both funnel through) surfaces the
@@ -263,10 +278,10 @@ async function ensureInto({ manifestDir = defaultManifestDir(), installDir, key 
   }
 
   if (exists) {
-    const receipt = readReceipt(installDir);
-    if (!(key in receipt)) { return dest; }           // operator-supplied: hands off
-    if (receipt[key] === entry.sha256) { return dest; } // ours and current
-    winston.info(`[${FAMILY}] a newer sidecar build is pinned by the manifest — updating ${key}`);
+    const actual = await computeFileChecksum(dest);
+    if (actual === entry.sha256) { return dest; }     // matches the pin: current, whoever installed it
+    winston.info(`[${FAMILY}] ${key} on disk (${actual.slice(0, 12)}…) does not match the manifest pin `
+      + `(${entry.sha256.slice(0, 12)}…) — replacing it with the pinned build`);
   }
 
   await fsp.mkdir(installDir, { recursive: true });

--- a/test/unit/p2p-sidecar-fetch.test.mjs
+++ b/test/unit/p2p-sidecar-fetch.test.mjs
@@ -205,37 +205,87 @@ describe('p2p-sidecar-bootstrap: manifest-pinned fetch', () => {
     assert.equal(hits.length, 0, `no request may leave for a malformed pin, saw: ${hits.join(', ')}`);
   });
 
-  test('operator-placed binary (no receipt) is used as-is and never re-fetched', async () => {
-    const { manifestDir, installDir } = freshDirs('operator');
+  test('a binary matching the pin is used as-is — no receipt required, no download', async () => {
+    // Pin enforcement is a HASH check, not a provenance check: a hand-copied
+    // or image-baked file that IS the pinned build passes untouched.
+    const { manifestDir, installDir } = freshDirs('pinned-copy');
     writeManifest(manifestDir);
     const dest = path.join(installDir, KEY);
-    fs.writeFileSync(dest, 'my hand-built sidecar');
+    fs.writeFileSync(dest, GOOD_BODY); // right bytes, no receipt
 
     const resolved = await ensureSidecar({ manifestDir, installDir, probe: okProbe });
     assert.equal(resolved, dest);
-    assert.equal(fs.readFileSync(dest, 'utf8'), 'my hand-built sidecar');
-    assert.equal(hits.length, 0, 'an operator binary must never trigger a download');
+    assert.equal(hits.length, 0, 'a pin-matching binary must never trigger a download');
+    assert.equal(fs.existsSync(path.join(installDir, '.fetched.json')), false,
+      'and adoption must not fake a receipt — provenance stays honest');
   });
 
-  test('our own install is refreshed when the manifest moves on (receipt-gated)', async () => {
+  test('a binary that does not hash to the pin is replaced — whoever installed it', async () => {
+    // THE contract change (one pinned sidecar everywhere): provenance used
+    // to buy exemption — an unreceipted file was "operator property, never
+    // touched" — which let install types drift apart and a stale binary
+    // quietly reintroduce a fixed bug. Now the pin is law; the dev cargo
+    // build (checked before this module is consulted) is the one override.
+    const { manifestDir, installDir } = freshDirs('drifted');
+    writeManifest(manifestDir);
+    const dest = path.join(installDir, KEY);
+    fs.writeFileSync(dest, 'my hand-built sidecar'); // no receipt, wrong hash
+
+    const resolved = await ensureSidecar({ manifestDir, installDir, probe: okProbe });
+    assert.equal(resolved, dest);
+    assert.equal(hits.length, 1, 'the drifted binary must be re-fetched to the pin');
+    assert.deepEqual(fs.readFileSync(dest), GOOD_BODY, 'pinned bytes on disk');
+    assert.equal(fs.existsSync(`${dest}.old`), false, 'rename-aside swept');
+  });
+
+  test('a drifted binary that cannot be re-fetched fails the ensure and stays on disk untouched', async () => {
+    // Degrade loudly rather than run drift: the caller surfaces the cause
+    // (and the boot-retry ladder keeps trying); the file is left exactly as
+    // found — replacing it with nothing would be strictly worse.
+    const { manifestDir, installDir } = freshDirs('drift-dead');
+    writeManifest(manifestDir);
+    responseBody = EVIL_BODY; // the store serves bytes that fail the pin
+    const dest = path.join(installDir, KEY);
+    fs.writeFileSync(dest, 'my hand-built sidecar');
+
+    await assert.rejects(
+      () => ensureSidecar({ manifestDir, installDir, probe: okProbe }),
+      /checksum mismatch/);
+    assert.equal(fs.readFileSync(dest, 'utf8'), 'my hand-built sidecar',
+      'the existing file is untouched by a failed replacement');
+    assert.equal(fs.existsSync(path.join(installDir, `.staging-${KEY}`)), false, 'staging cleaned');
+  });
+
+  test('no manifest entry: an existing binary is untouched — nothing to enforce against', async () => {
+    const { manifestDir, installDir } = freshDirs('unpinned-platform');
+    // No manifest written at all.
+    const dest = path.join(installDir, KEY);
+    fs.writeFileSync(dest, 'self-built for an unpinned platform');
+    const resolved = await ensureSidecar({ manifestDir, installDir, probe: okProbe });
+    assert.equal(resolved, dest);
+    assert.equal(fs.readFileSync(dest, 'utf8'), 'self-built for an unpinned platform');
+    assert.equal(hits.length, 0);
+  });
+
+  test('an install is refreshed when the manifest moves on (hash-gated)', async () => {
     const { manifestDir, installDir } = freshDirs('upgrade');
     writeManifest(manifestDir);
     await ensureSidecar({ manifestDir, installDir, probe: okProbe });
     assert.equal(hits.length, 1);
 
-    // Same manifest again: receipt matches, no new download.
+    // Same manifest again: the on-disk hash matches the pin, no new download.
     reset();
     const again = await ensureSidecar({ manifestDir, installDir, probe: okProbe });
     assert.equal(again, path.join(installDir, KEY));
     assert.equal(hits.length, 1, 'a current install must not re-download');
 
-    // Manifest now pins a NEW build → refresh.
+    // Manifest now pins a NEW build → the on-disk hash no longer matches → refresh.
     const v2 = Buffer.from('sidecar v2 bytes, longer than before to be sure'.repeat(8));
     writeManifest(manifestDir, { body: v2 });
     responseBody = v2;
     reset();
     const upgraded = await ensureSidecar({ manifestDir, installDir, probe: okProbe });
-    assert.equal(hits.length, 2, 'a stale receipt must trigger exactly one refresh download');
+    assert.equal(hits.length, 2, 'a stale binary must trigger exactly one refresh download');
     assert.deepEqual(fs.readFileSync(upgraded), v2);
     const receipt = JSON.parse(fs.readFileSync(path.join(installDir, '.fetched.json'), 'utf8'));
     assert.equal(receipt[KEY], sha256(v2));


### PR DESCRIPTION
The plan addition from the #880 follow-up work: every install type must run exactly the manifest-pinned sidecar, so install classes can't drift apart in network behaviour and a stale binary can't quietly reintroduce a fixed bug (the v1.0.1 connection leak being the scar; the month-stale local rust-parser build that broke the waveform suite this week was the same failure class).

## What changes

Provenance no longer buys exemption. The old rule — *a binary without a fetch receipt is operator property, never touched* — becomes: **where the manifest pins this platform, whatever sits at the managed/prebuilt path must hash to the pin.**

- `ensureSidecar` hash-verifies what exists and replaces a mismatch with the pinned build (download → sha256 verify → execution probe → rename-aside swap), whoever installed it. Unfetchable pin → throws with the cause instead of running drift; the existing file is left as found and the #889 boot-retry ladder keeps trying.
- `acquireSidecarBinary` also verifies prebuilts at **read-only roots** (a bundle's staged binary): a match is used as-is — the normal bundle case, now integrity-asserted for free — a mismatch is bypassed for the managed install. (Verified the bundle manifest is a Resources-backed symlink, so real pins resolve at runtime.)
- **The dev cargo build stays the one deliberate override** (development loop + self-built unpinned platforms), logged when used. Platforms with no manifest entry keep the old behaviour — nothing to enforce against.
- `.fetched.json` becomes provenance-only. Docs updated (`docs/p2p-sidecar-distribution.md`, `bin/p2p-sidecar/README.md`).

## Verification

- Unit suite rewritten to the new contract, house negative control: **2 new cases fail against the receipt-gated code, 16/16 with the hash gate** (pin-matching copy adopted without download or fake receipt; drift replaced; unfetchable drift throws with the file left untouched; unpinned platform untouched).
- **Live smoke at full fidelity**: drifted binary planted, loopback store serving the *real released v1.0.2 asset*, real server boot → drift detected with both hashes logged → pinned build downloaded and verified against the *committed* manifest sha → probed → swapped → stack up joined → receipt recorded → worktree restored clean.
- Sweep: unit 559/559 · all four discovery p2p integration suites green (the dev-build override keeps them running unchanged) · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)