### PR TITLE
feat(discovery): hide incompatible-model peers from the catalog listing by default

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -628,8 +628,22 @@ export function setup(mstream) {
     }).sort((a, b) => (b.seeders - a.seeders)
       || (b.online - a.online)
       || ((b.payload.rowCount || 0) - (a.payload.rowCount || 0)));
+    // Hide-by-default: an UNHELD catalog peer whose announced model cannot
+    // power the local similar search is dead weight in the listing — and
+    // test networks' throwaway announcements (the "Stranger" ghosts,
+    // modelId test-model) land exactly in this class, so they stop
+    // cluttering real servers' panels. Held/pinned peers always show
+    // (they occupy the operator's shelf; hiding owned state would
+    // mislead), unknown compatibility (no local model yet) hides nothing,
+    // and ?includeIncompatible=1 shows everything — the blocklist and
+    // debugging still need eyes on the full catalog.
+    const includeIncompatible = req.query.includeIncompatible === '1';
+    const visible = includeIncompatible
+      ? peers
+      : peers.filter((peer) => peer.compatible !== false || peer.fetched !== null);
     res.json({
-      peers,
+      peers: visible,
+      hiddenIncompatible: peers.length - visible.length,
       localModelId: localModel,
       autoFetch: config.program.discoveryP2p.autoFetch,
       storage: {

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -1838,3 +1838,147 @@ describe('discovery seeds — unreachable list degrades gracefully', () => {
     assert.equal((await post('enabled', { enabled: true })).status, 200);
   });
 });
+
+// ── Catalog listing: incompatible-model peers hide by default ────────────────
+// The "Stranger" filter: test networks' throwaway announcements (name
+// "Stranger", modelId test-model — the 2026-07-27 ghosts, and any test agent
+// still announcing) carry a model that cannot power this server's similar
+// search, so the catalog listing hides them by default instead of cluttering
+// every real panel. Held peers always show (they occupy the operator's
+// shelf), ?includeIncompatible=1 shows everything (the blocklist needs
+// eyes on the full catalog), and — covered by the suites above, where no
+// local model is ever established — unknown compatibility hides nothing.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — catalog hides incompatible-model peers', () => {
+  let server;
+  let dir;
+  let musicDir;
+  let strangerNode;
+  let friendNode;
+
+  // One embed-eligible (≥30s) track, so the collect pass actually runs and
+  // establishes the local model — the shared fixtures are all short tones,
+  // which leaves embedding_model_id unset forever (the zero-touch suite's
+  // writeSineWav precedent; the helper is scoped there, so a local copy).
+  function writeLongTone(filePath, seconds) {
+    const rate = 8000;
+    const n = rate * seconds;
+    const data = Buffer.alloc(n * 2);
+    for (let i = 0; i < n; i++) {
+      data.writeInt16LE(Math.round(Math.sin((2 * Math.PI * 440 * i) / rate) * 12000), i * 2);
+    }
+    const header = Buffer.alloc(44);
+    header.write('RIFF', 0); header.writeUInt32LE(36 + data.length, 4);
+    header.write('WAVE', 8); header.write('fmt ', 12);
+    header.writeUInt32LE(16, 16); header.writeUInt16LE(1, 20); header.writeUInt16LE(1, 22);
+    header.writeUInt32LE(rate, 24); header.writeUInt32LE(rate * 2, 28);
+    header.writeUInt16LE(2, 32); header.writeUInt16LE(16, 34);
+    header.write('data', 36); header.writeUInt32LE(data.length, 40);
+    fs.writeFileSync(filePath, Buffer.concat([header, data]));
+  }
+  const catalogOf = async (all) => {
+    const r = await fetch(
+      `${server.baseUrl}/api/v1/admin/discovery/p2p/catalog${all ? '?includeIncompatible=1' : ''}`);
+    return r.json();
+  };
+
+  before(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-compat-'));
+    musicDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-compat-lib-'));
+    writeLongTone(path.join(musicDir, 'long-tone.wav'), 35);
+    server = await startServer({
+      dlnaMode: 'disabled',
+      waitForScan: true, // the scan's collect pass establishes the local model
+      extraFolders: { compatlib: musicDir },
+      extraConfig: {
+        discoveryP2p: { enabled: true, serverName: 'Compat Filter Server' },
+        scanOptions: { collectDiscoveryData: true, discoveryModel: 'test-fake' },
+      },
+    });
+    strangerNode = new RawSidecar(SIDECAR_BIN, path.join(dir, 'stranger'));
+    friendNode = new RawSidecar(SIDECAR_BIN, path.join(dir, 'friend'));
+    await strangerNode.ready;
+    await friendNode.ready;
+
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    for (const node of [strangerNode, friendNode]) {
+      await node.rpc('join', { bootstrap: [status.ticket] });
+      await node.waitForEvent('neighbor', (e) => e.up === true);
+    }
+
+    // The Stranger publishes a REAL (fetchable, valid) snapshot so the
+    // held-peers-always-show rule can be proven end to end below.
+    const snap = makeSnapshotFile(path.join(dir, 'stranger.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Ghost', title: 'Ghost Song', vec: [1, 0, 0, 0] }],
+    });
+    const pub = await strangerNode.rpc('publish', { path: snap });
+    await strangerNode.rpc('announce', {
+      payload: { hash: pub.hash, size: pub.size, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Stranger' },
+    });
+
+    // The embed pass establishes the local model well after waitForScan
+    // returns (enrichment drains in the background — the zero-touch suite's
+    // 90s precedent). Read the ESTABLISHED id from the route rather than
+    // assuming what test-fake stores, then announce the compatible peer
+    // with exactly that id — the compatibility contract under test, free of
+    // model-naming assumptions.
+    const localModelId = await pollUntil(async () => (await catalogOf(true)).localModelId,
+      { timeoutMs: 90000, what: 'the embed pass to establish the local model' });
+    assert.notEqual(localModelId, 'test-model', 'the Stranger must be genuinely incompatible');
+    await friendNode.rpc('announce', {
+      payload: { hash: 'f'.repeat(64), size: 4096, rowCount: 9,
+        modelId: localModelId, modelVersion: '1', snapshotSeq: 1, name: 'Friendly Peer' },
+    });
+
+    // Both announcements ingested — checked through the unfiltered view so
+    // the wait cannot depend on the filter under test.
+    await pollUntil(async () => {
+      const names = (await catalogOf(true)).peers.map((p) => p.payload.name);
+      return names.includes('Stranger') && names.includes('Friendly Peer') ? true : null;
+    }, { what: 'both announcements in the catalog' });
+  });
+
+  after(async () => {
+    if (strangerNode) { await strangerNode.stop(); }
+    if (friendNode) { await friendNode.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+    if (musicDir) { fs.rmSync(musicDir, { recursive: true, force: true }); }
+  });
+
+  test('the default listing hides the incompatible peer and counts it', async () => {
+    const c = await catalogOf(false);
+    const names = c.peers.map((p) => p.payload.name);
+    assert.ok(names.includes('Friendly Peer'), 'the compatible peer is listed');
+    assert.ok(!names.includes('Stranger'), 'the incompatible peer is hidden');
+    assert.equal(c.hiddenIncompatible, 1, 'and the panel is told how many it is not seeing');
+  });
+
+  test('?includeIncompatible=1 shows everything, correctly labeled', async () => {
+    const c = await catalogOf(true);
+    const stranger = c.peers.find((p) => p.payload.name === 'Stranger');
+    const friend = c.peers.find((p) => p.payload.name === 'Friendly Peer');
+    assert.ok(stranger, 'the incompatible peer is visible on request');
+    assert.equal(stranger.compatible, false);
+    assert.equal(friend.compatible, true);
+    assert.equal(c.hiddenIncompatible, 0, 'nothing hidden in the full view');
+  });
+
+  test('a HELD incompatible peer always shows — hiding owned shelf state would mislead', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/peer-dbs/fetch`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpointId: strangerNode.endpointId }),
+    });
+    assert.equal(r.status, 200, `manual fetch of the Stranger snapshot failed: ${await r.text()}`);
+
+    const c = await catalogOf(false);
+    const stranger = c.peers.find((p) => p.payload.name === 'Stranger');
+    assert.ok(stranger, 'held: visible despite the incompatible model');
+    assert.ok(stranger.fetched, 'and marked as on the shelf');
+    assert.equal(c.hiddenIncompatible, 0, 'nothing left hidden once the only incompatible peer is held');
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -7546,7 +7546,7 @@ const backupView = Vue.component('backup-view', {
 const discoveryView = Vue.component('discovery-view', {
   data() {
     return {
-      discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false },
+      discoveryP2p: { loaded: false, status: null, peers: [], storage: null, autoFetch: false, hiddenIncompatible: 0, showIncompatible: false },
       p2pIdentity: P2PIDENTITY,
       p2pToggling: false,
       peerFilter: '',
@@ -7684,7 +7684,16 @@ const discoveryView = Vue.component('discovery-view', {
                   </table>
                   <p v-else-if="discoveryP2p.peers.length > 0">No servers match
                     &ldquo;{{ peerFilter }}&rdquo; — [<a v-on:click="peerFilter = ''">clear</a>]</p>
-                  <p v-else>No servers heard yet — paste a friend's ticket above and give gossip a minute.</p>
+                  <p v-else-if="discoveryP2p.hiddenIncompatible === 0">No servers heard yet — paste a friend's ticket above and give gossip a minute.</p>
+                  <p v-if="discoveryP2p.hiddenIncompatible > 0 || discoveryP2p.showIncompatible"
+                    style="color: #757575; font-size: 0.9em;">
+                    <span v-if="discoveryP2p.hiddenIncompatible > 0">{{ discoveryP2p.hiddenIncompatible }}
+                      server{{ discoveryP2p.hiddenIncompatible === 1 ? '' : 's' }} hidden — incompatible embedding
+                      model (their libraries can't power this server's similar-search)
+                      [<a v-on:click="discoveryToggleIncompatible()">show</a>]</span>
+                    <span v-else>showing incompatible servers
+                      [<a v-on:click="discoveryToggleIncompatible()">hide</a>]</span>
+                  </p>
                   <p v-if="discoveryP2p.status.blockedPeers && discoveryP2p.status.blockedPeers.length > 0"
                     style="color: #757575; font-size: 0.9em;">
                     <b>Blocked servers</b> — announcements ignored, snapshots never fetched:<br>
@@ -7850,6 +7859,12 @@ const discoveryView = Vue.component('discovery-view', {
         ]
       });
     },
+    discoveryToggleIncompatible: async function() {
+      // Server-side filter, so the toggle re-fetches rather than un-hiding
+      // stale client state.
+      this.discoveryP2p.showIncompatible = !this.discoveryP2p.showIncompatible;
+      await this.loadDiscoveryP2p(true);
+    },
     loadDiscoveryP2p: async function(quiet) {
       try {
         const status = (await API.axios({
@@ -7866,9 +7881,11 @@ const discoveryView = Vue.component('discovery-view', {
         if (typeof status.rotationDays === 'number') { P2PSETTINGS.rotationDays = status.rotationDays; }
         if (status.enabled === true) {
           const cat = (await API.axios({
-            method: 'GET', url: `${API.url()}/api/v1/admin/discovery/p2p/catalog`
+            method: 'GET',
+            url: `${API.url()}/api/v1/admin/discovery/p2p/catalog${this.discoveryP2p.showIncompatible ? '?includeIncompatible=1' : ''}`
           })).data;
           this.discoveryP2p.peers = cat.peers;
+          this.discoveryP2p.hiddenIncompatible = cat.hiddenIncompatible || 0;
           this.discoveryP2p.storage = cat.storage;
           this.discoveryP2p.autoFetch = cat.autoFetch;
         }


### PR DESCRIPTION
First item of the Discover UI cleanup branch: hide catalog peers whose announced embedding model can't power this server's similar-search — which is exactly where the test networks' **"Stranger"** announcements (the 2026-07-27 ghosts, plus any test agent still announcing `modelId: test-model`) land, so they stop cluttering real servers' panels.

## Rules

| case | listed? |
|---|---|
| compatible model | yes |
| incompatible, **not held** | hidden by default, counted in `hiddenIncompatible` |
| incompatible but **on the shelf** (fetched/pinned) | always shown — hiding the operator's own storage would mislead |
| no local model established yet | nothing hidden — no signal, no verdict |
| `?includeIncompatible=1` | everything, correctly labeled — blocklisting needs eyes on the full catalog |

Panel: *"N servers hidden — incompatible embedding model [show]"* with a server-refetching toggle, and the empty-state no longer claims "No servers heard yet" when the truth is "everything heard is hidden".

## Verification

- Integration (real sidecars), negative-controlled — **3 tests fail against the unfiltered route**: default hide + count; full view with correct `compatible` labels; held-incompatible stays visible through a real manual fetch. The suite establishes a genuine local model (one embed-eligible 35s track, the zero-touch precedent) and the compatible peer announces **whatever id the server establishes** — no model-naming assumptions.
- Existing catalog/seed suites (including the Stranger-ingestion test) pass unchanged — their servers never establish a model, proving the no-signal-no-verdict rule.
- Panel verified in a live browser, both directions: hidden-count line with [show]; after toggling, the Stranger row renders with its *incompatible* label and Block/Download actions intact.
- Suite 47/47 · unit sweep 559/559 · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)