### PR TITLE
Apply-leg CI coverage: real-launcher apply smoke on every launcher PR

### DIFF
--- a/.github/workflows/build-rust-launcher.yml
+++ b/.github/workflows/build-rust-launcher.yml
@@ -55,6 +55,11 @@ on:
       - 'build/mstream-logo-cut.ico'
       - 'build/icon.png'
       - '.github/workflows/build-rust-launcher.yml'
+      # The check job RUNS these against the binary it builds — a smoke
+      # edit must re-run the job that executes it.
+      - 'test/smoke/update-watchdog-smoke.sh'
+      - 'test/smoke/update-watchdog-smoke.ps1'
+      - 'test/smoke/update-apply-smoke.sh'
 
 # One run at a time per ref: two master pushes touching the crate write the
 # SAME four binary paths, and binaries can't be content-merged, so runs must

--- a/.github/workflows/build-rust-launcher.yml
+++ b/.github/workflows/build-rust-launcher.yml
@@ -115,6 +115,52 @@ jobs:
         working-directory: rust-launcher
         run: cargo clippy --release --locked -- -D warnings
 
+      # ── Process-level smokes with the binary this job just built. ────────
+      # The unit tests above pin the DECISIONS (rollback plan matrix, apply
+      # tokens, failure caps); these prove the PROCESSES — real spawn, lock
+      # handoff, takeover relaunch, `current` re-point — per OS. Two flows:
+      #   watchdog: crash-at-boot version rolls back + holds
+      #     (test/smoke/update-watchdog-smoke.{sh,ps1})
+      #   apply: an armed status file applies the staged version, and the
+      #     fresh launcher does NOT re-apply off the stale arm
+      #     (test/smoke/update-apply-smoke.sh; ~2.5min — the launcher's
+      #     60s update poll twice)
+      # Linux needs a display (the desktop face refuses headless) and the
+      # gtk runtime already pulled in by the build deps; the tray itself may
+      # degrade ("tray unavailable") — the smokes assert on processes and
+      # files, never the tray.
+      - name: Install xvfb (linux smokes)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y xvfb
+
+      - name: Update watchdog smoke
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run -a sh test/smoke/update-watchdog-smoke.sh
+          else
+            sh test/smoke/update-watchdog-smoke.sh
+          fi
+
+      - name: Update apply smoke
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run -a sh test/smoke/update-apply-smoke.sh
+          else
+            sh test/smoke/update-apply-smoke.sh
+          fi
+
+      # Windows: the watchdog smoke (rustc-compiled stubs; the runner has
+      # the toolchain). It exercises the junction re-point + DETACHED_PROCESS
+      # takeover — the same takeover machinery the apply path uses.
+      - name: Update watchdog smoke (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File test\smoke\update-watchdog-smoke.ps1
+
   # ── Shipped binaries: build, self-test, commit (master pushes). ───────────
   build:
     name: Build ${{ matrix.binary_name }}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:smoke:windows": "node test/smoke/windows-native-daemons.mjs",
     "test:smoke:update-watchdog": "sh test/smoke/update-watchdog-smoke.sh",
     "test:smoke:update-watchdog:win": "powershell -NoProfile -ExecutionPolicy Bypass -File test/smoke/update-watchdog-smoke.ps1",
+    "test:smoke:update-apply": "sh test/smoke/update-apply-smoke.sh",
     "test:smoke:boot-probe:win51": "powershell -NoProfile -ExecutionPolicy Bypass -File test/smoke/boot-probe-51-smoke.ps1",
     "fetch-p2p-sidecar": "node scripts/fetch-p2p-sidecar.mjs",
     "fetch-mstream-player": "node scripts/fetch-mstream-player.mjs",

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -428,6 +428,48 @@ test('auto mode without a supervisor stages but never self-exits', { skip: posix
   }
 });
 
