### PR TITLE
feat(console): ship Ghostty in the macOS .pkg installer

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1109,6 +1109,29 @@ jobs:
           pkgbuild --analyze --root pkgwork/root pkgwork/component.plist
           /usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" pkgwork/component.plist
           pkgbuild --root pkgwork/root --component-plist pkgwork/component.plist --scripts pkgwork/scripts --install-location /Applications --identifier io.mstream.server --version "$VER" pkgwork/component.pkg
+          # Second component: the bundled Ghostty console (bin/ghostty/).
+          # Its payload root maps to /Library/Application Support/mStream -
+          # the fixed system path the launcher checks third
+          # (rust-launcher paths.rs find_console_app): a pkg install has no
+          # versioned bundle dir and no `current` link. The app ships
+          # byte-identical (ditto, relocatable=false, never re-signed), so
+          # Ghostty's own notarization rides along inside our pkg.
+          CONSOLE_LINE=""
+          CONSOLE_CHOICE=""
+          CONSOLE_REF=""
+          if [ -d "$D/console/Ghostty.app" ]; then
+            rm -rf pkgwork/console-root && mkdir -p pkgwork/console-root/console
+            ditto "$D/console/Ghostty.app" pkgwork/console-root/console/Ghostty.app
+            cp "$D/console/GHOSTTY-LICENSE.txt" pkgwork/console-root/console/
+            pkgbuild --analyze --root pkgwork/console-root pkgwork/console.plist
+            /usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" pkgwork/console.plist
+            pkgbuild --root pkgwork/console-root --component-plist pkgwork/console.plist --install-location "/Library/Application Support/mStream" --identifier io.mstream.console --version "$VER" pkgwork/console.pkg
+            CONSOLE_LINE='<line choice="io.mstream.console"/>'
+            CONSOLE_CHOICE='<choice id="io.mstream.console" visible="false"><pkg-ref id="io.mstream.console"/></choice>'
+            CONSOLE_REF="<pkg-ref id=\"io.mstream.console\" version=\"$VER\" onConclusion=\"none\">console.pkg</pkg-ref>"
+          else
+            echo "::warning::no console in the staged bundle - the pkg ships without io.mstream.console"
+          fi
           case "$KEY" in
             darwin-arm64) ARCHS="arm64" ;;
             *)            ARCHS="x86_64,arm64" ;;   # x64 payload runs under Rosetta
@@ -1120,9 +1143,10 @@ jobs:
             <options customize="never" require-scripts="false" hostArchitectures="$ARCHS"/>
             <volume-check><allowed-os-versions><os-version min="11.0"/></allowed-os-versions></volume-check>
             <domains enable_localSystem="true"/>
-            <choices-outline><line choice="default"><line choice="io.mstream.server"/></line></choices-outline>
+            <choices-outline><line choice="default"><line choice="io.mstream.server"/>$CONSOLE_LINE</line></choices-outline>
             <choice id="default"/>
             <choice id="io.mstream.server" visible="false"><pkg-ref id="io.mstream.server"/></choice>
+            $CONSOLE_CHOICE$CONSOLE_REF
             <pkg-ref id="io.mstream.server" version="$VER" onConclusion="none">component.pkg</pkg-ref>
           </installer-gui-script>
           EOF
@@ -1232,6 +1256,14 @@ jobs:
           kill -0 "$OLD_PID" 2>/dev/null || { echo "::error::the seeded old instance is not running - the restart-path test would be vacuous"; exit 1; }
           sudo installer -pkg "$PKG" -target /
           test -d /Applications/mStream.app || { echo "::error::pkg install did not produce /Applications/mStream.app"; exit 1; }
+          CONSOLE_APP="/Library/Application Support/mStream/console/Ghostty.app"
+          test -d "$CONSOLE_APP" || { echo "::error::pkg install did not produce $CONSOLE_APP"; exit 1; }
+          codesign --verify --strict "$CONSOLE_APP" || { echo "::error::bundled console signature broken after pkg install"; exit 1; }
+          # File-first, not `--version | head -1`: this step runs under
+          # pipefail, and head closing the pipe early would fail a healthy
+          # multi-line --version with SIGPIPE.
+          "$CONSOLE_APP/Contents/MacOS/ghostty" --version > "$RUNNER_TEMP/console-version.txt" 2>&1
+          head -1 "$RUNNER_TEMP/console-version.txt"
           if kill -0 "$OLD_PID" 2>/dev/null; then
             echo "::error::postinstall left the old running instance alive"; exit 1
           fi
