### PR TITLE
feat(console): bundle Ghostty on macOS — first-class setup wizard terminal

### DIFF
--- a/bin/ghostty/LICENSE
+++ b/bin/ghostty/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/ghostty/README.md
+++ b/bin/ghostty/README.md
@@ -1,0 +1,38 @@
+# Bundled Ghostty console (macOS)
+
+`manifest.json` pins the [Ghostty](https://ghostty.org) release the macOS
+bundles ship as `console/Ghostty.app`, beside `mStream.app`. The bundler
+(`scripts/build-bun.mjs`) downloads the pinned `Ghostty.dmg` from
+`https://release.files.ghostty.org/<version>/`, refuses anything that does
+not hash to the pinned sha256, extracts the app, and asserts its
+Developer ID TeamIdentifier matches the pinned one — the app itself ships
+**byte-identical and untouched**, keeping Mitchell Hashimoto's notarization
+intact (verified: `spctl -t exec` accepts the extracted app as "Notarized
+Developer ID"; Ghostty staples the dmg, not the app, so the check is
+online — irrelevant to us, because the tray launches the inner binary
+directly, which involves no Gatekeeper prompt).
+
+Why it exists: Apple's Terminal.app has no pixel protocol at all, so the
+setup wizard's wordmark and Quick Connect QR degrade to character art for
+every default-terminal mac user. Ghostty speaks kitty graphics, truecolor,
+and OSC 11, and its config-file-declared commands launch with **no**
+"Allow Ghostty to execute…" dialog (commands passed as CLI arguments
+trigger it — the launcher must never use `-e`). The tray's "Set up
+mStream" item writes a config (command, title, 120×42, `auto-update =
+off`, `macos-icon = custom` pointing at mStream.icns so the Dock shows the
+mStream mark) and spawns the bundled app's binary with `XDG_CONFIG_HOME`
+scoped to that config — the user's own Ghostty install, if any, keeps its
+own config untouched. No bundled Ghostty (or a non-mac platform) falls
+back to the previous behavior (Terminal.app `.command` / `wt.exe` /
+emulator walk).
+
+`LICENSE` is Ghostty's MIT license at the pinned tag, staged into the
+bundle as `console/GHOSTTY-LICENSE.txt` — the app bundle itself carries no
+license file, and MIT asks the notice to travel with the software.
+
+Updating the pin: download the new `Ghostty.dmg`, `shasum -a 256` it,
+update `manifest.json` (version, sha256, size — teamId only if their
+signing identity genuinely changed), refresh `LICENSE` from the matching
+tag, and re-validate the trust probes recorded in the player repo's
+PLAN.md Phase 8 (config-command consent-free launch, `macos-custom-icon`,
+kitty graphics) before shipping.

--- a/bin/ghostty/manifest.json
+++ b/bin/ghostty/manifest.json
@@ -1,0 +1,10 @@
+{
+  "family": "ghostty-console",
+  "schema": 1,
+  "project": "ghostty-org/ghostty",
+  "version": "1.3.1",
+  "file": "Ghostty.dmg",
+  "sha256": "18cff2b0a6cee90eead9c7d3064e808a252a40baf214aa752c1ecb793b8f5f69",
+  "size": 33808867,
+  "teamId": "24VZTF6M5V"
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,11 @@ runtime — no Node.js install.
 
 A bundle is a **folder**, not a single file: the desktop launcher, the server
 binary (`mstream-server`), `webapp/` (the UI), and `bin/` (sidecar binaries).
-Keep them together; the bundle itself can live anywhere.
+macOS bundles also carry `console/Ghostty.app` — a pinned, untouched copy of
+the [Ghostty](https://ghostty.org) terminal (MIT; its license ships beside it)
+that the tray's setup wizard opens in, because Apple's Terminal.app can't
+draw the wizard's pixel artwork. Keep them together; the bundle itself can
+live anywhere.
 
 ## Install with one command
 
@@ -140,9 +144,12 @@ Restart server · Quit), and opens your browser at the player. Start-at-login
 is on by default; one click in the tray menu turns it off. **Set up mStream**
 opens a terminal running the guided setup wizard (the bundled
 `mstream-player setup`) — music folders, admin account, extras — and stays
-useful later: reopened, it picks up what the server already has. Headless
-installs get the same invitation as a boot log line whenever the server has
-no folders and no accounts yet.
+useful later: reopened, it picks up what the server already has. On macOS it
+opens in the bundled mStream console (Ghostty, with the mStream Dock icon),
+which draws the wizard's artwork and Quick Connect QR as real pixels;
+without the console it falls back to Terminal.app, and Windows prefers
+Windows Terminal. Headless installs get the same invitation as a boot log
+line whenever the server has no folders and no accounts yet.
 
 **Terminal users lose nothing.** The same desktop binary run from a terminal
 behaves exactly like the server itself (same flags, output, and exit codes) —

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -247,6 +247,46 @@ pub fn find_player_bin(server_bin: &Path, data_home: &Path) -> Option<PathBuf> {
     managed.exists().then_some(managed)
 }
 
+/// What the macOS "Set up mStream" launch needs to prefer the bundled
+/// Ghostty console over Terminal.app. Constructed on every platform (the
+/// resolver just never finds one off-mac), read only by the macOS spawn.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub struct ConsoleLaunch {
+    /// console/Ghostty.app (the whole bundle; the launch execs its inner
+    /// binary directly — no LaunchServices, no Gatekeeper prompt).
+    pub ghostty_app: PathBuf,
+    /// mStream.icns inside mStream.app — becomes the console's Dock icon
+    /// (`macos-icon = custom`). None just keeps Ghostty's own icon.
+    pub icon_icns: Option<PathBuf>,
+}
+
+/// The bundled Ghostty console — macOS bundles stage it at
+/// console/Ghostty.app BESIDE mStream.app (never inside: both notarization
+/// seals stay independent; scripts/build-bun.mjs). Two layouts can hold one:
+/// running out of the versioned bundle dir itself (an ancestor of the server
+/// binary), and the ~/Applications copy of mStream.app, whose versioned dir
+/// is wherever the install root's `current` link points. None on the other
+/// platforms and on consoleless installs — the caller falls back to the
+/// Terminal.app path.
+pub fn find_console_app(server_bin: &Path) -> Option<PathBuf> {
+    find_console_app_in(server_bin, &data_home().join("app"))
+}
+
+fn find_console_app_in(server_bin: &Path, install_root: &Path) -> Option<PathBuf> {
+    let ghostty = |app: &Path| app.join("Contents").join("MacOS").join("ghostty");
+    let mut dir = server_bin.parent();
+    for _ in 0..6 {
+        let Some(d) = dir else { break };
+        let candidate = d.join("console").join("Ghostty.app");
+        if ghostty(&candidate).exists() {
+            return Some(candidate);
+        }
+        dir = d.parent();
+    }
+    let current = install_root.join("current").join("console").join("Ghostty.app");
+    ghostty(&current).exists().then_some(current)
+}
+
 /// Escape a literal string for use inside a POSIX ERE (the pgrep -f
 /// patterns built from filesystem paths): a HOME containing '+', '?',
 /// '(' or brackets must match itself — a metacharacter that COMPILES but
@@ -500,6 +540,44 @@ mod tests {
         let bundled = bundle.join("bin/mstream-player").join(&key);
         std::fs::write(&bundled, b"x").unwrap();
         assert_eq!(find_player_bin(&server, &home), Some(bundled), "bundled copy wins");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn find_console_app_walks_bundle_then_install_root() {
+        let root = env::temp_dir().join(format!("mstream-launcher-console-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let bundle = root.join("mStream-9.9.9-darwin-arm64");
+        let server = bundle.join("mStream.app/Contents/MacOS/mstream-server");
+        let install_root = root.join("approot");
+        std::fs::create_dir_all(server.parent().unwrap()).unwrap();
+        assert_eq!(find_console_app_in(&server, &install_root), None, "nothing staged yet");
+
+        let ghostty_bin_dir = bundle.join("console/Ghostty.app/Contents/MacOS");
+        std::fs::create_dir_all(&ghostty_bin_dir).unwrap();
+        std::fs::write(ghostty_bin_dir.join("ghostty"), b"x").unwrap();
+        assert_eq!(
+            find_console_app_in(&server, &install_root),
+            Some(bundle.join("console/Ghostty.app")),
+            "ancestor walk finds the bundle's console"
+        );
+
+        // The ~/Applications copy: the server binary is inside the copied
+        // .app, nowhere near console/ — resolution goes through the install
+        // root's `current` link (unix-only mechanics, like the install).
+        #[cfg(unix)]
+        {
+            let apps_copy = root.join("Applications/mStream.app/Contents/MacOS/mstream-server");
+            std::fs::create_dir_all(apps_copy.parent().unwrap()).unwrap();
+            assert_eq!(find_console_app_in(&apps_copy, &install_root), None, "no current link yet");
+            std::fs::create_dir_all(&install_root).unwrap();
+            std::os::unix::fs::symlink(&bundle, install_root.join("current")).unwrap();
+            assert_eq!(
+                find_console_app_in(&apps_copy, &install_root),
+                Some(install_root.join("current/console/Ghostty.app")),
+                "the ~/Applications copy resolves through current"
+            );
+        }
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -286,15 +286,32 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
 /// Run the bundled terminal player's setup wizard in a fresh terminal
 /// window, pointed at this launcher's server. Same per-OS "what is a
 /// terminal" seams as open_logs_terminal; the caller logs a failure — a
-/// missing terminal emulator must never take the tray down.
+/// missing terminal emulator must never take the tray down. Ok carries
+/// WHICH surface opened (support surface: "it opened in Terminal, not the
+/// mStream console — why?" should be one log line away).
+///
+/// `console`: the bundled Ghostty (macOS bundles only, resolved by
+/// paths::find_console_app) — preferred over Terminal.app because Apple's
+/// terminal has no pixel protocol at all, so the wizard's wordmark and QR
+/// degrade to character art there. Ignored on the other platforms.
 pub fn open_setup_terminal(
     player_bin: &std::path::Path,
     server_url: &str,
     scratch_dir: &std::path::Path,
-) -> Result<(), String> {
+    console: Option<&crate::paths::ConsoleLaunch>,
+) -> Result<String, String> {
     #[cfg(target_os = "macos")]
     {
         use std::os::unix::fs::PermissionsExt;
+        let mut console_note = String::new();
+        if let Some(c) = console {
+            match spawn_ghostty_setup(c, player_bin, server_url, scratch_dir) {
+                Ok(()) => return Ok("bundled Ghostty console".into()),
+                // A broken bundled console must degrade to Terminal.app, not
+                // dead-end the button — but the reason rides along.
+                Err(e) => console_note = format!(" (bundled console failed: {e})"),
+            }
+        }
         // Terminal.app opens an executable .command file as a document — no
         // AppleEvents automation consent (see open_logs_terminal). The CSI 8
         // resize asks for the window the wizard's two-column pages were
@@ -311,7 +328,7 @@ pub fn open_setup_terminal(
         std::process::Command::new("/usr/bin/open")
             .arg(&script)
             .spawn()
-            .map(|_| ())
+            .map(|_| format!("Terminal.app{console_note}"))
             .map_err(|e| format!("open {}: {e}", script.display()))
     }
     #[cfg(windows)]
@@ -322,25 +339,26 @@ pub fn open_setup_terminal(
         // on Win11): it draws the wizard's pixel art via sixel. Without it,
         // a fresh conhost window still runs the wizard — crossterm enables
         // VT there and the art degrades to half-blocks.
+        let _ = console;
         if std::process::Command::new("wt.exe")
             .arg(player_bin)
             .args(["setup", "--server", server_url])
             .spawn()
             .is_ok()
         {
-            return Ok(());
+            return Ok("wt.exe".into());
         }
         const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
         std::process::Command::new(player_bin)
             .args(["setup", "--server", server_url])
             .creation_flags(CREATE_NEW_CONSOLE)
             .spawn()
-            .map(|_| ())
+            .map(|_| "conhost fallback".into())
             .map_err(|e| format!("spawn {}: {e}", player_bin.display()))
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        let _ = scratch_dir; // no script file on this path
+        let _ = (scratch_dir, console); // no script file / no bundled console here
         let cmd = format!(
             "exec {player} setup --server {url}",
             player = sh_quote(player_bin),
@@ -355,13 +373,78 @@ pub fn open_setup_terminal(
         ];
         for (bin, args) in candidates {
             if std::process::Command::new(bin).args(args).spawn().is_ok() {
-                return Ok(());
+                return Ok(bin.into());
             }
         }
         Err("no terminal emulator found (tried x-terminal-emulator, gnome-terminal, \
              konsole, xfce4-terminal, xterm)"
             .to_string())
     }
+}
+
+/// Write the config and launch the bundled Ghostty console running the
+/// wizard. Everything rides in the CONFIG FILE, never `-e`: Ghostty confirms
+/// argument-passed commands with an "Allow Ghostty to execute…" dialog (its
+/// anti-injection guard) but treats config-declared commands as user-trusted
+/// and prompts for nothing (probed 2026-08-24, player PLAN.md Phase 8).
+/// XDG_CONFIG_HOME is scoped to the spawn, so a user's own Ghostty install
+/// keeps its own configuration untouched.
+#[cfg(target_os = "macos")]
+fn spawn_ghostty_setup(
+    console: &crate::paths::ConsoleLaunch,
+    player_bin: &std::path::Path,
+    server_url: &str,
+    scratch_dir: &std::path::Path,
+) -> Result<(), String> {
+    let bin = console.ghostty_app.join("Contents").join("MacOS").join("ghostty");
+    if !bin.exists() {
+        return Err(format!("no ghostty binary at {}", bin.display()));
+    }
+    let cfg_home = scratch_dir.join("console-config");
+    let cfg_dir = cfg_home.join("ghostty");
+    std::fs::create_dir_all(&cfg_dir).map_err(|e| format!("mkdir {}: {e}", cfg_dir.display()))?;
+    let cfg = cfg_dir.join("config");
+    std::fs::write(&cfg, ghostty_setup_config(console, player_bin, server_url))
+        .map_err(|e| format!("write {}: {e}", cfg.display()))?;
+    std::process::Command::new(&bin)
+        .env("XDG_CONFIG_HOME", &cfg_home)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("spawn {}: {e}", bin.display()))
+}
+
+/// The console's config, regenerated on every click so it always reflects
+/// this build's idea of the paths. `command` uses the explicit `shell:`
+/// prefix — the value runs via `/bin/sh -c`, so the sh-quoting handles the
+/// "Application Support" spaces every managed install has.
+/// `quit-after-last-window-closed` keeps the console from lingering in the
+/// Dock as a windowless app after the wizard exits; `macos-icon = custom`
+/// puts the mStream mark on that Dock tile while it lives.
+#[cfg(target_os = "macos")]
+fn ghostty_setup_config(
+    console: &crate::paths::ConsoleLaunch,
+    player_bin: &std::path::Path,
+    server_url: &str,
+) -> String {
+    let mut body = String::from(
+        "# Written by mStream's tray 'Set up mStream' item - safe to delete.\n\
+         auto-update = off\n\
+         title = mStream Setup\n\
+         window-width = 120\n\
+         window-height = 42\n\
+         confirm-close-surface = false\n\
+         quit-after-last-window-closed = true\n",
+    );
+    if let Some(icns) = &console.icon_icns {
+        // Config values run to end of line — a spaced path needs no quoting.
+        body.push_str(&format!("macos-icon = custom\nmacos-custom-icon = {}\n", icns.display()));
+    }
+    body.push_str(&format!(
+        "command = shell:{player} setup --server {url}\n",
+        player = sh_quote(player_bin),
+        url = sh_quote_str(server_url),
+    ));
+    body
 }
 
 /// Start the NEW launcher for the apply-update handoff, detached, and return
@@ -517,6 +600,35 @@ fn sh_quote_str(s: &str) -> String {
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     #[test]
+    fn ghostty_config_quotes_spaced_paths_and_never_uses_dash_e() {
+        let c = crate::paths::ConsoleLaunch {
+            ghostty_app: "/tmp/x/Ghostty.app".into(),
+            icon_icns: Some("/App Root/Resources/mStream.icns".into()),
+        };
+        let cfg = super::ghostty_setup_config(
+            &c,
+            std::path::Path::new("/Application Support/bin/mstream-player"),
+            "http://localhost:3000",
+        );
+        // shell: + sh-quoting is what survives "Application Support" spaces;
+        // the command must live in the CONFIG, never a -e argument (consent
+        // dialog).
+        assert!(
+            cfg.contains("command = shell:'/Application Support/bin/mstream-player' setup --server 'http://localhost:3000'"),
+            "{cfg}"
+        );
+        // Config values run to end of line — the spaced icns path rides raw.
+        assert!(cfg.contains("macos-custom-icon = /App Root/Resources/mStream.icns\n"), "{cfg}");
+        assert!(cfg.contains("macos-icon = custom\n"), "{cfg}");
+        assert!(cfg.contains("auto-update = off\n"), "{cfg}");
+        assert!(cfg.contains("quit-after-last-window-closed = true\n"), "{cfg}");
+
+        let plain = crate::paths::ConsoleLaunch { ghostty_app: "/t/G.app".into(), icon_icns: None };
+        let cfg2 = super::ghostty_setup_config(&plain, std::path::Path::new("/p"), "http://x:1");
+        assert!(!cfg2.contains("macos-icon"), "no icns means Ghostty keeps its own icon: {cfg2}");
+    }
+
+    #[test]
     #[ignore = "spawns a real Terminal window - run manually with --ignored"]
     fn manual_open_logs_terminal() {
         let dir = std::env::temp_dir().join("mstream-viewlogs-demo").join("logs");
@@ -530,14 +642,22 @@ mod tests {
     #[ignore = "spawns a real Terminal window - run manually with --ignored"]
     fn manual_open_setup_terminal() {
         // MSTREAM_DEMO_PLAYER = a real player binary; MSTREAM_DEMO_SERVER =
-        // the URL to point its wizard at.
+        // the URL to point its wizard at; MSTREAM_DEMO_CONSOLE = optionally,
+        // a Ghostty.app to prefer (with MSTREAM_DEMO_ICNS for the Dock icon).
         let player = std::path::PathBuf::from(
             std::env::var("MSTREAM_DEMO_PLAYER").expect("set MSTREAM_DEMO_PLAYER"),
         );
         let url = std::env::var("MSTREAM_DEMO_SERVER")
             .unwrap_or_else(|_| "http://localhost:3000".into());
+        let console = std::env::var("MSTREAM_DEMO_CONSOLE").ok().map(|app| {
+            crate::paths::ConsoleLaunch {
+                ghostty_app: std::path::PathBuf::from(app),
+                icon_icns: std::env::var("MSTREAM_DEMO_ICNS").ok().map(std::path::PathBuf::from),
+            }
+        });
         let dir = std::env::temp_dir().join("mstream-setup-demo");
         std::fs::create_dir_all(&dir).unwrap();
-        super::open_setup_terminal(&player, &url, &dir).unwrap();
+        let via = super::open_setup_terminal(&player, &url, &dir, console.as_ref()).unwrap();
+        eprintln!("opened via {via}");
     }
 }

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -93,6 +93,13 @@ pub fn run(args: LauncherArgs) -> ! {
     // once, like the server binary: an install doesn't gain or lose its
     // bundled player mid-session.
     let player_bin = paths::find_player_bin(&bin, &data_home);
+    // The bundled Ghostty console (macOS bundles stage it at console/ beside
+    // mStream.app; other platforms simply never find one). Its Dock icon is
+    // mStream's own icns out of the .app — cosmetic, so absence is fine.
+    let console = paths::find_console_app(&bin).map(|ghostty_app| {
+        let icns = server_dir.join("..").join("Resources").join("mStream.icns");
+        paths::ConsoleLaunch { ghostty_app, icon_icns: icns.exists().then_some(icns) }
+    });
 
     // ── Single instance: the lock lives in the data home, so two launchers
     // managing the same data/port exclude each other (two --portable
@@ -510,8 +517,9 @@ pub fn run(args: LauncherArgs) -> ! {
                         log.line("menu: set up mstream");
                         match player_bin.as_deref() {
                             Some(player) => {
-                                if let Err(e) = platform::open_setup_terminal(player, &url, &data_home) {
-                                    log.line(&format!("setup wizard failed: {e}"));
+                                match platform::open_setup_terminal(player, &url, &data_home, console.as_ref()) {
+                                    Ok(via) => log.line(&format!("setup wizard opened via {via}")),
+                                    Err(e) => log.line(&format!("setup wizard failed: {e}")),
                                 }
                             }
                             // Unreachable through the menu (the item is

--- a/scripts/build-bun.mjs
+++ b/scripts/build-bun.mjs
@@ -473,6 +473,103 @@ if (!t.musl) {
   }
 }
 
+// ── Ghostty console (macOS only) ─────────────────────────────────────────────
+// The setup wizard's first-class terminal: Apple's Terminal.app has no pixel
+// protocol, so without this every default-terminal mac user gets character-art
+// fallbacks. The pinned Ghostty.dmg (bin/ghostty/manifest.json) is downloaded,
+// sha-verified, and its Ghostty.app staged BESIDE mStream.app at console/ —
+// never nested, never re-signed: the app ships byte-identical so Mitchell
+// Hashimoto's notarization stays intact, and CI's sign step (scoped to
+// mStream.app) never touches it. The tray prefers it for "Set up mStream" and
+// falls back to Terminal.app when absent.
+if (isMac) {
+  const skipConsole = (why) => {
+    if (process.env.CI && !process.env.MSTREAM_ALLOW_MISSING_CONSOLE) {
+      console.error(`  FATAL: ghostty console staging failed for ${key}: ${why} (set MSTREAM_ALLOW_MISSING_CONSOLE=1 to bundle without it on purpose)`);
+      process.exit(1);
+    }
+    console.warn(`  ghostty console not staged (${why}) — Setup falls back to Terminal.app`);
+  };
+  let gm = null;
+  try {
+    gm = JSON.parse(readFileSync(join(root, 'bin', 'ghostty', 'manifest.json'), 'utf8'));
+  } catch (_err) {
+    // unreadable/absent manifest = the same no-pin skip below
+  }
+  const TOKEN = /^[A-Za-z0-9._-]+$/;
+  if (!gm || !TOKEN.test(gm.version || '') || !TOKEN.test(gm.file || '')
+      || !/^[0-9a-f]{64}$/.test(gm.sha256 || '') || !Number.isInteger(gm.size) || gm.size <= 0
+      || !/^[A-Z0-9]{10}$/.test(gm.teamId || '')) {
+    skipConsole('bin/ghostty/manifest.json missing or malformed');
+  } else if (process.platform !== 'darwin') {
+    skipConsole('dmg extraction needs a macOS build host (hdiutil)');
+  } else {
+    const base = (process.env.MSTREAM_CONSOLE_BASE || '').replace(/\/+$/, '');
+    const url = base ? `${base}/${gm.file}` : `https://release.files.ghostty.org/${gm.version}/${gm.file}`;
+    const cacheDir = join(root, 'dist', 'console-cache');
+    mkdirSync(cacheDir, { recursive: true });
+    const cached = join(cacheDir, `${gm.sha256.slice(0, 12)}-${gm.file}`);
+    let ok = existsSync(cached)
+      && createHash('sha256').update(readFileSync(cached)).digest('hex') === gm.sha256;
+    if (!ok) {
+      console.log(`  fetching ghostty console: ${url}`);
+      try {
+        const res = await fetch(url, { redirect: 'follow' });
+        if (!res.ok) { throw new Error(`HTTP ${res.status}`); }
+        const bytes = Buffer.from(await res.arrayBuffer());
+        const gotSha = createHash('sha256').update(bytes).digest('hex');
+        if (gotSha !== gm.sha256 || bytes.length !== gm.size) {
+          // A hash mismatch is NEVER skippable — wrong bytes must not ship,
+          // and must not poison the cache.
+          console.error(`  FATAL: ${gm.file} failed verification (sha ${gotSha.slice(0, 12)}… vs pinned ${gm.sha256.slice(0, 12)}…, ${bytes.length} vs ${gm.size} bytes)`);
+          process.exit(1);
+        }
+        writeFileSync(cached, bytes);
+        ok = true;
+      } catch (err) {
+        skipConsole(`download failed: ${err.message}`);
+      }
+    }
+    if (ok) {
+      const mnt = join(root, 'dist', `console-mnt-${key}`);
+      rmSync(mnt, { recursive: true, force: true });
+      const attach = spawnSync('hdiutil', ['attach', '-nobrowse', '-readonly', '-mountpoint', mnt, cached], { stdio: 'pipe' });
+      if (attach.status !== 0) {
+        skipConsole(`hdiutil attach failed: ${attach.stderr}`);
+      } else {
+        try {
+          const src = join(mnt, 'Ghostty.app');
+          const dest = join(stageDir, 'console', 'Ghostty.app');
+          mkdirSync(join(stageDir, 'console'), { recursive: true });
+          rmSync(dest, { recursive: true, force: true });
+          // ditto, not cpSync: the .app's framework symlinks and resource
+          // forks must survive exactly, and ditto is the macOS tool for it.
+          const copy = spawnSync('ditto', [src, dest], { stdio: 'pipe' });
+          if (copy.status !== 0) { throw new Error(`ditto: ${copy.stderr}`); }
+          // The pin covers the dmg's bytes; assert the signer on the staged
+          // app too, so a re-signed upstream re-release under a reused
+          // version can never slide through a manifest edit unnoticed.
+          const sig = spawnSync('codesign', ['-dv', dest], { stdio: 'pipe', encoding: 'utf8' });
+          const team = (sig.stderr.match(/TeamIdentifier=([A-Z0-9]{10})/) || [])[1];
+          if (team !== gm.teamId) { throw new Error(`TeamIdentifier ${team} != pinned ${gm.teamId}`); }
+          const verify = spawnSync('codesign', ['--verify', '--strict', dest], { stdio: 'pipe', encoding: 'utf8' });
+          if (verify.status !== 0) { throw new Error(`codesign --verify: ${verify.stderr}`); }
+          // MIT: the license travels with the software (the app carries none).
+          cpSync(join(root, 'bin', 'ghostty', 'LICENSE'), join(stageDir, 'console', 'GHOSTTY-LICENSE.txt'));
+          console.log(`  staged ghostty console ${gm.version}: console/Ghostty.app (signed ${gm.teamId}, dmg sha verified)`);
+        } catch (err) {
+          rmSync(join(stageDir, 'console'), { recursive: true, force: true });
+          console.error(`  FATAL: ghostty console staging failed after a verified download: ${err.message}`);
+          process.exit(1);
+        } finally {
+          spawnSync('hdiutil', ['detach', mnt, '-force'], { stdio: 'pipe' });
+          rmSync(mnt, { recursive: true, force: true });
+        }
+      }
+    }
+  }
+}
+
 // Iroh remote-access tunnel: @number0/iroh ships as a NAPI-RS *native addon*
 // (prebuilt .node), not a spawned exe like the rust sidecars. A Bun standalone
 // binary can't resolve it from node_modules, so we stage the target's .node next


