### PR TITLE
Boot hold: serve a live diagnosis and self-heal instead of crash-looping on environmental failures

### DIFF
--- a/src/db/bun-sqlite-adapter.js
+++ b/src/db/bun-sqlite-adapter.js
@@ -13,12 +13,19 @@ import { Database } from 'bun:sqlite';
 // name ('SQLITE_ERROR', ...) or undefined (e.g. FTS5 MATCH parse errors).
 // Callers key on the node-style code — notably the FTS5->LIKE search fallback
 // in src/api/search.js and src/api/subsonic/handlers.js — so translate it here
-// so the shim is behaviourally indistinguishable from node:sqlite.
+// so the shim is behaviourally indistinguishable from node:sqlite. The
+// numeric result code matters too: node:sqlite carries it in `errcode`,
+// bun's SQLiteError in `errno` — mirror it across so consumers that map
+// codes (util/boot-errors.js classifying a boot failure as environmental)
+// see one shape on both runtimes.
 function withNodeErrors(fn) {
   try {
     return fn();
   } catch (err) {
-    if (err && err.name === 'SQLiteError') { err.code = 'ERR_SQLITE_ERROR'; }
+    if (err && err.name === 'SQLiteError') {
+      err.code = 'ERR_SQLITE_ERROR';
+      if (err.errcode === undefined && Number.isInteger(err.errno)) { err.errcode = err.errno; }
+    }
     throw err;
   }
 }
