### PR TITLE
Installers restart a running mStream into the new version

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1067,9 +1067,17 @@ jobs:
           # plist); ditto preserves the signed bundle bit-exactly.
           rm -rf pkgwork/root && mkdir -p pkgwork/root
           ditto "$APP" pkgwork/root/mStream.app
+          # postinstall (build/pkg-postinstall.sh): restart a RUNNING
+          # mStream into the freshly installed copy — terminate the
+          # launcher by exact path (the supervision pipe stops its server
+          # gracefully), relaunch as the console user with --takeover.
+          # Without it the pkg is a pure payload swap and the old version
+          # keeps serving until a manual Quit + reopen.
+          mkdir -p pkgwork/scripts
+          install -m 755 build/pkg-postinstall.sh pkgwork/scripts/postinstall
           pkgbuild --analyze --root pkgwork/root pkgwork/component.plist
           /usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" pkgwork/component.plist
-          pkgbuild --root pkgwork/root --component-plist pkgwork/component.plist --install-location /Applications --identifier io.mstream.server --version "$VER" pkgwork/component.pkg
+          pkgbuild --root pkgwork/root --component-plist pkgwork/component.plist --scripts pkgwork/scripts --install-location /Applications --identifier io.mstream.server --version "$VER" pkgwork/component.pkg
           case "$KEY" in
             darwin-arm64) ARCHS="arm64" ;;
             *)            ARCHS="x86_64,arm64" ;;   # x64 payload runs under Rosetta
@@ -1177,8 +1185,37 @@ jobs:
           set -euo pipefail
           VER=$(node -pe "require('./package.json').version")
           PKG="dist/installer/mStream-$VER-darwin-arm64.pkg"
+          # Seed a RUNNING "old version" at the exact path the payload
+          # replaces, so the postinstall's restart path (terminate old,
+          # relaunch new as the console user) is proven here — not just its
+          # nothing-running no-op. A COMPILED stub, never a copied system
+          # binary: AMFI SIGKILLs a platform-signed binary run from inside a
+          # foreign .app (measured — a copied /bin/sleep dies at exec with
+          # 137, which would make this whole seed silently vacuous).
+          printf '#include <unistd.h>\nint main(void){for(;;)sleep(9);return 0;}\n' | cc -x c - -o old-stub
+          sudo mkdir -p /Applications/mStream.app/Contents/MacOS
+          sudo cp old-stub /Applications/mStream.app/Contents/MacOS/mStream
+          /Applications/mStream.app/Contents/MacOS/mStream &
+          OLD_PID=$!
+          sleep 1
+          kill -0 "$OLD_PID" 2>/dev/null || { echo "::error::the seeded old instance is not running - the restart-path test would be vacuous"; exit 1; }
           sudo installer -pkg "$PKG" -target /
           test -d /Applications/mStream.app || { echo "::error::pkg install did not produce /Applications/mStream.app"; exit 1; }
+          if kill -0 "$OLD_PID" 2>/dev/null; then
+            echo "::error::postinstall left the old running instance alive"; exit 1
+          fi
+          NEW=0
+          for i in $(seq 1 15); do
+            pgrep -f "^/Applications/mStream.app/Contents/MacOS/mStream" >/dev/null 2>&1 && { NEW=1; break; }
+            sleep 1
+          done
+          [ "$NEW" = "1" ] || { echo "::error::postinstall did not relaunch mStream"; exit 1; }
+          echo "postinstall restarted the running instance into the new app"
+          # Quiet the relaunched app before the deterministic half below
+          # (its server would otherwise boot on the runner's default port).
+          pkill -f "^/Applications/mStream.app/Contents/MacOS/" 2>/dev/null || true
+          sleep 2
+          pkill -9 -f "^/Applications/mStream.app/Contents/MacOS/" 2>/dev/null || true
           test -e /Applications/mStream.app/Contents/MacOS/webapp/index.html || { echo "::error::webapp symlink broken after pkg install"; exit 1; }
           OUT=$(/Applications/mStream.app/Contents/MacOS/mstream-server -V)
           echo "installed server -V -> $OUT"

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -240,6 +240,37 @@ jobs:
           try { & .\install.ps1 *>&1 | Out-Null; throw "installed a bundle that cannot boot" } catch { if ("$_" -notmatch 'would not BOOT') { throw } }
           $j3 = Get-Item "$env:RUNNER_TEMP\app\current" -Force
           if (($j3.Target | Select-Object -First 1) -notmatch 'mStream-9\.9\.9-win-x64$') { throw "current moved off 9.9.9 after probe refusal: $($j3.Target)" }