### PR DESCRIPTION
Phase 8's macOS slice: mac bundles now ship a pinned, **untouched** Ghostty 1.3.1 at `console/Ghostty.app`, and the tray's **Set up mStream** opens the wizard there — pixel wordmark, pixel Quick Connect QR, truecolor, and the mStream mark on the Dock tile. Terminal.app (no pixel protocol at all) remains the fallback.

**Bundler** — `bin/ghostty/manifest.json` pins {version, dmg sha256, size, TeamIdentifier}; `build-bun.mjs` downloads the dmg (`MSTREAM_CONSOLE_BASE` for mirrors), hard-refuses sha/size mismatches, extracts via hdiutil+ditto, asserts the staged app's Developer ID team against the pin, and stages it **beside** `mStream.app` — never nested, never re-signed, so Ghostty's own notarization stays intact (`spctl -t exec` accepts the round-tripped app as "Notarized Developer ID") and CI's mStream.app-scoped signing never touches it. MIT license ships as `console/GHOSTTY-LICENSE.txt`. Non-mac targets skip silently; darwin CI legs are fatal-on-missing like the player stage.

**Launcher** — `find_console_app` resolves both layouts (versioned bundle dir via ancestor walk; the ~/Applications copy via the install root's `current` link). The launch lives entirely in a generated **config file, never `-e`** (argument commands trigger Ghostty's "Allow Ghostty to execute…" consent; config commands are trusted — probed live): 120×42, `auto-update = off`, `macos-icon = custom` → mStream.icns, `quit-after-last-window-closed` so no windowless Dock ghost, and `command = shell:…` so `/bin/sh -c` handles the "Application Support" spaces. `XDG_CONFIG_HOME` is scoped to the spawn — a user's own Ghostty configuration is untouched. Console failures degrade to Terminal.app with the reason logged; `open_setup_terminal` now reports which surface opened.

**Verification**
- cargo 36/36 (console resolution over both temp layouts incl. the `current`-link case; config quoting with spaced paths; never-`-e` pinned by test), clippy `-D warnings` clean on host + windows targets
- darwin-arm64 bundle built end to end: dmg fetched + sha-verified, TeamIdentifier asserted, framework/terminfo symlinks survive the zip, `codesign --verify --strict` passes on the round-trip
- live launch through the production code path against the staged bundle: launcher log reports `opened via bundled Ghostty console`; the wizard process runs from the spaced bundle path under `/bin/sh` exactly as the `shell:` design intends
- linux-x64 build confirmed byte-untouched by the new block

**Known v1 limits** (follow-ups, not blockers): the `.pkg` payload carries `mStream.app` alone, so pkg installs fall back to Terminal.app; the console adds ~35MB to the darwin zips (accepted in the plan); the Windows exe-icon + Linux `.desktop` branding riders land as their own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)