### PR TITLE
Headless guards: supervision-gated auto apply + a boot watchdog inside the server binary

### DIFF
--- a/cli-boot-wrapper.js
+++ b/cli-boot-wrapper.js
@@ -5,6 +5,7 @@
 import { watchSupervisorStdin } from './src/util/supervision.js';
 import { maybeRunWorker } from './src/util/worker-process.js';
 import { resolveDefaultConfig, ensureDesktopDefaultConfig } from './src/util/boot-config.js';
+import { guardHeadlessBoot } from './src/util/boot-watchdog.js';
 import pkg from './package.json' with { type: 'json' };
 
 const version = pkg.version;
@@ -27,6 +28,18 @@ if (await maybeRunWorker()) {
   // which the parser needs for its help text.
   const resolved = resolveDefaultConfig({ portable: process.argv.includes('--portable') });
   const { json, supervised, quickConnectOffByDefault } = parseArgs(process.argv.slice(2), resolved.path);
+
+  // Headless boot watchdog (src/util/boot-watchdog.js): on a managed
+  // install whose committed version keeps crashing during boot, roll
+  // `current` back and hand this invocation to the previous version's
+  // binary — in which case this await never resolves (exec semantics: the
+  // child inherits our stdio and its exit exits us). Sits HERE on purpose:
+  // after parseArgs, so the installers' `-V` exec probe stays pure and
+  // never touches the attempt counter, and before the config/db/module
+  // work where boot crashes actually happen. Supervised (tray-launcher)
+  // boots skip it — the launcher's own watchdog owns that recovery with
+  // better signals.
+  if (!supervised) { await guardHeadlessBoot(process.argv.slice(2)); }
 
   // First run of a standalone binary with no explicit config: create the
   // desktop-profile config (storage under the data home, Quick Connect on

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,8 +61,15 @@ About page shows the state and holds the controls:
 - `updates.mode` — `notify` (report only, download nothing), `stage`
   (the default, described above), or `auto` (additionally restart into the
   update once the server is idle — no active streams, no scan running).
-  On a headless install, `auto` exits with code 0 after staging and expects
-  a process supervisor (systemd, pm2) configured to start mStream again.
+  On a headless install, `auto` applies by exiting with code 0 so the
+  process supervisor's restart lands on the new version — but only when a
+  supervisor that restarts on a clean exit is actually detectable: pm2, or
+  systemd with `Restart=always`/`on-success` (the default `Restart=no` and
+  `on-failure` don't restart an exit 0, so they don't count). For
+  supervisors mStream can't see — a docker `--restart` policy, runit, your
+  own wrapper loop — set `MSTREAM_SUPERVISED=1`. With nothing detected,
+  `auto` behaves like `stage` and says so in the log and the admin panel:
+  exiting would be an outage, not an apply.
 - `updates.check` — set `false` and mStream never phones home; the admin
   panel's "check now" button still works on demand.
 
@@ -79,10 +86,14 @@ restores the `~/Applications` copy on macOS, relaunches, and records the
 failed version in `update-hold.json` so the daily check doesn't re-stage it.
 The admin panel shows the held version; the hold clears automatically the
 moment a release newer than it ships (or by hand via the panel's
-"clear hold & retry"). Headless installs get the server-side half of this —
-a held version is never staged or applied, and a `current` link left on one
-is re-pointed at the running version — but with no launcher watching the
-boot, the rollback itself needs the supervisor or a re-run of the installer.
+"clear hold & retry"). Headless installs have their own watchdog built into
+the server binary itself: it counts boot attempts before any of the work
+that can crash, and on the third failed boot of the version `current` is
+committed to, it rolls `current` back, records the hold, and hands that
+very invocation over to the previous version's binary — no supervisor
+required (set `MSTREAM_BOOT_WATCHDOG=0` to disable it). The server-side
+guards back both watchdogs up: a held version is never staged or applied,
+and a `current` link left on one is re-pointed at the running version.
 
 Rolling back? Re-run the installer with `MSTREAM_VERSION=<old tag>`, restart,
 and then **skip the bad release** (the admin panel's skip link, or

--- a/src/server.js
+++ b/src/server.js
@@ -61,6 +61,7 @@ import { classifyError } from './util/web-error.js';
 import { isAdminAllowed } from './util/admin-network.js';
 import { writeJsonAtomic, completedWrites } from './util/atomic-json.js';
 import * as updateCheck from './util/update-check.js';
+import * as bootWatchdog from './util/boot-watchdog.js';
 
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -723,6 +724,10 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   const onListening = async () => {
     currentBind = bind;
     rebootInFlight = false;   // a reboot's re-serve is complete
+    // A successful listen acknowledges this boot: the headless boot
+    // watchdog's attempt counter (armed pre-boot in cli-boot-wrapper.js)
+    // starts over. Cheap no-op everywhere the guard never ran.
+    bootWatchdog.markBootOk();
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
 
     // A settings change landed while the reboot above was already past its

--- a/src/util/boot-watchdog.js
+++ b/src/util/boot-watchdog.js
@@ -1,0 +1,257 @@
+// Headless boot watchdog — the pre-boot half of the bad-release recovery
+// story. The desktop half lives in rust-launcher/src/rollback.rs; the
+// hold-file contract they share is src/util/update-shared.js.
+//
+// A staged update flips $ROOT/current at STAGE time, so a release that
+// passes the installers' exec probe (`-V` answers) but crashes during a
+// real boot takes every later start down with it. Under the tray launcher
+// the launcher's watchdog rolls back; headless there is no launcher — just
+// a supervisor (or a human) restarting a binary that can never finish
+// booting, and no running server means no update checker, so even a FIXED
+// release can never arrive on its own.
+//
+// This guard runs from cli-boot-wrapper.js right after argv parsing —
+// before the config parse, db open, and module loads where boot crashes
+// actually happen — and:
+//
+//   1. counts boot attempts per version in the data home
+//      (boot-attempts.json; cleared by server.js the moment a listen
+//      succeeds, so only boots that never got that far accumulate);
+//   2. on the third unacknowledged attempt of a managed install whose
+//      `current` is committed to THIS version, appends the version to
+//      update-hold.json (so the checker never re-stages it), re-points
+//      `current` at the newest lower same-key version that still execs,
+//      and hands THIS invocation over to that binary — spawn with
+//      inherited stdio + mirrored exit, not exit-and-pray: a supervisor
+//      with Restart=no (systemd's default), or no supervisor at all,
+//      still ends up running the working version right now.
+//
+// Never engaged: under the launcher (--supervised — its watchdog owns the
+// recovery, with better signals), for `-V`/`-h` (the installers' exec
+// probe must stay pure — the wrapper fast-exits those before calling us),
+// for workers, or on any layout that is not a managed install committed to
+// this binary's own version. MSTREAM_BOOT_WATCHDOG=0 disables it outright.
+//
+// Deliberately dependency-light: node builtins, esm-helpers, and
+// update-shared.js. Importing anything heavier would move the guard BEHIND
+// the crash classes it exists to guard.
+import fs from 'fs';
+import fsp from 'fs/promises';
+import path from 'path';
+import { spawn, spawnSync } from 'child_process';
+import { userDataHome, isBunStandalone } from './esm-helpers.js';
+import { compareVersions, parseBundleName, readHoldEntries, appendHold } from './update-shared.js';
+import packageJson from '../../package.json' with { type: 'json' };
+
+// The third invocation acts: two real crashes first — one more than the
+// launcher's in-session retry, because a supervisor's restart pacing is
+// unknown and the counter spans invocations.
+const MAX_BOOT_ATTEMPTS = 3;
+const ATTEMPTS_FILE = 'boot-attempts.json';
+const PROBE_TIMEOUT_MS = 10_000;
+
+export function attemptsFilePath(dataHome = userDataHome()) {
+  return path.join(dataHome, ATTEMPTS_FILE);
+}
+
+// The server binary's path inside a bundle (install.sh's server_rel /
+// scripts/build-bun.mjs staging), per platform. Exported for the tests
+// that fabricate bundles.
+export function serverRel(platform = process.platform) {
+  if (platform === 'win32') { return 'mstream-server.exe'; }
+  if (platform === 'darwin') { return path.join('mStream.app', 'Contents', 'MacOS', 'mstream-server'); }
+  return 'mstream-server';
+}
+
+function readAttempts(file) {
+  try {
+    const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (doc && typeof doc.version === 'string' && Number.isInteger(doc.attempts) && doc.attempts > 0) {
+      return doc;
+    }
+  } catch { /* absent or mangled = no attempts */ }
+  return null;
+}
+
+// Record this boot attempt for `version` BEFORE the crash-prone phase runs;
+// returns the running count. A different recorded version resets the count
+// — attempts never carry across versions. Sync + tmp-rename: this precedes
+// the event loop mattering, and a torn file must read as "no attempts",
+// never as a crash of its own.
+export function bumpAttempts(version, dataHome = userDataHome()) {
+  const file = attemptsFilePath(dataHome);
+  const prev = readAttempts(file);
+  const attempts = prev && prev.version === version ? prev.attempts + 1 : 1;
+  const doc = { schema: 1, version, attempts, firstAt: prev && prev.version === version ? prev.firstAt : new Date().toISOString() };
+  fs.mkdirSync(dataHome, { recursive: true });
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(doc));
+  fs.renameSync(tmp, file);
+  return attempts;
+}
+
+export function clearAttempts(dataHome = userDataHome()) {
+  try { fs.unlinkSync(attemptsFilePath(dataHome)); } catch { /* absent is clear */ }
+}
+
+// Called from server.js the moment a listen succeeds: this boot is
+// acknowledged, the counter starts over. Unconditional and cheap — the
+// file only ever exists for unsupervised managed boots.
+export function markBootOk() {
+  clearAttempts();
+}
+
+// `<bin> -V`, bounded — the same bar as the installers' probe-before-flip
+// and the desktop watchdog: never roll back INTO a binary that cannot exec.
+function probeServer(bin) {
+  const r = spawnSync(bin, ['-V'], { timeout: PROBE_TIMEOUT_MS, stdio: 'ignore' });
+  return r.status === 0;
+}
+
+// The managed root this binary runs from, plus what `current` is committed
+// to. Geometry from the real executable path (mirroring detectInstallMethod
+// in update-check.js), or the MSTREAM_UPDATE_ROOT escape hatch — which also
+// waives the standalone requirement, exactly as it does there, so tests and
+// operators can exercise the guard from a source run. null = not managed.
+export function findManagedContext({
+  execPath = process.execPath,
+  env = process.env,
+  standalone = isBunStandalone,
+  platform = process.platform,
+  fsx = fs,
+} = {}) {
+  let root = null;
+  if (env.MSTREAM_UPDATE_ROOT) {
+    root = env.MSTREAM_UPDATE_ROOT;
+  } else if (standalone) {
+    let real = execPath;
+    try { real = fsx.realpathSync(execPath); } catch { /* keep the literal path */ }
+    let dir = path.dirname(real);
+    for (let i = 0; i < 8; i++) {
+      const parent = path.dirname(dir);
+      if (parent === dir) { break; }
+      if (parseBundleName(path.basename(dir)) && fsx.existsSync(path.join(parent, 'current'))) {
+        root = parent;
+        break;
+      }
+      dir = parent;
+    }
+  }
+  if (!root) { return null; }
+  let target;
+  try { target = fsx.readlinkSync(path.join(root, 'current')); } catch { return null; }
+  const parsed = parseBundleName(path.basename(target));
+  if (!parsed) { return null; }
+  return { root, currentVersion: parsed.version, key: parsed.key, platform };
+}
+
+// The newest lower same-key version on disk that is not held and still
+// execs — the same candidate rules as the launcher's plan_rollback.
+export function planRollback({ root, key, failedVersion, dataHome, platform = process.platform, fsx = fs, probe = probeServer }) {
+  const held = readHoldEntries(dataHome).map((h) => h.version);
+  const candidates = [];
+  for (const entry of fsx.readdirSync(root)) {
+    const parsed = parseBundleName(entry);
+    if (!parsed || parsed.key !== key) { continue; }
+    const cmp = compareVersions(parsed.version, failedVersion);
+    if (cmp === null || cmp >= 0 || held.includes(parsed.version)) { continue; }
+    const bundle = path.join(root, entry);
+    if (fsx.existsSync(path.join(bundle, serverRel(platform)))) {
+      candidates.push({ version: parsed.version, bundle });
+    }
+  }
+  candidates.sort((a, b) => compareVersions(b.version, a.version) || 0);
+  const pick = candidates.find((c) => probe(path.join(c.bundle, serverRel(platform))));
+  return pick ? { targetVersion: pick.version, targetBundle: pick.bundle } : null;
+}
+
+// Replace `link` with a symlink/junction to `target` — same contract as
+// replaceLink in update-check.js (tmp + rename where the platform allows;
+// Windows may refuse a rename onto a junction, keeping the pre-existing
+// unlink+create exposure). Duplicated so this module stays light.
+async function replaceLink(target, link) {
+  const tmp = `${link}.tmp-${process.pid}`;
+  const kind = process.platform === 'win32' ? 'junction' : 'dir';
+  await fsp.rm(tmp, { force: true }).catch(() => {});
+  await fsp.symlink(target, tmp, kind);
+  try {
+    await fsp.rename(tmp, link);
+  } catch {
+    await fsp.rm(tmp, { force: true }).catch(() => {});
+    await fsp.unlink(link).catch(() => {});
+    await fsp.symlink(target, link, kind);
+  }
+}
+
+export async function executeRollback({ root, failedVersion, targetBundle, dataHome }) {
+  // Hold FIRST: even if the re-point dies, the record exists — the next
+  // server to run (any path: a manual start of the previous version, the
+  // fixed release) refuses to re-stage the bad one, and its enforceHold
+  // pass finishes the re-point.
+  await appendHold(dataHome, failedVersion, 'server crashed during boot (headless watchdog)');
+  await replaceLink(targetBundle, path.join(root, 'current'));
+  // The stale status file is left alone on purpose: it belongs to the
+  // LAUNCHER conversation, and an unsupervised boot means no launcher is
+  // polling it — while a tray session elsewhere on this data home would be
+  // exactly the reader we must not clobber.
+}
+
+// Hand the rest of THIS invocation to the previous version's server:
+// inherited stdio (the --supervised stdin pipe, if any, flows through to
+// the child), forwarded signals, mirrored exit code.
+function handoff(bin, argv) {
+  const child = spawn(bin, argv, { stdio: 'inherit' });
+  for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+    try {
+      process.on(sig, () => { try { child.kill(sig); } catch { /* already gone */ } });
+    } catch { /* SIGHUP on windows */ }
+  }
+  child.on('error', (err) => {
+    console.error(`[boot-watchdog] could not start ${bin}: ${err.message}`);
+    process.exit(1);
+  });
+  child.on('close', (code) => { process.exit(code === null ? 1 : code); });
+}
+
+// The guard cli-boot-wrapper.js calls right after argv parsing. Resolves
+// (falsy) to continue booting normally; on a rollback it hands this
+// invocation to the previous version's binary and NEVER resolves — exec
+// semantics: the child owns our stdio, its exit exits us via handoff().
+// Every failure inside deliberately degrades to "continue booting": the
+// guard must never be the reason a healthy install won't start.
+export async function guardHeadlessBoot(argv, { env = process.env } = {}) {
+  if (env.MSTREAM_BOOT_WATCHDOG === '0') { return false; }
+  let ctx = null;
+  try { ctx = findManagedContext({ env }); } catch { /* not our call */ }
+  if (!ctx) { return false; }
+  const ourVersion = packageJson.version;
+  // Only when the layout is committed to US — a `current` already pointing
+  // elsewhere (an operator's re-point, a finished rollback with the
+  // supervisor still pinned to the old path) is not ours to count against.
+  if (ctx.currentVersion !== ourVersion) { return false; }
+  const dataHome = userDataHome();
+  let attempts;
+  try { attempts = bumpAttempts(ourVersion, dataHome); } catch { return false; }
+  if (attempts < MAX_BOOT_ATTEMPTS) { return false; }
+  let plan = null;
+  try {
+    plan = planRollback({ root: ctx.root, key: ctx.key, failedVersion: ourVersion, dataHome });
+  } catch { /* fall through to the no-plan path */ }
+  if (!plan) {
+    console.error(`[boot-watchdog] mStream ${ourVersion} has not finished booting in ${attempts - 1} attempts `
+      + 'and there is nothing usable on disk to roll back to - continuing anyway');
+    return false;
+  }
+  console.error(`[boot-watchdog] mStream ${ourVersion} crashed during boot ${attempts - 1} times - `
+    + `rolling back to ${plan.targetVersion} and holding ${ourVersion} (update-hold.json)`);
+  try {
+    await executeRollback({ root: ctx.root, failedVersion: ourVersion, targetBundle: plan.targetBundle, dataHome });
+  } catch (err) {
+    console.error(`[boot-watchdog] rollback failed: ${err.message} - continuing with this version`);
+    return false;
+  }
+  handoff(path.join(plan.targetBundle, serverRel()), argv);
+  // Never resolves: the spawned child (and its exit-mirroring handlers)
+  // keep the process alive; nothing after this await may run.
+  return new Promise(() => {});
+}