+          # relaunch arming: with a LAUNCHER this script owns running the
+          # old version, a fresh install must arm update-status.json for the
+          # tray to consume (never kill anything itself). Real exe required
+          # (a stopped/fake one skips the block silently); rustc again.
+          Set-Content idle.rs 'fn main(){loop{std::thread::sleep(std::time::Duration::from_secs(9));}}'
+          rustc -O --crate-name idlestub idle.rs -o "$env:RUNNER_TEMP\app\mStream-9.9.9-win-x64\mStream.exe" 2>rustc2.err
+          if ($LASTEXITCODE -ne 0) { Get-Content rustc2.err; throw "idle stub build failed" }
+          $stub = Start-Process -FilePath "$env:RUNNER_TEMP\app\mStream-9.9.9-win-x64\mStream.exe" -PassThru
+          Start-Sleep -Seconds 1
+          if ($stub.HasExited) { throw "seeded launcher stub is not running - the arming test would be vacuous" }
+          # The upgrade bundle's server must PASS -V and the deep probe, or
+          # the pre-flip refusals (correctly) fire before arming can happen.
+          Set-Content ok.rs 'fn main(){let a=std::env::args().nth(1);if a.as_deref()==Some("-V"){println!("9.9.12");return;}if a.as_deref()==Some("--boot-probe"){println!("boot-probe: ok");return;}}'
+          rustc -O --crate-name okstub ok.rs -o ok-server.exe 2>rustc3.err
+          if ($LASTEXITCODE -ne 0) { Get-Content rustc3.err; throw "ok stub build failed" }
+          $pb2 = 'mStream-9.9.12-win-x64'
+          Remove-Item rel\mStream-*.zip, rel\manifest.json -Force
+          Push-Location rel
+          New-Item -ItemType Directory -Force $pb2 | Out-Null
+          Copy-Item ..\ok-server.exe "$pb2\mstream-server.exe"
+          Set-Content "$pb2\README.txt" 'fake'
+          python3 -m zipfile -c "$pb2.zip" $pb2
+          Remove-Item -Recurse -Force $pb2
+          Pop-Location
+          bash scripts/release-manifest.sh 9.9.12 rel
+          $armOut = & .\install.ps1 *>&1 | Out-String
+          if ($armOut -notmatch 'restarts into 9\.9\.12 within a minute') { throw "arming note missing: $armOut" }
+          $armDoc = Get-Content "$env:LOCALAPPDATA\mStream\update-status.json" -Raw | ConvertFrom-Json
+          if (-not $armDoc.applyRequested -or $armDoc.stagedVersion -ne '9.9.12') { throw "status file not armed: $($armDoc | ConvertTo-Json -Compress)" }
+          Stop-Process -Id $stub.Id -Force
+          Start-Sleep -Seconds 1
           # uninstall
           $env:MSTREAM_UNINSTALL = '1'
           & .\install.ps1 *>&1 | Tee-Object -Variable un

