### PR TITLE
chore(discovery): delete the dead isStackRunning export

### DIFF
--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -17,8 +17,6 @@ let running = false;
 let starting = null;
 let stopping = null;
 
-export function isStackRunning() { return running; }
-
 // Crash-recovery state for the status route / admin panel. `attempts` spans
 // crash -> recovered (cancelRecovery zeroes it on success, stop, or
 // disable), so attempts > 0 reads as "recovery owns the sidecar right now";


### PR DESCRIPTION
The last item from #880's handoff list (open item 2): `isStackRunning()` has been exported and unused since the stack module's creation — confirmed dead across `src/`, `test/`, `webapp/`, and `scripts/` through every PR since. Anything wanting liveness uses the status route, which asks the sidecar itself instead of trusting the intent flag.

Unit suites for the module green (18 tests), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)