### PR TITLE
Apply updates automatically by default

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -51,27 +51,37 @@ manages its own folder.
 ## Automatic updates
 
 mStream checks the release feed once a day (plus once shortly after boot)
-and, by default, **downloads new versions in the background and applies them
-on the next restart**: installs made by the one-liner stage the new version
-beside the running one and flip `current`, so any restart — the tray menu,
-a reboot, a service restart — lands on it. Windows `setup.exe` installs
-download the verified installer; applying it is one click. The admin panel's
-About page shows the state and holds the controls:
+and, by default, **updates itself**: new versions download in the
+background, stage beside the running one behind `current`, and apply on
+their own once the server is genuinely idle — nothing streaming, no scan
+running, and a quiet stretch (about ten minutes) since the last request,
+so a restart never lands under someone actively browsing. Under the tray
+app the restart is seamless; a `.pkg` install downloads the verified
+installer and waits for your click (Installer.app needs a human). The
+admin panel's About page shows the state and holds the controls:
 
-- `updates.mode` — `notify` (report only, download nothing), `stage`
-  (the default, described above), or `auto` (additionally restart into the
-  update once the server is idle — no active streams, no scan running).
-  On a headless install, `auto` applies by exiting with code 0 so the
-  process supervisor's restart lands on the new version — but only when a
-  supervisor that restarts on a clean exit is actually detectable: pm2, or
-  systemd with `Restart=always`/`on-success` (the default `Restart=no` and
-  `on-failure` don't restart an exit 0, so they don't count). For
-  supervisors mStream can't see — a docker `--restart` policy, runit, your
-  own wrapper loop — set `MSTREAM_SUPERVISED=1`. With nothing detected,
-  `auto` behaves like `stage` and says so in the log and the admin panel:
-  exiting would be an outage, not an apply.
+- `updates.mode` — `auto` (the default, described above), `stage`
+  (download and stage only; applying takes a restart or a click — the
+  previous default), or `notify` (report only, download nothing). A mode
+  set in the config stays exactly as set — the default only fills the
+  blank. On a headless install, `auto` applies by exiting with code 0 so
+  the process supervisor's restart lands on the new version — but only
+  when a supervisor that restarts on a clean exit is actually detectable:
+  pm2, or systemd with `Restart=always`/`on-success` (the default
+  `Restart=no` and `on-failure` don't restart an exit 0, so they don't
+  count). For supervisors mStream can't see — a docker `--restart` policy,
+  runit, your own wrapper loop — set `MSTREAM_SUPERVISED=1`. With nothing
+  detected, `auto` behaves like `stage` and says so in the log and the
+  admin panel: exiting would be an outage, not an apply.
 - `updates.check` — set `false` and mStream never phones home; the admin
   panel's "check now" button still works on demand.
+
+Auto became the default only once the whole recovery ladder was in place:
+a release is sha256-verified and boot-probed **before** it can take over a
+working install, and one that still crashes at first boot is rolled back
+and held automatically — by the tray app on desktops, by the server binary
+itself headless — until a newer release ships. A bad release followed by a
+fixed one heals end to end with no operator action.
 
 The check and the downloads honor `MSTREAM_RELEASE_BASE` for mirrors, verify
 every download against the release's `manifest.json` sha256s, and only ever

--- a/src/server.js
+++ b/src/server.js
@@ -103,6 +103,10 @@ let configWritesAtRead = 0;
 // = "not fully booted yet", which idle() treats as busy — auto-apply never
 // fires into a half-started server).
 let taskQueueMod = null;
+// When a request last touched this server (the auto-update idle gate's
+// quiet-window clock — see the middleware that maintains it). Module scope
+// on purpose: a soft reboot() must not reset a user's recency to zero.
+let lastUserRequestAt = Date.now();
 // Bumped by every reboot(); each request tags its socket with the generation
 // serving it, so reboot()'s grace-period sweep can tell "still busy with an
 // OLD-app response" (destroy: that handler must not live on) from "idle
@@ -358,6 +362,22 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     );
     next();
   });