--- a/build/pkg-postinstall.sh
+++ b/build/pkg-postinstall.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# postinstall for the macOS .pkg (staged into the pkg by build-bun.yml):
+# restart a RUNNING mStream into the copy this install just replaced.
+# Without it, the pkg is a pure payload swap and the old version keeps
+# serving its already-loaded code until a manual Quit + reopen (field
+# report, 2026-08-25).
+#
+# Approach: terminate the LAUNCHER by exact path and let the supervision
+# contract do the graceful part — the launcher's death drops the server's
+# stdin pipe, and a --supervised server exits cleanly on that EOF
+# (src/util/supervision.js; the same guarantee that makes force-killed
+# launchers leak-proof). No AppleEvents, so no TCC automation prompts from
+# an installer context. GUI app only: a bare mstream-server someone runs
+# from this tree (a launchd unit, a terminal) is deliberately left alone —
+# an installer never kills a server it does not manage.
+#
+# Runs as root; the relaunch drops to the CONSOLE user (an app opened as
+# root would run the tray in the wrong session). Every path is best-effort:
+# a postinstall must never fail the install — exit 0 always.
+set -u
+
+DEST="${2:-/Applications}"
+APP="$DEST/mStream.app"
+LAUNCHER="$APP/Contents/MacOS/mStream"
+[ -x "$LAUNCHER" ] || exit 0
+
+# pgrep -f matches the whole command line; the path is specific enough that
+# its regex metacharacters (the .app dot) over-matching is not a concern.
+running_pids=$(pgrep -f "^$LAUNCHER" 2>/dev/null || true)
+[ -n "$running_pids" ] || exit 0
+
+user=$(stat -f%Su /dev/console 2>/dev/null || true)
+# A sudo-driven install (CI's `sudo installer`, an admin's terminal) can
+# show root or a system account at the console; the invoking user is the
+# better answer there.
+case "$user" in ""|root|_*) user="${SUDO_USER:-}" ;; esac
+uid=$(id -u "$user" 2>/dev/null || true)
+[ -n "$user" ] && [ "$user" != "root" ] && [ -n "$uid" ] || exit 0
+
+# Run a command as the console user. In the installer this process is root
+# (launchctl asuser targets the user's GUI session); run standalone as that
+# user — the test harness's shape — the wrappers are unnecessary AND sudo
+# would prompt, so call directly.
+run_as_console_user() {
+    if [ "$(id -u)" = "$uid" ]; then
+        "$@"
+    else
+        launchctl asuser "$uid" sudo -u "$user" "$@"
+    fi
+}
+
+echo "mStream is running from $APP - restarting it into the new version"
+kill -TERM $running_pids 2>/dev/null || true
+i=0
+while [ $i -lt 20 ] && pgrep -f "^$LAUNCHER" >/dev/null 2>&1; do
+    i=$((i + 1)); sleep 1
+done
+if pgrep -f "^$LAUNCHER" >/dev/null 2>&1; then
+    kill -KILL $(pgrep -f "^$LAUNCHER") 2>/dev/null || true
+    sleep 1
+fi
+# The launcher is gone; its supervised server follows via the stdin-EOF
+# contract. Give that a beat, then reap any straggler UNDER THE APP PATH
+# only (never a server running from somewhere else).
+sleep 2
+straggler=$(pgrep -f "^$APP/Contents/MacOS/mstream-server" 2>/dev/null || true)
+[ -n "$straggler" ] && kill -TERM $straggler 2>/dev/null
+
+# Relaunch as the console user. --takeover: this is an update handoff, not
+# a first run — no browser announce, and the single-instance lock is
+# retried briefly if the old process is still tearing down. `open` goes
+# through LaunchServices (the shape a real user launch has); if it refuses
+# (test harnesses with a bare fake .app; an exotic Gatekeeper state), fall
+# back to spawning the binary directly, detached.
+if ! run_as_console_user /usr/bin/open -a "$APP" --args --takeover 2>/dev/null; then
+    run_as_console_user /usr/bin/nohup "$LAUNCHER" --takeover >/dev/null 2>&1 &
+fi
+exit 0

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,10 +43,15 @@ mirrors). Older versions are kept beside `current` for rollback — once mStream
 is no longer running from one, delete it whenever you like.
 
 Re-running to upgrade re-points the app-menu / Start Menu entry and the
