### PR TITLE
feat(discovery): hybrid admin panel — tabbed header, mesh map, cards/list view

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -570,6 +570,12 @@ export function setup(mstream) {
       ticket: discoveryP2p.getEndpointTicket(),
       joined,
       neighbors,
+      // Who those neighbors are (endpoint ids), tracked from the sidecar's
+      // neighbor events. Bounded by the gossip fan-out (hyparview active
+      // view), so never more than a handful. The panel's mesh map joins
+      // these against the catalog for names; `neighbors` above (the
+      // sidecar's own count) stays the authority for how many.
+      neighborIds: discoveryP2p.getNeighborIds(),
       // Sidecar memory + watchdog posture (#885): lastRssMb is the
       // mesh-health watch's most recent reading (null before the first
       // tick or where RSS can't be read), restarts counts watchdog kills
@@ -853,6 +859,21 @@ export function setup(mstream) {
     });
     joiValidate(schema, req.body);
     await admin.editRotationDays(req.body.rotationDays);
+    res.json({});
+  });
+
+  // RSS ceiling (MB) for the sidecar memory watchdog (#885); 0 turns the
+  // watchdog off. Live: the mesh-health watch reads the config fresh every
+  // tick, so the next tick enforces the new ceiling — no restart and no
+  // stack bounce. Bounds mirror the config Joi
+  // (discoveryP2pOptions.sidecarMaxRssMb).
+  mstream.post("/api/v1/admin/discovery/p2p/sidecar-max-rss", async (req, res) => {
+    requireP2pEnabled();
+    const schema = Joi.object({
+      sidecarMaxRssMb: Joi.number().integer().min(0).max(100000).required(),
+    });
+    joiValidate(schema, req.body);
+    await admin.editSidecarMaxRssMb(req.body.sidecarMaxRssMb);
     res.json({});
   });
 

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -601,6 +601,16 @@ export function setup(mstream) {
     });
   });
 
+  // The Discovery panel's Activity feed: the discovery/p2p slice of the log
+  // stream from its own fixed-size ring (logger.js) — mesh joins, snapshot
+  // fetches, rotation and recovery lines, immune to wash-out from chatty
+  // non-discovery logging. Same delta-poll contract as /admin/logs/recent;
+  // the two endpoints' seq cursors are independent.
+  mstream.get("/api/v1/admin/discovery/p2p/activity", (req, res) => {
+    requireP2pEnabled();
+    res.json(logger.getP2pActivity(req.query.since));
+  });
+
   // The catalog: every peer we've heard a signed announcement from (newest
   // per peer), enriched with what the shelf knows (fetched? current?) and
   // sorted most-useful-first: online-now (heard within ~90s — announcers

--- a/src/logger.js
+++ b/src/logger.js
@@ -54,36 +54,81 @@ const MAX_CAPACITY = 10000;
 // the configured value via setBufferCapacity().
 const BOOT_DEFAULT_CAPACITY = 500;
 
-let ring = new Array(BOOT_DEFAULT_CAPACITY);
-let ringCapacity = BOOT_DEFAULT_CAPACITY;
-let ringHead = 0;   // index of the next slot to write
-let ringCount = 0;  // number of valid entries currently stored
-let seqCounter = 0; // monotonic id so clients can ask "entries after N"
+// The discovery/p2p ring's fixed capacity — deliberately not a config knob.
+// Worst case is capacity × MAX_ENTRY_LEN ≈ 2MB, but real discovery lines run
+// ~100–200 bytes, so a full ring is ~150KB.
+const P2P_RING_CAPACITY = 500;
 
