### PR TITLE
test: harden three timeout budgets that flaked on loaded windows-latest runners

### DIFF
--- a/test/integration/backup-api.test.mjs
+++ b/test/integration/backup-api.test.mjs
@@ -296,18 +296,27 @@ describe('backup API: validation hardening', () => {
   // for the run's natural length and these tests time out — verified
   // by mutation (the earlier version of this test passed even with the
   // cancel deleted, because the ghost-guard alone made status idle).
+  // 40 files x 4000ms ≈ 160s natural runtime. The throttle costs the
+  // passing path nothing (the worker is killed within a file or two) —
+  // it only sets the ceiling the cancellation budgets below must stay
+  // well under to keep discriminating "cancelled" from "ran to
+  // completion" on a loaded CI runner.
   async function startSlowRun(libraryRoot, libraryId, destPath) {
     for (let i = 0; i < 40; i++) {
       fs.writeFileSync(path.join(libraryRoot, `slow-${String(i).padStart(2, '0')}.mp3`), `slow-${i}`);
     }
     const created = await api('POST', '/api/v1/admin/backup/destinations', {
-      libraryId, destPath, triggerType: 'manual', interFileDelayMs: 800,
+      libraryId, destPath, triggerType: 'manual', interFileDelayMs: 4000,
     });
     assert.equal(created.status, 200);
     const did = created.json.id;
     await api('POST', `/api/v1/admin/backup/destinations/${did}/run`);
+    // Ceiling, not a wait: returns on the first active poll. 30s because
+    // activation includes a worker-process spawn, which loaded
+    // windows-latest runners stretch far past the old ~5s (100x50ms) poll.
     let active = null;
-    for (let i = 0; i < 100; i++) {
+    const activeDeadline = Date.now() + 30_000;
+    while (Date.now() < activeDeadline) {
       const s = await api('GET', '/api/v1/admin/backup/status');
       if (s.json.active && s.json.active.destinationId === did) { active = s.json.active; break; }
       await sleep(50);
@@ -344,7 +353,7 @@ describe('backup API: validation hardening', () => {
     const del = await api('DELETE', `/api/v1/admin/backup/destinations/${did}`);
     assert.equal(del.status, 200);
 
-    // The discriminating assertion: the ~32s natural run must be gone
+    // The discriminating assertion: the ~160s natural run must be gone
     // from the queue slot within seconds.
     await assertQueueFreesWithin(10_000, 'destination DELETE');
 
@@ -383,7 +392,13 @@ describe('backup API: validation hardening', () => {
     // destination-DELETE route 404s), holding the serial queue slot
     // for the run's natural length. This path also reboots the HTTP
     // server, so the poller tolerates the reboot's connection gap.
-    await assertQueueFreesWithin(20_000, 'library DELETE');
+    // 90s ceiling (still a poll — passes the moment the slot frees):
+    // the reboot is a server boot, and boots have blown far smaller
+    // budgets on loaded windows-latest runners (see waitForReady's 90s
+    // rationale in helpers/server.mjs); a 20s budget flaked there
+    // ("library DELETE: queue slot still held after 20000ms"). The
+    // ~160s natural run keeps 90s discriminating.
+    await assertQueueFreesWithin(90_000, 'library DELETE');
 
     const s = await api('GET', '/api/v1/admin/backup/status');
     assert.equal(s.json.active, null, 'no phantom run may survive a library delete');

--- a/test/scanner/scanner-multi-art.test.mjs
+++ b/test/scanner/scanner-multi-art.test.mjs
@@ -484,6 +484,12 @@ describe('multi-art parity (rust vs JS scanner)', () => {
 
 describe('stale-art reaping (disk is truth)', () => {
   // Per-runner fixture copies — these tests delete and replace images.
+  // That makes every test here build its OWN fixture (a dozen ffmpeg
+  // spawns) plus run TWO scans — more work than the shared-fixture 120s
+  // tests above, so all of them get the 240s ceiling: the rust reap leg
+  // has blown a 120s budget on a loaded windows-latest runner while the
+  // JS twin passed in 60s alongside it (the budget was load headroom,
+  // not runtime).
   async function reapScenario(t, label, runner) {
     const root = path.join(scratch, `reap-${label}`);
     await buildArtFixture(root);
@@ -536,7 +542,7 @@ describe('stale-art reaping (disk is truth)', () => {
     } finally { db.close(); }
   }
 
-  test('rust: deleted folder image reaped; on-disk art kept', { timeout: 120_000 }, async (t) => {
+  test('rust: deleted folder image reaped; on-disk art kept', { timeout: 240_000 }, async (t) => {
     if (!available()) { return t.skip('ffmpeg or rust-parser unavailable'); }
     await reapScenario(t, 'rust', c => runScan(rustBin, c));
   });
@@ -546,7 +552,7 @@ describe('stale-art reaping (disk is truth)', () => {
     await reapScenario(t, 'js', c => runJsScan(c));
   });
 
-  test('replaced embedded cover: stale album_art link reconciled away (cache file stays)', { timeout: 120_000 }, async (t) => {
+  test('replaced embedded cover: stale album_art link reconciled away (cache file stays)', { timeout: 240_000 }, async (t) => {
     if (!available()) { return t.skip('ffmpeg or rust-parser unavailable'); }
     const root = path.join(scratch, 'replace-cover');
     await buildArtFixture(root);

--- a/test/scanner/scanner-schema-guard.test.mjs
+++ b/test/scanner/scanner-schema-guard.test.mjs
@@ -259,6 +259,12 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
 // visited-realpath set (collectFiles); the Rust scanner gets ancestor-loop
 // detection from walkdir. Neither had a regression test — a removed guard
 // would only show up as a stack overflow in production.
+//
+// The per-test timeout is purely the hang-detector for a regressed guard
+// (which never terminates), so generosity costs nothing. 240s because a
+// HEALTHY run — one scanner child over three tiny files — has blown a 60s
+// budget on a loaded windows-latest runner ("test timed out after
+// 60000ms"): child-process boot under load, not the walk.
 describe('symlink cycle termination (followSymlinks=true)', () => {
   function buildCycleLib(tmp) {
     const lib = path.join(tmp, 'music');
@@ -282,7 +288,7 @@ describe('symlink cycle termination (followSymlinks=true)', () => {
     return lib;
   }
 
-  test('JS scanner terminates and indexes each file exactly once', { timeout: 60000 }, async (t) => {
+  test('JS scanner terminates and indexes each file exactly once', { timeout: 240_000 }, async (t) => {
     const tmp = makeTmp('cycle-js');
     const lib = buildCycleLib(tmp);
     if (lib === null) { t.skip('symlink/junction creation not permitted'); return; }
@@ -305,7 +311,7 @@ describe('symlink cycle termination (followSymlinks=true)', () => {
     assert.strictEqual(new Set(rows).size, 3);
   });
 
-  test('Rust scanner terminates and indexes each file exactly once', { timeout: 60000 }, async (t) => {
+  test('Rust scanner terminates and indexes each file exactly once', { timeout: 240_000 }, async (t) => {
     const ext = process.platform === 'win32' ? '.exe' : '';
     const rustBin = [
       path.resolve(__dirname, `../../rust-parser/target/release/rust-parser${ext}`),


### PR DESCRIPTION
## What

Three full-ci windows-latest shards showed load-dependent timeout flakes on PRs that don't touch their code, each passing on rerun or on identical code in adjacent runs. All three budgets were fixed ceilings sized for healthy runners — the loaded windows-latest class the repo already documents in `waitForReady`'s 90s rationale (`test/helpers/server.mjs`) can legitimately exceed them. The waits themselves were already event-driven (poll-with-early-return or per-test hang timeouts), so the fix is right-sized ceilings with the rationale recorded in the repo's comment idiom.

## Changes

**`backup-api.test.mjs` — "deleting a LIBRARY mid-run cancels its backups"** (flaked: "queue slot still held after 20000ms")
This budget must stay *below* the run's natural length to keep catching a removed cancel (the mutation-tested property), so both sides move up: `interFileDelayMs` 800→4000 lifts the natural run ~32s→~160s, letting the ceiling go 20s→90s — matching the documented boot ceiling, apt because this path reboots the HTTP server. The throttle is free in the passing path (the worker dies within a file or two; locally the cancellation tests finish in 16–226ms). Also converts `startSlowRun`'s fixed 100×50ms activation poll to a 30s time ceiling, since activation includes a load-sensitive worker spawn. The two destination tests keep their 10s budgets with a much wider margin.

**`scanner-multi-art.test.mjs` — "rust: deleted folder image reaped"** (blew its 120s per-test timeout while the JS twin passed in 60s in the same run)
Accidental twin asymmetry: the reap tests build their *own* fixture (a dozen ffmpeg spawns) plus two scans — more work than the shared-fixture 120s tests above them — yet only the JS twin had 240s. The rust leg and the same-shaped `replaced embedded cover` test move to 240s, with the incident recorded on the describe block.

**`scanner-schema-guard.test.mjs` — symlink-cycle termination** (flaked: "test timed out after 60000ms" at 82s wall)
The timeout is purely the hang-detector for a regressed cycle guard, which never terminates — generosity costs nothing but failure latency. Both twins 60s→240s, rationale added to the describe comment (child-process boot under load, not the walk).

## Reviewer notes

- One behavioral trade-off: in a regressed (cancel-removed) world the backup suite's later `waitForIdle(60s)` calls now also fail after the targeted assertion fires at its own budget — noisier failure, same detection.
- Verified locally on the posix legs: all three suites green (backup-api 18/18, multi-art 12/12 with ffmpeg + rust binary present, schema-guard 18/18) and `eslint` clean.
- Branch note: this reuses `fix/torrent-seed-existing` (its torrent work already merged via #779), so the diff here is only the three test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)