--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -30,9 +30,13 @@
 //            a restart / a click
 //   auto   - additionally apply when idle: under the launcher, by flagging
 //            applyRequested in the status file (the launcher restarts into
-//            the staged version); headless, by exiting 0 — documented as
-//            "auto expects a process supervisor" (systemd/pm2 restart lands
-//            on the new version via the flipped `current` link)
+//            the staged version); headless, by exiting 0 so the supervisor's
+//            restart lands on the new version via the flipped `current`
+//            link — but ONLY when a restart-on-clean-exit supervisor is
+//            actually detectable (detectSupervisor: MSTREAM_SUPERVISED,
+//            pm2, systemd with Restart=always/on-success). Unsupervised,
+//            auto degrades to stage-and-log: exiting would be an outage,
+//            not an apply.
 //
 // Boot-failure holds (update-hold.json, beside the status file): when an
 // applied update crashes before it ever serves, the launcher's boot
@@ -48,13 +52,20 @@
 import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import winston from 'winston';
 import * as config from '../state/config.js';
 import { writeJsonAtomic } from './atomic-json.js';
 import { downloadToFile, computeFileChecksum } from './ffmpeg-bootstrap.js';
 import { appRoot, isBunStandalone, userDataHome, underSystemPrefix } from './esm-helpers.js';
