### PR TITLE
chore(player): pin mstream-player v0.5.0 (windows exe icon + wizard window titles)

### DIFF
--- a/bin/mstream-player/manifest.json
+++ b/bin/mstream-player/manifest.json
@@ -2,39 +2,39 @@
   "family": "mstream-player",
   "schema": 2,
   "repo": "IrosTheBeggar/mstream-terminal-player",
-  "tag": "v0.4.1",
-  "builtFrom": "62b06a74fefd6989ac875323366835b6f8134ed5",
-  "release": "https://github.com/IrosTheBeggar/mstream-terminal-player/releases/tag/v0.4.1",
+  "tag": "v0.5.0",
+  "builtFrom": "b4293b5dbfa9efb1fda73f76896f5e90148ea10a",
+  "release": "https://github.com/IrosTheBeggar/mstream-terminal-player/releases/tag/v0.5.0",
   "assets": {
     "mstream-player-darwin-arm64": {
       "file": "mstream-player-darwin-arm64",
-      "sha256": "0511de551fba4c66c1bb432c57e7fa9a3e491fdc27ddc284acbf77458c13e1c6",
-      "size": 20772064
+      "sha256": "c7d1b57c137245f1d298289a7f6bf361fefff80e199f0d328e6878e033c82840",
+      "size": 20772016
     },
     "mstream-player-darwin-x64": {
       "file": "mstream-player-darwin-x64",
-      "sha256": "5d2a245b98e1a4b6871633c97fecda2509f0f38038fda0a2ff8b5066e0f45e9c",
-      "size": 23547856
+      "sha256": "1dd6abac554974241c800578b5f123161deea0b2b567db6156a1840435501851",
+      "size": 23547952
     },
     "mstream-player-linux-arm": {
       "file": "mstream-player-linux-arm",
-      "sha256": "7f269e22d1c816774d6ba5ad87342761fe51afe22e6e971417f693df5aeef861",
-      "size": 23715980
+      "sha256": "df7a88f47686ff6a2852c0af7fe6f8670d700d1364df2581931e49a14a0402e4",
+      "size": 23716004
     },
     "mstream-player-linux-arm64": {
       "file": "mstream-player-linux-arm64",
-      "sha256": "c9dc3bde687775779624d704a48c8d7933b42516638a2ebeed02c1a1871a3d9f",
-      "size": 25163240
+      "sha256": "65f0e65cd40585d9a92d0988d4585d62736f6c97f8412f6d70bae1655cd48ab7",
+      "size": 25138696
     },
     "mstream-player-linux-x64": {
       "file": "mstream-player-linux-x64",
-      "sha256": "51c534a557753f593387ecbd739375bdb1a4be72253c665dc80c21f20200f6d4",
+      "sha256": "a41fa4938dca958bf567461db54e9384b1bf1a3a65e16c9491ac7cd32c2c8566",
       "size": 29447672
     },
     "mstream-player-win32-x64.exe": {
       "file": "mstream-player-win32-x64.exe",
-      "sha256": "b7d766b3527f46ee6278be142ea5522485ec1b07dc6ace1ae105bc1753adc2f4",
-      "size": 25936384
+      "sha256": "893af65ba09e72763eda8d7a2f0081bf6d2efba6705f60c95ee823c14f4fab42",
+      "size": 26040320
     }
   }
 }


### PR DESCRIPTION
Bumps the committed player pin v0.4.1 → v0.5.0 (mstream-terminal-player PR #15): the exe now embeds the mStream icon group on Windows (Explorer / shortcuts / taskbar / conhost), and the wizard names its window — "mStream Setup" / "mStream Quick Connect" — restoring the terminal's own title on exit.

Generated by `scripts/update-mstream-player-manifest.mjs v0.5.0`: all six binaries downloaded and sha256-verified; `builtFrom` matches the tag commit.

Released-bytes verification before pinning, on this machine:
- darwin-arm64: sha matches the release manifest, full six-scenario e2e battery ALL PASS, title protocol (`CSI 22;2t` → `OSC 0` → `CSI 23;2t`) verified in a pty capture of the released binary
- win32-x64: sha matches; a resedit PE parse of the released exe shows one icon group (16/32/48/64/128 @32bpp) + `mstream-player 0.5.0` VersionInfo — which also makes the planned bundler-side icon stamp unnecessary for this binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)