### PR TITLE
fix(config): tolerate UTF-8 BOM in -j config files

### DIFF
--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -123,9 +123,14 @@ pub struct Endpoint {
 /// run — the server generates it — and these defaults are exactly what that
 /// generated config yields.
 pub fn read_endpoint(config: &Path) -> Endpoint {
+    // trim_start_matches('\u{feff}'): PowerShell 5.1's `Set-Content -Encoding
+    // UTF8` writes a BOM and serde_json refuses it — the server side strips it
+    // too (util/atomic-json.js stripBom), and the two sides must read the SAME
+    // config the same way, or a BOM'd port lands the server on 8000 while the
+    // launcher probes the 3000 fallback forever.
     let v = std::fs::read_to_string(config)
         .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok());
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s.trim_start_matches('\u{feff}')).ok());
     let port = v
         .as_ref()
         .and_then(|v| v.get("port"))
@@ -188,7 +193,7 @@ pub fn server_url(ep: &Endpoint) -> String {
 pub fn library_is_configured(config: &Path) -> bool {
     std::fs::read_to_string(config)
         .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s.trim_start_matches('\u{feff}')).ok())
         .and_then(|v| v.get("folders").and_then(|f| f.as_object().map(|o| !o.is_empty())))
         .unwrap_or(false)
 }
@@ -496,6 +501,18 @@ mod tests {
         std::fs::write(&bundled, b"x").unwrap();
         assert_eq!(find_player_bin(&server, &home), Some(bundled), "bundled copy wins");
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bom_from_powershell_utf8_is_tolerated() {
+        // PowerShell 5.1's `Set-Content -Encoding UTF8` prepends a BOM; the
+        // server strips it before parsing, so this side must too — a BOM'd
+        // port must not send the launcher probing the 3000 fallback.
+        let p = env::temp_dir().join(format!("mstream-launcher-bom-{}.json", std::process::id()));
+        std::fs::write(&p, "\u{feff}{ \"port\": 8123, \"folders\": { \"m\": { \"root\": \"/x\" } } }").unwrap();
+        assert_eq!(read_endpoint(&p).port, 8123);
+        assert!(library_is_configured(&p));
+        let _ = std::fs::remove_file(&p);
     }
 
     #[test]

--- a/src/server.js
+++ b/src/server.js
@@ -215,9 +215,14 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     // (Desktop-launch users see the launcher's own boot-failure dialog; this
     // message is what its server log carries.)
     const denied = err.code === 'EROFS' || err.code === 'EACCES' || err.code === 'EPERM';
+    // EJSONPARSE (util/atomic-json.js readJsonFile): the config file itself
+    // is broken JSON — say so with the path, don't bury it under the generic
+    // validate line (a hand-edited config on Windows is the common case).
     winston.error(denied
       ? `mStream could not start — it can't write to ${configFile}: the location is read-only or permission was denied (${err.message})`
-      : 'Failed to validate config file', { stack: err });
+      : err.code === 'EJSONPARSE'
+        ? `mStream could not start — config file ${err.message}`
+        : 'Failed to validate config file', { stack: err });
     process.exit(1);
   }
 

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import Joi from 'joi';
 import winston from 'winston';
 import { appRoot, dataRoot } from '../util/esm-helpers.js';
+import { readJsonFile } from '../util/atomic-json.js';
 import { getTransCodecs, getTransBitrates } from '../api/transcode.js';
 import { CLIENT_TYPE, ENABLED_FOR } from '../torrent/constants.js';
 import { EMBEDDING_MODELS, DEFAULT_EMBEDDING_MODEL, RETIRED_EMBEDDING_MODELS }
@@ -821,7 +822,7 @@ export async function setup(configFileArg) {
     await fs.writeFile(configFileArg, JSON.stringify({}), 'utf8');
   }
 
-  const programData = JSON.parse(await fs.readFile(configFileArg, 'utf8'));
+  const programData = await readJsonFile(configFileArg);
   configFile = configFileArg;
 
   // Verify paths are real