-function pushEntry(level, message) {
-  if (ringCapacity <= 0) { return; }
-  if (message.length > MAX_ENTRY_LEN) {
-    message = message.slice(0, MAX_ENTRY_LEN) + '… [truncated]';
+// One fixed-capacity circular buffer of recent log entries. Two instances
+// below: the main ring behind the admin live-log viewer, and a discovery/p2p
+// ring behind the Discovery panel's Activity feed — its own ring so a chatty
+// scan can never wash mesh events out of the feed.
+class LogRing {
+  constructor(capacity) {
+    this.ring = new Array(capacity);
+    this.capacity = capacity;
+    this.head = 0;       // index of the next slot to write
+    this.count = 0;      // number of valid entries currently stored
+    this.seqCounter = 0; // monotonic id so clients can ask "entries after N"
   }
-  seqCounter += 1;
-  ring[ringHead] = { seq: seqCounter, t: new Date().toISOString(), level, message };
-  ringHead = (ringHead + 1) % ringCapacity;
-  if (ringCount < ringCapacity) { ringCount += 1; }
+
+  push(level, message) {
+    if (this.capacity <= 0) { return; }
+    if (message.length > MAX_ENTRY_LEN) {
+      message = message.slice(0, MAX_ENTRY_LEN) + '… [truncated]';
+    }
+    this.seqCounter += 1;
+    this.ring[this.head] = { seq: this.seqCounter, t: new Date().toISOString(), level, message };
+    this.head = (this.head + 1) % this.capacity;
+    if (this.count < this.capacity) { this.count += 1; }
+  }
+
+  // Entries oldest→newest. `sinceSeq` returns only entries with a greater seq
+  // (what the live poll uses); 0 returns the whole buffer.
+  snapshot(sinceSeq) {
+    const out = [];
+    if (this.capacity <= 0 || this.count === 0) { return out; }
+    // Oldest valid entry sits `count` slots behind the write head.
+    const start = (this.head - this.count + this.capacity * 2) % this.capacity;
+    for (let i = 0; i < this.count; i++) {
+      const e = this.ring[(start + i) % this.capacity];
+      if (e && e.seq > sinceSeq) { out.push(e); }
+    }
+    return out;
+  }
+
+  // The poll contract shared by both ring endpoints: a stale/out-of-range
+  // cursor (e.g. a client holding a high seq from before a server restart
+  // reset the counter) falls back to the full buffer so the view recovers
+  // instead of showing nothing.
+  read(sinceSeq) {
+    let since = Number(sinceSeq) || 0;
+    if (since < 0 || since > this.seqCounter) { since = 0; }
+    return { entries: this.snapshot(since), lastSeq: this.seqCounter, capacity: this.capacity };
+  }
+
+  resize(capacity) {
+    const keep = capacity === 0 ? [] : this.snapshot(0).slice(-capacity);
+    this.ring = new Array(capacity);
+    this.capacity = capacity;
+    this.head = 0;
+    this.count = 0;
+    for (const e of keep) {
+      this.ring[this.head] = e;
+      this.head = (this.head + 1) % this.capacity;
+      this.count += 1;
+    }
+  }
 }
 
-// Entries oldest→newest. `sinceSeq` returns only entries with a greater seq
-// (what the live poll uses); 0 returns the whole buffer.
-function snapshot(sinceSeq) {
-  const out = [];
-  if (ringCapacity <= 0 || ringCount === 0) { return out; }
-  // Oldest valid entry sits `ringCount` slots behind the write head.
-  const start = (ringHead - ringCount + ringCapacity * 2) % ringCapacity;
-  for (let i = 0; i < ringCount; i++) {
-    const e = ring[(start + i) % ringCapacity];
-    if (e && e.seq > sinceSeq) { out.push(e); }
-  }
-  return out;
-}
+const mainRing = new LogRing(BOOT_DEFAULT_CAPACITY);
+const p2pRing = new LogRing(P2P_RING_CAPACITY);
+
+// Every discovery-stack module logs under a bracketed prefix, and nothing
+// outside the stack uses these ([discovery-p2p], [discovery-p2p-stack],
+// [discovery-peer-dbs], [discovery-catalog], [discovery-seeds],
+// [p2p-sidecar]) — so line-start prefix matching IS the event filter.
+const P2P_LINE = /^\[(discovery-|p2p-sidecar)/;
 
 // winston re-exports the winston-transport base class as winston.Transport,
 // so we don't need a separate winston-transport dependency to subclass it.
@@ -103,7 +148,8 @@ class MemoryRingTransport extends winston.Transport {
           : (info.stack.stack || info.stack.message || '');
         if (stackText) { message += os.EOL + stackText; }
       }
-      pushEntry(level, message);
+      mainRing.push(level, message);
+      if (P2P_LINE.test(message)) { p2pRing.push(level, message); }
     } catch { /* logging must never throw */ }
     callback();
   }
@@ -205,28 +251,22 @@ export function reset() {
 // buffer is independent of whether logs are written to disk.
 export function setBufferCapacity(n) {
   const next = Math.max(0, Math.min(MAX_CAPACITY, Math.floor(Number(n) || 0)));
-  if (next === ringCapacity) { return; }
-
-  const keep = next === 0 ? [] : snapshot(0).slice(-next);
-  ring = new Array(next);
-  ringCapacity = next;
-  ringHead = 0;
-  ringCount = 0;
-  for (const e of keep) {
-    ring[ringHead] = e;
-    ringHead = (ringHead + 1) % ringCapacity;
-    ringCount += 1;
-  }
+  if (next === mainRing.capacity) { return; }
+  mainRing.resize(next);
 }
 
 // Read recent log entries for the admin live-log viewer. `sinceSeq` is the
 // highest seq the client has already seen; entries newer than it are returned
 // (oldest→newest) along with the current `lastSeq` cursor and the buffer
-// `capacity`. A stale/out-of-range cursor (e.g. a client holding a high seq
-// from before a server restart reset the counter to 0) falls back to the full
-// buffer so the view recovers instead of showing nothing.
+// `capacity` (see LogRing.read for the stale-cursor recovery contract).
 export function getRecentLogs(sinceSeq) {
-  let since = Number(sinceSeq) || 0;
-  if (since < 0 || since > seqCounter) { since = 0; }
-  return { entries: snapshot(since), lastSeq: seqCounter, capacity: ringCapacity };
+  return mainRing.read(sinceSeq);
+}
+
+// The discovery/p2p slice of the log stream, from its own fixed-size ring —
+// the Discovery panel's Activity feed. Same poll contract as getRecentLogs;
+// the two rings' seq counters are independent, so cursors from one endpoint
+// mean nothing at the other.
+export function getP2pActivity(sinceSeq) {
+  return p2pRing.read(sinceSeq);
 }

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -49,6 +49,9 @@ const neighborIds = new Set();
 events.on('neighbor', (msg) => {
   if (typeof msg.id !== 'string' || msg.id === '') { return; }
   if (msg.up === true) { neighborIds.add(msg.id); } else { neighborIds.delete(msg.id); }
+  // Feeds the panel's Activity ring (and plain log readers). Self-throttling:
+  // the active view caps how many links exist to churn.
+  winston.info(`[discovery-p2p] mesh neighbor ${msg.up === true ? 'up' : 'down'}: ${msg.id.slice(0, 12)}…`);
 });
 export function getNeighborIds() { return [...neighborIds]; }
 

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -40,6 +40,18 @@ import * as config from './config.js';
 // The catalog module (discovery-catalog.js) is the main subscriber.
 export const events = new EventEmitter();
 
+// Who the sidecar is gossiping with right now, tracked from its 'neighbor'
+// events. hyparview caps the active view (5 by default), so this set is
+// protocol-bounded — it can never grow past the mesh fan-out no matter how
+// many servers exist. Best-effort by nature: the count in the sidecar's
+// status reply stays the authority for "how many"; this answers "who".
+const neighborIds = new Set();
+events.on('neighbor', (msg) => {
+  if (typeof msg.id !== 'string' || msg.id === '') { return; }
+  if (msg.up === true) { neighborIds.add(msg.id); } else { neighborIds.delete(msg.id); }
+});
+export function getNeighborIds() { return [...neighborIds]; }
+
 // Unexpected-death hook, set by the stack (discovery-p2p-stack.js).
 //
 // The sidecar is a child process, so an OOM kill, a panic, or an operator's
@@ -343,6 +355,9 @@ function teardown(why) {
   proc = null;
   endpointId = null;
   endpointTicket = null;
+  // The mesh dies with the process — a fresh sidecar re-reports its
+  // neighbors as they weave back in.
+  neighborIds.clear();
   for (const [, waiter] of pending) {
     clearTimeout(waiter.timer);
     waiter.reject(new Error(`p2p-sidecar ${why}`));

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -718,6 +718,17 @@ export async function editRotationDays(val) {
   config.program.discoveryP2p.rotationDays = val;
 }
 
+// RSS ceiling (MB) for the sidecar memory watchdog (0 = watchdog off).
+// Live: the mesh-health watch reads the config fresh every tick, so the
+// next tick enforces the new ceiling — no restart, no stack bounce.
+export async function editSidecarMaxRssMb(val) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.discoveryP2p) { loadConfig.discoveryP2p = {}; }
+  loadConfig.discoveryP2p.sidecarMaxRssMb = val;
+  await saveFile(loadConfig, config.configFile);
+  config.program.discoveryP2p.sidecarMaxRssMb = val;
+}
+
 // Append a bootstrap peer (deduplicated) so a friend joined through the
 // UI survives restarts — the join RPC itself is session-only.
 export async function editAddBootstrapPeer(val) {

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -199,6 +199,7 @@ describe('discovery p2p — route gating (no sidecar needed)', () => {
       ['POST', 'peer-dbs/fetch', { endpointId: 'a'.repeat(64) }],
       ['POST', 'peer-dbs/remove', { endpointId: 'a'.repeat(64) }],
       ['POST', 'description', { description: 'nope' }],
+      ['POST', 'sidecar-max-rss', { sidecarMaxRssMb: 512 }],
       ['GET', 'catalog', undefined],
     ]) {
       const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/${route}`, {
@@ -226,6 +227,41 @@ describe('discovery p2p — enabled, validation contract', () => {
     const r = await fetch(`${server.baseUrl}/api/v1/ping`);
     assert.equal(r.status, 200);
     assert.equal((await r.json()).discoveryP2p, true);
+  });
+
+  test('status exposes neighborIds as an array — empty with no mesh', async () => {
+    // The panel's mesh map renders from this; before any peer joins (or
+    // where no sidecar binary exists at all) it must be a clean [] rather
+    // than absent, so the SVG math never branches on undefined.
+    const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+    assert.ok(Array.isArray(s.neighborIds), 'neighborIds is always an array');
+    assert.equal(s.neighborIds.length, 0, 'no mesh yet — nobody listed');
+  });
+
+  test('sidecar-max-rss: a valid ceiling saves live and reads back; junk is 400', async () => {
+    const url = `${server.baseUrl}/api/v1/admin/discovery/p2p/sidecar-max-rss`;
+    const post = (body) => fetch(url, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    const ok = await post({ sidecarMaxRssMb: 384 });
+    assert.equal(ok.status, 200);
+    let s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+    assert.equal(s.watchdog.maxRssMb, 384, 'the watchdog ceiling reflects the write immediately');
+
+    // 0 is the documented off switch, not an error.
+    assert.equal((await post({ sidecarMaxRssMb: 0 })).status, 200);
+    s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+    assert.equal(s.watchdog.maxRssMb, 0, '0 = watchdog off');
+
+    for (const body of [{}, { sidecarMaxRssMb: -1 }, { sidecarMaxRssMb: 1.5 },
+      { sidecarMaxRssMb: 'lots' }, { sidecarMaxRssMb: 100001 }]) {
+      const r = await post(body);
+      assert.equal(r.status, 400, `body ${JSON.stringify(body)} should be 400`);
+    }
+    s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+    assert.equal(s.watchdog.maxRssMb, 0, 'rejected writes change nothing');
   });
 
   test('publish and announce are 404 until an export snapshot has been built', async () => {
@@ -377,6 +413,16 @@ describe('discovery p2p — enabled, validation contract', () => {
     assert.equal(heard.payload.hash, ann.hash);
     assert.equal(heard.payload.name, 'Gossip Test Server');
     assert.ok(Number.isInteger(heard.payload.snapshotSeq));
+
+    // The server saw the same link from its side: the peer's endpoint id
+    // shows up in status.neighborIds (the panel's mesh map draws from
+    // this). Event-tracked, so poll — the neighbor event may land a beat
+    // after the announcement round-trips.
+    const withNeighbor = await pollUntil(async () => {
+      const s = await (await fetch(api('status'))).json();
+      return s.neighborIds.includes(peer.endpointId) ? s : null;
+    }, { what: 'the peer to appear in status.neighborIds' });
+    assert.ok(withNeighbor.neighbors >= 1, 'the count agrees a link exists');
 
     // Ticketless fetch: hash + provider from the announcement, address
     // resolution via the peer's memory lookup (seeded by the join ticket).

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -201,6 +201,7 @@ describe('discovery p2p — route gating (no sidecar needed)', () => {
       ['POST', 'description', { description: 'nope' }],
       ['POST', 'sidecar-max-rss', { sidecarMaxRssMb: 512 }],
       ['GET', 'catalog', undefined],
+      ['GET', 'activity', undefined],
     ]) {
       const r = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/${route}`, {
         method,
@@ -423,6 +424,19 @@ describe('discovery p2p — enabled, validation contract', () => {
       return s.neighborIds.includes(peer.endpointId) ? s : null;
     }, { what: 'the peer to appear in status.neighborIds' });
     assert.ok(withNeighbor.neighbors >= 1, 'the count agrees a link exists');
+
+    // And the Activity feed heard about it: the dedicated p2p log ring
+    // carries the neighbor-up line — and ONLY prefixed discovery lines,
+    // even though this server has logged plenty of non-discovery lines
+    // since boot (the wash-in negative control).
+    const activity = await (await fetch(api('activity'))).json();
+    assert.ok(activity.entries.length > 0, 'the feed has entries');
+    assert.ok(activity.entries.every((e) => /^\[(discovery-|p2p-sidecar)/.test(e.message)),
+      'every feed entry is a discovery/p2p line — boot noise stays out');
+    assert.ok(activity.entries.some((e) =>
+      e.message.includes('mesh neighbor up') && e.message.includes(peer.endpointId.slice(0, 12))),
+    'the neighbor-up event for this peer is in the feed');
+    assert.ok(Number.isInteger(activity.lastSeq), 'delta-poll cursor present');
 
     // Ticketless fetch: hash + provider from the announcement, address
     // resolution via the peer's memory lookup (seeded by the join ticket).

--- a/test/unit/log-ring.test.mjs
+++ b/test/unit/log-ring.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * The dual log-ring in src/logger.js: one main ring behind the admin
+ * live-log viewer, one fixed-size discovery/p2p ring behind the Discovery
+ * panel's Activity feed. The p2p ring exists so a chatty scan can never
+ * wash mesh events out of the feed — these tests pin that isolation, the
+ * prefix filter, and the independent seq-cursor contracts.
+ *
+ * Importing src/logger.js configures the global winston instance (console +
+ * ring transports), so logging here prints a few lines to the test output —
+ * harmless, and exactly the production write path we want under test.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import winston from 'winston';
+import * as logger from '../../src/logger.js';
+
+// The ring transport pushes entries inside the transport's log() call, which
+// winston invokes synchronously on winston.info(); the setImmediate inside is
+// only the 'logged' event. One microtask hop keeps us honest anyway.
+const settle = () => new Promise((r) => setImmediate(r));
+
+describe('log rings: main + dedicated discovery/p2p', () => {
+  test('a p2p-prefixed line lands in both rings; a plain line only in main', async () => {
+    const mainBefore = logger.getRecentLogs(0).lastSeq;
+    const p2pBefore = logger.getP2pActivity(0).lastSeq;
+
+    winston.info('[discovery-p2p] mesh neighbor up: abcdef123456…');
+    winston.info('scan finished: 1234 files in 5s'); // the wash-out threat
+    winston.warn('[p2p-sidecar] exited (code=1 signal=null)');
+    await settle();
+
+    const main = logger.getRecentLogs(mainBefore);
+    const p2p = logger.getP2pActivity(p2pBefore);
+
+    assert.equal(main.entries.length, 3, 'main ring sees every line');
+    assert.equal(p2p.entries.length, 2, 'p2p ring sees only the prefixed lines');
+    assert.ok(p2p.entries[0].message.startsWith('[discovery-p2p] mesh neighbor up'));
+    assert.equal(p2p.entries[1].level, 'warn', 'level survives into the ring');
+    assert.ok(p2p.entries.every((e) => /^\[(discovery-|p2p-sidecar)/.test(e.message)),
+      'nothing un-prefixed leaks into the feed');
+  });
+
+  test('seq cursors are independent and delta polls return only news', async () => {
+    winston.info('plain line — main ring only');
+    await settle();
+    const p2pCursor = logger.getP2pActivity(0).lastSeq;
+
+    winston.info('another plain line');
+    await settle();
+    assert.equal(logger.getP2pActivity(p2pCursor).entries.length, 0,
+      'plain lines never advance the p2p ring');
+
+    winston.info('[discovery-seeds] mesh-health watch: all quiet');
+    await settle();
+    const delta = logger.getP2pActivity(p2pCursor);
+    assert.equal(delta.entries.length, 1, 'exactly the one new p2p line');
+    assert.equal(delta.lastSeq, p2pCursor + 1);
+
+    // The stale-cursor recovery contract: an impossible cursor (from before
+    // a restart) falls back to the full buffer instead of returning nothing.
+    const recovered = logger.getP2pActivity(delta.lastSeq + 1000);
+    assert.ok(recovered.entries.length > 0, 'stale cursor recovers the buffer');
+  });
+
+  test('an oversized p2p line is truncated, not dropped', async () => {
+    const cursor = logger.getP2pActivity(0).lastSeq;
+    winston.info(`[discovery-catalog] ${'x'.repeat(5000)}`);
+    await settle();
+    const { entries } = logger.getP2pActivity(cursor);
+    assert.equal(entries.length, 1);
+    assert.ok(entries[0].message.endsWith('… [truncated]'));
+    assert.ok(entries[0].message.length <= 4000 + '… [truncated]'.length);
+  });
+
+  test('resizing the main ring leaves the p2p ring untouched', async () => {
+    const cursor = logger.getP2pActivity(0).lastSeq;
+    winston.info('[discovery-peer-dbs] fetched snapshot from aaaa…');
+    await settle();
+
+    logger.setBufferCapacity(10);
+    const p2p = logger.getP2pActivity(cursor);
+    assert.equal(p2p.entries.length, 1, 'p2p ring survives a main-ring resize');
+    assert.equal(p2p.capacity, 500, 'p2p capacity is fixed, not the configured one');
+    assert.equal(logger.getRecentLogs(0).capacity, 10, 'main ring took the new capacity');
+
+    logger.setBufferCapacity(500); // restore for any suite that runs after us
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -781,7 +781,7 @@ const P2PIDENTITY = { serverName: '', serverDescription: '' };
 // Same shared-object pattern (and the same must-be-hoisted TDZ rule) for
 // the editable p2p settings: the Discovery card fills it from the status
 // route, the max-storage modal edits it.
-const P2PSETTINGS = { maxPeerDbStorageMb: 500, autoFetchCount: 6, rotationDays: 7, peerRetentionDays: 30 };
+const P2PSETTINGS = { maxPeerDbStorageMb: 500, autoFetchCount: 6, rotationDays: 7, peerRetentionDays: 30, sidecarMaxRssMb: 256 };
 
 const foldersView = Vue.component('folders-view', {
   data() {
@@ -7551,7 +7551,12 @@ const discoveryView = Vue.component('discovery-view', {
       p2pToggling: false,
       peerFilter: '',
       friendTicket: '',
-      joinPending: false
+      joinPending: false,
+      // Which header pane is showing (mesh map by default) and how the
+      // server list renders. Session-local by design — a page load lands
+      // everyone on the same view.
+      headerTab: 'mesh',
+      listMode: 'cards'
     };
   },
   template: `
@@ -7588,75 +7593,229 @@ const discoveryView = Vue.component('discovery-view', {
                   <p v-if="!discoveryP2p.status.binaryFound" style="color: #b71c1c;">
                     The p2p-sidecar binary was not found for this platform — the network is unavailable.
                   </p>
-                  <p><b>Endpoint:</b> <code style="word-break: break-all;">{{ discoveryP2p.status.endpointId || '(sidecar not running yet)' }}</code></p>
-                  <p><b>Announcing as:</b> {{ p2pIdentity.serverName }}
-                    <span v-if="p2pIdentity.serverDescription"> — {{ p2pIdentity.serverDescription }}</span>
-                    <span v-else style="color: #9e9e9e;"> — no description (other servers see only the name)</span>
-                    [<a v-on:click="openModal('edit-p2p-identity-modal')">{{ t('admin.settings.edit') }}</a>]
-                  </p>
-                  <p><b>Network:</b>
-                    <span v-if="discoveryP2p.status.neighbors > 0" style="color: #2e7d32;">connected
-                      — {{ discoveryP2p.status.neighbors }} mesh neighbor{{ discoveryP2p.status.neighbors === 1 ? '' : 's' }}</span>
-                    <span v-else-if="meshRecovering" style="color: #c62828;">reconnecting — the sidecar died and
-                      is being replayed automatically (attempt {{ discoveryP2p.status.recovery.attempts }})</span>
-                    <span v-else-if="discoveryP2p.status.joined" style="color: #e65100;">joined, waiting for
-                      neighbors — the mesh weaves in within a minute or two of another server coming online</span>
-                    <span v-else>not joined yet</span>
-                  </p>
-                  <p v-if="discoveryP2p.status.watchdog && discoveryP2p.status.watchdog.lastRssMb !== null"><b>Sidecar memory:</b>
-                    {{ discoveryP2p.status.watchdog.lastRssMb.toFixed(0) }} MB resident<span
-                      v-if="discoveryP2p.status.watchdog.maxRssMb > 0"> — auto-restarts over {{ discoveryP2p.status.watchdog.maxRssMb }} MB</span><span
-                      v-else style="color: #e65100;"> — memory watchdog off</span><span
-                      v-if="discoveryP2p.status.watchdog.restarts > 0" style="color: #e65100;"> ·
-                      {{ discoveryP2p.status.watchdog.restarts }} watchdog restart{{ discoveryP2p.status.watchdog.restarts === 1 ? '' : 's' }} since boot</span>
-                  </p>
-                  <div v-if="meshSearching" style="max-width: 480px;">
-                    <div class="progress" style="margin: 4px 0 6px 0;"><div class="indeterminate"></div></div>
-                    <span style="color: #757575; font-size: 0.85em;">{{ meshRecovering
-                      ? 'reconnecting — crash recovery replays the stack on a widening ladder; no action needed'
-                      : 'searching for peers — this page updates itself every few seconds' }}</span>
+                  <div style="background: #2a2a34; border-radius: 2px; padding: 16px 20px; color: #ddd; margin-bottom: 14px;">
+                    <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap;">
+                      <div style="display: flex; align-items: center; gap: 8px; font-size: 0.9em; color: #9e9ea8; flex-wrap: wrap;">
+                        <span v-if="discoveryP2p.status.neighbors > 0" style="display: inline-flex; align-items: center; gap: 7px;">
+                          <span style="width: 9px; height: 9px; border-radius: 50%; background: #2e7d32; flex-shrink: 0;"></span>
+                          <span style="color: #fff; font-weight: 600;">connected</span>
+                          <span>— {{ discoveryP2p.status.neighbors }} mesh neighbor{{ discoveryP2p.status.neighbors === 1 ? '' : 's' }}</span>
+                        </span>
+                        <span v-else-if="meshRecovering" style="display: inline-flex; align-items: center; gap: 7px;">
+                          <span style="width: 9px; height: 9px; border-radius: 50%; background: #ef5350; flex-shrink: 0;"></span>
+                          <span style="color: #ef9a9a; font-weight: 600;">reconnecting</span>
+                          <span>— the sidecar died and is being replayed (attempt {{ discoveryP2p.status.recovery.attempts }})</span>
+                        </span>
+                        <span v-else-if="discoveryP2p.status.joined" style="display: inline-flex; align-items: center; gap: 7px;">
+                          <span style="width: 9px; height: 9px; border-radius: 50%; background: #ffb74d; flex-shrink: 0;"></span>
+                          <span style="color: #ffcc80; font-weight: 600;">joined, waiting for neighbors</span>
+                        </span>
+                        <span v-else style="display: inline-flex; align-items: center; gap: 7px;">
+                          <span style="width: 9px; height: 9px; border-radius: 50%; background: #666672; flex-shrink: 0;"></span>
+                          <span style="font-weight: 600;">not joined yet</span>
+                        </span>
+                        <span v-if="discoveryP2p.status.watchdog && discoveryP2p.status.watchdog.lastRssMb !== null">
+                          · sidecar {{ discoveryP2p.status.watchdog.lastRssMb.toFixed(0) }} MB<span
+                            v-if="discoveryP2p.status.watchdog.restarts > 0" style="color: #ffcc80;"> ({{ discoveryP2p.status.watchdog.restarts }} watchdog restart{{ discoveryP2p.status.watchdog.restarts === 1 ? '' : 's' }})</span>
+                        </span>
+                        <span>· announcing as <span style="color: #ddd; font-weight: 600;">{{ p2pIdentity.serverName }}</span>
+                          [<a style="color: #90caf9;" v-on:click="openModal('edit-p2p-identity-modal')">{{ t('admin.settings.edit') }}</a>]</span>
+                      </div>
+                      <div style="display: flex; gap: 12px; font-size: 0.9em; flex-shrink: 0;">
+                        <span style="color: #666672;">[<a style="color: #90caf9;" v-on:click="loadDiscoveryP2p()">Refresh</a>]</span>
+                        <span style="color: #666672;">[<a style="color: #ef9a9a;" v-on:click="disableP2p()">Disable</a>]</span>
+                      </div>
+                    </div>
+                    <div v-if="meshSearching" style="max-width: 520px; margin-top: 8px;">
+                      <div class="progress" style="margin: 0 0 4px 0; background-color: #3a3a47;"><div class="indeterminate"></div></div>
+                      <span style="color: #9e9ea8; font-size: 0.85em;">{{ meshRecovering
+                        ? 'reconnecting — crash recovery replays the stack on a widening ladder; no action needed'
+                        : 'searching for peers — this page updates itself every few seconds' }}</span>
+                    </div>
+                    <div style="display: flex; gap: 8px; margin-top: 12px; border-bottom: 1px solid #3a3a47; padding-bottom: 10px; flex-wrap: wrap;">
+                      <div v-on:click="headerTab = 'mesh'" :style="headerTabStyle('mesh')">Mesh</div>
+                      <div v-on:click="headerTab = 'stats'" :style="headerTabStyle('stats')">Stats</div>
+                      <div v-on:click="headerTab = 'activity'" :style="headerTabStyle('activity')">Activity</div>
+                      <div v-on:click="headerTab = 'invite'" :style="headerTabStyle('invite')">Invite</div>
+                      <div v-on:click="headerTab = 'config'" :style="headerTabStyle('config')">Config</div>
+                    </div>
+                    <div v-if="headerTab === 'mesh'" style="display: flex; gap: 20px; align-items: center; min-height: 200px; flex-wrap: wrap;">
+                      <svg viewBox="0 0 300 210" width="300" height="210" style="flex-shrink: 0;">
+                        <line v-for="n in meshMap.neighbors" :key="'l-' + n.id" x1="150" y1="105"
+                          :x2="n.x" :y2="n.y" stroke="#4a7c59" stroke-width="2"></line>
+                        <circle v-for="n in meshMap.outer" :key="'o-' + n.id" :cx="n.x" :cy="n.y" r="7"
+                          fill="none" :stroke="n.incompatible ? '#8a6d3b' : '#666672'" stroke-width="1.5"
+                          stroke-dasharray="2 3"></circle>
+                        <circle v-for="n in meshMap.neighbors" :key="'n-' + n.id" :cx="n.x" :cy="n.y" r="10"
+                          fill="#2e7d32"></circle>
+                        <circle cx="150" cy="105" r="18" fill="#EEE" stroke="#2e7d32" stroke-width="3"></circle>
+                        <text x="150" y="109" text-anchor="middle" font-size="11" font-weight="700"
+                          fill="#2a2a34" font-family="inherit">you</text>
+                        <text v-for="n in meshMap.neighbors" :key="'nt-' + n.id" :x="n.lx" :y="n.ly"
+                          text-anchor="middle" font-size="10" fill="#bdbdc6" font-family="inherit">{{ n.label }}</text>
+                        <text v-for="n in meshMap.outer" :key="'ot-' + n.id" :x="n.lx" :y="n.ly"
+                          text-anchor="middle" font-size="9" :fill="n.incompatible ? '#a08a5a' : '#8a8a96'"
+                          font-family="inherit">{{ n.label }}</text>
+                      </svg>
+                      <div style="display: flex; flex-direction: column; gap: 8px; font-size: 0.85em; min-width: 220px;">
+                        <div style="display: flex; align-items: center; gap: 8px;"><span style="width: 10px; height: 10px; border-radius: 50%; background: #2e7d32; flex-shrink: 0;"></span><span style="color: #bdbdc6;">gossip link — live mesh neighbor</span></div>
+                        <div style="display: flex; align-items: center; gap: 8px;"><span style="width: 10px; height: 10px; border-radius: 50%; border: 1.5px dashed #666672; box-sizing: border-box; flex-shrink: 0;"></span><span style="color: #bdbdc6;">known, not currently linked</span></div>
+                        <div style="display: flex; align-items: center; gap: 8px;"><span style="width: 10px; height: 10px; border-radius: 50%; border: 1.5px dashed #a08a5a; box-sizing: border-box; flex-shrink: 0;"></span><span style="color: #bdbdc6;">incompatible model</span></div>
+                        <div style="color: #9e9ea8; line-height: 1.5; margin-top: 4px;" v-if="heldPeers.length > 0">You hold
+                          {{ heldPeers.length }} snapshot{{ heldPeers.length === 1 ? '' : 's' }} from these servers and seed
+                          {{ heldPeers.length === 1 ? 'it' : 'them' }} back to the mesh.</div>
+                        <div style="color: #666672; font-size: 0.95em;" v-if="meshMap.overflow > 0">+{{ meshMap.overflow }} more
+                          server{{ meshMap.overflow === 1 ? '' : 's' }} not drawn</div>
+                      </div>
+                    </div>
+                    <div v-if="headerTab === 'stats'" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 12px; min-height: 200px; padding-top: 12px; align-content: start;">
+                      <div style="border: 1px solid #3a3a47; border-radius: 2px; padding: 12px 14px;">
+                        <div style="font-size: 1.3em; font-weight: 700; color: #fff;">{{ discoveryP2p.status.neighbors }}</div>
+                        <div style="font-size: 0.85em; color: #9e9ea8; margin-top: 2px;">mesh neighbors</div>
+                        <div style="font-size: 0.8em; color: #666672; margin-top: 4px;">live gossip links</div>
+                      </div>
+                      <div style="border: 1px solid #3a3a47; border-radius: 2px; padding: 12px 14px;">
+                        <div style="font-size: 1.3em; font-weight: 700; color: #fff;">{{ knownServersTotal }}</div>
+                        <div style="font-size: 0.85em; color: #9e9ea8; margin-top: 2px;">servers known</div>
+                        <div style="font-size: 0.8em; color: #666672; margin-top: 4px;">{{ discoveryP2p.hiddenIncompatible }} hidden ·
+                          {{ (discoveryP2p.status.blockedPeers || []).length }} blocked</div>
+                      </div>
+                      <div style="border: 1px solid #3a3a47; border-radius: 2px; padding: 12px 14px;">
+                        <div style="font-size: 1.3em; font-weight: 700; color: #fff;">{{ heldPeers.length }}<span
+                          v-if="discoveryP2p.status.autoFetchCount > 0" style="font-size: 0.7em; color: #9e9ea8;"> of {{ discoveryP2p.status.autoFetchCount }}</span></div>
+                        <div style="font-size: 0.85em; color: #9e9ea8; margin-top: 2px;">snapshots held</div>
+                        <div style="font-size: 0.8em; color: #666672; margin-top: 4px;" v-if="discoveryP2p.storage">
+                          {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }}</div>
+                      </div>
+                      <div style="border: 1px solid #3a3a47; border-radius: 2px; padding: 12px 14px;">
+                        <div style="font-size: 1.3em; font-weight: 700; color: #fff;">{{ heldTrackTotal.toLocaleString() }}</div>
+                        <div style="font-size: 0.85em; color: #9e9ea8; margin-top: 2px;">peer tracks searchable</div>
+                        <div style="font-size: 0.8em; color: #666672; margin-top: 4px;">across {{ heldPeers.length }} held
+                          librar{{ heldPeers.length === 1 ? 'y' : 'ies' }}</div>
+                      </div>
+                      <div style="border: 1px solid #3a3a47; border-radius: 2px; padding: 12px 14px;">
+                        <div style="font-size: 1.3em; font-weight: 700; color: #fff;">{{ discoveryP2p.status.watchdog && discoveryP2p.status.watchdog.lastRssMb !== null
+                          ? discoveryP2p.status.watchdog.lastRssMb.toFixed(0) + ' MB' : '—' }}</div>
+                        <div style="font-size: 0.85em; color: #9e9ea8; margin-top: 2px;">sidecar memory</div>
+                        <div style="font-size: 0.8em; color: #666672; margin-top: 4px;">{{ discoveryP2p.status.watchdog && discoveryP2p.status.watchdog.maxRssMb > 0
+                          ? 'ceiling ' + discoveryP2p.status.watchdog.maxRssMb + ' MB · ' + discoveryP2p.status.watchdog.restarts + ' restart' + (discoveryP2p.status.watchdog.restarts === 1 ? '' : 's')
+                          : 'watchdog off' }}</div>
+                      </div>
+                      <div style="border: 1px solid #3a3a47; border-radius: 2px; padding: 12px 14px;">
+                        <div style="font-size: 1.3em; font-weight: 700; color: #fff;">{{ heldPeers.length }}</div>
+                        <div style="font-size: 0.85em; color: #9e9ea8; margin-top: 2px;">seeding</div>
+                        <div style="font-size: 0.8em; color: #666672; margin-top: 4px;">snapshots served back to the mesh</div>
+                      </div>
+                    </div>
+                    <div v-if="headerTab === 'activity'" style="min-height: 200px; display: flex; align-items: center; justify-content: center; padding: 12px 0;">
+                      <div style="border: 1px dashed #505061; border-radius: 2px; padding: 22px 28px; max-width: 460px; text-align: center;">
+                        <div style="font-weight: 700; color: #fff; margin-bottom: 6px;">Activity — coming soon</div>
+                        <div style="font-size: 0.85em; color: #9e9ea8; line-height: 1.6;">Mesh joins, snapshot updates, rotation and
+                        recovery events will land here in a future release.</div>
+                      </div>
+                    </div>
+                    <div v-if="headerTab === 'invite'" style="min-height: 200px; padding-top: 12px;">
+                      <p style="font-size: 0.85em; color: #9e9ea8; margin: 0 0 8px 0;"><b style="color: #fff;">Endpoint:</b>
+                        <code style="word-break: break-all; color: #8a8a96;">{{ discoveryP2p.status.endpointId || '(sidecar not running yet)' }}</code></p>
+                      <p v-if="discoveryP2p.status.ticket" style="margin-bottom: 4px; font-size: 0.85em; color: #9e9ea8;"><b style="color: #fff;">Your ticket</b>
+                        — a friend pastes this into the box below on <i>their</i> Discovery page to befriend this server:<br>
+                        <textarea readonly rows="2" style="width:100%; font-size: 0.8em; color: #bdbdc6; border-color: #505061;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>
+                      </p>
+                      <p style="margin: 8px 0 2px 0; font-size: 0.85em; color: #9e9ea8;"><b style="color: #fff;">Befriend a server</b>
+                        — paste the ticket from a friend's Discovery page (saved to your config, so the friendship survives restarts):</p>
+                      <div style="display: flex; gap: 8px; max-width: 640px; align-items: center; margin-bottom: 8px;">
+                        <input v-model="friendTicket" id="p2p-friend-ticket" type="text" placeholder="endpoint…"
+                          style="flex: 1; margin: 0; color: #ddd; border-bottom: 1px solid #7f7f9a;" v-on:keyup.enter="discoveryJoinPeer()">
+                        <a v-on:click="discoveryJoinPeer()" :class="{disabled: joinPending || !friendTicket.trim()}"
+                          class="waves-effect waves-light btn green" style="flex-shrink: 0;">
+                          {{ joinPending ? 'Joining…' : 'Join' }}</a>
+                      </div>
+                    </div>
+                    <div v-if="headerTab === 'config'" style="min-height: 200px; padding-top: 6px;">
+                      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 0 28px;">
+                        <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 10px; padding: 9px 0; border-bottom: 1px solid #3a3a47; font-size: 0.85em;">
+                          <span style="color: #9e9ea8;">Snapshot storage cap</span>
+                          <span style="color: #ddd; text-align: right;"><b>{{ discoveryP2p.status.maxPeerDbStorageMb }} MB</b>
+                            [<a style="color: #90caf9;" v-on:click="openModal('edit-p2p-max-storage-modal')">{{ t('admin.settings.edit') }}</a>]</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 10px; padding: 9px 0; border-bottom: 1px solid #3a3a47; font-size: 0.85em;">
+                          <span style="color: #9e9ea8;">Forget offline servers</span>
+                          <span style="color: #ddd; text-align: right;"><b>{{ discoveryP2p.status.peerRetentionDays > 0
+                            ? 'after ' + discoveryP2p.status.peerRetentionDays + ' days of silence' : 'never' }}</b>
+                            [<a style="color: #90caf9;" v-on:click="openModal('edit-p2p-peer-retention-modal')">{{ t('admin.settings.edit') }}</a>]</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 10px; padding: 9px 0; border-bottom: 1px solid #3a3a47; font-size: 0.85em;">
+                          <span style="color: #9e9ea8;">Auto-fetch snapshots</span>
+                          <span style="color: #ddd; text-align: right;"><b>{{ discoveryP2p.autoFetch === false ? 'off'
+                            : discoveryP2p.status.autoFetchCount === 0 ? 'on — 0 servers (downloads paused)'
+                            : 'up to ' + discoveryP2p.status.autoFetchCount + ' servers' }}</b>
+                            [<a style="color: #90caf9;" v-on:click="openModal('edit-p2p-auto-fetch-count-modal')">{{ t('admin.settings.edit') }}</a>]</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 10px; padding: 9px 0; border-bottom: 1px solid #3a3a47; font-size: 0.85em;">
+                          <span style="color: #9e9ea8;">Rotate downloads</span>
+                          <span style="color: #ddd; text-align: right;"><b>{{ discoveryP2p.status.rotationDays > 0
+                            ? 'after ' + discoveryP2p.status.rotationDays + ' days' : 'never' }}</b>
+                            [<a style="color: #90caf9;" v-on:click="openModal('edit-p2p-rotation-modal')">{{ t('admin.settings.edit') }}</a>]</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 10px; padding: 9px 0; border-bottom: 1px solid #3a3a47; font-size: 0.85em;">
+                          <span style="color: #9e9ea8;">Community seeds</span>
+                          <span style="color: #ddd; text-align: right;"><b>{{ discoveryP2p.status.communitySeeds ? 'on — public network' : 'off — friends only' }}</b></span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 10px; padding: 9px 0; border-bottom: 1px solid #3a3a47; font-size: 0.85em;">
+                          <span style="color: #9e9ea8;">Sidecar memory ceiling</span>
+                          <span style="color: #ddd; text-align: right;"><b>{{ discoveryP2p.status.watchdog && discoveryP2p.status.watchdog.maxRssMb > 0
+                            ? discoveryP2p.status.watchdog.maxRssMb + ' MB' : 'watchdog off' }}</b>
+                            [<a style="color: #90caf9;" v-on:click="openModal('edit-p2p-sidecar-max-rss-modal')">{{ t('admin.settings.edit') }}</a>]</span>
+                        </div>
+                      </div>
+                      <div style="font-size: 0.8em; color: #666672; margin-top: 10px;">Rotation only ever swaps a stale unpinned
+                      download for a new server — it never deletes without replacing. Incompatible-model servers are hidden from
+                      the list below; the [show] link reveals them.</div>
+                    </div>
                   </div>
-                  <p v-if="discoveryP2p.status.ticket" style="margin-bottom: 4px;"><b>Your ticket</b> — a friend pastes this
-                  into the box below on <i>their</i> Discovery page to befriend this server:<br>
-                    <textarea readonly rows="2" style="width:100%; font-size: 0.8em;" onclick="this.select()">{{ discoveryP2p.status.ticket }}</textarea>
-                  </p>
-                  <p style="margin: 8px 0 2px 0;"><b>Befriend a server</b> — paste the ticket from a friend's Discovery page
-                  (saved to your config, so the friendship survives restarts):</p>
-                  <div style="display: flex; gap: 8px; max-width: 640px; align-items: center; margin-bottom: 8px;">
-                    <input v-model="friendTicket" id="p2p-friend-ticket" type="text" placeholder="endpoint…"
-                      style="flex: 1; margin: 0;" v-on:keyup.enter="discoveryJoinPeer()">
-                    <a v-on:click="discoveryJoinPeer()" :class="{disabled: joinPending || !friendTicket.trim()}"
-                      class="waves-effect waves-light btn green" style="flex-shrink: 0;">
-                      {{ joinPending ? 'Joining…' : 'Join' }}</a>
+                  <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 4px 0 2px 0;">
+                    <b>Servers you follow</b>
+                    <div style="display: inline-flex; border: 1px solid #bdbdbd; border-radius: 2px; overflow: hidden;">
+                      <div v-on:click="listMode = 'cards'" :style="listBtnStyle('cards')">cards</div>
+                      <div v-on:click="listMode = 'list'" :style="listBtnStyle('list')">list</div>
+                    </div>
                   </div>
-                  <p v-if="discoveryP2p.storage"><b>Peer snapshots:</b>
-                    {{ discoveryBytes(discoveryP2p.storage.usedBytes) }} of {{ discoveryBytes(discoveryP2p.storage.capBytes) }} used
-                    [<a v-on:click="openModal('edit-p2p-max-storage-modal')">{{ t('admin.settings.edit') }}</a>]
-                    — auto-fetch {{ discoveryP2p.autoFetch === false ? 'off'
-                      : discoveryP2p.status.autoFetchCount === 0 ? 'on (0 servers — automatic downloads paused)'
-                      : 'on (up to ' + discoveryP2p.status.autoFetchCount + ' servers)' }}
-                    [<a v-on:click="openModal('edit-p2p-auto-fetch-count-modal')">{{ t('admin.settings.edit') }}</a>]
-                    — community seeds {{ discoveryP2p.status.communitySeeds ? 'on (public network)' : 'off (friends only)' }}
-                  </p>
-                  <p><b>Forget offline servers:</b>
-                    {{ discoveryP2p.status.peerRetentionDays > 0
-                      ? 'after ' + discoveryP2p.status.peerRetentionDays + ' days of silence'
-                      : 'never (offline servers stay listed forever)' }}
-                    [<a v-on:click="openModal('edit-p2p-peer-retention-modal')">{{ t('admin.settings.edit') }}</a>]
-                  </p>
-                  <p><b>Rotate downloads:</b>
-                    {{ discoveryP2p.status.rotationDays > 0
-                      ? 'swap the oldest unpinned download for a new server after ' + discoveryP2p.status.rotationDays + ' days'
-                      : 'never (downloads stay until removed by hand)' }}
-                    [<a v-on:click="openModal('edit-p2p-rotation-modal')">{{ t('admin.settings.edit') }}</a>]
-                  </p>
                   <div v-if="discoveryP2p.peers.length > 5" class="input-field" style="max-width: 360px; margin: 4px 0 0 0;">
                     <input v-model="peerFilter" id="p2p-peer-filter" type="text" placeholder="Search servers — name or description">
                   </div>
                   <p v-if="peerFilter && discoveryP2p.peers.length > 0" style="color: #757575; font-size: 0.85em; margin: 2px 0;">
                     {{ filteredPeers.length }} of {{ discoveryP2p.peers.length }} servers
                   </p>
-                  <table v-if="filteredPeers.length > 0">
+                  <div v-if="listMode === 'cards' && filteredPeers.length > 0"
+                    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 14px; margin: 8px 0;">
+                    <div v-for="peer in filteredPeers" :key="'card-' + peer.from"
+                      :style="'border: 1px solid #e0e0e0; border-radius: 2px; padding: 12px 14px; display: flex; flex-direction: column; gap: 7px;' + (peer.online ? '' : ' opacity: 0.75;')">
+                      <div style="display: flex; justify-content: space-between; align-items: center; gap: 8px;">
+                        <b style="min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{{ peer.payload.name || (peer.from.slice(0, 12) + '…') }}</b>
+                        <span :title="peer.updatedAt" style="display: inline-flex; align-items: center; gap: 5px; font-size: 0.8em; flex-shrink: 0;">
+                          <span :style="'width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: ' + (peer.online ? '#2e7d32' : '#9e9e9e') + ';'"></span>
+                          {{ peer.online ? 'online' : 'offline' + discoveryAge(peer.updatedAt) }}</span>
+                      </div>
+                      <div v-if="peer.payload.description" style="color: #757575; font-size: 0.85em;">{{ peer.payload.description }}</div>
+                      <div style="color: #616161; font-size: 0.85em;">{{ peer.payload.rowCount }} tracks
+                        · {{ peer.seeders }} seeder{{ peer.seeders === 1 ? '' : 's' }}</div>
+                      <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+                        <span v-if="peer.fetched" :style="'padding: 2px 8px; border-radius: 10px; font-size: 0.75em; font-weight: 600; background: ' + (peer.fetched.stale ? '#fff8e1; color: #8d6e00' : '#e8f5e9; color: #2e7d32') + ';'">
+                          {{ peer.fetched.stale ? 'update available' : 'downloaded' }}</span>
+                        <span v-else style="padding: 2px 8px; border-radius: 10px; font-size: 0.75em; font-weight: 600; background: #f5f5f5; color: #757575;">not downloaded</span>
+                        <span v-if="peer.fetched && peer.fetched.pinned" style="padding: 2px 8px; border-radius: 10px; font-size: 0.75em; font-weight: 600; background: #ececf2; color: #505061;">pinned</span>
+                        <span v-if="peer.compatible === false" style="padding: 2px 8px; border-radius: 10px; font-size: 0.75em; font-weight: 600; background: #fff3e0; color: #a06010;">incompatible model</span>
+                      </div>
+                      <div style="display: flex; gap: 10px; font-size: 0.85em; border-top: 1px solid #eee; padding-top: 7px; flex-wrap: wrap;">
+                        <span>[<a v-on:click="discoveryFetchPeer(peer.from)">{{ peer.fetched ? 'Update' : 'Download' }}</a>]</span>
+                        <span v-if="peer.fetched">[<a v-on:click="discoveryRemovePeer(peer.from)">Remove</a>]</span>
+                        <span v-if="peer.fetched">[<a v-on:click="discoveryPinPeer(peer.from, !peer.fetched.pinned)">{{ peer.fetched.pinned ? 'Unpin' : 'Pin' }}</a>]</span>
+                        <span v-if="!peer.online && !peer.fetched">[<a v-on:click="discoveryForgetPeer(peer.from)">Forget</a>]</span>
+                        <span>[<a v-on:click="discoveryBlockPeer(peer.from)" style="color: #b71c1c;">Block</a>]</span>
+                      </div>
+                    </div>
+                  </div>
+                  <table v-else-if="filteredPeers.length > 0">
                     <thead><tr><th>Server</th><th>Tracks</th><th>Seeders</th><th>Online</th><th>Model</th><th>Downloaded</th><th></th></tr></thead>
                     <tbody>
                       <tr v-for="peer in filteredPeers" :key="peer.from">
@@ -7701,8 +7860,6 @@ const discoveryView = Vue.component('discovery-view', {
                       <code>{{ id.slice(0, 12) }}…</code> [<a v-on:click="discoveryUnblockPeer(id)">Unblock</a>]
                     </span>
                   </p>
-                  <p>[<a v-on:click="loadDiscoveryP2p()">Refresh</a>]
-                  [<a v-on:click="disableP2p()" style="color: #b71c1c;">Disable</a>]</p>
                 </div>
               </div>
             </div>
@@ -7743,6 +7900,61 @@ const discoveryView = Vue.component('discovery-view', {
         || (p.payload.description || '').toLowerCase().includes(q)
         || p.from.toLowerCase().includes(q));
     },
+    heldPeers: function() {
+      return this.discoveryP2p.peers.filter((p) => p.fetched);
+    },
+    heldTrackTotal: function() {
+      return this.heldPeers.reduce((sum, p) => sum + (Number(p.payload.rowCount) || 0), 0);
+    },
+    // "Known" counts what the catalog holds, whether or not the
+    // incompatible filter is hiding some of it from the list.
+    knownServersTotal: function() {
+      return this.discoveryP2p.peers.length
+        + (this.discoveryP2p.showIncompatible ? 0 : this.discoveryP2p.hiddenIncompatible);
+    },
+    // Node positions for the mesh map SVG (300×210, you at 150,105).
+    // Neighbors (from status.neighborIds, protocol-bounded to the gossip
+    // fan-out) sit on an inner ring with solid links; every other catalog
+    // peer is a dashed dot on the outer ring, amber when its embedding
+    // model is incompatible. Deterministic layout — sorted by id — so the
+    // 10s poll never makes the map jiggle. The map draws what the list
+    // shows: peers hidden by the incompatible filter aren't drawn either.
+    meshMap: function() {
+      const CX = 150; const CY = 105;
+      const byId = {};
+      for (const p of this.discoveryP2p.peers) { byId[p.from] = p; }
+      const label = (id) => {
+        const known = byId[id];
+        const name = known && known.payload.name ? known.payload.name : id.slice(0, 8) + '…';
+        return name.length > 18 ? name.slice(0, 17) + '…' : name;
+      };
+      const place = (ids, radius, labelRadius, startDeg) => ids.map((id, i) => {
+        const a = ((startDeg + (360 / Math.max(ids.length, 1)) * i) * Math.PI) / 180;
+        const lr = labelRadius + (Math.sin(a) > 0.3 ? 8 : 0); // below-center labels clear their node
+        return {
+          id,
+          x: Math.round(CX + radius * Math.cos(a)),
+          y: Math.round(CY + radius * Math.sin(a)),
+          lx: Math.round(CX + lr * Math.cos(a)),
+          ly: Math.round(CY + lr * Math.sin(a)),
+          label: label(id),
+          incompatible: !!(byId[id] && byId[id].compatible === false),
+        };
+      });
+      const neighborIds = [...(this.discoveryP2p.status.neighborIds || [])].sort().slice(0, 8);
+      const neighborSet = new Set(neighborIds);
+      const outerAll = this.discoveryP2p.peers
+        .filter((p) => !neighborSet.has(p.from))
+        .map((p) => p.from).sort();
+      const outerIds = outerAll.slice(0, 8);
+      return {
+        // Neighbors fan out from the top, catalog dots from the bottom —
+        // sparse maps (one node per ring) then never collide label-wise.
+        neighbors: place(neighborIds, 58, 82, -90),
+        outer: place(outerIds, 88, 100, 114),
+        overflow: outerAll.length - outerIds.length,
+      };
+    },
   },
   created: async function () {
     this.loadDiscoveryP2p();
@@ -7764,6 +7976,18 @@ const discoveryView = Vue.component('discovery-view', {
     openModal: function(modalView) {
       modVM.currentViewModal = modalView;
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
+    },
+    headerTabStyle: function(tab) {
+      const base = 'padding: 6px 16px; border-radius: 2px; font-size: 0.85em; font-weight: 600; cursor: pointer; letter-spacing: 0.4px; ';
+      return base + (this.headerTab === tab
+        ? 'background: #505061; color: #fff;'
+        : 'background: transparent; color: #9e9ea8; border: 1px solid #3a3a47;');
+    },
+    listBtnStyle: function(mode) {
+      const base = 'padding: 4px 14px; font-size: 0.85em; font-weight: 600; cursor: pointer; ';
+      return base + (this.listMode === mode
+        ? 'background: #505061; color: #fff;'
+        : 'background: #fff; color: #616161;');
     },
     // The consent moment. What used to be "edit the config file and
     // restart" is now this dialog — it must say what enabling actually
@@ -7879,6 +8103,7 @@ const discoveryView = Vue.component('discovery-view', {
         if (typeof status.peerRetentionDays === 'number') { P2PSETTINGS.peerRetentionDays = status.peerRetentionDays; }
         if (typeof status.autoFetchCount === 'number') { P2PSETTINGS.autoFetchCount = status.autoFetchCount; }
         if (typeof status.rotationDays === 'number') { P2PSETTINGS.rotationDays = status.rotationDays; }
+        if (status.watchdog && typeof status.watchdog.maxRssMb === 'number') { P2PSETTINGS.sidecarMaxRssMb = status.watchdog.maxRssMb; }
         if (status.enabled === true) {
           const cat = (await API.axios({
             method: 'GET',
@@ -9447,6 +9672,67 @@ const editP2pRotationView = Vue.component('edit-p2p-rotation-modal', {
         });
 
         P2PSETTINGS.rotationDays = Number(this.editValue);
+
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+
+        iziToast.success({
+          title: t('admin.settings.updated'),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } catch(err) {
+        iziToast.error({
+          title: t('admin.modal.updateFailed'),
+          message: escHtml(err.response?.data?.error || ''),
+          position: 'topCenter',
+          timeout: 3500
+        });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+const editP2pSidecarMaxRssView = Vue.component('edit-p2p-sidecar-max-rss-modal', {
+  data() {
+    return {
+      submitPending: false,
+      editValue: P2PSETTINGS.sidecarMaxRssMb
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Sidecar memory ceiling</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-p2p-sidecar-max-rss" required type="number" min="0" max="100000">
+          <label for="edit-p2p-sidecar-max-rss">Max resident memory (MB)</label>
+          <span class="helper-text">If the p2p-sidecar's memory grows past this, the watchdog restarts it automatically — the mesh reweaves within a minute and downloads are unaffected. Applies from the next health check, no restart needed. 0 turns the watchdog off.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/sidecar-max-rss`,
+          data: { sidecarMaxRssMb: Number(this.editValue) }
+        });
+
+        P2PSETTINGS.sidecarMaxRssMb = Number(this.editValue);
 
         M.Modal.getInstance(document.getElementById('admin-modal')).close();
 

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -7556,7 +7556,11 @@ const discoveryView = Vue.component('discovery-view', {
       // server list renders. Session-local by design — a page load lands
       // everyone on the same view.
       headerTab: 'mesh',
-      listMode: 'cards'
+      listMode: 'cards',
+      // Activity feed: delta-polled from the dedicated p2p log ring. seq
+      // cursors are server-side; entries accumulate here while the tab is
+      // open (capped client-side to the ring's own size).
+      p2pActivity: { entries: [], lastSeq: 0 }
     };
   },
   template: `
@@ -7635,7 +7639,7 @@ const discoveryView = Vue.component('discovery-view', {
                     <div style="display: flex; gap: 8px; margin-top: 12px; border-bottom: 1px solid #3a3a47; padding-bottom: 10px; flex-wrap: wrap;">
                       <div v-on:click="headerTab = 'mesh'" :style="headerTabStyle('mesh')">Mesh</div>
                       <div v-on:click="headerTab = 'stats'" :style="headerTabStyle('stats')">Stats</div>
-                      <div v-on:click="headerTab = 'activity'" :style="headerTabStyle('activity')">Activity</div>
+                      <div v-on:click="headerTab = 'activity'; loadDiscoveryActivity()" :style="headerTabStyle('activity')">Activity</div>
                       <div v-on:click="headerTab = 'invite'" :style="headerTabStyle('invite')">Invite</div>
                       <div v-on:click="headerTab = 'config'" :style="headerTabStyle('config')">Config</div>
                     </div>
@@ -7707,12 +7711,17 @@ const discoveryView = Vue.component('discovery-view', {
                         <div style="font-size: 0.8em; color: #666672; margin-top: 4px;">snapshots served back to the mesh</div>
                       </div>
                     </div>
-                    <div v-if="headerTab === 'activity'" style="min-height: 200px; display: flex; align-items: center; justify-content: center; padding: 12px 0;">
-                      <div style="border: 1px dashed #505061; border-radius: 2px; padding: 22px 28px; max-width: 460px; text-align: center;">
-                        <div style="font-weight: 700; color: #fff; margin-bottom: 6px;">Activity — coming soon</div>
-                        <div style="font-size: 0.85em; color: #9e9ea8; line-height: 1.6;">Mesh joins, snapshot updates, rotation and
-                        recovery events will land here in a future release.</div>
+                    <div v-if="headerTab === 'activity'" style="min-height: 200px; padding-top: 12px;">
+                      <div v-if="activityFeed.length === 0" style="color: #9e9ea8; font-size: 0.85em; padding-top: 8px;">
+                        Nothing yet — mesh joins, snapshot fetches, rotation and recovery events land here as they happen.</div>
+                      <div v-else style="max-height: 240px; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; font-family: monospace; font-size: 0.8em;">
+                        <div v-for="e in activityFeed" :key="e.seq" style="color: #bdbdc6; line-height: 1.45; word-break: break-word;">
+                          <span style="color: #666672;">{{ discoveryLogTime(e.t) }}</span>
+                          <span :style="e.level === 'warn' || e.level === 'error' ? 'color: #ffcc80;' : ''"> {{ e.message }}</span>
+                        </div>
                       </div>
+                      <div style="font-size: 0.75em; color: #666672; margin-top: 8px;">newest first · held in memory only — the
+                      full history lives in the server logs</div>
                     </div>
                     <div v-if="headerTab === 'invite'" style="min-height: 200px; padding-top: 12px;">
                       <p style="font-size: 0.85em; color: #9e9ea8; margin: 0 0 8px 0;"><b style="color: #fff;">Endpoint:</b>
@@ -7903,6 +7912,11 @@ const discoveryView = Vue.component('discovery-view', {
     heldPeers: function() {
       return this.discoveryP2p.peers.filter((p) => p.fetched);
     },
+    // Newest first for the Activity tab; display capped so the DOM stays
+    // small even after a long-open tab accumulates the whole ring.
+    activityFeed: function() {
+      return this.p2pActivity.entries.slice(-200).reverse();
+    },
     heldTrackTotal: function() {
       return this.heldPeers.reduce((sum, p) => sum + (Number(p.payload.rowCount) || 0), 0);
     },
@@ -7967,6 +7981,7 @@ const discoveryView = Vue.component('discovery-view', {
       if (document.hidden || this.p2pToggling) { return; }
       if (!this.discoveryP2p.status || this.discoveryP2p.status.enabled !== true) { return; }
       this.loadDiscoveryP2p(true);
+      if (this.headerTab === 'activity') { this.loadDiscoveryActivity(); }
     }, 10000);
   },
   beforeDestroy: function () {
@@ -8082,6 +8097,30 @@ const discoveryView = Vue.component('discovery-view', {
           }],
         ]
       });
+    },
+    loadDiscoveryActivity: async function() {
+      try {
+        const r = (await API.axios({
+          method: 'GET',
+          url: `${API.url()}/api/v1/admin/discovery/p2p/activity?since=${this.p2pActivity.lastSeq}`
+        })).data;
+        // lastSeq below the cursor means the server restarted and its seq
+        // counter reset — start the accumulation over instead of appending
+        // a second copy of history.
+        if (r.lastSeq < this.p2pActivity.lastSeq) { this.p2pActivity.entries = []; }
+        this.p2pActivity.entries.push(...r.entries);
+        if (this.p2pActivity.entries.length > 500) {
+          this.p2pActivity.entries.splice(0, this.p2pActivity.entries.length - 500);
+        }
+        this.p2pActivity.lastSeq = r.lastSeq;
+      } catch (err) { /* quiet — the 10s poll or next tab click retries */ }
+    },
+    discoveryLogTime: function(iso) {
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) { return iso; }
+      const sameDay = d.toDateString() === new Date().toDateString();
+      return sameDay ? d.toTimeString().slice(0, 8)
+        : `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${d.toTimeString().slice(0, 5)}`;
     },
     discoveryToggleIncompatible: async function() {
       // Server-side filter, so the toggle re-fetches rather than un-hiding


### PR DESCRIPTION
Implements the hybrid Discovery panel design (from the design-canvas exploration): the enabled view becomes a dark header card with five switchable tabs over a server list with a cards/list toggle.

## The five tabs

| Tab | Content | Backend |
|---|---|---|
| **Mesh** | SVG map: you + gossip links (solid green) + known servers (dashed; amber = incompatible model) | new `status.neighborIds` |
| **Stats** | 6 tiles: neighbors, servers known, snapshots held, peer tracks searchable, sidecar memory, seeding | none — existing routes |
| **Activity** | Live feed of discovery events — from a **dedicated p2p log ring**, see below | new `activity` route (zero new storage) |
| **Invite** | endpoint + ticket + befriend box | none — existing |
| **Config** | storage cap, forget days, auto-fetch, rotate days, community seeds, **sidecar memory ceiling** | new `sidecar-max-rss` route |

The status line (state dot, neighbor count, sidecar RSS, announce name) stays constant above the tabs; Refresh/Disable move up beside it. The list keeps every existing behavior in both modes — filter, Download/Update/Remove/Pin/Forget/Block, hidden-incompatible counts (#892), blocked list.

## New APIs — disk-growth check applied

Per the working rule for this project: every new API was assessed for unbounded storage growth before building. **None of the three stores anything new on disk.**

- **`status.neighborIds`** — in-memory `Set` fed by the sidecar's `neighbor` events, cleared on teardown. Protocol-bounded: hyparview caps the active view, so this can never exceed the gossip fan-out regardless of network size.
- **`POST …/sidecar-max-rss`** — single config-key write (the #885 watchdog ceiling, previously editable only in the config file), Joi bounds mirroring the config schema (0 = watchdog off), live on the next health tick.
- **`GET …/activity`** — the Activity feed reuses the existing logging infra instead of inventing an event store. `src/logger.js`'s ring buffer is generalized into a `LogRing` class instantiated twice: the main ring behind the admin live-log viewer (contract unchanged), plus a fixed-500-entry ring that captures only discovery-stack lines. Every stack module already logs under a bracketed prefix (`[discovery-*]`, `[p2p-sidecar]`) and nothing else uses those — so line-start prefix matching IS the event filter, and the dedicated ring means a chatty scan can never wash mesh events out of the feed. Memory: ~150KB typical, 2MB absolute worst case (500 × the 4KB entry cap). Deep history remains the already-rotating, already-pruned on-disk logs. One gap filled: neighbor up/down now gets a log line (it was tracked silently) — self-throttling since the active view caps how many links exist to churn.
- **Stats** need no API at all — every tile reads from the status/catalog responses the panel already polls.

## Verification

- `test/integration/discovery-p2p.test.mjs` 49/49 against the real binary: `neighborIds` shape (always an array, empty pre-mesh); the live-neighbor assertion inside the gossip-loop suite; the `sidecar-max-rss` contract (valid writes read back including the 0 off-switch; junk 400s change nothing; 403 when disabled); the Activity feed carries the real peer's neighbor-up line and **every** entry matches the prefix filter (wash-in negative control against a server that logged plenty of non-discovery lines since boot); `activity` in the disabled-403 list.
- New `test/unit/log-ring.test.mjs` (4 tests): prefix isolation between the rings, independent seq cursors + stale-cursor recovery, oversized-entry truncation, and main-ring resize leaving the p2p ring untouched.
- Adjacent suites (watchdog, boot-retry, crash-recovery model, sidecar-fetch): 34/34.
- Live browser smoke against two real peer sidecars, twice: all five tabs with real data; ceiling modal round-trip (set 384 via the UI → status + config reflect it); cards↔list toggle; the mesh map showing linked vs known-offline as a peer left; and the Activity tab streaming sidecar-ready, catalog joins, neighbor-ups, an auto-fetch failure with its retry note, then the neighbor-down when the peer departed.

## Notes for review

- The mesh map draws what the list shows: peers hidden by the incompatible filter aren't drawn either. Deterministic sorted-by-id layout so the 10s poll never makes it jiggle; caps at 8 nodes/ring with a "+N more" line.
- `neighbors` (the sidecar's own count) stays the authority in the status line; `neighborIds` is best-effort event tracking for the map. They converged correctly in the live smoke, including on churn.
- The header tab and list mode are session-local by design (no persistence) — a reload lands everyone on Mesh + cards.
- The Activity feed polls only while its tab is open, delta-cursored, with restart-reset detection client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
