### PR TITLE
feat(federation): the request engine — in-network pairing over discovery DMs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6089,6 +6089,7 @@ paths:
                       streamKbps: { type: integer }
                       dailyMb: { type: integer }
                       maxStreams: { type: integer }
+                  acceptRequests: { type: boolean, description: "Whether the federation-requests inbox is open (federation.acceptRequests)" }
         "405": { $ref: "#/components/responses/AdminLocked" }
     post:
       tags: [Federation]
@@ -6235,6 +6236,158 @@ paths:
       responses:
         "200": { $ref: "#/components/responses/EmptySuccess" }
         "404": { description: Key not found. }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/requests:
+    get:
+      tags: [Federation]
+      summary: List federation requests (both directions)
+      description: Every tracked exchange — outbound requests this server composed and inbound ones in its opt-in inbox. `peer_name` and `message` on inbound rows are the sender's self-asserted strings; display them as untrusted (the identity anchor is `peer_endpoint_id`).
+      responses:
+        "200":
+          description: The inbox flag plus request rows, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  acceptRequests: { type: boolean }
+                  requests:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: integer }
+                        uuid: { type: string }
+                        direction: { type: string, enum: [in, out] }
+                        peer_endpoint_id: { type: string }
+                        peer_name: { type: string, nullable: true }
+                        message: { type: string, nullable: true }
+                        offered_libraries: { type: array, items: { type: string } }
+                        state: { type: string, description: "pending-delivery / delivered / received / accepted / granting / completed / rejected / refused / expired / cancelled / blocked" }
+                        reject_reason: { type: string, nullable: true }
+                        fail_count: { type: integer }
+                        next_attempt_at: { type: string, nullable: true }
+                        minted_key_id: { type: integer, nullable: true }
+                        created_peer_id: { type: integer, nullable: true }
+                        created_at: { type: string }
+                        expires_at: { type: string }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+    post:
+      tags: [Federation]
+      summary: Send a federation request to a discovery peer
+      description: "Composes and queues the request over the discovery DM transport, retrying with backoff until delivered, refused, or expired (14-day TTL). No credential travels in the request — tickets only flow after the peer explicitly accepts. Requires the discovery network AND federation to be enabled. `offerVpaths` is what THIS server will grant back on accept (may be empty for a one-way ask)."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [endpointId]
+              properties:
+                endpointId: { type: string, description: The peer's discovery endpoint id (a catalog row) }
+                message: { type: string, maxLength: 500 }
+                offerVpaths: { type: array, maxItems: 32, items: { type: string } }
+      responses:
+        "200":
+          description: The created request row (state `pending-delivery`).
+        "404": { description: Unknown offered library. }
+        "409": { description: "Feature not enabled, peer blocked, or a request to this peer is already live." }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/requests/{id}/accept:
+    post:
+      tags: [Federation]
+      summary: Accept an inbox request (mints the key, sends the ticket)
+      description: "Mints a key scoped to the chosen libraries — the limit fields pre-fill from `federation.limits` exactly like a manual mint — and owes the sender a `federation-accept` DM carrying the swap-ready ticket. With `acceptTheirOffer` (default true) the exchange stays open until their grant-back arrives; declining completes it one-way. Requires the federation endpoint to be running."
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vpaths]
+              properties:
+                vpaths: { type: array, minItems: 1, items: { type: string } }
+                streamKbps: { type: integer, minimum: 0 }
+                dailyMb: { type: integer, minimum: 0 }
+                maxStreams: { type: integer, minimum: 0 }
+                expiresAt: { type: string, format: date-time, nullable: true }
+                acceptTheirOffer: { type: boolean, default: true }
+      responses:
+        "200":
+          description: The updated request row (state `accepted`).
+        "404": { description: Request or library not found. }
+        "409": { description: "Wrong state, federation off, or its endpoint not running." }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/requests/{id}/reject:
+    post:
+      tags: [Federation]
+      summary: Reject an inbox request
+      description: "Marks it rejected, sends a best-effort courtesy DM (with the optional reason), and tombstones the sender for 7 days — new requests from them are dropped without troubling the inbox."
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason: { type: string, maxLength: 200 }
+      responses:
+        "200":
+          description: The updated request row.
+        "404": { description: Request not found. }
+        "409": { description: Wrong state. }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/requests/{id}/cancel:
+    post:
+      tags: [Federation]
+      summary: Withdraw an outbound request
+      description: Cancels a pending or delivered request; a delivered one also gets a best-effort courtesy withdraw DM so the peer's inbox can clear itself.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+      responses:
+        "200":
+          description: The updated request row.
+        "404": { description: Request not found. }
+        "409": { description: Wrong state. }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/requests/{id}:
+    delete:
+      tags: [Federation]
+      summary: Dismiss a finished request record
+      description: Deletes a terminal-state row from the list. Live exchanges must be cancelled or rejected first.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+      responses:
+        "200": { $ref: "#/components/responses/EmptySuccess" }
+        "404": { description: Request not found. }
+        "409": { description: The request is still live. }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/federation/accept-requests:
+    post:
+      tags: [Federation]
+      summary: Toggle the federation-requests inbox (live)
+      description: "Persists `federation.acceptRequests` and pushes the DM-accept policy down to the discovery sidecar in the same call. Off is the default — the sidecar refuses request DMs at the transport until this opts in. Replies to this server's own outbound requests are unaffected (their window opens automatically while an exchange is live)."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled: { type: boolean }
+      responses:
+        "200":
+          description: The stored flag.
         "405": { $ref: "#/components/responses/AdminLocked" }
 
   /api/v1/admin/federation/peers:

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -99,6 +99,9 @@ export function register(mstream) {
       online: relayUrl !== null, relayUrl,
       // What the mint dialog pre-fills; per-key values live on the key rows.
       limitDefaults: config.program.federation.limits,
+      // The federation-requests inbox (V67): whether discovery peers may
+      // send this server pairing requests.
+      acceptRequests: config.program.federation.acceptRequests === true,
     });
   });
 
@@ -233,6 +236,146 @@ export function register(mstream) {
     }
     winston.info(`[federation] ${req.user.username} reset the endpoint binding on key id=${req.params.id}`);
     res.json({});
