### PR TITLE
feat(webapp): default player-on-bottom and metadata-in-queue to on

### DIFF
--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -6,9 +6,9 @@ const VUEPLAYERCORE = (() => {
   };
 
   mstreamModule.altLayout = {
-    'moveMeta': false,
+    'moveMeta': true,
     'audioBookCtrls': false,
-    'flipPlayer': false,
+    'flipPlayer': true,
     'compressArt': false,
     'hideTopBar': false,
     'waveformBar': true
@@ -16,17 +16,12 @@ const VUEPLAYERCORE = (() => {
 
   try {
     const altLayout = JSON.parse(localStorage.getItem('altLayout'));
-    mstreamModule.altLayout.flipPlayer = typeof altLayout.flipPlayer === 'boolean' ? altLayout.flipPlayer : false;
+    mstreamModule.altLayout.flipPlayer = typeof altLayout.flipPlayer === 'boolean' ? altLayout.flipPlayer : true;
     mstreamModule.altLayout.audioBookCtrls = typeof altLayout.audioBookCtrls === 'boolean' ? altLayout.audioBookCtrls : false;
-    mstreamModule.altLayout.moveMeta = typeof altLayout.moveMeta === 'boolean' ? altLayout.moveMeta : false;
+    mstreamModule.altLayout.moveMeta = typeof altLayout.moveMeta === 'boolean' ? altLayout.moveMeta : true;
     mstreamModule.altLayout.compressArt = typeof altLayout.compressArt === 'boolean' ? altLayout.compressArt : false;
     mstreamModule.altLayout.hideTopBar = typeof altLayout.hideTopBar === 'boolean' ? altLayout.hideTopBar : false;
     mstreamModule.altLayout.waveformBar = typeof altLayout.waveformBar === 'boolean' ? altLayout.waveformBar : true;
-
-    if (altLayout.flipPlayer === true) {
-      document.getElementById('content').classList.add('col-rev');
-      document.getElementById('flip-me').classList.add('col-rev');
-    }
 
     // When the top bar is disabled, mark the body so CSS can:
     //   - hide #nav-bar
@@ -37,6 +32,14 @@ const VUEPLAYERCORE = (() => {
       document.body.classList.add('top-bar-hidden');
     }
   } catch (e) {}
+
+  // Apply the resolved player position. This runs outside the try/catch above so
+  // it also fires on a fresh browser with no stored altLayout, where flipPlayer
+  // now defaults to true.
+  if (mstreamModule.altLayout.flipPlayer === true) {
+    document.getElementById('content').classList.add('col-rev');
+    document.getElementById('flip-me').classList.add('col-rev');
+  }
 
   const replayGainPreGainSettings = [
     -15.0,


### PR DESCRIPTION
Flips two of the default UI's layout toggles to on out of the box:

- **Player On Bottom** (`altLayout.flipPlayer`)
- **Metadata in Queue** (`altLayout.moveMeta`)

Existing users are unaffected — anything already stored in `localStorage.altLayout` still wins. The new default only fills in for keys that were never written, and both toggles keep working exactly as before.

One structural change came with it: applying the `col-rev` classes moved out of the localStorage `try`/`catch`. It used to read the *parsed* blob, so on a fresh browser — where `JSON.parse(null)` throws and the whole block is skipped — the flipped default would have set the flag without ever reversing the DOM. It now runs after the catch, off the resolved value.

Scope is the default UI only (`webapp/alpha/`); `webapp/velvet/` is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