@@ -36,9 +43,13 @@ class StatementSync {
 export class DatabaseSync {
   #db;
   constructor(location, options = {}) {
-    this.#db = options.readOnly
+    // The open itself must be wrapped too: a bun:sqlite open failure
+    // (SQLITE_CANTOPEN on a vanished volume, SQLITE_READONLY on a bad
+    // mount) is exactly what the boot-failure classifier needs to see in
+    // node:sqlite's shape — unwrapped, those crashed unclassified.
+    this.#db = withNodeErrors(() => (options.readOnly
       ? new Database(location, { readonly: true })
-      : new Database(location, { create: true });
+      : new Database(location, { create: true })));
   }
   exec(sql) { return withNodeErrors(() => this.#db.exec(sql)); }
   prepare(sql) { return new StatementSync(withNodeErrors(() => this.#db.prepare(sql))); }

--- a/src/db/manager.js
+++ b/src/db/manager.js
@@ -201,8 +201,20 @@ export function transaction(fn) {
 
 export function close() {
   stopSharedCleanup();
+  // The caches memoize rows read through the handle being released; the next
+  // initDB() must re-read them from whatever file it opens. This matters for
+  // the boot hold (server.js): a failed initDB can populate some caches from
+  // a damaged database before throwing, the operator replaces the file, and
+  // the retry's initDB would otherwise serve users/libraries from the old
+  // bytes (loadUsersCache & co. early-return when already populated).
+  invalidateCache();
+  _anonymousUserId = null;
   if (db) {
-    db.close();
+    // A half-configured handle (constructor succeeded, a pragma threw — the
+    // boot-hold entry path) may refuse to close cleanly; that must not turn
+    // the release into a crash. Releasing also matters on Windows: an open
+    // handle blocks the operator from replacing a damaged mstream.db.
+    try { db.close(); } catch (err) { winston.warn(`Could not close the database handle: ${err.message}`); }
     db = null;
   }
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -171,6 +171,18 @@ winston.configure({
   exitOnError: false
 });
 
+// A transport write failure — ENOSPC on the log file when the disk fills
+// being the case that matters — is re-emitted as 'error' on the default
+// logger (winston Logger._onEvent), and an unlistened 'error' on a stream is
+// an uncaught exception: logging about a full disk would KILL the process,
+// which is exactly the moment the boot hold needs logging to stay soft
+// (server.js). The facade doesn't expose the default logger instance;
+// startTimer()'s Profiler carries a public reference to it. exitOnError
+// above does not cover this path — that flag is for the exception handler.
+winston.startTimer().logger.on('error', (err) => {
+  try { fs.writeSync(2, `[logger] transport error: ${err && err.message ? err.message : err}\n`); } catch { /* stderr gone too */ }
+});
+
 function dateKey() {
   const d = new Date();
   const pad = n => String(n).padStart(2, '0');
@@ -217,6 +229,12 @@ function rotateIfNeeded() {
 }
 
 export function addFileLogger(filepath) {
+  // Already writing to this exact directory: nothing to do. The 60s
+  // rotateIfNeeded interval owns date rollover and re-pruning. This makes
+  // the call idempotent for serveIt re-runs — a soft reboot, and especially
+  // the boot hold's 15s retry loop, which would otherwise close/reopen the
+  // stream and re-stat every retained log file on every retry.
+  if (fileTransport && currentDirname === filepath) { return; }
   if (fileTransport) { reset(); }
 
   fs.mkdirSync(filepath, { recursive: true });

--- a/src/server.js
+++ b/src/server.js
@@ -62,6 +62,7 @@ import { isAdminAllowed } from './util/admin-network.js';
 import { writeJsonAtomic, completedWrites } from './util/atomic-json.js';
 import * as updateCheck from './util/update-check.js';
 import * as bootWatchdog from './util/boot-watchdog.js';
+import { classifyBootError, renderHoldPage } from './util/boot-errors.js';
 
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -138,6 +139,190 @@ function rebootStub(req, res) {
   res.end('mStream is restarting');
 }
 
+// ── Boot hold ────────────────────────────────────────────────────────────
+// When a FIRST boot fails on something ENVIRONMENTAL — a full disk, a
+// read-only or vanished volume, a damaged database file (util/boot-errors.js
+// draws the line) — exiting is the worst available move: every supervisor
+// around us (s6 in the docker image, the desktop launcher, systemd) restarts
+// a crashed process, so the user gets an infinite banner/crash loop on a
+// dead port, and the actual cause ("disk I/O error") scrolls by unexplained.
+// Instead the boot HOLDS: the configured port is bound, every request
+// answers 503 with the real diagnosis — a human page for browsers, JSON
+// otherwise — and the full boot is retried on a timer. The moment a retry
+// succeeds, serveIt()'s keep-listener path swaps the real app onto the
+// socket, exactly like a soft reboot.
+//
+// Deliberately FIRST boots only: a soft reboot that hits the same failure
+// still exits (with the same diagnosis logged), because the previous life's
+// timers and watchers would otherwise outlive their closed db handle inside
+// the hold — see the classifier call site. A supervised install restarts
+// once and lands right here; an unsupervised one dies with the reason on
+// its last lines. Non-environmental failures crash precisely as before.
+//
+// Holding is the whole state: bootHoldMemory is non-null exactly while the
+// boot is held (its retries included), and onListening clears it the moment
+// a boot completes. Exactly one retry timer is ever pending — each timer
+// runs one retry, and only that retry's failure arms the next.
+let bootHoldMemory = null;  // { since, attempts, lastHeadline, diagnosis }
+
+function bootHoldRetryMs() {
+  // Test hook: the integration suite can't wait 15 s per retry.
+  const n = parseInt(process.env.MSTREAM_BOOT_HOLD_RETRY_MS, 10);
+  return Number.isFinite(n) ? Math.max(250, n) : 15000;
+}
+
+function bootHoldRetrySeconds() {
+  return Math.max(1, Math.ceil(bootHoldRetryMs() / 1000));
+}
+
+// The three operator-facing lines of a diagnosis, together — the hold's
+// gated logging and the reboot-path exit must print the same shape.
+function logBootDiagnosis(diagnosis) {
+  winston.error(diagnosis.headline);
+  winston.error(`  ${diagnosis.detail}`);
+  winston.error(`  ${diagnosis.hint}`);
+}
+
+function bootHoldHandler(req, res) {
+  // Defensive null-arm: unreachable today (the handler is only attached
+  // while bootHoldMemory is set), but a throw in a raw 'request' handler
+  // would be an uncaught exception — the one thing a hold must never do.
+  const d = bootHoldMemory ? bootHoldMemory.diagnosis : null;
+  const retrySeconds = bootHoldRetrySeconds();
+  res.statusCode = 503;
+  res.setHeader('Retry-After', String(retrySeconds));
+  res.setHeader('X-MStream-Boot-Hold', d ? d.reason : 'unknown');
+  res.setHeader('Connection', 'close');
+  if ((req.headers.accept || '').includes('text/html')) {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.end(renderHoldPage(d, { retrySeconds }));
+  } else {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(d
+      ? { error: d.headline, code: d.reason, detail: d.detail, hint: d.hint }
+      : { error: 'mStream cannot start yet', code: 'unknown' }));
+  }
+}
+
+// Put the not-yet-listening server serveIt already built for this bind on
+// the air as the hold listener. The listener object, its liveSockets
+// bookkeeping and the socket tagging were all wired by serveIt's
+// !keepListener branch — reusing it (instead of building a second one) is
+// what lets the keep-listener swap hand this exact socket to the app on
+// recovery. If the bind itself fails there is nothing to hold WITH: reject
+// with the ORIGINAL boot error and let the wrapper exit non-zero, the
+// pre-hold behaviour.
+function adoptHoldListener(bind, cause) {
+  return new Promise((resolve, reject) => {
+    const held = server;
+    if (!held || held.listening) {
+      // Can't happen on the paths that lead here (see enterBootHold); bail
+      // to the pre-hold behaviour rather than crash with a puzzle.
+      return reject(cause);
+    }
+    held.on('request', bootHoldHandler);
+    let bound = false;
+    held.on('error', (err) => {
+      if (!bound) {
+        winston.error(`Cannot hold the boot: ${bindLabel(bind)} is unavailable (${err.code || err.message}) — giving up with the original error`);
+        reject(cause);
+        return;
+      }
+      // Post-bind errors mirror the real listener's handler, which never
+      // attaches to a hold-born socket (recovery takes the keep-listener
+      // path, which returns before registering it): ignore a superseded
+      // instance, treat anything else as fatal.
+      if (held !== server) {
+        winston.warn(`Ignoring '${err.code || err.message}' from a superseded server instance`);
+        try { held.close(); } catch (_) { /* already closed */ }
+        return;
+      }
+      winston.error(`Server error: ${err.message}`, { stack: err });
+      try { fs.writeSync(2, `mStream fatal: ${err.message}\n`); } catch (_) { /* stderr gone */ }
+      process.exit(1);
+    });
+    held.once('listening', () => {
+      bound = true;
+      currentBind = bind;
+      resolve();
+    });
+    held.listen(bind.port, bind.address);
+  });
+}
+
+async function enterBootHold(configFile, bind, diagnosis, cause) {
+  // The failure can leave a half-open handle behind (initDB assigns db
+  // before the first pragma runs). Release it — and the caches a partial
+  // init may have filled — so the hold pins nothing: on Windows an open
+  // handle blocks the operator from replacing a damaged mstream.db, the
+  // very fix the hold page asks for.
+  dbManager.close();
+
+  if (!bootHoldMemory) {
+    bootHoldMemory = { since: Date.now(), attempts: 0, lastHeadline: null, diagnosis: null };
+  }
+  const mem = bootHoldMemory;
+  mem.attempts += 1;
+  mem.diagnosis = diagnosis;
+
+  // Loud once, again whenever the diagnosis CHANGES (the disk filled, then
+  // the volume vanished...), and a heartbeat every 20 attempts (~5 min at
+  // the default interval) — so a long hold can't scroll out of the logs,
+  // and can't flood them either (the admin live-log ring is finite).
+  const changed = diagnosis.headline !== mem.lastHeadline;
+  if (changed || mem.attempts % 20 === 1) {
+    logBootDiagnosis(diagnosis);
+    if (changed) { winston.error('The underlying boot error follows for the record', { stack: cause }); }
+    winston.error(`Boot is HOLDING on ${bindLabel(currentBind || bind)} — all requests answer 503 with the diagnosis above; retrying every ${bootHoldRetrySeconds()}s until it is fixed (attempt ${mem.attempts})`);
+    mem.lastHeadline = diagnosis.headline;
+  }
+
+  if (server && server.listening) {
+    // Already on the air (a failed retry re-entering, or a retry whose
+    // config read failed): refresh the handler — off() first keeps the
+    // attach count at exactly one, and is a no-op when not attached.
+    server.off('request', bootHoldHandler);
+    server.on('request', bootHoldHandler);
+  } else {
+    await adoptHoldListener(bind, cause);
+  }
+
+  // The diagnosis handler stays attached THROUGH the retry (no "restarting"
+  // stub flash, and a retry that blocks on a dead network mount leaves the
+  // truthful page up instead of a stale stub); serveIt's keep-listener swap
+  // detaches it on success.
+  setTimeout(() => {
+    retryBoot(configFile).catch((err) => {
+      // retryBoot handles serveIt's rejection itself; reaching here means
+      // the retry plumbing broke — nothing is scheduled anymore, so limping
+      // on would strand the process in a hold that never retries.
+      winston.error('Boot-hold retry machinery failed', { stack: err });
+      try { fs.writeSync(2, `mStream fatal: boot-hold retry failed: ${err.message}\n`); } catch (_) { /* stderr gone */ }
+      process.exit(1);
+    });
+  }, bootHoldRetryMs());
+}
+
+async function retryBoot(configFile) {
+  // Belt for a timer that somehow outlives its hold (success clears the
+  // memory in onListening): re-running serveIt against a healthy server
+  // would close its database out from under it.
+  if (!bootHoldMemory) { return; }
+  try {
+    await serveIt(configFile, { relisten: currentBind });
+  } catch (err) {
+    // The failure moved — from environmental to something the classifier
+    // refuses to hold (a migration bug, bad certs). Same contract as a
+    // failed first boot: say it and exit non-zero.
+    winston.error('mStream failed to start', { stack: err });
+    try { fs.writeSync(2, `mStream fatal: ${err.message}\n`); } catch (_) { /* stderr gone */ }
+    process.exit(1);
+  }
+  // A holdable re-failure re-entered enterBootHold (which armed the next
+  // retry); a success ran onListening, which clears bootHoldMemory. Either
+  // way this invocation's work is done.
+}
+
 // Put a rejected bind change back: the previous port/address into the config
 // file (atomically — the admin's own saves go through the same writer), so
 // the next start doesn't fail on the value this one just refused.
@@ -205,18 +390,39 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     configWritesAtRead = completedWrites(configFile);
     await config.setup(configFile);
   } catch (err) {
+    if (bootHoldMemory) {
+      // A hold retry: the config usually shares the volume with the database
+      // (the docker layout mounts both under /config), so the very failure
+      // being held can make the config read/validate/persist throw too — an
+      // exit here would tear down an active, correctly-diagnosing hold and
+      // resume the supervisor crash loop. Stay held on the socket we have
+      // and say what the retry hit; the next retry re-reads the file.
+      await enterBootHold(configFile, currentBind, {
+        reason: 'config',
+        headline: 'mStream cannot start: reading its config file failed during a retry.',
+        detail: `${configFile} — ${err.message}`,
+        hint: 'If the config was just edited, fix it; if its volume is the one that failed, fixing the volume clears this too.',
+      }, err);
+      return;
+    }
     // A permission/read-only failure is NOT a malformed config, and saying so
     // sends the user hunting through a file that is usually fine (or absent):
     // name the real cause instead. dataRoot already redirects writable state
     // away from a read-only app (util/esm-helpers.js), so reaching this means
     // the chosen location itself is unwritable — an explicit -j/MSTREAM_CONFIG
     // pointing somewhere read-only, or a container mount without permission.
+    // A full disk gets its own words for the same reason: config.setup also
+    // creates storage directories and persists generated ids, and "Failed to
+    // validate" would point the operator at entirely the wrong thing.
     // (Desktop-launch users see the launcher's own boot-failure dialog; this
     // message is what its server log carries.)
     const denied = err.code === 'EROFS' || err.code === 'EACCES' || err.code === 'EPERM';
+    const noSpace = err.code === 'ENOSPC' || err.code === 'EDQUOT';
     winston.error(denied
       ? `mStream could not start — it can't write to ${configFile}: the location is read-only or permission was denied (${err.message})`
-      : 'Failed to validate config file', { stack: err });
+      : noSpace
+        ? `mStream could not start — the disk is full (${err.message}${err.path ? ` at ${err.path}` : ''})`
+        : 'Failed to validate config file', { stack: err });
     process.exit(1);
   }
 
@@ -388,10 +594,45 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   // 'exit' hook nor its signal handlers can run). Must happen BEFORE
   // initDB(): an orphan still writing would lock-fight this boot's
   // migrations, and a migration failure aborts the boot.
-  reapOrphanedScanner(config.program.storage.dbDirectory);
+  //
+  // Both the reap and the database open can fail for reasons that are the
+  // MACHINE's, not this build's — a full disk (SQLITE_IOERR_SHMSIZE at the
+  // WAL pragma was the 2026-08-25 production incident), a read-only or
+  // unmounted volume, a damaged db file. Those hold the boot (see Boot hold
+  // above) instead of crashing into the supervisor's restart loop; anything
+  // the classifier does not recognize as environmental rethrows and crashes
+  // exactly as before.
+  try {
+    // Skipped on hold retries: the first attempt already reaped, a booted
+    // server is the only thing that spawns scanners (so no new orphan can
+    // appear mid-hold), and the reap's deliberately synchronous process
+    // probes (multi-second on Windows) would stall the very event loop
+    // serving the diagnosis page every retry.
+    if (!bootHoldMemory) {
+      reapOrphanedScanner(config.program.storage.dbDirectory);
+    }
 
-  // Setup DB
-  dbManager.initDB();
+    // Setup DB
+    dbManager.initDB();
+  } catch (err) {
+    const diagnosis = classifyBootError(err, config.program.storage.dbDirectory);
+    if (!diagnosis) { throw err; }
+    if (relisten !== null && bootHoldMemory === null) {
+      // A REBOOT's re-serve, not a fresh boot or a hold retry (holds and
+      // their retries are exactly the bootHoldMemory-set states): the
+      // previous life's task-queue timers, watchers and in-flight handlers
+      // are still armed, and initDB already closed their database handle —
+      // holding here would leave them to crash into a dead db minutes later
+      // (there is no global uncaughtException net). Keep the reboot contract
+      // (exit non-zero) but say WHY first; a supervised install restarts
+      // once and that fresh boot lands in the hold below with the same
+      // diagnosis.
+      logBootDiagnosis(diagnosis);
+      throw err;
+    }
+    await enterBootHold(configFile, bind, diagnosis, err);
+    return;
+  }
 
   // The separate music-discovery DB opens at boot only when collection is
   // enabled (the admin toggle initializes it on demand otherwise). Failure
@@ -752,6 +993,11 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     // watchdog's attempt counter (armed pre-boot in cli-boot-wrapper.js)
     // starts over. Cheap no-op everywhere the guard never ran.
     bootWatchdog.markBootOk();
+    if (bootHoldMemory) {
+      const heldFor = Math.round((Date.now() - bootHoldMemory.since) / 1000);
+      winston.info(`Boot hold cleared: mStream started after ${heldFor}s and ${bootHoldMemory.attempts} ${bootHoldMemory.attempts === 1 ? 'retry' : 'retries'}`);
+      bootHoldMemory = null;
+    }
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
 
     // A settings change landed while the reboot above was already past its
@@ -880,6 +1126,9 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     // socket was created stay in place; nothing about them is per-app.
     winston.info(`Reboot: bind unchanged (${bindLabel(bind)}) — keeping the listening socket`);
     server.off('request', rebootStub);
+    // A recovering boot hold keeps its diagnosis handler attached through
+    // the retry (see enterBootHold) — this swap is where it comes off.
+    server.off('request', bootHoldHandler);
     server.on('request', mstream);
     // Fire-and-forget on purpose: same contract as the 'listening' event
     // dispatch below (a rejection surfaces the same way in both paths).

--- a/src/util/boot-errors.js
+++ b/src/util/boot-errors.js
@@ -1,0 +1,240 @@
+// Boot-time database failures come in two kinds. Bugs — a migration with a
+// typo, a schema from this build's future — must crash loudly: restarting
+// cannot help, and the stack IS the diagnosis. Environmental failures — a
+// full disk, a read-only or vanished volume, a damaged database file — are
+// the opposite: the stack is noise ("disk I/O error", errcode 4874), and
+// every supervisor around us (s6 in the docker image, the desktop launcher,
+// systemd) answers a crash by restarting, turning the failure into an
+// infinite banner-spamming boot loop with a dead port (the 2026-08-25
+// disk-full incident, to the letter). classifyBootError() draws that line:
+// a non-null result means "environmental — hold the boot, serve this
+// diagnosis, retry"; null means "not ours to soften — crash as before".
+// server.js owns the holding; this module owns the judgement and the words.
+import fs from 'fs';
+import path from 'path';
+
+// SQLite primary result codes (the low byte of the extended code).
+const SQLITE_BUSY = 5;
+const SQLITE_LOCKED = 6;
+const SQLITE_READONLY = 8;
+const SQLITE_IOERR = 10;
+const SQLITE_CORRUPT = 11;
+const SQLITE_FULL = 13;
+const SQLITE_CANTOPEN = 14;
+const SQLITE_NOTADB = 26;
+
+// SQLITE_IOERR_* subcode names (extended code >> 8) worth spelling out —
+// "disk I/O error" alone sends the operator nowhere, but "SHMSIZE" is
+// googlable and tells us exactly which syscall failed in a bug report.
+const IOERR_SUBCODES = {
+  1: 'READ', 2: 'SHORT_READ', 3: 'WRITE', 4: 'FSYNC', 5: 'DIR_FSYNC',
+  6: 'TRUNCATE', 7: 'FSTAT', 13: 'ACCESS', 15: 'LOCK', 18: 'SHMOPEN',
+  19: 'SHMSIZE', 20: 'SHMLOCK', 21: 'SHMMAP', 24: 'MMAP',
+};
+
+// Below this much free space, an SQLITE_IOERR at open is called a full disk
+// outright: growing the WAL shared-memory file (32 KB) or replaying a WAL
+// needs room, and "I/O error on a disk with 3 MB free" has exactly one
+// realistic cause. Above it, the honest answer is the broader io-error text.
+const LOW_DISK_BYTES = 64 * 1024 * 1024;
+
+// Free space on the filesystem holding `dir`, or null when it can't be read:
+// statfs is missing on some runtimes (older Bun builds), and the directory
+// itself may be the thing that's broken. Enrichment only — never load-bearing.
+export function freeSpace(dir) {
+  try {
+    const s = fs.statfsSync(dir);
+    return {
+      freeBytes: Number(s.bavail) * Number(s.bsize),
+      totalBytes: Number(s.blocks) * Number(s.bsize),
+    };
+  } catch (_err) {
+    return null;
+  }
+}
+
+export function formatBytes(n) {
+  if (!Number.isFinite(n) || n < 0) { return 'unknown'; }
+  if (n >= 1024 ** 3) { return `${(n / 1024 ** 3).toFixed(1)} GB`; }
+  if (n >= 1024 ** 2) { return `${(n / 1024 ** 2).toFixed(1)} MB`; }
+  if (n >= 1024) { return `${Math.round(n / 1024)} KB`; }
+  return `${n} B`;
+}
+
+// A diagnosis: { reason, headline, detail, hint }. `reason` is a stable
+// machine token (tests, the X-MStream-Boot-Hold header); the three strings
+// are operator-facing. `probe` is injectable so unit tests can dictate the
+// free-space reading instead of inheriting the CI runner's disk.
+export function classifyBootError(err, dbDirectory, probe = freeSpace) {
+  if (!err) { return null; }
+  const dbPath = path.join(dbDirectory || '.', 'mstream.db');
+  const space = probe(dbDirectory);
+  const spaceNote = space
+    ? `${formatBytes(space.freeBytes)} free of ${formatBytes(space.totalBytes)}`
+    : 'free space unreadable';
+
+  const diskFull = (saidWhat) => ({
+    reason: 'disk-full',
+    headline: 'mStream cannot start: the disk holding its database is full.',
+    detail: `${dbPath} — ${spaceNote}; ${saidWhat}`,
+    hint: `Free up space on the volume that holds ${dbDirectory} (or grow it).`,
+  });
+  const unwritable = (saidWhat) => ({
+    reason: 'db-unwritable',
+    headline: 'mStream cannot start: it cannot write to its database.',
+    detail: `${dbPath} — ${saidWhat}`,
+    hint: `Check ownership and permissions on ${dbDirectory} — in docker, the PUID/PGID mapping of the config volume is the usual culprit; a volume mounted read-only is the other.`,
+  });
+  const missingDir = () => ({
+    reason: 'db-missing-dir',
+    headline: 'mStream cannot start: its database directory is missing.',
+    detail: `${dbDirectory} does not exist.`,
+    hint: 'If this directory lives on a mounted volume, the mount is gone — reattach it. Otherwise fix storage.dbDirectory in the config file.',
+  });
+
+  // node:sqlite tags errors with code ERR_SQLITE_ERROR and the extended
+  // result code in `errcode`; the bun:sqlite adapter normalizes `code` the
+  // same way but the number rides in bun's own `errno`.
+  const sqliteCode = err.code === 'ERR_SQLITE_ERROR'
+    ? (Number.isInteger(err.errcode) ? err.errcode : (Number.isInteger(err.errno) ? err.errno : null))
+    : null;
+  if (sqliteCode !== null) {
+    const primary = sqliteCode & 0xff;
+    const sub = sqliteCode >> 8;
+    const saidWhat = `SQLite said: ${err.errstr || err.message} (code ${sqliteCode})`;
+
+    switch (primary) {
+      case SQLITE_FULL:
+        return diskFull(saidWhat);
+      case SQLITE_IOERR: {
+        const subName = IOERR_SUBCODES[sub] ? `SQLITE_IOERR_${IOERR_SUBCODES[sub]}` : `SQLITE_IOERR subcode ${sub}`;
+        if (space && space.freeBytes < LOW_DISK_BYTES) {
+          return diskFull(`${saidWhat}, ${subName}`);
+        }
+        return {
+          reason: 'db-io',
+          headline: 'mStream cannot start: the disk or filesystem holding its database failed a low-level I/O operation.',
+          detail: `${dbPath} — ${saidWhat}, ${subName}; ${spaceNote}`,
+          hint: `This usually means a nearly-full disk, a failing drive, or a network/overlay filesystem that misbehaves under SQLite — check the volume that holds ${dbDirectory}.`,
+        };
+      }
+      case SQLITE_BUSY:
+      case SQLITE_LOCKED:
+        return {
+          reason: 'db-locked',
+          headline: 'mStream cannot start: another process is holding its database.',
+          detail: `${dbPath} — ${saidWhat}`,
+          hint: `Is a second mStream instance (or a stuck scanner) pointed at the same database directory ${dbDirectory}?`,
+        };
+      case SQLITE_READONLY:
+        return unwritable(saidWhat);
+      case SQLITE_CANTOPEN:
+        // The config layer normally creates the directory; reaching CANTOPEN
+        // with the directory absent means it vanished after that — a volume
+        // that came unmounted being the case worth naming.
+        if (dbDirectory && !fs.existsSync(dbDirectory)) { return missingDir(); }
+        return unwritable(saidWhat);
+      case SQLITE_CORRUPT:
+      case SQLITE_NOTADB:
+        return {
+          reason: 'db-damaged',
+          headline: 'mStream cannot start: its database file is damaged.',
+          detail: `${dbPath} — ${saidWhat}`,
+          hint: `Restore ${dbPath} from a backup if you have one. Moving the file aside lets mStream start fresh and rebuild the library by scanning — but playlists, play history and shares live in that file and would be lost with it.`,
+        };
+      default:
+        // Everything else — SQL logic errors, constraint violations, schema
+        // mismatches — is a bug or an incompatibility, not an environment.
+        return null;
+    }
+  }
+
+  // Plain filesystem errors: the scanner-pidfile reap, or the sqlite driver
+  // surfacing an open() failure as an fs error.
+  switch (err.code) {
+    case 'ENOSPC':
+    case 'EDQUOT':
+      return diskFull(`the filesystem said: ${err.message}`);
+    case 'EROFS':
+    case 'EACCES':
+    case 'EPERM':
+      return unwritable(err.message);
+    case 'ENOENT':
+      // Only when the database directory itself is gone: an ENOENT with the
+      // directory intact is some other path — let it crash and be seen.
+      if (dbDirectory && !fs.existsSync(dbDirectory)) { return missingDir(); }
+      return null;
+    case 'EMFILE':
+    case 'ENFILE':
+      return {
+        reason: 'fs-limit',
+        headline: 'mStream cannot start: the process ran out of open-file descriptors.',
+        detail: err.message,
+        hint: 'Raise the open-files limit for the mStream process (ulimit -n, or LimitNOFILE in a systemd unit).',
+      };
+    case 'EIO':
+      return {
+        reason: 'db-io',
+        headline: 'mStream cannot start: the disk holding its database reported an I/O error.',
+        detail: `${dbPath} — ${err.message}; ${spaceNote}`,
+        hint: `Check the health of the volume that holds ${dbDirectory} — kernel logs (dmesg) usually name the device.`,
+      };
+    default:
+      return null;
+  }
+}
+
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+// The page a browser sees while the boot holds. Self-contained (no webapp
+// assets — the app never mounted its static routes), self-refreshing (when a
+// retry succeeds, the next refresh lands in the real app), and honest about
+// what is wrong and what fixes it. API callers get JSON from the same 503
+// handler; this is only the text/html arm.
+export function renderHoldPage(diagnosis, { retrySeconds = 15 } = {}) {
+  const d = diagnosis || {
+    headline: 'mStream cannot start yet.',
+    detail: '',
+    hint: '',
+  };
+  // Refresh tracks the retry cadence but is clamped: never faster than 5s
+  // (pointless 503 churn), never slower than 15s (after a fix lands, the
+  // next refresh is what carries the user into the real app — a long retry
+  // interval must not also mean a long stare at a stale error page).
+  const refreshSeconds = Math.min(Math.max(Number(retrySeconds) || 15, 5), 15);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="${refreshSeconds}">
+<title>mStream — cannot start</title>
+<style>
+  body { margin: 0; padding: 3rem 1.5rem; background: #16181d; color: #e6e8eb;
+         font: 16px/1.6 system-ui, -apple-system, "Segoe UI", sans-serif; }
+  main { max-width: 44rem; margin: 0 auto; }
+  h1 { font-size: 1.4rem; margin: 0 0 1rem; color: #ff9f43; }
+  .detail { background: #0d0f12; border: 1px solid #2a2e36; border-radius: 6px;
+            padding: 0.9rem 1.1rem; white-space: pre-wrap; word-break: break-word;
+            font-family: ui-monospace, Consolas, monospace; font-size: 0.85rem; color: #aeb4bd; }
+  .hint { margin-top: 1.2rem; }
+  .footer { margin-top: 2rem; font-size: 0.85rem; color: #7b8494; }
+</style>
+</head>
+<body>
+<main>
+<h1>${escapeHtml(d.headline)}</h1>
+<div class="detail">${escapeHtml(d.detail)}</div>
+<p class="hint">${escapeHtml(d.hint)}</p>
+<p class="footer">mStream retries automatically every ${Number(retrySeconds)}&thinsp;s and starts the moment the problem is fixed — this page refreshes itself.</p>
+</main>
+</body>
+</html>
+`;
+}

--- a/test/helpers/server.mjs
+++ b/test/helpers/server.mjs
@@ -17,7 +17,7 @@ import { ensureFixtures } from './fixtures.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
-function findFreePort() {
+export function findFreePort() {
   return new Promise((resolve, reject) => {
     const srv = net.createServer();
     srv.unref();
@@ -50,7 +50,20 @@ async function waitForReady(baseUrl, { timeoutMs = 90_000, getExitError = () => 
     try {
       const r = await fetch(`${baseUrl}/api/`);
       if (r.status < 500) { return; }
-    } catch (err) { lastErr = err; }
+      // A boot hold (server.js) answers 503 with the process ALIVE, so
+      // neither the exit check nor the timeout would ever name the cause —
+      // every affected test would burn the full budget and report
+      // "unknown". Treat it as the terminal boot failure it is and
+      // surface the server's own diagnosis.
+      const holdReason = r.headers.get('x-mstream-boot-hold');
+      if (holdReason) {
+        const body = await r.json().catch(() => null);
+        throw new Error(`server is in a boot hold (${holdReason}): ${body?.error || ''} ${body?.detail || ''}`.trim());
+      }
+    } catch (err) {
+      if (/boot hold/.test(err.message)) { throw err; }
+      lastErr = err;
+    }
     await sleep(50);
   }
   throw new Error(`server not ready within ${timeoutMs}ms: ${lastErr?.message || 'unknown'}`);

--- a/test/integration/boot-hold.test.mjs
+++ b/test/integration/boot-hold.test.mjs
@@ -1,0 +1,186 @@
+// The boot hold end to end (src/server.js + src/util/boot-errors.js): a
+// server whose database cannot open for an ENVIRONMENTAL reason must not
+// crash into the supervisor's restart loop — it binds its port, answers
+// every request 503 with the diagnosis, retries on a timer, and swaps the
+// real app in the moment the problem is fixed.
+//
+// The environmental stand-in is a damaged mstream.db (garbage bytes →
+// SQLITE_NOTADB at the WAL pragma): fully cross-platform, unlike faking
+// ENOSPC. The recovery step deletes the damaged file while the server is
+// HOLDING — which doubles as a regression test for the hold's
+// dbManager.close() call: a leaked half-open handle would make that
+// delete fail with EPERM on Windows.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { findFreePort } from '../helpers/server.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const RETRY_MS = 500;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function tryFetch(url, headers = {}) {
+  try {
+    return await fetch(url, { headers });
+  } catch (_err) {
+    return null; // not bound yet / connection refused
+  }
+}
+
+test('an environmental db failure holds the boot with a 503 diagnosis, then recovers when fixed', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-boot-hold-'));
+  const dirs = {
+    db: path.join(tmp, 'db'),
+    logs: path.join(tmp, 'logs'),
+    art: path.join(tmp, 'image-cache'),
+    waveform: path.join(tmp, 'waveform-cache'),
+    music: path.join(tmp, 'music'),
+    home: path.join(tmp, 'home'),
+  };
+  await Promise.all(Object.values(dirs).map((d) => fs.mkdir(d, { recursive: true })));
+
+  const port = await findFreePort();
+  const base = `http://127.0.0.1:${port}`;
+  const configPath = path.join(tmp, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify({
+    port,
+    address: '127.0.0.1',
+    folders: { lib: { root: dirs.music } },
+    storage: {
+      dbDirectory: dirs.db,
+      logsDirectory: dirs.logs,
+      albumArtDirectory: dirs.art,
+      waveformCacheDirectory: dirs.waveform,
+    },
+    // The helper suite's hermetic guards (test/helpers/server.mjs): no
+    // album-art downloads, no discovery/embedding workers, no BPM pass, no
+    // community seeds — and a boot scan pushed past this test's lifetime.
+    scanOptions: { autoAlbumArt: false, collectDiscoveryData: false, analyzeBpm: false, bootScanDelay: 60 },
+    discoveryP2p: { seedListUrl: 'http://127.0.0.1:9/discovery-seeds.json', useCommunitySeeds: false },
+  }, null, 2));
+
+  // The damage: sixteen-plus non-SQLite bytes, so the header check fails
+  // with SQLITE_NOTADB on the first statement.
+  const dbFile = path.join(dirs.db, 'mstream.db');
+  await fs.writeFile(dbFile, 'mStream test fixture: deliberately not a SQLite database file.');
+
+  const child = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', configPath], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      MSTREAM_BOOT_HOLD_RETRY_MS: String(RETRY_MS),
+      MSTREAM_TEST_BAKED_SEEDS: '[]',
+      // Sandbox anything that keys on the user's data home (the boot
+      // watchdog's attempt file, dataRoot fallbacks) into the temp dir.
+      HOME: dirs.home,
+      XDG_DATA_HOME: path.join(dirs.home, '.local', 'share'),
+      APPDATA: path.join(dirs.home, 'AppData', 'Roaming'),
+      LOCALAPPDATA: path.join(dirs.home, 'AppData', 'Local'),
+    },
+  });
+  let out = '';
+  child.stdout.on('data', (d) => { out = (out + d).slice(-8192); });
+  child.stderr.on('data', (d) => { out = (out + d).slice(-8192); });
+  const exited = new Promise((resolve) => child.once('exit', (code) => resolve(code)));
+
+  try {
+    // Phase 1: the hold. The port must come up (bound by the hold listener,
+    // not the app) and answer 503 with the machine-readable diagnosis.
+    // Generous ceiling for loaded CI runners, same reasoning as the server
+    // helper's waitForReady.
+    const deadline = Date.now() + 90_000;
+    let held = null;
+    while (Date.now() < deadline) {
+      assert.equal(child.exitCode, null, `server exited during the hold phase:\n${out}`);
+      held = await tryFetch(`${base}/api/`);
+      if (held) { break; }
+      await sleep(50);
+    }
+    assert.ok(held, `no response from the held server within 90s:\n${out}`);
+    assert.equal(held.status, 503);
+    assert.equal(held.headers.get('x-mstream-boot-hold'), 'db-damaged');
+    const body = await held.json();
+    assert.equal(body.code, 'db-damaged');
+    assert.match(body.error, /damaged/);
+    assert.match(body.hint, /playlists/);
+
+    // Browsers get the human page from the same handler. Polled like the
+    // /api/ probe: every hold response closes its connection, so a single
+    // fetch can race a just-closed socket on a loaded runner.
+    let page = null;
+    const pageDeadline = Date.now() + 30_000;
+    while (!page && Date.now() < pageDeadline) {
+      page = await tryFetch(`${base}/`, { accept: 'text/html,application/xhtml+xml' });
+      if (!page) { await sleep(100); }
+    }
+    assert.ok(page, `no response for the HTML hold page:\n${out}`);
+    assert.equal(page.status, 503);
+    assert.match(page.headers.get('content-type'), /text\/html/);
+    const html = await page.text();
+    assert.match(html, /mStream cannot start/);
+    assert.match(html, /refreshes itself/);
+
+    // The whole point: several retry periods pass and the process is still
+    // this same, single, live process — no crash, no supervisor loop.
+    await sleep(RETRY_MS * 3);
+    assert.equal(child.exitCode, null, `server crashed instead of holding:\n${out}`);
+    const stillHeld = await tryFetch(`${base}/api/`);
+    assert.equal(stillHeld?.status, 503, 'must still be holding before the fix');
+
+    // Phase 1b: a config failure during a retry must not end the hold.
+    // (The docker layout keeps config.json on the same volume as the db,
+    // so the held failure can take the config read down with it.) Break
+    // the config, watch the diagnosis flip to 'config', restore it, watch
+    // it flip back — the process must stay alive throughout.
+    const goodConfig = await fs.readFile(configPath, 'utf8');
+    await fs.writeFile(configPath, '{ not json at all');
+    const flipDeadline = Date.now() + 30_000;
+    let flipped = null;
+    while (Date.now() < flipDeadline) {
+      assert.equal(child.exitCode, null, `server exited after a config failure mid-hold:\n${out}`);
+      const r = await tryFetch(`${base}/api/`);
+      if (r && r.headers.get('x-mstream-boot-hold') === 'config') { flipped = r; break; }
+      await sleep(100);
+    }
+    assert.ok(flipped, `hold never reported the config failure:\n${out}`);
+    await fs.writeFile(configPath, goodConfig);
+    const backDeadline = Date.now() + 30_000;
+    let back = false;
+    while (Date.now() < backDeadline) {
+      assert.equal(child.exitCode, null, `server exited restoring the config mid-hold:\n${out}`);
+      const r = await tryFetch(`${base}/api/`);
+      if (r && r.headers.get('x-mstream-boot-hold') === 'db-damaged') { back = true; break; }
+      await sleep(100);
+    }
+    assert.ok(back, `hold never returned to the db diagnosis after the config was restored:\n${out}`);
+
+    // Phase 2: the fix. Deleting the damaged file must succeed while the
+    // server holds (the hold's dbManager.close() released the half-open
+    // handle — on Windows a leaked handle turns this into EPERM), and the
+    // next retry must boot the real app onto the SAME socket.
+    await fs.rm(dbFile);
+    const recoverDeadline = Date.now() + 90_000;
+    let recovered = null;
+    while (Date.now() < recoverDeadline) {
+      assert.equal(child.exitCode, null, `server exited during recovery:\n${out}`);
+      const r = await tryFetch(`${base}/api/`);
+      if (r && r.status < 500) { recovered = r; break; }
+      await sleep(100);
+    }
+    assert.ok(recovered, `server did not recover within 90s of the fix:\n${out}`);
+    assert.equal(child.exitCode, null);
+  } finally {
+    child.kill();
+    await Promise.race([exited, sleep(10_000)]);
+    await fs.rm(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
+});

--- a/test/unit/boot-errors.test.mjs
+++ b/test/unit/boot-errors.test.mjs
@@ -1,0 +1,132 @@
+// classifyBootError() draws the crash-vs-hold line for boot failures
+// (src/util/boot-errors.js): environmental causes — full disk, read-only or
+// missing volume, damaged db file — produce a diagnosis the boot hold
+// serves; everything else returns null and crashes exactly as before. The
+// free-space probe is injected so these tests dictate the disk state
+// instead of inheriting the runner's.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { classifyBootError, renderHoldPage, formatBytes } from '../../src/util/boot-errors.js';
+
+const EXISTING_DIR = os.tmpdir();
+const MISSING_DIR = path.join(os.tmpdir(), 'mstream-definitely-absent', 'db');
+
+// node:sqlite error shape (the real 2026-08-25 crash carried exactly this:
+// code ERR_SQLITE_ERROR, errcode 4874, errstr 'disk I/O error').
+const sqliteErr = (errcode, errstr = 'disk I/O error') =>
+  Object.assign(new Error(errstr), { code: 'ERR_SQLITE_ERROR', errcode, errstr });
+
+const fsErr = (code, message = `${code}: it broke`) =>
+  Object.assign(new Error(message), { code });
+
+const noSpace = () => ({ freeBytes: 1024, totalBytes: 100 * 2 ** 30 });
+const plentySpace = () => ({ freeBytes: 500 * 2 ** 30, totalBytes: 1000 * 2 ** 30 });
+
+test('SQLITE_IOERR_SHMSIZE (4874) on a full disk classifies as disk-full', () => {
+  const d = classifyBootError(sqliteErr(4874), EXISTING_DIR, noSpace);
+  assert.equal(d.reason, 'disk-full');
+  assert.match(d.detail, /SHMSIZE/);
+  assert.match(d.headline, /full/);
+});
+
+test('SQLITE_IOERR with plenty of space classifies as db-io, naming the subcode', () => {
+  const d = classifyBootError(sqliteErr(4874), EXISTING_DIR, plentySpace);
+  assert.equal(d.reason, 'db-io');
+  assert.match(d.detail, /SQLITE_IOERR_SHMSIZE/);
+});
+
+test('SQLITE_IOERR with statfs unavailable stays db-io and says space is unreadable', () => {
+  const d = classifyBootError(sqliteErr(4874), EXISTING_DIR, () => null);
+  assert.equal(d.reason, 'db-io');
+  assert.match(d.detail, /free space unreadable/);
+});
+
+test('SQLITE_FULL (13) classifies as disk-full regardless of statfs', () => {
+  const d = classifyBootError(sqliteErr(13, 'database or disk is full'), EXISTING_DIR, plentySpace);
+  assert.equal(d.reason, 'disk-full');
+});
+
+test('SQLITE_CORRUPT and SQLITE_NOTADB classify as db-damaged with a data-loss-aware hint', () => {
+  for (const code of [11, 26]) {
+    const d = classifyBootError(sqliteErr(code, 'file is not a database'), EXISTING_DIR, plentySpace);
+    assert.equal(d.reason, 'db-damaged', `errcode ${code}`);
+    assert.match(d.hint, /playlists/, 'the hint must warn what a fresh start loses');
+  }
+});
+
+test('SQLITE_READONLY classifies as db-unwritable', () => {
+  const d = classifyBootError(sqliteErr(8, 'attempt to write a readonly database'), EXISTING_DIR, plentySpace);
+  assert.equal(d.reason, 'db-unwritable');
+});
+
+test('SQLITE_BUSY and SQLITE_LOCKED classify as db-locked', () => {
+  for (const code of [5, 6]) {
+    assert.equal(classifyBootError(sqliteErr(code, 'database is locked'), EXISTING_DIR, plentySpace).reason,
+      'db-locked', `errcode ${code}`);
+  }
+});
+
+test('SQLITE_CANTOPEN splits on whether the db directory still exists', () => {
+  assert.equal(classifyBootError(sqliteErr(14, 'unable to open database file'), EXISTING_DIR, plentySpace).reason,
+    'db-unwritable');
+  assert.equal(classifyBootError(sqliteErr(14, 'unable to open database file'), MISSING_DIR, plentySpace).reason,
+    'db-missing-dir');
+});
+
+test('non-environmental SQLite codes are not holdable', () => {
+  // 1 = SQLITE_ERROR (a migration typo), 787 = SQLITE_CONSTRAINT_FOREIGNKEY.
+  for (const code of [1, 787]) {
+    assert.equal(classifyBootError(sqliteErr(code, 'SQL logic error'), EXISTING_DIR, plentySpace), null,
+      `errcode ${code}`);
+  }
+});
+
+test('the bun:sqlite shape (errno instead of errcode) still classifies', () => {
+  const err = Object.assign(new Error('disk I/O error'), { code: 'ERR_SQLITE_ERROR', errno: 4874 });
+  const d = classifyBootError(err, EXISTING_DIR, noSpace);
+  assert.equal(d.reason, 'disk-full');
+});
+
+test('plain filesystem errors map to their environmental classes', () => {
+  assert.equal(classifyBootError(fsErr('ENOSPC'), EXISTING_DIR, noSpace).reason, 'disk-full');
+  assert.equal(classifyBootError(fsErr('EDQUOT'), EXISTING_DIR, noSpace).reason, 'disk-full');
+  assert.equal(classifyBootError(fsErr('EACCES'), EXISTING_DIR, plentySpace).reason, 'db-unwritable');
+  assert.equal(classifyBootError(fsErr('EROFS'), EXISTING_DIR, plentySpace).reason, 'db-unwritable');
+  assert.equal(classifyBootError(fsErr('EPERM'), EXISTING_DIR, plentySpace).reason, 'db-unwritable');
+  assert.equal(classifyBootError(fsErr('EMFILE'), EXISTING_DIR, plentySpace).reason, 'fs-limit');
+  assert.equal(classifyBootError(fsErr('EIO'), EXISTING_DIR, plentySpace).reason, 'db-io');
+});
+
+test('ENOENT is holdable only when the db directory itself is gone', () => {
+  assert.equal(classifyBootError(fsErr('ENOENT'), EXISTING_DIR, plentySpace), null);
+  assert.equal(classifyBootError(fsErr('ENOENT'), MISSING_DIR, plentySpace).reason, 'db-missing-dir');
+});
+
+test('unrecognized errors are never holdable', () => {
+  assert.equal(classifyBootError(new Error('undefined is not a function'), EXISTING_DIR, plentySpace), null);
+  assert.equal(classifyBootError(new TypeError('boom'), EXISTING_DIR, plentySpace), null);
+  assert.equal(classifyBootError(null, EXISTING_DIR, plentySpace), null);
+});
+
+test('renderHoldPage escapes diagnosis text and names the retry cadence', () => {
+  const html = renderHoldPage({
+    headline: 'mStream cannot start: <script>alert(1)</script>',
+    detail: 'a & b < c',
+    hint: 'do "this"',
+  }, { retrySeconds: 15 });
+  assert.ok(!html.includes('<script>alert'), 'headline must be escaped');
+  assert.match(html, /&lt;script&gt;/);
+  assert.match(html, /a &amp; b &lt; c/);
+  assert.match(html, /every 15/);
+  assert.match(html, /refreshes itself/);
+});
+
+test('formatBytes covers the ranges the diagnosis prints', () => {
+  assert.equal(formatBytes(0), '0 B');
+  assert.equal(formatBytes(2048), '2 KB');
+  assert.match(formatBytes(5 * 2 ** 20), /5\.0 MB/);
+  assert.match(formatBytes(3 * 2 ** 30), /3\.0 GB/);
+  assert.equal(formatBytes(-1), 'unknown');
+});

--- a/test/unit/logger-error-resilience.test.mjs
+++ b/test/unit/logger-error-resilience.test.mjs
@@ -1,0 +1,26 @@
+// A winston transport write failure (ENOSPC on the log file when the disk
+// fills) is re-emitted as 'error' on the default logger; with no listener
+// that is an uncaught exception that kills the process — at exactly the
+// moment the boot hold (src/server.js) needs logging to stay soft.
+// src/logger.js attaches the listener at module init; this proves it holds.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import winston from 'winston';
+import '../../src/logger.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('a transport error does not crash the process', async () => {
+  const t = new winston.transports.Console({ silent: true });
+  winston.add(t);
+  try {
+    // Without src/logger.js's logger-level 'error' listener this emit is an
+    // uncaught exception: the test (and its runner process) would die here,
+    // not fail an assertion.
+    t.emit('error', new Error('fake ENOSPC'));
+    await sleep(50);
+    assert.ok(true, 'process survived a transport error');
+  } finally {
+    winston.remove(t);
+  }
+});


### PR DESCRIPTION
## Why

The 2026-08-25 production incident: the disk holding `/config` filled, and a container restart put mStream into an infinite boot loop — banner + `Error: disk I/O error` (`SQLITE_IOERR_SHMSIZE`, errcode 4874: SQLite couldn't grow the WAL shared-memory file) repeating forever under s6, port dead, `docker ps` claiming "Up". Nothing anywhere said *the disk is full*.

## What

**Layer 1 — say what's actually wrong.** New `src/util/boot-errors.js` classifies boot-time DB failures: SQLite result codes (both runtimes) + plain fs codes, enriched with a `statfs` reading of the db directory. `disk I/O error` becomes *"mStream cannot start: the disk holding its database is full — /config/db, 0 B free of 98 GB"* with a concrete hint.

**Layer 2 — hold instead of crash.** For classified **environmental** failures on a **first boot** (`disk-full`, `db-io`, `db-damaged`, `db-unwritable`, `db-missing-dir`, `db-locked`, `fs-limit`), the server binds its configured port and answers everything **503**: a self-refreshing diagnosis page for browsers, JSON + `X-MStream-Boot-Hold: <reason>` for API callers. The full boot retries every 15s (`MSTREAM_BOOT_HOLD_RETRY_MS` to tune) and a successful retry swaps the real app onto the *same socket* via the existing keep-listener machinery — fix the disk, and the next page refresh is the app.

Deliberate boundaries, documented in place:
- **Unrecognized failures crash exactly as before** (a migration bug must stay loud, and the R2 boot-watchdog rollback still works).
- **Soft reboots keep their exit contract** (the previous life's timers must not outlive their closed db handle); the supervisor's single restart lands in the hold with the same diagnosis.
- A config failure *during a retry* re-enters the hold (config usually shares the volume with the db) instead of exiting.

## Hardening from the adversarial review (8 finder angles, findings verified then fixed)

- **`logger.js`**: a winston transport write error (ENOSPC on the log file) was an unhandled `'error'` on the default logger → process death *while logging about the full disk*. Now listened for (empirically reproduced both ways), and `addFileLogger` is idempotent for same-dir re-runs.
- **`bun-sqlite-adapter.js`**: the constructor is now wrapped and `errno`→`errcode` mirrored, so open-time failures classify under Bun builds too.
- **`manager.close()`**: invalidates memoized user/library caches and tolerates a half-open handle — a damaged db replaced mid-hold is re-read for real, and the released handle means the file is replaceable on Windows.
- Watchdog counter is left alone (an earlier draft cleared it and would have defeated bad-build rollback), the scanner reap is skipped on retries (its synchronous process probes would stall the diagnosis page), hold logging is throttled (a weekend hold can't flood the admin live-log ring), and the hold reuses the listener `serveIt` already built, with a proper fatal error handler for the socket's post-recovery life.
- `test/helpers/server.mjs` `waitForReady` now reports a boot hold as a terminal failure with the server's own diagnosis instead of burning 90s and saying "unknown".

Known limitations (deliberate, noted in review): boot steps *after* `initDB` (lyrics/backup init writes) can still crash-fast if the disk is at the exact boundary where the WAL opens but the next write fails; the desktop tray launcher currently shows a held server as "Running (unverified)" — launcher-side hold awareness is queued as a follow-up.

## Tests

- `test/unit/boot-errors.test.mjs` — 15 classifier/rendering cases (incl. the real incident error shape, Bun's `errno` shape, non-holdable fallthroughs, HTML escaping).
- `test/integration/boot-hold.test.mjs` — end-to-end: damaged `mstream.db` → hold (JSON + HTML 503s, process survives multiple retry windows) → config broken mid-hold → diagnosis flips to `config` → restored → flips back → damaged file **deleted while held** (proves the handle release; would be EPERM on Windows otherwise) → app recovers on the same socket.
- `test/unit/logger-error-resilience.test.mjs` — a transport error must not kill the process.
- Full suite: 2,444 pass / 1 load-flake (dlna ECONNRESET while 8 review agents saturated the CPU; passes 20/20 in isolation — same class as the pre-existing federation-dial flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)