+test('supervised auto mode arms the launcher through the status file', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-arm-'));
+  try {
+    await publish('9.9.50');
+    const srv = await startServer({
+      waitForScan: true,   // idle must gate on supervision state, not the boot scan
+      env: scrubSupervision(envFor(home)),
+      extraArgs: ['--supervised'], stdin: 'pipe',
+      extraConfig: { updates: { mode: 'auto', check: true } },
+    });
+    try {
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.50');
+      // The launcher contract: the on-disk file carries the arm plus a
+      // FRESH per-request token (the launcher retries a failed apply only
+      // when a new token appears - update-watchdog/apply smokes drive the
+      // consuming side with the real binary).
+      const statusPath = path.join(dataHomeOf(home), 'update-status.json');
+      const start = Date.now();
+      let doc = null;
+      while (Date.now() - start < 15_000) {
+        try {
+          doc = JSON.parse(await fs.readFile(statusPath, 'utf8'));
+          if (doc.applyRequested === true) { break; }
+        } catch { /* not written yet */ }
+        await sleep(150);
+      }
+      assert.equal(doc?.applyRequested, true, `status file never armed: ${JSON.stringify(doc)}`);
+      assert.equal(doc.stagedVersion, '9.9.50');
+      assert.ok(!Number.isNaN(Date.parse(doc.applyRequestedAt)), `token must be a timestamp: ${doc.applyRequestedAt}`);
+      // Supervised = the LAUNCHER restarts us; the server itself must not
+      // exit (that is the headless branch's move, gated separately).
+      await sleep(3000);
+      assert.equal(srv.proc.exitCode, null, 'a supervised server must never self-exit');
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test('auto mode with MSTREAM_SUPERVISED=1 applies by exiting 0', { skip: posixOnly }, async () => {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-sup-'));
   try {

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -12,6 +12,8 @@ real processes. Run them by hand when working on the matching code.
 | Native-Windows daemons (`windows-native-daemons.mjs`) | `npm run test:smoke:windows` | Transmission / qBittorrent installed on Windows, plus env config |
 | Boot-watchdog rollback (`update-watchdog-smoke.sh`) | `npm run test:smoke:update-watchdog` | a built launcher (`cd rust-launcher && cargo build --release`); Linux headless needs `xvfb-run` |
 | Boot-watchdog rollback, Windows (`update-watchdog-smoke.ps1`) | `npm run test:smoke:update-watchdog:win` | a built launcher plus `rustc` on PATH (the stub servers are compiled on the spot) |
+| Update apply cycle (`update-apply-smoke.sh`) | `npm run test:smoke:update-apply` | a built launcher + `python3`; ~2.5 min (two 60s launcher polls); Linux headless needs `xvfb-run` |
+| Boot-probe under PowerShell 5.1 (`boot-probe-51-smoke.ps1`) | `npm run test:smoke:boot-probe:win51` | `rustc` + git-bash + real Python; run under `powershell.exe` (Desktop 5.1) — that floor is the point |
 
 Each script just runs the harness; bringing the daemons up (and tearing them
 down) is the operator's job. The setup, credentials and env knobs are
@@ -27,6 +29,15 @@ documented at:
   root whose `current` version crashes at boot and asserts the launcher's
   rollback (re-pointed `current`, recorded hold, takeover into the previous
   version). Scratch HOME; never touches real data or login items.
+- **Update apply cycle:** the header comment of
+  [update-apply-smoke.sh](update-apply-smoke.sh) — the positive half: an
+  armed `update-status.json` applies the staged version (takeover, `current`
+  honored, status rewritten clean) with no stale-arm relaunch churn.
+- **CI note:** the update watchdog + apply smokes ALSO run automatically on
+  launcher PRs (the `check` matrix in `build-rust-launcher.yml` runs them
+  with the binary it just built) — this table stays the manual entry point
+  for everything else, and for the 5.1 harness, which needs a real
+  Windows PowerShell.
 
 The CLI-audio adapter routing harness is a sibling but self-contained (it runs
 mpv/vlc/mplayer/mpd inside Docker, no external daemons): `npm run test:cli-audio`

--- a/test/smoke/update-apply-smoke.sh
+++ b/test/smoke/update-apply-smoke.sh
@@ -61,7 +61,19 @@ DATA="$FAKEHOME/$DATA_REL"
 # dir (inside ROOT) but not the stub script path.
 mkdir -p "$FAKEHOME" "$ROOT" "$DATA/conf"
 ROOT=$(cd "$ROOT" && pwd -P)
-trap 'pkill -f "$ROOT/" 2>/dev/null; sleep 1; pkill -9 -f "$ROOT/" 2>/dev/null; rm -rf "$SMOKE"' EXIT INT TERM
+# Status-pinning cleanup function, not an inline trap: a pkill that finds
+# nothing returns 1, and dash applies set -e inside EXIT traps — see
+# update-watchdog-smoke.sh for the war story.
+cleanup() {
+    status=$?
+    pkill -f "$ROOT/" 2>/dev/null || true
+    sleep 1
+    pkill -9 -f "$ROOT/" 2>/dev/null || true
+    rm -rf "$SMOKE" 2>/dev/null || true
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' INT TERM
 
 mk_bundle() { # version marker pre-serve-line
     b="$ROOT/mStream-$1-$KEY"

--- a/test/smoke/update-apply-smoke.sh
+++ b/test/smoke/update-apply-smoke.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# Apply-cycle smoke (posix): the POSITIVE half of the launcher's update
+# story, with the real launcher binary — the counterpart of
+# update-watchdog-smoke.sh's crash half. Proves the armed-status-file
+# contract end to end:
+#
+#   1. Fabricates a mid-update managed root: the launcher+server of the
+#      OLD version (0.0.1) about to run, `current` already flipped to the
+#      staged NEW version (9.9.9), and update-status.json armed
+#      (applyRequested + a fresh applyRequestedAt token) — exactly what
+#      the server's auto mode leaves for the launcher.
+#   2. Starts the OLD launcher from its versioned dir. Its server stub
+#      SERVES an mStream-identifying page (the identity probe must pass:
+#      the launcher only ever applies from a live-server phase).
+#   3. Expects, within one poll cycle (~60s): the apply — old server
+#      stopped, takeover into the NEW launcher behind `current`, the NEW
+#      version's server serving. The NEW stub rewrites the status file
+#      clean (current 9.9.9, nothing armed) the way a real supervised
+#      server does at boot — and the settle window then proves the fresh
+#      launcher does NOT re-apply off the old arm (exactly one relaunch
+#      in the log).
+#
+# Needs: a built launcher (cd rust-launcher && cargo build --release, or
+# MSTREAM_LAUNCHER_BIN), python3 (the serving stubs), node or sed (version
+# parse). Linux headless needs xvfb-run. Scratch HOME; ~2.5 minutes,
+# dominated by the launcher's 60s update poll.
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+LAUNCHER="${MSTREAM_LAUNCHER_BIN:-$REPO/rust-launcher/target/release/mstream-launcher}"
+[ -x "$LAUNCHER" ] || {
+    echo "no launcher at $LAUNCHER - build it (cd rust-launcher && cargo build --release) or set MSTREAM_LAUNCHER_BIN" >&2
+    exit 1
+}
+command -v python3 >/dev/null 2>&1 || { echo "python3 required (serving stubs)" >&2; exit 1; }
+PORT=3873
+
+case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64) KEY="darwin-arm64" ;;
+    Darwin-*) KEY="darwin-x64" ;;
+    Linux-aarch64 | Linux-arm64) KEY="linux-arm64" ;;
+    *) KEY="linux-x64" ;;
+esac
+if [ "$(uname -s)" = Darwin ]; then
+    FACE_REL="mStream.app/Contents/MacOS/mStream"
+    SERVER_REL="mStream.app/Contents/MacOS/mstream-server"
+    DATA_REL="Library/Application Support/mStream"
+else
+    FACE_REL="mstream-desktop"
+    SERVER_REL="mstream-server"
+    DATA_REL=".local/share/mstream"
+fi
+
+SMOKE="${TMPDIR:-/tmp}/mstream-apply-smoke-$$"
+FAKEHOME="$SMOKE/home"
+ROOT="$SMOKE/root"
+DATA="$FAKEHOME/$DATA_REL"
+# Everything the launcher writes is canonical (macOS /var -> /private/var);
+# create, then compare in the same form. Cleanup matches the path ANYWHERE
+# in the command line: the stubs exec python3, whose argv keeps the serve
+# dir (inside ROOT) but not the stub script path.
+mkdir -p "$FAKEHOME" "$ROOT" "$DATA/conf"
+ROOT=$(cd "$ROOT" && pwd -P)
+trap 'pkill -f "$ROOT/" 2>/dev/null; sleep 1; pkill -9 -f "$ROOT/" 2>/dev/null; rm -rf "$SMOKE"' EXIT INT TERM
+
+mk_bundle() { # version marker pre-serve-line
+    b="$ROOT/mStream-$1-$KEY"
+    mkdir -p "$b/$(dirname "$SERVER_REL")" "$b/serve"
+    cp "$LAUNCHER" "$b/$FACE_REL"
+    : > "$b/serve/mStream-$2.txt"   # directory listing carries the identity
+    printf '#!/bin/sh\nif [ "${1:-}" = -V ]; then echo %s; exit 0; fi\n%s\nexec python3 -m http.server %s --bind 127.0.0.1 --directory '\''%s/serve'\''\n' \
+        "$1" "$3" "$PORT" "$b" > "$b/$SERVER_REL"
+    chmod +x "$b/$SERVER_REL"
+}
+
+# OLD 0.0.1: just serves. NEW 9.9.9: first rewrites the status file clean —
+# the contract every real supervised server honors at boot (setup() writes
+# its own version and cleared flags) and the reason a stale arm can never
+# relaunch-loop a fresh launcher.
+mk_bundle "0.0.1" "OLD-marker" ":"
+mk_bundle "9.9.9" "NEW-marker" "printf '{\"schema\":1,\"current\":\"9.9.9\",\"staged\":false,\"applyRequested\":false}' > '$DATA/update-status.json'"
+ln -s "$ROOT/mStream-9.9.9-$KEY" "$ROOT/current"
+echo '{"port":'"$PORT"'}' > "$DATA/conf/default.json"
+
+# The armed file the server's auto mode leaves for the launcher.
+printf '{"schema":1,"current":"0.0.1","latest":"9.9.9","available":true,"method":"managed","staged":true,"stagedVersion":"9.9.9","applyRequested":true,"applyRequestedAt":"2026-01-01T00:00:00.000Z"}\n' \
+    > "$DATA/update-status.json"
+
+echo "starting the OLD (0.0.1) launcher; current is staged at 9.9.9; apply is armed..."
+HOME="$FAKEHOME" \
+MSTREAM_LAUNCHER_SKIP_AUTOSTART=1 \
+MSTREAM_LAUNCHER_DIRECT_RELAUNCH=1 \
+"$ROOT/mStream-0.0.1-$KEY/$FACE_REL" --no-open &
+OLD_PID=$!
+
+body() { curl -sf --max-time 3 "http://127.0.0.1:$PORT/" 2>/dev/null || true; }
+
+# Phase 1: old serving (probe must see mStream before any apply may fire).
+i=0; while [ $i -lt 30 ]; do body | grep -q "mStream-OLD-marker" && break; i=$((i + 1)); sleep 1; done
+body | grep -q "mStream-OLD-marker" || { echo "FAIL old version never served"; exit 1; }
+echo "  old version serving; waiting out the launcher's 60s update poll..."
+
+# Phase 2: the apply (one poll cycle + boot slack).
+i=0; while [ $i -lt 90 ]; do body | grep -q "mStream-NEW-marker" && break; i=$((i + 1)); sleep 1; done
+
+echo "== assertions =="
+fail=0
+if body | grep -q "mStream-NEW-marker"; then
+    echo "PASS takeover happened - the staged 9.9.9 is serving"
+else
+    echo "FAIL still serving: $(body | head -c 120)"; fail=1
+fi
+if kill -0 "$OLD_PID" 2>/dev/null; then
+    echo "FAIL the old launcher is still alive"; fail=1
+else
+    echo "PASS the old launcher exited"
+fi
+grep -q '"current":"9.9.9"' "$DATA/update-status.json" && ! grep -q '"applyRequested":true' "$DATA/update-status.json" \
+    && echo "PASS status file rewritten clean by the new version" \
+    || { echo "FAIL status file: $(cat "$DATA/update-status.json")"; fail=1; }
+
+# Phase 3: settle - the NEW launcher's own first poll (60s after ITS start)
+# must find the clean file and do NOTHING. A second relaunch line here is
+# the stale-arm loop the guards exist to prevent.
+echo "  settle window (the new launcher's first poll must be a no-op)..."
+sleep 70
+relaunches=$(grep -c "update: relaunching via" "$DATA/logs/launcher.log" 2>/dev/null || echo 0)
+if [ "$relaunches" = "1" ]; then
+    echo "PASS exactly one relaunch in the log - no stale-arm churn"
+else
+    echo "FAIL relaunch count: $relaunches"; tail -20 "$DATA/logs/launcher.log" 2>/dev/null; fail=1
+fi
+body | grep -q "mStream-NEW-marker" && echo "PASS 9.9.9 still serving after settle" || { echo "FAIL not serving after settle"; fail=1; }
+exit $fail

--- a/test/smoke/update-watchdog-smoke.ps1
+++ b/test/smoke/update-watchdog-smoke.ps1
@@ -120,9 +120,12 @@ try {
         -ArgumentList '--tray', '--no-open' -PassThru
 
     # Two instant crashes + the rollback land within a few seconds; poll 60.
-    $prevDeprefixed = DePrefix $prevBundle
+    # SUFFIX match, not string equality: the launcher writes canonical long
+    # paths into the junction, while $env:TEMP can be the 8.3 short form
+    # (RUNNER~1 on the CI images) — equality failed a fully-correct rollback.
+    $prevSuffix = 'mStream-0\.0\.1-win-x64$'
     for ($i = 0; $i -lt 60; $i++) {
-        if ((CurrentTarget) -eq $prevDeprefixed) { break }
+        if ((CurrentTarget) -match $prevSuffix) { break }
         Start-Sleep -Seconds 1
     }
 
@@ -130,7 +133,7 @@ try {
     Get-Content (Join-Path $data 'logs\launcher.log') -ErrorAction SilentlyContinue
     Write-Host "== assertions =="
     $fail = 0
-    if ((CurrentTarget) -eq $prevDeprefixed) {
+    if ((CurrentTarget) -match $prevSuffix) {
         Write-Host 'PASS current re-pointed at 0.0.1'
     } else {
         Write-Host "FAIL current -> $(CurrentTarget)"; $fail = 1

--- a/test/smoke/update-watchdog-smoke.sh
+++ b/test/smoke/update-watchdog-smoke.sh
@@ -55,8 +55,20 @@ DATA="$FAKEHOME/$DATA_REL"
 # the stub servers are #!/bin/sh scripts, so their argv starts with
 # "/bin/sh " and an anchored pattern would kill the launcher but leak the
 # stub (it ignores stdin, so the supervision EOF cannot reap it either).
-# $ROOT is a unique scratch path — unanchored is still precise.
-trap 'pkill -f "$ROOT/" 2>/dev/null; sleep 1; pkill -9 -f "$ROOT/" 2>/dev/null; rm -rf "$SMOKE"' EXIT INT TERM
+# $ROOT is a unique scratch path — unanchored is still precise. A FUNCTION
+# that pins the exit status: a pkill with nothing left to kill returns 1,
+# and under set -e some shells (dash on the ubuntu runners) apply errexit
+# INSIDE the EXIT trap — an all-PASS run exited 1 out of its own cleanup.
+cleanup() {
+    status=$?
+    pkill -f "$ROOT/" 2>/dev/null || true
+    sleep 1
+    pkill -9 -f "$ROOT/" 2>/dev/null || true
+    rm -rf "$SMOKE" 2>/dev/null || true
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' INT TERM
 mkdir -p "$FAKEHOME" "$ROOT" "$DATA"
 # The watchdog resolves its own exe path, so everything it writes is in
 # CANONICAL form (macOS: /var -> /private/var). Compare in the same form.


### PR DESCRIPTION
R4 of the auto-update audit — the **last** of the four blockers before flipping `updates.mode` to `auto` by default (after #897 launcher watchdog, #898 headless guards, #900 pre-flip probe).

## Why

The apply leg — the launcher consuming an armed `update-status.json` — was the one joint of the feature with no automated process-level coverage. The watchdog smokes proved the *crash* half but ran only by hand; the positive apply cycle (takeover into the staged version, the guards that keep a stale arm from relaunch-looping a fresh launcher) had never run outside ad-hoc sessions.

## What

**`test/smoke/update-apply-smoke.sh`** (`npm run test:smoke:update-apply`): the real launcher binary on a fabricated mid-update layout — old version running and *serving* (the identity probe must pass; applies only fire from a live-server phase), `current` staged at the new version, `applyRequested` armed with a token. Asserts the full cycle inside one 60s poll: takeover, the staged version serving, the old launcher exited, and the status file rewritten clean by the "new server" (the supervised boot contract). Then a second poll-length **settle window** proves exactly one relaunch in the log — the fresh launcher's first poll must be a no-op on the cleaned file, pinning the stale-arm loop guards as processes, not just unit tests.

**CI wiring** — the `check` matrix in build-rust-launcher.yml now runs, with the binary it just built: the watchdog smoke on all three OSes (xvfb on linux; the rustc-stub `.ps1` on windows — junction re-point + `DETACHED_PROCESS` takeover) and the apply smoke on linux+macos. The unit tests pin the decisions; these pin the processes, on every launcher PR. (~3 min added to a path-filtered job.)

**Arming contract integration test**: supervised auto mode writes `applyRequested: true` plus a fresh, parseable `applyRequestedAt` token to the on-disk status file, and the server itself never exits — the write side of the exact contract the smokes consume with the real binary.

Plus the smoke README rows (including the contributed 5.1 boot-probe harness from #900) and the npm script.

## Testing

- Apply smoke: 5/5 PASS locally on macOS (~2.5 min, exit 0).
- New arming test green; full update-check integration file 8/8.
- `sh -n` clean; no production code changed — this PR is tests, smokes, and CI wiring only.
- The CI wiring proves itself on this very PR: the check matrix runs the smokes on all three OSes here.

## Audit status after this merges

R1–R4 complete. Remaining before the default flip are non-code items: R5 (the flip itself: Joi default + docs + admin copy + pkg caveat) and R6 (release-ops runbook — notably that yanking a release does not stop already-staged installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)