-login item at the new version, but never stops a running mStream: Quit it
-from the tray icon and start it again to switch. A copy you extracted by hand
-somewhere else (or run with `--portable`) is left untouched — the script only
-manages its own folder.
+login item at the new version — and if the tray app is running from a copy
+the script manages, it restarts itself into the new version within a
+minute (the script only asks; the tray performs its usual graceful stop
+and takeover — set `MSTREAM_NO_RELAUNCH=1` to leave it on the old version
+until you restart it yourself). The macOS `.pkg` and Windows `setup.exe`
+do the equivalent themselves. What is never touched: a headless
+`mstream-server` you started (any installer only ever tells you about it),
+and a copy you extracted by hand somewhere else (or run with `--portable`)
+— the script only manages its own folder.
 
 ## Automatic updates
 

--- a/install.ps1
+++ b/install.ps1
@@ -367,11 +367,42 @@ try {
         } finally { $envKey.Close() }
     }
 
+    # A LAUNCHER this script manages is running the old version: ask IT to
+    # restart into the new one through the same armed-status-file contract
+    # the in-app updater uses - the tray polls update-status.json once a
+    # minute and performs the graceful stop + takeover itself, with its
+    # full guard set (never a held version, never its own version, only
+    # while its server is up). The installer itself still never kills
+    # anything; headless servers and copies we don't own keep the warning.
+    $relaunchArmed = $false
+    if ($installedFresh -and -not $env:MSTREAM_NO_RELAUNCH) {
+        $ownedLauncher = @(Get-Process mStream -ErrorAction SilentlyContinue | Where-Object {
+            $_.Path -and $_.Path.StartsWith("$root\", [StringComparison]::OrdinalIgnoreCase) -and
+            ((Split-Path $_.Path -Parent) -ne $final)
+        })
+        if ($ownedLauncher.Count -gt 0) {
+            $dataHome = Join-Path $env:LOCALAPPDATA 'mStream'
+            New-Item -ItemType Directory -Force $dataHome | Out-Null
+            $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+            # No `current` field on purpose: the launcher treats an absent
+            # current as "staged version is new", and this script cannot
+            # know the running version.
+            $doc = '{"schema":1,"latest":"' + $ver + '","available":true,"method":"managed",' +
+                   '"staged":true,"stagedVersion":"' + $ver + '","applyRequested":true,' +
+                   '"applyRequestedAt":"' + $now + '"}'
+            $tmpStatus = Join-Path $dataHome ".update-status-installer-$PID"
+            Set-Content -Path $tmpStatus -Value $doc -Encoding ASCII
+            Move-Item -Force $tmpStatus (Join-Path $dataHome 'update-status.json')
+            $relaunchArmed = $true
+            Write-Host "  the running mStream restarts into $ver within a minute (its tray does the switch; set MSTREAM_NO_RELAUNCH=1 to leave it on the old version)"
+        }
+    }
+
     # An instance running from somewhere else stays on its own version until
     # it is restarted - the script never kills a user's server. Say so, with
     # the exact path, instead of letting "installed" imply "upgraded".
     $elsewhere = @($runningFrom | Where-Object { $_ -ne $final -and $_ -ne $current })
-    if ($elsewhere) {
+    if ($elsewhere -and -not $relaunchArmed) {
         Write-Warning ("mStream is currently running from $($elsewhere -join ', ') - it keeps running that version " +
                        "until you Quit it (tray icon) and start the new one; the Start Menu entry now points at $ver.")
     }

--- a/install.sh
+++ b/install.sh
@@ -377,6 +377,7 @@ fi
 # told that the running instance stays on the OLD version until they quit
 # it - nothing here can (or should) kill their server under them.
 running_from=""
+running_owned_launcher=""
 if command -v ps >/dev/null 2>&1; then
     # `ps -A -o pid=,args=` - the POSIX spelling - NOT `pgrep -a` and NOT
     # `ps -ax`: on macOS/BSD pgrep, -a means "include ancestors" and prints
@@ -397,8 +398,21 @@ if command -v ps >/dev/null 2>&1; then
         # Skip the version this run is installing (a real path never goes
         # through the `current` symlink, so compare against the bundle dir).
         case "$exe" in
-            "$ROOT/$bundle/"*|"$ROOT/current/"*|"") ;;
-            *) running_from="$exe"; break ;;
+            "$ROOT/$bundle/"*|"$ROOT/current/"*|"") continue ;;
+        esac
+        [ -z "$running_from" ] && running_from="$exe"
+        # A LAUNCHER running from a copy this script owns can be asked to
+        # restart itself into the new version (see the arming step below) —
+        # keep scanning rather than break, so a server matched first does
+        # not hide it.
+        case "$exe" in
+            */mstream-desktop|*/MacOS/mStream)
+                case "$exe" in
+                    "$ROOT/"*) running_owned_launcher="$exe" ;;
+                    "$HOME/Applications/mStream.app/"*)
+                        apps_copy_is_ours && running_owned_launcher="$exe" ;;
+                esac
+                ;;
         esac
     done
 fi
