### PR TITLE
Deep pre-flip probe: refuse releases that exec but cannot boot

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -218,6 +218,28 @@ jobs:
           try { & .\install.ps1 *>&1 | Out-Null; throw "installed a bundle that cannot exec" } catch { if ("$_" -notmatch 'does not run on this system') { throw } }
           $j2 = Get-Item "$env:RUNNER_TEMP\app\current" -Force
           if (($j2.Target | Select-Object -First 1) -notmatch 'mStream-9\.9\.9-win-x64$') { throw "current moved off 9.9.9: $($j2.Target)" }
+          # the DEEP probe: a bundle that EXECS (-V answers, so the shallow
+          # probe passes) but reports it would not BOOT must be refused on
+          # the "boot-probe:" sentinel with current untouched. Needs a real
+          # exe — rustc is preinstalled on the runner; stderr to a file, not
+          # 2>&1 (under EAP=Stop native stderr becomes a terminating error).
+          $pb = 'mStream-9.9.11-win-x64'
+          Set-Content stub.rs 'fn main(){let a=std::env::args().nth(1);if a.as_deref()==Some("-V"){println!("9.9.11");return;}if a.as_deref()==Some("--boot-probe"){println!("boot-probe: FAIL simulated boot regression");std::process::exit(1);}}'
+          rustc -O --crate-name probestub stub.rs -o probe-stub.exe 2>rustc.err
+          if ($LASTEXITCODE -ne 0) { Get-Content rustc.err; throw "rustc stub build failed" }
+          Push-Location rel
+          New-Item -ItemType Directory -Force $pb | Out-Null
+          Copy-Item ..\probe-stub.exe "$pb\mstream-server.exe"
+          Set-Content "$pb\README.txt" 'probe'
+          python3 -m zipfile -c "$pb.zip" $pb
+          Remove-Item -Recurse -Force $pb
+          Pop-Location
+          Remove-Item rel\mStream-*.zip -Exclude "$pb.zip" -Force
+          Remove-Item rel\manifest.json -Force
+          bash scripts/release-manifest.sh 9.9.11 rel
+          try { & .\install.ps1 *>&1 | Out-Null; throw "installed a bundle that cannot boot" } catch { if ("$_" -notmatch 'would not BOOT') { throw } }
+          $j3 = Get-Item "$env:RUNNER_TEMP\app\current" -Force
+          if (($j3.Target | Select-Object -First 1) -notmatch 'mStream-9\.9\.9-win-x64$') { throw "current moved off 9.9.9 after probe refusal: $($j3.Target)" }
           # uninstall
           $env:MSTREAM_UNINSTALL = '1'
           & .\install.ps1 *>&1 | Tee-Object -Variable un

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -246,6 +246,12 @@ jobs:
           if (Test-Path "$env:RUNNER_TEMP\app") { throw "app root survived uninstall" }
           if (($un | Out-String) -notmatch 'left in place') { throw "no data-home note" }
           Write-Host "install.ps1 contract OK"
+          # The runner appends `exit $LASTEXITCODE` to pwsh steps, and the
+          # deep-probe stub's --boot-probe exit 1 is the last NATIVE exit
+          # code set (script invocations and cmdlets never reset it) — so a
+          # fully-passing run would end red. Every check above is a throw;
+          # reaching here IS the pass.
+          exit 0
 
       # The darwin-only paths: ~/Applications copy + sibling ownership marker,
       # login-item re-pointing through the RIGHT launcher, and the

