### PR TITLE
feat(first-run): tray "Set up mStream" item + headless boot invitation

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1641,6 +1641,46 @@ jobs:
           echo "$OUT" | grep -Eq '^mstream-player [0-9]+\.[0-9]+\.[0-9]+' || { echo "::error::staged mstream-player --version produced no/invalid output"; echo "$OUT"; exit 1; }
           echo "OK: staged mstream-player executes ($(basename "$PL"))"
 
+      - name: Smoke test first-run invitation (fresh boot)
+        # The first-boot wizard invitation (server.js onListening): a
+        # pristine install must print the "not set up yet" browser line
+        # and - where the staged player can actually load - the exact
+        # runnable `"<player>" setup --server` command. Runs on a COPY of
+        # the staged bundle: the smoke battery above boots the bundle in
+        # place, so its save/ is no longer pristine. Kept as its own step
+        # on purpose - the main smoke's run block sits near the workflow
+        # expression cap.
+        if: matrix.smoke
+        shell: bash
+        run: |
+          D=$(ls -d dist/stage/mStream-*-${{ matrix.key }})
+          cp -R "$D" "$RUNNER_TEMP/inv"
+          case "${{ matrix.key }}" in
+            darwin-*) SRV="$RUNNER_TEMP/inv/mStream.app/Contents/MacOS/mstream-server" ;;
+            win-*)    SRV="$RUNNER_TEMP/inv/mstream-server.exe" ;;
+            *)        SRV="$RUNNER_TEMP/inv/mstream-server" ;;
+          esac
+          printf '{ "port": 3123, "address": "127.0.0.1" }' > "$RUNNER_TEMP/inv-config.json"
+          L="$RUNNER_TEMP/inv-boot.log"
+          "$SRV" -j "$RUNNER_TEMP/inv-config.json" > "$L" 2>&1 &
+          SPID=$!
+          for i in $(seq 1 40); do grep -q "Access mStream locally" "$L" 2>/dev/null && break; sleep 1; done
+          kill $SPID 2>/dev/null || true
+          grep -q "Access mStream locally: http://localhost:3123" "$L" || { echo "::error::fresh boot never listened"; tail -40 "$L"; exit 1; }
+          grep -q "not set up yet" "$L" || { echo "::error::first-run line missing on a pristine boot"; tail -40 "$L"; exit 1; }
+          WANT_WIZARD=yes
+          case "${{ matrix.key }}" in
+            linux-*) ldconfig -p 2>/dev/null | grep -q libasound.so.2 || WANT_WIZARD=no ;;
+          esac
+          if [ "$WANT_WIZARD" = yes ]; then
+            grep -q 'setup --server http://localhost:3123' "$L" || { echo "::error::wizard invitation missing (player staged and loadable)"; tail -40 "$L"; exit 1; }
+            PL=$(sed -n 's/.*Run: "\(.*\)" setup --server.*/\1/p' "$L" | head -1)
+            [ -f "$PL" ] || { echo "::error::printed wizard path does not exist: $PL"; exit 1; }
+            echo "OK: invitation printed a real player at $PL"
+          else
+            grep -q 'setup --server' "$L" && { echo "::error::wizard line printed but this runner has no libasound"; exit 1; }
+            echo "OK: no libasound on this runner - wizard line correctly suppressed"
+          fi
       - name: Smoke test desktop launcher (spawn + supervise + no-orphan)
         # The launcher IS the bundle's double-click face now. Prove the
         # integrated shape on each native leg: launcher finds its

--- a/docs/install.md
+++ b/docs/install.md
@@ -135,9 +135,14 @@ directly, with `manifest.json` holding their sha256s:
 Windows, `mStream.app` on macOS, `mstream-desktop` on Linux — starts the
 server in the background, puts an mStream icon in your tray / menu bar
 (a status line — "Running · up 3h 12m", or Starting… / Stopped — then Open
-mStream · Quick Connect · Start at login · View logs · Restart server · Quit),
-and opens your browser at the player. Start-at-login is on by default; one
-click in the tray menu turns it off.
+mStream · Quick Connect · Set up mStream · Start at login · View logs ·
+Restart server · Quit), and opens your browser at the player. Start-at-login
+is on by default; one click in the tray menu turns it off. **Set up mStream**
+opens a terminal running the guided setup wizard (the bundled
+`mstream-player setup`) — music folders, admin account, extras — and stays
+useful later: reopened, it picks up what the server already has. Headless
+installs get the same invitation as a boot log line whenever the server has
+no folders and no accounts yet.
 
 **Terminal users lose nothing.** The same desktop binary run from a terminal
 behaves exactly like the server itself (same flags, output, and exit codes) —

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -207,6 +207,41 @@ pub fn browse_target(config: &Path, ep: &Endpoint) -> String {
     }
 }
 
