### PR TITLE
feat(tray): terminal-first tray — Quick Connect page, Open Admin Panel, first-run wizard auto-open

### DIFF
--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1689,6 +1689,7 @@ jobs:
         run: |
           D=$(ls -d dist/stage/mStream-*-${{ matrix.key }})
           cp -R "$D" "$RUNNER_TEMP/inv"
+          rm -rf "$RUNNER_TEMP/inv/save"   # the copy must be DB-pristine too: the main smoke's library would trip the setupComplete backfill
           case "${{ matrix.key }}" in
             darwin-*) SRV="$RUNNER_TEMP/inv/mStream.app/Contents/MacOS/mstream-server" ;;
             win-*)    SRV="$RUNNER_TEMP/inv/mstream-server.exe" ;;

--- a/.github/workflows/build-bun.yml
+++ b/.github/workflows/build-bun.yml
@@ -1689,7 +1689,7 @@ jobs:
         run: |
           D=$(ls -d dist/stage/mStream-*-${{ matrix.key }})
           cp -R "$D" "$RUNNER_TEMP/inv"
-          rm -rf "$RUNNER_TEMP/inv/save"   # the copy must be DB-pristine too: the main smoke's library would trip the setupComplete backfill
+          rm -rf "$RUNNER_TEMP/inv/save" "$RUNNER_TEMP/inv/mStream.app/Contents/MacOS/save"   # DB-pristine on BOTH layouts: darwin's dataRoot lives inside the .app
           case "${{ matrix.key }}" in
             darwin-*) SRV="$RUNNER_TEMP/inv/mStream.app/Contents/MacOS/mstream-server" ;;
             win-*)    SRV="$RUNNER_TEMP/inv/mstream-server.exe" ;;

--- a/docs/install.md
+++ b/docs/install.md
@@ -139,7 +139,7 @@ directly, with `manifest.json` holding their sha256s:
 Windows, `mStream.app` on macOS, `mstream-desktop` on Linux — starts the
 server in the background, puts an mStream icon in your tray / menu bar
 (a status line — "Running · up 3h 12m", or Starting… / Stopped — then Open
-mStream · Quick Connect · Set up mStream · Start at login · View logs ·
+Admin Panel · Quick Connect · Set up mStream · Start at login · View logs ·
 Restart server · Quit), and opens your browser at the player. Start-at-login
 is on by default; one click in the tray menu turns it off. **Set up mStream**
 opens a terminal running the guided setup wizard (the bundled

--- a/docs/install.md
+++ b/docs/install.md
@@ -139,19 +139,17 @@ directly, with `manifest.json` holding their sha256s:
 Windows, `mStream.app` on macOS, `mstream-desktop` on Linux — starts the
 server in the background, puts an mStream icon in your tray / menu bar
 (a status line — "Running · up 3h 12m", or Starting… / Stopped — then Open
-Admin Panel · Quick Connect · Set up mStream · Start at login · View logs ·
+Admin Panel · Quick Connect · Start at login · View logs ·
 Restart server · Quit), and opens your browser at the player. Start-at-login
-is on by default; one click in the tray menu turns it off. **Set up mStream**
-opens a terminal running the guided setup wizard (the bundled
-`mstream-player setup`) — music folders, admin account, extras. It is
-one-time onboarding: on a first install it opens by itself, and once the
-server is set up the menu item greys out (the wizard itself declines
-configured servers) — everything after that lives in the admin panel. On
-macOS it
-opens in the bundled mStream console (Ghostty, with the mStream Dock icon),
-which draws the wizard's artwork and Quick Connect QR as real pixels;
-without the console it falls back to Terminal.app, and Windows prefers
-Windows Terminal. **Quick Connect** opens the same way on macOS and Windows —
+is on by default; one click in the tray menu turns it off. On a **first
+install** the tray opens the guided setup wizard by itself (the bundled
+`mstream-player setup` — music folders, admin account, extras) in a real
+terminal: the bundled mStream console (Ghostty, with the mStream Dock icon)
+on macOS, which draws the wizard's artwork and Quick Connect QR as real
+pixels; Terminal.app without the console, and Windows Terminal on Windows.
+The wizard is one-time onboarding — the server records `setupComplete` in
+its config the moment the first folder or account lands, and everything
+after that lives in the admin panel. **Quick Connect** opens the same way on macOS and Windows —
 the wizard's pairing page (a scannable pixel QR plus the app links) in a
 terminal window; on Linux, or when an install has no player binary, it opens
 the web player's Quick Connect modal instead. Headless installs get the

--- a/docs/install.md
+++ b/docs/install.md
@@ -143,8 +143,11 @@ Admin Panel · Quick Connect · Set up mStream · Start at login · View logs ·
 Restart server · Quit), and opens your browser at the player. Start-at-login
 is on by default; one click in the tray menu turns it off. **Set up mStream**
 opens a terminal running the guided setup wizard (the bundled
-`mstream-player setup`) — music folders, admin account, extras — and stays
-useful later: reopened, it picks up what the server already has. On macOS it
+`mstream-player setup`) — music folders, admin account, extras. It is
+one-time onboarding: on a first install it opens by itself, and once the
+server is set up the menu item greys out (the wizard itself declines
+configured servers) — everything after that lives in the admin panel. On
+macOS it
 opens in the bundled mStream console (Ghostty, with the mStream Dock icon),
 which draws the wizard's artwork and Quick Connect QR as real pixels;
 without the console it falls back to Terminal.app, and Windows prefers