--- a/cli-boot-wrapper.js
+++ b/cli-boot-wrapper.js
@@ -27,7 +27,17 @@ if (await maybeRunWorker()) {
   // --portable is pre-scanned because it changes WHERE the default resolves,
   // which the parser needs for its help text.
   const resolved = resolveDefaultConfig({ portable: process.argv.includes('--portable') });
-  const { json, supervised, quickConnectOffByDefault } = parseArgs(process.argv.slice(2), resolved.path);
+  const { json, supervised, bootProbe, quickConnectOffByDefault } = parseArgs(process.argv.slice(2), resolved.path);
+
+  // The installers' deep pre-flip probe (src/util/boot-probe.js): validate
+  // that THIS build would boot with THIS machine's config and database,
+  // print the sentinel, and exit — before the first-run config generation
+  // below (the probe must never create anything) and before the boot
+  // watchdog (a probe is not a boot attempt, same purity rule as -V).
+  if (bootProbe) {
+    const probe = await import('./src/util/boot-probe.js');
+    await probe.runBootProbe(json); // exits; never returns
+  }
 
   // Headless boot watchdog (src/util/boot-watchdog.js): on a managed
   // install whose committed version keeps crashing during boot, roll
@@ -89,6 +99,7 @@ if (await maybeRunWorker()) {
 function parseArgs(args, defaultJson) {
   let json = defaultJson;
   let supervised = false;
+  let bootProbe = false;
   let quickConnectOffByDefault = false;
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -115,11 +126,20 @@ Options:
   --supervised         exit when the launching process closes stdin (for
                        supervisors that run mStream as a managed child and
                        hold its stdin pipe open)
+  --boot-probe         check that this build would boot with this machine's
+                       config and database, print a "boot-probe:" line, and
+                       exit 0/1 without starting anything (the installers
+                       run this before switching an install to a new
+                       version)
   -h, --help           display help for command`);
       process.exit(0);
     }
     if (arg === '--supervised') {
       supervised = true;
+      continue;
+    }
+    if (arg === '--boot-probe') {
+      bootProbe = true;
       continue;
     }
     if (arg === '--portable') {
@@ -147,5 +167,5 @@ Options:
     console.error(`error: unknown option '${arg}'`);
     process.exit(1);
   }
-  return { json, supervised, quickConnectOffByDefault };
+  return { json, supervised, bootProbe, quickConnectOffByDefault };
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -77,7 +77,13 @@ The check and the downloads honor `MSTREAM_RELEASE_BASE` for mirrors, verify
 every download against the release's `manifest.json` sha256s, and only ever
 stage into layouts the installer owns: package-manager installs (deb/rpm,
 the macOS `.pkg`), Docker, npm, and hand-extracted copies are told about
-updates but never touched.
+updates but never touched. Before switching an install to a freshly
+extracted version, the installers probe it twice: `-V` (does the binary
+run here at all) and `--boot-probe` (would it actually *boot* — the new
+build loads its module graph, runs your existing config through its
+schema, and opens the database read-only, all without writing anything).
+A version that fails either probe never takes over a working install: the
+stage fails loudly and the next release retries.
 
 If an applied update crashes before it ever serves, the desktop launcher's
 **boot watchdog** rolls it back on its own: after a failed retry it

--- a/install.ps1
+++ b/install.ps1
@@ -241,6 +241,42 @@ try {
         }
     }
 
+    # The DEEP probe, for bundles that know it: --boot-probe loads the
+    # module graph, runs the existing config through the new build's schema,
+    # and opens the database read-only - the execs-but-cannot-boot classes
+    # -V is blind to. Exit 0 = would boot; nonzero WITH a "boot-probe:"
+    # sentinel = would not; nonzero with NO sentinel = a bundle that
+    # predates the flag (unknown option), which counts as a pass (-V
+    # vouched; manual rollbacks must keep installing old bundles). The
+    # local EAP=Continue window keeps native stderr as captured output -
+    # under Stop, PS 5.1 turns it into a terminating NativeCommandError.
+    $probeFail = $false
+    $probeLines = @()
+    if ($newServerV) {
+        $eap = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $probeText = (& (Join-Path $final 'mstream-server.exe') --boot-probe 2>&1 | Out-String)
+        $probeCode = $LASTEXITCODE
+        $ErrorActionPreference = $eap
+        if ($probeCode -ne 0 -and $probeText -match 'boot-probe:') {
+            $probeFail = $true
+            $probeLines = @($probeText -split "`r?`n" | Where-Object { $_ -match '^boot-probe:' })
+        }
+    }
+    if ($probeFail) {
+        $curTarget = $null
+        if (Test-Path $current) {
+            $curItem = Get-Item $current -Force
+            if ($curItem.Attributes -band [IO.FileAttributes]::ReparsePoint) { $curTarget = $curItem.Target | Select-Object -First 1 }
+        }
+        if ($curTarget -and (Test-Path $curTarget) -and ((Resolve-Path $curTarget).Path -ne $final)) {
+            throw ("the new mstream-server ($ver) would not BOOT on this system - keeping the existing install " +
+                   "($($probeLines -join '; '); current stays at $curTarget; the new copy is at $final)")
+        }
+        # First install / same-version re-run: nothing working is displaced.
+        Write-Warning "the boot probe flagged a problem this install may hit at first start: $($probeLines -join '; ')"
+    }
+
     # `current` as a junction (no admin needed, unlike a symlink), so a
     # shortcut and the PATH entry keep working across upgrades. A REAL
     # directory named current (older manual layout) is moved aside, not

--- a/install.sh
+++ b/install.sh
@@ -421,6 +421,39 @@ if [ -z "$new_server_v" ] && [ -L "$ROOT/current" ] && [ -e "$ROOT/current" ] \
     exit 1
 fi
 
+# The DEEP probe, for bundles that know it: `--boot-probe` loads the module
+# graph, runs the machine's existing config through the new build's schema,
+# and opens the database read-only - the execs-but-cannot-boot classes `-V`
+# is blind to. Its contract: exit 0 = would boot; nonzero WITH a
+# "boot-probe:" sentinel = would not; nonzero with NO sentinel = a bundle
+# that predates the flag (unknown option), which counts as a pass - `-V`
+# already vouched, and the manual-rollback flow must keep installing old
+# bundles. It never writes anything and bounds its own runtime, and it runs
+# with the operator's environment (MSTREAM_CONFIG and friends pass through),
+# so it judges exactly the boot the flip would commit this machine to.
+probe_fail=""
+probe_out=""
+if [ -n "$new_server_v" ]; then
+    if probe_out=$("$ROOT/$bundle/$server_rel" --boot-probe 2>&1); then
+        probe_fail=""
+    elif printf '%s\n' "$probe_out" | grep -q "^boot-probe:"; then
+        probe_fail=1
+    fi
+fi
+if [ -n "$probe_fail" ]; then
+    if [ -L "$ROOT/current" ] && [ -e "$ROOT/current" ] \
+        && [ "$(readlink "$ROOT/current")" != "$ROOT/$bundle" ]; then
+        echo "the new mstream-server ($version) would not BOOT on this system - keeping the existing install" >&2
+        printf '%s\n' "$probe_out" | grep "^boot-probe:" | sed 's/^/    /' >&2
+        echo "  current stays at $(readlink "$ROOT/current"); the new copy is at $ROOT/$bundle" >&2
+        exit 1
+    fi
+    # First install / same-version re-run: nothing working is displaced -
+    # proceed, but say what the probe saw (same policy as the exec probe).
+    echo "  NOTE: the boot probe flagged a problem this install may hit at first start:" >&2
+    printf '%s\n' "$probe_out" | grep "^boot-probe:" | sed 's/^/    /' >&2
+fi
+
 # `current` -> this version. If a previous manual layout left a REAL
 # directory named current, move it aside rather than nest into it.
 if [ -e "$ROOT/current" ] && [ ! -L "$ROOT/current" ]; then

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:smoke:windows": "node test/smoke/windows-native-daemons.mjs",
     "test:smoke:update-watchdog": "sh test/smoke/update-watchdog-smoke.sh",
     "test:smoke:update-watchdog:win": "powershell -NoProfile -ExecutionPolicy Bypass -File test/smoke/update-watchdog-smoke.ps1",
+    "test:smoke:boot-probe:win51": "powershell -NoProfile -ExecutionPolicy Bypass -File test/smoke/boot-probe-51-smoke.ps1",
     "fetch-p2p-sidecar": "node scripts/fetch-p2p-sidecar.mjs",
     "fetch-mstream-player": "node scripts/fetch-mstream-player.mjs",
     "test:smoke:sidecar-volume": "bash test/smoke/docker/p2p-sidecar-volume-smoke.sh"

--- a/rust-launcher/src/rollback.rs
+++ b/rust-launcher/src/rollback.rs
@@ -153,8 +153,12 @@ fn record_hold(data_home: &Path, version: &str, reason: &str) -> Result<(), Stri
 }
 
 /// `<bin> -V`, bounded: does the rollback target's server still exec here?
-/// Same bar as the installers' probe-before-flip — never hand off into a
-/// binary that cannot even start (the watchdog would just fire again).
+/// Deliberately SHALLOW — the installers' pre-flip probe also runs the deep
+/// `--boot-probe` (module graph, config, db schema), but a rollback target
+/// is judged availability-first: it RAN on this machine before, and after a
+/// crash the choice is between a server with a caveat (say, scans refusing
+/// on a migrated db) and no server at all. Never hand off into a binary
+/// that cannot even start, nothing stricter.
 pub fn probe_server(bin: &Path) -> bool {
     let Ok(mut child) = std::process::Command::new(bin)
         .arg("-V")

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -1264,7 +1264,7 @@ fn load_icon() -> Icon {
         buf.truncate(info.buffer_size());
         let rgba = match info.color_type {
             png::ColorType::Rgba => buf,
-            png::ColorType::Rgb => buf.chunks_exact(3).flat_map(|p| [p[0], p[1], p[2], 255]).collect(),
+            png::ColorType::Rgb => buf.as_chunks::<3>().0.iter().flat_map(|p| [p[0], p[1], p[2], 255]).collect(),
             _ => return None,
         };
         Some((rgba, info.width, info.height))

--- a/src/util/boot-probe.js
+++ b/src/util/boot-probe.js
@@ -1,0 +1,132 @@
+// The deep pre-flip probe (`mstream-server --boot-probe`) — the stage-time
+// half of the bad-release defense. The installers already exec-probe a
+// freshly extracted bundle with `-V` before flipping $ROOT/current; that
+// proves the binary RUNS, not that it can BOOT. The crash classes that get
+// through — a broken module graph, a config this build refuses, a database
+// schema from its future — used to be caught only AFTER the flip, by the
+// R1/R2 watchdogs (launcher / headless), which recover by rolling back.
+// This probe moves the detection BEFORE the flip, where refusal is the
+// cleanest outcome there is: the stage fails loudly, `current` never
+// moves, the daily check retries, and the next release heals — the
+// oldest, best-tested recovery path in the whole feature.
+//
+// Contract with the installers (install.sh / install.ps1):
+//   - exit 0 = this build would boot here; nonzero = it would not.
+//   - EVERY probe run prints a sentinel line starting "boot-probe:". A
+//     bundle that predates this flag fails with an unknown-option error
+//     and NO sentinel — the installers treat that as a pass (`-V` already
+//     vouched), so a new installer can still stage old bundles (the
+//     documented manual-rollback flow).
+//   - No side effects, ever: nothing is created or written (no config
+//     generation, no db open read-write, no attempt counters — the R2
+//     boot watchdog is bypassed the same way `-V` bypasses it), so the
+//     probe is safe to run while the OLD server is live, which is exactly
+//     when managed staging runs it.
+//   - Self-bounded: an async hang trips an internal timeout instead of
+//     stalling the stage until its 30-minute kill.
+//
+// What it deliberately does NOT check: music-folder existence (an
+// environment problem that would fail the OLD version too — refusing the
+// update wouldn't help), and anything network- or port-shaped (the old
+// server is still serving).
+import fs from 'fs';
+import path from 'path';
+
+const PROBE_TIMEOUT_MS = 30_000;
+
+function ok(detail) {
+  console.log(`boot-probe: ok (${detail})`);
+  process.exit(0);
+}
+
+function fail(reason) {
+  console.log(`boot-probe: FAIL ${reason}`);
+  process.exit(1);
+}
+
+// `configPath` is the same path the real boot would use (the wrapper's
+// resolved default ladder, or an explicit -j).
+export async function runBootProbe(configPath) {
+  const timer = setTimeout(() => {
+    fail(`timed out after ${PROBE_TIMEOUT_MS / 1000}s`);
+  }, PROBE_TIMEOUT_MS);
+  if (timer.unref) { timer.unref(); }
+
+  const checked = [];
+
+  // 1. The module graph — the same import the real boot performs before
+  // serveIt(). Catches bundling regressions, missing/broken native deps
+  // (the sqlite driver, onnx, iroh), and top-level module errors: the
+  // single biggest execs-but-cannot-boot class.
+  let config;
+  try {
+    await import('../server.js');
+    config = await import('../state/config.js');
+    checked.push('module graph');
+  } catch (err) {
+    clearTimeout(timer);
+    return fail(`module graph did not load: ${err.message}`);
+  }
+
+  // 2. The config THIS machine already has, through THIS build's schema —
+  // read + parse + validate only, never written, never generated (a fresh
+  // install has no config yet: nothing to check, the real boot generates
+  // its own defaults).
+  let parsed = null;
+  if (fs.existsSync(configPath)) {
+    let raw;
+    try {
+      raw = fs.readFileSync(configPath, 'utf8');
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      clearTimeout(timer);
+      return fail(`config ${configPath} did not parse: ${err.message}`);
+    }
+    try {
+      await config.testValidation(parsed);
+      checked.push('config');
+    } catch (err) {
+      clearTimeout(timer);
+      return fail(`config ${configPath} fails this build's schema: ${err.message}`);
+    }
+  }
+
+  // 3. The database, read-only. Two things worth knowing before a flip:
+  // the sqlite driver actually opens a real db here (native-module proof
+  // beyond a bare import), and the db's schema is not from this build's
+  // FUTURE — user_version above our SCHEMA_VERSION means this build is an
+  // older release being staged over a migrated db (a manual rollback
+  // across a schema bump), where scans would refuse after the flip.
+  // Anything environmental (locked, unreadable) is a note, not a failure:
+  // the probe judges THIS BUILD, not this disk.
+  try {
+    const { DatabaseSync } = await import('../db/sqlite-driver.js');
+    const { SCHEMA_VERSION } = await import('../db/schema.js');
+    const dbDir = (parsed && parsed.storage && parsed.storage.dbDirectory)
+      || config.getDefaults().storage.dbDirectory;
+    const dbPath = path.join(dbDir, 'mstream.db');
+    if (fs.existsSync(dbPath)) {
+      let dbVersion = null;
+      try {
+        const db = new DatabaseSync(dbPath, { readOnly: true });
+        dbVersion = db.prepare('PRAGMA user_version').get().user_version;
+        db.close();
+      } catch (err) {
+        console.log(`boot-probe: note - could not inspect the database read-only (${err.message}) - continuing`);
+      }
+      if (dbVersion !== null) {
+        if (dbVersion > SCHEMA_VERSION) {
+          clearTimeout(timer);
+          return fail(`this build's database schema (v${SCHEMA_VERSION}) predates the existing database (v${dbVersion}) - after a flip, scans would refuse to run`);
+        }
+        checked.push(`db schema v${dbVersion}<=v${SCHEMA_VERSION}`);
+      }
+    }
+  } catch (err) {
+    clearTimeout(timer);
+    return fail(`database driver did not load: ${err.message}`);
+  }
+
+  clearTimeout(timer);
+  ok(checked.join(', ') || 'nothing to check yet');
+}