+  });
+
+  // ── Federation requests (in-network pairing over discovery DMs) ─────
+  //
+  // The engine (state/federation-requests.js) throws plain Errors; these
+  // routes map them: unknown rows 404, state/feature conflicts 409,
+  // everything else 400. Dynamic imports keep the p2p modules unloaded
+  // until the feature is actually touched, same as the federation imports
+  // above.
+
+  function requestError(err) {
+    if (/not found/i.test(err.message)) { return new WebError(err.message, 404); }
+    if (/not enabled|not running|already|cannot (accept|reject|cancel)/i.test(err.message)) {
+      return new WebError(err.message, 409);
+    }
+    return new WebError(err.message, 400);
+  }
+
+  mstream.get('/api/v1/admin/federation/requests', async (req, res) => {
+    const reqDb = await import('../db/federation-requests.js');
+    res.json({
+      acceptRequests: config.program.federation.acceptRequests === true,
+      requests: reqDb.listRequests(),
+    });
+  });
+
+  mstream.post('/api/v1/admin/federation/requests', async (req, res) => {
+    const schema = Joi.object({
+      endpointId: Joi.string().min(16).max(128).required(),
+      message: Joi.string().max(500).allow('').optional(),
+      offerVpaths: Joi.array().items(Joi.string()).max(32).unique().default([]),
+    });
+    joiValidate(schema, req.body);
+    // Offered names must exist NOW so a typo fails the compose, not the
+    // grant-back two DMs later (deleted-meanwhile is still handled there).
+    for (const name of req.body.offerVpaths || []) {
+      if (!db.getLibraryByName(name)) { throw new WebError(`Unknown library: ${name}`, 404); }
+    }
+    const engine = await import('../state/federation-requests.js');
+    try {
+      const row = await engine.compose({
+        peerEndpointId: req.body.endpointId,
+        message: req.body.message || null,
+        offeredLibraries: req.body.offerVpaths || [],
+      });
+      winston.info(`[federation] ${req.user.username} sent a federation request to ${req.body.endpointId.slice(0, 12)}…`);
+      res.json(row);
+    } catch (err) {
+      winston.warn(`[federation] ${req.user.username} compose failed: ${err.message}`);
+      throw requestError(err);
+    }
+  });
+
+  mstream.post('/api/v1/admin/federation/requests/:id/accept', async (req, res) => {
+    joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), req.params);
+    joiValidate(Joi.object({
+      vpaths: Joi.array().items(Joi.string()).min(1).unique().required(),
+      ...limitsSchema,
+      expiresAt: expirySchema,
+      acceptTheirOffer: Joi.boolean().default(true),
+    }), req.body);
+
+    const libraryIds = req.body.vpaths.map((name) => {
+      const lib = db.getLibraryByName(name);
+      if (!lib) { throw new WebError(`Unknown library: ${name}`, 404); }
+      return lib.id;
+    });
+    const engine = await import('../state/federation-requests.js');
+    try {
+      const row = await engine.accept(Number(req.params.id), {
+        libraryIds,
+        vpathNames: req.body.vpaths,
+        limits: resolveLimits(req.body),
+        expiresAt: normalizeExpiry(req.body.expiresAt),
+        acceptTheirOffer: req.body.acceptTheirOffer !== false,
+      });
+      winston.info(`[federation] ${req.user.username} accepted federation request id=${req.params.id}`);
+      res.json(row);
+    } catch (err) {
+      winston.warn(`[federation] ${req.user.username} accept failed for request id=${req.params.id}: ${err.message}`);
+      throw requestError(err);
+    }
+  });
+
+  mstream.post('/api/v1/admin/federation/requests/:id/reject', async (req, res) => {
+    joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), req.params);
+    joiValidate(Joi.object({ reason: Joi.string().max(200).allow('').optional() }), req.body);
+    const engine = await import('../state/federation-requests.js');
+    try {
+      const row = await engine.reject(Number(req.params.id), req.body.reason || null);
+      winston.info(`[federation] ${req.user.username} rejected federation request id=${req.params.id}`);
+      res.json(row);
+    } catch (err) {
+      throw requestError(err);
+    }
+  });
+
+  mstream.post('/api/v1/admin/federation/requests/:id/cancel', async (req, res) => {
+    joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), req.params);
+    const engine = await import('../state/federation-requests.js');
+    try {
+      const row = await engine.cancel(Number(req.params.id));
+      winston.info(`[federation] ${req.user.username} cancelled federation request id=${req.params.id}`);
+      res.json(row);
+    } catch (err) {
+      throw requestError(err);
+    }
+  });
+
+  // Dismiss a finished record. Live exchanges must be cancelled/rejected
+  // first — deleting one mid-flight would orphan its retry state.
+  mstream.delete('/api/v1/admin/federation/requests/:id', async (req, res) => {
+    joiValidate(Joi.object({ id: Joi.number().integer().min(1).required() }), req.params);
+    const reqDb = await import('../db/federation-requests.js');
+    const row = reqDb.getRequestById(Number(req.params.id));
+    if (!row) { throw new WebError('Request not found', 404); }
+    if (reqDb.ACTIVE_STATES.includes(row.state)) {
+      throw new WebError(`cannot dismiss a request in state '${row.state}' — cancel or reject it first`, 409);
+    }
+    reqDb.deleteRequest(row.id);
+    winston.info(`[federation] ${req.user.username} dismissed federation request id=${row.id} (${row.state})`);
+    res.json({});
+  });
+
+  // The inbox switch, live: persists federation.acceptRequests and pushes
+  // the DM-accept policy down to the sidecar in the same breath.
+  mstream.post('/api/v1/admin/federation/accept-requests', async (req, res) => {
+    joiValidate(Joi.object({ enabled: Joi.boolean().required() }), req.body);
+    const enabled = req.body.enabled;
+
+    const raw = await admin.loadFile(config.configFile);
+    if (!raw.federation) { raw.federation = {}; }
+    raw.federation.acceptRequests = enabled;
+    await admin.saveFile(raw, config.configFile);
+    config.program.federation.acceptRequests = enabled;
+
+    const engine = await import('../state/federation-requests.js');
+    await engine.pushAcceptPolicy();
+    winston.info(`[federation] ${req.user.username} turned the federation-requests inbox ${enabled ? 'on' : 'off'}`);
+    res.json({ acceptRequests: enabled });
   });
 
   // ── Peers (servers this one can read) ──────────────────────────────

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -780,7 +780,14 @@ export function setup(mstream) {
   // deliberately leaves collection on — local Discover/similar features
   // don't depend on the network. NOT behind requireP2pEnabled, obviously.
   mstream.post("/api/v1/admin/discovery/p2p/enabled", async (req, res) => {
-    const schema = Joi.object({ enabled: Joi.boolean().required() });
+    const schema = Joi.object({
+      enabled: Joi.boolean().required(),
+      // The enable-flow checkbox: also open the federation-requests inbox,
+      // which requires the federation feature itself — this orchestrates
+      // both. Only meaningful with enabled=true; a partial federation
+      // failure leaves discovery ON and reports the cause in the response.
+      acceptFederationRequests: Joi.boolean().optional(),
+    });
     joiValidate(schema, req.body);
     const stack = await import('../state/discovery-p2p-stack.js');
 
@@ -821,7 +828,59 @@ export function setup(mstream) {
       await stack.stopDiscoveryP2pStack().catch(() => {});
       throw new WebError(`failed to start the discovery network: ${err.message}`, 500);
     }
-    res.json({ enabled: true, collectForced });
+
+    // The "also accept federation requests" checkbox: turn federation on
+    // (endpoint included) and open the inbox, atomically from the UI's
+    // point of view. Discovery is already up and STAYS up on failure here
+    // — the checkbox is an add-on, not a condition; the operator gets the
+    // cause in `federationError` and can retry from the Federation tab.
+    let federationError = null;
+    if (req.body.acceptFederationRequests === true) {
+      const prior = {
+        enabled: config.program.federation.enabled === true,
+        acceptRequests: config.program.federation.acceptRequests === true,
+      };
+      try {
+        const raw = await admin.loadFile(config.configFile);
+        if (!raw.federation) { raw.federation = {}; }
+        raw.federation.enabled = true;
+        raw.federation.acceptRequests = true;
+        await admin.saveFile(raw, config.configFile);
+        config.program.federation.enabled = true;
+        config.program.federation.acceptRequests = true;
+
+        const federation = await import('../state/federation.js');
+        await federation.start({
+          targetPort: config.program.port,
+          secretKey: config.program.federation.secretKey,
+        });
+        const engine = await import('../state/federation-requests.js');
+        await engine.pushAcceptPolicy();
+        winston.info(`discovery P2P enabled with the federation-requests inbox by admin '${req.user?.username}'`);
+      } catch (err) {
+        winston.warn(`federation-inbox enable failed for admin '${req.user?.username}' — discovery stays on: ${err.message}`);
+        federationError = err.message;
+        // Roll the federation flags back to what they were — never
+        // disable a federation the operator had on before this call.
+        try {
+          const raw = await admin.loadFile(config.configFile);
+          if (!raw.federation) { raw.federation = {}; }
+          raw.federation.enabled = prior.enabled;
+          raw.federation.acceptRequests = prior.acceptRequests;
+          await admin.saveFile(raw, config.configFile);
+        } catch (rollbackErr) {
+          winston.warn(`federation flag rollback failed: ${rollbackErr.message}`);
+        }
+        config.program.federation.enabled = prior.enabled;
+        config.program.federation.acceptRequests = prior.acceptRequests;
+      }
+    }
+    res.json({
+      enabled: true, collectForced,
+      ...(req.body.acceptFederationRequests === true
+        ? { acceptRequests: federationError === null, ...(federationError ? { federationError } : {}) }
+        : {}),
+    });
   });
 
   // Disk cap for fetched peer snapshots. Live: the fetch paths read the

--- a/src/db/federation-requests.js
+++ b/src/db/federation-requests.js
@@ -1,0 +1,189 @@
+// Accessors for federation_requests (SCHEMA_V67) — the in-network
+// federation-request exchange tracked from both roles. Split from
+// db/federation.js the way the state machine is split from
+// state/federation.js: requests are a lifecycle, keys/peers are the
+// durable product.
+//
+// Time discipline (the EXPIRED_SQL lesson from V62): every timestamp in
+// this table is SQLite's canonical UTC 'YYYY-MM-DD HH:MM:SS' and every
+// comparison happens IN SQL against datetime('now'), so nothing here ever
+// round-trips a stored value through JS Date parsing. JS callers pass
+// offsets as SECONDS and the SQL applies them with datetime('now', '+N
+// seconds').
+
+import { getDB } from './manager.js';
+
+// Non-terminal states, per direction. The state machine itself lives in
+// src/state/federation-requests.js — these lists exist so the TTL sweep
+// and the due-retry query stay honest about what "still live" means.
+export const ACTIVE_STATES = ['pending-delivery', 'delivered', 'received', 'accepted', 'granting'];
+
+// States that OWE the peer a DM (see the SCHEMA_V67 comment): the retry
+// queue only ever picks these up. in/granting deliberately absent — that
+// row is waiting to RECEIVE, not to send.
+const DM_OWING = `(
+     (direction = 'out' AND state = 'pending-delivery')
+  OR (direction = 'in'  AND state = 'accepted')
+  OR (direction = 'out' AND state = 'granting')
+)`;
+
+export function createRequest({
+  uuid, direction, peerEndpointId, peerName = null, message = null,
+  offeredLibraries = [], state, ttlSeconds, nextAttemptInSeconds = null,
+}) {
+  const result = getDB().prepare(`
+    INSERT INTO federation_requests
+      (uuid, direction, peer_endpoint_id, peer_name, message,
+       offered_libraries, state, next_attempt_at, expires_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?,
+            CASE WHEN ? IS NULL THEN NULL ELSE datetime('now', '+' || ? || ' seconds') END,
+            datetime('now', '+' || ? || ' seconds'))
+  `).run(uuid, direction, peerEndpointId, peerName, message,
+    JSON.stringify(offeredLibraries), state,
+    nextAttemptInSeconds, nextAttemptInSeconds, ttlSeconds);
+  return getRequestById(Number(result.lastInsertRowid));
+}
+
+function inflate(row) {
+  if (!row) { return null; }
+  let offered = [];
+  try { offered = JSON.parse(row.offered_libraries || '[]'); } catch (_err) { /* tolerate hand-edited rows */ }
+  return { ...row, offered_libraries: Array.isArray(offered) ? offered : [] };
+}
+
+export function getRequestById(id) {
+  return inflate(getDB().prepare('SELECT * FROM federation_requests WHERE id = ?').get(id));
+}
+
+export function getRequestByUuid(uuid) {
+  return inflate(getDB().prepare('SELECT * FROM federation_requests WHERE uuid = ?').get(uuid));
+}
+
+// Admin listing — newest first, both directions together (the UI groups).
+export function listRequests() {
+  return getDB().prepare(`
+    SELECT * FROM federation_requests ORDER BY created_at DESC, id DESC
+  `).all().map(inflate);
+}
+
+// One-statement state advance + bookkeeping patch. Only the fields a
+// transition actually owns get touched; updated_at always moves. Retry
+// scheduling: nextAttemptInSeconds > 0 arms the timer, null disarms it
+// (terminal states and states that owe nothing).
+export function updateRequest(id, {
+  state, failCount, nextAttemptInSeconds, mintedKeyId, createdPeerId,
+  rejectReason, acceptTheirOffer,
+} = {}) {
+  const sets = [`updated_at = datetime('now')`];
+  const args = [];
+  if (state !== undefined) { sets.push('state = ?'); args.push(state); }
+  if (failCount !== undefined) { sets.push('fail_count = ?'); args.push(failCount); }
+  if (nextAttemptInSeconds !== undefined) {
+    if (nextAttemptInSeconds === null) {
+      sets.push('next_attempt_at = NULL');
+    } else {
+      sets.push(`next_attempt_at = datetime('now', '+' || ? || ' seconds')`);
+      args.push(nextAttemptInSeconds);
+    }
+  }
+  if (mintedKeyId !== undefined) { sets.push('minted_key_id = ?'); args.push(mintedKeyId); }
+  if (createdPeerId !== undefined) { sets.push('created_peer_id = ?'); args.push(createdPeerId); }
+  if (rejectReason !== undefined) { sets.push('reject_reason = ?'); args.push(rejectReason); }
+  if (acceptTheirOffer !== undefined) { sets.push('accept_their_offer = ?'); args.push(acceptTheirOffer ? 1 : 0); }
+  args.push(id);
+  return getDB().prepare(`UPDATE federation_requests SET ${sets.join(', ')} WHERE id = ?`).run(...args).changes > 0;
+}
+
+// Rows whose owed DM is due. LIMIT keeps one sweep from monopolising the
+// process after a long offline stretch — the next sweep picks up the rest.
+export function getDueRetries(limit = 10) {
+  return getDB().prepare(`
+    SELECT * FROM federation_requests
+     WHERE ${DM_OWING}
+       AND next_attempt_at IS NOT NULL
+       AND next_attempt_at <= datetime('now')
+     ORDER BY next_attempt_at
+     LIMIT ?
+  `).all(limit).map(inflate);
+}
+
+// Presence kick: a peer we owe a DM just announced — pull its rows forward
+// so the next sweep (or the caller) retries immediately instead of waiting
+// out a 6-hour backoff rung.
+export function markPeerAttemptsDue(peerEndpointId) {
+  return getDB().prepare(`
+    UPDATE federation_requests
+       SET next_attempt_at = datetime('now'), updated_at = datetime('now')
+     WHERE peer_endpoint_id = ?
+       AND ${DM_OWING}
+       AND next_attempt_at IS NOT NULL
+       AND next_attempt_at > datetime('now')
+  `).run(peerEndpointId).changes;
+}
+
+// ── Inbound abuse-control queries ───────────────────────────────────────────
+
+// Whether ANY exchange is still live, either direction — the DM transport
+// must accept while replies are expected, whatever the inbox setting says
+// (see pushAcceptPolicy in state/federation-requests.js).
+export function hasActiveRequests() {
+  return getDB().prepare(`
+    SELECT 1 FROM federation_requests
+     WHERE state IN (${ACTIVE_STATES.map(() => '?').join(', ')})
+     LIMIT 1
+  `).get(...ACTIVE_STATES) !== undefined;
+}
+
+export function countPendingInbound() {
+  return getDB().prepare(`
+    SELECT COUNT(*) AS n FROM federation_requests
+     WHERE direction = 'in' AND state = 'received'
+  `).get().n;
+}
+
+export function hasActiveFromPeer(peerEndpointId) {
+  return getDB().prepare(`
+    SELECT 1 FROM federation_requests
+     WHERE direction = 'in' AND peer_endpoint_id = ?
+       AND state IN ('received', 'accepted', 'granting')
+     LIMIT 1
+  `).get(peerEndpointId) !== undefined;
+}
+
+// The 7-day tombstone: a peer we rejected recently gets auto-refused
+// without troubling the inbox again.
+export function recentlyRejectedPeer(peerEndpointId, days = 7) {
+  return getDB().prepare(`
+    SELECT 1 FROM federation_requests
+     WHERE direction = 'in' AND peer_endpoint_id = ? AND state = 'rejected'
+       AND updated_at > datetime('now', '-' || ? || ' days')
+     LIMIT 1
+  `).get(peerEndpointId, days) !== undefined;
+}
+
+// TTL sweep: any live row past its expires_at goes terminal. Returns the
+// count plus the minted keys the expiry orphans — rows dying in a state
+// that still OWED the credential-bearing DM (in/accepted owes the accept
+// ticket, out/granting owes the grant ticket) never confirmed delivery, so
+// their minted keys reached nobody and the caller revokes them.
+export function expireOverdueRequests() {
+  const db = getDB();
+  const orphanKeyIds = db.prepare(`
+    SELECT minted_key_id FROM federation_requests
+     WHERE ${DM_OWING}
+       AND state IN ('accepted', 'granting')
+       AND minted_key_id IS NOT NULL
+       AND expires_at <= datetime('now')
+  `).all().map((r) => r.minted_key_id);
+  const expired = db.prepare(`
+    UPDATE federation_requests
+       SET state = 'expired', next_attempt_at = NULL, updated_at = datetime('now')
+     WHERE state IN (${ACTIVE_STATES.map(() => '?').join(', ')})
+       AND expires_at <= datetime('now')
+  `).run(...ACTIVE_STATES).changes;
+  return { expired, orphanKeyIds };
+}
+
+export function deleteRequest(id) {
+  return getDB().prepare('DELETE FROM federation_requests WHERE id = ?').run(id).changes > 0;
+}

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -81,7 +81,7 @@ import { HASH_GENERATION } from './audio-hash.js';
 // V63 indexes cue_points.library_id and play_events.library_id so the
 // library-delete cascade seeks instead of scanning. See SCHEMA_V63.
 // V64 indexes tracks.year so the DLNA By-Year browse seeks. See SCHEMA_V64.
-export const SCHEMA_VERSION = 66;
+export const SCHEMA_VERSION = 67;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2392,6 +2392,65 @@ export const SCHEMA_V66 = `
   SELECT 1;
 `;
 
+// ── Federation requests (V67) ───────────────────────────────────────────────
+//
+// In-network federation requests: an operator who found a server on the
+// public discovery network asks it for a federation pairing over the
+// sidecar's DM transport, and the whole exchange — request, accept +
+// ticket, mutual grant-back — is tracked in one table serving both roles.
+//
+// One row per request per side. `direction` says which role this server
+// plays: 'out' = we composed it (peer_endpoint_id is the recipient),
+// 'in' = it arrived in our inbox (peer_endpoint_id is the sender, and
+// peer_name/message are the sender's SELF-ASSERTED, length-capped strings —
+// display them as untrusted; the identity anchor is the endpoint id).
+//
+// States (TEXT, no CHECK — the state machine lives in
+// src/state/federation-requests.js and new states must not need a
+// migration):
+//   out: pending-delivery → delivered → granting → completed
+//        terminals: rejected | refused | expired | cancelled
+//   in:  received → accepted → granting → completed
+//        terminals: rejected | expired | cancelled (sender withdrew) | blocked
+// 'granting' is the mutual-exchange middle: an OUT row in granting OWES the
+// grant DM (retried via next_attempt_at); an IN row in granting is WAITING
+// for the peer's grant to arrive. fail_count/next_attempt_at drive the
+// retry ladder for whichever DM the row currently owes.
+//
+// offered_libraries is a JSON array of library NAMES: on an OUT row, ours
+// (what we'll grant back on accept); on an IN row, theirs (what the sender
+// says it will grant us). accept_their_offer records the accept-dialog
+// choice so a re-delivered grant after the accept knows whether it was
+// wanted. minted_key_id / created_peer_id link what the exchange produced;
+// SET NULL keeps the audit row alive when a key or peer is later revoked.
+//
+// expires_at is NOT NULL by design: every request carries its TTL from
+// birth (14 days), after which the sweep marks non-terminal rows expired.
+export const SCHEMA_V67 = `
+  CREATE TABLE IF NOT EXISTS federation_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    uuid TEXT NOT NULL UNIQUE,
+    direction TEXT NOT NULL CHECK (direction IN ('in', 'out')),
+    peer_endpoint_id TEXT NOT NULL,
+    peer_name TEXT,
+    message TEXT,
+    offered_libraries TEXT NOT NULL DEFAULT '[]',
+    accept_their_offer INTEGER NOT NULL DEFAULT 1,
+    state TEXT NOT NULL,
+    reject_reason TEXT,
+    fail_count INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TEXT,
+    minted_key_id INTEGER REFERENCES federation_keys(id) ON DELETE SET NULL,
+    created_peer_id INTEGER REFERENCES federation_peers(id) ON DELETE SET NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at TEXT NOT NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_federation_requests_peer
+    ON federation_requests(peer_endpoint_id);
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2777,4 +2836,8 @@ export const MIGRATIONS = [
   // INFO, and only a re-parse can backfill the NULLs older builds left.
   // See SCHEMA_V66.
   { version: 66, sql: SCHEMA_V66, rescanRequired: true },
+  // V67 adds the federation_requests table — in-network federation
+  // requests over the discovery DM transport. Pure new table + index, no
+  // rescan. See SCHEMA_V67.
+  { version: 67, sql: SCHEMA_V67 },
 ];

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -448,6 +448,13 @@ const federationOptions = Joi.object({
   secretKey: Joi.string().optional(),
   serverName: Joi.string().max(64).allow('').default(''),
   limits: federationLimitsOptions.default(federationLimitsOptions.validate({}).value),
+  // The federation-requests inbox: whether OTHER discovery peers may send
+  // this server pairing requests over the DM transport. Opt-in (default
+  // off) — the sidecar's DM handler is fail-closed until the stack pushes
+  // this flag down via setDmAccept. Gates NEW inbound requests only:
+  // replies to this server's own outbound requests always pass (see
+  // pushAcceptPolicy in state/federation-requests.js).
+  acceptRequests: Joi.boolean().default(false),
 });
 
 // The music-discovery P2P layer (p2p-sidecar: iroh-blobs snapshot sharing

--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -142,11 +142,20 @@ export async function startDiscoveryP2pStack() {
     const p2p = await import('./discovery-p2p.js');
     const catalog = await import('./discovery-catalog.js');
     const seeds = await import('./discovery-seeds.js');
+    const fedRequests = await import('./federation-requests.js');
     catalog.subscribe();
+    // Federation requests ride the same event pipe (dm + announcement) —
+    // subscribed before the spawn for the same reason as the catalog, and
+    // idempotent the same way.
+    fedRequests.subscribe();
     // Armed BEFORE the spawn, so a sidecar that dies seconds into its life
     // is covered too. Idempotent — re-registering just replaces the slot.
     p2p.setUnexpectedExitHandler(scheduleRecovery);
     await p2p.start();
+    // The sidecar boots refusing DMs; push the operator's inbox policy (or
+    // the open-for-replies window) down now that it's up. A failure here
+    // only means the inbox stays closed — never a failed start.
+    await fedRequests.pushAcceptPolicy();
     // Two-phase bootstrap. Phase one joins the topic IMMEDIATELY with
     // what's known locally (baked seeds + cached list + the operator's
     // bootstrapPeers) — the subscription must never wait on a network

--- a/src/state/federation-requests.js
+++ b/src/state/federation-requests.js
@@ -1,0 +1,582 @@
+// The federation-requests engine: in-network pairing over the discovery
+// DM transport. One state machine serving both roles — requester and
+// recipient — persisted in federation_requests (SCHEMA_V67, accessors in
+// db/federation-requests.js).
+//
+//   A (requester)                                B (recipient)
+//     compose() ── dm federation-request ──────▶ inbox row (opt-in gate)
+//                                                accept() mints a key
+//     ◀────────── dm federation-accept {ticket} ──
+//     addFederationPeer(B) + testPeer            (A now reads B)
+//     if A offered: mint ── dm federation-grant {ticket} ──▶ addFederationPeer(A)
+//
+// SECURITY INVARIANT: no credential ever travels in the request itself —
+// tickets only flow AFTER an explicit accept, so a rejected (or ignored)
+// recipient never holds anything. Sender identity on every inbound DM is
+// the QUIC-authenticated endpoint id from the sidecar; handlers only act
+// on a uuid when the sender matches the row's peer. peer_name/message are
+// self-asserted, size-capped, control-stripped — and still untrusted.
+//
+// Delivery semantics ride sendDm's three outcomes (see discovery-p2p.js):
+// resolved-delivered advances the row; resolved-refused is terminal for a
+// cold request ('refused' — the plan's "inbox off gets a typed refusal,
+// not silence") but only transient for accept/grant (the peer ASKED for
+// this pairing — a momentarily-off inbox shouldn't strand a half-built
+// one); rejection (unreachable) walks the retry ladder. Retries are keyed
+// off next_attempt_at and swept every SWEEP_MS; a peer's catalog
+// announcement pulls its due times forward, so "peer came online" retries
+// happen at announce cadence instead of a six-hour rung.
+//
+// All handlers are idempotent by uuid: a re-delivered accept re-acks at
+// the transport and no-ops here; nothing double-mints or double-adds.
+
+import crypto from 'crypto';
+import winston from 'winston';
+import * as config from './config.js';
+import * as reqDb from '../db/federation-requests.js';
+import * as fedDb from '../db/federation.js';
+import * as db from '../db/manager.js';
+import * as p2p from './discovery-p2p.js';
+
+export const REQUEST_TTL_SECONDS = 14 * 24 * 3600;
+// Retry ladder for owed DMs (seconds): 1m → 5m → 30m → 6h, then 6h forever
+// until the TTL ends it. Index = min(fail_count - 1, last).
+const BACKOFF_SECONDS = [60, 300, 1800, 21600];
+const SWEEP_MS = 60 * 1000;
+const INBOX_CAP = 50;
+const TOMBSTONE_DAYS = 7;
+// Inbound string caps — transport already caps the envelope at 8 KB; these
+// keep single fields honest. Mirror the compose-side Joi in the routes.
+const CAP = { name: 64, message: 500, reason: 200, offerItems: 32, offerName: 64 };
+
+const sanitize = (v, max) => {
+  if (typeof v !== 'string') { return null; }
+  const clean = v.replace(/[\p{Cc}]/gu, '').trim();
+  return clean ? clean.slice(0, max) : null;
+};
+const validUuid = (v) => typeof v === 'string' && /^[A-Za-z0-9-]{8,64}$/.test(v);
+
+// ── Wiring ──────────────────────────────────────────────────────────────────
+
+let subscribed = false;
+let sweepTimer = null;
+const inFlight = new Set(); // row ids with an attempt currently running
+
+// Idempotent; called from the discovery stack start (which also replays on
+// crash recovery — same contract as discovery-catalog.subscribe()).
+export function subscribe() {
+  if (subscribed) { return; }
+  subscribed = true;
+  p2p.events.on('dm', (msg) => {
+    handleInbound(msg).catch((err) => {
+      winston.warn(`[federation-requests] inbound dm handler failed: ${err.message}`);
+    });
+  });
+  // Presence signal: a peer announcing on the catalog topic is reachable
+  // right now — pull any DMs we owe it forward and try immediately.
+  p2p.events.on('announcement', (msg) => {
+    try {
+      if (reqDb.markPeerAttemptsDue(msg.from) > 0) {
+        winston.info(`[federation-requests] peer ${msg.from.slice(0, 12)}… is online — retrying owed messages`);
+        runSweep().catch((err) => winston.warn(`[federation-requests] presence-kicked sweep failed: ${err.message}`));
+      }
+    } catch (err) {
+      winston.warn(`[federation-requests] presence kick failed: ${err.message}`);
+    }
+  });
+  sweepTimer = setInterval(() => {
+    runSweep().catch((err) => winston.warn(`[federation-requests] sweep failed: ${err.message}`));
+  }, SWEEP_MS);
+  if (sweepTimer.unref) { sweepTimer.unref(); }
+}
+
+// Push the DM-accept policy down to the sidecar's fail-closed flag. The
+// transport must accept in TWO situations: the operator opened the inbox
+// (acceptRequests), OR any exchange is still live — a requester with its
+// inbox off still has to receive the accept/grant/reject replies to its
+// own outbound requests (verb-level gating in handleInbound keeps NEW
+// requests out either way). Called at stack start, from the live admin
+// toggle, after compose/cancel, and once per sweep — so the window closes
+// within a sweep of the last exchange ending. Lenient offline (the
+// sidecar boots refusing, and the flag is re-pushed on every start).
+export async function pushAcceptPolicy() {
+  const accept = config.program.federation.acceptRequests === true || reqDb.hasActiveRequests();
+  try {
+    await p2p.setDmAccept(accept);
+  } catch (err) {
+    winston.warn(`[federation-requests] setDmAccept(${accept}) failed — inbox stays closed at the transport: ${err.message}`);
+  }
+}
+
+// ── Outbound: compose / cancel ──────────────────────────────────────────────
+
+// Queue a federation request to a discovery peer and attempt delivery
+// immediately. offeredLibraries = OUR library names to grant back on
+// accept (may be empty = one-way ask). Throws plain Errors; the admin
+// route maps them onto status codes.
+export async function compose({ peerEndpointId, message = null, offeredLibraries = [] }) {
+  if (config.program.discoveryP2p.enabled !== true) { throw new Error('the discovery network is not enabled'); }
+  if (config.program.federation.enabled !== true) { throw new Error('federation is not enabled'); }
+  if (config.program.discoveryP2p.blockedPeers.includes(peerEndpointId)) {
+    throw new Error('this peer is blocked');
+  }
+  const existing = reqDb.listRequests().find((r) => r.direction === 'out'
+    && r.peer_endpoint_id === peerEndpointId && reqDb.ACTIVE_STATES.includes(r.state));
+  if (existing) { throw new Error(`a request to this peer is already ${existing.state}`); }
+
+  const catalog = await import('./discovery-catalog.js');
+  const peerName = catalog.get(peerEndpointId)?.payload?.name || null;
+  const row = reqDb.createRequest({
+    uuid: crypto.randomUUID(),
+    direction: 'out',
+    peerEndpointId,
+    peerName,
+    message: sanitize(message, CAP.message),
+    offeredLibraries,
+    state: 'pending-delivery',
+    ttlSeconds: REQUEST_TTL_SECONDS,
+    nextAttemptInSeconds: 0,
+  });
+  winston.info(`[federation-requests] ${row.uuid} composed for peer ${peerEndpointId.slice(0, 12)}… `
+    + `(offering ${offeredLibraries.length ? offeredLibraries.join(', ') : 'nothing'})`);
+  // Open our own transport window so the accept/reject reply can land even
+  // when the operator's inbox is otherwise off.
+  await pushAcceptPolicy();
+  attempt(row.id).catch((err) => winston.warn(`[federation-requests] first delivery attempt failed: ${err.message}`));
+  return reqDb.getRequestById(row.id);
+}
+
+// Withdraw an outbound request. The courtesy DM is best-effort and only
+// worth sending when the peer actually saw the request.
+export function cancel(id) {
+  const row = reqDb.getRequestById(id);
+  if (!row || row.direction !== 'out') { throw new Error('Request not found'); }
+  if (!['pending-delivery', 'delivered'].includes(row.state)) {
+    throw new Error(`cannot cancel a request in state '${row.state}'`);
+  }
+  reqDb.updateRequest(id, { state: 'cancelled', nextAttemptInSeconds: null });
+  winston.info(`[federation-requests] ${row.uuid} cancelled by the operator`);
+  if (row.state === 'delivered') {
+    sendCourtesy(row, { type: 'federation-withdraw', uuid: row.uuid });
+  }
+  return reqDb.getRequestById(id);
+}
+
+// ── Recipient actions: accept / reject ──────────────────────────────────────
+
+// Accept an inbox request: mint the key (the route resolved names → ids
+// and the limit fields already), then owe the peer a federation-accept DM
+// carrying the swap-ready ticket. acceptTheirOffer records whether we
+// expect their grant-back after our accept lands.
+export async function accept(id, { libraryIds, vpathNames, limits, expiresAt = null, acceptTheirOffer = true }) {
+  const row = reqDb.getRequestById(id);
+  if (!row || row.direction !== 'in') { throw new Error('Request not found'); }
+  if (row.state !== 'received') { throw new Error(`cannot accept a request in state '${row.state}'`); }
+  if (config.program.discoveryP2p.blockedPeers.includes(row.peer_endpoint_id)) {
+    throw new Error('this peer is blocked'); // blocked after the request landed
+  }
+  if (config.program.federation.enabled !== true) { throw new Error('federation is not enabled'); }
+  const federation = await import('./federation.js');
+  if (!federation.getEndpointTicket()) { throw new Error('the federation endpoint is not running'); }
+
+  const keyName = `request: ${row.peer_name || row.peer_endpoint_id.slice(0, 12)}`.slice(0, 64);
+  const minted = fedDb.createFederationKey(keyName, libraryIds, limits, expiresAt);
+  reqDb.updateRequest(id, {
+    state: 'accepted',
+    mintedKeyId: minted.id,
+    acceptTheirOffer: acceptTheirOffer && row.offered_libraries.length > 0,
+    nextAttemptInSeconds: 0,
+    failCount: 0,
+  });
+  winston.info(`[federation-requests] ${row.uuid} accepted — minted key '${keyName}' `
+    + `for [${vpathNames.join(', ')}]; sending the ticket`);
+  attempt(id).catch((err) => winston.warn(`[federation-requests] accept delivery attempt failed: ${err.message}`));
+  return reqDb.getRequestById(id);
+}
+
+export function reject(id, reason = null) {
+  const row = reqDb.getRequestById(id);
+  if (!row || row.direction !== 'in') { throw new Error('Request not found'); }
+  if (row.state !== 'received') { throw new Error(`cannot reject a request in state '${row.state}'`); }
+  const clean = sanitize(reason, CAP.reason);
+  reqDb.updateRequest(id, { state: 'rejected', rejectReason: clean, nextAttemptInSeconds: null });
+  winston.info(`[federation-requests] ${row.uuid} rejected${clean ? ` (${clean})` : ''} — `
+    + `peer ${row.peer_endpoint_id.slice(0, 12)}… tombstoned for ${TOMBSTONE_DAYS} days`);
+  sendCourtesy(row, { type: 'federation-reject', uuid: row.uuid, ...(clean ? { reason: clean } : {}) });
+  return reqDb.getRequestById(id);
+}
+
+// ── Delivery: the owed-DM attempt loop ──────────────────────────────────────
+
+// Build the swap-ready mstrfed1: ticket for a minted key. Throws when the
+// endpoint isn't up yet — the caller treats that like any transport
+// failure and retries.
+async function ticketForMintedKey(keyId) {
+  const federation = await import('./federation.js');
+  const endpointTicket = federation.getEndpointTicket();
+  if (!endpointTicket) { throw new Error('federation endpoint not running'); }
+  const keyRow = fedDb.getFederationKeyById(keyId);
+  if (!keyRow) { throw new Error('minted key vanished (revoked?)'); }
+  const os = await import('os');
+  return federation.buildFederationTicket({
+    endpointTicket,
+    key: keyRow.key,
+    serverName: config.program.federation.serverName || os.hostname(),
+    libraries: fedDb.getFederationKeyLibraries(keyId).map((l) => l.name),
+    expiresAt: keyRow.expires_at ? `${keyRow.expires_at.replace(' ', 'T')}Z` : null,
+  });
+}
+
+function payloadForRow(row) {
+  if (row.direction === 'out' && row.state === 'pending-delivery') {
+    return Promise.resolve({
+      type: 'federation-request',
+      uuid: row.uuid,
+      name: config.program.discoveryP2p.serverName,
+      offer: row.offered_libraries,
+      ...(row.message ? { msg: row.message } : {}),
+    });
+  }
+  if (row.direction === 'in' && row.state === 'accepted') {
+    return (async () => ({
+      type: 'federation-accept',
+      uuid: row.uuid,
+      ticket: await ticketForMintedKey(row.minted_key_id),
+      wantOffer: row.accept_their_offer === 1,
+    }))();
+  }
+  if (row.direction === 'out' && row.state === 'granting') {
+    return (async () => ({
+      type: 'federation-grant',
+      uuid: row.uuid,
+      ticket: await ticketForMintedKey(row.minted_key_id),
+    }))();
+  }
+  return Promise.resolve(null); // state owes nothing — a stale sweep pick
+}
+
+function advanceAfterDelivery(row) {
+  if (row.direction === 'out' && row.state === 'pending-delivery') {
+    return { state: 'delivered', nextAttemptInSeconds: null, failCount: 0 };
+  }
+  if (row.direction === 'in' && row.state === 'accepted') {
+    // Their grant is the next move (when we wanted their offer); nothing
+    // more to send either way.
+    const expectGrant = row.accept_their_offer === 1;
+    return { state: expectGrant ? 'granting' : 'completed', nextAttemptInSeconds: null, failCount: 0 };
+  }
+  if (row.direction === 'out' && row.state === 'granting') {
+    return { state: 'completed', nextAttemptInSeconds: null, failCount: 0 };
+  }
+  return null;
+}
+
+// One delivery attempt for whatever DM the row currently owes.
+async function attempt(id) {
+  if (inFlight.has(id)) { return; }
+  inFlight.add(id);
+  try {
+    const row = reqDb.getRequestById(id);
+    if (!row) { return; }
+    const payload = await payloadForRow(row);
+    if (!payload) { return; }
+
+    let outcome;
+    try {
+      outcome = await p2p.sendDm(row.peer_endpoint_id, payload);
+    } catch (err) {
+      // Never reached (offline / pre-DM build / timeout): walk the ladder.
+      const failCount = row.fail_count + 1;
+      const delay = BACKOFF_SECONDS[Math.min(failCount - 1, BACKOFF_SECONDS.length - 1)];
+      reqDb.updateRequest(id, { failCount, nextAttemptInSeconds: delay });
+      winston.info(`[federation-requests] ${row.uuid} ${payload.type} undeliverable `
+        + `(attempt ${failCount}: ${err.message}) — retrying in ${delay}s`);
+      return;
+    }
+
+    if (outcome.delivered === true) {
+      const patch = advanceAfterDelivery(row);
+      if (patch) { reqDb.updateRequest(id, patch); }
+      winston.info(`[federation-requests] ${row.uuid} ${payload.type} delivered to `
+        + `${row.peer_endpoint_id.slice(0, 12)}… → ${patch ? patch.state : row.state}`);
+      return;
+    }
+
+    // Reached and refused. A refused cold request is terminal by design
+    // (the peer's typed "no"); rate limiting is always transient; and an
+    // accept/grant refusal only means the peer's inbox is momentarily off —
+    // they asked for this pairing, so keep trying until the TTL says stop.
+    const transient = outcome.reason === 'rate-limited'
+      || (payload.type !== 'federation-request' && outcome.reason === 'not-accepting');
+    if (transient) {
+      const failCount = row.fail_count + 1;
+      const delay = BACKOFF_SECONDS[Math.min(failCount - 1, BACKOFF_SECONDS.length - 1)];
+      reqDb.updateRequest(id, { failCount, nextAttemptInSeconds: delay });
+      winston.info(`[federation-requests] ${row.uuid} ${payload.type} refused (${outcome.reason}) — retrying in ${delay}s`);
+      return;
+    }
+    reqDb.updateRequest(id, {
+      state: 'refused',
+      rejectReason: `transport: ${outcome.reason}`,
+      nextAttemptInSeconds: null,
+    });
+    revokeUndeliveredKey(row, `refused (${outcome.reason})`);
+    winston.warn(`[federation-requests] ${row.uuid} ${payload.type} refused by `
+      + `${row.peer_endpoint_id.slice(0, 12)}… (${outcome.reason}) — terminal`);
+  } finally {
+    inFlight.delete(id);
+  }
+}
+
+// A minted key whose credential DM never confirmed delivery reaches nobody
+// — revoke it rather than leave a live credential pointing at a dead
+// exchange. (The lost-ack edge — peer got the ticket but our promise died
+// — surfaces as their testPeer failing later, visibly and logged.)
+function revokeUndeliveredKey(row, why) {
+  if (!row.minted_key_id) { return; }
+  if (!(row.direction === 'in' && row.state === 'accepted') && !(row.direction === 'out' && row.state === 'granting')) { return; }
+  try {
+    if (fedDb.deleteFederationKey(row.minted_key_id)) {
+      winston.info(`[federation-requests] ${row.uuid} revoked undelivered key id=${row.minted_key_id} (${why})`);
+    }
+  } catch (err) {
+    winston.warn(`[federation-requests] ${row.uuid} failed to revoke orphaned key id=${row.minted_key_id}: ${err.message}`);
+  }
+}
+
+// Best-effort one-shot notification (reject / withdraw): no retry ladder,
+// no state impact — an unreachable peer just finds out via its own TTL.
+function sendCourtesy(row, payload) {
+  p2p.sendDm(row.peer_endpoint_id, payload).then((r) => {
+    if (r.delivered !== true) {
+      winston.info(`[federation-requests] ${row.uuid} courtesy ${payload.type} refused (${r.reason})`);
+    }
+  }).catch((err) => {
+    winston.info(`[federation-requests] ${row.uuid} courtesy ${payload.type} not delivered: ${err.message}`);
+  });
+}
+
+// The periodic pass: expire the overdue, then retry whatever owed DM is
+// due. Exported for tests (which drive it instead of waiting on the
+// interval). TTL expiry runs even while the sidecar is down — it's pure
+// bookkeeping; delivery attempts need the transport up.
+export async function runSweep() {
+  const { expired, orphanKeyIds } = reqDb.expireOverdueRequests();
+  if (expired > 0) {
+    winston.info(`[federation-requests] expired ${expired} request(s) past their ${REQUEST_TTL_SECONDS / 86400}-day TTL`);
+    for (const keyId of orphanKeyIds) {
+      try {
+        if (fedDb.deleteFederationKey(keyId)) {
+          winston.info(`[federation-requests] revoked undelivered key id=${keyId} (request expired)`);
+        }
+      } catch (err) {
+        winston.warn(`[federation-requests] failed to revoke orphaned key id=${keyId}: ${err.message}`);
+      }
+    }
+  }
+  if (config.program.discoveryP2p.enabled !== true || !p2p.isRunning()) { return; }
+  const due = reqDb.getDueRetries();
+  await Promise.allSettled(due.map((row) => attempt(row.id)));
+  // Re-derive the transport window: the last live exchange ending (or a
+  // new one appearing via another path) changes what setDmAccept should be.
+  await pushAcceptPolicy();
+}
+
+// ── Inbound DMs ─────────────────────────────────────────────────────────────
+
+async function handleInbound({ from, payload }) {
+  if (!payload || typeof payload !== 'object' || typeof payload.type !== 'string') { return; }
+  if (!payload.type.startsWith('federation-')) { return; } // not ours
+  // The inbox setting gates NEW requests only. Replies to our own
+  // exchanges (accept/grant/reject/withdraw) pass regardless — the
+  // transport was open for exactly their sake (see pushAcceptPolicy), and
+  // rowForSender's uuid + sender match is their real auth.
+  if (payload.type === 'federation-request' && config.program.federation.acceptRequests !== true) {
+    winston.warn(`[federation-requests] dropped ${payload.type} from ${from.slice(0, 12)}… — the inbox is off`);
+    return;
+  }
+  if (config.program.discoveryP2p.blockedPeers.includes(from)) {
+    winston.warn(`[federation-requests] dropped ${payload.type} from blocked peer ${from.slice(0, 12)}…`);
+    return;
+  }
+  if (!validUuid(payload.uuid)) {
+    winston.warn(`[federation-requests] dropped ${payload.type} from ${from.slice(0, 12)}… — bad uuid`);
+    return;
+  }
+  switch (payload.type) {
+    case 'federation-request': handleRequest(from, payload); return;
+    case 'federation-accept': await handleAccept(from, payload); return;
+    case 'federation-grant': await handleGrant(from, payload); return;
+    case 'federation-reject': handleReject(from, payload); return;
+    case 'federation-withdraw': handleWithdraw(from, payload); return;
+    default:
+      winston.warn(`[federation-requests] dropped unknown verb '${payload.type}' from ${from.slice(0, 12)}…`);
+  }
+}
+
+// A new request lands in the inbox — after every spam gate. All drops are
+// silent to the sender by design (indistinguishable from "ignored", which
+// TTLs out on their side) but always logged here.
+function handleRequest(from, payload) {
+  if (reqDb.getRequestByUuid(payload.uuid)) { return; } // idempotent re-delivery
+  if (reqDb.recentlyRejectedPeer(from, TOMBSTONE_DAYS)) {
+    winston.warn(`[federation-requests] dropped request from ${from.slice(0, 12)}… — rejected within ${TOMBSTONE_DAYS} days`);
+    return;
+  }
+  if (reqDb.hasActiveFromPeer(from)) {
+    winston.warn(`[federation-requests] dropped request from ${from.slice(0, 12)}… — one active request per peer`);
+    return;
+  }
+  if (reqDb.countPendingInbound() >= INBOX_CAP) {
+    winston.warn(`[federation-requests] dropped request from ${from.slice(0, 12)}… — inbox is full (${INBOX_CAP})`);
+    return;
+  }
+  const offer = Array.isArray(payload.offer)
+    ? payload.offer.slice(0, CAP.offerItems).map((n) => sanitize(n, CAP.offerName)).filter(Boolean)
+    : [];
+  const row = reqDb.createRequest({
+    uuid: payload.uuid,
+    direction: 'in',
+    peerEndpointId: from,
+    peerName: sanitize(payload.name, CAP.name),
+    message: sanitize(payload.msg, CAP.message),
+    offeredLibraries: offer,
+    state: 'received',
+    ttlSeconds: REQUEST_TTL_SECONDS,
+  });
+  winston.info(`[federation-requests] request ${row.uuid} received from `
+    + `'${row.peer_name || 'unnamed'}' (${from.slice(0, 12)}…), offering `
+    + `${offer.length ? offer.join(', ') : 'nothing'} — awaiting the operator`);
+}
+
+// Resolve a row by uuid ONLY when the sender is the row's peer — the QUIC
+// identity is the auth here; anyone else probing uuids gets dropped+logged.
+function rowForSender(from, uuid, direction, verb) {
+  const row = reqDb.getRequestByUuid(uuid);
+  if (!row || row.direction !== direction) {
+    winston.warn(`[federation-requests] dropped ${verb} from ${from.slice(0, 12)}… — no matching request`);
+    return null;
+  }
+  if (row.peer_endpoint_id !== from) {
+    winston.warn(`[federation-requests] dropped ${verb} for ${uuid} — sender ${from.slice(0, 12)}… is not the peer on the row`);
+    return null;
+  }
+  return row;
+}
+
+// The peer accepted our request: their ticket makes them our peer (we can
+// read them), and if we offered libraries — and they said they want them —
+// we now owe the grant-back.
+async function handleAccept(from, payload) {
+  const row = rowForSender(from, payload.uuid, 'out', 'accept');
+  if (!row) { return; }
+  if (['granting', 'completed'].includes(row.state)) { return; } // idempotent re-delivery
+  if (!['pending-delivery', 'delivered'].includes(row.state)) {
+    winston.warn(`[federation-requests] ${row.uuid} late accept ignored (state '${row.state}')`);
+    return;
+  }
+  const peerId = await addPeerFromTicket(row, payload.ticket, 'accept');
+  if (peerId === null) { return; }
+
+  const wantOffer = payload.wantOffer !== false;
+  const grantNames = wantOffer ? row.offered_libraries : [];
+  const libraryIds = grantNames
+    .map((name) => {
+      const lib = db.getLibraryByName(name);
+      if (!lib) { winston.warn(`[federation-requests] ${row.uuid} offered library '${name}' no longer exists — skipping it`); }
+      return lib ? lib.id : null;
+    })
+    .filter((x) => x !== null);
+
+  if (libraryIds.length === 0) {
+    reqDb.updateRequest(row.id, { state: 'completed', createdPeerId: peerId, nextAttemptInSeconds: null });
+    winston.info(`[federation-requests] ${row.uuid} completed — paired with ${from.slice(0, 12)}… (no grant-back${wantOffer ? '' : ' — peer declined the offer'})`);
+    return;
+  }
+  const keyName = `request: ${row.peer_name || from.slice(0, 12)}`.slice(0, 64);
+  const limits = config.program.federation.limits;
+  const minted = fedDb.createFederationKey(keyName, libraryIds, limits, null);
+  reqDb.updateRequest(row.id, {
+    state: 'granting',
+    createdPeerId: peerId,
+    mintedKeyId: minted.id,
+    nextAttemptInSeconds: 0,
+    failCount: 0,
+  });
+  winston.info(`[federation-requests] ${row.uuid} accepted by peer — minted grant-back key '${keyName}' `
+    + `(config-default limits); sending the ticket`);
+  attempt(row.id).catch((err) => winston.warn(`[federation-requests] grant delivery attempt failed: ${err.message}`));
+}
+
+// The requester's grant-back after our accept: their ticket makes them our
+// peer too, and the exchange is complete.
+async function handleGrant(from, payload) {
+  const row = rowForSender(from, payload.uuid, 'in', 'grant');
+  if (!row) { return; }
+  if (row.state === 'completed') { return; } // idempotent re-delivery
+  if (!['granting', 'accepted'].includes(row.state)) {
+    winston.warn(`[federation-requests] ${row.uuid} unexpected grant ignored (state '${row.state}')`);
+    return;
+  }
+  const peerId = await addPeerFromTicket(row, payload.ticket, 'grant');
+  if (peerId === null) { return; }
+  reqDb.updateRequest(row.id, { state: 'completed', createdPeerId: peerId, nextAttemptInSeconds: null });
+  winston.info(`[federation-requests] ${row.uuid} completed — mutual pairing with ${from.slice(0, 12)}…`);
+}
+
+function handleReject(from, payload) {
+  const row = rowForSender(from, payload.uuid, 'out', 'reject');
+  if (!row) { return; }
+  if (!['pending-delivery', 'delivered'].includes(row.state)) { return; }
+  const reason = sanitize(payload.reason, CAP.reason);
+  reqDb.updateRequest(row.id, { state: 'rejected', rejectReason: reason, nextAttemptInSeconds: null });
+  winston.info(`[federation-requests] ${row.uuid} rejected by ${from.slice(0, 12)}…${reason ? ` (${reason})` : ''}`);
+}
+
+function handleWithdraw(from, payload) {
+  const row = rowForSender(from, payload.uuid, 'in', 'withdraw');
+  if (!row) { return; }
+  if (row.state !== 'received') { return; }
+  reqDb.updateRequest(row.id, { state: 'cancelled', nextAttemptInSeconds: null });
+  winston.info(`[federation-requests] ${row.uuid} withdrawn by its sender`);
+}
+
+// Parse a received mstrfed1: ticket and add its issuer as a federation
+// peer. Returns the peer id, an existing peer's id on a re-delivery
+// (UNIQUE api_key), or null on garbage (logged; the row stays put so a
+// corrected re-send can still land).
+async function addPeerFromTicket(row, ticket, verb) {
+  const federation = await import('./federation.js');
+  let parsed;
+  try {
+    parsed = federation.parseFederationTicket(ticket);
+  } catch (err) {
+    winston.warn(`[federation-requests] ${row.uuid} ${verb} carried an unparseable ticket: ${err.message}`);
+    return null;
+  }
+  let peer;
+  try {
+    peer = fedDb.addFederationPeer({
+      name: row.peer_name || parsed.name || 'Federation request',
+      endpointTicket: parsed.endpointTicket,
+      apiKey: parsed.apiKey,
+    });
+  } catch (err) {
+    if (/UNIQUE/.test(err.message)) {
+      const existing = fedDb.getFederationPeers().find((p) => p.api_key === parsed.apiKey);
+      if (existing) { return existing.id; }
+    }
+    winston.warn(`[federation-requests] ${row.uuid} failed to add peer from ${verb} ticket: ${err.message}`);
+    return null;
+  }
+  winston.info(`[federation-requests] ${row.uuid} added peer '${peer.name}' (id=${peer.id}) from the ${verb} ticket`);
+  (async () => {
+    try {
+      const client = await import('./federation-client.js');
+      await client.testPeer(peer);
+    } catch (err) {
+      winston.warn(`[federation-requests] initial test-connect for peer '${peer.name}' failed: ${err.message}`);
+    }
+  })();
+  return peer.id;
+}

--- a/src/state/federation-requests.js
+++ b/src/state/federation-requests.js
@@ -115,6 +115,10 @@ export async function pushAcceptPolicy() {
 // accept (may be empty = one-way ask). Throws plain Errors; the admin
 // route maps them onto status codes.
 export async function compose({ peerEndpointId, message = null, offeredLibraries = [] }) {
+  // Import before the guards: the stretch from the one-active-request check
+  // down to createRequest must stay synchronous, or two racing composes (a
+  // double-click) could both pass the guard and queue duplicate rows.
+  const catalog = await import('./discovery-catalog.js');
   if (config.program.discoveryP2p.enabled !== true) { throw new Error('the discovery network is not enabled'); }
   if (config.program.federation.enabled !== true) { throw new Error('federation is not enabled'); }
   if (config.program.discoveryP2p.blockedPeers.includes(peerEndpointId)) {
@@ -124,7 +128,6 @@ export async function compose({ peerEndpointId, message = null, offeredLibraries
     && r.peer_endpoint_id === peerEndpointId && reqDb.ACTIVE_STATES.includes(r.state));
   if (existing) { throw new Error(`a request to this peer is already ${existing.state}`); }
 
-  const catalog = await import('./discovery-catalog.js');
   const peerName = catalog.get(peerEndpointId)?.payload?.name || null;
   const row = reqDb.createRequest({
     uuid: crypto.randomUUID(),
@@ -169,6 +172,11 @@ export function cancel(id) {
 // carrying the swap-ready ticket. acceptTheirOffer records whether we
 // expect their grant-back after our accept lands.
 export async function accept(id, { libraryIds, vpathNames, limits, expiresAt = null, acceptTheirOffer = true }) {
+  // Import first: the read→check→mint→update stretch below is synchronous,
+  // so two racing accepts (an operator double-click) cannot both pass the
+  // state check and double-mint — the loser reads 'accepted' and throws.
+  // reject() and cancel() get the same guarantee free by having no awaits.
+  const federation = await import('./federation.js');
   const row = reqDb.getRequestById(id);
   if (!row || row.direction !== 'in') { throw new Error('Request not found'); }
   if (row.state !== 'received') { throw new Error(`cannot accept a request in state '${row.state}'`); }
@@ -176,7 +184,6 @@ export async function accept(id, { libraryIds, vpathNames, limits, expiresAt = n
     throw new Error('this peer is blocked'); // blocked after the request landed
   }
   if (config.program.federation.enabled !== true) { throw new Error('federation is not enabled'); }
-  const federation = await import('./federation.js');
   if (!federation.getEndpointTicket()) { throw new Error('the federation endpoint is not running'); }
 
   const keyName = `request: ${row.peer_name || row.peer_endpoint_id.slice(0, 12)}`.slice(0, 64);
@@ -468,7 +475,7 @@ function rowForSender(from, uuid, direction, verb) {
 // read them), and if we offered libraries — and they said they want them —
 // we now owe the grant-back.
 async function handleAccept(from, payload) {
-  const row = rowForSender(from, payload.uuid, 'out', 'accept');
+  let row = rowForSender(from, payload.uuid, 'out', 'accept');
   if (!row) { return; }
   if (['granting', 'completed'].includes(row.state)) { return; } // idempotent re-delivery
   if (!['pending-delivery', 'delivered'].includes(row.state)) {
@@ -477,6 +484,11 @@ async function handleAccept(from, payload) {
   }
   const peerId = await addPeerFromTicket(row, payload.ticket, 'accept');
   if (peerId === null) { return; }
+  // addPeerFromTicket yielded: a rapid duplicate of this accept may have
+  // advanced the row meanwhile — re-read so only one handler mints the
+  // grant-back (everything from here to updateRequest is synchronous).
+  row = reqDb.getRequestById(row.id);
+  if (!row || !['pending-delivery', 'delivered'].includes(row.state)) { return; }
 
   const wantOffer = payload.wantOffer !== false;
   const grantNames = wantOffer ? row.offered_libraries : [];

--- a/test/db/db-federation-requests.test.mjs
+++ b/test/db/db-federation-requests.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * federation_requests (V67) accessor semantics — db/federation-requests.js
+ * against a real manager-backed DB:
+ *  - uuid uniqueness and the direction CHECK;
+ *  - updateRequest's partial patches (only named fields move, updated_at
+ *    always does);
+ *  - the DM-owing due-retry selection: out/pending-delivery, in/accepted,
+ *    out/granting — and NEVER in/granting (that row is waiting to receive);
+ *  - the presence kick pulling FUTURE attempts to now, and only those;
+ *  - abuse-control queries: inbox count, one-active-per-peer, the 7-day
+ *    rejection tombstone;
+ *  - TTL expiry sweeping only live states and reporting orphaned minted
+ *    keys (accepted/granting rows whose credential DM never confirmed);
+ *  - ON DELETE SET NULL keeping the audit row when its key/peer dies.
+ *
+ * Time comparisons live in SQL (datetime('now')), so tests move rows with
+ * SQL offsets rather than JS Date math — the V62 lesson.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let tmpDir, reqDb, fedDb, manager;
+
+function mkRequest(overrides = {}) {
+  return reqDb.createRequest({
+    uuid: overrides.uuid ?? `uuid-${Math.random().toString(36).slice(2, 10)}`,
+    direction: 'out',
+    peerEndpointId: 'peer-aaaaaaaaaaaaaaaa',
+    state: 'pending-delivery',
+    ttlSeconds: 14 * 24 * 3600,
+    ...overrides,
+  });
+}
+
+// Move a row's timestamp columns around in SQL — the only honest way to
+// simulate the passage of time against datetime('now') comparisons.
+function shift(id, column, seconds) {
+  // `? || ' seconds'` keeps negative offsets valid ('-5 seconds'); the
+  // production accessors' '+' prefix form only ever sees non-negatives.
+  manager.getDB().prepare(
+    `UPDATE federation_requests SET ${column} = datetime('now', ? || ' seconds') WHERE id = ?`
+  ).run(seconds, id);
+}
+
+describe('federation_requests accessors (V67)', () => {
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-fedreq-db-'));
+    fs.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
+      storage: {
+        dbDirectory: path.join(tmpDir, 'db'),
+        albumArtDirectory: path.join(tmpDir, 'art'),
+        logsDirectory: path.join(tmpDir, 'logs'),
+      },
+      port: 0,
+    }));
+    const config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    manager = await import('../../src/db/manager.js');
+    manager.initDB();
+    reqDb = await import('../../src/db/federation-requests.js');
+    fedDb = await import('../../src/db/federation.js');
+  });
+
+  after(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* windows locks */ }
+    setImmediate(() => process.exit(0)); // module-level timers, like the other DB-backed suites
+  });
+
+  test('create + fetch round-trips, offered_libraries inflates, uuid is unique', () => {
+    const row = mkRequest({ uuid: 'uniq-1', offeredLibraries: ['music', 'tapes'], peerName: 'Bob' });
+    assert.equal(row.state, 'pending-delivery');
+    assert.deepEqual(row.offered_libraries, ['music', 'tapes']);
+    assert.equal(reqDb.getRequestByUuid('uniq-1').id, row.id);
+    assert.throws(() => mkRequest({ uuid: 'uniq-1' }), /UNIQUE/);
+  });
+
+  test('direction is CHECK-constrained', () => {
+    assert.throws(() => mkRequest({ direction: 'sideways' }), /CHECK/);
+  });
+
+  test('updateRequest patches only what it is given', () => {
+    const row = mkRequest();
+    reqDb.updateRequest(row.id, { state: 'delivered', nextAttemptInSeconds: null });
+    let got = reqDb.getRequestById(row.id);
+    assert.equal(got.state, 'delivered');
+    assert.equal(got.next_attempt_at, null);
+    assert.equal(got.fail_count, 0, 'untouched fields stay put');
+    reqDb.updateRequest(row.id, { failCount: 3, nextAttemptInSeconds: 60 });
+    got = reqDb.getRequestById(row.id);
+    assert.equal(got.state, 'delivered', 'state untouched by the second patch');
+    assert.equal(got.fail_count, 3);
+    assert.ok(got.next_attempt_at > got.created_at, 'retry armed in the future');
+  });
+
+  test('due-retries picks exactly the DM-owing states, in-granting never', () => {
+    const owedOut = mkRequest({ uuid: 'due-1' });                                            // out/pending-delivery
+    const owedAccept = mkRequest({ uuid: 'due-2', direction: 'in', state: 'accepted' });
+    const owedGrant = mkRequest({ uuid: 'due-3', state: 'granting' });                       // out/granting
+    const waiting = mkRequest({ uuid: 'due-4', direction: 'in', state: 'granting' });        // waiting to RECEIVE
+    const terminal = mkRequest({ uuid: 'due-5', state: 'rejected' });
+    for (const r of [owedOut, owedAccept, owedGrant, waiting, terminal]) {
+      shift(r.id, 'next_attempt_at', -5); // all nominally due
+    }
+    const dueIds = reqDb.getDueRetries(50).map((r) => r.uuid);
+    assert.ok(dueIds.includes('due-1') && dueIds.includes('due-2') && dueIds.includes('due-3'));
+    assert.ok(!dueIds.includes('due-4'), 'in/granting owes nothing');
+    assert.ok(!dueIds.includes('due-5'), 'terminal states owe nothing');
+    for (const r of [owedOut, owedAccept, owedGrant, waiting, terminal]) { reqDb.deleteRequest(r.id); }
+  });
+
+  test('the presence kick pulls only FUTURE attempts forward, only for that peer', () => {
+    const target = mkRequest({ uuid: 'kick-1', peerEndpointId: 'peer-kick', });
+    const other = mkRequest({ uuid: 'kick-2', peerEndpointId: 'peer-other' });
+    shift(target.id, 'next_attempt_at', 6 * 3600);
+    shift(other.id, 'next_attempt_at', 6 * 3600);
+    assert.equal(reqDb.markPeerAttemptsDue('peer-kick'), 1);
+    const dueIds = reqDb.getDueRetries(50).map((r) => r.uuid);
+    assert.ok(dueIds.includes('kick-1'), 'kicked row is due now');
+    assert.ok(!dueIds.includes('kick-2'), 'other peers keep their backoff');
+    assert.equal(reqDb.markPeerAttemptsDue('peer-kick'), 0, 'already-due rows are not re-touched');
+    for (const r of [target, other]) { reqDb.deleteRequest(r.id); }
+  });
+
+  test('abuse-control queries: inbox count, active-per-peer, tombstone window', () => {
+    const inbox = mkRequest({ uuid: 'ab-1', direction: 'in', state: 'received', peerEndpointId: 'peer-ab' });
+    assert.equal(reqDb.countPendingInbound(), 1);
+    assert.equal(reqDb.hasActiveFromPeer('peer-ab'), true);
+    assert.equal(reqDb.hasActiveFromPeer('peer-unknown'), false);
+
+    reqDb.updateRequest(inbox.id, { state: 'rejected' });
+    assert.equal(reqDb.countPendingInbound(), 0);
+    assert.equal(reqDb.hasActiveFromPeer('peer-ab'), false, 'rejected is not active');
+    assert.equal(reqDb.recentlyRejectedPeer('peer-ab'), true, 'fresh rejection tombstones');
+    // Age the rejection out of the 7-day window.
+    manager.getDB().prepare(
+      `UPDATE federation_requests SET updated_at = datetime('now', '-8 days') WHERE id = ?`
+    ).run(inbox.id);
+    assert.equal(reqDb.recentlyRejectedPeer('peer-ab'), false, 'tombstone expires after the window');
+    reqDb.deleteRequest(inbox.id);
+  });
+
+  test('hasActiveRequests reflects any live row, either direction', () => {
+    manager.getDB().exec('DELETE FROM federation_requests'); // earlier tests leave rows
+    assert.equal(reqDb.hasActiveRequests(), false);
+    const row = mkRequest({ uuid: 'act-1', direction: 'in', state: 'granting' });
+    assert.equal(reqDb.hasActiveRequests(), true);
+    reqDb.updateRequest(row.id, { state: 'completed' });
+    assert.equal(reqDb.hasActiveRequests(), false);
+    reqDb.deleteRequest(row.id);
+  });
+
+  test('TTL expiry sweeps live states only and reports orphaned minted keys', () => {
+    const lib = manager.getDB().prepare(
+      "INSERT INTO libraries (name, root_path) VALUES ('ttl-lib', '/x')"
+    ).run();
+    const key = fedDb.createFederationKey('ttl-key', [Number(lib.lastInsertRowid)]);
+
+    const orphan = mkRequest({ uuid: 'ttl-1', direction: 'in', state: 'accepted' });
+    reqDb.updateRequest(orphan.id, { mintedKeyId: key.id });
+    const plain = mkRequest({ uuid: 'ttl-2', state: 'delivered' });
+    const done = mkRequest({ uuid: 'ttl-3', state: 'completed' });
+    for (const r of [orphan, plain, done]) { shift(r.id, 'expires_at', -5); }
+
+    const { expired, orphanKeyIds } = reqDb.expireOverdueRequests();
+    assert.equal(expired, 2, 'the two live rows expire');
+    assert.deepEqual(orphanKeyIds, [key.id], 'the undelivered accept ticket key is reported');
+    assert.equal(reqDb.getRequestById(orphan.id).state, 'expired');
+    assert.equal(reqDb.getRequestById(plain.id).state, 'expired');
+    assert.equal(reqDb.getRequestById(done.id).state, 'completed', 'terminal rows are untouched');
+    for (const r of [orphan, plain, done]) { reqDb.deleteRequest(r.id); }
+  });
+
+  test('minted_key_id / created_peer_id go NULL when their targets die, row survives', () => {
+    const lib = manager.getDB().prepare(
+      "INSERT INTO libraries (name, root_path) VALUES ('fk-lib', '/y')"
+    ).run();
+    const key = fedDb.createFederationKey('fk-key', [Number(lib.lastInsertRowid)]);
+    const peer = fedDb.addFederationPeer({ name: 'fk-peer', endpointTicket: 'et', apiKey: 'fedk_fk_test' });
+    const row = mkRequest({ uuid: 'fk-1', state: 'completed' });
+    reqDb.updateRequest(row.id, { mintedKeyId: key.id, createdPeerId: peer.id });
+
+    fedDb.deleteFederationKey(key.id);
+    fedDb.deleteFederationPeer(peer.id);
+    const got = reqDb.getRequestById(row.id);
+    assert.equal(got.minted_key_id, null);
+    assert.equal(got.created_peer_id, null);
+    assert.equal(got.state, 'completed', 'the audit row itself survives');
+    reqDb.deleteRequest(row.id);
+  });
+});

--- a/test/integration/federation-requests.test.mjs
+++ b/test/integration/federation-requests.test.mjs
@@ -1,0 +1,336 @@
+/**
+ * The federation-requests engine over real iroh DMs: this process runs the
+ * real stack — engine + discovery-p2p sidecar + federation endpoint + DB —
+ * and a bare RawSidecar plays the remote peer, scripted by the test (it
+ * has no engine, so every remote move is explicit and assertable).
+ *
+ * Covered end-to-end:
+ *  - OUT happy path: compose → delivered → peer accepts (ticket) → we add
+ *    the peer AND owe the grant-back → peer receives a REAL parseable
+ *    grant ticket whose key exists here → completed;
+ *  - accept re-delivery is idempotent (no second peer, no second key);
+ *  - IN happy path: request lands (sanitized), operator accepts with
+ *    custom limits → peer gets the accept ticket (limits on the minted
+ *    key) → peer grants back → completed;
+ *  - reject sends the courtesy DM and tombstones the peer for 7 days
+ *    (the next request from them is dropped without a row);
+ *  - cancel sends the courtesy withdraw;
+ *  - a transport-refused cold request goes terminal ('refused');
+ *  - an unreachable peer walks the retry ladder instead of dying;
+ *  - the inbox toggle gates NEW requests at the verb level while replies
+ *    keep flowing (the open-for-replies transport window).
+ *
+ * ⚠ SIDECAR-VERSION GATE: needs a DM-capable sidecar (≥v1.0.3) — the
+ * suite skips wholesale where no binary exists and probe-skips against a
+ * pre-DM build, same as discovery-dm.test.mjs.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { RawSidecar, pollUntil } from '../helpers/raw-sidecar.mjs';
+import { resolveSidecarBinary } from '../../src/state/discovery-p2p.js';
+
+const SIDECAR_BIN = resolveSidecarBinary();
+
+(SIDECAR_BIN ? describe : describe.skip)('federation requests — engine over real DMs', () => {
+  let tmpDir, stub, bob;
+  let config, manager, fedDb, reqDb, engine, p2p, federation, iroh;
+  let libId;
+  let sidecarHasDm = false;
+  let ourTicket; // our discovery endpoint ticket — how bob addresses us
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-fedreq-'));
+    fs.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'music'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
+      storage: {
+        dbDirectory: path.join(tmpDir, 'db'),
+        albumArtDirectory: path.join(tmpDir, 'art'),
+        logsDirectory: path.join(tmpDir, 'logs'),
+      },
+      port: 0,
+      discoveryP2p: { enabled: true },
+      federation: { enabled: true, acceptRequests: true, serverName: 'Engine Test Server' },
+    }));
+
+    config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    manager = await import('../../src/db/manager.js');
+    manager.initDB();
+    libId = Number(manager.getDB().prepare(
+      'INSERT INTO libraries (name, root_path) VALUES (?, ?)'
+    ).run('music', path.join(tmpDir, 'music')).lastInsertRowid);
+    // The raw INSERT bypasses the manager's lazy library cache (already
+    // snapshotted by initDB) — drop it so getLibraryByName sees the row,
+    // the way the real add-library route would.
+    manager.invalidateCache();
+
+    fedDb = await import('../../src/db/federation.js');
+    reqDb = await import('../../src/db/federation-requests.js');
+    p2p = await import('../../src/state/discovery-p2p.js');
+    engine = await import('../../src/state/federation-requests.js');
+    federation = await import('../../src/state/federation.js');
+    iroh = await import('../../src/state/iroh-common.js');
+
+    // The federation endpoint (for real accept/grant tickets) bridges to a
+    // stub backend — its HTTP side is not under test here.
+    stub = http.createServer((req, res) => { res.writeHead(200); res.end('{}'); });
+    await new Promise((r) => stub.listen(0, '127.0.0.1', r));
+    await federation.start({
+      targetPort: stub.address().port,
+      secretKey: iroh.generateSecretKey(),
+      awaitOnline: false,
+    });
+
+    await p2p.start();
+    ourTicket = p2p.getEndpointTicket();
+    engine.subscribe();
+    await engine.pushAcceptPolicy();
+
+    bob = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'bob'));
+    await bob.ready;
+    try {
+      await bob.rpc('setDmAccept', { accept: true });
+      sidecarHasDm = true;
+    } catch (_err) {
+      sidecarHasDm = false; // pre-DM binary — every test gates off
+    }
+    // Seed our address book with bob so bare-id dials (the catalog flow)
+    // resolve without external discovery.
+    if (sidecarHasDm) { await p2p.join([bob.ticket]); }
+  });
+
+  after(async () => {
+    if (bob) { await bob.stop(); }
+    try { await federation?.stop(); } catch { /* endpoint may be down */ }
+    try { await p2p?.stop(); } catch { /* sidecar may be down */ }
+    if (stub) { stub.close(); }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* windows locks */ }
+    setImmediate(() => process.exit(0)); // module-level timers, like the other DB-backed suites
+  });
+
+  const gate = (t) => {
+    if (!sidecarHasDm) { t.skip('pinned sidecar predates the dm protocol'); return true; }
+    return false;
+  };
+
+  // A syntactically-valid mstrfed1: ticket for the scripted peer — the
+  // endpoint ticket inside is fake (nothing dials it here; testPeer's
+  // failure is fire-and-forget), the KEY is what the engine stores.
+  const bobTicket = (key, name = "Bob's Server") => federation.buildFederationTicket({
+    endpointTicket: 'endpoint-ticket-of-bob',
+    key,
+    serverName: name,
+    libraries: ['bobshare'],
+  });
+
+  test('OUT: compose → accept → mutual grant-back → completed', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    const row = await engine.compose({
+      peerEndpointId: bob.endpointId,
+      message: 'shall we?',
+      offeredLibraries: ['music'],
+    });
+    assert.equal(row.state, 'pending-delivery');
+
+    // Duplicate guard: one active request per peer.
+    await assert.rejects(
+      engine.compose({ peerEndpointId: bob.endpointId }),
+      /already/);
+
+    // Bob's inbox sees the request — sanitized fields, no credentials.
+    const evt = await bob.waitForEvent('dm', (e) => e.payload?.type === 'federation-request');
+    assert.equal(evt.payload.uuid, row.uuid);
+    assert.equal(evt.payload.msg, 'shall we?');
+    assert.deepEqual(evt.payload.offer, ['music']);
+    assert.ok(!JSON.stringify(evt.payload).includes('fedk_'), 'no credential travels in the request');
+    await pollUntil(() => reqDb.getRequestById(row.id).state === 'delivered', { what: 'delivered state' });
+
+    // Bob accepts, wants our offer.
+    const r = await bob.rpc('dm', {
+      to: ourTicket,
+      payload: { type: 'federation-accept', uuid: row.uuid, ticket: bobTicket('fedk_bob_key_1'), wantOffer: true },
+    });
+    assert.equal(r.delivered, true, 'our transport window is open for the reply');
+
+    // The grant-back lands on bob with a REAL ticket: our endpoint, a key
+    // that exists here, scoped to the offered library.
+    const grant = await bob.waitForEvent('dm', (e) => e.payload?.type === 'federation-grant');
+    assert.equal(grant.payload.uuid, row.uuid);
+    const parsed = federation.parseFederationTicket(grant.payload.ticket);
+    assert.equal(parsed.endpointTicket, federation.getEndpointTicket());
+    assert.deepEqual(parsed.libraries, ['music']);
+    const grantKey = fedDb.getFederationKeyByKey(parsed.apiKey);
+    assert.ok(grantKey, 'the grant ticket carries a live key');
+    assert.equal(grantKey.stream_kbps, config.program.federation.limits.streamKbps,
+      'automatic grant-back uses the config-default limits');
+
+    await pollUntil(() => reqDb.getRequestById(row.id).state === 'completed', { what: 'completed state' });
+    const done = reqDb.getRequestById(row.id);
+    const peer = fedDb.getFederationPeers().find((p) => p.id === done.created_peer_id);
+    assert.ok(peer, 'bob became a federation peer');
+    assert.equal(done.minted_key_id, grantKey.id);
+
+    // Idempotency: a re-delivered accept changes nothing.
+    const peersBefore = fedDb.getFederationPeers().length;
+    const keysBefore = fedDb.getFederationKeys().length;
+    await bob.rpc('dm', {
+      to: ourTicket,
+      payload: { type: 'federation-accept', uuid: row.uuid, ticket: bobTicket('fedk_bob_key_1'), wantOffer: true },
+    });
+    await new Promise((r2) => setTimeout(r2, 500));
+    assert.equal(fedDb.getFederationPeers().length, peersBefore, 'no duplicate peer');
+    assert.equal(fedDb.getFederationKeys().length, keysBefore, 'no duplicate key');
+    assert.equal(reqDb.getRequestById(row.id).state, 'completed');
+  });
+
+  test('IN: request → operator accept with custom limits → grant-back → completed', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    const uuid = 'in-happy-0001';
+    await bob.rpc('dm', {
+      to: ourTicket,
+      payload: {
+        type: 'federation-request', uuid,
+        name: 'Bobby<script>', // control char stripped, rest kept verbatim (UI escapes)
+        offer: ['bobshare'],
+        msg: 'let me in',
+      },
+    });
+    const row = await pollUntil(() => reqDb.getRequestByUuid(uuid), { what: 'inbox row' });
+    assert.equal(row.direction, 'in');
+    assert.equal(row.state, 'received');
+    assert.equal(row.peer_name, 'Bobby<script>', 'control chars stripped, content stored as data');
+    assert.deepEqual(row.offered_libraries, ['bobshare']);
+    assert.equal(row.peer_endpoint_id, bob.endpointId, 'sender identity is the QUIC-authenticated id');
+
+    await engine.accept(row.id, {
+      libraryIds: [libId],
+      vpathNames: ['music'],
+      limits: { streamKbps: 1234, dailyMb: 0, maxStreams: 2 },
+      expiresAt: null,
+      acceptTheirOffer: true,
+    });
+
+    const acceptEvt = await bob.waitForEvent('dm', (e) => e.payload?.type === 'federation-accept' && e.payload.uuid === uuid);
+    assert.equal(acceptEvt.payload.wantOffer, true);
+    const parsed = federation.parseFederationTicket(acceptEvt.payload.ticket);
+    const key = fedDb.getFederationKeyByKey(parsed.apiKey);
+    assert.equal(key.stream_kbps, 1234, 'accept-dialog limits land on the minted key');
+    assert.equal(key.max_streams, 2);
+    await pollUntil(() => reqDb.getRequestById(row.id).state === 'granting', { what: 'granting state' });
+
+    await bob.rpc('dm', {
+      to: ourTicket,
+      payload: { type: 'federation-grant', uuid, ticket: bobTicket('fedk_bob_key_2', 'Bobby Grants') },
+    });
+    await pollUntil(() => reqDb.getRequestById(row.id).state === 'completed', { what: 'completed state' });
+    assert.ok(reqDb.getRequestById(row.id).created_peer_id, 'their grant made them our peer');
+  });
+
+  test('reject sends the courtesy DM and tombstones the peer', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    const uuid = 'in-reject-0001';
+    await bob.rpc('dm', { to: ourTicket, payload: { type: 'federation-request', uuid, name: 'Bobby' } });
+    const row = await pollUntil(() => reqDb.getRequestByUuid(uuid), { what: 'inbox row' });
+
+    await engine.reject(row.id, 'no thanks');
+    assert.equal(reqDb.getRequestById(row.id).state, 'rejected');
+    const evt = await bob.waitForEvent('dm', (e) => e.payload?.type === 'federation-reject' && e.payload.uuid === uuid);
+    assert.equal(evt.payload.reason, 'no thanks');
+
+    // The tombstone: a fresh request from the same peer is dropped silently.
+    await bob.rpc('dm', { to: ourTicket, payload: { type: 'federation-request', uuid: 'in-tombstoned-01', name: 'Bobby' } });
+    await new Promise((r2) => setTimeout(r2, 700));
+    assert.equal(reqDb.getRequestByUuid('in-tombstoned-01'), null, 'tombstoned peer cannot refill the inbox');
+  });
+
+  test('cancel sends the courtesy withdraw', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // The OUT slot to bob is free again (the first request completed).
+    const row = await engine.compose({ peerEndpointId: bob.endpointId, offeredLibraries: [] });
+    await pollUntil(() => reqDb.getRequestById(row.id).state === 'delivered', { what: 'delivered state' });
+    await engine.cancel(row.id);
+    assert.equal(reqDb.getRequestById(row.id).state, 'cancelled');
+    await bob.waitForEvent('dm', (e) => e.payload?.type === 'federation-withdraw' && e.payload.uuid === row.uuid);
+  });
+
+  test('inbox off: transport refuses cold, but stays open for live exchanges (verb-gated)', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    config.program.federation.acceptRequests = false;
+    let seed = null;
+    // A fresh identity — bob has spent his per-remote rate budget on our
+    // limiter by this point in the suite; carol's is clean, so refusals
+    // here can only come from the accept flag / verb gate under test.
+    const carol = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'carol'));
+    try {
+      await carol.ready;
+      // (a) No live exchanges + inbox off → the transport itself refuses:
+      // the sender gets the typed fail-closed answer, nothing reaches Node.
+      await engine.pushAcceptPolicy();
+      const cold = await carol.rpc('dm', {
+        to: ourTicket,
+        payload: { type: 'federation-request', uuid: 'inbox-off-00001', name: 'Carol' },
+      });
+      assert.equal(cold.delivered, false, 'fail-closed at the transport');
+      assert.equal(cold.reason, 'not-accepting');
+
+      // (b) A live outbound exchange re-opens the window (replies must be
+      // able to land) — but NEW requests are still dropped at the verb
+      // gate, silently to the sender, logged here.
+      seed = reqDb.createRequest({
+        uuid: 'inbox-off-seed-1', direction: 'out', peerEndpointId: bob.endpointId,
+        state: 'delivered', ttlSeconds: 3600,
+      });
+      await engine.pushAcceptPolicy();
+      const gated = await carol.rpc('dm', {
+        to: ourTicket,
+        payload: { type: 'federation-request', uuid: 'inbox-off-00002', name: 'Carol' },
+      });
+      assert.equal(gated.delivered, true, 'the reply window is open');
+      await new Promise((r2) => setTimeout(r2, 700));
+      assert.equal(reqDb.getRequestByUuid('inbox-off-00002'), null, 'new requests are verb-gated while the inbox is off');
+    } finally {
+      await carol.stop();
+      if (seed) { reqDb.deleteRequest(seed.id); }
+      config.program.federation.acceptRequests = true;
+      await engine.pushAcceptPolicy();
+    }
+  });
+
+  test('a refusing peer makes a cold request terminal (refused)', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    await bob.rpc('setDmAccept', { accept: false });
+    try {
+      const row = await engine.compose({ peerEndpointId: bob.endpointId });
+      await pollUntil(() => reqDb.getRequestById(row.id).state === 'refused', { what: 'refused state' });
+      const got = reqDb.getRequestById(row.id);
+      assert.equal(got.reject_reason, 'transport: not-accepting');
+      assert.equal(got.next_attempt_at, null, 'terminal — no retry armed');
+    } finally {
+      await bob.rpc('setDmAccept', { accept: true });
+    }
+  });
+
+  test('an unreachable peer walks the retry ladder', { timeout: 90000 }, async (t) => {
+    if (gate(t)) { return; }
+    const ghost = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'ghost'));
+    await ghost.ready;
+    const ghostId = ghost.endpointId;
+    await p2p.join([ghost.ticket]); // seed the address book, then kill it
+    await ghost.stop();
+
+    const row = await engine.compose({ peerEndpointId: ghostId });
+    // The dial burns its failure budget (up to ~25s), then the ladder arms.
+    await pollUntil(() => reqDb.getRequestById(row.id).fail_count === 1,
+      { timeoutMs: 60000, what: 'first failed attempt' });
+    const got = reqDb.getRequestById(row.id);
+    assert.equal(got.state, 'pending-delivery', 'still live — not terminal');
+    assert.ok(got.next_attempt_at, 'retry armed');
+    engine.cancel(row.id); // leave the table quiet for the other tests
+  });
+});

--- a/test/integration/federation-requests.test.mjs
+++ b/test/integration/federation-requests.test.mjs
@@ -12,6 +12,9 @@
  *  - IN happy path: request lands (sanitized), operator accepts with
  *    custom limits → peer gets the accept ticket (limits on the minted
  *    key) → peer grants back → completed;
+ *  - concurrent duplicate accepts — an operator double-click, or a peer
+ *    double-sending its accept DM — mint exactly ONE key (the check→mint
+ *    stretch must not yield between reading the row and advancing it);
  *  - reject sends the courtesy DM and tombstones the peer for 7 days
  *    (the next request from them is dropped without a row);
  *  - cancel sends the courtesy withdraw;
@@ -230,6 +233,63 @@ const SIDECAR_BIN = resolveSidecarBinary();
     });
     await pollUntil(() => reqDb.getRequestById(row.id).state === 'completed', { what: 'completed state' });
     assert.ok(reqDb.getRequestById(row.id).created_peer_id, 'their grant made them our peer');
+  });
+
+  test('RACE: two concurrent operator accepts mint exactly one key', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // A synthetic sender straight off the events bus — the race under test
+    // is engine-internal, no wire needed (and no rate-limit spend on bob).
+    const racer = 'ab'.repeat(32);
+    p2p.events.emit('dm', { from: racer, payload: { type: 'federation-request', uuid: 'race-op-accept-1', name: 'Racer' } });
+    const row = await pollUntil(() => reqDb.getRequestByUuid('race-op-accept-1'), { what: 'race inbox row' });
+
+    const keysBefore = fedDb.getFederationKeys().length;
+    const opts = {
+      libraryIds: [libId], vpathNames: ['music'],
+      limits: { streamKbps: 0, dailyMb: 0, maxStreams: 0 },
+      expiresAt: null, acceptTheirOffer: false,
+    };
+    // A double-click: both calls enter in the same tick. Unless the engine
+    // keeps the state-check→mint stretch synchronous, both pass the check.
+    const results = await Promise.allSettled([engine.accept(row.id, opts), engine.accept(row.id, opts)]);
+    assert.equal(results.filter((r) => r.status === 'fulfilled').length, 1, 'exactly one accept wins');
+    assert.match(results.find((r) => r.status === 'rejected').reason.message, /cannot accept/);
+    assert.equal(fedDb.getFederationKeys().length - keysBefore, 1, 'exactly one key minted');
+    const done = reqDb.getRequestById(row.id);
+    assert.equal(done.state, 'accepted');
+    assert.ok(fedDb.getFederationKeyById(done.minted_key_id), 'the row references the surviving key');
+
+    // Tidy: this exchange goes nowhere (fake peer) — drop it so later tests'
+    // transport-window and count math stay clean.
+    fedDb.deleteFederationKey(done.minted_key_id);
+    reqDb.deleteRequest(row.id);
+    await engine.pushAcceptPolicy();
+  });
+
+  test('RACE: a double-sent peer accept mints exactly one grant-back key', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    const racePeer = 'cd'.repeat(32);
+    const row = await engine.compose({ peerEndpointId: racePeer, offeredLibraries: ['music'] });
+    // The background dial to a nonexistent id fails on its own clock; the
+    // row stays 'pending-delivery', which handleAccept legitimately acts on.
+    const keysBefore = fedDb.getFederationKeys().length;
+    const peersBefore = fedDb.getFederationPeers().length;
+    const payload = { type: 'federation-accept', uuid: row.uuid, ticket: bobTicket('fedk_race_bob', 'Race Bob'), wantOffer: true };
+    // The same accept delivered twice back-to-back: both handlers pass the
+    // state check before either mints unless the engine re-reads after its
+    // awaits (addPeerFromTicket yields).
+    p2p.events.emit('dm', { from: racePeer, payload });
+    p2p.events.emit('dm', { from: racePeer, payload });
+    await pollUntil(() => ['granting', 'completed'].includes(reqDb.getRequestById(row.id).state), { what: 'granting state' });
+    await new Promise((r) => setTimeout(r, 500)); // let the losing handler finish
+    assert.equal(fedDb.getFederationPeers().length - peersBefore, 1, 'one peer (UNIQUE api_key dedupe)');
+    assert.equal(fedDb.getFederationKeys().length - keysBefore, 1, 'exactly one grant-back key minted');
+    const done = reqDb.getRequestById(row.id);
+    assert.ok(fedDb.getFederationKeyById(done.minted_key_id), 'the row references the surviving key');
+
+    fedDb.deleteFederationKey(done.minted_key_id);
+    reqDb.deleteRequest(row.id);
+    await engine.pushAcceptPolicy();
   });
 
   test('reject sends the courtesy DM and tombstones the peer', { timeout: 60000 }, async (t) => {


### PR DESCRIPTION
PR 3 of the discovery→federation migration arc (#805 = per-key limits, #806 + sidecar v1.0.3 = the DM transport, pinned by #924). This is the request engine: an operator who found a server on the public discovery network asks it for a federation pairing **over the network itself**; on accept, the two servers exchange `mstrfed1:` tickets automatically and become mutual peers. PR 4 (the admin UI) is the last piece — until it lands, everything here is reachable through the admin API only.

## The exchange

```
A (requester)                                   B (recipient)
  compose: message + offered libraries
  ── dm federation-request {uuid, name, offer, msg} ──▶ inbox row (opt-in)
                                                        admin accepts: library picker
                                                        + the same prefilled limit
                                                        fields as a manual mint
  ◀── dm federation-accept {uuid, ticket, wantOffer} ──
  addFederationPeer(B) + testPeer      (A now reads B)
  if A offered and B wants it: mint with config-default limits
  ── dm federation-grant {uuid, ticket} ───────────────▶ addFederationPeer(A)
                                                        (B now reads A)
```

**Security invariant:** no credential ever travels in a request — tickets only flow *after* an explicit accept, so a rejected (or ignored) recipient never holds anything. Sender identity on every inbound DM is the QUIC-authenticated endpoint id; accept/grant/reject replies are only honored from the row's own peer. `peer_name`/`message` are self-asserted, size-capped, control-stripped — and still displayed-as-untrusted data (UI escaping is a PR 4 checklist item; the identity anchor is the endpoint id).

## What's in it

- **V67**: `federation_requests` — one table for both roles (`direction` in/out), offered-library names as JSON, `minted_key_id`/`created_peer_id` audit links (SET NULL — revoking a key later never erases the history), NOT NULL `expires_at` (every request carries its 14-day TTL from birth).
- **The state machine** (`src/state/federation-requests.js`):
  - out: `pending-delivery → delivered → granting → completed`; in: `received → accepted → granting → completed`; terminals `rejected / refused / expired / cancelled / blocked`.
  - Delivery rides `sendDm`'s three outcomes: a **refused cold request is terminal** (`refused` — the typed "inbox off" answer, no retry); refused accepts/grants stay **transient** (the peer asked for this pairing — a momentarily-off inbox shouldn't strand a half-built one); **unreachable walks the ladder** (1m→5m→30m→6h until the TTL), and a peer's catalog announcement pulls its due retries forward — "peer came online" beats a six-hour rung.
  - A minted key whose credential DM never confirmed delivery is **revoked** on terminal/expiry — no live keys pointing at dead exchanges.
- **The transport window**: `setDmAccept` = `acceptRequests` **OR any live exchange**. A requester whose own inbox is off still receives its accept/reject replies; NEW requests stay verb-gated either way. The window re-derives at stack start, on toggle, on compose, and once per sweep.
- **Inbound spam gates** (behind the sidecar's 8KB/rate caps): uuid dedupe, one active request per sender, inbox cap 50, a 7-day tombstone after a rejection, blockedPeers (checked at receive AND at accept time), field caps + control-char stripping. Every drop is logged; to the sender a drop is indistinguishable from "ignored", which TTLs out on their side.
- **Config/routes**: `federation.acceptRequests` (default **false**) + a live toggle route; `GET/POST /admin/federation/requests`, `:id/accept|reject|cancel`, `DELETE :id`; `POST /admin/discovery/p2p/enabled` grows `acceptFederationRequests` — the enable-flow checkbox orchestration (turns federation + the inbox on together; a partial federation failure rolls its flags back, **discovery stays up**, and the cause lands in the response).
- **Stack wiring**: the engine subscribes and pushes the accept policy on every discovery stack start — crash-recovery replays included.

## Testing

- **DB suite 9/9**: due-retry selection (in/granting owes nothing), presence kick touching only future attempts of that peer, tombstone window, TTL expiry reporting orphaned minted keys, FK SET NULL survival.
- **Engine e2e 7/7 over real iroh DMs** — this process runs the real engine + sidecar + federation endpoint; a scripted `RawSidecar` plays the peer:
  - mutual-grant happy path both directions (the grant ticket is parsed and verified against the real endpoint + a live key row scoped to the offered library);
  - re-delivered accept is idempotent (no duplicate peer/key);
  - accept-dialog limits land on the minted key; courtesy reject (with reason) + withdraw DMs arrive; the tombstone drops the next request;
  - refused-terminal, unreachable-ladder, and the fail-closed vs open-for-replies window (cold refusal at the transport; verb-gated drop while a live exchange holds the window open).
  - Gated like the DM suite: skips wholesale with no sidecar binary, probe-skips against a pre-DM build.
- `redocly lint` 0 errors; eslint clean on all touched files; full `npm test` run before opening.

## After this

PR 4: the UI (catalog "Federate…" action, Requests inbox card, the discovery-enable checkbox) + escaping of remote strings. The WAN smoke (relays + N0 bare-id resolution across the real internet) is planned against this PR's engine on the big server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