+  // Activity clock for auto-update's idle gate (update-check.js): an auto
+  // restart must wait out a QUIET window, not just "no bytes in flight" —
+  // an actively browsing user has no in-flight response at most instants.
+  // Every request refreshes the clock EXCEPT the admin card's own
+  // update-status poll (GET /api/v1/admin/update, every 5s while the About
+  // page is open): the surface that DISPLAYS an update must never be the
+  // reason it cannot apply. An idle player tab makes no periodic requests
+  // (the jukebox and server-audio polls only run while those modes are in
+  // use — which genuinely is activity), so an open-but-abandoned tab goes
+  // quiet on its own.
+  mstream.use((req, res, next) => {
+    if (!(req.method === 'GET' && req.path === '/api/v1/admin/update')) {
+      lastUserRequestAt = Date.now();
+    }
+    next();
+  });
   // Trust Proxy
   if (config.program.trustProxy) {
     mstream.set("trust proxy", true);
@@ -573,13 +593,17 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   transcode.setup(mstream);
   updateCheck.setup(mstream, {
     // Idle = safe to restart into a staged update: no socket carrying an
-    // in-flight response (the same tagging reboot()'s drain sweep uses) and
-    // no scan running. Conservative before boot completes.
+    // in-flight response (the same tagging reboot()'s drain sweep uses),
+    // no scan running, AND a quiet window since the last user request (the
+    // activity-clock middleware above) — in-flight alone misses an actively
+    // browsing user, who has no response in flight at most instants.
+    // Conservative before boot completes.
     hasBusySockets: () => {
       for (const s of liveSockets) { if (s._mstreamBusy) { return true; } }
       return false;
     },
     isScanning: () => (taskQueueMod ? taskQueueMod.isScanning() : true),
+    msSinceActivity: () => Date.now() - lastUserRequestAt,
   });
   scrobblerApi.setup(mstream);
   remoteApi.setupAfterAuth(mstream, server);

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -343,14 +343,24 @@ const updatesOptions = Joi.object({
   // works, it is only the schedule that stops.
   check: Joi.boolean().default(true),
   // notify: report only, download nothing until a human clicks.
-  // stage (default): background-download the new version - managed installs
-  //   stage it behind $ROOT/current, Windows setup.exe installs download the
+  // stage: background-download the new version - managed installs stage it
+  //   behind $ROOT/current, Windows setup.exe installs download the
   //   verified installer - but applying still takes a restart or a click.
-  // auto: additionally apply when the server is idle (no busy connections,
-  //   no scan): under the tray launcher by asking it to restart into the
-  //   staged version; headless by exiting 0, which expects a process
-  //   supervisor (systemd/pm2) configured to start mStream again.
-  mode: Joi.string().valid('notify', 'stage', 'auto').default('stage'),
+  // auto (default): additionally apply once the server is genuinely idle
+  //   (no busy connections, no scan, and a quiet window since the last user
+  //   request): under the tray launcher by asking it to restart into the
+  //   staged version; headless by exiting 0 - but only when a supervisor
+  //   that restarts on a clean exit is detectable (pm2, systemd with
+  //   Restart=always/on-success, or MSTREAM_SUPERVISED=1) - otherwise auto
+  //   behaves like stage. Default flipped to auto only after the full
+  //   recovery ladder shipped: the installers' pre-flip --boot-probe
+  //   refusal, and the launcher/headless boot watchdogs that roll a
+  //   crash-at-boot release back and hold it until a fixed release ships -
+  //   a bad release self-heals to the next good one with no operator
+  //   action. A config that pins mode keeps its choice (Joi defaults never
+  //   override an explicit value); .pkg installs stay download-only under
+  //   auto by design (Installer.app needs a human).
+  mode: Joi.string().valid('notify', 'stage', 'auto').default('auto'),
   // Hold one version back: report it, never stage or apply it. The
   // companion of a manual rollback (docs/install.md) — without it the next
   // daily check would silently re-stage the very release the operator just

--- a/src/util/update-check.js
+++ b/src/util/update-check.js
@@ -25,18 +25,23 @@
 //
 // Modes (config: updates.mode, live-read so admin toggles need no reboot):
 //   notify - check only; every download/install is user-initiated
-//   stage  - (default) background-stage for managed installs and
-//            background-download the Windows installer; applying still takes
-//            a restart / a click
-//   auto   - additionally apply when idle: under the launcher, by flagging
-//            applyRequested in the status file (the launcher restarts into
-//            the staged version); headless, by exiting 0 so the supervisor's
-//            restart lands on the new version via the flipped `current`
-//            link — but ONLY when a restart-on-clean-exit supervisor is
-//            actually detectable (detectSupervisor: MSTREAM_SUPERVISED,
-//            pm2, systemd with Restart=always/on-success). Unsupervised,
-//            auto degrades to stage-and-log: exiting would be an outage,
-//            not an apply.
+//   stage  - background-stage for managed installs and background-download
+//            the Windows installer; applying still takes a restart / a click
+//   auto   - (default) additionally apply when idle: under the launcher, by
+//            flagging applyRequested in the status file (the launcher
+//            restarts into the staged version); headless, by exiting 0 so
+//            the supervisor's restart lands on the new version via the
+//            flipped `current` link — but ONLY when a restart-on-clean-exit
+//            supervisor is actually detectable (detectSupervisor:
+//            MSTREAM_SUPERVISED, pm2, systemd with Restart=always/
+//            on-success). Unsupervised, auto degrades to stage-and-log:
+//            exiting would be an outage, not an apply. "Idle" means no
+//            in-flight responses, no scan, AND a quiet window since the
+//            last user request (IDLE_QUIET_MS) — auto became the default
+//            only once the full recovery ladder shipped (pre-flip
+//            --boot-probe refusal; the launcher and headless boot
+//            watchdogs' rollback-and-hold; supervision gating), so a bad
+//            release self-heals to the next good one at every stage.
 //
 // Boot-failure holds (update-hold.json, beside the status file): when an
 // applied update crashes before it ever serves, the launcher's boot
@@ -79,6 +84,16 @@ const STAGE_TIMEOUT_MS = 30 * 60 * 1000; // a bundle download on a slow link
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // daily
 const BOOT_CHECK_DELAY_MS = 30 * 1000;
 const AUTO_APPLY_POLL_MS = 15 * 60 * 1000;
+// auto's idle gate demands QUIET, not merely "no bytes in flight": an
+// actively browsing user has no in-flight response at most instants, and a
+// restart under them is exactly the rudeness auto-by-default must not
+// have. The env override exists for the integration tests and for
+// operators who want snappier applies on a box nobody browses.
+const IDLE_QUIET_MS = 10 * 60 * 1000;
+function idleQuietMs() {
+  const v = Number(process.env.MSTREAM_UPDATE_IDLE_QUIET_MS);
+  return Number.isFinite(v) && v >= 0 ? v : IDLE_QUIET_MS;
+}
 
 // ── Pure helpers (unit-tested with injected fs) ─────────────────────────────
 // compareVersions / parseBundleName / the hold-file readers live in
@@ -185,7 +200,10 @@ export function detectInstallMethod({
 // ── Module state ────────────────────────────────────────────────────────────
 
 let _install = null;        // { method, root? } — detected once per process
-let _hooks = { hasBusySockets: () => false, isScanning: () => false };
+// msSinceActivity defaults to "forever quiet": a caller that wires no
+// activity clock (tests driving setup() directly) keeps pre-quiet-gate
+// behavior rather than never applying.
+let _hooks = { hasBusySockets: () => false, isScanning: () => false, msSinceActivity: () => Infinity };
 let _bootTimer = null;
 let _checkTimer = null;
 let _applyTimer = null;
@@ -224,7 +242,7 @@ const state = {
 };
 
 function updatesConfig() {
-  return config.program?.updates || { check: true, mode: 'stage', skipVersion: '' };
+  return config.program?.updates || { check: true, mode: 'auto', skipVersion: '' };
 }
 
 // The operator held this version back (updates.skipVersion — the companion
@@ -807,8 +825,10 @@ async function pruneOldVersions(root) {
 // ── Applying ────────────────────────────────────────────────────────────────
 
 function idle() {
-  try { return !_hooks.hasBusySockets() && !_hooks.isScanning(); }
-  catch { return false; }
+  try {
+    return !_hooks.hasBusySockets() && !_hooks.isScanning()
+      && _hooks.msSinceActivity() >= idleQuietMs();
+  } catch { return false; }
 }
 
 // The human clicked "restart to update" in the webapp. Managed under the
@@ -1093,7 +1113,13 @@ export function setup(mstream, hooks = {}) {
   if (_bootTimer.unref) { _bootTimer.unref(); }
   _checkTimer = setInterval(() => { checkNow().catch(() => {}); }, CHECK_INTERVAL_MS);
   if (_checkTimer.unref) { _checkTimer.unref(); }
-  _applyTimer = setInterval(() => { maybeAutoApply(); }, AUTO_APPLY_POLL_MS);
+  // The apply poll paces itself to the idle gate's quiet window when that
+  // is the shorter of the two: once a server has been quiet for the window,
+  // the arm should land within roughly one more window — not up to 15
+  // minutes later. (Every request is activity — including "check now" —
+  // so the TIMER is what fires the arm on a genuinely idle box.)
+  _applyTimer = setInterval(() => { maybeAutoApply(); },
+    Math.max(1000, Math.min(AUTO_APPLY_POLL_MS, idleQuietMs())));
   if (_applyTimer.unref) { _applyTimer.unref(); }
 }
 

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -136,7 +136,8 @@ test('managed round-trip: check, auto-stage, current flip, tamper refusal, live 
     assert.equal(s.current, packageJson.version);
     assert.equal(s.staged, false);
 
-    // Check: finds 9.9.9 and (mode=stage default) starts staging on its own.
+    // Check: finds 9.9.9 and (default mode: staging is part of both stage
+    // and auto) starts the download on its own.
     const check = await (await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' })).json();
     assert.equal(check.available, true);
     assert.equal(check.latest, '9.9.9');
@@ -278,7 +279,7 @@ test('boot-failure holds: held version never stages, a newer release supersedes 
       let s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update`)).json();
       assert.deepEqual(s.heldVersions, ['9.9.20']);
 
-      // The held version is reported but never staged (mode=stage default
+      // The held version is reported but never staged (the default mode
       // would otherwise download and flip on this very check).
       s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' })).json();
       assert.equal(s.available, true);
@@ -402,7 +403,7 @@ test('auto mode without a supervisor stages but never self-exits', { skip: posix
     await publish('9.9.30');
     const srv = await startServer({
       waitForScan: true,   // the idle gate must be about supervision, not the boot scan
-      env: scrubSupervision(envFor(home)),
+      env: { ...scrubSupervision(envFor(home)), MSTREAM_UPDATE_IDLE_QUIET_MS: '0' },
       extraConfig: { updates: { mode: 'auto', check: true } },
     });
     try {
@@ -428,13 +429,49 @@ test('auto mode without a supervisor stages but never self-exits', { skip: posix
   }
 });
 
+test('the idle gate holds an armed apply until a quiet window elapses', { skip: posixOnly }, async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-quiet-'));
+  try {
+    await publish('9.9.60');
+    const srv = await startServer({
+      waitForScan: true,
+      // A short but real quiet window: recent activity must block the arm,
+      // and its expiry must release it. The status poll itself is excluded
+      // from the activity clock (GET /api/v1/admin/update), so polling for
+      // the outcome cannot keep the server "active".
+      env: { ...scrubSupervision(envFor(home)), MSTREAM_UPDATE_IDLE_QUIET_MS: '6000' },
+      extraArgs: ['--supervised'], stdin: 'pipe',
+      extraConfig: { updates: { mode: 'auto', check: true } },
+    });
+    try {
+      await fetch(`${srv.baseUrl}/api/v1/admin/update/check`, { method: 'POST' });
+      await pollStatus(srv.baseUrl, (x) => x.staged && x.stagedVersion === '9.9.60');
+      // Fresh activity (a normal request): the quiet window has not
+      // elapsed, so nothing may arm — the apply poll is paced to the
+      // window, so give it one full cycle to prove the restraint.
+      await fetch(`${srv.baseUrl}/api/`);
+      await sleep(2000);
+      let s = await (await fetch(`${srv.baseUrl}/api/v1/admin/update`)).json();
+      assert.equal(s.applyRequested, false, 'an active server must not arm the apply');
+      // Go quiet (only excluded status polls from here): the timer arms it
+      // within roughly one window past the quiet threshold.
+      s = await pollStatus(srv.baseUrl, (x) => x.applyRequested === true, 20_000);
+      assert.equal(s.stagedVersion, '9.9.60');
+    } finally {
+      await srv.stop();
+    }
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test('supervised auto mode arms the launcher through the status file', { skip: posixOnly }, async () => {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-upd-arm-'));
   try {
     await publish('9.9.50');
     const srv = await startServer({
       waitForScan: true,   // idle must gate on supervision state, not the boot scan
-      env: scrubSupervision(envFor(home)),
+      env: { ...scrubSupervision(envFor(home)), MSTREAM_UPDATE_IDLE_QUIET_MS: '0' },
       extraArgs: ['--supervised'], stdin: 'pipe',
       extraConfig: { updates: { mode: 'auto', check: true } },
     });
@@ -476,7 +513,7 @@ test('auto mode with MSTREAM_SUPERVISED=1 applies by exiting 0', { skip: posixOn
     await publish('9.9.31');
     const srv = await startServer({
       waitForScan: true,
-      env: { ...scrubSupervision(envFor(home)), MSTREAM_SUPERVISED: '1' },
+      env: { ...scrubSupervision(envFor(home)), MSTREAM_SUPERVISED: '1', MSTREAM_UPDATE_IDLE_QUIET_MS: '0' },
       extraConfig: { updates: { mode: 'auto', check: true } },
     });
     try {

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -3619,7 +3619,7 @@ const infoView = Vue.component('info-view', {
                     <td colspan="2" style="color:#c62828;">{{update.s.error}}</td>
                   </tr>
                   <tr>
-                    <td><b title="notify: report only. stage (default): download updates in the background; applying still takes a restart or a click. auto: additionally restart into the update when the server is idle (headless installs need a process supervisor that restarts mStream).">Mode:</b> {{update.s.mode}}</td>
+                    <td><b title="notify: report only. stage: download updates in the background; applying still takes a restart or a click. auto (default): additionally restart into the update once the server is idle - nothing streaming, no scan, and a quiet stretch since the last request. Headless installs self-apply only when a supervisor that restarts mStream is detected; otherwise auto downloads and waits for the next restart.">Mode:</b> {{update.s.mode}}</td>
                     <td>[<a v-on:click="updCycleMode()">change</a>]</td>
                   </tr>
                   <tr>


### PR DESCRIPTION
R5 of the auto-update audit — **the flip itself**, landing last by design: every rung of the recovery ladder shipped and was proven first (#897 launcher watchdog, #898 headless guards, #900 pre-flip probe, #901 apply-leg CI).

## What changes

**`updates.mode` defaults to `auto`.** A config that pins a mode keeps its choice — Joi defaults only fill the blank. Behavior by install shape, under the default:

- **Tray installs (managed):** updates download, stage, and apply on their own once the server is genuinely idle; a release that fails the pre-flip probes never takes over, and one that still crashes at first boot rolls back and is held until a fixed release ships.
- **Headless managed:** self-apply (exit 0) only under a supervisor that provably restarts on a clean exit (pm2, systemd `Restart=always`/`on-success`, or `MSTREAM_SUPERVISED=1`); otherwise auto stages and waits for the next restart — with the headless boot watchdog covering a crash-at-boot regardless.
- **`.pkg`:** download-only under auto, by design (Installer.app needs a human).
- **deb/rpm, Docker, npm, portable:** unchanged — told about updates, never touched.

**The idle gate grows the quiet window the audit called for.** "No bytes in flight" misses an actively *browsing* user (no in-flight response at most instants). Every request now refreshes an activity clock — except the admin card's own `GET /api/v1/admin/update` poll, since the surface that displays an update must never be the reason it can't apply — and auto applies only after ~10 quiet minutes on top of the existing no-streams/no-scan checks. An idle player tab makes no periodic requests (verified: the jukebox and server-audio polls only run while those modes are active, which genuinely is activity), so an abandoned tab goes quiet on its own. The apply poll paces itself to `min(15min, quiet window)`, so the arm lands within about one window of real idleness. `MSTREAM_UPDATE_IDLE_QUIET_MS` overrides the window (tests; boxes nobody browses).

Docs (`install.md`) and the admin card copy follow the new default, including why the flip is safe now.

## Testing

- New integration test proves the gate both ways: fresh activity blocks the arm through a full poll cycle; going quiet arms it within ~one window (the status poll is excluded from the clock, so observing the outcome can't perturb it — and the first draft of this very test found the design nuance that "check now" is itself activity, which is why the timer paces to the window).
- The three existing auto-mode tests pin the window to 0 so supervision and arming stay the thing under test.
- Full suites green: 576 unit / 701 integration (9/9 on the update file).

## After this

R6 (release-ops runbook) is the last audit item — pure documentation: bad-release procedure, "yanking does not stop already-staged installs, ship a fixed patch fast", skipVersion/clearHold as the per-install brakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)