### PR TITLE
test(waveform): CI-size every ffmpeg-fallback timeout

### DIFF
--- a/test/scanner/waveform-fallback.test.mjs
+++ b/test/scanner/waveform-fallback.test.mjs
@@ -66,6 +66,11 @@ after(async () => {
 // this file ran 27-30s apiece, and one of them blew a 60s timeout with
 // nothing actually wrong. The rust-binary waveform suites, which spawn
 // nothing per case, stayed at 2-8s on that same runner.
+//
+// 2026-08: a slower windows runner reran the lesson — PASSING tests in this
+// file measured 87-135s and one blew the then-120s cap, again with nothing
+// wrong. Hence the uniform 240s per-test timeout: the caps exist to fail a
+// genuinely hung ffmpeg rather than hang the shard, not to race the runner.
 const fixtureCache = new Map();
 async function fixtureFor(name, codec, freq) {
   const ext = path.extname(name);
@@ -115,7 +120,7 @@ async function makeCase(tracks) {
 const newAbort = () => ({ stopped: false });
 
 describe('waveform ffmpeg fallback', () => {
-  test('generates a waveform for Opus, which symphonia cannot decode', { timeout: 120_000 }, async (t) => {
+  test('generates a waveform for Opus, which symphonia cannot decode', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
 
@@ -131,7 +136,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(failedMarkerPath(cache, 'aaa')), 'success leaves no marker');
   });
 
-  test('mp3s are left to the rust pass; only unsupported codecs are picked up', { timeout: 120_000 }, async (t) => {
+  test('mp3s are left to the rust pass; only unsupported codecs are picked up', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([
       { name: 'a.opus', hash: 'aaa' },
@@ -146,7 +151,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(cacheFilePath(cache, 'bbb')));
   });
 
-  test('an already-cached key is skipped', { timeout: 120_000 }, async (t) => {
+  test('an already-cached key is skipped', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
     await fsp.writeFile(cacheFilePath(cache, 'aaa'), Buffer.alloc(NUM_BARS, 7));
@@ -158,7 +163,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa'))[0], 7, 'existing cache untouched');
   });
 
-  test('a symphonia-only marker is retried and cleared when ffmpeg succeeds', { timeout: 120_000 }, async (t) => {
+  test('a symphonia-only marker is retried and cleared when ffmpeg succeeds', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // An mp3 symphonia choked on: not an unsupported codec, so it only
     // reaches the fallback via its marker.
@@ -174,7 +179,7 @@ describe('waveform ffmpeg fallback', () => {
       'a marker that is no longer true must be removed');
   });
 
-  test('a marker naming ffmpeg is not retried', { timeout: 120_000 }, async (t) => {
+  test('a marker naming ffmpeg is not retried', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
     await fsp.writeFile(failedMarkerPath(cache, 'aaa'), 'symphonia\nffmpeg\n');
@@ -186,7 +191,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(cacheFilePath(cache, 'aaa')));
   });
 
-  test('undecodable content records an ffmpeg failure exactly once', { timeout: 120_000 }, async (t) => {
+  test('undecodable content records an ffmpeg failure exactly once', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([{ name: 'a.opus', hash: 'aaa', create: false }]);
     await fsp.writeFile(path.join(lib, 'a.opus'), 'this is not an opus stream');
@@ -201,7 +206,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(second.total, 0, 'a recorded failure is not re-attempted');
   });
 
-  test('duplicate content decodes once; a vanished copy falls through to a live one', { timeout: 120_000 }, async (t) => {
+  test('duplicate content decodes once; a vanished copy falls through to a live one', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([
       { name: 'gone.opus', hash: 'dup' },
@@ -217,7 +222,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(fs.existsSync(cacheFilePath(cache, 'dup')));
   });
 
-  test('a key whose every copy has vanished leaves no marker', { timeout: 120_000 }, async (t) => {
+  test('a key whose every copy has vanished leaves no marker', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([{ name: 'a.opus', hash: 'aaa' }]);
     fs.rmSync(path.join(lib, 'a.opus'));
@@ -231,7 +236,7 @@ describe('waveform ffmpeg fallback', () => {
       'the file may come back unchanged — do not poison the key');
   });
 
-  test('abort stops the run without generating anything further', { timeout: 120_000 }, async (t) => {
+  test('abort stops the run without generating anything further', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache } = await makeCase([
       { name: 'a.opus', hash: 'aaa' },
@@ -250,7 +255,7 @@ describe('waveform ffmpeg fallback', () => {
 
   // ── Regressions from the adversarial review of PR #818 ────────────────────
 
-  test('an unreachable cache dir reports zero DURABLE progress — the self-chain spin guard', { timeout: 120_000 }, async (t) => {
+  test('an unreachable cache dir reports zero DURABLE progress — the self-chain spin guard', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // The dir vanished after boot (unmounted volume, deleted tree). Every
     // decode succeeds but nothing can persist; the old chain gate counted
@@ -276,7 +281,7 @@ describe('waveform ffmpeg fallback', () => {
       'the chain gate must refuse a round that landed nothing');
   });
 
-  test('a cache-write failure is NOT recorded as ffmpeg’s verdict on the audio', { timeout: 120_000 }, async (t) => {
+  test('a cache-write failure is NOT recorded as ffmpeg’s verdict on the audio', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, lib } = await makeCase([{ name: 'good.opus', hash: 'aaa' }]);
     // The cache "directory" is a FILE. Every write into it fails, and —
@@ -307,7 +312,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(fs.readFileSync(cacheFilePath(cache, 'aaa')).length, NUM_BARS);
   });
 
-  test('an undecodable file whose marker cannot be written counts no durable progress', { timeout: 120_000 }, async (t) => {
+  test('an undecodable file whose marker cannot be written counts no durable progress', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // Pins recordFfmpegFailure's boolean return AND the markersRecorded
     // gate, in both directions: the decode genuinely fails (so `failed`
@@ -328,7 +333,7 @@ describe('waveform ffmpeg fallback', () => {
       'a round that recorded nothing must not chain');
   });
 
-  test('an unreadable file is not given a permanent ffmpeg verdict', { timeout: 120_000 }, async (t) => {
+  test('an unreadable file is not given a permanent ffmpeg verdict', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // A path that exists but cannot be READ — a lock, an ACL change, a
     // stale mount. ffmpeg exits non-zero exactly as it would for corrupt
@@ -356,7 +361,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.equal(retry.generated, 1, 'the key must still be reachable once readable again');
   });
 
-  test('a deferred artifact routes the key here whatever its container', { timeout: 120_000 }, async (t) => {
+  test('a deferred artifact routes the key here whatever its container', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // The rust pass writes a `.w2.deferred` artifact for a codec it has no
     // decoder for. The container may be one CANDIDATE_EXTS never queries
@@ -380,7 +385,7 @@ describe('waveform ffmpeg fallback', () => {
       'and a deferral must never have been a failure');
   });
 
-  test('an unreadable copy does not end the walk while a good copy remains', { timeout: 120_000 }, async (t) => {
+  test('an unreadable copy does not end the walk while a good copy remains', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     const { db, cache, lib } = await makeCase([
       { name: 'bad.opus', hash: 'dup2', create: false },
@@ -401,7 +406,7 @@ describe('waveform ffmpeg fallback', () => {
     assert.ok(!fs.existsSync(failedMarkerPath(cache, 'dup2')));
   });
 
-  test('opus inside a .ogg container is picked up via the extension source', { timeout: 120_000 }, async (t) => {
+  test('opus inside a .ogg container is picked up via the extension source', { timeout: 240_000 }, async (t) => {
     if (!ffmpegOk) { return t.skip('no bundled ffmpeg'); }
     // The rust pass probes these, finds no decoder, and skips them
     // silently (no marker) — so the ONLY route to a waveform is this


### PR DESCRIPTION
Fixes the flake that hit [PR #893's full-ci run](https://github.com/IrosTheBeggar/mStream/actions/runs/32844312214): `test (windows-latest · 1/3)` timed out `mp3s are left to the rust pass; only unsupported codecs are picked up` at its 120s cap — on a discovery-only PR that touches nothing in the scanner.

**Why it's the timeout, not the test:** the same shard's log shows a *passing* sibling in the same suite taking **135.3s** and another at 86.8s, plus an ffmpeg-timeout warning mid-suite — the runner was slow, and this suite is spawn-bound by design (a single ffmpeg spawn has measured ~15s on Windows CI, per the suite's own header comment). This is the same lesson as f93c95a7 ("the ffmpeg fallback suite needs a CI-sized timeout"), one notch further.

**The change:** all 16 per-test caps go 120s → 240s uniformly. Singling out the one test that happened to blow would leave its siblings primed for the identical flake — the observed 135s *pass* proves the margin was thin everywhere. The caps exist to fail a genuinely hung ffmpeg rather than hang the shard, not to race the runner. The header comment records the 2026-08 measurement alongside the original ones so the next bump (if ever) has the history in one place.

No production code touched. Suite passes 17/17 in 2.4s locally (macOS, where spawns are ~1s — exactly the platform asymmetry the comment documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