@@ -1265,6 +1297,8 @@ jobs:
           echo "pkg-installed server served 200 on :3557"
           sudo rm -rf /Applications/mStream.app
           sudo pkgutil --forget io.mstream.server
+          sudo rm -rf "/Library/Application Support/mStream/console"
+          sudo pkgutil --forget io.mstream.console
           echo "PKG INSTALL SMOKE OK"
 
       # darwin-x64 is the one shipped artifact whose binaries never execute

--- a/bin/ghostty/README.md
+++ b/bin/ghostty/README.md
@@ -1,7 +1,11 @@
 # Bundled Ghostty console (macOS)
 
 `manifest.json` pins the [Ghostty](https://ghostty.org) release the macOS
-bundles ship as `console/Ghostty.app`, beside `mStream.app`. The bundler
+bundles ship as `console/Ghostty.app`, beside `mStream.app`. The .pkg
+installer carries the same app as its own component (`io.mstream.console`,
+payload at `/Library/Application Support/mStream/console/` — a pkg install
+has no versioned bundle dir, so the launcher checks that fixed system path
+third). The bundler
 (`scripts/build-bun.mjs`) downloads the pinned `Ghostty.dmg` from
 `https://release.files.ghostty.org/<version>/`, refuses anything that does
 not hash to the pinned sha256, extracts the app, and asserts its

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -262,17 +262,23 @@ pub struct ConsoleLaunch {
 
 /// The bundled Ghostty console — macOS bundles stage it at
 /// console/Ghostty.app BESIDE mStream.app (never inside: both notarization
-/// seals stay independent; scripts/build-bun.mjs). Two layouts can hold one:
-/// running out of the versioned bundle dir itself (an ancestor of the server
-/// binary), and the ~/Applications copy of mStream.app, whose versioned dir
-/// is wherever the install root's `current` link points. None on the other
-/// platforms and on consoleless installs — the caller falls back to the
-/// Terminal.app path.
+/// seals stay independent; scripts/build-bun.mjs). Three layouts can hold
+/// one, checked most-specific first: running out of the versioned bundle dir
+/// itself (an ancestor of the server binary); the ~/Applications copy of
+/// mStream.app, whose versioned dir is wherever the install root's `current`
+/// link points; and the .pkg install, whose io.mstream.console component
+/// lands at the fixed system path (/Applications/mStream.app has no
+/// versioned dir or current link at all). None on the other platforms and
+/// on consoleless installs — the caller falls back to the Terminal.app path.
 pub fn find_console_app(server_bin: &Path) -> Option<PathBuf> {
-    find_console_app_in(server_bin, &data_home().join("app"))
+    find_console_app_in(
+        server_bin,
+        &data_home().join("app"),
+        Path::new("/Library/Application Support/mStream"),
+    )
 }
 
-fn find_console_app_in(server_bin: &Path, install_root: &Path) -> Option<PathBuf> {
+fn find_console_app_in(server_bin: &Path, install_root: &Path, system_root: &Path) -> Option<PathBuf> {
     let ghostty = |app: &Path| app.join("Contents").join("MacOS").join("ghostty");
     let mut dir = server_bin.parent();
     for _ in 0..6 {
@@ -284,7 +290,11 @@ fn find_console_app_in(server_bin: &Path, install_root: &Path) -> Option<PathBuf
         dir = d.parent();
     }
     let current = install_root.join("current").join("console").join("Ghostty.app");
-    ghostty(&current).exists().then_some(current)
+    if ghostty(&current).exists() {
+        return Some(current);
+    }
+    let system = system_root.join("console").join("Ghostty.app");
+    ghostty(&system).exists().then_some(system)
 }
 
 /// Escape a literal string for use inside a POSIX ERE (the pgrep -f
@@ -550,32 +560,50 @@ mod tests {
         let bundle = root.join("mStream-9.9.9-darwin-arm64");
         let server = bundle.join("mStream.app/Contents/MacOS/mstream-server");
         let install_root = root.join("approot");
+        let system_root = root.join("syslib");
         std::fs::create_dir_all(server.parent().unwrap()).unwrap();
-        assert_eq!(find_console_app_in(&server, &install_root), None, "nothing staged yet");
+        assert_eq!(find_console_app_in(&server, &install_root, &system_root), None, "nothing staged yet");
 
         let ghostty_bin_dir = bundle.join("console/Ghostty.app/Contents/MacOS");
         std::fs::create_dir_all(&ghostty_bin_dir).unwrap();
         std::fs::write(ghostty_bin_dir.join("ghostty"), b"x").unwrap();
         assert_eq!(
-            find_console_app_in(&server, &install_root),
+            find_console_app_in(&server, &install_root, &system_root),
             Some(bundle.join("console/Ghostty.app")),
             "ancestor walk finds the bundle's console"
         );
 
-        // The ~/Applications copy: the server binary is inside the copied
-        // .app, nowhere near console/ — resolution goes through the install
-        // root's `current` link (unix-only mechanics, like the install).
+        // The .pkg layout: the server binary is inside /Applications'
+        // mStream.app, with NO versioned dir and NO current link — the
+        // io.mstream.console component's fixed system path is the answer.
+        let apps_copy = root.join("Applications/mStream.app/Contents/MacOS/mstream-server");
+        std::fs::create_dir_all(apps_copy.parent().unwrap()).unwrap();
+        assert_eq!(
+            find_console_app_in(&apps_copy, &install_root, &system_root),
+            None,
+            "no current link and no system console yet"
+        );
+        let sys_bin_dir = system_root.join("console/Ghostty.app/Contents/MacOS");
+        std::fs::create_dir_all(&sys_bin_dir).unwrap();
+        std::fs::write(sys_bin_dir.join("ghostty"), b"x").unwrap();
+        assert_eq!(
+            find_console_app_in(&apps_copy, &install_root, &system_root),
+            Some(system_root.join("console/Ghostty.app")),
+            "the pkg install resolves through the system path"
+        );
+
+        // The ~/Applications copy of a SCRIPT install: resolution goes
+        // through the install root's `current` link, which outranks the
+        // system path when both exist (unix-only mechanics, like the
+        // install).
         #[cfg(unix)]
         {
-            let apps_copy = root.join("Applications/mStream.app/Contents/MacOS/mstream-server");
-            std::fs::create_dir_all(apps_copy.parent().unwrap()).unwrap();
-            assert_eq!(find_console_app_in(&apps_copy, &install_root), None, "no current link yet");
             std::fs::create_dir_all(&install_root).unwrap();
             std::os::unix::fs::symlink(&bundle, install_root.join("current")).unwrap();
             assert_eq!(
-                find_console_app_in(&apps_copy, &install_root),
+                find_console_app_in(&apps_copy, &install_root, &system_root),
                 Some(install_root.join("current/console/Ghostty.app")),
-                "the ~/Applications copy resolves through current"
+                "the current link outranks the pkg system path"
             );
         }
         let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
Closes the #911 known-limit: pkg installs fell back to Terminal.app because the payload was `mStream.app` alone. Two halves:

**Launcher (this commit)** — `find_console_app` gains a third candidate, checked after the bundle-dir ancestor walk and the install root's `current` link (both outrank it): the fixed system path `/Library/Application Support/mStream/console/Ghostty.app`, where the pkg's new component lands. Precedence is pinned by test — a script install coexisting with a stale pkg console keeps resolving its own copy. cargo 36 green, clippy `-D warnings` clean host + windows.

**Workflow (to be committed on this branch — see the task comment below)** — the pkg build step gains a second component: `io.mstream.console`, payload root mapping to `/Library/Application Support/mStream`, non-relocatable, ditto'd byte-identical from the staged bundle (never re-signed), wired into distribution.xml as a hidden default choice; the runner's install-smoke gains console asserts and cleanup. Skipped with a warning when the bundle was built consoleless (`MSTREAM_ALLOW_MISSING_CONSOLE`).

**Already proven in the local lab** (pre-branch): a locally built two-tree pkg round-trips Ghostty byte-intact — `pkgbuild --analyze` infers both bundles cleanly, strict `codesign --verify` passes on the extracted payload, the binary runs, and the production `open_setup_terminal` launched the wizard from the pkg-extracted console. The one thing only CI can answer — Apple's notary accepting a pkg whose payload contains another team's (already-notarized) app — gets answered by this PR's own darwin legs, which sign, notarize, build the pkg, and install-smoke it on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)