+/// The platform key of the terminal player binary — mirrors playerKey() in
+/// src/util/mstream-player-bootstrap.js (the manifest and the bundle are
+/// keyed by the full filename). No musl arm: launcher builds are glibc-only,
+/// and musl bundles are headless.
+pub fn player_key() -> String {
+    let plat = if cfg!(target_os = "macos") {
+        "darwin"
+    } else if cfg!(windows) {
+        "win32"
+    } else {
+        "linux"
+    };
+    let arch = match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        "x86_64" => "x64",
+        other => other,
+    };
+    let ext = if cfg!(windows) { ".exe" } else { "" };
+    format!("mstream-player-{plat}-{arch}{ext}")
+}
+
+/// The terminal player for the "Set up mStream" item: the copy build-bun
+/// stages next to the server binary in every desktop bundle, else one the
+/// server's runtime fetch installed in the shared data home. None disables
+/// the item — a greyed entry beats a terminal window that dies instantly.
+pub fn find_player_bin(server_bin: &Path, data_home: &Path) -> Option<PathBuf> {
+    let key = player_key();
+    let bundled = server_bin.parent()?.join("bin").join("mstream-player").join(&key);
+    if bundled.exists() {
+        return Some(bundled);
+    }
+    let managed = data_home.join("bin").join("mstream-player").join(&key);
+    managed.exists().then_some(managed)
+}
+
 /// Escape a literal string for use inside a POSIX ERE (the pgrep -f
 /// patterns built from filesystem paths): a HOME containing '+', '?',
 /// '(' or brackets must match itself — a metacharacter that COMPILES but
