### PR TITLE
Boot watchdog: roll back updates that crash at boot, hold them, self-heal on the next release

### DIFF
--- a/.github/workflows/build-rust-launcher.yml
+++ b/.github/workflows/build-rust-launcher.yml
@@ -1,8 +1,8 @@
 name: Build Rust Launcher
 
 # Two duties, mirroring build-rust-parser.yml:
-#   - PR check (build + clippy on all three desktop OSes) so the crate can't
-#     bit-rot between phases.
+#   - PR check (build + test + clippy on all three desktop OSes) so the crate
+#     can't bit-rot between phases.
 #   - On master pushes touching the crate: build the four shipped launcher
 #     binaries, self-test each, and COMMIT them to bin/rust-launcher/ — the
 #     bundler (scripts/build-bun.mjs) stages the launcher from there as the
@@ -98,6 +98,18 @@ jobs:
       - name: Build (release)
         working-directory: rust-launcher
         run: cargo build --release --locked
+
+      # Per-OS on purpose, and --release so the build step's artifacts are
+      # reused: the boot-watchdog rollback module (rollback.rs) is cfg'd per
+      # target — junction re-point via mklink on Windows, atomic symlink swap
+      # on unix, the ~/Applications shape on macOS — so a test run on one
+      # platform proves little about the others. Before this step NOTHING in
+      # CI ran the launcher's tests at all: the windows junction arm had
+      # never executed anywhere, and a linux-only dead-code error shipped to
+      # a PR unseen by a mac-side cargo test.
+      - name: Test
+        working-directory: rust-launcher
+        run: cargo test --release --locked
 
       - name: Clippy
         working-directory: rust-launcher

--- a/docs/install.md
+++ b/docs/install.md
@@ -72,6 +72,18 @@ stage into layouts the installer owns: package-manager installs (deb/rpm,
 the macOS `.pkg`), Docker, npm, and hand-extracted copies are told about
 updates but never touched.
 
+If an applied update crashes before it ever serves, the desktop launcher's
+**boot watchdog** rolls it back on its own: after a failed retry it
+re-points `current` at the previous version (kept on disk for exactly this),
+restores the `~/Applications` copy on macOS, relaunches, and records the
+failed version in `update-hold.json` so the daily check doesn't re-stage it.
+The admin panel shows the held version; the hold clears automatically the
+moment a release newer than it ships (or by hand via the panel's
+"clear hold & retry"). Headless installs get the server-side half of this —
+a held version is never staged or applied, and a `current` link left on one
+is re-pointed at the running version — but with no launcher watching the
+boot, the rollback itself needs the supervisor or a re-run of the installer.
+
 Rolling back? Re-run the installer with `MSTREAM_VERSION=<old tag>`, restart,
 and then **skip the bad release** (the admin panel's skip link, or
 `updates.skipVersion` in the config) — otherwise the next daily check

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:smoke:docker": "node test/smoke/docker/run-docker-stack-smoke.mjs",
     "test:smoke:windows": "node test/smoke/windows-native-daemons.mjs",
     "test:smoke:update-watchdog": "sh test/smoke/update-watchdog-smoke.sh",
+    "test:smoke:update-watchdog:win": "powershell -NoProfile -ExecutionPolicy Bypass -File test/smoke/update-watchdog-smoke.ps1",
     "fetch-p2p-sidecar": "node scripts/fetch-p2p-sidecar.mjs",
     "fetch-mstream-player": "node scripts/fetch-mstream-player.mjs",
     "test:smoke:sidecar-volume": "bash test/smoke/docker/p2p-sidecar-volume-smoke.sh"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:cli-audio": "docker build -f test/cli-audio/Dockerfile -t mstream-cli-audio-smoke . && docker run --rm mstream-cli-audio-smoke",
     "test:smoke:docker": "node test/smoke/docker/run-docker-stack-smoke.mjs",
     "test:smoke:windows": "node test/smoke/windows-native-daemons.mjs",
+    "test:smoke:update-watchdog": "sh test/smoke/update-watchdog-smoke.sh",
     "fetch-p2p-sidecar": "node scripts/fetch-p2p-sidecar.mjs",
     "fetch-mstream-player": "node scripts/fetch-mstream-player.mjs",
     "test:smoke:sidecar-volume": "bash test/smoke/docker/p2p-sidecar-volume-smoke.sh"

--- a/rust-launcher/src/main.rs
+++ b/rust-launcher/src/main.rs
@@ -18,6 +18,7 @@
 mod autostart;
 mod paths;
 mod platform;
+mod rollback;
 mod server;
 mod tray_app;
 

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -311,26 +311,30 @@ pub fn parse_update_status(doc: &str) -> Option<UpdateStatus> {
     })
 }
 