--- a/docs/install.md
+++ b/docs/install.md
@@ -148,8 +148,12 @@ useful later: reopened, it picks up what the server already has. On macOS it
 opens in the bundled mStream console (Ghostty, with the mStream Dock icon),
 which draws the wizard's artwork and Quick Connect QR as real pixels;
 without the console it falls back to Terminal.app, and Windows prefers
-Windows Terminal. Headless installs get the same invitation as a boot log
-line whenever the server has no folders and no accounts yet.
+Windows Terminal. **Quick Connect** opens the same way on macOS and Windows —
+the wizard's pairing page (a scannable pixel QR plus the app links) in a
+terminal window; on Linux, or when an install has no player binary, it opens
+the web player's Quick Connect modal instead. Headless installs get the
+setup invitation as a boot log line whenever the server has no folders and
+no accounts yet.
 
 **Terminal users lose nothing.** The same desktop binary run from a terminal
 behaves exactly like the server itself (same flags, output, and exit codes) —

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -202,8 +202,8 @@ pub fn library_is_configured(config: &Path) -> bool {
 /// boot, a second instance yielding, a macOS reopen): the player when there
 /// is music, the ADMIN PANEL when the library has no folders yet — a fresh
 /// install's player is a dead end, and the admin panel is where folders get
-/// added. The tray's explicit "Open mStream" item stays literal (always the
-/// player) so the menu does what it says.
+/// added. The tray's explicit "Open Admin Panel" item does NOT route
+/// through this — it always opens /admin, literally what it says.
 pub fn browse_target(config: &Path, ep: &Endpoint) -> String {
     if library_is_configured(config) {
         server_url(ep)

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -187,25 +187,38 @@ pub fn server_url(ep: &Endpoint) -> String {
     }
 }
 
-/// Whether the config declares any music folders. Unreadable or absent
-/// config counts as unconfigured — on a true first run the file appears
-/// mid-boot, and the right answer is the same either way.
-pub fn library_is_configured(config: &Path) -> bool {
-    std::fs::read_to_string(config)
+/// Whether this install has been through first-run setup, per the config's
+/// one-time `setupComplete` marker — written by the SERVER the moment the
+/// first library or first user lands (util/admin.js markSetupComplete), and
+/// backfilled at boot for installs that predate it. The legacy `folders`
+/// check rides along as a belt: an older server never writes the flag, but
+/// old-style configs still carry their folders, so a new launcher over an
+/// old configured install doesn't re-run first-run behavior. Unreadable or
+/// absent config counts as not-set-up — on a true first run the file
+/// appears mid-boot, and the right answer is the same either way.
+pub fn setup_complete(config: &Path) -> bool {
+    let Some(v) = std::fs::read_to_string(config)
         .ok()
         .and_then(|s| serde_json::from_str::<serde_json::Value>(s.trim_start_matches('\u{feff}')).ok())
-        .and_then(|v| v.get("folders").and_then(|f| f.as_object().map(|o| !o.is_empty())))
-        .unwrap_or(false)
+    else {
+        return false;
+    };
+    if v.get("setupComplete").and_then(|b| b.as_bool()) == Some(true) {
+        return true;
+    }
+    v.get("folders").and_then(|f| f.as_object().map(|o| !o.is_empty())).unwrap_or(false)
 }
 
 /// Where a launcher-initiated browser open should land (the announce after
-/// boot, a second instance yielding, a macOS reopen): the player when there
-/// is music, the ADMIN PANEL when the library has no folders yet — a fresh
-/// install's player is a dead end, and the admin panel is where folders get
-/// added. The tray's explicit "Open Admin Panel" item does NOT route
-/// through this — it always opens /admin, literally what it says.
+/// boot, a second instance yielding, a macOS reopen): the player once setup
+/// has happened, the ADMIN PANEL before it — a fresh install's player is a
+/// dead end. (The post-boot announce goes further and opens the setup
+/// wizard itself on fresh installs; this is its browser fallback and every
+/// other gesture's routing.) The tray's explicit "Open Admin Panel" item
+/// does NOT route through this — it always opens /admin, literally what it
+/// says.
 pub fn browse_target(config: &Path, ep: &Endpoint) -> String {
-    if library_is_configured(config) {
+    if setup_complete(config) {
         server_url(ep)
     } else {
         format!("{}/admin", server_url(ep))
@@ -554,6 +567,30 @@ mod tests {
     }
 
     #[test]
+    fn setup_complete_reads_the_flag_with_a_legacy_folders_belt() {
+        let p = env::temp_dir().join(format!("mstream-launcher-setup-{}.json", std::process::id()));
+        // Absent config = a true first run (the server writes it mid-boot).
+        let _ = std::fs::remove_file(&p);
+        assert!(!setup_complete(&p));
+        // Fresh modern config: no flag, no folders.
+        std::fs::write(&p, "{ \"port\": 3000 }").unwrap();
+        assert!(!setup_complete(&p));
+        // The server wrote the one-time marker.
+        std::fs::write(&p, "{ \"setupComplete\": true }").unwrap();
+        assert!(setup_complete(&p));
+        // An explicit false stays false (never written by us, but honest).
+        std::fs::write(&p, "{ \"setupComplete\": false }").unwrap();
+        assert!(!setup_complete(&p));
+        // Legacy belt: an OLD server never writes the flag, but old-style
+        // configs still carry their folders.
+        std::fs::write(&p, "{ \"folders\": { \"m\": { \"root\": \"/x\" } } }").unwrap();
+        assert!(setup_complete(&p));
+        std::fs::write(&p, "{ \"folders\": {} }").unwrap();
+        assert!(!setup_complete(&p));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
     fn find_console_app_walks_bundle_then_install_root() {
         let root = env::temp_dir().join(format!("mstream-launcher-console-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
@@ -615,9 +652,9 @@ mod tests {
         // server strips it before parsing, so this side must too — a BOM'd
         // port must not send the launcher probing the 3000 fallback.
         let p = env::temp_dir().join(format!("mstream-launcher-bom-{}.json", std::process::id()));
-        std::fs::write(&p, "\u{feff}{ \"port\": 8123, \"folders\": { \"m\": { \"root\": \"/x\" } } }").unwrap();
+        std::fs::write(&p, "\u{feff}{ \"port\": 8123, \"setupComplete\": true }").unwrap();
         assert_eq!(read_endpoint(&p).port, 8123);
-        assert!(library_is_configured(&p));
+        assert!(setup_complete(&p));
         let _ = std::fs::remove_file(&p);
     }
 
@@ -686,26 +723,22 @@ mod tests {
 
     #[test]
     fn library_configured_detection() {
+        // Garbage shapes must read as not-set-up, never panic.
         let dir = env::temp_dir();
         let f = |name: &str, body: &str| {
             let p = dir.join(format!("mstream-lib-{}-{}.json", std::process::id(), name));
             std::fs::write(&p, body).unwrap();
             p
         };
-        assert!(!library_is_configured(Path::new("/definitely/not/there.json")), "absent config = unconfigured");
-        let empty = f("empty", "{}");
-        assert!(!library_is_configured(&empty), "no folders key = unconfigured");
-        let bare = f("bare", r#"{"folders":{}}"#);
-        assert!(!library_is_configured(&bare), "empty folders object = unconfigured");
         let garbage = f("garbage", r#"{"folders":"nope"}"#);
-        assert!(!library_is_configured(&garbage), "non-object folders = unconfigured");
-        let real = f("real", r#"{"folders":{"music":{"root":"/m"}}}"#);
-        assert!(library_is_configured(&real));
-        for p in [empty, bare, garbage, real] { let _ = std::fs::remove_file(p); }
+        assert!(!setup_complete(&garbage), "non-object folders = not set up");
+        let flag_garbage = f("flaggarbage", r#"{"setupComplete":"yes"}"#);
+        assert!(!setup_complete(&flag_garbage), "non-bool flag = not set up");
+        for p in [garbage, flag_garbage] { let _ = std::fs::remove_file(p); }
     }
 
     #[test]
-    fn browse_target_lands_on_admin_until_folders_exist() {
+    fn browse_target_lands_on_admin_until_setup_completes() {
         let ep = Endpoint { ip: IpAddr::V4(Ipv4Addr::LOCALHOST), port: 3000 };
         assert_eq!(browse_target(Path::new("/nope.json"), &ep), "http://localhost:3000/admin");
         let p = env::temp_dir().join(format!("mstream-bt-{}.json", std::process::id()));

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -283,7 +283,45 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
     }
 }
 
-/// Run the bundled terminal player's setup wizard in a fresh terminal
+/// Which wizard-family page a terminal launch opens. Each carries its own
+/// subcommand, window title, and scratch script name, so the Setup and
+/// Quick Connect tray items never clobber each other's launch files.
+#[derive(Clone, Copy)]
+pub enum WizardPage {
+    /// The full first-run wizard (`mstream-player setup`).
+    Setup,
+    /// The standalone Quick Connect page (`mstream-player qr`) — the
+    /// wizard's Done screen: pairing QR plus the app buttons.
+    QuickConnect,
+}
+
+impl WizardPage {
+    fn subcommand(self) -> &'static str {
+        match self {
+            WizardPage::Setup => "setup",
+            WizardPage::QuickConnect => "qr",
+        }
+    }
+    // Only the mac ghostty config (and this file's mac-gated tests) call
+    // this; allow, not cfg, keeps the enum's surface uniform across
+    // platforms.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    fn title(self) -> &'static str {
+        match self {
+            WizardPage::Setup => "mStream Setup",
+            WizardPage::QuickConnect => "mStream Quick Connect",
+        }
+    }
+    #[cfg(target_os = "macos")]
+    fn script_name(self) -> &'static str {
+        match self {
+            WizardPage::Setup => "setup-mstream.command",
+            WizardPage::QuickConnect => "quickconnect-mstream.command",
+        }
+    }
+}
+
+/// Run one of the terminal player's wizard-family pages in a fresh terminal
 /// window, pointed at this launcher's server. Same per-OS "what is a
 /// terminal" seams as open_logs_terminal; the caller logs a failure — a
 /// missing terminal emulator must never take the tray down. Ok carries
@@ -294,18 +332,19 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
 /// paths::find_console_app) — preferred over Terminal.app because Apple's
 /// terminal has no pixel protocol at all, so the wizard's wordmark and QR
 /// degrade to character art there. Ignored on the other platforms.
-pub fn open_setup_terminal(
+pub fn open_wizard_terminal(
     player_bin: &std::path::Path,
     server_url: &str,
     scratch_dir: &std::path::Path,
     console: Option<&crate::paths::ConsoleLaunch>,
+    page: WizardPage,
 ) -> Result<String, String> {
     #[cfg(target_os = "macos")]
     {
         use std::os::unix::fs::PermissionsExt;
         let mut console_note = String::new();
         if let Some(c) = console {
-            match spawn_ghostty_setup(c, player_bin, server_url, scratch_dir) {
+            match spawn_ghostty_page(c, player_bin, server_url, scratch_dir, page) {
                 Ok(()) => return Ok("bundled Ghostty console".into()),
                 // A broken bundled console must degrade to Terminal.app, not
                 // dead-end the button — but the reason rides along.
@@ -317,10 +356,11 @@ pub fn open_setup_terminal(
         // resize asks for the window the wizard's two-column pages were
         // designed around; Terminal.app honors it, and a terminal that
         // doesn't just keeps its size (the wizard reflows).
-        let script = scratch_dir.join("setup-mstream.command");
+        let script = scratch_dir.join(page.script_name());
         let body = format!(
-            "#!/bin/sh\n# Written by mStream's tray 'Set up mStream' item - safe to delete.\nprintf '\\033[8;42;120t'\nclear\nexec {player} setup --server {url}\n",
+            "#!/bin/sh\n# Written by mStream's tray - safe to delete.\nprintf '\\033[8;42;120t'\nclear\nexec {player} {sub} --server {url}\n",
             player = sh_quote(player_bin),
+            sub = page.subcommand(),
             url = sh_quote_str(server_url),
         );
         std::fs::write(&script, body).map_err(|e| format!("write {}: {e}", script.display()))?;
@@ -342,7 +382,7 @@ pub fn open_setup_terminal(
         let _ = console;
         if std::process::Command::new("wt.exe")
             .arg(player_bin)
-            .args(["setup", "--server", server_url])
+            .args([page.subcommand(), "--server", server_url])
             .spawn()
             .is_ok()
         {
@@ -350,7 +390,7 @@ pub fn open_setup_terminal(
         }
         const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
         std::process::Command::new(player_bin)
-            .args(["setup", "--server", server_url])
+            .args([page.subcommand(), "--server", server_url])
             .creation_flags(CREATE_NEW_CONSOLE)
             .spawn()
             .map(|_| "conhost fallback".into())
@@ -360,8 +400,9 @@ pub fn open_setup_terminal(
     {
         let _ = (scratch_dir, console); // no script file / no bundled console here
         let cmd = format!(
-            "exec {player} setup --server {url}",
+            "exec {player} {sub} --server {url}",
             player = sh_quote(player_bin),
+            sub = page.subcommand(),
             url = sh_quote_str(server_url),
         );
         let candidates = [
@@ -390,11 +431,12 @@ pub fn open_setup_terminal(
 /// XDG_CONFIG_HOME is scoped to the spawn, so a user's own Ghostty install
 /// keeps its own configuration untouched.
 #[cfg(target_os = "macos")]
-fn spawn_ghostty_setup(
+fn spawn_ghostty_page(
     console: &crate::paths::ConsoleLaunch,
     player_bin: &std::path::Path,
     server_url: &str,
     scratch_dir: &std::path::Path,
+    page: WizardPage,
 ) -> Result<(), String> {
     let bin = console.ghostty_app.join("Contents").join("MacOS").join("ghostty");
     if !bin.exists() {
@@ -404,7 +446,7 @@ fn spawn_ghostty_setup(
     let cfg_dir = cfg_home.join("ghostty");
     std::fs::create_dir_all(&cfg_dir).map_err(|e| format!("mkdir {}: {e}", cfg_dir.display()))?;
     let cfg = cfg_dir.join("config");
-    std::fs::write(&cfg, ghostty_setup_config(console, player_bin, server_url))
+    std::fs::write(&cfg, ghostty_page_config(console, player_bin, server_url, page))
         .map_err(|e| format!("write {}: {e}", cfg.display()))?;
     std::process::Command::new(&bin)
         .env("XDG_CONFIG_HOME", &cfg_home)
@@ -421,27 +463,30 @@ fn spawn_ghostty_setup(
 /// Dock as a windowless app after the wizard exits; `macos-icon = custom`
 /// puts the mStream mark on that Dock tile while it lives.
 #[cfg(target_os = "macos")]
-fn ghostty_setup_config(
+fn ghostty_page_config(
     console: &crate::paths::ConsoleLaunch,
     player_bin: &std::path::Path,
     server_url: &str,
+    page: WizardPage,
 ) -> String {
-    let mut body = String::from(
-        "# Written by mStream's tray 'Set up mStream' item - safe to delete.\n\
+    let mut body = format!(
+        "# Written by mStream's tray - safe to delete.\n\
          auto-update = off\n\
-         title = mStream Setup\n\
+         title = {title}\n\
          window-width = 120\n\
          window-height = 42\n\
          confirm-close-surface = false\n\
          quit-after-last-window-closed = true\n",
+        title = page.title(),
     );
     if let Some(icns) = &console.icon_icns {
         // Config values run to end of line — a spaced path needs no quoting.
         body.push_str(&format!("macos-icon = custom\nmacos-custom-icon = {}\n", icns.display()));
     }
     body.push_str(&format!(
-        "command = shell:{player} setup --server {url}\n",
+        "command = shell:{player} {sub} --server {url}\n",
         player = sh_quote(player_bin),
+        sub = page.subcommand(),
         url = sh_quote_str(server_url),
     ));
     body
@@ -605,10 +650,11 @@ mod tests {
             ghostty_app: "/tmp/x/Ghostty.app".into(),
             icon_icns: Some("/App Root/Resources/mStream.icns".into()),
         };
-        let cfg = super::ghostty_setup_config(
+        let cfg = super::ghostty_page_config(
             &c,
             std::path::Path::new("/Application Support/bin/mstream-player"),
             "http://localhost:3000",
+            super::WizardPage::Setup,
         );
         // shell: + sh-quoting is what survives "Application Support" spaces;
         // the command must live in the CONFIG, never a -e argument (consent
@@ -624,8 +670,25 @@ mod tests {
         assert!(cfg.contains("quit-after-last-window-closed = true\n"), "{cfg}");
 
         let plain = crate::paths::ConsoleLaunch { ghostty_app: "/t/G.app".into(), icon_icns: None };
-        let cfg2 = super::ghostty_setup_config(&plain, std::path::Path::new("/p"), "http://x:1");
+        let cfg2 = super::ghostty_page_config(&plain, std::path::Path::new("/p"), "http://x:1", super::WizardPage::Setup);
         assert!(!cfg2.contains("macos-icon"), "no icns means Ghostty keeps its own icon: {cfg2}");
+
+        // The Quick Connect page: same machinery, its own subcommand + title.
+        let qc = super::ghostty_page_config(&plain, std::path::Path::new("/p"), "http://x:1", super::WizardPage::QuickConnect);
+        assert!(qc.contains("command = shell:'/p' qr --server 'http://x:1'"), "{qc}");
+        assert!(qc.contains("title = mStream Quick Connect\n"), "{qc}");
+    }
+
+    #[test]
+    fn each_page_maps_to_its_own_subcommand_title_and_script() {
+        use super::WizardPage::*;
+        assert_eq!(Setup.subcommand(), "setup");
+        assert_eq!(QuickConnect.subcommand(), "qr");
+        assert_eq!(Setup.title(), "mStream Setup");
+        assert_eq!(QuickConnect.title(), "mStream Quick Connect");
+        // Distinct script files: the two tray items must never clobber
+        // each other's .command.
+        assert_ne!(Setup.script_name(), QuickConnect.script_name());
     }
 
     #[test]
@@ -657,7 +720,12 @@ mod tests {
         });
         let dir = std::env::temp_dir().join("mstream-setup-demo");
         std::fs::create_dir_all(&dir).unwrap();
-        let via = super::open_setup_terminal(&player, &url, &dir, console.as_ref()).unwrap();
+        // MSTREAM_DEMO_PAGE=qr opens the Quick Connect page instead.
+        let page = match std::env::var("MSTREAM_DEMO_PAGE").as_deref() {
+            Ok("qr") => super::WizardPage::QuickConnect,
+            _ => super::WizardPage::Setup,
+        };
+        let via = super::open_wizard_terminal(&player, &url, &dir, console.as_ref(), page).unwrap();
         eprintln!("opened via {via}");
     }
 }

--- a/rust-launcher/src/server.rs
+++ b/rust-launcher/src/server.rs
@@ -117,9 +117,23 @@ fn probe_mstream(addr: &SocketAddr) -> bool {
         }
     }
     let text = String::from_utf8_lossy(&buf);
-    let status_ok = text
-        .lines()
-        .next()
-        .is_some_and(|l| l.starts_with("HTTP/") && l.contains(" 200"));
-    status_ok && text.contains("mStream")
+    let status = text.lines().next().unwrap_or("");
+    if !status.starts_with("HTTP/") {
+        return false;
+    }
+    // 200 + the webapp title = the open/public root. A server with accounts
+    // answers `/` with 302 → /login instead — equally mStream, and treating
+    // it as not-up left the tray stuck on "Starting…" for every
+    // password-protected install (found by the setupComplete two-boot
+    // smoke; the announce and status line both hang off this probe).
+    if status.contains(" 200") {
+        return text.contains("mStream");
+    }
+    if status.contains(" 302") || status.contains(" 303") || status.contains(" 307") {
+        return text
+            .lines()
+            .take_while(|l| !l.is_empty())
+            .any(|l| l.to_ascii_lowercase().starts_with("location:") && l.contains("/login"));
+    }
+    false
 }

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -356,7 +356,7 @@ pub fn run(args: LauncherArgs) -> ! {
                     update_item_view(upd.as_ref(), &updates_dir(), relaunch_target_exists(exe_real.as_deref()));
                 let update = MenuItem::with_id("update", utext.clone(), uaction != UpdateAction::None, None);
                 upd_text = utext;
-                let open_item = MenuItem::with_id("open", "Open mStream", true, None);
+                let open_item = MenuItem::with_id("open", "Open Admin Panel", true, None);
                 let qc_item = MenuItem::with_id("quick-connect", "Quick Connect", true, None);
                 // Guided first-run setup (folders, account, extras) in a real
                 // terminal. Stays useful after first run — the wizard seeds
@@ -506,7 +506,11 @@ pub fn run(args: LauncherArgs) -> ! {
                 }
                 AppEvent::Menu(id) => match id.as_str() {
                     "open" => {
-                        let _ = open::that_detached(url.clone());
+                        // The admin panel, explicitly — the tray is the
+                        // operator's surface, and listening happens in the
+                        // apps/players. (The post-boot browser announce keeps
+                        // its own routing: paths::browse_target.)
+                        let _ = open::that_detached(format!("{url}/admin"));
                     }
                     "quick-connect" => {
                         // The wizard's Quick Connect page (pixel pairing QR)

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -304,6 +304,7 @@ pub fn run(args: LauncherArgs) -> ! {
     // Update-awareness: the server's checker writes update-status.json in
     // the shared data home; the tray re-reads it on every minute tick.
     let mut update_item: Option<MenuItem> = None;
+    let mut setup_item_slot: Option<MenuItem> = None;
     let mut upd: Option<paths::UpdateStatus> = paths::read_update_status();
     let mut upd_text = String::new();
     // The apply request we last ACTED on (the file's applyRequestedAt, else
@@ -358,11 +359,19 @@ pub fn run(args: LauncherArgs) -> ! {
                 upd_text = utext;
                 let open_item = MenuItem::with_id("open", "Open Admin Panel", true, None);
                 let qc_item = MenuItem::with_id("quick-connect", "Quick Connect", true, None);
-                // Guided first-run setup (folders, account, extras) in a real
-                // terminal. Stays useful after first run — the wizard seeds
-                // itself from the server's committed state — so it is always
-                // offered, greyed only when this install has no player binary.
-                let setup_item = MenuItem::with_id("setup", "Set up mStream", player_bin.is_some(), None);
+                // Guided first-run setup (folders, account, extras) in a
+                // real terminal — ONE-TIME onboarding by design (operator
+                // decision, PR #915): once the library is configured the
+                // item greys out, because post-setup work belongs to the
+                // admin panel; the wizard itself parks on configured
+                // servers as the backstop. Also greyed when this install
+                // has no player binary. Re-checked each minute tick.
+                let setup_item = MenuItem::with_id(
+                    "setup",
+                    "Set up mStream",
+                    player_bin.is_some() && !paths::library_is_configured(&config),
+                    None,
+                );
                 let auto_item =
                     CheckMenuItem::with_id("autostart", "Start at login", true, autostart::is_enabled(), None);
                 let logs_item = MenuItem::with_id("logs", "View logs", true, None);
@@ -374,6 +383,7 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&open_item);
                 let _ = menu.append(&qc_item);
                 let _ = menu.append(&setup_item);
+                setup_item_slot = Some(setup_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&auto_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
@@ -502,6 +512,12 @@ pub fn run(args: LauncherArgs) -> ! {
                     {
                         status_rendered_at = Some(now);
                         show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                    }
+                    // The one-time wizard's launch point follows the library
+                    // state (a cheap config read at minute cadence): the
+                    // setup that just finished greys its own menu item.
+                    if let Some(item) = &setup_item_slot {
+                        item.set_enabled(player_bin.is_some() && !paths::library_is_configured(&config_loop));
                     }
                 }
                 AppEvent::Menu(id) => match id.as_str() {

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -304,7 +304,6 @@ pub fn run(args: LauncherArgs) -> ! {
     // Update-awareness: the server's checker writes update-status.json in
     // the shared data home; the tray re-reads it on every minute tick.
     let mut update_item: Option<MenuItem> = None;
-    let mut setup_item_slot: Option<MenuItem> = None;
     let mut upd: Option<paths::UpdateStatus> = paths::read_update_status();
     let mut upd_text = String::new();
     // The apply request we last ACTED on (the file's applyRequestedAt, else
@@ -359,19 +358,6 @@ pub fn run(args: LauncherArgs) -> ! {
                 upd_text = utext;
                 let open_item = MenuItem::with_id("open", "Open Admin Panel", true, None);
                 let qc_item = MenuItem::with_id("quick-connect", "Quick Connect", true, None);
-                // Guided first-run setup (folders, account, extras) in a
-                // real terminal — ONE-TIME onboarding by design (operator
-                // decision, PR #915): once the library is configured the
-                // item greys out, because post-setup work belongs to the
-                // admin panel; the wizard itself parks on configured
-                // servers as the backstop. Also greyed when this install
-                // has no player binary. Re-checked each minute tick.
-                let setup_item = MenuItem::with_id(
-                    "setup",
-                    "Set up mStream",
-                    player_bin.is_some() && !paths::library_is_configured(&config),
-                    None,
-                );
                 let auto_item =
                     CheckMenuItem::with_id("autostart", "Start at login", true, autostart::is_enabled(), None);
                 let logs_item = MenuItem::with_id("logs", "View logs", true, None);
@@ -382,8 +368,6 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&open_item);
                 let _ = menu.append(&qc_item);
-                let _ = menu.append(&setup_item);
-                setup_item_slot = Some(setup_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&auto_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
@@ -513,12 +497,6 @@ pub fn run(args: LauncherArgs) -> ! {
                         status_rendered_at = Some(now);
                         show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
                     }
-                    // The one-time wizard's launch point follows the library
-                    // state (a cheap config read at minute cadence): the
-                    // setup that just finished greys its own menu item.
-                    if let Some(item) = &setup_item_slot {
-                        item.set_enabled(player_bin.is_some() && !paths::library_is_configured(&config_loop));
-                    }
                 }
                 AppEvent::Menu(id) => match id.as_str() {
                     "open" => {
@@ -550,20 +528,6 @@ pub fn run(args: LauncherArgs) -> ! {
                         }
                         if !opened {
                             let _ = open::that_detached(format!("{url}/#quick-connect"));
-                        }
-                    }
-                    "setup" => {
-                        log.line("menu: set up mstream");
-                        match player_bin.as_deref() {
-                            Some(player) => {
-                                match platform::open_wizard_terminal(player, &url, &data_home, console.as_ref(), platform::WizardPage::Setup) {
-                                    Ok(via) => log.line(&format!("setup wizard opened via {via}")),
-                                    Err(e) => log.line(&format!("setup wizard failed: {e}")),
-                                }
-                            }
-                            // Unreachable through the menu (the item is
-                            // disabled), kept for the record.
-                            None => log.line("setup wizard unavailable: no mstream-player binary in this install"),
                         }
                     }
                     "autostart" => {

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -693,7 +693,33 @@ pub fn run(args: LauncherArgs) -> ! {
                         }
                         if announce && !opened {
                             opened = true;
-                            let _ = open::that_detached(target);
+                            // First install (no music folders yet): open the
+                            // guided terminal wizard itself — the same
+                            // surface as the tray's "Set up mStream" — on
+                            // the platforms with a terminal story. The
+                            // browser admin panel stays the fallback (no
+                            // player binary, or the terminal launch failed)
+                            // and the linux behavior; configured installs
+                            // keep opening the player as always. The
+                            // announce gates (--takeover, --autostarted,
+                            // --no-open) suppress this exactly like the
+                            // browser pop — an update relaunch must never
+                            // pop a terminal.
+                            let mut wizard_opened = false;
+                            if target.ends_with("/admin") && cfg!(any(target_os = "macos", windows)) {
+                                if let Some(player) = player_bin.as_deref() {
+                                    match platform::open_wizard_terminal(player, &url, &data_home, console.as_ref(), platform::WizardPage::Setup) {
+                                        Ok(via) => {
+                                            log.line(&format!("first-run announce: setup wizard opened via {via}"));
+                                            wizard_opened = true;
+                                        }
+                                        Err(e) => log.line(&format!("first-run announce: wizard failed ({e}) - opening the admin panel")),
+                                    }
+                                }
+                            }
+                            if !wizard_opened {
+                                let _ = open::that_detached(target);
+                            }
                         }
                     }
                 }

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -509,15 +509,34 @@ pub fn run(args: LauncherArgs) -> ! {
                         let _ = open::that_detached(url.clone());
                     }
                     "quick-connect" => {
-                        // The web UI opens its Quick Connect modal on this
-                        // hash (webapp/assets/js/quick-connect.js).
-                        let _ = open::that_detached(format!("{url}/#quick-connect"));
+                        // The wizard's Quick Connect page (pixel pairing QR)
+                        // in a real terminal on the desktop platforms; the
+                        // webapp's modal hash stays the linux behavior
+                        // (webapp/assets/js/quick-connect.js) and the
+                        // fallback when this install has no player binary or
+                        // the terminal launch itself fails.
+                        log.line("menu: quick connect");
+                        let mut opened = false;
+                        if cfg!(any(target_os = "macos", windows)) {
+                            if let Some(player) = player_bin.as_deref() {
+                                match platform::open_wizard_terminal(player, &url, &data_home, console.as_ref(), platform::WizardPage::QuickConnect) {
+                                    Ok(via) => {
+                                        log.line(&format!("quick connect opened via {via}"));
+                                        opened = true;
+                                    }
+                                    Err(e) => log.line(&format!("quick connect terminal failed: {e} - falling back to the webapp")),
+                                }
+                            }
+                        }
+                        if !opened {
+                            let _ = open::that_detached(format!("{url}/#quick-connect"));
+                        }
                     }
                     "setup" => {
                         log.line("menu: set up mstream");
                         match player_bin.as_deref() {
                             Some(player) => {
-                                match platform::open_setup_terminal(player, &url, &data_home, console.as_ref()) {
+                                match platform::open_wizard_terminal(player, &url, &data_home, console.as_ref(), platform::WizardPage::Setup) {
                                     Ok(via) => log.line(&format!("setup wizard opened via {via}")),
                                     Err(e) => log.line(&format!("setup wizard failed: {e}")),
                                 }

--- a/src/server.js
+++ b/src/server.js
@@ -408,9 +408,16 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   // not damage.
   if (!config.program.setupComplete
       && (dbManager.getAllLibraries().length > 0 || dbManager.getAllUsers().length > 0)) {
-    adminUtil.markSetupComplete().catch((err) => {
+    // Awaited on purpose: the launcher reads the flag from the config file
+    // when its health probe reports the server up, and an upgrader's very
+    // first boot of a flag-aware build must have the backfill ON DISK
+    // before listen — a fire-and-forget write raced that read, and losing
+    // it would greet a years-old install with the first-run wizard.
+    try {
+      await adminUtil.markSetupComplete();
+    } catch (err) {
       winston.warn(`could not backfill setupComplete: ${err.message}`);
-    });
+    }
   }
 
   // The separate music-discovery DB opens at boot only when collection is

--- a/src/server.js
+++ b/src/server.js
@@ -61,6 +61,7 @@ import * as backupManager from './backup/manager.js';
 import { classifyError } from './util/web-error.js';
 import { isAdminAllowed } from './util/admin-network.js';
 import { writeJsonAtomic, completedWrites } from './util/atomic-json.js';
+import * as adminUtil from './util/admin.js';
 import * as updateCheck from './util/update-check.js';
 import * as bootWatchdog from './util/boot-watchdog.js';
 
@@ -398,6 +399,19 @@ export async function serveIt(configFile, { relisten = null } = {}) {
 
   // Setup DB
   dbManager.initDB();
+
+  // Backfill the one-time onboarding marker for installs that predate it:
+  // any library or any user means this server was set up long ago, and the
+  // flag's absence must not greet an upgrader (or a config restored beside
+  // an existing database) with first-run behavior. Best-effort — a
+  // read-only config just means the boot log re-invites, which is noise,
+  // not damage.
+  if (!config.program.setupComplete
+      && (dbManager.getAllLibraries().length > 0 || dbManager.getAllUsers().length > 0)) {
+    adminUtil.markSetupComplete().catch((err) => {
+      winston.warn(`could not backfill setupComplete: ${err.message}`);
+    });
+  }
 
   // The separate music-discovery DB opens at boot only when collection is
   // enabled (the admin toggle initializes it on demand otherwise). Failure
@@ -760,15 +774,16 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     bootWatchdog.markBootOk();
     winston.info(`Access mStream locally: ${protocol}://localhost:${config.program.port}`);
 
-    // First-boot invitation. No folders AND no accounts means genuinely
-    // untouched — a deliberate public-mode server has folders, so it never
-    // sees this after setup. The terminal-wizard line appears only when the
+    // First-boot invitation, keyed to the one-time setupComplete marker
+    // (util/admin.js markSetupComplete — written at the first library or
+    // first user, backfilled above for installs that predate the flag).
+    // The terminal-wizard line appears only when the
     // player binary is already on this machine (bundles ship it; musl and
     // docker hosts have no build and get the browser line alone) AND its
     // libraries load here (headless linux without ALSA can't even run its
     // --version) — checking is a stat plus at most one ldconfig, never a
     // download.
-    if (Object.keys(config.program.folders || {}).length === 0 && dbManager.getAllUsers().length === 0) {
+    if (!config.program.setupComplete) {
       winston.info('This server is not set up yet — open the address above in a browser to add music folders and an admin account.');
       const wizard = installedPlayerPath();
       if (wizard && playerLoadableHere()) {

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -752,6 +752,13 @@ const schema = Joi.object({
   downloadSizeLimit: Joi.string().pattern(/^(0|[0-9]+(\.[0-9]+)?(KB|MB|GB))$/i).default('0'),
   db: dbOptions.default(dbOptions.validate({}).value),
   compression: compressionOptions.default(compressionOptions.validate({}).value),
+  // One-time onboarding marker: the launcher auto-opens the setup wizard
+  // while this is false/absent, and the server's boot log prints the setup
+  // invitation. Written true by util/admin.js markSetupComplete() the moment
+  // the FIRST library or FIRST user lands (and backfilled at boot for
+  // installs that predate the flag — see serveIt). Never unset: deleting
+  // every folder later must not resurrect first-run behavior.
+  setupComplete: Joi.boolean().default(false),
   folders: Joi.object().pattern(
     Joi.string(),
     Joi.object({

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -82,6 +82,26 @@ function mergeChanges(current, base, mine) {
   return out;
 }
 
+// ── One-time onboarding marker ───────────────────────────────────────────────
+
+// Written the moment the FIRST library or FIRST user lands (both call this;
+// it self-no-ops after the first write). The launcher reads the raw config
+// file for this flag to decide whether to auto-open the setup wizard, and
+// the boot log's setup invitation keys off it too — one source of truth the
+// SERVER owns; the wizard itself never touches the config. updateJsonAtomic
+// so a racing settings save can't resurrect a pre-write document. The
+// in-memory mirror keeps this boot's invitation logic coherent without a
+// reboot; no reboot is requested — nothing running consumes the flag live.
+export async function markSetupComplete() {
+  if (config.program.setupComplete) { return; }
+  config.program.setupComplete = true;
+  await updateJsonAtomic(config.configFile, (current) => {
+    current.setupComplete = true;
+    return current;
+  });
+  winston.info('First-run setup marker written (setupComplete: true)');
+}
+
 // ── Directory / Library management (now in SQLite) ──────────────────────────
 
 export async function addDirectory(directory, vpath, autoAccess, isAudioBooks, followSymlinks, mstream) {
@@ -114,6 +134,7 @@ export async function addDirectory(directory, vpath, autoAccess, isAudioBooks, f
   }
 
   db.invalidateCache();
+  await markSetupComplete();
 
   // Add to express routing
   mstream.use(`/media/${vpath}/`, express.static(directory));
@@ -285,6 +306,7 @@ export async function addUser(username, password, admin, vpaths, allowMkdir, all
   }
 
   db.invalidateCache();
+  await markSetupComplete();
 }
 
 export async function deleteUser(username) {


### PR DESCRIPTION
The tray's **Quick Connect** item opened the web player's modal (`{url}/#quick-connect`). On macOS and Windows it now opens the wizard's standalone pairing page — `mstream-player qr`, the Done screen with the scannable **pixel QR** and app buttons — through the exact machinery Set up mStream uses: the bundled Ghostty console (mStream Dock icon, Terminal.app fallback) on macOS, `wt.exe` (conhost fallback) on Windows.

Mechanically, `open_setup_terminal` generalizes to `open_wizard_terminal(page)`: a `WizardPage` enum carries the subcommand (`setup`/`qr`), the window title ("mStream Setup" / "mStream Quick Connect" — matching the OSC titles the v0.5.0 player sets itself), and a **distinct** `.command` script name so the two tray items never clobber each other's launch files (pinned by test).

**Kept on purpose**: Linux stays on the webapp modal (consistent with the no-bundled-console posture), and every platform falls back to the modal when the install has no player binary or the terminal launch fails — with the reason in the launcher log.

Verification: cargo 37/37 (page mapping, both pages' ghostty configs, never-`-e` still pinned), clippy `-D warnings` clean on host + windows targets, and a live launch through the production code path on this machine — `opened via bundled Ghostty console` with the `qr` page running from the staged bundle against a sandbox server.

One behavior note for review: against a configured server, the `qr` page authenticates from the player's saved session (created when setup ran on that machine); without one it renders the page with a polite fetch-error note rather than a QR — same class of experience as the web modal asking for a login. Fresh servers (open admin) need no auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)