@@ -598,10 +612,36 @@ if [ -n "$installed_fresh" ]; then
     echo "installed mStream $version to $ROOT/$bundle"
 fi
 [ -n "$desktop_note" ] && echo "  $desktop_note"
+
+# A LAUNCHER this script manages is running the old version: ask IT to
+# restart into the new one, through the same armed-status-file contract the
+# in-app updater uses — the tray polls update-status.json once a minute and
+# performs the graceful stop + takeover itself (src/util/update-check.js is
+# the contract's writer-side twin; rust-launcher/src/tray_app.rs consumes
+# it, with every guard it applies to the in-app flow: never into a version
+# held after a failed boot, never into its own version, only while its
+# server is actually up). The installer itself still never kills anything —
+# a headless server, or any copy we don't own, keeps the NOTE below.
+relaunched_note=""
+if [ -n "$installed_fresh" ] && [ -n "$running_owned_launcher" ] && [ -z "${MSTREAM_NO_RELAUNCH:-}" ]; then
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    mkdir -p "$data_home"
+    tmp_status="$data_home/.update-status-installer-$$"
+    # No `current` field on purpose: the launcher treats an absent current
+    # as "staged version is new" — this script cannot know the running
+    # version, and must not guess at it.
+    printf '{"schema":1,"latest":"%s","available":true,"method":"managed","staged":true,"stagedVersion":"%s","applyRequested":true,"applyRequestedAt":"%s"}\n' \
+        "$version" "$version" "$now" > "$tmp_status"
+    mv "$tmp_status" "$data_home/update-status.json"
+    relaunched_note=1
+    echo "  the running mStream restarts into $version within a minute (its tray does the"
+    echo "  switch; set MSTREAM_NO_RELAUNCH=1 to leave it on the old version instead)"
+fi
+
 # An instance running from somewhere else stays on its own version until
 # it is restarted - the script never kills a user's server. Say so, with
 # the exact path, instead of letting "installed" imply "upgraded".
-if [ -n "$running_from" ]; then
+if [ -n "$running_from" ] && [ -z "$relaunched_note" ]; then
     echo "  NOTE: mStream is currently running from $running_from" >&2
     echo "        it keeps running that version until you Quit it (tray menu) and start" >&2
     echo "        the new one - the app menu / Start Menu entry now points at $version." >&2

--- a/test/integration/update-check.test.mjs
+++ b/test/integration/update-check.test.mjs
@@ -539,6 +539,80 @@ test('auto mode with MSTREAM_SUPERVISED=1 applies by exiting 0', { skip: posixOn
   }
 });
 