@@ -420,6 +455,47 @@ mod tests {
         let out = read_endpoint(&p);
         let _ = std::fs::remove_file(&p);
         out
+    }
+
+    #[test]
+    fn player_key_matches_node_bootstrap_shape() {
+        // The manifest and the bundle are keyed by the full filename; this
+        // must stay in lockstep with playerKey() in
+        // src/util/mstream-player-bootstrap.js.
+        let key = player_key();
+        #[cfg(target_os = "macos")]
+        assert!(key.starts_with("mstream-player-darwin-"), "{key}");
+        #[cfg(windows)]
+        {
+            assert!(key.starts_with("mstream-player-win32-"), "{key}");
+            assert!(key.ends_with(".exe"), "{key}");
+        }
+        #[cfg(all(unix, not(target_os = "macos")))]
+        assert!(key.starts_with("mstream-player-linux-"), "{key}");
+        assert!(!key.contains("x86_64") && !key.contains("aarch64"), "node arch names, not Rust's: {key}");
+    }
+
+    #[test]
+    fn find_player_bin_prefers_bundled_then_managed() {
+        let root = env::temp_dir().join(format!("mstream-launcher-player-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let bundle = root.join("bundle");
+        let home = root.join("home");
+        let key = player_key();
+        let server = bundle.join("mstream-server");
+        std::fs::create_dir_all(bundle.join("bin/mstream-player")).unwrap();
+        std::fs::create_dir_all(home.join("bin/mstream-player")).unwrap();
+
+        assert_eq!(find_player_bin(&server, &home), None, "neither copy exists yet");
+
+        let managed = home.join("bin/mstream-player").join(&key);
+        std::fs::write(&managed, b"x").unwrap();
+        assert_eq!(find_player_bin(&server, &home), Some(managed), "managed fallback");
+
+        let bundled = bundle.join("bin/mstream-player").join(&key);
+        std::fs::write(&bundled, b"x").unwrap();
+        assert_eq!(find_player_bin(&server, &home), Some(bundled), "bundled copy wins");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -509,6 +509,7 @@ fn sh_quote(p: &std::path::Path) -> String {
     sh_quote_str(&p.display().to_string())
 }
 
+#[cfg(unix)]
 fn sh_quote_str(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -283,6 +283,87 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
     }
 }
 
+/// Run the bundled terminal player's setup wizard in a fresh terminal
+/// window, pointed at this launcher's server. Same per-OS "what is a
+/// terminal" seams as open_logs_terminal; the caller logs a failure — a
+/// missing terminal emulator must never take the tray down.
+pub fn open_setup_terminal(
+    player_bin: &std::path::Path,
+    server_url: &str,
+    scratch_dir: &std::path::Path,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Terminal.app opens an executable .command file as a document — no
+        // AppleEvents automation consent (see open_logs_terminal). The CSI 8
+        // resize asks for the window the wizard's two-column pages were
+        // designed around; Terminal.app honors it, and a terminal that
+        // doesn't just keeps its size (the wizard reflows).
+        let script = scratch_dir.join("setup-mstream.command");
+        let body = format!(
+            "#!/bin/sh\n# Written by mStream's tray 'Set up mStream' item - safe to delete.\nprintf '\\033[8;42;120t'\nclear\nexec {player} setup --server {url}\n",
+            player = sh_quote(player_bin),
+            url = sh_quote_str(server_url),
+        );
+        std::fs::write(&script, body).map_err(|e| format!("write {}: {e}", script.display()))?;
+        let _ = std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755));
+        std::process::Command::new("/usr/bin/open")
+            .arg(&script)
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| format!("open {}: {e}", script.display()))
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        let _ = scratch_dir; // no script file on this path
+        // Windows Terminal first (App Execution Alias on PATH, preinstalled
+        // on Win11): it draws the wizard's pixel art via sixel. Without it,
+        // a fresh conhost window still runs the wizard — crossterm enables
+        // VT there and the art degrades to half-blocks.
+        if std::process::Command::new("wt.exe")
+            .arg(player_bin)
+            .args(["setup", "--server", server_url])
+            .spawn()
+            .is_ok()
+        {
+            return Ok(());
+        }
+        const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+        std::process::Command::new(player_bin)
+            .args(["setup", "--server", server_url])
+            .creation_flags(CREATE_NEW_CONSOLE)
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| format!("spawn {}: {e}", player_bin.display()))
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let _ = scratch_dir; // no script file on this path
+        let cmd = format!(
+            "exec {player} setup --server {url}",
+            player = sh_quote(player_bin),
+            url = sh_quote_str(server_url),
+        );
+        let candidates = [
+            ("x-terminal-emulator", ["-e", "sh", "-c", cmd.as_str()]),
+            ("gnome-terminal", ["--", "sh", "-c", cmd.as_str()]),
+            ("konsole", ["-e", "sh", "-c", cmd.as_str()]),
+            ("xfce4-terminal", ["-x", "sh", "-c", cmd.as_str()]),
+            ("xterm", ["-e", "sh", "-c", cmd.as_str()]),
+        ];
+        for (bin, args) in candidates {
+            if std::process::Command::new(bin).args(args).spawn().is_ok() {
+                return Ok(());
+            }
+        }
+        Err("no terminal emulator found (tried x-terminal-emulator, gnome-terminal, \
+             konsole, xfce4-terminal, xterm)"
+            .to_string())
+    }
+}
+
 /// Start the NEW launcher for the apply-update handoff, detached, and return
 /// so the caller can exit. Always passes `--takeover`: the new instance
 /// retries the single-instance lock briefly (we still hold it for the last