--- a/test/integration/boot-probe.test.mjs
+++ b/test/integration/boot-probe.test.mjs
@@ -1,0 +1,105 @@
+// The deep pre-flip probe (`--boot-probe`, src/util/boot-probe.js) as the
+// installers run it: a real wrapper child process, judged only by its exit
+// code and its "boot-probe:" sentinel lines. The full staging-refusal path
+// (server -> install.sh -> probe -> refusal) lives in update-check.test.mjs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { attemptsFilePath } from '../../src/util/boot-watchdog.js';
+import { SCHEMA_VERSION } from '../../src/db/schema.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+function dataHomeOf(home) {
+  return process.platform === 'darwin'
+    ? path.join(home, 'Library', 'Application Support', 'mStream')
+    : process.platform === 'win32'
+      ? path.join(home, 'localappdata', 'mStream')
+      : path.join(home, '.local', 'share', 'mstream');
+}
+
+function runProbe(home, extraArgs = []) {
+  return spawnSync(process.execPath, ['cli-boot-wrapper.js', '--boot-probe', ...extraArgs], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      HOME: home,
+      USERPROFILE: home,
+      LOCALAPPDATA: path.join(home, 'localappdata'),
+      XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    },
+  });
+}
+
+async function makeDb(dir, userVersion) {
+  const { DatabaseSync } = await import('../../src/db/sqlite-driver.js');
+  await fs.mkdir(dir, { recursive: true });
+  const db = new DatabaseSync(path.join(dir, 'mstream.db'));
+  db.exec(`PRAGMA user_version = ${userVersion}`);
+  db.close();
+}
+
+test('a probeable machine passes, and the probe creates NOTHING', async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-probe-fresh-'));
+  try {
+    const r = runProbe(home);
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.stdout, /^boot-probe: ok /m);
+    // Purity is the whole contract: the probe runs while the OLD server is
+    // live, and it must never generate a config, open a db read-write, or
+    // count a boot attempt (same rule as -V).
+    assert.deepEqual(await fs.readdir(home), [], 'the probe must create nothing');
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test('a config this build cannot parse or validate fails the probe with the sentinel', async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-probe-cfg-'));
+  try {
+    const bad = path.join(home, 'bad.json');
+    await fs.writeFile(bad, 'not json at all{');
+    let r = runProbe(home, ['-j', bad]);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /^boot-probe: FAIL config .* did not parse/m);
+
+    const badSchema = path.join(home, 'bad-schema.json');
+    await fs.writeFile(badSchema, JSON.stringify({ port: 'nope' }));
+    r = runProbe(home, ['-j', badSchema]);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /^boot-probe: FAIL config .* fails this build's schema/m);
+    assert.equal(await fs.stat(attemptsFilePath(dataHomeOf(home))).catch(() => null), null,
+      'a probe failure is not a boot attempt');
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test('a database from this build\'s future fails the probe; a current one passes', async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-probe-db-'));
+  try {
+    const dbDir = path.join(home, 'db');
+    const conf = path.join(home, 'conf.json');
+    await fs.writeFile(conf, JSON.stringify({ storage: { dbDirectory: dbDir } }));
+
+    await makeDb(dbDir, SCHEMA_VERSION + 50);
+    let r = runProbe(home, ['-j', conf]);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /^boot-probe: FAIL this build's database schema .* predates the existing database/m);
+
+    await makeDb(dbDir, SCHEMA_VERSION);
+    r = runProbe(home, ['-j', conf]);
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.stdout, new RegExp(`db schema v${SCHEMA_VERSION}<=v${SCHEMA_VERSION}`));
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -36,7 +36,7 @@ function hostKey() {
 
 let relDir; let relPort; let relServer; let tmpHome;
 
-function makeBundle(version, key, { broken = false } = {}) {
+function makeBundle(version, key, { broken = false, probeFail = false } = {}) {
   const b = `mStream-${version}-${key}`;
   const dir = path.join(relDir, b);
   const inner = key.startsWith('darwin')
@@ -46,9 +46,14 @@ function makeBundle(version, key, { broken = false } = {}) {
   const server = path.join(inner, 'mstream-server');
   // broken = a binary this host "cannot exec": the probe-before-flip in
   // install.sh must refuse it and the stager must report a failed stage.
+  // probeFail = the subtler bad release: -V answers (the exec probe
+  // passes), but the DEEP probe reports it would not boot - install.sh
+  // must refuse on the sentinel.
   const stub = broken
     ? `printf '#!/bin/sh\\nexit 1\\n' > '${server}'`
-    : `printf '#!/bin/sh\\n[ "$1" = -V ] && echo ${version}\\nexit 0\\n' > '${server}'`;
+    : probeFail
+      ? `printf '#!/bin/sh\\n[ "$1" = -V ] && { echo ${version}; exit 0; }\\n[ "$1" = --boot-probe ] && { echo "boot-probe: FAIL simulated boot regression"; exit 1; }\\nexit 0\\n' > '${server}'`
+      : `printf '#!/bin/sh\\n[ "$1" = -V ] && echo ${version}\\nexit 0\\n' > '${server}'`;
   spawnSync('bash', ['-c', `${stub} && chmod +x '${server}'`]);
   spawnSync('bash', ['-c', `echo 'fake bundle' > '${dir}/README.txt'`]);
   const zip = spawnSync('python3', ['-m', 'zipfile', '-c', `${b}.zip`, b], { cwd: relDir });
@@ -56,11 +61,11 @@ function makeBundle(version, key, { broken = false } = {}) {
   spawnSync('rm', ['-rf', dir]);
 }
 
-async function publish(version, { tamper = false, broken = false } = {}) {
+async function publish(version, { tamper = false, broken = false, probeFail = false } = {}) {
   for (const f of await fs.readdir(relDir)) {
     if (f.endsWith('.zip') || f === 'manifest.json') { await fs.rm(path.join(relDir, f)); }
   }
-  makeBundle(version, hostKey(), { broken });
+  makeBundle(version, hostKey(), { broken, probeFail });
   const gen = spawnSync('sh', [path.join(REPO_ROOT, 'scripts', 'release-manifest.sh'), version, relDir]);
   assert.equal(gen.status, 0, `manifest generation failed: ${gen.stderr}`);
   if (tamper) {
@@ -357,6 +362,39 @@ test('enforceHold re-points a current link left on a held version', { skip: posi
 function scrubSupervision(env) {
   return { ...env, MSTREAM_SUPERVISED: '', pm_id: '', INVOCATION_ID: '' };
 }
+
+test('a release that execs but would not boot is refused BEFORE the flip', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-probe-'));
+  try {
+    await publish('9.9.40');
+    const srv = await startServer({
+      waitForScan: false, env: envFor(home),
+      extraArgs: ['--supervised'], stdin: 'pipe',
+    });
+    try {
+      // A good release stages and flips normally.
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.40');
+      const root = path.join(home, 'app');
+      assert.equal(path.basename(await fs.readlink(path.join(root, 'current'))), `mStream-9.9.40-${hostKey()}`);
+
+      // The subtle bad release: -V answers, the deep probe says "would not
+      // boot". install.sh must refuse on the sentinel and leave `current`
+      // exactly where it was - the stage-time refusal that self-heals when
+      // the next release ships, with no watchdog ever needed.
+      await publish('9.9.41', { probeFail: true });
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      const s = await pollStatus(srv.baseUrl, (x) => (x.error || '').includes('would not BOOT'));
+      assert.match(s.error, /Staging failed/);
+      assert.equal(path.basename(await fs.readlink(path.join(root, 'current'))), `mStream-9.9.40-${hostKey()}`,
+        'a probe-refused release must never reach current');
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
 
 test('auto mode without a supervisor stages but never self-exits', { skip: posixOnly }, async () => {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-nosup-'));

--- a/test/smoke/boot-probe-51-smoke.ps1
+++ b/test/smoke/boot-probe-51-smoke.ps1
@@ -1,0 +1,156 @@
+# Boot-probe smoke under REAL Windows PowerShell 5.1 (manual): validates
+# install.ps1's --boot-probe handling on the `irm | iex` floor that CI
+# cannot cover (its windows legs run pwsh 7).
+#
+#   Case 1 (refusal): an upgrade bundle that EXECS (-V answers) but fails
+#     --boot-probe with the "boot-probe:" sentinel must be refused - a
+#     thrown 'would not BOOT' message carrying the sentinel text, and the
+#     `current` junction left on the working install.
+#   Case 2 (pass): a probe-ok upgrade must proceed with NO stray error
+#     records surfacing from the probe's stderr capture - the local
+#     ErrorActionPreference='Continue' window in install.ps1 is exactly
+#     what is under test here.
+#
+# Why 5.1 specifically: under EAP=Stop, 5.1 turns ANY native stderr line
+# into a terminating NativeCommandError - even through a `2>` file
+# redirect (this harness hit that on release-manifest.sh's stderr SUCCESS
+# line while being built). Without install.ps1's capture window, any
+# stderr line from the probe would kill every 5.1 install.
+#
+# Needs: rustc on PATH (stub servers compiled on the spot), git-bash (for
+# scripts/release-manifest.sh; found via git.exe - bare `bash` from
+# PowerShell resolves to WSL's System32\bash.exe, never use it), and a
+# real python (the Microsoft Store stub is detected and refused).
+# Scratch-scoped: MSTREAM_INSTALL_DIR under %TEMP%, no registry, no real
+# data. Run: npm run test:smoke:boot-probe:win51
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+if ($PSVersionTable.PSEdition -ne 'Desktop') {
+    Write-Warning "running under $($PSVersionTable.PSEdition) $($PSVersionTable.PSVersion) - the point of this smoke is Windows PowerShell 5.1 (Desktop); results are not the floor's"
+}
+"powershell edition/version: $($PSVersionTable.PSEdition) $($PSVersionTable.PSVersion)"
+
+$repo = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+if (-not (Get-Command rustc -ErrorAction SilentlyContinue)) { throw 'rustc not on PATH (install the cargo toolchain)' }
+# A real python: the WindowsApps Store stub answers `python` but cannot run
+# code. Probe it before trusting it with the zip + feed duties.
+& python -c "import zipfile, http.server" 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'python on PATH is missing or is the Microsoft Store stub - install real Python' }
+# git-bash, located via git.exe (layouts: <root>\cmd\git.exe or <root>\bin\git.exe).
+$gitBash = $null
+$git = Get-Command git -ErrorAction SilentlyContinue
+if ($git) {
+    $gitRoot = Split-Path (Split-Path $git.Source -Parent) -Parent
+    foreach ($cand in @((Join-Path $gitRoot 'bin\bash.exe'), (Join-Path (Split-Path $git.Source -Parent) 'bash.exe'))) {
+        if (Test-Path $cand) { $gitBash = $cand; break }
+    }
+}
+if (-not $gitBash) { $gitBash = 'C:\Program Files\Git\bin\bash.exe' }
+if (-not (Test-Path $gitBash)) { throw 'git-bash not found (needed for scripts/release-manifest.sh)' }
+
+$smoke = Join-Path $env:TEMP "mstream-probe51-$PID"
+$rel = Join-Path $smoke 'rel'
+$app = Join-Path $smoke 'app'
+if (Test-Path $smoke) { Remove-Item -Recurse -Force $smoke }
+New-Item -ItemType Directory -Force $rel | Out-Null
+$fail = 0
+
+function Make-Stub([string]$ver, [string]$probeBody) {
+    $b = Join-Path $rel "mStream-$ver-win-x64"
+    New-Item -ItemType Directory -Force $b | Out-Null
+    $src = Join-Path $smoke "stub$($ver -replace '[^0-9]','').rs"
+    $code = 'fn main(){let a=std::env::args().nth(1);if a.as_deref()==Some("-V"){println!("' + $ver + '");return;}if a.as_deref()==Some("--boot-probe"){' + $probeBody + '}}'
+    Set-Content -Path $src -Value $code -Encoding ASCII
+    # --crate-name: rustc derives it from the file name otherwise; stderr to
+    # a file, never 2>&1 (the 5.1 NativeCommandError trap).
+    $errf = "$src.err"
+    & rustc -O --crate-name ('s' + ($ver -replace '[^0-9]','')) $src -o (Join-Path $b 'mstream-server.exe') 2>$errf | Out-Null
+    if ($LASTEXITCODE -ne 0) { Get-Content $errf; throw "rustc failed for $ver" }
+    Set-Content (Join-Path $b 'README.txt') 'stub'
+    Push-Location $rel
+    & python -m zipfile -c "mStream-$ver-win-x64.zip" "mStream-$ver-win-x64" 2>$null
+    Pop-Location
+    if ($LASTEXITCODE -ne 0) { throw "zip failed for $ver" }
+    Remove-Item -Recurse -Force $b
+}
+
+function Publish([string]$ver) {
+    Get-ChildItem $rel -Filter 'manifest.json' -ErrorAction SilentlyContinue | Remove-Item -Force
+    # The generator logs its SUCCESS line to stderr; under EAP=Stop, 5.1
+    # terminates on that record even with a 2> redirect - the same local
+    # EAP=Continue window install.ps1 uses around --boot-probe.
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $null = (& $gitBash (($repo -replace '\\','/') + '/scripts/release-manifest.sh') $ver ($rel -replace '\\','/') 2>&1 | Out-String)
+    $ErrorActionPreference = $eap
+    if (-not (Test-Path (Join-Path $rel 'manifest.json'))) { throw "manifest generation failed for $ver" }
+}
+
+function CurrentTarget {
+    $i = Get-Item (Join-Path $app 'current') -Force -ErrorAction SilentlyContinue
+    if ($i -and ($i.Attributes -band [IO.FileAttributes]::ReparsePoint)) { return ($i.Target | Select-Object -First 1) }
+    return ''
+}
+
+$feed = Start-Process -FilePath python -ArgumentList '-m','http.server','8766','--bind','127.0.0.1','--directory',$rel -PassThru -WindowStyle Hidden
+Start-Sleep -Seconds 2
+
+$saved = @{}
+foreach ($k in 'MSTREAM_RELEASE_BASE','MSTREAM_INSTALL_DIR','MSTREAM_NO_DESKTOP','MSTREAM_NO_PATH') { $saved[$k] = [Environment]::GetEnvironmentVariable($k) }
+$env:MSTREAM_RELEASE_BASE = 'http://127.0.0.1:8766'
+$env:MSTREAM_INSTALL_DIR = $app
+$env:MSTREAM_NO_DESKTOP = '1'
+$env:MSTREAM_NO_PATH = '1'
+try {
+    Push-Location $repo
+
+    Make-Stub '9.9.9' 'println!("boot-probe: ok");std::process::exit(0);'
+    Publish '9.9.9'
+    & .\install.ps1 *>&1 | Out-Null
+    if ((CurrentTarget) -notmatch 'mStream-9\.9\.9-win-x64$') { throw "baseline install failed: current -> $(CurrentTarget)" }
+    Write-Host 'baseline 9.9.9 installed (probe-ok path exercised on first install)'
+
+    # Case 1: refusal - execs but cannot boot
+    Get-ChildItem $rel -Filter 'mStream-*.zip' | Remove-Item -Force
+    Make-Stub '9.9.11' 'println!("boot-probe: FAIL simulated boot regression");std::process::exit(1);'
+    Publish '9.9.11'
+    $threw = $null
+    $Error.Clear()
+    try { & .\install.ps1 *>&1 | Out-Null } catch { $threw = "$_" }
+    if ($threw -and $threw -match 'would not BOOT' -and $threw -match 'boot-probe: FAIL simulated boot regression') {
+        Write-Host 'PASS refusal thrown with would-not-BOOT + sentinel text'
+    } else {
+        Write-Host "FAIL refusal message wrong or absent: [$threw]"; $fail = 1
+    }
+    if ((CurrentTarget) -match 'mStream-9\.9\.9-win-x64$') {
+        Write-Host 'PASS current unchanged after refusal (still 9.9.9)'
+    } else {
+        Write-Host "FAIL current moved: $(CurrentTarget)"; $fail = 1
+    }
+
+    # Case 2: pass path - probe-ok upgrade, no stray 5.1 error records
+    Get-ChildItem $rel -Filter 'mStream-*.zip' | Remove-Item -Force
+    Make-Stub '9.9.12' 'println!("boot-probe: ok");std::process::exit(0);'
+    Publish '9.9.12'
+    $Error.Clear()
+    $out = & .\install.ps1 *>&1 | Out-String
+    if ((CurrentTarget) -match 'mStream-9\.9\.12-win-x64$') {
+        Write-Host 'PASS pass-path upgrade flipped current to 9.9.12'
+    } else {
+        Write-Host "FAIL pass-path: current -> $(CurrentTarget)"; $fail = 1
+    }
+    $strays = @($Error | Where-Object { "$_" -match 'NativeCommandError|boot-probe' })
+    if ($strays.Count -eq 0 -and $out -notmatch 'NativeCommandError') {
+        Write-Host 'PASS no stray error records from the probe capture'
+    } else {
+        Write-Host "FAIL stray error records: $($strays.Count)"; $fail = 1
+    }
+} finally {
+    Pop-Location -ErrorAction SilentlyContinue
+    foreach ($k in $saved.Keys) { [Environment]::SetEnvironmentVariable($k, $saved[$k]) }
+    Stop-Process -Id $feed.Id -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 1
+    Remove-Item -Recurse -Force $smoke -ErrorAction SilentlyContinue
+}
+if ($fail -eq 0) { Write-Host 'BOOT-PROBE 5.1 SMOKE: ALL PASS' } else { Write-Host 'BOOT-PROBE 5.1 SMOKE: FAILURES' }
+exit $fail


### PR DESCRIPTION
R3 of the auto-update audit (after #897's launcher watchdog and #898's headless guards) — the third of the four blockers before flipping `updates.mode` to `auto` by default.

## Why

The installers exec-probe a freshly extracted bundle with `-V` before flipping `$ROOT/current`. That proves the binary *runs*, not that it can *boot* — a broken module graph, a config the new build's schema refuses, or a database from the build's future all slip through and get caught only **after** the flip, by the R1/R2 watchdogs (recover-by-rollback). Stage-time refusal is strictly better where it's possible: `current` never moves, nothing needs recovering, the daily check retries, and the next release heals — the oldest, best-tested path in the feature.

## What

**`mstream-server --boot-probe`** ([boot-probe.js](../blob/claude/preflip-boot-probe-afecf4/src/util/boot-probe.js)), run by both installers right after `-V`:

1. **Module graph** — the same `import('./src/server.js')` the real boot performs: bundling regressions, native deps (sqlite driver, onnx, iroh), top-level module errors.
2. **Config** — the machine's *existing* config through the *new* build's Joi schema, validate-only (never generated, never written; a fresh install has nothing to check).
3. **Database, read-only** — real driver open plus `PRAGMA user_version` vs the build's `SCHEMA_VERSION`: an older build staged over a migrated db (manual rollback across a schema bump) is refused *before* it can leave scans refusing. Environmental problems (locked/unreadable db) are a note, not a failure — the probe judges the build, not the disk.

Zero side effects by contract (no config generation, no attempt counting — same purity rule as `-V`, pinned by test), self-bounded, and safe to run while the old server is live — which is exactly when managed staging runs it.

**Installer contract** (install.sh / install.ps1): exit 0 = pass; nonzero **with** a `boot-probe:` sentinel = refuse when a working install would be displaced (first installs get a diagnostic and proceed, same policy as `-V`); nonzero with **no** sentinel = a bundle that predates the flag → treated as a pass (`-V` vouched), so new installers keep staging old bundles — the documented manual-rollback flow keeps working, and the existing CI installer-contract stubs stay green by construction. install.ps1 captures the probe under a local `ErrorActionPreference='Continue'` window (the PS 5.1 native-stderr trap the Windows validation pass documented).

**Deliberate asymmetry, now documented in rollback.rs:** the watchdogs' rollback-target probe stays shallow (`-V`). A rollback target ran on this machine before, and post-crash the choice is a server-with-a-caveat vs no server — availability-first. Pre-flip, nothing is lost by being strict.

## Testing

- 3 new probe integration tests: pass-and-creates-nothing (purity), config parse/schema refusals with the sentinel, future-schema-db refusal + current-schema pass.
- 1 new staging-refusal test driving the real loop: server → `install.sh` → probe → refusal, `current` untouched — alongside the existing tamper/broken-binary refusal tests.
- Every branch also verified by hand against the **compiled Bun binary** (module graph from `$bunfs`, Bun sqlite adapter's `readOnly` path) — the shape the installers actually probe.
- Full suites green: 576 unit / 700 integration; `sh -n install.sh`; launcher `cargo test` 31/31 (comment-only change there).

## Out of scope

R4 (apply-leg CI smoke) — last audit item before the default flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)