+test('install.sh over a running managed launcher arms the tray restart', { skip: posixOnly }, async (t) => {
+  // The fake "running launcher" must be a real binary at the owned path
+  // (argv[0] is what the ps scan matches) — compiled, never a copied
+  // system binary: AMFI SIGKILLs platform-signed binaries run from foreign
+  // trees, which silently vacates the test.
+  const cc = spawnSync('cc', ['--version']);
+  if (cc.status !== 0) { t.skip('no C compiler for the launcher stub'); return; }
+  // realpath'd: install.sh canonicalizes its ROOT (macOS /var ->
+  // /private/var), and the running-launcher ownership check is a string
+  // prefix on the stub's reported path — both sides must be canonical.
+  const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-inst-arm-')));
+  let stub = null;
+  try {
+    const root = path.join(home, 'app');
+    const oldBundle = path.join(root, `mStream-0.0.1-${hostKey()}`);
+    await fs.mkdir(oldBundle, { recursive: true });
+    const face = path.join(oldBundle, 'mstream-desktop');
+    const ccRun = spawnSync('sh', ['-c',
+      `printf '#include <unistd.h>\\nint main(void){for(;;)sleep(9);return 0;}\\n' | cc -x c - -o '${face}'`]);
+    assert.equal(ccRun.status, 0, `stub compile failed: ${ccRun.stderr}`);
+    const { spawn } = await import('node:child_process');
+    stub = spawn(face, [], { stdio: 'ignore', detached: true });
+    // unref, or the child handle keeps the test runner's event loop alive
+    // forever after the assertions pass (measured: the run hung at exit).
+    stub.unref();
+    await sleep(500);
+    assert.equal(stub.exitCode, null, 'the fake launcher must actually be running');
+
+    const env = {
+      ...process.env,
+      HOME: home,
+      XDG_DATA_HOME: path.join(home, '.local', 'share'),
+      MSTREAM_RELEASE_BASE: `http://127.0.0.1:${relPort}`,
+      MSTREAM_INSTALL_DIR: root,
+      MSTREAM_NO_DESKTOP: '1',
+    };
+    // ASYNC spawn, never spawnSync: the fake release feed serves from THIS
+    // process's event loop, and a sync wait deadlocks install.sh's curl
+    // against the very server it downloads from (measured: a permanent
+    // hang, immune even to spawnSync's timeout).
+    const runInstall = (extraEnv = {}) => new Promise((resolve) => {
+      const p = spawn('sh', [path.join(REPO_ROOT, 'install.sh')], { env: { ...env, ...extraEnv } });
+      let stdout = ''; let stderr = '';
+      p.stdout.on('data', (d) => { stdout += d; });
+      p.stderr.on('data', (d) => { stderr += d; });
+      const t = setTimeout(() => p.kill('SIGKILL'), 120_000);
+      p.on('close', (status) => { clearTimeout(t); resolve({ status, stdout, stderr }); });
+    });
+    await publish('9.9.70');
+    const r = await runInstall();
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.stdout, /restarts into 9\.9\.70 within a minute/);
+    assert.doesNotMatch(r.stderr, /keeps running that version/);
+    const statusDoc = JSON.parse(await fs.readFile(path.join(dataHomeOf(home), 'update-status.json'), 'utf8'));
+    assert.equal(statusDoc.applyRequested, true);
+    assert.equal(statusDoc.stagedVersion, '9.9.70');
+    assert.equal(statusDoc.method, 'managed');
+    assert.ok(!Number.isNaN(Date.parse(statusDoc.applyRequestedAt)),
+      `token must be a timestamp: ${statusDoc.applyRequestedAt}`);
+
+    // Opt-out: MSTREAM_NO_RELAUNCH keeps today's told-not-touched note and
+    // leaves the status file un-armed for the new version.
+    await publish('9.9.71');
+    const r2 = await runInstall({ MSTREAM_NO_RELAUNCH: '1' });
+    assert.equal(r2.status, 0, r2.stdout + r2.stderr);
+    assert.match(r2.stderr, /keeps running that version/);
+    const statusDoc2 = JSON.parse(await fs.readFile(path.join(dataHomeOf(home), 'update-status.json'), 'utf8'));
+    assert.equal(statusDoc2.stagedVersion, '9.9.70', 'opt-out must not re-arm for the new version');
+  } finally {
+    if (stub && stub.exitCode === null) { stub.kill('SIGKILL'); }
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test('non-managed installs refuse staging; apply refuses with nothing staged', { skip: posixOnly }, async () => {
   await publish('9.9.9');
   const env = updEnv();

--- a/test/smoke/update-apply-smoke.sh
+++ b/test/smoke/update-apply-smoke.sh
@@ -94,8 +94,11 @@ mk_bundle "9.9.9" "NEW-marker" "printf '{\"schema\":1,\"current\":\"9.9.9\",\"st
 ln -s "$ROOT/mStream-9.9.9-$KEY" "$ROOT/current"
 echo '{"port":'"$PORT"'}' > "$DATA/conf/default.json"
 
-# The armed file the server's auto mode leaves for the launcher.
-printf '{"schema":1,"current":"0.0.1","latest":"9.9.9","available":true,"method":"managed","staged":true,"stagedVersion":"9.9.9","applyRequested":true,"applyRequestedAt":"2026-01-01T00:00:00.000Z"}\n' \
+# The armed file, in the MINIMAL form install.sh's relaunch arming writes
+# (no `current` — the installer cannot know the running version, and the
+# launcher treats its absence as "staged version is new"). The server's own
+# auto mode writes a superset; consuming the minimal form here covers both.
+printf '{"schema":1,"latest":"9.9.9","available":true,"method":"managed","staged":true,"stagedVersion":"9.9.9","applyRequested":true,"applyRequestedAt":"2026-01-01T00:00:00.000Z"}\n' \
     > "$DATA/update-status.json"
 
 echo "starting the OLD (0.0.1) launcher; current is staged at 9.9.9; apply is armed..."


### PR DESCRIPTION
R7 (from a maintainer field report): install the latest over a running older server on macOS and the old version keeps serving until a manual Quit + reopen. Three installers, three shapes of the fix — and an installer still never kills a server it doesn't manage.

## What

- **`.pkg`** — the package was a pure payload swap (`pkgbuild`, no scripts). New `postinstall` ([build/pkg-postinstall.sh](../blob/claude/installer-relaunch-afecf4/build/pkg-postinstall.sh)): terminate the **launcher** by exact path — the supervision pipe stops its server gracefully, the same guarantee that makes force-killed launchers leak-proof — then relaunch as the **console user** with `--takeover` (no browser pop, lock-retry semantics). No AppleEvents, so no TCC automation prompts from installer context. GUI app only: a bare `mstream-server` running from the same tree is left alone.
- **install.sh / install.ps1 (managed layouts)** — no process-killing at all: when a launcher the script *owns* is running the old version, the installer **arms `update-status.json`** (`applyRequested` + fresh token) and the tray performs its usual graceful stop-and-takeover within a minute, through the same contract the in-app updater uses — guards included (held versions, own version, live-server phase only). Works with every launcher already in the field. `MSTREAM_NO_RELAUNCH=1` opts out; headless servers and foreign copies keep the told-not-touched NOTE.
- **Windows `setup.exe`** — already handled: the `.iss` `[Code]` section terminates install-dir processes deterministically and the `[Run]` entry relaunches. No change.

## Testing

- The arm64 **CI pkg install-smoke now seeds a *running* old instance** before `sudo installer`, so the postinstall's restart path (terminate → relaunch as console user) is proven on every darwin build — with a liveness guard on the seed itself, because the naive seed is silently vacuous: **AMFI SIGKILLs a copied platform binary inside a foreign `.app`** (measured, exit 137 — the seed compiles a stub with `cc` instead).
- New integration test drives the install.sh arming with a real compiled fake launcher: armed file with a parseable token on install; `MSTREAM_NO_RELAUNCH=1` keeps the NOTE and never re-arms. Two harness traps found and encoded: the fake feed serves from the test's own event loop, so install.sh must be spawned **async** or its `curl` deadlocks against the very server it downloads from; and tmp paths must be realpath'd for the ownership prefix check.
- postinstall exercised locally on all three paths (running → terminated; no app / not running → clean no-op, exit 0 always — a postinstall must never fail an install).
- Full suites green: 576 unit / 703 integration; `sh -n` clean on both scripts.

Closes the roadmap's R7. With this, every install and update path converges on the same behavior: the version you just installed is the version that's running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)