@@ -425,7 +506,11 @@ pub fn spawn_installer_detached(installer: &std::path::Path, silent: bool) -> Re
 /// home ("Application Support") guarantees a space.
 #[cfg(unix)]
 fn sh_quote(p: &std::path::Path) -> String {
-    format!("'{}'", p.display().to_string().replace('\'', "'\\''"))
+    sh_quote_str(&p.display().to_string())
+}
+
+fn sh_quote_str(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 #[cfg(all(test, target_os = "macos"))]
@@ -438,5 +523,20 @@ mod tests {
         std::fs::write(dir.join("launcher.log"), "[demo] launcher.log content\n").unwrap();
         std::fs::write(dir.join("server-console.log"), "[demo] server-console.log content\n").unwrap();
         super::open_logs_terminal(&dir).unwrap();
+    }
+
+    #[test]
+    #[ignore = "spawns a real Terminal window - run manually with --ignored"]
+    fn manual_open_setup_terminal() {
+        // MSTREAM_DEMO_PLAYER = a real player binary; MSTREAM_DEMO_SERVER =
+        // the URL to point its wizard at.
+        let player = std::path::PathBuf::from(
+            std::env::var("MSTREAM_DEMO_PLAYER").expect("set MSTREAM_DEMO_PLAYER"),
+        );
+        let url = std::env::var("MSTREAM_DEMO_SERVER")
+            .unwrap_or_else(|_| "http://localhost:3000".into());
+        let dir = std::env::temp_dir().join("mstream-setup-demo");
+        std::fs::create_dir_all(&dir).unwrap();
+        super::open_setup_terminal(&player, &url, &dir).unwrap();
     }
 }

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -89,6 +89,10 @@ pub fn run(args: LauncherArgs) -> ! {
     let server_dir = bin.parent().map(Path::to_path_buf).unwrap_or_else(|| PathBuf::from("."));
     let config = paths::resolve_config_path(&args.server_args, &server_dir);
     let ep = paths::read_endpoint(&config);
+    // The terminal setup wizard the "Set up mStream" item runs — resolved
+    // once, like the server binary: an install doesn't gain or lose its
+    // bundled player mid-session.
+    let player_bin = paths::find_player_bin(&bin, &data_home);
 
     // ── Single instance: the lock lives in the data home, so two launchers
     // managing the same data/port exclude each other (two --portable
@@ -347,6 +351,11 @@ pub fn run(args: LauncherArgs) -> ! {
                 upd_text = utext;
                 let open_item = MenuItem::with_id("open", "Open mStream", true, None);
                 let qc_item = MenuItem::with_id("quick-connect", "Quick Connect", true, None);
+                // Guided first-run setup (folders, account, extras) in a real
+                // terminal. Stays useful after first run — the wizard seeds
+                // itself from the server's committed state — so it is always
+                // offered, greyed only when this install has no player binary.
+                let setup_item = MenuItem::with_id("setup", "Set up mStream", player_bin.is_some(), None);
                 let auto_item =
                     CheckMenuItem::with_id("autostart", "Start at login", true, autostart::is_enabled(), None);
                 let logs_item = MenuItem::with_id("logs", "View logs", true, None);
@@ -357,6 +366,7 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&open_item);
                 let _ = menu.append(&qc_item);
+                let _ = menu.append(&setup_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&auto_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
@@ -495,6 +505,19 @@ pub fn run(args: LauncherArgs) -> ! {
                         // The web UI opens its Quick Connect modal on this
                         // hash (webapp/assets/js/quick-connect.js).
                         let _ = open::that_detached(format!("{url}/#quick-connect"));
+                    }
+                    "setup" => {
+                        log.line("menu: set up mstream");
+                        match player_bin.as_deref() {
+                            Some(player) => {
+                                if let Err(e) = platform::open_setup_terminal(player, &url, &data_home) {
+                                    log.line(&format!("setup wizard failed: {e}"));
+                                }
+                            }
+                            // Unreachable through the menu (the item is
+                            // disabled), kept for the record.
+                            None => log.line("setup wizard unavailable: no mstream-player binary in this install"),
+                        }
                     }
                     "autostart" => {
                         // muda toggles the checkbox before we hear about it,

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@ import https from 'https';
 import net from 'net';
 import crypto from 'crypto';
 import { dataRoot, usingFallbackDataRoot } from './util/esm-helpers.js';
-import { installedPlayerPath } from './util/mstream-player-bootstrap.js';
+import { installedPlayerPath, playerLoadableHere } from './util/mstream-player-bootstrap.js';
 
 import * as dbApi from './api/db.js';
 import * as discoveryApi from './api/discovery.js';
@@ -759,12 +759,14 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     // untouched — a deliberate public-mode server has folders, so it never
     // sees this after setup. The terminal-wizard line appears only when the
     // player binary is already on this machine (bundles ship it; musl and
-    // docker hosts have no build and get the browser line alone) — checking
-    // is a stat, never a download.
+    // docker hosts have no build and get the browser line alone) AND its
+    // libraries load here (headless linux without ALSA can't even run its
+    // --version) — checking is a stat plus at most one ldconfig, never a
+    // download.
     if (Object.keys(config.program.folders || {}).length === 0 && dbManager.getAllUsers().length === 0) {
       winston.info('This server is not set up yet — open the address above in a browser to add music folders and an admin account.');
       const wizard = installedPlayerPath();
-      if (wizard) {
+      if (wizard && playerLoadableHere()) {
         winston.info(`Prefer a guided terminal setup? Run: "${wizard}" setup --server ${protocol}://localhost:${config.program.port}`);
       }
     }

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import https from 'https';
 import net from 'net';
 import crypto from 'crypto';
 import { dataRoot, usingFallbackDataRoot } from './util/esm-helpers.js';
+import { installedPlayerPath } from './util/mstream-player-bootstrap.js';
 
 import * as dbApi from './api/db.js';
 import * as discoveryApi from './api/discovery.js';
@@ -753,6 +754,20 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     // starts over. Cheap no-op everywhere the guard never ran.
     bootWatchdog.markBootOk();
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
+
+    // First-boot invitation. No folders AND no accounts means genuinely
+    // untouched — a deliberate public-mode server has folders, so it never
+    // sees this after setup. The terminal-wizard line appears only when the
+    // player binary is already on this machine (bundles ship it; musl and
+    // docker hosts have no build and get the browser line alone) — checking
+    // is a stat, never a download.
+    if (Object.keys(config.program.folders || {}).length === 0 && dbManager.getAllUsers().length === 0) {
+      winston.info('This server is not set up yet — open the address above in a browser to add music folders and an admin account.');
+      const wizard = installedPlayerPath();
+      if (wizard) {
+        winston.info(`Prefer a guided terminal setup? Run: "${wizard}" setup --server ${protocol}://localhost:${config.program.port}`);
+      }
+    }
 
     // A settings change landed while the reboot above was already past its
     // config read (see rebootPending): go straight around again rather than

--- a/src/util/mstream-player-bootstrap.js
+++ b/src/util/mstream-player-bootstrap.js
@@ -36,7 +36,7 @@
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
+import { spawn, execSync } from 'node:child_process';
 import winston from 'winston';
 import { appRoot, dataRoot } from './esm-helpers.js';
 import { downloadToFile, computeFileChecksum } from './ffmpeg-bootstrap.js';
@@ -150,6 +150,21 @@ export function installedPlayerPath({ bundledDir = defaultManifestDir(), install
     if (fs.existsSync(candidate)) { return candidate; }
   }
   return null;
+}
+
+// The linux player links libasound at LOAD time (it is an audio engine
+// first), so on a headless box without ALSA even `--version` dies with a
+// loader error — an invitation must not greet a fresh install with that.
+// Non-linux platforms link only ever-present system audio (CoreAudio /
+// WASAPI), so they are always loadable.
+export function playerLoadableHere() {
+  if (process.platform !== 'linux') { return true; }
+  try {
+    return execSync('ldconfig -p', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+      .includes('libasound.so.2');
+  } catch (_err) {
+    return false; // no ldconfig ⇒ can't prove ALSA ⇒ don't print a command that may die
+  }
 }
 
 // The one place a download URL is built from the pins. Exported so the

--- a/src/util/mstream-player-bootstrap.js
+++ b/src/util/mstream-player-bootstrap.js
@@ -140,6 +140,18 @@ export function canAutoFetch(opts = {}) {
   return manifestEntry(opts) !== null;
 }
 
+// A player binary that is ALREADY on this machine — the bundled copy next to
+// the server (build-bun stages it into every non-musl bundle) or a previously
+// fetched managed one — or null. Never downloads: this feeds boot-time
+// messaging, which must not cost a network round-trip or imply consent to one.
+export function installedPlayerPath({ bundledDir = defaultManifestDir(), installDir = managedPlayerDir(), key = playerKey() } = {}) {
+  for (const dir of [bundledDir, installDir]) {
+    const candidate = path.join(dir, key);
+    if (fs.existsSync(candidate)) { return candidate; }
+  }
+  return null;
+}
+
 // The one place a download URL is built from the pins. Exported so the
 // bundler and the unit tests share the exact shape — callers only ever hand
 // it a manifestEntry() result, i.e. already-validated tokens.

--- a/test/unit/mstream-player-fetch.test.mjs
+++ b/test/unit/mstream-player-fetch.test.mjs
@@ -34,7 +34,7 @@ import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
 
-import { ensurePlayer, manifestEntry, canAutoFetch, deriveAssetUrl, playerKey, installedPlayerPath, reset } from '../../src/util/mstream-player-bootstrap.js';
+import { ensurePlayer, manifestEntry, canAutoFetch, deriveAssetUrl, playerKey, installedPlayerPath, playerLoadableHere, reset } from '../../src/util/mstream-player-bootstrap.js';
 
 const KEY = playerKey();
 const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
@@ -129,6 +129,14 @@ describe('mstream-player-bootstrap: manifest-pinned fetch', () => {
 
     // Boot-time messaging must never cost a network round-trip.
     assert.deepEqual(hits, []);
+  });
+
+  test('playerLoadableHere: non-linux is always loadable; linux answers from ldconfig', () => {
+    const loadable = playerLoadableHere();
+    assert.equal(typeof loadable, 'boolean');
+    if (process.platform !== 'linux') {
+      assert.equal(loadable, true, 'CoreAudio/WASAPI hosts never gate the invitation');
+    }
   });
 
   test('happy path: downloads (from the pinned file name), verifies, installs, and writes the receipt', async () => {

--- a/test/unit/mstream-player-fetch.test.mjs
+++ b/test/unit/mstream-player-fetch.test.mjs
@@ -34,7 +34,7 @@ import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
 
-import { ensurePlayer, manifestEntry, canAutoFetch, deriveAssetUrl, playerKey, reset } from '../../src/util/mstream-player-bootstrap.js';
+import { ensurePlayer, manifestEntry, canAutoFetch, deriveAssetUrl, playerKey, installedPlayerPath, reset } from '../../src/util/mstream-player-bootstrap.js';
 
 const KEY = playerKey();
 const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
@@ -111,6 +111,24 @@ describe('mstream-player-bootstrap: manifest-pinned fetch', () => {
     // server (exactly how an air-gapped mirror would). Tests probing the
     // override/refusal behavior adjust this themselves.
     process.env.MSTREAM_PLAYER_BASE = baseUrl;
+  });
+
+  test('installedPlayerPath: bundled copy wins, managed is the fallback, absence is null — and it never fetches', () => {
+    const bundledDir = path.join(tmpRoot, 'present-bundled');
+    const installDir = path.join(tmpRoot, 'present-managed');
+    fs.mkdirSync(bundledDir, { recursive: true });
+    fs.mkdirSync(installDir, { recursive: true });
+
+    assert.equal(installedPlayerPath({ bundledDir, installDir }), null);
+
+    fs.writeFileSync(path.join(installDir, KEY), GOOD_BODY);
+    assert.equal(installedPlayerPath({ bundledDir, installDir }), path.join(installDir, KEY));
+
+    fs.writeFileSync(path.join(bundledDir, KEY), GOOD_BODY);
+    assert.equal(installedPlayerPath({ bundledDir, installDir }), path.join(bundledDir, KEY));
+
+    // Boot-time messaging must never cost a network round-trip.
+    assert.deepEqual(hits, []);
   });
 
   test('happy path: downloads (from the pinned file name), verifies, installs, and writes the receipt', async () => {


### PR DESCRIPTION
Wires the v0.4.0 setup wizard (companion to #907) into both first-run surfaces:

**Tray launcher** — new "Set up mStream" menu item (between Quick Connect and the autostart toggle) opens a real terminal running the bundled `mstream-player setup --server <this server>`. Per-OS seams mirror `open_logs_terminal`:
- macOS: executable `.command` via `open` (no AppleEvents consent prompt), with a CSI 8 resize to the wizard's designed 120×42
- Windows: `wt.exe` first (Windows Terminal renders the wizard's pixel art via sixel), falling back to a fresh conhost (`CREATE_NEW_CONSOLE`; the wizard degrades to half-blocks)
- Linux: the same emulator-candidate walk as View logs

The player binary is resolved once at boot — the copy build-bun stages next to the server binary first, then the server's runtime-fetched managed copy — and the item is greyed out when neither exists (musl installs have no player build).

**Server** — when a boot finds no folders **and** no accounts, the boot log invites setup: the browser line always, plus the exact runnable wizard command when a player binary is already present (`installedPlayerPath()` is a stat, never a download). A deliberately public server has folders, so it never nags after setup.

**Old-server compat note**: the shipped wizard treats scan-progress endpoints as garnish (`Err(_) => {}`) — against a server without `/api/v1/scan/status` it silently misses the final "scan complete" flip and nothing else; no error surfaces.

Verification:
- `cargo test`: 35 green, including new `player_key` (node-name lockstep) and `find_player_bin` (bundled-beats-managed) coverage; clippy clean
- node suite: 2390 tests, 0 failures (discovery-p2p files excluded — they fail identically on a pristine tree in this environment)
- live macOS smoke: fresh sandboxed server printed both invitation lines with the exact runnable command; `open_setup_terminal` drew the wizard in Terminal.app at 120×42 against that server; after configuring folders+admin through the wizard's own API surface and rebooting, neither line printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)