@@ -963,7 +964,7 @@ export async function setup(configFileArg) {
   // Persist a stable DLNA UUID so renderers recognise the server across reboots
   if (!program.dlna.uuid) {
     program.dlna.uuid = crypto.randomUUID();
-    const rawConfig = JSON.parse(await fs.readFile(configFileArg, 'utf8'));
+    const rawConfig = await readJsonFile(configFileArg);
     if (!rawConfig.dlna) { rawConfig.dlna = {}; }
     rawConfig.dlna.uuid = program.dlna.uuid;
     await fs.writeFile(configFileArg, JSON.stringify(rawConfig, null, 2), 'utf8');
@@ -1007,7 +1008,7 @@ export async function setup(configFileArg) {
   // pattern as dlna.uuid above.
   if (!program.discovery.mdns.instanceId) {
     program.discovery.mdns.instanceId = crypto.randomUUID();
-    const rawConfig = JSON.parse(await fs.readFile(configFileArg, 'utf8'));
+    const rawConfig = await readJsonFile(configFileArg);
     if (!rawConfig.discovery) { rawConfig.discovery = {}; }
     if (!rawConfig.discovery.mdns) { rawConfig.discovery.mdns = {}; }
     rawConfig.discovery.mdns.instanceId = program.discovery.mdns.instanceId;

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -18,7 +18,7 @@ import * as subsonicServer from '../subsonic/subsonic-server.js';
 import { getDirname } from './esm-helpers.js';
 import { launchWorker } from './worker-process.js';
 import { invalidateWhitelistCache } from './admin-network.js';
-import { updateJsonAtomic, completedWrites } from './atomic-json.js';
+import { updateJsonAtomic, completedWrites, readJsonFile } from './atomic-json.js';
 
 const __dirname = getDirname(import.meta.url);
 
@@ -43,7 +43,7 @@ const __dirname = getDirname(import.meta.url);
 const loaded = new WeakMap();   // returned object -> { file, base (deep clone), writes }
 
 export async function loadFile(file) {
-  const doc = JSON.parse(await fs.readFile(file, 'utf-8'));
+  const doc = await readJsonFile(file);
   if (doc && typeof doc === 'object') {
     loaded.set(doc, { file: path.resolve(file), base: structuredClone(doc), writes: completedWrites(file) });
   }

--- a/src/util/atomic-json.js
+++ b/src/util/atomic-json.js
@@ -25,6 +25,29 @@ const chains = new Map();   // absolute path -> tail of the write chain
 const completed = new Map(); // absolute path -> number of writes that have landed
 let seq = 0;
 
+// A UTF-8 BOM survives readFile('utf8') as a leading U+FEFF, and JSON.parse
+// refuses it — and PowerShell 5.1's `Set-Content -Encoding UTF8` writes one,
+// so a hand-edited config on Windows is the common case here, not a corner
+// (found by mStream#908's Windows smoke). Strip it wherever a JSON file the
+// user may have written by hand is read.
+export function stripBom(text) {
+  return text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+}
+
+// Read + parse a user-editable JSON file: BOM-tolerant, and a parse failure
+// names the file and says it is invalid JSON (code EJSONPARSE) instead of
+// surfacing a bare SyntaxError with no path in it.
+export async function readJsonFile(file) {
+  const text = stripBom(await fs.readFile(file, 'utf8'));
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    const wrapped = new Error(`${file} is not valid JSON: ${err.message}`);
+    wrapped.code = 'EJSONPARSE';
+    throw wrapped;
+  }
+}
+
 // How many writes to `file` have COMPLETED (rename done). A reader that
 // captures this before reading and compares afterwards knows whether a write
 // may have landed after its read — server.js's reboot uses it to decide

--- a/src/util/boot-probe.js
+++ b/src/util/boot-probe.js
@@ -31,6 +31,7 @@
 // server is still serving).
 import fs from 'fs';
 import path from 'path';
+import { stripBom } from './atomic-json.js';
 
 const PROBE_TIMEOUT_MS = 30_000;
 
@@ -77,7 +78,7 @@ export async function runBootProbe(configPath) {
     let raw;
     try {
       raw = fs.readFileSync(configPath, 'utf8');
-      parsed = JSON.parse(raw);
+      parsed = JSON.parse(stripBom(raw));
     } catch (err) {
       clearTimeout(timer);
       return fail(`config ${configPath} did not parse: ${err.message}`);

--- a/test/integration/boot-probe.test.mjs
+++ b/test/integration/boot-probe.test.mjs
@@ -83,6 +83,25 @@ test('a config this build cannot parse or validate fails the probe with the sent
   }
 });
 
+test('a BOM\'d config parses — the probe must agree with the boot on PowerShell-written files', async () => {
+  // PowerShell 5.1's `Set-Content -Encoding UTF8` prepends a UTF-8 BOM
+  // (mStream#908's Windows smoke). The boot strips it (util/atomic-json.js
+  // stripBom); the probe must too, or a config the real boot accepts would
+  // block staging as "a config this build refuses".
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-probe-bom-'));
+  try {
+    const conf = path.join(home, 'bom.json');
+    await fs.writeFile(conf, '﻿' + JSON.stringify({ port: 3999 }), 'utf8');
+    const r = runProbe(home, ['-j', conf]);
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.match(r.stdout, /^boot-probe: ok /m);
+    // Purity holds: the probe reads tolerantly but never rewrites the file.
+    assert.equal((await fs.readFile(conf, 'utf8')).charCodeAt(0), 0xFEFF);
+  } finally {
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test('a database from this build\'s future fails the probe; a current one passes', async () => {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-probe-db-'));
   try {

--- a/test/unit/json-bom.test.mjs
+++ b/test/unit/json-bom.test.mjs
@@ -1,0 +1,59 @@
+/**
+ * util/atomic-json.js stripBom/readJsonFile: a config file written by
+ * PowerShell 5.1's `Set-Content -Encoding UTF8` carries a UTF-8 BOM, and
+ * JSON.parse refuses it — the server used to die on boot with a bare
+ * SyntaxError that named nothing (found by mStream#908's Windows smoke).
+ * Every read of a user-editable JSON file goes through these now: the boot
+ * parse and the uuid re-reads in state/config.js, the admin editors'
+ * loadFile, and the pre-flip --boot-probe (which must agree with the boot,
+ * or a BOM'd config would block staging that the real boot accepts).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { stripBom, readJsonFile } from '../../src/util/atomic-json.js';
+import { loadFile } from '../../src/util/admin.js';
+
+const BOM = '﻿';
+
+describe('BOM-tolerant JSON reads', () => {
+  let dir;
+  before(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-bom-'));
+  });
+  after(async () => { await fs.rm(dir, { recursive: true, force: true }); });
+
+  test('stripBom removes exactly one leading BOM and nothing else', () => {
+    assert.equal(stripBom(`${BOM}{}`), '{}');
+    assert.equal(stripBom('{}'), '{}');
+    assert.equal(stripBom(''), '');
+    // Interior U+FEFF is content (a zero-width no-break space), not a BOM.
+    assert.equal(stripBom(`{"a":"x${BOM}y"}`), `{"a":"x${BOM}y"}`);
+  });
+
+  test('readJsonFile parses a BOM\'d document exactly like a clean one', async () => {
+    const file = path.join(dir, 'bom.json');
+    await fs.writeFile(file, `${BOM}{ "port": 3999 }`, 'utf8');
+    assert.deepEqual(await readJsonFile(file), { port: 3999 });
+  });
+
+  test('invalid JSON fails with the file named, not a bare SyntaxError', async () => {
+    const file = path.join(dir, 'broken.json');
+    await fs.writeFile(file, `${BOM}{ "port": `, 'utf8');
+    await assert.rejects(readJsonFile(file), (err) => {
+      assert.equal(err.code, 'EJSONPARSE');
+      assert.match(err.message, /broken\.json is not valid JSON: /);
+      return true;
+    });
+  });
+
+  test('the admin editors read through it too', async () => {
+    const file = path.join(dir, 'admin.json');
+    await fs.writeFile(file, `${BOM}{ "port": 3000, "trustProxy": false }`, 'utf8');
+    const doc = await loadFile(file);
+    assert.equal(doc.trustProxy, false);
+  });
+});


### PR DESCRIPTION
PowerShell 5.1's `Set-Content -Encoding UTF8` writes a UTF-8 BOM, and a config saved that way crashed the server at boot with a bare SyntaxError naming nothing — found by #908's Windows behavioral smoke, and a plausible paper cut for anyone hand-writing a config on Windows.

Both JSON.parse and serde_json refuse the BOM, so the fix covers **every reader of the user-editable config**, not just the boot parse:

- `util/atomic-json.js` gains `stripBom()` + `readJsonFile()` — BOM-tolerant, and a parse failure names the file (`code: 'EJSONPARSE'`) instead of a bare SyntaxError.
- `state/config.js` (boot parse + both uuid-persist re-reads), `util/admin.js` `loadFile` (admin editors), and `util/boot-probe.js` read through them. The probe leg is consistency-critical: a BOM'd config the real boot accepts must not block update staging as "a config this build refuses". The uuid re-writes also normalize the BOM away on their next save.
- `server.js`'s boot catch now headlines the EJSONPARSE message (`mStream could not start — config file <path> is not valid JSON: …`) instead of the generic validate line.
- **Launcher too** (`rust-launcher/src/paths.rs`): `read_endpoint` and `library_is_configured` strip the BOM — otherwise a fixed server boots on the BOM'd config's port while the launcher silently probes the 3000 fallback forever, per the mirror contract at the top of that file.

Verification: new `test/unit/json-bom.test.mjs` (stripBom cases including interior U+FEFF left untouched, readJsonFile happy/error shapes, admin `loadFile` through a BOM'd file); a new boot-probe integration leg proving a BOM'd `-j` config passes the probe **and is not rewritten** (probe purity); a cargo test covering both launcher reads on a BOM'd file. 16/16 node on the affected suites, 34/34 cargo, clippy `-D warnings` clean, eslint clean on touched files (the six `require-await` warnings in admin.js pre-date this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)