-/// The bundle-dir naming the installers create: mStream-<X.Y.Z>-<key>.
-/// Mirrors parseBundleName in src/util/update-check.js closely enough for
-/// target derivation (the final existence check is the real gate).
-pub fn is_bundle_dir_name(name: &str) -> bool {
-    let Some(rest) = name.strip_prefix("mStream-") else { return false };
-    let Some(dash) = rest.find(|c: char| !(c.is_ascii_digit() || c == '.')) else { return false };
+/// The bundle-dir naming the installers create: mStream-<X.Y.Z>-<key> ->
+/// (version, key). Mirrors parseBundleName in src/util/update-check.js
+/// closely enough for target derivation (the final existence check is the
+/// real gate).
+pub(crate) fn parse_bundle_dir_name(name: &str) -> Option<(String, String)> {
+    let rest = name.strip_prefix("mStream-")?;
+    let dash = rest.find(|c: char| !(c.is_ascii_digit() || c == '.'))?;
     if dash == 0 || !rest[dash..].starts_with('-') {
-        return false;
+        return None;
     }
-    if sanitize_version(&rest[..dash]).is_none() {
-        return false;
-    }
+    let version = sanitize_version(&rest[..dash])?;
     let key = &rest[dash + 1..];
-    ["darwin-", "linux-", "win-"].iter().any(|p| key.starts_with(p))
+    let ok = ["darwin-", "linux-", "win-"].iter().any(|p| key.starts_with(p))
         && key.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-        && !key.ends_with('-')
+        && !key.ends_with('-');
+    ok.then(|| (version, key.to_string()))
+}
+
+pub fn is_bundle_dir_name(name: &str) -> bool {
+    parse_bundle_dir_name(name).is_some()
 }
 
 /// The launcher face's path inside a bundle, per platform.
-fn launcher_rel() -> &'static str {
+pub(crate) fn launcher_rel() -> &'static str {
     if cfg!(windows) {
         "mStream.exe"
     } else if cfg!(target_os = "macos") {
@@ -555,6 +559,12 @@ mod tests {
         assert!(!is_bundle_dir_name("current"));
         assert!(!is_bundle_dir_name("mStream-latest-linux-x64"));
         assert!(!is_bundle_dir_name("mStream.app"));
+        // The parsed halves, for the rollback module's candidate scan.
+        assert_eq!(
+            parse_bundle_dir_name("mStream-6.21.2-linux-arm64-musl"),
+            Some(("6.21.2".to_string(), "linux-arm64-musl".to_string()))
+        );
+        assert_eq!(parse_bundle_dir_name("mStream-6.21.2-linux-x64.replaced-2026"), None);
     }
 
     #[test]

--- a/rust-launcher/src/rollback.rs
+++ b/rust-launcher/src/rollback.rs
@@ -1,0 +1,643 @@
+// Boot-failure rollback — the launcher-side safety net for a staged update
+// that passes the installers' exec probe (`-V` answers) but cannot actually
+// BOOT: a config/db/module-load regression crashes the new server before it
+// ever serves. Before this module, that shape was a dead install: `current`,
+// the login item, and the ~/Applications copy all point at the broken
+// version (the stage-time flip), the launcher shows "Stopped" and never
+// restarts a crashed server, and — because the SERVER is the update checker
+// — the follow-up fixed release is never even discovered.
+//
+// The watchdog's contract (tray_app.rs decides WHEN; this module decides
+// WHETHER and does the work):
+//
+//   plan_rollback   — is this a managed layout committed to OUR version,
+//                     with a lower same-key version on disk whose server
+//                     still execs? Pure-ish and injected, so the decision
+//                     matrix is unit-testable.
+//   execute_rollback— record the failed version in update-hold.json (the
+//                     server reads it and refuses to re-stage that version,
+//                     src/util/update-check.js — without the hold, the next
+//                     daily check re-flips onto the very release the
+//                     watchdog just backed out of), neutralize the stale
+//                     status file (its applyRequested was armed by a
+//                     now-dead server; the rolled-back launcher must not
+//                     act on it), re-point `current`, and on macOS restore
+//                     the ~/Applications copy from the target bundle (the
+//                     .old.* aside is long swept — the versioned root copy
+//                     is the rollback source). Returns the launcher face to
+//                     hand off to via platform::relaunch + --takeover.
+//
+// A hold clears in two ways, both server-side: any boot of a version >= the
+// held one deletes the entry (the fix shipped, or the failure was
+// environmental and a human re-applied successfully), and the admin panel's
+// clearHold override drops them all. So the "bad release, then a working
+// release" flow needs no human: bad boots, watchdog rolls back, hold blocks
+// re-staging, the fixed release stages and applies normally.
+use crate::paths;
+use std::cmp::Ordering;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// One file, two writers who never overlap: the launcher appends here only
+/// while no server runs (the rollback moment); the server prunes/clears it
+/// while the launcher only reads. Lives beside update-status.json in the
+/// shared data home.
+pub const HOLD_FILE: &str = "update-hold.json";
+const MAX_HELD: usize = 8;
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub struct RollbackPlan {
+    pub root: PathBuf,
+    /// The version this launcher shipped in — the one that failed to boot.
+    pub failed_version: String,
+    /// The versioned bundle dir to roll back to.
+    pub target_bundle: PathBuf,
+    pub target_version: String,
+    /// macOS: the ~/Applications copy this launcher runs from, whose
+    /// contents (refreshed to the failed version at stage time) must be
+    /// restored from target_bundle. None when running from a versioned dir.
+    pub apps_copy: Option<PathBuf>,
+}
+
+/// Strict numeric-triple compare (mirrors compareVersions in
+/// src/util/update-check.js): None for anything that is not X.Y.Z.
+fn compare_triples(a: &str, b: &str) -> Option<Ordering> {
+    fn parse(s: &str) -> Option<[u64; 3]> {
+        let mut it = s.split('.');
+        let out = [
+            it.next()?.parse().ok()?,
+            it.next()?.parse().ok()?,
+            it.next()?.parse().ok()?,
+        ];
+        it.next().is_none().then_some(out)
+    }
+    Some(parse(a)?.cmp(&parse(b)?))
+}
+
+/// The server binary's path inside a bundle, per platform (install.sh's
+/// server_rel / scripts/build-bun.mjs staging).
+fn server_rel() -> &'static str {
+    if cfg!(windows) {
+        "mstream-server.exe"
+    } else if cfg!(target_os = "macos") {
+        "mStream.app/Contents/MacOS/mstream-server"
+    } else {
+        "mstream-server"
+    }
+}
+
+/// Versions held after failed boots, read tolerantly: the file is our own
+/// but may be absent, from a newer schema, or hand-mangled — garbage entries
+/// drop out rather than wedging the watchdog.
+pub fn held_versions(data_home: &Path) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(data_home.join(HOLD_FILE)) else {
+        return Vec::new();
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Vec::new();
+    };
+    v.get("held")
+        .and_then(|h| h.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|e| e.get("version").and_then(|x| x.as_str()))
+                .filter_map(paths::sanitize_version)
+                .take(MAX_HELD)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Append `version` to the hold file (dedup; oldest entries give way past
+/// the cap). Written atomically — a torn hold file would read as "nothing
+/// held" and re-open the re-stage loop the hold exists to close.
+fn record_hold(data_home: &Path, version: &str, reason: &str) -> Result<(), String> {
+    let path = data_home.join(HOLD_FILE);
+    let mut held: Vec<serde_json::Value> = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
+        .and_then(|v| v.get("held").and_then(|h| h.as_array()).cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|e| {
+            e.get("version")
+                .and_then(|x| x.as_str())
+                .and_then(paths::sanitize_version)
+                .is_some()
+        })
+        .collect();
+    if !held
+        .iter()
+        .any(|e| e.get("version").and_then(|x| x.as_str()) == Some(version))
+    {
+        let at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        held.push(serde_json::json!({ "version": version, "at": at, "reason": reason }));
+    }
+    while held.len() > MAX_HELD {
+        held.remove(0);
+    }
+    let doc = serde_json::json!({ "schema": 1, "held": held });
+    let tmp = data_home.join(format!("{HOLD_FILE}.tmp-{}", std::process::id()));
+    std::fs::write(&tmp, serde_json::to_string_pretty(&doc).unwrap_or_default())
+        .map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, &path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename onto {}: {e}", path.display())
+    })
+}
+
+/// `<bin> -V`, bounded: does the rollback target's server still exec here?
+/// Same bar as the installers' probe-before-flip — never hand off into a
+/// binary that cannot even start (the watchdog would just fire again).
+pub fn probe_server(bin: &Path) -> bool {
+    let Ok(mut child) = std::process::Command::new(bin)
+        .arg("-V")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    else {
+        return false;
+    };
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(st)) => return st.success(),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(_) => return false,
+        }
+    }
+}
+
+/// Decide whether a rollback is possible, and to what. None = not our call
+/// (not a managed layout, the layout is not committed to our version, or
+/// nothing usable to roll back to) — the caller falls through to today's
+/// Stopped-with-dialog behavior.
+///
+/// `exe_real` is the canonicalized running-launcher path; `our_version` the
+/// MSTREAM_BUNDLE_VERSION build stamp (a parameter so tests can fabricate
+/// layouts); `probe` injects probe_server.
+pub fn plan_rollback(
+    exe_real: Option<&Path>,
+    our_version: &str,
+    home: &Path,
+    data_home: &Path,
+    probe: &dyn Fn(&Path) -> bool,
+) -> Option<RollbackPlan> {
+    let exe = exe_real?;
+
+    // Layout (a): running from a versioned bundle dir — root is its parent.
+    let mut root: Option<PathBuf> = None;
+    let mut apps_copy: Option<PathBuf> = None;
+    let mut dir = exe.parent();
+    for _ in 0..8 {
+        let Some(d) = dir else { break };
+        if d.file_name()
+            .and_then(|n| n.to_str())
+            .and_then(paths::parse_bundle_dir_name)
+            .is_some()
+        {
+            root = d.parent().map(Path::to_path_buf);
+            break;
+        }
+        dir = d.parent();
+    }
+
+    // Layout (b): the macOS ~/Applications copy the installer owns (sibling
+    // marker). The marker's second line names a custom install root; older
+    // version-only markers fall back to the per-OS default root, exactly as
+    // detectInstallMethod does server-side.
+    if root.is_none() {
+        let apps = home.join("Applications").join("mStream.app");
+        let marker = home.join("Applications").join(".mstream-installer");
+        if exe.starts_with(&apps) && marker.exists() {
+            let mut r = data_home.join("app");
+            if let Ok(text) = std::fs::read_to_string(&marker) {
+                if let Some(line) = text.lines().nth(1) {
+                    let line = line.trim();
+                    if !line.is_empty() && Path::new(line).is_absolute() {
+                        r = PathBuf::from(line);
+                    }
+                }
+            }
+            apps_copy = Some(apps);
+            root = Some(r);
+        }
+    }
+
+    let root = root?;
+    let link = root.join("current");
+    let cur_target = std::fs::read_link(&link).ok()?;
+    let (cur_ver, key) = paths::parse_bundle_dir_name(cur_target.file_name()?.to_str()?)?;
+    // Only when the layout is committed to US: a `current` already pointing
+    // elsewhere (an operator's manual re-point, a takeover raced by a stage)
+    // is not ours to fight.
+    if cur_ver != our_version {
+        return None;
+    }
+
+    let held = held_versions(data_home);
+
+    // Candidates: lower same-key versions with a server binary, newest
+    // first, minus every held version — never roll back INTO a known-bad
+    // (two broken releases in a row must land on the last good one, not
+    // ping-pong between the broken pair).
+    let mut candidates: Vec<(String, PathBuf)> = Vec::new();
+    for entry in std::fs::read_dir(&root).ok()?.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some((ver, k)) = paths::parse_bundle_dir_name(name) else { continue };
+        if k != key
+            || compare_triples(&ver, our_version) != Some(Ordering::Less)
+            || held.contains(&ver)
+        {
+            continue;
+        }
+        let bundle = root.join(name);
+        if bundle.join(server_rel()).exists() {
+            candidates.push((ver, bundle));
+        }
+    }
+    candidates.sort_by(|a, b| compare_triples(&b.0, &a.0).unwrap_or(Ordering::Equal));
+    let (target_version, target_bundle) = candidates
+        .into_iter()
+        .find(|(_, bundle)| probe(&bundle.join(server_rel())))?;
+
+    Some(RollbackPlan {
+        root,
+        failed_version: our_version.to_string(),
+        target_bundle,
+        target_version,
+        apps_copy,
+    })
+}
+
+/// Perform the rollback. Returns the launcher face to relaunch via
+/// platform::relaunch (+ --takeover). Order matters: the hold is recorded
+/// FIRST — even if a later step dies, the record exists and the (rolled-back
+/// or manually restarted) server's enforceHold finishes the re-point.
+pub fn execute_rollback(
+    plan: &RollbackPlan,
+    data_home: &Path,
+    log: &dyn Fn(&str),
+) -> Result<PathBuf, String> {
+    if let Err(e) = record_hold(
+        data_home,
+        &plan.failed_version,
+        "server exited before it finished starting after an update",
+    ) {
+        // Without the record the server re-stages the bad version within a
+        // day — a daily crash/rollback cycle instead of a stuck install.
+        // Still better than not rolling back; proceed loudly.
+        log(&format!("update watchdog: could not record the hold: {e}"));
+    }
+
+    // The status file's applyRequested was armed by a now-dead server for
+    // the version being backed out. The rolled-back launcher polls that
+    // file within a minute; deleting it is what keeps a stale arm from
+    // relaunching anything (the next healthy supervised server rewrites it
+    // at boot).
+    let _ = std::fs::remove_file(data_home.join("update-status.json"));
+
+    repoint_current(&plan.root.join("current"), &plan.target_bundle)?;
+    log(&format!(
+        "update watchdog: current re-pointed at {}",
+        plan.target_bundle.display()
+    ));
+
+    #[cfg(not(target_os = "macos"))]
+    let face = plan.root.join("current").join(paths::launcher_rel());
+    #[cfg(target_os = "macos")]
+    let face = match &plan.apps_copy {
+        Some(dest) => {
+            match restore_apps_copy(dest, &plan.target_bundle, &plan.target_version, &plan.root) {
+                Ok(()) => {
+                    log("update watchdog: ~/Applications/mStream.app restored from the previous version");
+                    dest.join("Contents").join("MacOS").join("mStream")
+                }
+                Err(e) => {
+                    // The versioned launcher still works; the Apps copy heals
+                    // on the next install run (or the server-side enforceHold
+                    // pass restores it once the rolled-back server runs).
+                    log(&format!(
+                        "update watchdog: could not restore ~/Applications ({e}) - relaunching the versioned copy"
+                    ));
+                    plan.root.join("current").join(paths::launcher_rel())
+                }
+            }
+        }
+        None => plan.root.join("current").join(paths::launcher_rel()),
+    };
+
+    if !face.exists() {
+        return Err(format!("no launcher at {} after the re-point", face.display()));
+    }
+    Ok(face)
+}
+
+/// Replace `link` with a symlink to `target` as atomically as the platform
+/// allows — the same contract as replaceLink in src/util/update-check.js.
+#[cfg(unix)]
+fn repoint_current(link: &Path, target: &Path) -> Result<(), String> {
+    let tmp = link.with_file_name(format!("current.tmp-{}", std::process::id()));
+    let _ = std::fs::remove_file(&tmp);
+    std::os::unix::fs::symlink(target, &tmp)
+        .map_err(|e| format!("symlink {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, link).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename onto {}: {e}", link.display())
+    })
+}
+
+/// Windows `current` is a junction (symlinks need privilege; junctions do
+/// not). No atomic replace exists for junctions — delete + recreate, the
+/// same brief exposure install.ps1 already has. mklink is a cmd builtin.
+#[cfg(windows)]
+fn repoint_current(link: &Path, target: &Path) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    if std::fs::symlink_metadata(link).is_ok() {
+        // remove_dir on a junction removes the link only, never the target.
+        std::fs::remove_dir(link).map_err(|e| format!("remove {}: {e}", link.display()))?;
+    }
+    let out = std::process::Command::new("cmd")
+        .arg("/C")
+        .arg("mklink")
+        .arg("/J")
+        .arg(link)
+        .arg(target)
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map_err(|e| format!("spawn cmd mklink: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "mklink /J failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    // Verify through canonicalize (read_link on a junction may carry the
+    // \\?\ prefix; canonicalizing both sides compares them in one form).
+    match (std::fs::canonicalize(link), std::fs::canonicalize(target)) {
+        (Ok(a), Ok(b)) if a == b => Ok(()),
+        _ => Err(format!("{} does not resolve to {}", link.display(), target.display())),
+    }
+}
+
+/// Restore ~/Applications/mStream.app from the rollback target's bundle.
+/// ditto (not a plain copy) preserves the bundle's internal symlink, xattrs,
+/// and the notarization staple — and nothing is ever written INSIDE the
+/// bundle (the sibling marker carries ownership), so the seal survives.
+/// We may be RUNNING from `dest`: a rename keeps our mapped binary valid,
+/// and the aside joins the .old.* family the next launcher's sweep reclaims.
+#[cfg(target_os = "macos")]
+fn restore_apps_copy(
+    dest: &Path,
+    bundle: &Path,
+    version: &str,
+    root: &Path,
+) -> Result<(), String> {
+    let src = bundle.join("mStream.app");
+    if !src.exists() {
+        return Err(format!("{} has no mStream.app", bundle.display()));
+    }
+    let installing = dest.with_file_name("mStream.app.installing-rollback");
+    let _ = std::fs::remove_dir_all(&installing);
+    let st = std::process::Command::new("/usr/bin/ditto")
+        .arg(&src)
+        .arg(&installing)
+        .status()
+        .map_err(|e| format!("ditto: {e}"))?;
+    if !st.success() {
+        return Err(format!("ditto exited {st}"));
+    }
+    if dest.exists() {
+        let at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let aside = dest.with_file_name(format!("mStream.app.old.{at}.rolledback"));
+        std::fs::rename(dest, &aside).map_err(|e| format!("move aside: {e}"))?;
+    }
+    std::fs::rename(&installing, dest).map_err(|e| format!("move into place: {e}"))?;
+    // Same two lines install.sh writes: version, then the install root.
+    let marker = dest.with_file_name(".mstream-installer");
+    let _ = std::fs::write(&marker, format!("{version}\n{}\n", root.display()));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("mstream-rollback-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn mk_bundle(root: &Path, ver: &str, key: &str, with_server: bool) -> PathBuf {
+        let b = root.join(format!("mStream-{ver}-{key}"));
+        let srv = b.join(server_rel());
+        std::fs::create_dir_all(srv.parent().unwrap()).unwrap();
+        if with_server {
+            std::fs::write(&srv, "stub").unwrap();
+        }
+        b
+    }
+
+    fn link_current(root: &Path, target: &Path) {
+        let link = root.join("current");
+        let _ = std::fs::remove_file(&link);
+        #[cfg(windows)]
+        let _ = std::fs::remove_dir(&link); // a dir symlink deletes as a dir
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(target, &link).unwrap();
+    }
+
+    fn host_key() -> &'static str {
+        if cfg!(windows) {
+            "win-x64"
+        } else if cfg!(target_os = "macos") {
+            "darwin-arm64"
+        } else {
+            "linux-x64"
+        }
+    }
+
+    const YES: fn(&Path) -> bool = |_| true;
+
+    #[test]
+    fn triples_compare_numerically_or_not_at_all() {
+        assert_eq!(compare_triples("6.21.2", "6.9.9"), Some(Ordering::Greater));
+        assert_eq!(compare_triples("6.9.0", "6.21.0"), Some(Ordering::Less));
+        assert_eq!(compare_triples("6.21.2", "6.21.2"), Some(Ordering::Equal));
+        assert_eq!(compare_triples("6.21", "6.21.2"), None);
+        assert_eq!(compare_triples("6.21.2-beta.1", "6.21.2"), None);
+    }
+
+    #[test]
+    fn plan_picks_the_newest_lower_same_key_version() {
+        let root = tmpdir("plan");
+        let key = host_key();
+        let ours = mk_bundle(&root, "6.22.0", key, true);
+        mk_bundle(&root, "6.20.0", key, true);
+        let want = mk_bundle(&root, "6.21.0", key, true);
+        mk_bundle(&root, "6.21.5", "linux-arm64-musl", true); // other family: never
+        link_current(&root, &ours);
+        let exe = ours.join(paths::launcher_rel());
+        let plan = plan_rollback(Some(&exe), "6.22.0", &root.join("nohome"), &root, &YES).unwrap();
+        assert_eq!(plan.target_version, "6.21.0");
+        assert_eq!(plan.target_bundle, want);
+        assert_eq!(plan.failed_version, "6.22.0");
+        assert_eq!(plan.root, root);
+        assert!(plan.apps_copy.is_none());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn plan_refuses_when_current_is_not_ours_or_nothing_qualifies() {
+        let root = tmpdir("refuse");
+        let key = host_key();
+        let ours = mk_bundle(&root, "6.22.0", key, true);
+        let other = mk_bundle(&root, "6.23.0", key, true);
+        let exe = ours.join(paths::launcher_rel());
+
+        // current committed to a DIFFERENT version: not ours to fight.
+        link_current(&root, &other);
+        assert!(plan_rollback(Some(&exe), "6.22.0", &root.join("nohome"), &root, &YES).is_none());
+
+        // current is ours, but the only lower version has no server binary.
+        link_current(&root, &ours);
+        mk_bundle(&root, "6.21.0", key, false);
+        assert!(plan_rollback(Some(&exe), "6.22.0", &root.join("nohome"), &root, &YES).is_none());
+
+        // A candidate appears — but the probe refuses it.
+        mk_bundle(&root, "6.21.1", key, true);
+        let no: fn(&Path) -> bool = |_| false;
+        assert!(plan_rollback(Some(&exe), "6.22.0", &root.join("nohome"), &root, &no).is_none());
+
+        // No exe at all.
+        assert!(plan_rollback(None, "6.22.0", &root.join("nohome"), &root, &YES).is_none());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn plan_skips_held_versions() {
+        let root = tmpdir("held");
+        let key = host_key();
+        let ours = mk_bundle(&root, "6.23.0", key, true);
+        mk_bundle(&root, "6.22.0", key, true); // known-bad: held below
+        let want = mk_bundle(&root, "6.21.0", key, true);
+        link_current(&root, &ours);
+        std::fs::write(
+            root.join(HOLD_FILE),
+            r#"{"schema":1,"held":[{"version":"6.22.0","at":0,"reason":"t"},{"version":"garbage"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(held_versions(&root), vec!["6.22.0".to_string()]);
+        let exe = ours.join(paths::launcher_rel());
+        let plan = plan_rollback(Some(&exe), "6.23.0", &root.join("nohome"), &root, &YES).unwrap();
+        assert_eq!(plan.target_bundle, want, "the held middle version is skipped");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn apps_copy_shape_follows_the_marker_root() {
+        let home = tmpdir("home");
+        let data_home = home.join("data");
+        let root = home.join("custom-root");
+        std::fs::create_dir_all(&root).unwrap();
+        let key = host_key();
+        let ours = mk_bundle(&root, "6.22.0", key, true);
+        let want = mk_bundle(&root, "6.21.0", key, true);
+        link_current(&root, &ours);
+        let apps = home.join("Applications");
+        let exe = apps.join("mStream.app").join("Contents").join("MacOS").join("mStream");
+        std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        std::fs::write(&exe, "stub").unwrap();
+        // No marker: user-owned copy, never ours to roll back.
+        assert!(plan_rollback(Some(&exe), "6.22.0", &home, &data_home, &YES).is_none());
+        std::fs::write(
+            apps.join(".mstream-installer"),
+            format!("6.22.0\n{}\n", root.display()),
+        )
+        .unwrap();
+        let plan = plan_rollback(Some(&exe), "6.22.0", &home, &data_home, &YES).unwrap();
+        assert_eq!(plan.root, root, "marker line 2 names the custom root");
+        assert_eq!(plan.target_bundle, want);
+        assert_eq!(plan.apps_copy, Some(apps.join("mStream.app")));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn holds_record_dedupes_and_caps() {
+        let dh = tmpdir("record");
+        record_hold(&dh, "6.22.0", "t").unwrap();
+        record_hold(&dh, "6.22.0", "t").unwrap();
+        assert_eq!(held_versions(&dh), vec!["6.22.0".to_string()]);
+        for i in 0..12 {
+            record_hold(&dh, &format!("7.0.{i}"), "t").unwrap();
+        }
+        let held = held_versions(&dh);
+        assert_eq!(held.len(), MAX_HELD, "capped");
+        assert!(held.contains(&"7.0.11".to_string()), "newest kept");
+        assert!(!held.contains(&"6.22.0".to_string()), "oldest dropped");
+        // Absent / garbage files read as nothing held.
+        assert!(held_versions(&dh.join("nope")).is_empty());
+        std::fs::write(dh.join(HOLD_FILE), "not json").unwrap();
+        assert!(held_versions(&dh).is_empty());
+        let _ = std::fs::remove_dir_all(&dh);
+    }
+
+    #[test]
+    fn execute_repoints_current_and_clears_the_stale_status_file() {
+        let root = tmpdir("exec");
+        let data_home = root.join("data");
+        std::fs::create_dir_all(&data_home).unwrap();
+        std::fs::write(
+            data_home.join("update-status.json"),
+            r#"{"applyRequested":true,"stagedVersion":"6.22.0"}"#,
+        )
+        .unwrap();
+        let key = host_key();
+        let ours = mk_bundle(&root, "6.22.0", key, true);
+        let prev = mk_bundle(&root, "6.21.0", key, true);
+        // The face the handoff needs must exist in the rollback target.
+        let face = prev.join(paths::launcher_rel());
+        std::fs::create_dir_all(face.parent().unwrap()).unwrap();
+        std::fs::write(&face, "stub").unwrap();
+        link_current(&root, &ours);
+        let plan = RollbackPlan {
+            root: root.clone(),
+            failed_version: "6.22.0".to_string(),
+            target_bundle: prev.clone(),
+            target_version: "6.21.0".to_string(),
+            apps_copy: None,
+        };
+        let got = execute_rollback(&plan, &data_home, &|_| {}).unwrap();
+        assert_eq!(got, root.join("current").join(paths::launcher_rel()));
+        assert_eq!(
+            std::fs::canonicalize(root.join("current")).unwrap(),
+            std::fs::canonicalize(&prev).unwrap()
+        );
+        assert_eq!(held_versions(&data_home), vec!["6.22.0".to_string()]);
+        assert!(
+            !data_home.join("update-status.json").exists(),
+            "stale armed status file must not survive a rollback"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/rust-launcher/src/rollback.rs
+++ b/rust-launcher/src/rollback.rs
@@ -56,6 +56,9 @@ pub struct RollbackPlan {
     /// macOS: the ~/Applications copy this launcher runs from, whose
     /// contents (refreshed to the failed version at stage time) must be
     /// restored from target_bundle. None when running from a versioned dir.
+    /// Only macOS execute code reads it — planning stays one shared,
+    /// cross-platform-tested path, so other targets carry the field unread.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub apps_copy: Option<PathBuf>,
 }
 

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -7,7 +7,7 @@
 // the EventLoopProxy. The server child lives in an Arc<Mutex<...>> shared
 // with the watcher; a generation counter keeps a stale watcher (from before
 // a restart) from reporting the new child's state.
-use crate::{autostart, paths, platform, server, LauncherArgs};
+use crate::{autostart, paths, platform, rollback, server, LauncherArgs};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -20,6 +20,11 @@ use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 
 const STOP_GRACE: Duration = Duration::from_secs(8);
 const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
+/// Spawns a crash-before-serving server gets before the boot watchdog steps
+/// in: the second attempt absorbs transient causes (a port released late, a
+/// filesystem hiccup) so a rollback is only ever answered to a REPEATED
+/// boot failure.
+const MAX_BOOT_ATTEMPTS: u32 = 2;
 /// How long a `--takeover` relaunch retries the single-instance lock: the
 /// old launcher holds it for at most its own stop_current (STOP_GRACE) plus
 /// process teardown, so this only needs to comfortably exceed that.
@@ -226,10 +231,34 @@ pub fn run(args: LauncherArgs) -> ! {
         });
     }
 
+    // ── Our own REAL location (canonicalized so a start through the
+    // `current` symlink still resolves to the versioned tree the walk-ups
+    // need) — the update surface below and the boot watchdog both key off it.
+    let exe_real = std::env::current_exe()
+        .ok()
+        .map(|p| std::fs::canonicalize(&p).unwrap_or(p));
+    // A --server-bin/MSTREAM_SERVER_BIN override means a failing server is
+    // NOT the bundle's own build — a rollback would punish the wrong version.
+    let watchdog_eligible = args.server_bin.is_none();
+
     match spawn_generation(&shared, &bin, &args.server_args, &server_log, ep, &proxy, &log) {
         Ok(()) => {}
         Err(e) => {
             log.line(&format!("server failed to spawn: {e}"));
+            // A managed layout whose committed version cannot even SPAWN its
+            // server is the boot watchdog's case too — same recovery as a
+            // crash-before-serving, just caught one step earlier.
+            if watchdog_eligible {
+                if let Some(face) = attempt_boot_rollback(exe_real.as_deref(), &log) {
+                    match platform::relaunch(&face, &args.server_args) {
+                        Ok(()) => {
+                            log.line("update watchdog: handed off to the previous version");
+                            std::process::exit(0);
+                        }
+                        Err(re) => log.line(&format!("update watchdog: relaunch failed: {re}")),
+                    }
+                }
+            }
             platform::fatal_alert(&format!(
                 "mStream could not start its server process:\n{e}\n\nSee {}",
                 server_log.display()
@@ -256,6 +285,10 @@ pub fn run(args: LauncherArgs) -> ! {
     // server the probe could not verify (Phase::Unverified).
     let mut spawned_at = Instant::now();
     let mut ever_up = false;
+    // Crash-before-serving spawns for the CURRENT boot cycle (reset the
+    // moment a server proves alive): past MAX_BOOT_ATTEMPTS the boot
+    // watchdog decides whether a staged update gets rolled back.
+    let mut boot_failures: u32 = 0;
     let mut opened = false;
     // Update-awareness: the server's checker writes update-status.json in
     // the shared data home; the tray re-reads it on every minute tick.
@@ -275,11 +308,6 @@ pub fn run(args: LauncherArgs) -> ! {
     // version (the tray menu still lets a human retry) until a different
     // version stages.
     let mut apply_failures: Option<(String, u32)> = None;
-    // Our own REAL location (canonicalized so a start through the `current`
-    // symlink still resolves to the versioned tree the walk-up needs).
-    let exe_real = std::env::current_exe()
-        .ok()
-        .map(|p| std::fs::canonicalize(&p).unwrap_or(p));
     let url = paths::server_url(&ep);
     // A --takeover relaunch is mid-update, not a first run: never announce.
     let announce = !args.autostarted && !args.no_open && !args.takeover;
@@ -404,13 +432,23 @@ pub fn run(args: LauncherArgs) -> ! {
                         && upd.as_ref().is_some_and(|s| s.apply_requested)
                         && token.is_some()
                         && token != auto_apply_attempted
-                        // Never mid-boot: the takeover launcher's first poll
-                        // can land while the new server is still migrating,
+                        // Only while a server is actually alive. Not mid-boot
+                        // (Starting): the takeover launcher's first poll can
+                        // land while the new server is still migrating,
                         // reading a status file the OLD session armed — an
-                        // apply here kills a healthy boot. Once the server
-                        // is up (or the probe gave up on an SSL config) the
-                        // file is fresh again.
-                        && !matches!(phase, Phase::Starting)
+                        // apply here kills a healthy boot. And not Stopped:
+                        // a dead server cannot have MEANT the armed request
+                        // still in the file — acting on it from Stopped is
+                        // how a stale arm turns into a relaunch loop after a
+                        // crash (each relaunch is a fresh process whose
+                        // attempted-token starts empty).
+                        && matches!(phase, Phase::Running { .. } | Phase::Unverified { .. })
+                        // Never into a version the boot watchdog held after
+                        // a failed start (rollback.rs) — the hold outranks
+                        // whatever the status file still advertises.
+                        && !staged_ver
+                            .as_deref()
+                            .is_some_and(|v| rollback::held_versions(&paths::data_home()).iter().any(|h| h == v))
                         // Never into OURSELVES: after a successful handoff
                         // the stale file still says "apply X" until the new
                         // server rewrites it — but this launcher shipped IN
@@ -483,6 +521,9 @@ pub fn run(args: LauncherArgs) -> ! {
                         log.line("menu: restart server");
                         stop_current(&shared_loop);
                         spawned_at = Instant::now();
+                        // A human-initiated restart is a fresh intent: the
+                        // watchdog's failure budget starts over.
+                        boot_failures = 0;
                         phase = match spawn_generation(
                             &shared_loop,
                             &bin,
@@ -570,6 +611,7 @@ pub fn run(args: LauncherArgs) -> ! {
                         .unwrap_or(false);
                     if child_alive && generation == shared_loop.generation.load(Ordering::SeqCst) {
                         ever_up = true;
+                        boot_failures = 0;
                         log.line("server is up");
                         // The booting server just rewrote the status file
                         // (its version, cleared staged flags) — pick that up
@@ -624,6 +666,7 @@ pub fn run(args: LauncherArgs) -> ! {
                         // is "exited unexpectedly", not "stopped before it
                         // finished starting".
                         ever_up = true;
+                        boot_failures = 0;
                         log.line(&format!(
                             "server did not answer the identity probe within {}s but is still running - showing it as running (unverified); an SSL-only config or a bind the plaintext probe can't reach looks like this",
                             BOOT_TIMEOUT.as_secs()
@@ -638,16 +681,75 @@ pub fn run(args: LauncherArgs) -> ! {
                     let current = shared_loop.generation.load(Ordering::SeqCst);
                     if generation == current && !shared_loop.quitting.load(Ordering::SeqCst) {
                         log.line("server exited unexpectedly");
-                        phase = Phase::Stopped;
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
-                        if !ever_up {
-                            // Died before ever serving = a boot failure the
-                            // user would otherwise never see (no console).
-                            platform::fatal_alert(&format!(
-                                "The mStream server stopped before it finished starting.\n\nSee {}",
-                                server_log_loop.display()
-                            ));
+                        if ever_up {
+                            phase = Phase::Stopped;
+                        } else {
+                            // Died before ever serving = a boot failure. One
+                            // respawn absorbs transient causes; a repeated
+                            // failure goes to the boot watchdog, which rolls
+                            // a freshly applied update back to the previous
+                            // version (rollback.rs). Before the watchdog this
+                            // was a dead install: no server means no update
+                            // checker, so even a FIXED release could never
+                            // arrive on its own.
+                            boot_failures += 1;
+                            let mut exhausted = boot_failures >= MAX_BOOT_ATTEMPTS;
+                            if !exhausted {
+                                log.line(&format!(
+                                    "server died before serving (attempt {boot_failures}/{MAX_BOOT_ATTEMPTS}) - retrying"
+                                ));
+                                spawned_at = Instant::now();
+                                match spawn_generation(
+                                    &shared_loop, &bin, &args.server_args, &server_log_loop, ep, &proxy, &log,
+                                ) {
+                                    Ok(()) => phase = Phase::Starting,
+                                    Err(e) => {
+                                        log.line(&format!("retry spawn failed: {e}"));
+                                        exhausted = true;
+                                    }
+                                }
+                            }
+                            if exhausted {
+                                let face = if watchdog_eligible {
+                                    attempt_boot_rollback(exe_real.as_deref(), &log)
+                                } else {
+                                    None
+                                };
+                                if let Some(face) = face {
+                                    shared_loop.quitting.store(true, Ordering::SeqCst);
+                                    match platform::relaunch(&face, &args.server_args) {
+                                        Ok(()) => {
+                                            log.line("update watchdog: handed off to the previous version");
+                                            tray.take();
+                                            *control_flow = ControlFlow::Exit;
+                                            return;
+                                        }
+                                        Err(e) => {
+                                            // `current` is already re-pointed, so the
+                                            // next manual start (or reboot) lands on
+                                            // the good version despite this handoff
+                                            // failing.
+                                            shared_loop.quitting.store(false, Ordering::SeqCst);
+                                            log.line(&format!("update watchdog: relaunch failed: {e}"));
+                                            phase = Phase::Stopped;
+                                            platform::fatal_alert(&format!(
+                                                "The updated mStream could not start and was rolled back.\nStart mStream again to run the previous version.\n\nSee {}",
+                                                server_log_loop.display()
+                                            ));
+                                        }
+                                    }
+                                } else {
+                                    phase = Phase::Stopped;
+                                    // The dialog the user would otherwise
+                                    // never see (no console on a GUI launch).
+                                    platform::fatal_alert(&format!(
+                                        "The mStream server stopped before it finished starting.\n\nSee {}",
+                                        server_log_loop.display()
+                                    ));
+                                }
+                            }
                         }
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
                     }
                 }
             },
@@ -1032,6 +1134,34 @@ fn recover_after_failed_apply(
         Err(e) => {
             platform::fatal_alert(&format!("mStream could not restart its server:\n{e}"));
             Phase::Stopped
+        }
+    }
+}
+
+/// The boot watchdog's decision + execution: roll a managed layout back to
+/// the previous version after repeated crash-before-serving boots (see
+/// rollback.rs for the full contract). Returns the launcher face to hand
+/// off to, or None when rollback does not apply (not a managed layout,
+/// `current` not committed to us, nothing usable to roll back to) — the
+/// caller then falls through to the Stopped-with-dialog behavior.
+fn attempt_boot_rollback(exe_real: Option<&Path>, log: &Logger) -> Option<PathBuf> {
+    let data_home = paths::data_home();
+    let plan = rollback::plan_rollback(
+        exe_real,
+        env!("MSTREAM_BUNDLE_VERSION"),
+        &paths::home_dir(),
+        &data_home,
+        &rollback::probe_server,
+    )?;
+    log.line(&format!(
+        "update watchdog: mStream {} cannot boot here - rolling back to {}",
+        plan.failed_version, plan.target_version
+    ));
+    match rollback::execute_rollback(&plan, &data_home, &|m| log.line(m)) {
+        Ok(face) => Some(face),
+        Err(e) => {
+            log.line(&format!("update watchdog: rollback failed: {e}"));
+            None
         }
     }
 }

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1699,12 +1699,16 @@ export function setup(mstream) {
       check: Joi.boolean(),
       mode: Joi.string().valid('notify', 'stage', 'auto'),
       skipVersion: Joi.string().pattern(/^\d+\.\d+\.\d+$/).allow(''),
-    }).or('check', 'mode', 'skipVersion');
+      // Operator override for boot-failure holds (the launcher's watchdog
+      // rolled an update back): drop them all and let the next check retry.
+      clearHold: Joi.boolean(),
+    }).or('check', 'mode', 'skipVersion', 'clearHold');
     joiValidate(schema, req.body);
 
     if (req.body.check !== undefined) { await admin.editUpdatesCheck(req.body.check); }
     if (req.body.mode !== undefined) { await admin.editUpdatesMode(req.body.mode); }
     if (req.body.skipVersion !== undefined) { await admin.editUpdatesSkipVersion(req.body.skipVersion); }
+    if (req.body.clearHold === true) { await updateCheck.clearHolds(); }
     updateCheck.onSettingsChanged();
     res.json({});
   });

--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -33,6 +33,18 @@
 //            the staged version); headless, by exiting 0 — documented as
 //            "auto expects a process supervisor" (systemd/pm2 restart lands
 //            on the new version via the flipped `current` link)
+//
+// Boot-failure holds (update-hold.json, beside the status file): when an
+// applied update crashes before it ever serves, the launcher's boot
+// watchdog (rust-launcher/src/rollback.rs) re-points `current` at the
+// previous version and records the failed version here. This module's half
+// of that contract: never stage/apply a held version (or the next daily
+// check would re-flip onto the very release the watchdog backed out of),
+// keep `current` off held versions (enforceHold — the belt to the
+// launcher's suspenders), and drop entries once a version >= them boots:
+// the fixed release supersedes the hold, and a hand-re-applied version
+// that boots proves its hold stale. The admin settings expose clearHold as
+// the manual override.
 import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
@@ -56,6 +68,10 @@ const STAGE_TIMEOUT_MS = 30 * 60 * 1000; // a bundle download on a slow link
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // daily
 const BOOT_CHECK_DELAY_MS = 30 * 1000;
 const AUTO_APPLY_POLL_MS = 15 * 60 * 1000;
+// Shared with rust-launcher/src/rollback.rs — one file, two writers who
+// never overlap (the launcher appends only while no server runs).
+const HOLD_FILE = 'update-hold.json';
+const MAX_HELD = 8;
 
 // ── Pure helpers (unit-tested with injected fs) ─────────────────────────────
 
@@ -213,6 +229,8 @@ const state = {
   error: null,
   notifyOnly: false,        // apiVersion from the future: check works, staging refused
   skipped: false,           // latest === updates.skipVersion: report, never act
+  held: false,              // latest failed to boot after a previous update: report, never act
+  heldVersions: [],         // every version the boot watchdog has held (update-hold.json)
 };
 
 function updatesConfig() {
@@ -233,6 +251,100 @@ function supervisedByLauncher() {
 
 export function statusFilePath() {
   return path.join(userDataHome(), 'update-status.json');
+}
+
+export function holdFilePath() {
+  return path.join(userDataHome(), HOLD_FILE);
+}
+
+// The launcher's boot watchdog wrote this after rolling an update back.
+// Read tolerantly — the file is our own, but absent/newer-schema/mangled
+// must all read as "nothing held", never as a crash.
+function readHolds() {
+  try {
+    const doc = JSON.parse(fs.readFileSync(holdFilePath(), 'utf8'));
+    if (!doc || !Array.isArray(doc.held)) { return []; }
+    return doc.held
+      .filter((h) => h && typeof h.version === 'string' && VERSION_RE.test(h.version))
+      .slice(0, MAX_HELD);
+  } catch {
+    return [];
+  }
+}
+
+// Cached in state.heldVersions (refreshHolds) so the status poll doesn't
+// hit the disk: the file only changes at rollback time (no server runs) or
+// through this module's own prune/clear, both of which refresh the cache.
+function isHeld(version) {
+  return !!version && state.heldVersions.includes(version);
+}
+
+function refreshHolds() {
+  state.heldVersions = readHolds().map((h) => h.version);
+  state.held = !!state.latest && state.available && state.heldVersions.includes(state.latest);
+}
+
+// Drop holds a healthy boot has disproven or superseded: we are RUNNING a
+// version >= the held one, so either the fixed release landed or the held
+// version was re-applied by hand and boots after all. Holds for versions
+// NEWER than the running one are the active ones and stay. Called from
+// doCheck — which fires no earlier than the post-listen boot check, so a
+// crash-during-boot can never clear the very hold that protects against it.
+async function pruneHolds() {
+  const holds = readHolds();
+  if (!holds.length) { return; }
+  const keep = holds.filter((h) => compareVersions(state.current, h.version) < 0);
+  if (keep.length === holds.length) { return; }
+  for (const h of holds) {
+    if (!keep.includes(h)) {
+      winston.info(`[update] Boot-failure hold on ${h.version} cleared (running ${state.current})`);
+    }
+  }
+  try {
+    if (!keep.length) { await fsp.unlink(holdFilePath()); }
+    else { await writeJsonAtomic(holdFilePath(), { schema: 1, held: keep }); }
+  } catch (err) {
+    winston.warn(`[update] Could not rewrite ${holdFilePath()}: ${err.message}`);
+  }
+}
+
+// Operator override (admin settings, clearHold: true): drop every hold and
+// let the next check treat the release feed at face value again.
+export async function clearHolds() {
+  await fsp.unlink(holdFilePath()).catch(() => { /* absent is cleared */ });
+  refreshHolds();
+  winston.info('[update] Boot-failure holds cleared by the operator');
+}
+
+// Belt to the launcher's suspenders: the watchdog re-points `current` when
+// it rolls back, but if that re-point failed (or a hold arrived without
+// one), `current` still aims at a version that cannot boot — and on the
+// layouts where the login item goes through `current`, so does the next
+// reboot. Same recovery as a skip: point `current` back at the running
+// version, restore the macOS ~/Applications copy, disarm anything staged.
+async function enforceHold() {
+  if (!state.heldVersions.length) { return; }
+  if (state.stagedVersion && state.heldVersions.includes(state.stagedVersion)) {
+    state.staged = false;
+    state.stagedVersion = null;
+    state.applyRequested = false;
+    state.applyRequestedAt = null;
+    state.installerPath = null;
+  }
+  const m = detectInstall();
+  if (m.method !== 'managed' || !m.root) { return; }
+  const linkVer = await stagedVersionFromRoot(m.root);
+  if (!linkVer || linkVer === state.current || !state.heldVersions.includes(linkVer)) { return; }
+  winston.warn(`[update] current points at held version ${linkVer} - re-pointing at the running version`);
+  let ok = await unstageCurrent(m.root, linkVer);
+  if (process.platform === 'darwin') {
+    ok = (await restoreAppsCopy()) && ok;
+  }
+  if (!ok) {
+    state.error = `Version ${linkVer} failed to start and is held back, but the previous version could not be fully restored - `
+      + `re-run the installer with MSTREAM_VERSION=v${state.current} to finish the rollback`;
+    winston.warn(`[update] ${state.error}`);
+  }
 }
 
 export function getStatus() {
@@ -329,6 +441,13 @@ async function doCheck(force) {
   const cfg = updatesConfig();
   if (!cfg.check && !force) { return getStatus(); }
   detectInstall();
+  // Boot-failure holds first, and independent of the feed being reachable:
+  // running this far past listen proves THIS version boots (prune), and a
+  // `current` still aiming at a held version must be re-pointed even when
+  // GitHub is down (enforce).
+  await pruneHolds();
+  refreshHolds();
+  await enforceHold();
   try {
     const manifest = await fetchManifest();
     const v = validateManifest(manifest);
@@ -355,14 +474,15 @@ async function doCheck(force) {
     state.latest = manifest.version;
     state.available = compareVersions(manifest.version, state.current) > 0;
     state.skipped = state.available && isSkipped(manifest.version);
+    state.held = state.available && isHeld(manifest.version);
     if (!state.available) {
       state.downloadUrl = null;
     } else {
       const m = detectInstall();
       state.downloadUrl = downloadUrlFor(m.method, manifest);
-      winston.info(`[update] mStream ${manifest.version} is available (running ${state.current}, install: ${m.method}${state.skipped ? ', SKIPPED by updates.skipVersion' : ''})`);
+      winston.info(`[update] mStream ${manifest.version} is available (running ${state.current}, install: ${m.method}${state.skipped ? ', SKIPPED by updates.skipVersion' : ''}${state.held ? ', HELD after a failed start' : ''})`);
       const mode = updatesConfig().mode;
-      if (mode !== 'notify' && !state.notifyOnly && !state.skipped
+      if (mode !== 'notify' && !state.notifyOnly && !state.skipped && !state.held
           && (m.method === 'managed' || m.method === 'inno')
           && (!state.staged || state.stagedVersion !== manifest.version)) {
         stageNow(manifest); // async, single-flight; errors land in state
@@ -398,6 +518,9 @@ export function stageNow(manifest = null) {
   if (state.notifyOnly) { return { error: 'update format changed - re-run the install command' }; }
   if (state.latest && isSkipped(state.latest)) {
     return { error: `version ${state.latest} is held back by updates.skipVersion` };
+  }
+  if (state.latest && isHeld(state.latest)) {
+    return { error: `version ${state.latest} failed to start after a previous update and is held back - it clears when a newer release ships, or clear the hold to retry` };
   }
   if (m.method === 'inno' || m.method === 'pkg') {
     if (!state.latest || !state.available) { return { error: 'no update available' }; }
@@ -653,6 +776,9 @@ export async function requestApply() {
   if (isSkipped(state.stagedVersion)) {
     return { error: `version ${state.stagedVersion} is held back by updates.skipVersion` };
   }
+  if (isHeld(state.stagedVersion)) {
+    return { error: `version ${state.stagedVersion} failed to start after a previous update and is held back` };
+  }
   if (m.method === 'pkg') {
     if (!state.installerPath || !fs.existsSync(state.installerPath)) { return { error: 'installer not downloaded yet' }; }
     spawn('open', [state.installerPath], { detached: true, stdio: 'ignore' }).unref();
@@ -681,7 +807,7 @@ function scheduleHeadlessExit(why) {
 // auto mode: apply on our own once nothing is streaming and no scan runs.
 function maybeAutoApply() {
   if (updatesConfig().mode !== 'auto' || !state.staged || state.applyRequested) { return; }
-  if (isSkipped(state.stagedVersion)) { return; }
+  if (isSkipped(state.stagedVersion) || isHeld(state.stagedVersion)) { return; }
   const m = detectInstall();
   if (m.method !== 'managed' && m.method !== 'inno') { return; }
   if (!idle()) { return; }
@@ -855,8 +981,9 @@ export function onSettingsChanged() {
     .then(() => {
       maybeAutoApply();
       const cfg = updatesConfig();
-      if (cfg.check && cfg.mode !== 'notify' && state.available && !state.skipped && !state.staged) {
-        // e.g. notify -> stage, or an unskip: start the withheld download.
+      if (cfg.check && cfg.mode !== 'notify' && state.available && !state.skipped && !state.held && !state.staged) {
+        // e.g. notify -> stage, an unskip, or a cleared hold: start the
+        // withheld download.
         checkNow(true).catch(() => {});
       }
     });
@@ -871,6 +998,10 @@ export function onSettingsChanged() {
 export function setup(mstream, hooks = {}) {
   _hooks = { ..._hooks, ...hooks };
   detectInstall();
+  // Surface any boot-failure holds from the very first status write; the
+  // prune waits for the boot check (running that far past listen is the
+  // proof-of-boot that justifies clearing).
+  refreshHolds();
   // A staged flag from a PREVIOUS process run: if we ARE that version now,
   // clear it; if not (the restart didn't land on it), re-checking will
   // re-discover it within a day, or instantly via the boot check.
@@ -900,7 +1031,7 @@ export function stopForTests() {
   _install = null;
   _checking = null;
   _exiting = false;
-  state.skipped = false;
+  state.skipped = false; state.held = false; state.heldVersions = [];
   state.latest = null; state.available = false; state.staged = false;
   state.stagedVersion = null; state.applyRequested = false; state.applyRequestedAt = null; state.error = null;
   state.installerPath = null; state.downloadUrl = null; state.notifyOnly = false;

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -236,6 +236,121 @@ test('managed round-trip: check, auto-stage, current flip, tamper refusal, live 
   }
 });
 
+// The per-OS data home under a redirected HOME — where update-status.json
+// and update-hold.json land (userDataHome() in src/util/esm-helpers.js).
+function dataHomeOf(home) {
+  return process.platform === 'darwin'
+    ? path.join(home, 'Library', 'Application Support', 'mStream')
+    : path.join(home, '.local', 'share', 'mstream');
+}
+
+function envFor(home) {
+  return {
+    HOME: home,
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    MSTREAM_RELEASE_BASE: `http://127.0.0.1:${relPort}`,
+    MSTREAM_UPDATE_ROOT: path.join(home, 'app'),
+  };
+}
+
+test('boot-failure holds: held version never stages, a newer release supersedes it, clearHold overrides', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-hold-'));
+  try {
+    // As if the launcher's watchdog rolled 9.9.20 back before this boot.
+    const holdPath = path.join(dataHomeOf(home), 'update-hold.json');
+    await fs.mkdir(path.dirname(holdPath), { recursive: true });
+    await fs.writeFile(holdPath, JSON.stringify({
+      schema: 1,
+      held: [{ version: '9.9.20', at: 0, reason: 'server exited before it finished starting after an update' }],
+    }));
+    await publish('9.9.20');
+    const srv = await startServer({
+      waitForScan: false, env: envFor(home),
+      extraArgs: ['--supervised'], stdin: 'pipe',
+    });
+    try {
+      // The hold is visible from boot, before any check.
+      let s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update`)).json();
+      assert.deepEqual(s.heldVersions, ['9.9.20']);
+
+      // The held version is reported but never staged (mode=stage default
+      // would otherwise download and flip on this very check).
+      s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' })).json();
+      assert.equal(s.available, true);
+      assert.equal(s.latest, '9.9.20');
+      assert.equal(s.held, true);
+      assert.equal(s.staged, false);
+      await assert.rejects(fs.access(path.join(home, 'app', 'current')), 'a held version must never reach current');
+
+      // An explicit download is refused, with the reason.
+      const dl = await fetch(`${srv.baseUrl}/api/v1/admin/update/download`, { method: 'POST' });
+      assert.equal(dl.status, 409);
+      assert.match((await dl.json()).error, /failed to start .* held back/);
+
+      // A newer release supersedes the hold: it stages normally while the
+      // hold on the bad version stays on file (still newer than what runs).
+      await publish('9.9.21');
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      s = await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.21');
+      assert.equal(s.held, false);
+      assert.deepEqual(s.heldVersions, ['9.9.20']);
+
+      // Operator override: clearHold drops the record entirely.
+      const clear = await fetch(`${srv.baseUrl}/api/v1/admin/update/settings`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clearHold: true }),
+      });
+      assert.equal(clear.status, 200);
+      s = await pollStatus(srv.baseUrl, (x) => x.heldVersions.length === 0);
+      await assert.rejects(fs.access(holdPath), 'a cleared hold file must be gone');
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test('enforceHold re-points a current link left on a held version', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-enforce-'));
+  try {
+    // The layout a half-finished rollback leaves: current still aims at the
+    // held version, while the previous (running) version's folder exists.
+    const root = path.join(home, 'app');
+    const heldDir = path.join(root, `mStream-9.9.20-${hostKey()}`);
+    const runningDir = path.join(root, `mStream-${packageJson.version}-${hostKey()}`);
+    await fs.mkdir(heldDir, { recursive: true });
+    await fs.mkdir(runningDir, { recursive: true });
+    await fs.symlink(heldDir, path.join(root, 'current'));
+    const holdPath = path.join(dataHomeOf(home), 'update-hold.json');
+    await fs.mkdir(path.dirname(holdPath), { recursive: true });
+    await fs.writeFile(holdPath, JSON.stringify({ schema: 1, held: [{ version: '9.9.20', at: 0, reason: 't' }] }));
+    await publish('9.9.20'); // the held version is also "latest": nothing may stage
+    const srv = await startServer({
+      waitForScan: false, env: envFor(home),
+      extraArgs: ['--supervised'], stdin: 'pipe',
+    });
+    try {
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      const start = Date.now();
+      let target = null;
+      while (Date.now() - start < 10_000) {
+        target = await fs.readlink(path.join(root, 'current')).catch(() => null);
+        if (target === runningDir) { break; }
+        await sleep(100);
+      }
+      assert.equal(target, runningDir, 'current must be re-pointed at the running version');
+      const s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update`)).json();
+      assert.equal(s.held, true);
+      assert.equal(s.staged, false);
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test('non-managed installs refuse staging; apply refuses with nothing staged', { skip: posixOnly }, async () => {
   await publish('9.9.9');
   const env = updEnv();

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -11,6 +11,7 @@ real processes. Run them by hand when working on the matching code.
 | All-Docker torrent stack (`docker/`) | `npm run test:smoke:docker` | the compose stack up — see [docker/README.md](docker/README.md) |
 | Native-Windows daemons (`windows-native-daemons.mjs`) | `npm run test:smoke:windows` | Transmission / qBittorrent installed on Windows, plus env config |
 | Boot-watchdog rollback (`update-watchdog-smoke.sh`) | `npm run test:smoke:update-watchdog` | a built launcher (`cd rust-launcher && cargo build --release`); Linux headless needs `xvfb-run` |
+| Boot-watchdog rollback, Windows (`update-watchdog-smoke.ps1`) | `npm run test:smoke:update-watchdog:win` | a built launcher plus `rustc` on PATH (the stub servers are compiled on the spot) |
 
 Each script just runs the harness; bringing the daemons up (and tearing them
 down) is the operator's job. The setup, credentials and env knobs are

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -1,15 +1,16 @@
 # Smoke harnesses
 
 Manual, opt-in checks against **live external systems** — Docker'd or
-natively-installed torrent daemons. They are deliberately **not** part of
-`npm test`: they don't match `*.test.mjs`, they need infrastructure the
-unit/integration suite doesn't, and they talk to real daemons over the
-network. Run them by hand when working on the torrent path-handling code.
+natively-installed daemons, or the real desktop launcher binary. They are
+deliberately **not** part of `npm test`: they don't match `*.test.mjs`, they
+need infrastructure the unit/integration suite doesn't, and they talk to
+real processes. Run them by hand when working on the matching code.
 
 | Harness | Script | Needs |
 | --- | --- | --- |
 | All-Docker torrent stack (`docker/`) | `npm run test:smoke:docker` | the compose stack up — see [docker/README.md](docker/README.md) |
 | Native-Windows daemons (`windows-native-daemons.mjs`) | `npm run test:smoke:windows` | Transmission / qBittorrent installed on Windows, plus env config |
+| Boot-watchdog rollback (`update-watchdog-smoke.sh`) | `npm run test:smoke:update-watchdog` | a built launcher (`cd rust-launcher && cargo build --release`); Linux headless needs `xvfb-run` |
 
 Each script just runs the harness; bringing the daemons up (and tearing them
 down) is the operator's job. The setup, credentials and env knobs are
@@ -20,6 +21,11 @@ documented at:
   [windows-native-daemons.mjs](windows-native-daemons.mjs) — ports, download
   dirs, and the `MSTREAM_SECRET` / per-daemon env vars (set a daemon's config
   to `null` to skip it).
+- **Boot-watchdog rollback:** the header comment of
+  [update-watchdog-smoke.sh](update-watchdog-smoke.sh) — fabricates a managed
+  root whose `current` version crashes at boot and asserts the launcher's
+  rollback (re-pointed `current`, recorded hold, takeover into the previous
+  version). Scratch HOME; never touches real data or login items.
 
 The CLI-audio adapter routing harness is a sibling but self-contained (it runs
 mpv/vlc/mplayer/mpd inside Docker, no external daemons): `npm run test:cli-audio`

--- a/test/smoke/update-watchdog-smoke.ps1
+++ b/test/smoke/update-watchdog-smoke.ps1
@@ -1,0 +1,165 @@
+# Boot-watchdog rollback smoke, Windows edition (manual): proves the
+# launcher rolls a managed install.ps1-style layout back when the version
+# behind the `current` junction crashes at boot.
+#
+#   1. Fabricates a managed root: `current` (a junction, like install.ps1
+#      makes) -> a bundle whose mstream-server.exe answers -V (it "passed"
+#      the installers' exec probe) but exits 1 on a real boot, beside a
+#      previous version whose server idles forever. The REAL launcher
+#      binary rides in both bundles; the stub servers are compiled on the
+#      spot with rustc (find_server_bin wants a real .exe sibling).
+#   2. Pre-writes the stale armed update-status.json a real bad apply
+#      leaves behind.
+#   3. Starts the launcher behind `current` under a scratch LOCALAPPDATA
+#      and expects: one retry, then rollback - `current` re-pointed at the
+#      previous version (remove_dir + mklink /J + canonicalize verify, the
+#      code path this smoke exists to execute on real Windows), the failed
+#      version recorded in update-hold.json, the stale status file deleted,
+#      a takeover launcher running from `current`, and the failed-version
+#      launcher gone.
+#
+# Needs: a built launcher (cd rust-launcher; cargo build --release - or
+# MSTREAM_LAUNCHER_BIN pointing at one) and rustc on PATH (comes with the
+# cargo toolchain). Run in an interactive session if possible (the tray
+# face degrades gracefully without one, but that is the realistic shape).
+# The scratch LOCALAPPDATA plus MSTREAM_LAUNCHER_SKIP_AUTOSTART keep real
+# login items and data untouched. If the watchdog DECLINES or the rollback
+# fails, the launcher shows a message box - close it; the assertions below
+# will report the failure either way.
+$ErrorActionPreference = 'Stop'
+
+$repo = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$launcher = if ($env:MSTREAM_LAUNCHER_BIN) { $env:MSTREAM_LAUNCHER_BIN }
+    else { Join-Path $repo 'rust-launcher\target\release\mstream-launcher.exe' }
+if (-not (Test-Path $launcher)) {
+    throw "no launcher at $launcher - build it (cd rust-launcher; cargo build --release) or set MSTREAM_LAUNCHER_BIN"
+}
+if (-not (Get-Command rustc -ErrorAction SilentlyContinue)) {
+    throw 'rustc not on PATH - the stub servers are compiled on the spot (install the cargo toolchain)'
+}
+# The version baked into the launcher (build.rs reads package.json) - the
+# fabricated `current` bundle must carry it or the watchdog rightly declines.
+$pkgver = [string](Get-Content (Join-Path $repo 'package.json') -Raw | ConvertFrom-Json).version
+$key = 'win-x64'
+
+$tag = "mstream-watchdog-smoke-$PID"
+$smoke = Join-Path $env:TEMP $tag
+$fakeLocal = Join-Path $smoke 'localappdata'
+$root = Join-Path $smoke 'root'
+$data = Join-Path $fakeLocal 'mStream'
+if (Test-Path $smoke) { Remove-Item -Recurse -Force $smoke }
+New-Item -ItemType Directory -Force $root, $data | Out-Null
+
+# strip the \\?\ extended-length prefix the launcher's canonicalized paths
+# carry, so junction targets compare cleanly.
+function DePrefix([string]$p) { if ($p) { return ($p -replace '^\\\\\?\\', '') } else { return '' } }
+function CurrentTarget {
+    $item = Get-Item (Join-Path $root 'current') -Force -ErrorAction SilentlyContinue
+    if ($item -and ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        return DePrefix (($item.Target | Select-Object -First 1))
+    }
+    return ''
+}
+function SmokeProcs {
+    @(Get-Process mstream-launcher, mStream, mstream-server -ErrorAction SilentlyContinue |
+        Where-Object { $_.Path -and $_.Path -like "*$tag*" })
+}
+
+function Make-Bundle([string]$ver, [string]$stubBody) {
+    $b = Join-Path $root "mStream-$ver-$key"
+    New-Item -ItemType Directory -Force $b | Out-Null
+    Copy-Item $launcher (Join-Path $b 'mStream.exe')
+    $src = Join-Path $smoke "stub-$ver.rs"
+    Set-Content -Path $src -Value $stubBody -Encoding ASCII
+    & rustc -O $src -o (Join-Path $b 'mstream-server.exe') 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "rustc failed for the $ver stub" }
+    return $b
+}
+
+# The BAD current version: -V answers, a real boot crashes.
+$badBundle = Make-Bundle $pkgver @"
+fn main() {
+    if std::env::args().nth(1).as_deref() == Some("-V") { println!("$pkgver"); return; }
+    eprintln!("boom: simulated boot crash");
+    std::process::exit(1);
+}
+"@
+# The previous version: -V answers, a real boot idles forever (the identity
+# probe gives up into Unverified after 60s; this smoke never waits that long).
+$prevBundle = Make-Bundle '0.0.1' @'
+fn main() {
+    if std::env::args().nth(1).as_deref() == Some("-V") { println!("0.0.1"); return; }
+    loop { std::thread::sleep(std::time::Duration::from_secs(3600)); }
+}
+'@
+New-Item -ItemType Junction -Path (Join-Path $root 'current') -Target $badBundle | Out-Null
+
+# The stale armed status file a real bad apply leaves behind.
+Set-Content -Path (Join-Path $data 'update-status.json') -Encoding ASCII -Value (
+    '{"applyRequested":true,"applyRequestedAt":"2026-01-01T00:00:00.000Z",' +
+    "`"staged`":true,`"stagedVersion`":`"$pkgver`",`"method`":`"managed`"}")
+
+$savedLocal = $env:LOCALAPPDATA
+$savedProfile = $env:USERPROFILE
+$savedSkip = $env:MSTREAM_LAUNCHER_SKIP_AUTOSTART
+$fail = 1
+try {
+    $env:LOCALAPPDATA = $fakeLocal
+    $env:USERPROFILE = $smoke
+    $env:MSTREAM_LAUNCHER_SKIP_AUTOSTART = '1'
+    Write-Host "starting launcher (bad current: $pkgver, previous: 0.0.1)..."
+    # --tray: launched from a console this exe would otherwise become the
+    # transparent pass-through server face and never run the watchdog.
+    $bad = Start-Process -FilePath (Join-Path $root 'current\mStream.exe') `
+        -ArgumentList '--tray', '--no-open' -PassThru
+
+    # Two instant crashes + the rollback land within a few seconds; poll 60.
+    $prevDeprefixed = DePrefix $prevBundle
+    for ($i = 0; $i -lt 60; $i++) {
+        if ((CurrentTarget) -eq $prevDeprefixed) { break }
+        Start-Sleep -Seconds 1
+    }
+
+    Write-Host "== launcher.log =="
+    Get-Content (Join-Path $data 'logs\launcher.log') -ErrorAction SilentlyContinue
+    Write-Host "== assertions =="
+    $fail = 0
+    if ((CurrentTarget) -eq $prevDeprefixed) {
+        Write-Host 'PASS current re-pointed at 0.0.1'
+    } else {
+        Write-Host "FAIL current -> $(CurrentTarget)"; $fail = 1
+    }
+    $hold = Join-Path $data 'update-hold.json'
+    if ((Test-Path $hold) -and (Select-String -Path $hold -Pattern "`"version`": `"$pkgver`"" -Quiet)) {
+        Write-Host "PASS hold recorded for $pkgver"
+    } else {
+        Write-Host "FAIL no hold for $pkgver"; $fail = 1
+    }
+    if (Test-Path (Join-Path $data 'update-status.json')) {
+        Write-Host 'FAIL stale update-status.json survived'; $fail = 1
+    } else {
+        Write-Host 'PASS stale update-status.json deleted'
+    }
+    Start-Sleep -Seconds 3   # give the takeover a beat past its lock retry
+    $takeover = @(SmokeProcs | Where-Object { $_.Name -ne 'mstream-server' -and $_.Id -ne $bad.Id })
+    if ($takeover.Count -gt 0) {
+        Write-Host 'PASS a takeover launcher is running from the rolled-back layout'
+    } else {
+        Write-Host 'FAIL no takeover launcher running'; $fail = 1
+    }
+    if ($bad.HasExited) {
+        Write-Host 'PASS the failed-version launcher exited'
+    } else {
+        Write-Host 'FAIL the failed-version launcher is still alive'; $fail = 1
+    }
+} finally {
+    $env:LOCALAPPDATA = $savedLocal
+    $env:USERPROFILE = $savedProfile
+    $env:MSTREAM_LAUNCHER_SKIP_AUTOSTART = $savedSkip
+    SmokeProcs | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 1
+    $cur = Get-Item (Join-Path $root 'current') -Force -ErrorAction SilentlyContinue
+    if ($cur -and ($cur.Attributes -band [IO.FileAttributes]::ReparsePoint)) { $cur.Delete() }
+    Remove-Item -Recurse -Force $smoke -ErrorAction SilentlyContinue
+}
+exit $fail

--- a/test/smoke/update-watchdog-smoke.ps1
+++ b/test/smoke/update-watchdog-smoke.ps1
@@ -71,8 +71,14 @@ function Make-Bundle([string]$ver, [string]$stubBody) {
     Copy-Item $launcher (Join-Path $b 'mStream.exe')
     $src = Join-Path $smoke "stub-$ver.rs"
     Set-Content -Path $src -Value $stubBody -Encoding ASCII
-    & rustc -O $src -o (Join-Path $b 'mstream-server.exe') 2>&1 | Out-Null
-    if ($LASTEXITCODE -ne 0) { throw "rustc failed for the $ver stub" }
+    # --crate-name: rustc derives it from the file name otherwise, and dots
+    # in versions make an invalid crate name. stderr goes to a file, not
+    # 2>&1: under ErrorActionPreference=Stop, PS 5.1 turns any native
+    # stderr line into a terminating NativeCommandError.
+    $crate = 'stub_' + ($ver -replace '[^0-9A-Za-z]', '_')
+    $errf = Join-Path $smoke "rustc-$ver.err"
+    & rustc -O --crate-name $crate $src -o (Join-Path $b 'mstream-server.exe') 2>$errf | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "rustc failed for the $ver stub - see $errf" }
     return $b
 }
 

--- a/test/smoke/update-watchdog-smoke.sh
+++ b/test/smoke/update-watchdog-smoke.sh
@@ -51,7 +51,12 @@ SMOKE="${TMPDIR:-/tmp}/mstream-watchdog-smoke-$$"
 FAKEHOME="$SMOKE/home"
 ROOT="$SMOKE/root"
 DATA="$FAKEHOME/$DATA_REL"
-trap 'pkill -f "^$ROOT/" 2>/dev/null; sleep 1; pkill -9 -f "^$ROOT/" 2>/dev/null; rm -rf "$SMOKE"' EXIT INT TERM
+# Cleanup matches the path ANYWHERE in the command line, not ^-anchored:
+# the stub servers are #!/bin/sh scripts, so their argv starts with
+# "/bin/sh " and an anchored pattern would kill the launcher but leak the
+# stub (it ignores stdin, so the supervision EOF cannot reap it either).
+# $ROOT is a unique scratch path — unanchored is still precise.
+trap 'pkill -f "$ROOT/" 2>/dev/null; sleep 1; pkill -9 -f "$ROOT/" 2>/dev/null; rm -rf "$SMOKE"' EXIT INT TERM
 mkdir -p "$FAKEHOME" "$ROOT" "$DATA"
 # The watchdog resolves its own exe path, so everything it writes is in
 # CANONICAL form (macOS: /var -> /private/var). Compare in the same form.

--- a/test/smoke/update-watchdog-smoke.sh
+++ b/test/smoke/update-watchdog-smoke.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# Boot-watchdog rollback smoke (manual, posix): proves the launcher rolls a
+# managed install back when the version behind `current` crashes at boot.
+#
+#   1. Fabricates a managed root: `current` -> a bundle whose mstream-server
+#      answers -V (it "passed" the installers' exec probe) but exits 1 on a
+#      real boot, beside a previous version whose server idles forever.
+#      The REAL launcher binary rides in both bundles.
+#   2. Pre-writes the stale armed update-status.json a real bad apply leaves.
+#   3. Starts the launcher behind `current` under a scratch HOME and expects:
+#      one retry, then rollback — `current` re-pointed at the previous
+#      version, the failed version recorded in update-hold.json, the stale
+#      status file deleted, a takeover launcher running from `current`, and
+#      the failed-version launcher gone.
+#
+# Needs: a built launcher (cargo build --release in rust-launcher/, or
+# MSTREAM_LAUNCHER_BIN pointing at one). On Linux the desktop face needs a
+# display — run under xvfb-run on a headless box. macOS runs as-is. The
+# scratch HOME plus MSTREAM_LAUNCHER_SKIP_AUTOSTART keep real login items
+# and data untouched.
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+LAUNCHER="${MSTREAM_LAUNCHER_BIN:-$REPO/rust-launcher/target/release/mstream-launcher}"
+[ -x "$LAUNCHER" ] || {
+    echo "no launcher at $LAUNCHER - build it (cd rust-launcher && cargo build --release) or set MSTREAM_LAUNCHER_BIN" >&2
+    exit 1
+}
+# The version baked into the launcher (build.rs reads package.json) — the
+# fabricated `current` bundle must carry it or the watchdog rightly declines.
+PKGVER=$(node -p "require('$REPO/package.json').version" 2>/dev/null \
+    || sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' "$REPO/package.json" | head -1)
+
+case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64) KEY="darwin-arm64" ;;
+    Darwin-*) KEY="darwin-x64" ;;
+    Linux-aarch64 | Linux-arm64) KEY="linux-arm64" ;;
+    *) KEY="linux-x64" ;;
+esac
+if [ "$(uname -s)" = Darwin ]; then
+    FACE_REL="mStream.app/Contents/MacOS/mStream"
+    SERVER_REL="mStream.app/Contents/MacOS/mstream-server"
+    DATA_REL="Library/Application Support/mStream"
+else
+    FACE_REL="mstream-desktop"
+    SERVER_REL="mstream-server"
+    DATA_REL=".local/share/mstream"
+fi
+
+SMOKE="${TMPDIR:-/tmp}/mstream-watchdog-smoke-$$"
+FAKEHOME="$SMOKE/home"
+ROOT="$SMOKE/root"
+DATA="$FAKEHOME/$DATA_REL"
+trap 'pkill -f "^$ROOT/" 2>/dev/null; sleep 1; pkill -9 -f "^$ROOT/" 2>/dev/null; rm -rf "$SMOKE"' EXIT INT TERM
+mkdir -p "$FAKEHOME" "$ROOT" "$DATA"
+# The watchdog resolves its own exe path, so everything it writes is in
+# CANONICAL form (macOS: /var -> /private/var). Compare in the same form.
+ROOT=$(cd "$ROOT" && pwd -P)
+
+mk_bundle() { # version server-body
+    b="$ROOT/mStream-$1-$KEY"
+    mkdir -p "$b/$(dirname "$SERVER_REL")" "$b/$(dirname "$FACE_REL")"
+    cp "$LAUNCHER" "$b/$FACE_REL"
+    printf '%s\n' "$2" > "$b/$SERVER_REL"
+    chmod +x "$b/$SERVER_REL"
+}
+
+mk_bundle "$PKGVER" "#!/bin/sh
+if [ \"\${1:-}\" = -V ]; then echo $PKGVER; exit 0; fi
+echo 'boom: simulated boot crash' >&2
+exit 1"
+mk_bundle "0.0.1" '#!/bin/sh
+if [ "${1:-}" = -V ]; then echo 0.0.1; exit 0; fi
+while true; do sleep 3600; done'
+ln -s "$ROOT/mStream-$PKGVER-$KEY" "$ROOT/current"
+printf '{"applyRequested":true,"applyRequestedAt":"2026-01-01T00:00:00.000Z","staged":true,"stagedVersion":"%s","method":"managed"}\n' "$PKGVER" \
+    > "$DATA/update-status.json"
+
+echo "starting launcher (bad current: $PKGVER, previous: 0.0.1)..."
+HOME="$FAKEHOME" \
+MSTREAM_LAUNCHER_SKIP_AUTOSTART=1 \
+MSTREAM_LAUNCHER_DIRECT_RELAUNCH=1 \
+"$ROOT/current/$FACE_REL" --no-open &
+BAD_PID=$!
+
+# Two instant crashes + the rollback land within a few seconds; poll up to 30.
+i=0
+while [ $i -lt 30 ]; do
+    [ "$(readlink "$ROOT/current")" = "$ROOT/mStream-0.0.1-$KEY" ] && break
+    i=$((i + 1)); sleep 1
+done
+
+echo "== launcher.log =="
+cat "$DATA/logs/launcher.log" 2>/dev/null || true
+echo "== assertions =="
+fail=0
+if [ "$(readlink "$ROOT/current")" = "$ROOT/mStream-0.0.1-$KEY" ]; then
+    echo "PASS current re-pointed at 0.0.1"
+else
+    echo "FAIL current -> $(readlink "$ROOT/current")"; fail=1
+fi
+if grep -q "\"version\": \"$PKGVER\"" "$DATA/update-hold.json" 2>/dev/null; then
+    echo "PASS hold recorded for $PKGVER"
+else
+    echo "FAIL no hold for $PKGVER"; fail=1
+fi
+if [ -e "$DATA/update-status.json" ]; then
+    echo "FAIL stale update-status.json survived"; fail=1
+else
+    echo "PASS stale update-status.json deleted"
+fi
+sleep 2 # give the takeover a beat past its lock retry
+if pgrep -f "^$ROOT/current/" >/dev/null 2>&1; then
+    echo "PASS a takeover launcher is running from current"
+else
+    echo "FAIL no launcher running from current"; fail=1
+fi
+if kill -0 "$BAD_PID" 2>/dev/null; then
+    echo "FAIL the failed-version launcher is still alive"; fail=1
+else
+    echo "PASS the failed-version launcher exited"
+fi
+exit $fail

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -3449,8 +3449,9 @@ const infoView = Vue.component('info-view', {
                     <td><b>Available:</b> v{{update.s.latest}} &mdash; {{updLine()}}</td>
                     <td>
                       <span v-if="updAction()">[<a v-on:click="updDoAction()">{{updAction()}}</a>] </span>
-                      <a v-else-if="!update.s.skipped && update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank" rel="noopener">[downloads page] </a>
-                      <span v-if="update.s.skipped">[<a v-on:click="updSetSkip('')">unskip</a>]</span>
+                      <a v-else-if="!update.s.skipped && !update.s.held && update.s.downloadUrl" v-bind:href="update.s.downloadUrl" target="_blank" rel="noopener">[downloads page] </a>
+                      <span v-if="update.s.held" title="This version was rolled back after it failed to start. Clearing the hold lets the next check download and try it again.">[<a v-on:click="updClearHold()">clear hold &amp; retry</a>]</span>
+                      <span v-else-if="update.s.skipped">[<a v-on:click="updSetSkip('')">unskip</a>]</span>
                       <span v-else title="Hold this version back: never download or restart into it (e.g. after rolling back). Cleared by unskip or the next release.">[<a v-on:click="updSetSkip(update.s.latest)">skip</a>]</span>
                     </td>
                   </tr>
@@ -3484,6 +3485,7 @@ const infoView = Vue.component('info-view', {
       const s = this.update.s;
       if (s.notifyOnly) { return 'this build is too old to self-update; re-run the install command'; }
       if (s.skipped) { return 'held back (skipped) - it will not be downloaded or applied'; }
+      if (s.held) { return 'held back - it failed to start after a previous update and was rolled back; a newer release clears this automatically'; }
       if (s.downloading) { return 'downloading...'; }
       const stagedIsLatest = s.staged && s.stagedVersion === s.latest;
       if (stagedIsLatest && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
@@ -3498,7 +3500,7 @@ const infoView = Vue.component('info-view', {
     },
     updAction: function() {
       const s = this.update.s;
-      if (s.notifyOnly || s.downloading || s.skipped) { return null; }
+      if (s.notifyOnly || s.downloading || s.skipped || s.held) { return null; }
       // Act only on a staged copy of the CURRENT latest: with an older
       // version staged and a newer one advertised, the click must never
       // apply the old one while the line names the new one.
@@ -3564,6 +3566,15 @@ const infoView = Vue.component('info-view', {
         iziToast.success({ title: ver ? `v${ver} will be skipped` : 'Version skip cleared', position: 'topCenter', timeout: 2500 });
       } catch (err) {
         iziToast.error({ title: 'Failed to change skip setting', position: 'topCenter', timeout: 3500 });
+      }
+    },
+    updClearHold: async function() {
+      try {
+        await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/update/settings`, data: { clearHold: true } });
+        await ADMINDATA.getUpdateStatus();
+        iziToast.success({ title: 'Hold cleared - the next check may download it again', position: 'topCenter', timeout: 2500 });
+      } catch (err) {
+        iziToast.error({ title: 'Failed to clear the hold', position: 'topCenter', timeout: 3500 });
       }
     },
     updCycleMode: async function() {


### PR DESCRIPTION
## Why

Groundwork for making **apply-updates-automatically the default**. The audit of the auto-update path found one systemic gap: recovery from a bad release depends on the *new* server being healthy enough to run the update checker. A release that passes the installers' exec probe (`-V` answers) but crashes during a real boot — config/db/module-load regression — was a dead install:

- `current`, the login item, and the macOS `~/Applications` copy already point at the broken version (the stage-time flip), so every restart and reboot lands on it again.
- The launcher never restarts a crashed server, and with the server dead there is no checker — **a fixed follow-up release could never arrive on its own.**

## What

**Launcher boot watchdog** (`rust-launcher/src/rollback.rs`, wired in `tray_app.rs`): a crash-before-serving server gets one retry, then the watchdog

1. confirms the managed layout is committed to this launcher's own version (build stamp vs `current`), with no `--server-bin`/`MSTREAM_SERVER_BIN` override in play;
2. picks the newest lower same-key version on disk (prune always keeps one), exec-probes it, and skips known-bad versions;
3. records the failed version in **`update-hold.json`** (beside the status file), deletes the stale armed `update-status.json` (a stale `applyRequested` read from a Stopped phase is how a crash used to turn into a relaunch loop), re-points `current` (atomic symlink swap on unix, junction re-create on Windows), restores `~/Applications` on macOS via ditto from the versioned root copy;
4. hands off to the previous launcher through the existing verified takeover relaunch. The login item re-points for free (`ensure_default_on` re-asserts with the new exe path). A server that cannot even *spawn* takes the same path.

**Server side** (`src/util/update-check.js`): a held version is never staged or applied; a `current` link still aiming at one is re-pointed at the running version (`enforceHold` — belt to the launcher's suspenders); holds are pruned once a version ≥ them actually boots. So the headline flow needs no human: **bad release boots → watchdog rolls back → hold blocks re-staging → the fixed release stages and applies normally.** `clearHold: true` on the update-settings endpoint is the operator override, surfaced on the About card as "clear hold & retry".

**Guard rails**: rollback chains are bounded (targets are strictly lower versions, held versions are skipped, at most the 2–3 versions prune keeps), and the launcher's auto-apply poll now only acts from a live-server phase and never into a held version.

## Testing

- 6 new launcher unit tests (candidate selection matrix, hold dedupe/cap/tolerant parsing, marker-root `~/Applications` shape, execute effects) — 31/31 pass, clippy clean.
- 2 new integration tests (hold honored + superseded by a newer release + `clearHold`; `enforceHold` re-pointing) — full unit (563) and integration (688) suites pass.
- New live smoke `npm run test:smoke:update-watchdog` (`test/smoke/update-watchdog-smoke.sh`): fabricates a managed root whose `current` crashes at boot with the **real launcher binary** in both bundles, and asserts the retry, the re-point, the recorded hold, the stale-status deletion, and the takeover into the previous version. Scratch HOME — never touches real data or login items.

## Out of scope / follow-ups before flipping the default

- R2: headless guards (no exit-0 in auto without a detectable supervisor; boot-attempt counter in `cli-boot-wrapper.js`).
- R3: deeper pre-flip probe (`--boot-probe`).
- R4: CI coverage of the apply leg (auto-arming, takeover cycle).
- Inno/pkg installs have no versioned rollback material; the watchdog rightly declines there (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)