+import { VERSION_RE, compareVersions, parseBundleName, HOLD_FILE, readHoldEntries } from './update-shared.js';
 import packageJson from '../../package.json' with { type: 'json' };
+
+// The pure halves live in update-shared.js so the pre-boot headless guard
+// (boot-watchdog.js) can speak the same contract without importing this
+// module's heavy dependencies; re-exported here so every existing consumer
+// (tests included) keeps its import path.
+export { compareVersions, parseBundleName } from './update-shared.js';
 
 const REPO = 'IrosTheBeggar/mStream';
 const LATEST_BASE = `https://github.com/${REPO}/releases/latest/download`;
@@ -68,29 +79,10 @@ const STAGE_TIMEOUT_MS = 30 * 60 * 1000; // a bundle download on a slow link
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // daily
 const BOOT_CHECK_DELAY_MS = 30 * 1000;
 const AUTO_APPLY_POLL_MS = 15 * 60 * 1000;
-// Shared with rust-launcher/src/rollback.rs — one file, two writers who
-// never overlap (the launcher appends only while no server runs).
-const HOLD_FILE = 'update-hold.json';
-const MAX_HELD = 8;
 
 // ── Pure helpers (unit-tested with injected fs) ─────────────────────────────
-
-const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)$/;
-
-// Strict numeric-triple compare. Returns <0, 0, >0 — or null when either
-// side is not a plain X.Y.Z (prerelease-shaped strings are refused on
-// purpose: releases are always bare triples, so anything else in a manifest
-// is not a version to act on).
-export function compareVersions(a, b) {
-  const ma = VERSION_RE.exec(a);
-  const mb = VERSION_RE.exec(b);
-  if (!ma || !mb) { return null; }
-  for (let i = 1; i <= 3; i++) {
-    const d = Number(ma[i]) - Number(mb[i]);
-    if (d !== 0) { return d; }
-  }
-  return 0;
-}
+// compareVersions / parseBundleName / the hold-file readers live in
+// update-shared.js (see the import note above).
 
 // The release manifest contract (scripts/release-manifest.sh). `name` guards
 // against a non-mStream release capturing the GitHub "latest" pointer (the
@@ -108,12 +100,6 @@ export function validateManifest(m) {
     return { ok: false, reason: 'manifest assets are malformed' };
   }
   return { ok: true };
-}
-
-// mStream-<version>-<key>[.zip] -> { version, key }, or null.
-export function parseBundleName(name) {
-  const m = /^mStream-(\d+\.\d+\.\d+)-((?:darwin|linux|win)-[a-z0-9]+(?:-musl)?)(?:\.zip)?$/.exec(name);
-  return m ? { version: m[1], key: m[2] } : null;
 }
 
 // Where and how is this server installed? Decides what an update can DO:
@@ -231,6 +217,10 @@ const state = {
   skipped: false,           // latest === updates.skipVersion: report, never act
   held: false,              // latest failed to boot after a previous update: report, never act
   heldVersions: [],         // every version the boot watchdog has held (update-hold.json)
+  // Headless managed installs in auto mode: how the exit-0 apply would be
+  // restarted ('env' | 'pm2' | 'systemd'), or 'none' — in which case auto
+  // stages but never self-exits. null until the question has come up.
+  headlessSupervisor: null,
 };
 
 function updatesConfig() {
@@ -249,6 +239,72 @@ function supervisedByLauncher() {
   return process.argv.includes('--supervised');
 }
 
+// ── Supervision detection (auto mode, headless) ─────────────────────────────
+// auto's headless apply is exit(0) + "the supervisor starts mStream again"
+// (scheduleHeadlessExit). With no supervisor that exit IS an outage — a
+// server someone runs in tmux would vanish mid-day, minutes after a release
+// ships. Detection is deliberately conservative: only signals that imply a
+// restart actually FOLLOWS a clean exit count.
+//
+//   MSTREAM_SUPERVISED  the operator's word (any value but '' / '0') — for
+//                       supervisors this list can't see (docker restart
+//                       policies, runit, a bespoke wrapper loop)
+//   pm2                 pm_id in the env; pm2 autorestarts by default
+//   systemd             INVOCATION_ID plus the unit's Restart= policy being
+//                       always/on-success (unit name read from
+//                       /proc/self/cgroup, policy from `systemctl show`).
+//                       A bare INVOCATION_ID is NOT enough: systemd's
+//                       default is Restart=no, where exit 0 leaves the unit
+//                       dead — the very outage this gate exists to prevent.
+//                       on-failure also doesn't count: exit 0 is a success.
+//
+// Injected for tests; production goes through supervisorInfo(), which
+// caches — none of these facts can change for the lifetime of our pid.
+export function detectSupervisor({
+  env = process.env,
+  platform = process.platform,
+  readCgroup = () => fs.readFileSync('/proc/self/cgroup', 'utf8'),
+  queryRestart = (unit, userScope) => {
+    const args = userScope
+      ? ['--user', 'show', '-p', 'Restart', '--value', unit]
+      : ['show', '-p', 'Restart', '--value', unit];
+    const r = spawnSync('systemctl', args, { timeout: 5000, encoding: 'utf8' });
+    return r.status === 0 ? String(r.stdout).trim() : null;
+  },
+} = {}) {
+  if (env.MSTREAM_SUPERVISED && env.MSTREAM_SUPERVISED !== '0') {
+    return { supervised: true, via: 'env' };
+  }
+  // pm2 numbers its processes from 0, so pm_id='0' counts; an exported-but-
+  // EMPTY variable reads as unset (the convention everywhere else here).
+  if (env.pm_id != null && env.pm_id !== '') {
+    return { supervised: true, via: 'pm2' };
+  }
+  if (platform === 'linux' && env.INVOCATION_ID) {
+    try {
+      // cgroup v2: "0::/system.slice/mstream.service" — the unit is the
+      // LAST .service segment (a Delegate= sub-cgroup can sit below it;
+      // .scope units have no restart policy and rightly never match).
+      const line = String(readCgroup()).split('\n').find((l) => l.includes('::')) || '';
+      const cgPath = line.slice(line.indexOf('::') + 2);
+      const segments = cgPath.split('/').filter(Boolean);
+      const unit = [...segments].reverse().find((s) => s.endsWith('.service') && !s.startsWith('user@'));
+      const userScope = segments.some((s) => s === 'user.slice' || s.startsWith('user@'));
+      const policy = unit ? queryRestart(unit, userScope) : null;
+      if (policy === 'always' || policy === 'on-success') {
+        return { supervised: true, via: 'systemd' };
+      }
+    } catch { /* no cgroup / no systemctl: fall through to undetected */ }
+  }
+  return { supervised: false, via: null };
+}
+
+let _supervisor = null;
+function supervisorInfo() {
+  if (!_supervisor) { _supervisor = detectSupervisor(); }
+  return _supervisor;
+}
+
 export function statusFilePath() {
   return path.join(userDataHome(), 'update-status.json');
 }
@@ -257,19 +313,10 @@ export function holdFilePath() {
   return path.join(userDataHome(), HOLD_FILE);
 }
 
-// The launcher's boot watchdog wrote this after rolling an update back.
-// Read tolerantly — the file is our own, but absent/newer-schema/mangled
-// must all read as "nothing held", never as a crash.
+// A watchdog (the launcher's, or the headless boot guard's) wrote this
+// after rolling an update back. Tolerant parse lives in update-shared.js.
 function readHolds() {
-  try {
-    const doc = JSON.parse(fs.readFileSync(holdFilePath(), 'utf8'));
-    if (!doc || !Array.isArray(doc.held)) { return []; }
-    return doc.held
-      .filter((h) => h && typeof h.version === 'string' && VERSION_RE.test(h.version))
-      .slice(0, MAX_HELD);
-  } catch {
-    return [];
-  }
+  return readHoldEntries(userDataHome());
 }
 
 // Cached in state.heldVersions (refreshHolds) so the status poll doesn't
@@ -788,6 +835,15 @@ export async function requestApply() {
   state.applyRequestedAt = new Date().toISOString();
   await writeStatus();
   if (m.method === 'managed' && !supervisedByLauncher()) {
+    // An explicit human click still exits — the admin asked for a restart
+    // and is watching — but with no supervisor detected the "restart" half
+    // is theirs to perform, so say it loudly first.
+    const sup = supervisorInfo();
+    state.headlessSupervisor = sup.supervised ? sup.via : 'none';
+    if (!sup.supervised) {
+      winston.warn('[update] Applying on an explicit admin request with NO supervisor detected - '
+        + 'mStream stays stopped until it is started again');
+    }
     scheduleHeadlessExit('an admin requested the update');
     return { exiting: true };
   }
@@ -805,6 +861,7 @@ function scheduleHeadlessExit(why) {
 }
 
 // auto mode: apply on our own once nothing is streaming and no scan runs.
+let _noSupervisorLoggedFor = null;
 function maybeAutoApply() {
   if (updatesConfig().mode !== 'auto' || !state.staged || state.applyRequested) { return; }
   if (isSkipped(state.stagedVersion) || isHeld(state.stagedVersion)) { return; }
@@ -812,7 +869,23 @@ function maybeAutoApply() {
   if (m.method !== 'managed' && m.method !== 'inno') { return; }
   if (!idle()) { return; }
   if (m.method === 'managed' && !supervisedByLauncher()) {
-    scheduleHeadlessExit('auto mode, server idle');
+    // Headless apply = exit(0), which is only an APPLY when something
+    // restarts us afterwards. Without a detectable restart-on-clean-exit
+    // supervisor, exiting is an outage — so behave as `stage` instead
+    // (the update is staged and flipped; whatever restart comes next lands
+    // on it) and say so once per staged version, not every 15-minute poll.
+    const sup = supervisorInfo();
+    state.headlessSupervisor = sup.supervised ? sup.via : 'none';
+    if (!sup.supervised) {
+      if (_noSupervisorLoggedFor !== state.stagedVersion) {
+        _noSupervisorLoggedFor = state.stagedVersion;
+        winston.info(`[update] mStream ${state.stagedVersion} is staged and applies on the next restart. `
+          + 'Auto mode found no supervisor that would restart mStream after a self-exit '
+          + '(set MSTREAM_SUPERVISED=1 if one really is in charge).');
+      }
+      return;
+    }
+    scheduleHeadlessExit(`auto mode, server idle (supervisor: ${sup.via})`);
     return;
   }
   // Launcher-supervised (managed restart, or inno silent install): flag it;
@@ -1031,7 +1104,10 @@ export function stopForTests() {
   _install = null;
   _checking = null;
   _exiting = false;
+  _supervisor = null;
+  _noSupervisorLoggedFor = null;
   state.skipped = false; state.held = false; state.heldVersions = [];
+  state.headlessSupervisor = null;
   state.latest = null; state.available = false; state.staged = false;
   state.stagedVersion = null; state.applyRequested = false; state.applyRequestedAt = null; state.error = null;
   state.installerPath = null; state.downloadUrl = null; state.notifyOnly = false;

--- a/src/util/update-shared.js
+++ b/src/util/update-shared.js
@@ -1,0 +1,79 @@
+// Pure, dependency-light pieces of the release-update contract, shared by
+// the actors that speak it:
+//
+//   src/util/update-check.js   - the server-side checker/stager (re-exports
+//                                these, so its public API is unchanged)
+//   src/util/boot-watchdog.js  - the pre-boot headless rollback guard,
+//                                which must import nothing heavy: it runs
+//                                BEFORE the crash-prone boot phase it
+//                                exists to guard
+//   rust-launcher/src/rollback.rs mirrors compareVersions/parseBundleName
+//                                and the hold-file schema in Rust (the
+//                                desktop boot watchdog); a behavioural
+//                                change here must change there too.
+//
+// Keep this module to node builtins + atomic-json (itself fs/path only).
+import fs from 'fs';
+import fsp from 'fs/promises';
+import path from 'path';
+import { writeJsonAtomic } from './atomic-json.js';
+
+export const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+// Strict numeric-triple compare. Returns <0, 0, >0 — or null when either
+// side is not a plain X.Y.Z (prerelease-shaped strings are refused on
+// purpose: releases are always bare triples, so anything else in a manifest
+// is not a version to act on).
+export function compareVersions(a, b) {
+  const ma = VERSION_RE.exec(a);
+  const mb = VERSION_RE.exec(b);
+  if (!ma || !mb) { return null; }
+  for (let i = 1; i <= 3; i++) {
+    const d = Number(ma[i]) - Number(mb[i]);
+    if (d !== 0) { return d; }
+  }
+  return 0;
+}
+
+// mStream-<version>-<key>[.zip] -> { version, key }, or null.
+export function parseBundleName(name) {
+  const m = /^mStream-(\d+\.\d+\.\d+)-((?:darwin|linux|win)-[a-z0-9]+(?:-musl)?)(?:\.zip)?$/.exec(name);
+  return m ? { version: m[1], key: m[2] } : null;
+}
+
+// ── update-hold.json: boot-failure holds ────────────────────────────────────
+// Written when a watchdog rolls a crash-at-boot update back; read to keep
+// that version from being staged or applied again; entries drop once a
+// version >= them boots. Three writers, never concurrent: the launcher's
+// watchdog and the headless boot guard write only while no server runs, and
+// the server prunes/clears only about itself while it IS the one running.
+
+export const HOLD_FILE = 'update-hold.json';
+export const MAX_HELD = 8;
+
+// Tolerant read: the file is our own, but absent / newer-schema / mangled
+// must all read as "nothing held", never as a crash.
+export function readHoldEntries(dataHome) {
+  try {
+    const doc = JSON.parse(fs.readFileSync(path.join(dataHome, HOLD_FILE), 'utf8'));
+    if (!doc || !Array.isArray(doc.held)) { return []; }
+    return doc.held
+      .filter((h) => h && typeof h.version === 'string' && VERSION_RE.test(h.version))
+      .slice(0, MAX_HELD);
+  } catch {
+    return [];
+  }
+}
+
+// Append `version` (dedupe; oldest entries give way past the cap). Atomic —
+// a torn hold file would read as "nothing held" and re-open the re-stage
+// loop the hold exists to close.
+export async function appendHold(dataHome, version, reason) {
+  const held = readHoldEntries(dataHome);
+  if (!held.some((h) => h.version === version)) {
+    held.push({ version, at: new Date().toISOString(), reason });
+  }
+  while (held.length > MAX_HELD) { held.shift(); }
+  await fsp.mkdir(dataHome, { recursive: true });
+  await writeJsonAtomic(path.join(dataHome, HOLD_FILE), { schema: 1, held });
+}

--- a/test/integration/boot-watchdog.test.mjs
+++ b/test/integration/boot-watchdog.test.mjs
@@ -1,0 +1,168 @@
+// The headless boot watchdog end to end (src/util/boot-watchdog.js wired
+// into cli-boot-wrapper.js): a managed install whose committed version
+// crashes during boot — a malformed config, the same crash class a bad
+// release ships — recovers on the third invocation by rolling `current`
+// back, holding the failed version, and handing the invocation to the
+// previous version's binary.
+//
+// The wrapper is driven as a real child process; the managed layout comes
+// from the MSTREAM_UPDATE_ROOT escape hatch (the same knob update-check and
+// its integration suite use), which also waives the standalone-binary
+// requirement so a source run can exercise the guard. posix-only: the
+// previous version's stand-in server is a shell stub.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import fss from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { startServer } from '../helpers/server.mjs';
+import { serverRel, attemptsFilePath } from '../../src/util/boot-watchdog.js';
+import packageJson from '../../package.json' with { type: 'json' };
+
+const posixOnly = process.platform === 'win32';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+function hostKey() {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  return process.platform === 'darwin' ? `darwin-${arch}` : `linux-${arch}`;
+}
+
+function dataHomeOf(home) {
+  return process.platform === 'darwin'
+    ? path.join(home, 'Library', 'Application Support', 'mStream')
+    : path.join(home, '.local', 'share', 'mstream');
+}
+
+// A scratch managed layout: current -> a dir for the RUNNING (package.json)
+// version, a previous 0.0.1 bundle whose "server" is a stub that answers -V
+// and marks its takeover on a real run.
+async function makeLayout(home) {
+  const root = path.join(home, 'app');
+  const currentDir = path.join(root, `mStream-${packageJson.version}-${hostKey()}`);
+  const prevDir = path.join(root, `mStream-0.0.1-${hostKey()}`);
+  const prevServer = path.join(prevDir, serverRel());
+  await fs.mkdir(currentDir, { recursive: true });
+  await fs.mkdir(path.dirname(prevServer), { recursive: true });
+  await fs.writeFile(prevServer, '#!/bin/sh\n'
+    + 'if [ "${1:-}" = -V ]; then echo 0.0.1; exit 0; fi\n'
+    + 'echo "PREV-SERVER-TOOK-OVER args=$*"\n'
+    + 'exit 0\n');
+  await fs.chmod(prevServer, 0o755);
+  await fs.symlink(currentDir, path.join(root, 'current'));
+  return { root, currentDir, prevDir };
+}
+
+function runWrapper(args, home, root) {
+  return spawnSync(process.execPath, ['cli-boot-wrapper.js', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      HOME: home,
+      XDG_DATA_HOME: path.join(home, '.local', 'share'),
+      MSTREAM_UPDATE_ROOT: root,
+    },
+  });
+}
+
+test('three crashed boots roll back, hold the version, and hand off to the previous binary', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-bwd-loop-'));
+  try {
+    const { root, prevDir } = await makeLayout(home);
+    const dataHome = dataHomeOf(home);
+    const badConf = path.join(home, 'bad-config.json');
+    await fs.writeFile(badConf, 'not json at all{');
+
+    // Boots 1 and 2: the guard counts, the config crash proceeds as today.
+    for (const expected of [1, 2]) {
+      const r = runWrapper(['-j', badConf], home, root);
+      assert.equal(r.status, 1, `boot ${expected} must still fail on the broken config`);
+      const doc = JSON.parse(fss.readFileSync(attemptsFilePath(dataHome), 'utf8'));
+      assert.equal(doc.version, packageJson.version);
+      assert.equal(doc.attempts, expected);
+      assert.equal(
+        await fs.readlink(path.join(root, 'current')),
+        path.join(root, `mStream-${packageJson.version}-${hostKey()}`),
+        'current must not move before the attempt budget is spent'
+      );
+    }
+
+    // Boot 3: rollback + handoff. The stub exits 0 and the wrapper mirrors
+    // it; the same argv rides through to the previous binary.
+    const r3 = runWrapper(['-j', badConf], home, root);
+    assert.equal(r3.status, 0, `handoff run failed: ${r3.stderr}`);
+    assert.match(r3.stdout, /PREV-SERVER-TOOK-OVER args=-j /);
+    assert.match(r3.stderr, /\[boot-watchdog\] .* rolling back to 0\.0\.1/);
+    assert.equal(await fs.readlink(path.join(root, 'current')), prevDir);
+    const hold = JSON.parse(await fs.readFile(path.join(dataHome, 'update-hold.json'), 'utf8'));
+    assert.deepEqual(hold.held.map((h) => h.version), [packageJson.version]);
+
+    // Boot 4: current is no longer committed to this version — the guard
+    // stands down (no count, no re-roll) and the crash surfaces as-is.
+    const before = fss.readFileSync(attemptsFilePath(dataHome), 'utf8');
+    const r4 = runWrapper(['-j', badConf], home, root);
+    assert.equal(r4.status, 1);
+    assert.equal(fss.readFileSync(attemptsFilePath(dataHome), 'utf8'), before,
+      'a layout committed elsewhere must not be counted against');
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test('-V and -h never touch the attempt counter (the installers\' exec probe stays pure)', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-bwd-probe-'));
+  try {
+    const { root } = await makeLayout(home);
+    const v = runWrapper(['-V'], home, root);
+    assert.equal(v.status, 0);
+    assert.equal(v.stdout.trim(), packageJson.version);
+    const h = runWrapper(['-h'], home, root);
+    assert.equal(h.status, 0);
+    await assert.rejects(fs.access(attemptsFilePath(dataHomeOf(home))),
+      'probe invocations must leave no attempt record');
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test('a successful listen acknowledges the boot and clears the counter', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-bwd-ok-'));
+  try {
+    const { root } = await makeLayout(home);
+    const dataHome = dataHomeOf(home);
+    // As if one crashed boot already happened.
+    await fs.mkdir(dataHome, { recursive: true });
+    await fs.writeFile(attemptsFilePath(dataHome), JSON.stringify({
+      schema: 1, version: packageJson.version, attempts: 1, firstAt: new Date().toISOString(),
+    }));
+    const srv = await startServer({
+      waitForScan: false,
+      env: {
+        HOME: home,
+        XDG_DATA_HOME: path.join(home, '.local', 'share'),
+        MSTREAM_UPDATE_ROOT: root,
+      },
+    });
+    try {
+      // markBootOk fires in onListening; the helper resolving means the API
+      // answered, which is later still. Poll briefly for the unlink.
+      const start = Date.now();
+      let gone = false;
+      while (Date.now() - start < 10_000) {
+        if (!fss.existsSync(attemptsFilePath(dataHome))) { gone = true; break; }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      assert.equal(gone, true, 'the attempt counter must clear once the server listens');
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -351,6 +351,77 @@ test('enforceHold re-points a current link left on a held version', { skip: posi
   }
 });
 
+// Supervision signals the RUNNER environment may carry (GitHub's runners
+// live under systemd) must not leak into the spawned server: exported-but-
+// empty reads as unset on the detection side.
+function scrubSupervision(env) {
+  return { ...env, MSTREAM_SUPERVISED: '', pm_id: '', INVOCATION_ID: '' };
+}
+
+test('auto mode without a supervisor stages but never self-exits', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-nosup-'));
+  try {
+    await publish('9.9.30');
+    const srv = await startServer({
+      waitForScan: true,   // the idle gate must be about supervision, not the boot scan
+      env: scrubSupervision(envFor(home)),
+      extraConfig: { updates: { mode: 'auto', check: true } },
+    });
+    try {
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      // headlessSupervisor lands 'none' only after maybeAutoApply passed
+      // every earlier gate (staged, idle) and declined at supervision — so
+      // this both proves the decline AND that the decline was the only
+      // thing between the server and an exit.
+      const s = await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.30'
+        && x.headlessSupervisor === 'none');
+      assert.equal(s.mode, 'auto');
+      // The old behavior exited 0 about 1.5s after arming. Give it triple
+      // that, then require the server alive and still answering.
+      await sleep(5000);
+      assert.equal(srv.proc.exitCode, null, 'an unsupervised auto server must not self-exit');
+      const alive = await fetch(`${srv.baseUrl}/api/v1/admin/update`);
+      assert.equal(alive.status, 200);
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test('auto mode with MSTREAM_SUPERVISED=1 applies by exiting 0', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-sup-'));
+  try {
+    await publish('9.9.31');
+    const srv = await startServer({
+      waitForScan: true,
+      env: { ...scrubSupervision(envFor(home)), MSTREAM_SUPERVISED: '1' },
+      extraConfig: { updates: { mode: 'auto', check: true } },
+    });
+    try {
+      const exited = new Promise((resolve) => srv.proc.once('exit', resolve));
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.31')
+        .catch(() => { /* the exit can outrun the poll - the assert below decides */ });
+      const code = await Promise.race([
+        exited,
+        sleep(60_000).then(() => { throw new Error('supervised auto server never exited'); }),
+      ]);
+      assert.equal(code, 0, 'the headless apply is a clean exit for the supervisor to restart');
+      assert.equal(
+        path.basename(await fs.readlink(path.join(home, 'app', 'current'))),
+        `mStream-9.9.31-${hostKey()}`,
+        'the exit happened with the update staged behind current'
+      );
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test('non-managed installs refuse staging; apply refuses with nothing staged', { skip: posixOnly }, async () => {
   await publish('9.9.9');
   const env = updEnv();

--- a/test/unit/boot-watchdog.test.mjs
+++ b/test/unit/boot-watchdog.test.mjs
@@ -21,8 +21,6 @@ import {
 } from '../../src/util/boot-watchdog.js';
 import { readHoldEntries, appendHold, HOLD_FILE } from '../../src/util/update-shared.js';
 
-const posixOnly = process.platform === 'win32';
-
 function tmpdir(tag) {
   // realpath'd: the geometry walk canonicalizes the executable path (macOS
   // /var -> /private/var), and the assertions compare against these.
@@ -152,17 +150,18 @@ test('plan skips held versions - two bad releases in a row land on the last good
 
 // ── executeRollback ──────────────────────────────────────────────────────────
 
-// win32: node's junction targets read back with the \\?\ prefix, so the
-// strict readlink equality below belongs to the posix legs (the windows
-// junction mechanics are covered by the launcher's rust tests in CI).
-test('execute appends the hold and re-points current', { skip: posixOnly }, async () => {
+// Compared through realpath, not raw readlink: node's junction targets read
+// back with the \\?\ prefix on Windows, and canonicalizing both sides keeps
+// this exercising the REAL junction re-point on the windows CI shard — the
+// one platform-specific limb of the headless watchdog.
+test('execute appends the hold and re-points current', async () => {
   const root = tmpdir('exec');
   const key = hostKey();
   const bad = mkBundle(root, '6.22.0', key);
   const prev = mkBundle(root, '6.21.0', key);
   linkCurrent(root, bad);
   await executeRollback({ root, failedVersion: '6.22.0', targetBundle: prev, dataHome: root });
-  assert.equal(await fsp.readlink(path.join(root, 'current')), prev);
+  assert.equal(await fsp.realpath(path.join(root, 'current')), await fsp.realpath(prev));
   const held = readHoldEntries(root);
   assert.equal(held.length, 1);
   assert.equal(held[0].version, '6.22.0');

--- a/test/unit/boot-watchdog.test.mjs
+++ b/test/unit/boot-watchdog.test.mjs
@@ -1,0 +1,198 @@
+// The headless boot watchdog's decision pieces (src/util/boot-watchdog.js),
+// exercised against real scratch layouts — the same matrix the launcher's
+// rollback.rs pins in Rust, so the two watchdogs cannot drift apart
+// unnoticed. The full three-boots-then-rollback flow is covered end to end
+// in test/integration/boot-watchdog.test.mjs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  attemptsFilePath,
+  bumpAttempts,
+  clearAttempts,
+  markBootOk,
+  findManagedContext,
+  planRollback,
+  executeRollback,
+  serverRel,
+} from '../../src/util/boot-watchdog.js';
+import { readHoldEntries, appendHold, HOLD_FILE } from '../../src/util/update-shared.js';
+
+const posixOnly = process.platform === 'win32';
+
+function tmpdir(tag) {
+  // realpath'd: the geometry walk canonicalizes the executable path (macOS
+  // /var -> /private/var), and the assertions compare against these.
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `mstream-bwd-${tag}-`)));
+}
+
+function hostKey() {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  if (process.platform === 'darwin') { return `darwin-${arch}`; }
+  if (process.platform === 'win32') { return 'win-x64'; }
+  return `linux-${arch}`;
+}
+
+function mkBundle(root, version, key, { withServer = true } = {}) {
+  const bundle = path.join(root, `mStream-${version}-${key}`);
+  const server = path.join(bundle, serverRel());
+  fs.mkdirSync(path.dirname(server), { recursive: true });
+  if (withServer) { fs.writeFileSync(server, 'stub'); }
+  return bundle;
+}
+
+function linkCurrent(root, target) {
+  const link = path.join(root, 'current');
+  try { fs.unlinkSync(link); } catch { /* fresh */ }
+  fs.symlinkSync(target, link, process.platform === 'win32' ? 'junction' : 'dir');
+}
+
+// ── attempts lifecycle ───────────────────────────────────────────────────────
+
+test('attempts bump per version, reset on version change, clear on boot-ok', () => {
+  const dh = tmpdir('attempts');
+  assert.equal(bumpAttempts('6.22.0', dh), 1);
+  assert.equal(bumpAttempts('6.22.0', dh), 2);
+  assert.equal(bumpAttempts('6.22.0', dh), 3);
+  // A different version starts over — counts never carry across versions.
+  assert.equal(bumpAttempts('6.23.0', dh), 1);
+  clearAttempts(dh);
+  assert.equal(fs.existsSync(attemptsFilePath(dh)), false);
+  assert.equal(bumpAttempts('6.23.0', dh), 1, 'cleared means starting over');
+  // A mangled file reads as no attempts, never as a crash.
+  fs.writeFileSync(attemptsFilePath(dh), 'not json');
+  assert.equal(bumpAttempts('6.23.0', dh), 1);
+  fs.rmSync(dh, { recursive: true, force: true });
+});
+
+// ── findManagedContext ───────────────────────────────────────────────────────
+
+test('MSTREAM_UPDATE_ROOT forces the managed context, standalone or not', () => {
+  const root = tmpdir('ctx-env');
+  const bundle = mkBundle(root, '6.22.0', hostKey());
+  linkCurrent(root, bundle);
+  const ctx = findManagedContext({
+    execPath: '/anything/node',
+    env: { MSTREAM_UPDATE_ROOT: root },
+    standalone: false,
+  });
+  assert.equal(ctx.root, root);
+  assert.equal(ctx.currentVersion, '6.22.0');
+  assert.equal(ctx.key, hostKey());
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('geometry: a standalone binary inside a versioned dir beside current', () => {
+  const root = tmpdir('ctx-geo');
+  const bundle = mkBundle(root, '6.22.0', hostKey());
+  linkCurrent(root, bundle);
+  const ctx = findManagedContext({
+    execPath: path.join(bundle, serverRel()),
+    env: {},
+    standalone: true,
+  });
+  assert.equal(ctx.root, root);
+  assert.equal(ctx.currentVersion, '6.22.0');
+  // Same layout, but a source run (not standalone): never managed.
+  assert.equal(findManagedContext({
+    execPath: path.join(bundle, serverRel()), env: {}, standalone: false,
+  }), null);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('no current link, or a current that is not a bundle, is not managed', () => {
+  const root = tmpdir('ctx-none');
+  assert.equal(findManagedContext({ execPath: '/x', env: { MSTREAM_UPDATE_ROOT: root }, standalone: true }), null);
+  const oddDir = path.join(root, 'not-a-bundle');
+  fs.mkdirSync(oddDir);
+  linkCurrent(root, oddDir);
+  assert.equal(findManagedContext({ execPath: '/x', env: { MSTREAM_UPDATE_ROOT: root }, standalone: true }), null);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// ── planRollback ─────────────────────────────────────────────────────────────
+
+test('plan picks the newest lower same-key version whose server probes', () => {
+  const root = tmpdir('plan');
+  const key = hostKey();
+  mkBundle(root, '6.22.0', key);                       // the failing one
+  mkBundle(root, '6.20.0', key);
+  const want = mkBundle(root, '6.21.0', key);
+  mkBundle(root, '6.21.5', 'linux-arm64-musl');        // other family: never
+  mkBundle(root, '6.21.9', key, { withServer: false }); // no server binary
+  const plan = planRollback({
+    root, key, failedVersion: '6.22.0', dataHome: root, probe: () => true,
+  });
+  assert.equal(plan.targetVersion, '6.21.0');
+  assert.equal(plan.targetBundle, want);
+  // The probe is the last gate: a candidate that cannot exec is skipped
+  // (and with every candidate refused, there is no plan).
+  assert.equal(planRollback({
+    root, key, failedVersion: '6.22.0', dataHome: root, probe: () => false,
+  }), null);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('plan skips held versions - two bad releases in a row land on the last good one', async () => {
+  const root = tmpdir('plan-held');
+  const key = hostKey();
+  mkBundle(root, '6.23.0', key);
+  mkBundle(root, '6.22.0', key);                       // known-bad: held below
+  const want = mkBundle(root, '6.21.0', key);
+  await appendHold(root, '6.22.0', 'test');
+  const plan = planRollback({
+    root, key, failedVersion: '6.23.0', dataHome: root, probe: () => true,
+  });
+  assert.equal(plan.targetBundle, want);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// ── executeRollback ──────────────────────────────────────────────────────────
+
+// win32: node's junction targets read back with the \\?\ prefix, so the
+// strict readlink equality below belongs to the posix legs (the windows
+// junction mechanics are covered by the launcher's rust tests in CI).
+test('execute appends the hold and re-points current', { skip: posixOnly }, async () => {
+  const root = tmpdir('exec');
+  const key = hostKey();
+  const bad = mkBundle(root, '6.22.0', key);
+  const prev = mkBundle(root, '6.21.0', key);
+  linkCurrent(root, bad);
+  await executeRollback({ root, failedVersion: '6.22.0', targetBundle: prev, dataHome: root });
+  assert.equal(await fsp.readlink(path.join(root, 'current')), prev);
+  const held = readHoldEntries(root);
+  assert.equal(held.length, 1);
+  assert.equal(held[0].version, '6.22.0');
+  // Idempotent on a re-fire (a half-finished rollback retried).
+  await executeRollback({ root, failedVersion: '6.22.0', targetBundle: prev, dataHome: root });
+  assert.equal(readHoldEntries(root).length, 1, 'no duplicate hold entries');
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// ── the shared hold helpers (contract also consumed by update-check.js) ─────
+
+test('hold file: append dedupes and caps, read tolerates garbage', async () => {
+  const dh = tmpdir('holds');
+  await appendHold(dh, '6.22.0', 't');
+  await appendHold(dh, '6.22.0', 't');
+  assert.deepEqual(readHoldEntries(dh).map((h) => h.version), ['6.22.0']);
+  for (let i = 0; i < 12; i++) { await appendHold(dh, `7.0.${i}`, 't'); }
+  const held = readHoldEntries(dh).map((h) => h.version);
+  assert.equal(held.length, 8, 'capped');
+  assert.ok(held.includes('7.0.11'), 'newest kept');
+  assert.ok(!held.includes('6.22.0'), 'oldest dropped');
+  fs.writeFileSync(path.join(dh, HOLD_FILE), 'not json');
+  assert.deepEqual(readHoldEntries(dh), []);
+  fs.rmSync(dh, { recursive: true, force: true });
+});
+
+test('clearAttempts is a safe no-op when nothing was ever counted', () => {
+  const dh = tmpdir('noop');
+  clearAttempts(dh);           // absent file: no throw
+  clearAttempts(dh);           // twice: still nothing
+  assert.equal(typeof markBootOk, 'function'); // the onListening hook exists
+  fs.rmSync(dh, { recursive: true, force: true });
+});

--- a/test/unit/update-check.test.mjs
+++ b/test/unit/update-check.test.mjs
@@ -5,6 +5,7 @@ import {
   validateManifest,
   parseBundleName,
   detectInstallMethod,
+  detectSupervisor,
 } from '../../src/util/update-check.js';
 
 // ── compareVersions ──────────────────────────────────────────────────────────
@@ -256,4 +257,72 @@ test('a hand-extracted bundle with no current anywhere is portable', () => {
     fsx: fakeFs([]),
   });
   assert.equal(r.method, 'portable');
+});
+
+// ── detectSupervisor ─────────────────────────────────────────────────────────
+// The auto-mode headless gate: exit(0) counts as an APPLY only when
+// something restarts us afterwards. Only signals implying restart-on-clean-
+// exit may pass — a false positive here is a silent outage.
+
+function sup(env, extra = {}) {
+  return detectSupervisor({
+    env,
+    platform: extra.platform ?? 'linux',
+    readCgroup: extra.readCgroup ?? (() => { throw new Error('no cgroup'); }),
+    queryRestart: extra.queryRestart ?? (() => null),
+  });
+}
+
+test('nothing detectable = unsupervised; empty env vars read as unset', () => {
+  assert.deepEqual(sup({}), { supervised: false, via: null });
+  assert.deepEqual(sup({ MSTREAM_SUPERVISED: '' }), { supervised: false, via: null });
+  assert.deepEqual(sup({ MSTREAM_SUPERVISED: '0' }), { supervised: false, via: null });
+  assert.deepEqual(sup({ pm_id: '' }), { supervised: false, via: null });
+  assert.deepEqual(sup({ INVOCATION_ID: '' }), { supervised: false, via: null });
+});
+
+test('MSTREAM_SUPERVISED is the operator override; pm2 numbers from 0', () => {
+  assert.deepEqual(sup({ MSTREAM_SUPERVISED: '1' }), { supervised: true, via: 'env' });
+  assert.deepEqual(sup({ MSTREAM_SUPERVISED: 'yes' }), { supervised: true, via: 'env' });
+  assert.deepEqual(sup({ pm_id: '0' }), { supervised: true, via: 'pm2' });
+  assert.deepEqual(sup({ pm_id: '7' }), { supervised: true, via: 'pm2' });
+});
+
+test('systemd counts only with a restart-on-clean-exit policy', () => {
+  const env = { INVOCATION_ID: 'abc123' };
+  const system = () => '0::/system.slice/mstream.service\n';
+  const calls = [];
+  const q = (policy) => (unit, userScope) => { calls.push([unit, userScope]); return policy; };
+  assert.deepEqual(sup(env, { readCgroup: system, queryRestart: q('always') }),
+    { supervised: true, via: 'systemd' });
+  assert.deepEqual(calls.at(-1), ['mstream.service', false]);
+  assert.deepEqual(sup(env, { readCgroup: system, queryRestart: q('on-success') }),
+    { supervised: true, via: 'systemd' });
+  // Restart=no is systemd's DEFAULT, and on-failure ignores exit 0 — both
+  // leave the unit dead after a clean exit, so neither may count.
+  assert.equal(sup(env, { readCgroup: system, queryRestart: q('no') }).supervised, false);
+  assert.equal(sup(env, { readCgroup: system, queryRestart: q('on-failure') }).supervised, false);
+  // Query failure (no systemctl, no permission) is conservative: undetected.
+  assert.equal(sup(env, { readCgroup: system, queryRestart: () => null }).supervised, false);
+});
+
+test('systemd unit parsing: user units, Delegate= sub-cgroups, scopes, garbage', () => {
+  const env = { INVOCATION_ID: 'abc123' };
+  const calls = [];
+  const q = (unit, userScope) => { calls.push([unit, userScope]); return 'always'; };
+  // A user service: queried with --user, and user@N.service is NOT the unit.
+  const user = () => '0::/user.slice/user-1000.slice/user@1000.service/app.slice/mstream.service\n';
+  assert.equal(sup(env, { readCgroup: user, queryRestart: q }).supervised, true);
+  assert.deepEqual(calls.at(-1), ['mstream.service', true]);
+  // A Delegate= sub-cgroup below the unit still resolves to the unit.
+  const delegated = () => '0::/system.slice/mstream.service/payload\n';
+  assert.equal(sup(env, { readCgroup: delegated, queryRestart: q }).supervised, true);
+  assert.deepEqual(calls.at(-1), ['mstream.service', false]);
+  // A scope (systemd-run --scope) has no restart policy: never supervised.
+  const scope = () => '0::/user.slice/user-1000.slice/user@1000.service/run-u123.scope\n';
+  assert.equal(sup(env, { readCgroup: scope, queryRestart: q }).supervised, false);
+  // Unreadable cgroup: conservative.
+  assert.equal(sup(env, { readCgroup: () => { throw new Error('nope'); }, queryRestart: q }).supervised, false);
+  // INVOCATION_ID outside linux says nothing.
+  assert.equal(sup(env, { platform: 'darwin', readCgroup: () => '0::/x.service', queryRestart: q }).supervised, false);
 });

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -3488,7 +3488,15 @@ const infoView = Vue.component('info-view', {
       if (s.held) { return 'held back - it failed to start after a previous update and was rolled back; a newer release clears this automatically'; }
       if (s.downloading) { return 'downloading...'; }
       const stagedIsLatest = s.staged && s.stagedVersion === s.latest;
-      if (stagedIsLatest && s.method === 'managed') { return 'downloaded and staged; it takes over on the next restart'; }
+      if (stagedIsLatest && s.method === 'managed') {
+        // auto on a headless install with no restart-on-exit supervisor:
+        // the server deliberately does not self-exit (that would be an
+        // outage, not an apply) - the truth is "next restart", plus why.
+        if (s.mode === 'auto' && s.headlessSupervisor === 'none') {
+          return 'downloaded and staged; auto found no supervisor to restart under, so it takes over on the next restart';
+        }
+        return 'downloaded and staged; it takes over on the next restart';
+      }
       if (stagedIsLatest && s.method === 'inno') { return 'installer downloaded and verified'; }
       if (stagedIsLatest && s.method === 'pkg') { return 'installer downloaded; the running app keeps playing until you restart it after installing'; }
       if (s.method === 'managed' || s.method === 'inno') { return 'not downloaded yet'; }


### PR DESCRIPTION
**Stacked on #897** (base = its branch; GitHub retargets to master when it merges). R2 of the auto-update audit — the second of the blockers before flipping `updates.mode` to `auto` by default.

## Why

Two headless gaps the audit flagged:

- **auto's apply is exit-0** — "the supervisor restarts mStream." True under pm2 or a `Restart=always` unit; an outage everywhere else, including the `mstream-server`-in-tmux shape install.sh itself suggests. As a default, that's a server that silently vanishes mid-day, minutes after a release ships.
- **The launcher's boot watchdog (#897) doesn't exist headless.** A staged update that crashes at boot leaves a supervisor (or a human) restarting a binary that can never finish booting — and no running server means no checker, so the fixed release never arrives.

## What

**Supervision-gated auto apply** (`update-check.js`): the headless exit-0 fires only when a restart-on-clean-exit supervisor is detectable — `MSTREAM_SUPERVISED` (operator's word, for docker `--restart`/runit/wrapper loops), pm2 (`pm_id`), or systemd with `Restart=always`/`on-success` (unit read from `/proc/self/cgroup`, policy from `systemctl show`; a bare `INVOCATION_ID` deliberately does **not** count — systemd defaults to `Restart=no`, where exit 0 *is* the outage). Undetected → auto degrades to stage-and-log, once per staged version, with `headlessSupervisor: 'none'` in the status and a matching admin-card line. An explicit admin "apply" click still exits (the human asked and is watching), with a loud warning when unsupervised.

**Headless boot watchdog** (`src/util/boot-watchdog.js`, wired into `cli-boot-wrapper.js`): before the config/db/module work where boot crashes actually happen, count boot attempts per version in the data home; on the third failed boot of a managed install whose `current` is committed to this very version, append the hold, re-point `current` at the newest lower same-key version that still execs, and hand *this invocation* over to that binary — inherited stdio, forwarded signals, mirrored exit. Spawn-and-mirror instead of exit-and-pray: it works under a `Restart=no` unit, or no supervisor at all. Placement details that matter: `-V`/`-h` fast-exit *before* the guard (the installers' exec probe never touches the counter — pinned by a test), `--supervised` boots skip it entirely (the launcher's watchdog from #897 owns that recovery), and `server.js` clears the counter the moment a listen succeeds. `MSTREAM_BOOT_WATCHDOG=0` disables.

**Shared contract module** (`src/util/update-shared.js`): `compareVersions`/`parseBundleName` and the `update-hold.json` read/append move here so the pre-boot guard stays dependency-light; `update-check.js` re-exports them (no API change — the unit tests' imports are untouched). `rust-launcher/src/rollback.rs` remains the Rust mirror.

## Testing

- **13 new unit tests**: the watchdog decision matrix (newest-lower-same-key, held versions skipped, probe refusal, `MSTREAM_UPDATE_ROOT` hook, attempts lifecycle) and the `detectSupervisor` table (empty-env scrubbing, pm2 `pm_id=0`, systemd policies incl. `on-failure` rejected, user units, `Delegate=` sub-cgroups, scopes, unreadable cgroup).
- **5 new integration tests**: the three-crashes-then-rollback-and-handoff e2e (real wrapper child processes, a malformed config as the crash — plus the stand-down once `current` moves off the failed version), probe purity, listen-clears-counter, auto-unsupervised-never-self-exits (proven via the `headlessSupervisor: 'none'` gate, with runner supervision signals scrubbed — GitHub runners live under systemd), and auto-with-`MSTREAM_SUPERVISED=1`-exits-0-with-the-update-behind-`current`.
- Full suites green: **576 unit / 693 integration**.

## Out of scope

R3 (deeper pre-flip probe) and R4 (apply-leg CI smoke) from the audit; the one-line comment in `rollback.rs` about hold-file writers (left untouched here so the Windows validation pass on #897 owns that file exclusively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)