### PR TITLE
feat(federation): browse a peer's library from the webapp

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6144,6 +6144,120 @@ paths:
         "403":
           description: Discovery data collection is disabled on this server.
 
+  /api/v1/federation/peers:
+    get:
+      tags: [Federation]
+      summary: Peers this user can browse
+      description: |
+        The read-only projection of the paired servers, for the webapp's
+        Peers panel and the peer roots in the file explorer. Deliberately
+        NOT the admin route's payload: `api_key` and `endpoint_ticket` are
+        credentials and never appear here. Any logged-in user may call it —
+        browsing a peer is not an admin action. Nothing dials, so listing is
+        free; `lastSeen`/`lastStatus` are whatever the last admin
+        test-connection left on the row.
+
+        The ping's `federationBrowse` flag tells a client whether to offer
+        any of this (federation on, at least one peer), so clients never
+        probe.
+      responses:
+        "200":
+          description: The peers, oldest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  peers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: integer }
+                        name: { type: string }
+                        lastSeen: { type: string, nullable: true, description: "Last successful contact (SQLite datetime), or null" }
+                        lastStatus: { type: string, nullable: true, description: "'ok' or an error string from the last test-connection" }
+                        useDiscovery: { type: boolean, description: Whether this server sends the peer similarity queries }
+        "403":
+          description: Federation is disabled on this server.
+
+  /api/v1/federation/peers/{id}/api/{path}:
+    post:
+      tags: [Federation]
+      summary: Run one allowlisted read on a peer
+      description: |
+        The browsing half of federation: executes ONE read against a peer
+        and pipes its answer back, so the webapp can call `db/albums`,
+        `db/artists`, `db/genres`, `db/search`, `db/album-songs`,
+        `db/genre-songs`, `db/recent/added` or `file-explorer` against a
+        peer with exactly the shapes it uses locally.
+
+        The requested route is screened against the SHARED inbound allowlist
+        (`api/federation-auth.js`) before anything is dialed — the same
+        table that decides what a peer may ask of US, so the two directions
+        cannot drift. That screen is not the security boundary: the peer
+        re-checks its own copy, and the peer's auth wall plus the grants on
+        our key decide what is actually readable. Path segments are joined,
+        never resolved, so a `..` stays literal text and simply misses the
+        allowlist.
+
+        Method and path address the PEER's API (e.g.
+        `/api/v1/federation/peers/3/api/api/v1/db/albums`). Query strings
+        are NOT forwarded — the webapp appends this server's `?token=` to
+        its URLs, and that token must never reach a peer. Bodies are
+        re-serialized from the parsed JSON request.
+
+        Takes normal local-user auth and is NOT callable with a federation
+        key, so a peer can never chain proxies through this server.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer }, description: Peer row id }
+        - name: path
+          in: path
+          required: true
+          schema: { type: string }
+          description: "The route ON THE PEER, spanning multiple segments (e.g. api/v1/db/albums)"
+      requestBody:
+        required: false
+        description: Forwarded to the peer as JSON — whatever the target route expects.
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        "200":
+          description: "The peer's response, status and content-type forwarded verbatim."
+        "403":
+          description: "Federation is disabled, or the route is not on the federation allowlist."
+        "404":
+          description: "Unknown peer id (or the peer answered 404)."
+        "502":
+          description: "Peer unreachable — the dial + response deadline (15s) was exceeded."
+
+  /api/v1/federation/peers/{id}/art/{path}:
+    get:
+      tags: [Federation]
+      summary: A peer's album art
+      description: |
+        Serves cover art from a peer's `/album-art/<file>`, so rows in a
+        peer view render their real covers instead of the placeholder.
+        `compress` is forwarded (the only query param that is); the local
+        `?token=` authenticates the caller here and is stripped before the
+        dial. Conditional request headers are forwarded, so a cached cover
+        still revalidates with a 304.
+
+        `content-length` is deliberately not copied back: the peer gzips
+        its responses and fetch decompresses them, so the peer's length
+        would describe bytes this server is no longer sending.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer }, description: Peer row id }
+        - { name: path, in: path, required: true, schema: { type: string }, description: Art filename in the PEER's art store }
+        - { name: compress, in: query, required: false, schema: { type: string, enum: [s, m, l] }, description: Forwarded to the peer }
+      responses:
+        "200": { description: The image bytes from the peer. }
+        "304": { description: "Not modified — the peer's answer to a conditional request." }
+        "403": { description: Federation is disabled on this server. }
+        "404": { description: "Unknown peer id, or the peer has no such art file." }
+        "502": { description: "Peer unreachable — the 15s deadline was exceeded." }
+
   /api/v1/federation/peers/{id}/stream/{path}:
     get:
       tags: [Federation]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6197,9 +6197,9 @@ paths:
         table that decides what a peer may ask of US, so the two directions
         cannot drift. That screen is not the security boundary: the peer
         re-checks its own copy, and the peer's auth wall plus the grants on
-        our key decide what is actually readable. Path segments are joined,
-        never resolved, so a `..` stays literal text and simply misses the
-        allowlist.
+        our key decide what is actually readable. A path segment of `.` or
+        `..` is rejected outright (400) before the screen or any dial, so a
+        traversal attempt cannot slip past a prefix-allowlisted route.
 
         Method and path address the PEER's API (e.g.
         `/api/v1/federation/peers/3/api/api/v1/db/albums`). Query strings
@@ -6225,6 +6225,30 @@ paths:
       responses:
         "200":
           description: "The peer's response, status and content-type forwarded verbatim."
+        "400":
+          description: "The path contains a '.' or '..' segment."
+        "403":
+          description: "Federation is disabled, or the route is not on the federation allowlist."
+        "404":
+          description: "Unknown peer id (or the peer answered 404)."
+        "502":
+          description: "Peer unreachable — the dial + response deadline (15s) was exceeded."
+    get:
+      tags: [Federation]
+      summary: Run one allowlisted GET read on a peer
+      description: |
+        The GET half of the browse proxy — the route mirrors the peer's own
+        verb, so GET routes like `db/status` or `federation/health` come
+        through here. Same screening, auth, and error contract as the POST
+        form above.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer }, description: Peer row id }
+        - { name: path, in: path, required: true, schema: { type: string }, description: "The GET route ON THE PEER (e.g. api/v1/federation/health)" }
+      responses:
+        "200":
+          description: "The peer's response, status and content-type forwarded verbatim."
+        "400":
+          description: "The path contains a '.' or '..' segment."
         "403":
           description: "Federation is disabled, or the route is not on the federation allowlist."
         "404":

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -950,7 +950,7 @@ paths:
           discoveryP2p, discoveryReady).
         * **`user`** — identity plus the CALLER-SCOPED half of the ping
           boot payload (vpaths, permission flags, federationDiscovery,
-          vpathMetaData). Unlike ping, no `playlists` (fetch those from
+          federationBrowse, vpathMetaData). Unlike ping, no `playlists` (fetch those from
           the playlist routes), no `allowYoutubeDownload` (velvet-only;
           always `!noUpload`), and no `discoveryPath` (always identical
           to `discovery` on servers new enough to have this endpoint).
@@ -1030,8 +1030,9 @@ paths:
                     description: >
                       Present only for authenticated callers. The
                       caller-scoped half of the ping boot payload (vpaths,
-                      permission flags, federationDiscovery, vpathMetaData)
-                      plus the identity fields below.
+                      permission flags, federationDiscovery,
+                      federationBrowse, vpathMetaData) plus the identity
+                      fields below.
                     properties:
                       username: { type: string }
                       admin: { type: boolean }

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -75,9 +75,14 @@ export function isFederationPathAllowed(req) {
 // THIS list before dialing: a peer re-checks its own copy anyway, but
 // sharing one table means the two directions can never drift into a route
 // we proxy to but no peer will answer (or worse, the reverse).
-export function isFederationRouteAllowed(method, path) {
+// `exactOnly` drops the media/art prefixes. The OUTBOUND browse proxy only
+// forwards the exact db/file-explorer reads (the byte trees have their own
+// dedicated stream and art proxies), so it screens exactOnly and never inherits
+// /media//album-art as a second path. Inbound auth leaves it false — a paired
+// peer legitimately streams and fetches art from us over those prefixes.
+export function isFederationRouteAllowed(method, path, { exactOnly = false } = {}) {
   if (ALLOWED_EXACT.has(`${method} ${path}`)) { return true; }
-  if (method === 'GET' && ALLOWED_GET_PREFIXES.some((p) => path.startsWith(p))) { return true; }
+  if (!exactOnly && method === 'GET' && ALLOWED_GET_PREFIXES.some((p) => path.startsWith(p))) { return true; }
   return false;
 }
 

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -66,8 +66,18 @@ const ALLOWED_EXACT = new Set([
 const ALLOWED_GET_PREFIXES = ['/media/', '/album-art/'];
 
 export function isFederationPathAllowed(req) {
-  if (ALLOWED_EXACT.has(`${req.method} ${req.path}`)) { return true; }
-  if (req.method === 'GET' && ALLOWED_GET_PREFIXES.some((p) => req.path.startsWith(p))) { return true; }
+  return isFederationRouteAllowed(req.method, req.path);
+}
+
+// Same decision, addressable by (method, path) instead of a live request.
+// The OUTBOUND browse proxy (api/federation-browse.js) forwards local-user
+// calls to a peer's allowlisted routes, and it screens the path against
+// THIS list before dialing: a peer re-checks its own copy anyway, but
+// sharing one table means the two directions can never drift into a route
+// we proxy to but no peer will answer (or worse, the reverse).
+export function isFederationRouteAllowed(method, path) {
+  if (ALLOWED_EXACT.has(`${method} ${path}`)) { return true; }
+  if (method === 'GET' && ALLOWED_GET_PREFIXES.some((p) => path.startsWith(p))) { return true; }
   return false;
 }
 

--- a/src/api/federation-browse.js
+++ b/src/api/federation-browse.js
@@ -1,0 +1,194 @@
+// The browsing face of federation: read a PEER's library through this
+// server.
+//
+// Federation's inbound half has always been rich — a paired peer may call
+// our whole read allowlist (api/federation-auth.js): artists, albums,
+// genres, search, the file explorer, /media and /album-art. The outbound
+// half had exactly two consumer routes, the Discover aggregator and the
+// stream proxy, and BOTH need a path someone already handed you. Nothing
+// let a local user simply open a peer and look around. These three routes
+// are that missing half:
+//
+//   GET /api/v1/federation/peers                 peers this user can browse
+//   ALL /api/v1/federation/peers/:id/api/<path>  one allowlisted read
+//   GET /api/v1/federation/peers/:id/art/<file>  that peer's album art
+//
+// All three take normal local-user auth and stay OFF the federation-key
+// allowlist, so a peer can never chain a proxy through us — the same rule
+// api/federation-stream.js states for the byte proxy.
+//
+// The proxy screens the requested route against the SHARED inbound
+// allowlist (isFederationRouteAllowed) before dialing. The peer re-checks
+// its own copy regardless, so this is not the security boundary; it exists
+// so the two directions cannot drift into a route we proxy to but no peer
+// will answer. Past that screen this server adds no path judgement: the
+// path lives in the PEER's vpath namespace, and the peer's auth wall plus
+// the grants on our key decide what is actually readable.
+
+import { Readable } from 'node:stream';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as fedDb from '../db/federation.js';
+import { isFederationRouteAllowed } from './federation-auth.js';
+import { fedFetchWithDeadline } from './discovery-federation.js';
+import WebError from '../util/web-error.js';
+
+// Dial + response budget, matching testPeer and the stream proxy's header
+// phase. Browse answers are small and fully buffered by the peer before it
+// replies, so unlike a track body there is nothing to keep open past it.
+const DEADLINE_MS = 15 * 1000;
+
+// Copied from the peer's response. content-length is deliberately ABSENT:
+// the peer gzips its JSON (util/compression.js), fetch transparently
+// decompresses the body, and forwarding the compressed length would
+// describe bytes we are no longer sending. Node re-chunks instead.
+const FORWARD_RES = ['content-type', 'etag', 'last-modified', 'cache-control'];
+// Art revalidation only — enough for a 304 round-trip on cached covers.
+const FORWARD_REQ_ART = ['if-none-match', 'if-modified-since', 'accept'];
+
+// Query params forwarded to the peer, per route family. An ALLOWLIST, not
+// a filter: the webapp appends its local `?token=` to every <img> and
+// audio URL, and that token is OUR jwt — forwarding it would hand a peer a
+// working credential for this server. The allowlisted reads take no query
+// params at all, so the API proxy forwards none; art takes `compress`.
+const FORWARD_QUERY_ART = ['compress'];
+
+function requireFederation() {
+  if (config.program.federation.enabled !== true) {
+    throw new WebError('federation is disabled (config: federation.enabled)', 403);
+  }
+}
+
+function requirePeer(id) {
+  const peer = fedDb.getFederationPeerById(Number(id));
+  if (!peer) { throw new WebError('Peer not found', 404); }
+  return peer;
+}
+
+// Express 5 named wildcards hand back decoded segments; re-encode each so
+// the upstream URL survives spaces, #, %, ? in names exactly like the
+// webapp's own escaping does. Segments are joined, never resolved — a
+// `..` survives as the literal text `..` and simply fails the allowlist.
+function remotePathFrom(params) {
+  const segments = Array.isArray(params) ? params : String(params).split('/');
+  return segments.map(encodeURIComponent).join('/');
+}
+
+function forwardQuery(query, allowed) {
+  const out = new URLSearchParams();
+  for (const key of allowed) {
+    if (query[key] !== undefined) { out.set(key, String(query[key])); }
+  }
+  const s = out.toString();
+  return s ? `?${s}` : '';
+}
+
+// Shared tail: copy the peer's status + safe headers, pipe its body, tear
+// the upstream read down if the client goes away mid-transfer.
+function pipeUpstream(upstream, res, peer, label) {
+  res.status(upstream.status);
+  for (const h of FORWARD_RES) {
+    const v = upstream.headers.get(h);
+    if (v) { res.setHeader(h, v); }
+  }
+  if (!upstream.body) { return res.end(); }
+
+  const body = Readable.fromWeb(upstream.body);
+  res.on('close', () => { body.destroy(); });
+  body.on('error', (err) => {
+    winston.warn(`[federation] browse proxy: body from peer '${peer.name}' (id=${peer.id}) failed mid-stream on ${label}: ${err.message}`);
+    res.destroy();
+  });
+  body.pipe(res);
+}
+
+export function setup(mstream) {
+  // The peers a local user may browse. Admin's /api/v1/admin/federation/peers
+  // returns the row — which carries api_key and endpoint_ticket, both
+  // credentials. This one is the read-only projection every logged-in user
+  // gets: enough to name a peer, address it, and show whether the last
+  // contact worked. last_seen/last_status are whatever the admin's
+  // test-connection or a previous browse left behind; nothing here dials,
+  // so listing peers stays free.
+  mstream.get('/api/v1/federation/peers', (req, res) => {
+    requireFederation();
+    res.json({
+      peers: fedDb.getFederationPeers().map((p) => ({
+        id: p.id,
+        name: p.name,
+        lastSeen: p.last_seen || null,
+        lastStatus: p.last_status || null,
+        useDiscovery: p.use_discovery === 1,
+      })),
+    });
+  });
+
+  // One allowlisted read, executed on the peer. Method and path are the
+  // peer's own API surface, so the webapp calls db/albums, db/search or
+  // file-explorer against a peer with the same shapes it uses locally.
+  mstream.all('/api/v1/federation/peers/:id/api/*path', async (req, res) => {
+    requireFederation();
+
+    // Screen the route BEFORE looking the peer up: a request we would never
+    // proxy is answered the same way whether or not the peer exists, and
+    // nothing touches the database on the way to that answer.
+    const remotePath = `/${remotePathFrom(req.params.path)}`;
+    if (!isFederationRouteAllowed(req.method, remotePath)) {
+      // Not a probing signal the way a bad key is — this is an authenticated
+      // local user — but it is the only place a webapp bug that asks a peer
+      // for a route no peer serves becomes visible, so log it.
+      winston.warn(`[federation] browse proxy refused off-allowlist route ${req.method} ${remotePath} (peer id=${req.params.id})`);
+      throw new WebError('Route not available over federation', 403);
+    }
+
+    const peer = requirePeer(req.params.id);
+
+    const opts = { method: req.method, headers: {} };
+    // Bodies are re-serialized from the parsed request rather than piped:
+    // every allowlisted POST is a small JSON filter object, and rebuilding
+    // it means nothing but valid JSON crosses the bridge.
+    if (req.method !== 'GET' && req.method !== 'HEAD' && req.body !== undefined) {
+      opts.body = JSON.stringify(req.body ?? {});
+      opts.headers['Content-Type'] = 'application/json';
+    }
+
+    const fedClient = await import('../state/federation-client.js');
+    let upstream;
+    try {
+      upstream = await fedFetchWithDeadline(fedClient, peer, remotePath, opts, DEADLINE_MS);
+    } catch (err) {
+      winston.warn(`[federation] browse proxy: peer '${peer.name}' (id=${peer.id}) unreachable for ${req.method} ${remotePath}: ${err.message}`);
+      throw new WebError('Peer unreachable', 502);
+    }
+
+    pipeUpstream(upstream, res, peer, remotePath);
+  });
+
+  // A peer's cover art. Same shape as the stream proxy, minus ranges —
+  // art is small, and the browser only ever revalidates it.
+  mstream.get('/api/v1/federation/peers/:id/art/*path', async (req, res) => {
+    requireFederation();
+    const peer = requirePeer(req.params.id);
+
+    const remotePath = `/album-art/${remotePathFrom(req.params.path)}`;
+    const headers = {};
+    for (const h of FORWARD_REQ_ART) {
+      if (req.headers[h]) { headers[h] = req.headers[h]; }
+    }
+
+    const fedClient = await import('../state/federation-client.js');
+    let upstream;
+    try {
+      upstream = await fedFetchWithDeadline(
+        fedClient, peer,
+        remotePath + forwardQuery(req.query, FORWARD_QUERY_ART),
+        { headers }, DEADLINE_MS,
+      );
+    } catch (err) {
+      winston.warn(`[federation] art proxy: peer '${peer.name}' (id=${peer.id}) unreachable for '${remotePath}': ${err.message}`);
+      throw new WebError('Peer unreachable', 502);
+    }
+
+    pipeUpstream(upstream, res, peer, remotePath);
+  });
+}

--- a/src/api/federation-browse.js
+++ b/src/api/federation-browse.js
@@ -67,10 +67,15 @@ function requirePeer(id) {
 
 // Express 5 named wildcards hand back decoded segments; re-encode each so
 // the upstream URL survives spaces, #, %, ? in names exactly like the
-// webapp's own escaping does. Segments are joined, never resolved — a
-// `..` survives as the literal text `..` and simply fails the allowlist.
+// webapp's own escaping does. A `.` or `..` segment is rejected outright:
+// undici resolves them on the wire, which for a prefix-allowlisted route
+// (/media/, /album-art/) would let `/media/../api/v1/db/rated` slip past the
+// startsWith screen and dial the peer for a route we would never proxy.
 function remotePathFrom(params) {
   const segments = Array.isArray(params) ? params : String(params).split('/');
+  if (segments.some((s) => s === '.' || s === '..')) {
+    throw new WebError('Invalid path', 400);
+  }
   return segments.map(encodeURIComponent).join('/');
 }
 
@@ -132,8 +137,12 @@ export function setup(mstream) {
     // Screen the route BEFORE looking the peer up: a request we would never
     // proxy is answered the same way whether or not the peer exists, and
     // nothing touches the database on the way to that answer.
+    // exactOnly: this proxy forwards only the exact db/file-explorer reads.
+    // The /media and /album-art byte trees have their own dedicated stream and
+    // art proxies, so the API proxy must not inherit them as a second,
+    // range-less path.
     const remotePath = `/${remotePathFrom(req.params.path)}`;
-    if (!isFederationRouteAllowed(req.method, remotePath)) {
+    if (!isFederationRouteAllowed(req.method, remotePath, { exactOnly: true })) {
       // Not a probing signal the way a bad key is — this is an authenticated
       // local user — but it is the only place a webapp bug that asks a peer
       // for a route no peer serves becomes visible, so log it.
@@ -168,9 +177,11 @@ export function setup(mstream) {
   // art is small, and the browser only ever revalidates it.
   mstream.get('/api/v1/federation/peers/:id/art/*path', async (req, res) => {
     requireFederation();
+    // Build (and validate) the path before the peer lookup, so a bad path is
+    // refused without touching the database — as the API proxy does.
+    const remotePath = `/album-art/${remotePathFrom(req.params.path)}`;
     const peer = requirePeer(req.params.id);
 
-    const remotePath = `/album-art/${remotePathFrom(req.params.path)}`;
     const headers = {};
     for (const h of FORWARD_REQ_ART) {
       if (req.headers[h]) { headers[h] = req.headers[h]; }

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -103,6 +103,10 @@ export function buildClientBootPayload(user) {
   // Get user's library names
   const vpaths = user.vpaths || [];
 
+  // Read the peer list once — both federation flags below need it.
+  const federationEnabled = config.program.federation.enabled === true;
+  const federationPeers = federationEnabled ? fedDb.getFederationPeers() : [];
+
   const payload = {
     vpaths,
     noMkdir: config.program.noMkdir || user.allow_mkdir === false || user.allow_mkdir === 0,
@@ -112,17 +116,16 @@ export function buildClientBootPayload(user) {
     // seed vector comes from our discovery.db) plus at least one federated
     // peer that hasn't opted out of discovery. Caller-scoped by nature —
     // it reflects this server's live peer RELATIONSHIPS.
-    federationDiscovery: config.program.federation.enabled === true
+    federationDiscovery: federationEnabled
       && config.program.scanOptions.collectDiscoveryData === true
-      && fedDb.getFederationPeers().some((p) => p.use_discovery === 1),
+      && federationPeers.some((peer) => peer.use_discovery === 1),
     // Browsing a peer's library (api/federation-browse.js): the top-bar
     // server switcher. Same no-probe contract as the discovery flags — an
     // older build omits the key and the client simply never offers the
     // feature. Requires a peer to browse, so a federation-enabled server
     // with none stays quiet. Caller-scoped for the same reason
     // federationDiscovery is: it reports live peer RELATIONSHIPS.
-    federationBrowse: config.program.federation.enabled === true
-      && fedDb.getFederationPeers().length > 0,
+    federationBrowse: federationEnabled && federationPeers.length > 0,
     vpathMetaData: {}
   };
 

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -115,6 +115,14 @@ export function buildClientBootPayload(user) {
     federationDiscovery: config.program.federation.enabled === true
       && config.program.scanOptions.collectDiscoveryData === true
       && fedDb.getFederationPeers().some((p) => p.use_discovery === 1),
+    // Browsing a peer's library (api/federation-browse.js): the top-bar
+    // server switcher. Same no-probe contract as the discovery flags — an
+    // older build omits the key and the client simply never offers the
+    // feature. Requires a peer to browse, so a federation-enabled server
+    // with none stays quiet. Caller-scoped for the same reason
+    // federationDiscovery is: it reports live peer RELATIONSHIPS.
+    federationBrowse: config.program.federation.enabled === true
+      && fedDb.getFederationPeers().length > 0,
     vpathMetaData: {}
   };
 

--- a/src/server.js
+++ b/src/server.js
@@ -37,6 +37,7 @@ import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // scanner.js removed — parser now writes directly to SQLite
 import * as serverInfoApi from './api/server-info.js';
 import * as federationApi from './api/federation.js';
+import * as federationBrowseApi from './api/federation-browse.js';
 import * as federationDiscoveryApi from './api/federation-discovery.js';
 import * as federationLimitsApi from './api/federation-limits.js';
 import * as federationStreamApi from './api/federation-stream.js';
@@ -645,6 +646,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   federationApi.setup(mstream);
   federationDiscoveryApi.setup(mstream);
   federationStreamApi.setup(mstream);
+  federationBrowseApi.setup(mstream);
   ytdlApi.setup(mstream);
   torrentApi.setup(mstream);
   albumArtApi.setup(mstream);

--- a/test/integration/federation-browse.test.mjs
+++ b/test/integration/federation-browse.test.mjs
@@ -28,11 +28,31 @@ import os from 'node:os';
 import path from 'node:path';
 import { startServer } from '../helpers/server.mjs';
 import { buildFederationTicket } from '../../src/state/federation.js';
+import http from 'node:http';
 
 let irohAvailable = true;
 try { await import('@number0/iroh'); } catch { irohAvailable = false; }
 
 const json = (token) => ({ 'Content-Type': 'application/json', 'x-access-token': token });
+
+// A GET that sends the request-target verbatim. fetch/WHATWG resolves `.`/`..`
+// segments (even percent-encoded like %2e%2e) client-side, so a literal
+// traversal segment only reaches the server through a low-level client.
+function rawGet(baseUrl, rawPath, headers = {}) {
+  const u = new URL(baseUrl);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: u.hostname, port: u.port, path: rawPath, method: 'GET', headers },
+      (res) => {
+        let body = '';
+        res.on('data', (c) => { body += c; });
+        res.on('end', () => resolve({ status: res.statusCode, body }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
 
 describe('federation browse proxy — guards', () => {
   let srv, libDir, adminToken, peerId;
@@ -119,11 +139,26 @@ describe('federation browse proxy — guards', () => {
     });
     assert.equal(stats.status, 403);
 
-    // Path traversal is not resolved, so it simply misses the allowlist.
-    const traverse = await fetch(`${srv.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/db/../../etc/passwd`, {
-      headers: json(adminToken),
-    });
-    assert.equal(traverse.status, 403);
+    // A `..` path segment is rejected (400) before the allowlist screen or any
+    // dial. Sent raw (see rawGet): fetch resolves the `..` away client-side, so
+    // the old fetch form 403'd for the wrong reason — the server never saw a
+    // `..` at all.
+    const traverse = await rawGet(
+      srv.baseUrl,
+      `/api/v1/federation/peers/${peerId}/api/api/v1/db/../../etc/passwd`,
+      { 'x-access-token': adminToken },
+    );
+    assert.equal(traverse.status, 400);
+
+    // The shape that made this matter: a prefix-allowlisted path (/media/) with
+    // a `..` that undici would normalize on the wire into an off-allowlist
+    // route. Must be refused before the peer is dialed.
+    const prefixTraverse = await rawGet(
+      srv.baseUrl,
+      `/api/v1/federation/peers/${peerId}/api/media/../api/v1/db/rated`,
+      { 'x-access-token': adminToken },
+    );
+    assert.equal(prefixTraverse.status, 400);
 
     // Same answer for a peer that does not exist: the route is screened
     // first, so an off-allowlist path never reaches the database.
@@ -310,12 +345,19 @@ describe('federation browse proxy over iroh (B reads A)', {
     // Files. Albums and the explorer are covered above; these are the rest,
     // pinned here because each one is a separate entry in the allowlist and
     // a typo in the webapp's peer wrappers would 403 silently.
+    // Includes the album/genre drill-downs (getAlbumSongs / getGenreSongs) and
+    // the recursive Add-All — each is its own allowlist entry the peer wrappers
+    // call, and dropping one would 403 silently in the UI. Empty-result requests
+    // keep the assertions independent of A's fixture content.
     const calls = [
       ['api/v1/db/artists', '{}', b => Array.isArray(b.artists)],
       ['api/v1/db/genres', '{}', b => Array.isArray(b.genres)],
       ['api/v1/db/recent/added', JSON.stringify({ limit: '100' }), b => Array.isArray(b)],
       ['api/v1/db/search', JSON.stringify({ search: 'a' }), b => typeof b === 'object'],
       ['api/v1/db/artists-albums', JSON.stringify({ artist: 'Icarus' }), b => Array.isArray(b.albums)],
+      ['api/v1/db/album-songs', JSON.stringify({ album: 'zzz-none', artist: null, year: null }), b => Array.isArray(b)],
+      ['api/v1/db/genre-songs', JSON.stringify({ genre: 'zzz-none' }), b => Array.isArray(b)],
+      ['api/v1/file-explorer/recursive', JSON.stringify({ directory: '/ashared' }), b => typeof b === 'object' && b !== null],
     ];
 
     for (const [route, body, shapeOk] of calls) {

--- a/test/integration/federation-browse.test.mjs
+++ b/test/integration/federation-browse.test.mjs
@@ -1,0 +1,346 @@
+/**
+ * The browsing face of federation (src/api/federation-browse.js) — the
+ * OUTBOUND half that lets a local user open a peer and look around:
+ *
+ *   GET /api/v1/federation/peers                 peers this user can browse
+ *   ALL /api/v1/federation/peers/:id/api/<path>  one allowlisted read
+ *   GET /api/v1/federation/peers/:id/art/<file>  that peer's album art
+ *
+ * Part 1 (no iroh needed) pins the guards, using a syntactically valid
+ * ticket that points nowhere — the peer row is real, the endpoint is not:
+ *   - the peers projection never leaks api_key / endpoint_ticket
+ *   - off-allowlist routes are refused BEFORE the peer is even looked up
+ *   - unknown peer ids 404
+ *   - all three routes 403 when federation is off
+ *   - a FEDERATION KEY cannot reach any of them (no proxy chaining): the
+ *     routes are off the inbound allowlist, so the wall answers 403
+ *   - ping advertises federationBrowse only once a peer exists
+ *
+ * Part 2 (skips without the iroh binary) is the real thing: two spawned
+ * servers, B pairs with A over a pasted ticket, and B's webapp routes read
+ * A's library through the bridge.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { startServer } from '../helpers/server.mjs';
+import { buildFederationTicket } from '../../src/state/federation.js';
+
+let irohAvailable = true;
+try { await import('@number0/iroh'); } catch { irohAvailable = false; }
+
+const json = (token) => ({ 'Content-Type': 'application/json', 'x-access-token': token });
+
+describe('federation browse proxy — guards', () => {
+  let srv, libDir, adminToken, peerId;
+
+  before(async () => {
+    libDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-fedbrowse-'));
+    await fs.writeFile(path.join(libDir, 'song.txt'), 'a local file', 'utf8');
+
+    srv = await startServer({
+      extraFolders: { shared: libDir },
+      extraConfig: { federation: { enabled: true } },
+      users: [
+        { username: 'boss', password: 'pw', admin: true, vpaths: ['testlib', 'shared'] },
+        { username: 'listener', password: 'pw', admin: false, vpaths: ['shared'] },
+      ],
+    });
+
+    const login = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'boss', password: 'pw' }),
+    });
+    adminToken = (await login.json()).token;
+
+    // A peer row whose endpoint points nowhere. Everything short of an
+    // actual dial is exercisable against it.
+    const ticket = buildFederationTicket({
+      endpointTicket: 'endpointfake', key: 'fedk_unreachable-peer', serverName: 'Ghost NAS', libraries: ['music'],
+    });
+    const add = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers`, {
+      method: 'POST', headers: json(adminToken), body: JSON.stringify({ ticket }),
+    });
+    assert.equal(add.status, 200);
+    peerId = (await add.json()).id;
+  });
+
+  after(async () => {
+    await srv?.stop();
+    if (libDir) { await fs.rm(libDir, { recursive: true, force: true }).catch(() => {}); }
+  });
+
+  test('the peers list is a projection — no api_key, no endpoint_ticket', async () => {
+    const res = await fetch(`${srv.baseUrl}/api/v1/federation/peers`, { headers: json(adminToken) });
+    assert.equal(res.status, 200);
+    const { peers } = await res.json();
+
+    assert.equal(peers.length, 1);
+    assert.deepEqual(Object.keys(peers[0]).sort(), ['id', 'lastSeen', 'lastStatus', 'name', 'useDiscovery']);
+    assert.equal(peers[0].name, 'Ghost NAS');
+
+    // The credential columns must not appear under ANY key spelling.
+    const serialized = JSON.stringify(peers);
+    assert.ok(!serialized.includes('fedk_'), 'the peer api key must never reach a non-admin projection');
+    assert.ok(!serialized.includes('endpointfake'), 'the endpoint ticket must never reach a non-admin projection');
+  });
+
+  test('a non-admin user may list peers (browsing is not an admin action)', async () => {
+    const login = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'listener', password: 'pw' }),
+    });
+    const listenerToken = (await login.json()).token;
+
+    const res = await fetch(`${srv.baseUrl}/api/v1/federation/peers`, { headers: json(listenerToken) });
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).peers.length, 1);
+
+    // ...but the admin route stays admin-only.
+    const admin = await fetch(`${srv.baseUrl}/api/v1/admin/federation/peers`, { headers: json(listenerToken) });
+    assert.equal(admin.status, 403);
+  });
+
+  test('off-allowlist routes are refused, and refused before the peer lookup', async () => {
+    // A write the peer would never serve.
+    const write = await fetch(`${srv.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/db/rate-song`, {
+      method: 'POST', headers: json(adminToken), body: JSON.stringify({ filepath: 'x', rating: 10 }),
+    });
+    assert.equal(write.status, 403);
+
+    // A read that is deliberately NOT shared (per-user stats).
+    const stats = await fetch(`${srv.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/db/rated`, {
+      method: 'POST', headers: json(adminToken), body: '{}',
+    });
+    assert.equal(stats.status, 403);
+
+    // Path traversal is not resolved, so it simply misses the allowlist.
+    const traverse = await fetch(`${srv.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/db/../../etc/passwd`, {
+      headers: json(adminToken),
+    });
+    assert.equal(traverse.status, 403);
+
+    // Same answer for a peer that does not exist: the route is screened
+    // first, so an off-allowlist path never reaches the database.
+    const ghost = await fetch(`${srv.baseUrl}/api/v1/federation/peers/424242/api/api/v1/db/rate-song`, {
+      method: 'POST', headers: json(adminToken), body: '{}',
+    });
+    assert.equal(ghost.status, 403);
+  });
+
+  test('an unknown peer on an allowlisted route is a 404', async () => {
+    const res = await fetch(`${srv.baseUrl}/api/v1/federation/peers/424242/api/api/v1/db/albums`, {
+      method: 'POST', headers: json(adminToken), body: '{}',
+    });
+    assert.equal(res.status, 404);
+
+    const art = await fetch(`${srv.baseUrl}/api/v1/federation/peers/424242/art/cover.jpg`, {
+      headers: json(adminToken),
+    });
+    assert.equal(art.status, 404);
+  });
+
+  test('a federation key cannot chain a proxy through us', async () => {
+    const mint = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST', headers: json(adminToken), body: JSON.stringify({ name: 'chainer', vpaths: ['shared'] }),
+    });
+    assert.equal(mint.status, 200);
+    const { key } = await mint.json();
+
+    const fedH = { 'x-federation-key': key, 'Content-Type': 'application/json' };
+    // Sanity: the key itself works on an allowlisted route.
+    const ok = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedH });
+    assert.equal(ok.status, 200);
+
+    // None of the browse routes are on that allowlist.
+    for (const url of [
+      `${srv.baseUrl}/api/v1/federation/peers`,
+      `${srv.baseUrl}/api/v1/federation/peers/${peerId}/art/cover.jpg`,
+    ]) {
+      assert.equal((await fetch(url, { headers: fedH })).status, 403, url);
+    }
+    const proxied = await fetch(`${srv.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/db/albums`, {
+      method: 'POST', headers: fedH, body: '{}',
+    });
+    assert.equal(proxied.status, 403);
+  });
+
+  test('ping advertises federationBrowse once a peer exists', async () => {
+    const res = await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: json(adminToken) });
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).federationBrowse, true);
+  });
+});
+
+describe('federation browse proxy — federation disabled', () => {
+  let srv, libDir, token;
+
+  before(async () => {
+    libDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-fedbrowse-off-'));
+    await fs.writeFile(path.join(libDir, 'song.txt'), 'a local file', 'utf8');
+    srv = await startServer({
+      extraFolders: { shared: libDir },
+      users: [{ username: 'boss', password: 'pw', admin: true, vpaths: ['testlib', 'shared'] }],
+    });
+    const login = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'boss', password: 'pw' }),
+    });
+    token = (await login.json()).token;
+  });
+
+  after(async () => {
+    await srv?.stop();
+    if (libDir) { await fs.rm(libDir, { recursive: true, force: true }).catch(() => {}); }
+  });
+
+  test('every browse route 403s and ping keeps the feature hidden', async () => {
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/peers`, { headers: json(token) })).status, 403);
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/peers/1/art/cover.jpg`, { headers: json(token) })).status, 403);
+
+    const proxied = await fetch(`${srv.baseUrl}/api/v1/federation/peers/1/api/api/v1/db/albums`, {
+      method: 'POST', headers: json(token), body: '{}',
+    });
+    assert.equal(proxied.status, 403);
+
+    const ping = await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: json(token) });
+    assert.equal((await ping.json()).federationBrowse, false);
+  });
+});
+
+// ── Part 2: B browses A's library through a real iroh bridge ────────────────
+
+describe('federation browse proxy over iroh (B reads A)', {
+  skip: irohAvailable ? false : 'no @number0/iroh binary for this platform',
+}, () => {
+  let srvA, srvB, sharedA, privateA, peerId;
+
+  before(async () => {
+    // ── A: the peer being browsed. Two libraries, one granted. ──
+    sharedA = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-browse-a-shared-'));
+    privateA = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-browse-a-private-'));
+    await fs.writeFile(path.join(sharedA, 'shared-track.txt'), 'a track A shares', 'utf8');
+    await fs.writeFile(path.join(privateA, 'private-track.txt'), 'A keeps this', 'utf8');
+
+    srvA = await startServer({
+      extraFolders: { ashared: sharedA, aprivate: privateA },
+      extraConfig: { federation: { enabled: true, serverName: 'Server A' } },
+    });
+
+    // A is in public mode (no users), so minting needs no token.
+    const mint = await fetch(`${srvA.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'server-b', vpaths: ['ashared'] }),
+    });
+    assert.equal(mint.status, 200);
+    const minted = await mint.json();
+    assert.ok(minted.ticket, 'A should issue a ticket (its endpoint is up)');
+
+    // ── B: the browser. Pairs with A exactly as the admin UI would. ──
+    srvB = await startServer({ extraConfig: { federation: { enabled: true, serverName: 'Server B' } } });
+
+    const add = await fetch(`${srvB.baseUrl}/api/v1/admin/federation/peers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ticket: minted.ticket }),
+    });
+    assert.equal(add.status, 200);
+    peerId = (await add.json()).id;
+  });
+
+  after(async () => {
+    await srvB?.stop();
+    await srvA?.stop();
+    for (const d of [sharedA, privateA]) {
+      if (d) { await fs.rm(d, { recursive: true, force: true }).catch(() => {}); }
+    }
+  });
+
+  test("B's peers list names A", async () => {
+    const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers`);
+    assert.equal(res.status, 200);
+    const { peers } = await res.json();
+    assert.equal(peers.length, 1);
+    assert.equal(peers[0].id, peerId);
+  });
+
+  test('the file explorer lists only the libraries A granted', async () => {
+    const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/file-explorer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ directory: '/' }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const names = (body.directories || []).map(d => d.name);
+    assert.deepEqual(names, ['ashared'], 'only the granted library should be visible through the proxy');
+  });
+
+  test('a db read reaches A and comes back as JSON', async () => {
+    const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/db/albums`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type') || '', /application\/json/);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.albums), 'the peer answers the same shape the local route does');
+  });
+
+  test('a GET read works too, and the bridge is reused', async () => {
+    for (let i = 0; i < 2; i++) {
+      const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/federation/health`);
+      assert.equal(res.status, 200);
+      const health = await res.json();
+      assert.deepEqual(health.libraries, ['ashared']);
+      assert.equal(health.name, 'Server A');
+    }
+  });
+
+  test('every route the peer panels call is proxyable', async () => {
+    // The Peers panel offers Albums / Artists / Genres / Recently Added /
+    // Files. Albums and the explorer are covered above; these are the rest,
+    // pinned here because each one is a separate entry in the allowlist and
+    // a typo in the webapp's peer wrappers would 403 silently.
+    const calls = [
+      ['api/v1/db/artists', '{}', b => Array.isArray(b.artists)],
+      ['api/v1/db/genres', '{}', b => Array.isArray(b.genres)],
+      ['api/v1/db/recent/added', JSON.stringify({ limit: '100' }), b => Array.isArray(b)],
+      ['api/v1/db/search', JSON.stringify({ search: 'a' }), b => typeof b === 'object'],
+      ['api/v1/db/artists-albums', JSON.stringify({ artist: 'Icarus' }), b => Array.isArray(b.albums)],
+    ];
+
+    for (const [route, body, shapeOk] of calls) {
+      const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/api/${route}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+      assert.equal(res.status, 200, `${route} should proxy`);
+      assert.ok(shapeOk(await res.json()), `${route} should come back in its normal shape`);
+    }
+  });
+
+  test("A's own auth wall still refuses an ungranted library through the proxy", async () => {
+    const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/api/api/v1/file-explorer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ directory: '/aprivate' }),
+    });
+    // Whatever A decides, it must not be a 200 with A's private listing.
+    assert.notEqual(res.status, 200);
+  });
+
+  test('a missing cover on A becomes a 404 here, not a 502', async () => {
+    const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/art/no-such-cover.jpg`);
+    assert.equal(res.status, 404, 'the peer answered — the proxy forwards its status verbatim');
+  });
+});

--- a/webapp/alpha/api.js
+++ b/webapp/alpha/api.js
@@ -226,6 +226,50 @@ const MSTREAMAPI = (() => {
     return req('POST', mstreamModule.currentServer.host + 'api/v1/db/genre-songs', postObject);
   }
 
+  ///////////////////// Federation: browsing a PEER's library
+  //
+  // Every call below is the LOCAL call above it, re-pointed at one peer via
+  // the server's browse proxy (src/api/federation-browse.js). Same request
+  // bodies, same response shapes — which is the whole point: a peer view
+  // can reuse the local renderers instead of forking them.
+  //
+  // ignoreVPaths is deliberately NOT forwarded. It names vpaths in OUR
+  // library, and the peer's namespace is its own; the peer already scopes
+  // every answer to the libraries our key was granted.
+
+  function peerReq(peerId, method, apiPath, postObject) {
+    const url = `${mstreamModule.currentServer.host}api/v1/federation/peers/${encodeURIComponent(peerId)}/api/${apiPath}`;
+    return req(method, url, postObject);
+  }
+
+  // The peers this user may browse. Never carries api_key or the endpoint
+  // ticket — that projection is admin-only.
+  mstreamModule.federationPeers = () => {
+    return req('GET', mstreamModule.currentServer.host + 'api/v1/federation/peers', false);
+  };
+
+  // A peer's cover art, through the art proxy. `token` is the LOCAL token
+  // (the proxy strips it before dialing, so it never reaches the peer) —
+  // <img> tags can't set headers, same as every other art URL in the app.
+  mstreamModule.peerArtUrl = (peerId, artFile, compress) => {
+    let url = `${mstreamModule.currentServer.host}api/v1/federation/peers/${encodeURIComponent(peerId)}/art/${encodeURIComponent(artFile)}?`;
+    if (compress) { url += `compress=${encodeURIComponent(compress)}&`; }
+    return url + `token=${encodeURIComponent(mstreamModule.currentServer.token)}`;
+  };
+
+  mstreamModule.peer = {
+    dirparser: (peerId, directory) => peerReq(peerId, 'POST', 'api/v1/file-explorer', { directory }),
+    recursiveScan: (peerId, directory) => peerReq(peerId, 'POST', 'api/v1/file-explorer/recursive', { directory }),
+    search: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/search', postObject),
+    artists: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/artists', postObject || {}),
+    albums: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/albums', postObject || {}),
+    artistAlbums: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/artists-albums', postObject),
+    albumSongs: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/album-songs', postObject),
+    genres: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/genres', postObject || {}),
+    genreSongs: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/genre-songs', postObject),
+    recentlyAdded: (peerId, limit) => peerReq(peerId, 'POST', 'api/v1/db/recent/added', { limit: limit || 100 }),
+  };
+
   mstreamModule.searchAlbumArt = (postObject) => {
     return req('POST', mstreamModule.currentServer.host + 'api/v1/album-art/search', postObject);
   }

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -128,6 +128,12 @@ let peerContext = null;
 // server can't overwrite the new panel or get its rows stamped with the new
 // server's peer id.
 let browseGeneration = 0;
+
+// Same idea for the multi-server search fan-out: submitSearchForm bumps this,
+// and a peer answer from a superseded run is dropped instead of appended to the
+// current results. Re-submitting the SAME term would otherwise slip past the
+// term-only peerResultSlot check and duplicate every peer block.
+let searchGeneration = 0;
 // id -> { id, name }. addFederationSongWizard wants a display name for the
 // queue row and a row only carries the id. Filled by loadServerSwitcher()
 // and by anything else that learns a peer's name (e.g. search attribution).
@@ -454,6 +460,10 @@ function printdir(response) {
   }
 
   for (const file of response.files) {
+    // .m3u playlists resolve against THIS library's paths and there is no peer
+    // wrapper to load, queue, or download one — skip them on a peer rather than
+    // render rows whose handlers would call local APIs with a peer path.
+    if (file.type === 'm3u' && peerContext) { continue; }
     currentBrowsingList.push({ type: file.type, name: file.name })
     if (file.type === 'm3u') {
       filelist += createFileplaylistHtml(file.name);
@@ -3002,9 +3012,9 @@ async function setLivePlaylist() {
         VUEPLAYERCORE.addSongWizard(value.filepath, value.metadata, false, undefined, false, true);
       });  
     } else {
-      // Seed the playlist from the current queue — federated tracks left
-      // out, same as every later re-save (vp.js localQueueFilepaths).
-      MSTREAMAPI.savePlaylist(livePlaylistName, VUEPLAYERCORE.localQueueFilepaths(), true);
+      // Seed the empty playlist from the current queue (federated tracks left
+      // out — saveLiveQueue routes through localQueueFilepaths).
+      VUEPLAYERCORE.saveLiveQueue();
     }
 
     document.getElementById('set_live_playlist').classList.remove('green');
@@ -5337,6 +5347,9 @@ function federatedSearchOffered() {
 
 async function submitSearchForm() {
   try {
+    // A new search supersedes any in-flight fan-out (and an out-of-order local
+    // render) from a previous submit — see searchGeneration.
+    const searchGen = ++searchGeneration;
     document.getElementById('search-results').innerHTML += '<div class="loading-screen"><svg class="spinner" width="65px" height="65px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg"><circle class="spinner-path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle></svg></div>'
 
     const postObject = {
@@ -5365,6 +5378,7 @@ async function submitSearchForm() {
     // Searching a federated server searches THAT server (localIgnoreVPaths()
     // above already dropped the local folder filter for the peer case).
     const res = await browseApi('search', postObject);
+    if (searchGen !== searchGeneration) { return; }
 
     if (programState[0].state === 'searchPanel') {
       programState[0].searchTerm = postObject.search;
@@ -5391,7 +5405,7 @@ async function submitSearchForm() {
     // The same query, asked of every paired server. Fire-and-forget: this
     // server's results are already on screen, so a slow or dead peer costs
     // nothing but its own block.
-    if (fanOut) { searchPeers(postObject); }
+    if (fanOut) { searchPeers(postObject, searchGen); }
   }catch(err) {
     boilerplateFailure(err);
   }
@@ -5441,8 +5455,8 @@ function renderSearchRow(key, value, peer) {
 // search spans more than one server, this one included — an unlabelled block
 // next to labelled ones would be the ambiguous case.
 function serverResultHeader(title, note) {
-  return `<div style="padding:12px 12px 2px;font-size:13px;font-weight:600;color:#8bb7f0;">
-    ${escapeHtml(title)}${note ? ` <span style="color:#999;font-weight:400;">&mdash; ${escapeHtml(note)}</span>` : ''}
+  return `<div class="search-server-header">
+    ${escapeHtml(title)}${note ? ` <span class="search-server-note">&mdash; ${escapeHtml(note)}</span>` : ''}
   </div>`;
 }
 
@@ -5455,7 +5469,7 @@ function peerSearchHeader(peer, note) {
 // lives decides whether it can be queued as a local file, added to a
 // playlist, rated, or used as a Sonic Path seed — so the answer is always
 // on screen next to the result.
-async function searchPeers(postObject) {
+async function searchPeers(postObject, searchGen) {
   // Fast bail before the peer lookup: the search panel is not on screen.
   if (!document.getElementById('search-results-peers')) { return; }
 
@@ -5481,14 +5495,21 @@ async function searchPeers(postObject) {
       res = await MSTREAMAPI.peer.search(peer.id, body);
     } catch (err) {
       console.warn(`federation search failed on peer ${peer.id}`, err);
-      // One unreachable peer is a footnote on the results, not a failed
-      // search — say which peer is missing rather than come up silently
-      // short.
-      peerResultSlot(term)?.insertAdjacentHTML('beforeend', peerSearchHeader(peer, t('peers.unreachable')));
+      if (searchGen !== searchGeneration) { return; }
+      const failSlot = peerResultSlot(term);
+      if (!failSlot) { return; }
+      // An unreachable peer is a footnote on the results, not "no results" —
+      // name the missing peer AND hide the empty-state, so "No Results Found"
+      // never sits next to an "unreachable" note.
+      const failEmpty = document.getElementById('search-results-empty');
+      if (failEmpty) { failEmpty.classList.add('super-hide'); }
+      failSlot.insertAdjacentHTML('beforeend', peerSearchHeader(peer, t('peers.unreachable')));
       return;
     }
 
-    // The user may have moved on — a new query, or a different panel.
+    // The user may have moved on — a new query (searchGen), the same query
+    // re-run, or a different panel.
+    if (searchGen !== searchGeneration) { return; }
     const slot = peerResultSlot(term);
     if (!slot) { return; }
     const html = renderSearchResults(res, peer);

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -194,6 +194,19 @@ function artImgAttr(artFile, compress) {
   return url ? `src="${url}"` : 'src="assets/img/default.png"';
 }
 
+// Album-art URL for a specific SONG (queue row / now-playing card), which may
+// be a peer track. Unlike artUrl(), the peer identity comes from the song
+// itself (song.federation), not the ambient peerContext — a peer track can be
+// playing while the app is pointed back at this server. The caller guards the
+// no-art case (its two consumers differ: bundled default cover vs. null).
+function songArtUrl(artFile, song, compress) {
+  if (song && song.federation) {
+    return MSTREAMAPI.peerArtUrl(song.federation.peerId, artFile, compress);
+  }
+  const token = (song && song.authToken) || MSTREAMAPI.currentServer.token;
+  return `${MSTREAMAPI.currentServer.host}album-art/${artFile}?compress=${compress}&token=${token}`;
+}
+
 // Queue a row that may live on a peer. Peer tracks bypass addSongWizard
 // entirely (see addFederationSongWizard) — transcode, waveform prefetch,
 // live-playlist save and metadata lookup all resolve against the LOCAL
@@ -202,7 +215,10 @@ function queueRow(peer, filepath, metadata, position) {
   const meta = metadata || {};
   const hasMeta = Object.keys(meta).length > 0;
   if (peer) {
-    VUEPLAYERCORE.addFederationSongWizard(peer, filepath, meta, true, position);
+    // autoPlayOff mirrors the local branch (!hasMeta): a peer row normally
+    // carries metadata, so it should autoplay onto an empty queue just like a
+    // local one. Hard-coding true left peer tracks loaded but paused.
+    VUEPLAYERCORE.addFederationSongWizard(peer, filepath, meta, !hasMeta, position);
     return;
   }
   // lookupMetadata only when the row carried none — the same bargain
@@ -5296,9 +5312,10 @@ async function submitSearchForm() {
 
     const postObject = {
       search: document.getElementById('search-term').value,
-      ignoreVPaths: Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
-        return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
-      })
+      // Auto-DJ folder filter. localIgnoreVPaths() returns undefined on a peer
+      // (those vpaths name OUR libraries, so a name collision would silently
+      // empty the peer's results and leak our library names), so it's dropped.
+      ignoreVPaths: localIgnoreVPaths()
     };
     
     if (document.getElementById("search-in-artists") && document.getElementById("search-in-artists").checked === false) { postObject.noArtists = true; }
@@ -5316,8 +5333,8 @@ async function submitSearchForm() {
 
     try { localStorage.setItem('mstream-search-toggles', JSON.stringify(searchToggles)); } catch (_e) {}
 
-    // Searching a federated server searches THAT server; ignoreVPaths is
-    // dropped for it by peerReq, since it names libraries in our config.
+    // Searching a federated server searches THAT server (localIgnoreVPaths()
+    // above already dropped the local folder filter for the peer case).
     const res = await browseApi('search', postObject);
 
     if (programState[0].state === 'searchPanel') {
@@ -5579,7 +5596,18 @@ function highlightNavPanel(state) {
 function applyServerContext() {
   const select = document.getElementById('server-select');
   const want = peerContext ? String(peerContext.id) : '';
-  if (select && select.value !== want) { select.value = want; }
+  if (select) {
+    // loadServerSwitcher() builds the <option>s once at init, so a peer paired
+    // later (adopted via a federated search hit) has none — then select.value =
+    // id leaves selectedIndex -1 and the dropdown blank. Add the option first.
+    if (peerContext && !Array.from(select.options).some(o => o.value === want)) {
+      const opt = document.createElement('option');
+      opt.value = want;
+      opt.textContent = peerContext.name;
+      select.appendChild(opt);
+    }
+    if (select.value !== want) { select.value = want; }
+  }
 
   // One class does the whole job (see spa.css): it hides every .local-only
   // nav entry and reveals the read-only note. A body class rather than a
@@ -5589,7 +5617,16 @@ function applyServerContext() {
 
   const note = document.getElementById('nav-readonly-note');
   if (note && peerContext) {
+    // Built as DOM nodes, never innerHTML — peerContext.name is peer-controlled.
+    // The "back" link is the only way home when the top bar (and its switcher)
+    // is hidden, since this note stays visible in the always-shown side-nav.
     note.textContent = t('server.readOnlyNote', { name: peerContext.name });
+    const back = document.createElement('a');
+    back.className = 'nav-note-back';
+    back.textContent = t('server.backToThisServer');
+    back.onclick = () => switchServer(null);
+    note.appendChild(document.createElement('br'));
+    note.appendChild(back);
   }
 }
 

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -100,6 +100,116 @@ var programState = [];
 
 let curFileTracker;
 
+///////////////////////// Federation: which server the app is pointed at
+//
+// `peerContext` is the server the app is showing — null for this one, set by
+// the top-bar dropdown (see the server switcher further down). It is read
+// AMBIENTLY by the render helpers and by browseApi() below, so one set of
+// renderers and one set of browse calls serve both sides instead of a forked
+// peer universe.
+//
+// Every row a peer view renders also carries `data-peer`, and the CLICK
+// handlers read that attribute rather than the ambient context. Two
+// reasons: the DB-search panel mixes local and peer hits in one list, where
+// the ambient context is null and the attribute is the only truth; and a
+// row clicked after an async re-render is guaranteed to act on the peer it
+// was drawn for.
+//
+// Handlers that NAVIGATE (open an album, an artist, a folder) adopt the
+// row's peer first, which is what lets a peer album opened from search go
+// on browsing that peer. Handlers that merely QUEUE read the attribute and
+// leave the context alone — playing a peer track from a mixed search list
+// must not move the browser onto that peer.
+let peerContext = null;
+// id -> { id, name }. addFederationSongWizard wants a display name for the
+// queue row and a row only carries the id. Filled by loadServerSwitcher()
+// and by anything else that learns a peer's name (e.g. search attribution).
+const knownPeers = new Map();
+
+function rememberPeer(peer) {
+  if (peer && peer.id !== undefined && peer.id !== null) {
+    knownPeers.set(Number(peer.id), { id: Number(peer.id), name: peer.name || 'peer' });
+  }
+  return peer;
+}
+
+// Rendered into every row while a peer view is open.
+function peerAttr(peer) {
+  const p = peer === undefined ? peerContext : peer;
+  return p ? ` data-peer="${escapeHtml(p.id)}"` : '';
+}
+
+// The peer a clicked row belongs to, or null when the row is local.
+function peerOf(el) {
+  const raw = el && el.getAttribute ? el.getAttribute('data-peer') : null;
+  if (!raw) { return null; }
+  const id = Number(raw);
+  return knownPeers.get(id) || { id: id, name: 'peer' };
+}
+
+// Point the app at whatever server the clicked row came from — used by the
+// handlers that NAVIGATE. A federated hit in a multi-server search result is
+// the one place a row can disagree with the dropdown, and following it moves
+// the whole app (dropdown, nav, read-only note) onto that server rather than
+// leaving a half-switched UI. The queueing handlers use peerOf() instead and
+// leave the context alone.
+function adoptPeer(el) {
+  const next = peerOf(el);
+  const changed = (next ? next.id : null) !== (peerContext ? peerContext.id : null);
+  peerContext = next;
+  if (changed) { applyServerContext(); }
+  return peerContext;
+}
+
+// One browse call, routed to the peer being browsed or to this server.
+// The peer wrappers in api.js mirror the local names exactly, so the only
+// difference at the call site is which server answers.
+function browseApi(name, postObject) {
+  if (peerContext) { return MSTREAMAPI.peer[name](peerContext.id, postObject); }
+  return MSTREAMAPI[name](postObject);
+}
+
+// vpaths to hide, for a LOCAL call only. The Auto-DJ folder filter names
+// vpaths in this library; a peer's namespace is its own, and the peer
+// already scopes every answer to the libraries our key was granted.
+function localIgnoreVPaths() {
+  if (peerContext) { return undefined; }
+  return Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
+    return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
+  });
+}
+
+// Album-art URL for the panel being rendered: this server's /album-art, or
+// a peer's art through the proxy.
+function artUrl(artFile, compress) {
+  if (!artFile) { return null; }
+  if (peerContext) { return MSTREAMAPI.peerArtUrl(peerContext.id, artFile, compress); }
+  return `${MSTREAMAPI.currentServer.host}album-art/${escapeHtml(artFile)}?${compress ? `compress=${compress}&` : ''}token=${MSTREAMAPI.currentServer.token}`;
+}
+
+// The `aa` argument createMusicFileHtml expects: a full src attribute for
+// the panel's server, or the bundled default cover.
+function artImgAttr(artFile, compress) {
+  const url = artUrl(artFile, compress);
+  return url ? `src="${url}"` : 'src="assets/img/default.png"';
+}
+
+// Queue a row that may live on a peer. Peer tracks bypass addSongWizard
+// entirely (see addFederationSongWizard) — transcode, waveform prefetch,
+// live-playlist save and metadata lookup all resolve against the LOCAL
+// library, and this path is in the peer's namespace.
+function queueRow(peer, filepath, metadata, position) {
+  const meta = metadata || {};
+  const hasMeta = Object.keys(meta).length > 0;
+  if (peer) {
+    VUEPLAYERCORE.addFederationSongWizard(peer, filepath, meta, true, position);
+    return;
+  }
+  // lookupMetadata only when the row carried none — the same bargain
+  // searchFileClick strikes, and what the browse panels have always done.
+  VUEPLAYERCORE.addSongWizard(filepath, meta, !hasMeta, position);
+}
+
 const entityMap = {
   '&': '&amp;',
   '<': '&lt;',
@@ -118,11 +228,9 @@ function escapeHtml (string) {
 }
 
 function renderAlbum(id, artist, name, albumArtFile, year) {
-  const artSrc = albumArtFile
-    ? `${MSTREAMAPI.currentServer.host}album-art/${escapeHtml(albumArtFile)}?${VUEPLAYERCORE.altLayout.compressArt ? 'compress=l&' : ''}token=${MSTREAMAPI.currentServer.token}`
-    : null;
+  const artSrc = artUrl(albumArtFile, VUEPLAYERCORE.altLayout.compressArt ? 'l' : undefined);
 
-  return `<div class="album-grid-card" ${year ? `data-year="${escapeHtml(year)}"` : ''} ${artist ? `data-artist="${escapeHtml(artist)}"` : ''} ${id ? `data-album="${escapeHtml(id)}"` : ''} onclick="getAlbumsOnClick(this);">
+  return `<div class="album-grid-card"${peerAttr()} ${year ? `data-year="${escapeHtml(year)}"` : ''} ${artist ? `data-artist="${escapeHtml(artist)}"` : ''} ${id ? `data-album="${escapeHtml(id)}"` : ''} onclick="getAlbumsOnClick(this);">
     <div class="album-grid-art">
       ${artSrc
         ? `<img loading="lazy" src="${artSrc}">`
@@ -140,7 +248,7 @@ function renderAlbum(id, artist, name, albumArtFile, year) {
 
 function renderArtist(artist) {
   return `<li class="collection-item">
-      <div data-artist="${escapeHtml(artist)}" class="artistz" onclick="getArtistz(this)">${escapeHtml(artist)}</div>
+      <div data-artist="${escapeHtml(artist)}"${peerAttr()} class="artistz" onclick="getArtistz(this)">${escapeHtml(artist)}</div>
     </li>`;
 }
 
@@ -164,7 +272,7 @@ function renderFileWithMetadataHtml(filepath, lokiId, metadata) {
 
 function createMusicFileHtml(fileLocation, title, aa, rating, subtitle) {
   return `<li class="collection-item">
-    <div data-file_location="${escapeHtml(fileLocation)}" class="filez ${aa ? 'flex2' : ''}" onclick="onFileClick(this);">
+    <div data-file_location="${escapeHtml(fileLocation)}"${peerAttr()} class="filez ${aa ? 'flex2' : ''}" onclick="onFileClick(this);">
       ${aa ? `<img loading="lazy" class="album-art-box" ${aa}>` : '<svg class="music-image" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="M9 37.5c-3.584 0-6.5-2.916-6.5-6.5s2.916-6.5 6.5-6.5a6.43 6.43 0 012.785.634l.715.34V5.429l25-3.846V29c0 3.584-2.916 6.5-6.5 6.5s-6.5-2.916-6.5-6.5 2.916-6.5 6.5-6.5a6.43 6.43 0 012.785.634l.715.34V11.023l-19 2.931V31c0 3.584-2.916 6.5-6.5 6.5z" fill="#8bb7f0"/><path d="M37 2.166V29c0 3.308-2.692 6-6 6s-6-2.692-6-6 2.692-6 6-6a5.93 5.93 0 012.57.586l1.43.68V10.441l-1.152.178-18 2.776-.848.13V31c0 3.308-2.692 6-6 6s-6-2.692-6-6 2.692-6 6-6a5.93 5.93 0 012.57.586l1.43.68V5.858l24-3.692M38 1L12 5v19.683A6.962 6.962 0 009 24a7 7 0 107 7V14.383l18-2.776v11.076A6.962 6.962 0 0031 22a7 7 0 107 7V1z" fill="#4e7ab5"/></svg>'} 
       <span>
         ${subtitle !== undefined ? `<b>` : ''}
@@ -173,10 +281,10 @@ function createMusicFileHtml(fileLocation, title, aa, rating, subtitle) {
       </span>
     </div>
     <div class="song-button-box">
-      <span title="Play Now" onclick="playNow(this);" data-file_location="${escapeHtml(fileLocation)}" class="songDropdown">
+      <span title="Play Now" onclick="playNow(this);" data-file_location="${escapeHtml(fileLocation)}"${peerAttr()} class="songDropdown">
         <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M15.5 5H11l5 7-5 7h4.5l5-7z"/><path d="M8.5 5H4l5 7-5 7h4.5l5-7z"/></svg>
       </span>
-      <span title="Add To Playlist" onclick="createPopper3(this);" data-file_location="${escapeHtml(fileLocation)}" class="fileAddToPlaylist">
+      <span title="Add To Playlist" onclick="createPopper3(this);" data-file_location="${escapeHtml(fileLocation)}"${peerAttr()} class="fileAddToPlaylist">
         <svg class="pop-f" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 292.362 292.362"><path class="pop-f" d="M286.935 69.377c-3.614-3.617-7.898-5.424-12.848-5.424H18.274c-4.952 0-9.233 1.807-12.85 5.424C1.807 72.998 0 77.279 0 82.228c0 4.948 1.807 9.229 5.424 12.847l127.907 127.907c3.621 3.617 7.902 5.428 12.85 5.428s9.233-1.811 12.847-5.428L286.935 95.074c3.613-3.617 5.427-7.898 5.427-12.847 0-4.948-1.814-9.229-5.427-12.85z"/></svg>
       </span>
     </div>
@@ -185,15 +293,15 @@ function createMusicFileHtml(fileLocation, title, aa, rating, subtitle) {
 
 function renderDirHtml(name) {
   return `<li class="collection-item">
-    <div data-directory="${escapeHtml(name)}" class="dirz" onclick="handleDirClick(this);">
+    <div data-directory="${escapeHtml(name)}"${peerAttr()} class="dirz" onclick="handleDirClick(this);">
       <svg class="folder-image" viewBox="0 0 48 48" version="1.0" xmlns="http://www.w3.org/2000/svg"><path fill="#FFA000" d="M38 12H22l-4-4H8c-2.2 0-4 1.8-4 4v24c0 2.2 1.8 4 4 4h31c1.7 0 3-1.3 3-3V16c0-2.2-1.8-4-4-4z"/><path fill="#FFCA28" d="M42.2 18H15.3c-1.9 0-3.6 1.4-3.9 3.3L8 40h31.7c1.9 0 3.6-1.4 3.9-3.3l2.5-14c.5-2.4-1.4-4.7-3.9-4.7z"/></svg>
       <span class="item-text">${escapeHtml(name)}</span>
     </div>
     <div class="song-button-box">
-      <span style="padding-top:1px;" title="Add All To Queue" class="songDropdown" onclick="recursiveAddDir(this);" data-directory="${escapeHtml(name)}">
+      <span style="padding-top:1px;" title="Add All To Queue" class="songDropdown" onclick="recursiveAddDir(this);" data-directory="${escapeHtml(name)}"${peerAttr()}>
         <svg xmlns="http://www.w3.org/2000/svg" height="10" width="10" viewBox="0 0 1280 1276"><path d="M6760 12747 c-80 -5 -440 -10 -800 -11 -701 -2 -734 -4 -943 -57 -330 -84 -569 -281 -681 -563 -103 -256 -131 -705 -92 -1466 12 -241 16 -531 16 -1232 l0 -917 -1587 -4 c-1561 -3 -1590 -3 -1703 -24 -342 -62 -530 -149 -692 -322 -158 -167 -235 -377 -244 -666 -43 -1404 -42 -1813 7 -2355 21 -235 91 -400 233 -548 275 -287 730 -389 1591 -353 1225 51 2103 53 2330 7 l60 -12 6 -1489 c6 -1559 6 -1548 49 -1780 100 -535 405 -835 933 -921 88 -14 252 -17 1162 -24 591 -4 1099 -4 1148 1 159 16 312 56 422 112 118 59 259 181 333 290 118 170 195 415 227 722 18 173 21 593 6 860 -26 444 -32 678 -34 1432 l-2 811 54 7 c30 4 781 6 1670 5 1448 -2 1625 -1 1703 14 151 28 294 87 403 168 214 159 335 367 385 666 15 85 29 393 30 627 0 105 4 242 10 305 43 533 49 1047 15 1338 -44 386 -144 644 -325 835 -131 140 -278 220 -493 270 -92 21 -98 21 -1772 24 l-1680 3 3 1608 c2 1148 0 1635 -8 1706 -49 424 -255 701 -625 841 -243 91 -633 124 -1115 92z" transform="matrix(.1 0 0 -.1 0 1276)"/></svg>
       </span>
-      <span data-directory="${escapeHtml(name)}" title="Download Directory" class="downloadDir" onclick="recursiveFileDownload(this);">
+      <span data-directory="${escapeHtml(name)}"${peerAttr()} title="Download Directory" class="downloadDir" onclick="recursiveFileDownload(this);">
         <svg width="13" height="13" viewBox="0 0 2048 2048" xmlns="http://www.w3.org/2000/svg"><path d="M1803 960q0 53-37 90l-651 652q-39 37-91 37-53 0-90-37l-651-652q-38-36-38-90 0-53 38-91l74-75q39-37 91-37 53 0 90 37l294 294v-704q0-52 38-90t90-38h128q52 0 90 38t38 90v704l294-294q37-37 90-37 52 0 91 37l75 75q37 39 37 91z"/></svg>
       </span>
     </div>
@@ -244,8 +352,10 @@ function setBrowserRootPanel(panelName, showBar) {
   document.getElementById('upload_btn').classList.add('super-hide');
   document.getElementById('mkdir_btn').classList.add('super-hide');
 
+  // Inside a peer view every panel says whose library it is showing.
+  const label = peerContext ? `${escapeHtml(peerContext.name)} &middot; ${panelName}` : panelName;
   ([...document.getElementsByClassName('panel_one_name')]).forEach(el => {
-    el.innerHTML = panelName;
+    el.innerHTML = label;
   });
 
   currentBrowsingList = [];
@@ -268,7 +378,9 @@ async function senddir(root) {
   document.getElementById('filelist').innerHTML = getLoadingSvg();
 
   try {
-    const response = await MSTREAMAPI.dirparser(directoryString);
+    const response = peerContext
+      ? await MSTREAMAPI.peer.dirparser(peerContext.id, directoryString)
+      : await MSTREAMAPI.dirparser(directoryString);
     document.getElementById('directoryName').innerHTML = escapeHtml(response.path);
 
     if(root === true && response.path.length > 1) {
@@ -283,7 +395,9 @@ async function senddir(root) {
     // Show upload and mkdir buttons only when inside a vpath (not at root)
     const uploadBtn = document.getElementById('upload_btn');
     const mkdirBtn = document.getElementById('mkdir_btn');
-    if (fileExplorerArray.length > 0) {
+    // Both are writes, and a federation key carries no write permission —
+    // the peer's allowlist stops at reads, so never offer them there.
+    if (fileExplorerArray.length > 0 && !peerContext) {
       uploadBtn.classList.remove('super-hide');
       if (MSTREAMAPI.currentServer.noMkdir === true) {
         mkdirBtn.classList.add('super-hide');
@@ -351,6 +465,7 @@ if (typeof(Storage) !== "undefined" && localStorage.getItem("token")) {
 }
 
 function handleDirClick(el){
+  adoptPeer(el);
   fileExplorerArray.push(el.getAttribute('data-directory'));
   programState.push({
     state: 'fileExplorer',
@@ -377,47 +492,65 @@ function boilerplateFailure(err) {
 }
 
 function onFileClick(el) {
+  const peer = peerOf(el);
   // Sonic Path song-capture: an armed picker takes the next SINGLE row
   // click; bulk actions never come through here, so they queue normally.
   if (VUEPLAYERCORE.songCapture) {
+    // A peer track can't seed a path — the arc is computed from embeddings
+    // in the LOCAL index, and this filepath is in the peer's namespace.
+    // Say so and leave the picker armed for a local row.
+    if (peer) {
+      iziToast.warning({ title: t('sonicPath.federatedTrack'), position: 'topCenter', timeout: 3000 });
+      return;
+    }
     const capture = VUEPLAYERCORE.songCapture;
     VUEPLAYERCORE.songCapture = null;
     capture({ filepath: el.getAttribute("data-file_location") });
     return;
   }
-  VUEPLAYERCORE.addSongWizard(el.getAttribute("data-file_location"), {}, true);
+  queueRow(peer, el.getAttribute("data-file_location"));
 }
 
-// Metadata for the current DB-search results, keyed by (raw) filepath. The
-// search API returns the full canonical metadata object inline on track hits,
-// so the search-result handlers below enqueue with it directly and skip the
-// per-click /api/v1/db/metadata round-trip that the shared onFileClick/playNow
-// (used by the file browser, which has no inline metadata) still perform.
-// Rebuilt on every search in submitSearchForm().
+// Metadata for the current DB-search results, keyed by (peer, raw filepath).
+// The search API returns the full canonical metadata object inline on track
+// hits, so the search-result handlers below enqueue with it directly and skip
+// the per-click /api/v1/db/metadata round-trip that the shared
+// onFileClick/playNow (used by the file browser, which has no inline
+// metadata) still perform. Rebuilt on every search in submitSearchForm().
+//
+// The peer is part of the key because results from several servers share one
+// list, and two libraries can easily hold the same "music/Artist/01.flac".
 let searchResultMetadata = {};
 
+function searchKey(peerId, filepath) {
+  return `${peerId === undefined || peerId === null ? '' : peerId}:${filepath}`;
+}
+
 // Search-result variants of onFileClick / playNow: enqueue with the inline
-// metadata when we have it (so addSongWizard skips the lookup), else fall back
-// to a server lookup (lookupMetadata=true) for safety.
+// metadata when we have it (so the wizard skips the lookup), else fall back
+// to a server lookup for safety. A row from a peer queues over the bridge.
 function searchFileClick(el) {
+  const peer = peerOf(el);
   const fp = el.getAttribute("data-file_location");
-  const meta = searchResultMetadata[fp];
-  VUEPLAYERCORE.addSongWizard(fp, meta || {}, !meta);
+  queueRow(peer, fp, searchResultMetadata[searchKey(peer && peer.id, fp)]);
 }
 
 function searchPlayNow(el) {
+  const peer = peerOf(el);
   const fp = el.getAttribute("data-file_location");
-  const meta = searchResultMetadata[fp];
-  VUEPLAYERCORE.addSongWizard(fp, meta || {}, !meta, MSTREAMPLAYER.positionCache.val + 1);
+  queueRow(peer, fp, searchResultMetadata[searchKey(peer && peer.id, fp)], MSTREAMPLAYER.positionCache.val + 1);
 }
 
 async function recursiveAddDir(el) {
+  const peer = adoptPeer(el);
   try {
     const directoryString = getDirectoryString2(el);
-    const res = await MSTREAMAPI.recursiveScan(directoryString);
-    addAllSongs(res);
+    const res = peer
+      ? await MSTREAMAPI.peer.recursiveScan(peer.id, directoryString)
+      : await MSTREAMAPI.recursiveScan(directoryString);
+    res.forEach(fp => queueRow(peer, fp));
   } catch(err) {
-    boilerplateFailure(err);   
+    boilerplateFailure(err);
   }
 }
 
@@ -459,7 +592,7 @@ async function addFilePlaylist(el) {
 
 function addAll() {
   ([...document.getElementsByClassName('filez')]).forEach(el => {
-    VUEPLAYERCORE.addSongWizard(el.getAttribute("data-file_location"), {}, true);
+    queueRow(peerOf(el), el.getAttribute("data-file_location"));
   });
 }
 
@@ -473,17 +606,18 @@ async function queueAlbum(cardEl) {
   const album = cardEl.getAttribute('data-album') || null;
   const artist = cardEl.getAttribute('data-artist') || null;
   const year = cardEl.getAttribute('data-year') || null;
+  const peer = adoptPeer(cardEl);
 
   try {
-    const response = await MSTREAMAPI.albumSongs({
+    const response = await browseApi('albumSongs', {
       album,
       artist,
       year,
-      ignoreVPaths: Object.keys(MSTREAMPLAYER.ignoreVPaths).filter(v => MSTREAMPLAYER.ignoreVPaths[v] === true)
+      ignoreVPaths: localIgnoreVPaths()
     });
 
     response.forEach(song => {
-      VUEPLAYERCORE.addSongWizard(song.filepath, song.metadata || {}, true);
+      queueRow(peer, song.filepath, song.metadata || {});
     });
 
     iziToast.success({
@@ -498,7 +632,7 @@ async function queueAlbum(cardEl) {
 }
 
 function playNow(el) {
-  VUEPLAYERCORE.addSongWizard(el.getAttribute("data-file_location"), {}, true, MSTREAMPLAYER.positionCache.val + 1);
+  queueRow(peerOf(el), el.getAttribute("data-file_location"), undefined, MSTREAMPLAYER.positionCache.val + 1);
 }
 
 async function init() {
@@ -539,6 +673,11 @@ async function init() {
     // only when the server has the route (never probed).
     MSTREAMAPI.currentServer.discoveryPath = response.discoveryPath === true;
     document.getElementById('nav-sonic-path').classList.toggle('super-hide', response.discoveryPath !== true);
+
+    // Federation: is there another server to point this app at? The flag
+    // means "federation is on AND at least one peer is paired" — no probing.
+    MSTREAMAPI.currentServer.federationBrowse = response.federationBrowse === true;
+    if (MSTREAMAPI.currentServer.federationBrowse) { loadServerSwitcher(); }
 
     if (response.transcode) {
       MSTREAMPLAYER.transcodeOptions.serverEnabled = true;
@@ -603,6 +742,14 @@ async function init() {
 // never appeared. Removed entirely.
 
 function createPopper3(el) {
+  // Playlists store paths against THIS library — a peer's path would save
+  // as a row that resolves to nothing. Say so instead of opening a picker
+  // whose every option fails on submit (the same bargain the rating popper
+  // strikes on peer tracks in vp.js).
+  if (peerOf(el)) {
+    iziToast.info({ title: t('peers.noPlaylist'), position: 'topCenter', timeout: 2500 });
+    return;
+  }
   if (curFileTracker === el.getAttribute("data-file_location")) {
     curFileTracker = undefined;
     document.getElementById("pop-f").style.visibility = "hidden";
@@ -2436,6 +2583,13 @@ function downloadPlaylist() {
 }
 
 function recursiveFileDownload(el) {
+  // /api/v1/download/directory zips a path in THIS library. Downloading a
+  // peer's folder would need a second proxy (and the peer's own consent);
+  // until then, be honest rather than serve an empty archive.
+  if (peerOf(el)) {
+    iziToast.info({ title: t('peers.noDownload'), position: 'topCenter', timeout: 2500 });
+    return;
+  }
   const directoryString = getDirectoryString2(el);
   document.getElementById('downform').action = "api/v1/download/directory?token=" + MSTREAMAPI.currentServer.token;
 
@@ -2818,12 +2972,9 @@ async function setLivePlaylist() {
         VUEPLAYERCORE.addSongWizard(value.filepath, value.metadata, false, undefined, false, true);
       });  
     } else {
-      // save current queue
-      const songs = [];
-      for (let i = 0; i < MSTREAMPLAYER.playlist.length; i++) {
-        songs.push(MSTREAMPLAYER.playlist[i].filepath);
-      }
-      MSTREAMAPI.savePlaylist(livePlaylistName, songs, true);
+      // Seed the playlist from the current queue — federated tracks left
+      // out, same as every later re-save (vp.js localQueueFilepaths).
+      MSTREAMAPI.savePlaylist(livePlaylistName, VUEPLAYERCORE.localQueueFilepaths(), true);
     }
 
     document.getElementById('set_live_playlist').classList.remove('green');
@@ -2840,7 +2991,28 @@ async function setLivePlaylist() {
   }
 }
 
+// Tracks in the queue that live on a federated server. Playlists and shares
+// both resolve paths against THIS library, so neither can carry one.
+function federatedTracksInQueue() {
+  return MSTREAMPLAYER.playlist.filter(song => song.federation);
+}
+
+// Refuse an action that would have to write federated paths, naming the
+// count so the user can find them. Returns true when it refused.
+function refuseMixedQueue(titleKey) {
+  const mixed = federatedTracksInQueue();
+  if (mixed.length === 0) { return false; }
+  iziToast.warning({
+    title: t(titleKey),
+    message: t('playlist.federatedCount', { count: mixed.length }),
+    position: 'topCenter',
+    timeout: 5000
+  });
+  return true;
+}
+
 async function savePlaylist() {
+  if (refuseMixedQueue('playlist.cannotSaveMixed')) { return; }
   if (MSTREAMPLAYER.playlist.length == 0) {
     iziToast.warning({
       title: t('toast.noPlaylistToSave'),
@@ -2890,11 +3062,7 @@ async function getAllArtists() {
   programState = [{ state: 'allArtists' }];
 
   try {
-    const response = await MSTREAMAPI.artists({
-      ignoreVPaths: Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
-        return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
-      })
-    });
+    const response = await browseApi('artists', { ignoreVPaths: localIgnoreVPaths() });
 
     // parse through the json array and make an array of corresponding divs
     let artists = '<ul class="collection">';
@@ -2912,6 +3080,7 @@ async function getAllArtists() {
 }
 
 function getArtistz(el) {
+  adoptPeer(el);
   const artist = el.getAttribute('data-artist');
   programState.push({
     state: 'artist',
@@ -2929,12 +3098,7 @@ async function getArtistsAlbums(artist) {
   document.getElementById('filelist').innerHTML = getLoadingSvg();
 
   try {
-    const response = await MSTREAMAPI.artistAlbums({
-      artist: artist,
-      ignoreVPaths: Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
-        return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
-      })
-    });
+    const response = await browseApi('artistAlbums', { artist: artist, ignoreVPaths: localIgnoreVPaths() });
 
     let albums = '<div class="album-grid">';
     response.albums.forEach(value => {
@@ -2958,12 +3122,12 @@ async function getAllGenres() {
   programState = [{ state: 'allGenres' }];
 
   try {
-    const response = await MSTREAMAPI.genres();
+    const response = await browseApi('genres', {});
 
     let html = '<ul class="collection">';
     response.genres.forEach(value => {
       html += `<li class="collection-item">
-        <div data-genre="${escapeHtml(value.name)}" class="artistz" onclick="getGenreSongsList(this)">
+        <div data-genre="${escapeHtml(value.name)}"${peerAttr()} class="artistz" onclick="getGenreSongsList(this)">
           ${escapeHtml(value.name)} <span style="color:#888;font-size:13px;">(${value.track_count})</span>
         </div>
       </li>`;
@@ -2978,6 +3142,7 @@ async function getAllGenres() {
 }
 
 function getGenreSongsList(el) {
+  adoptPeer(el);
   const genre = el.getAttribute('data-genre');
   programState.push({
     state: 'genre',
@@ -2994,7 +3159,7 @@ async function getGenreSongs(genre) {
   document.getElementById('filelist').innerHTML = getLoadingSvg();
 
   try {
-    const response = await MSTREAMAPI.genreSongs({ genre: genre });
+    const response = await browseApi('genreSongs', { genre: genre });
 
     let songs = '<ul class="collection">';
     response.forEach(song => {
@@ -3023,11 +3188,7 @@ async function getAllAlbums() {
   programState = [{ state: 'allAlbums' }];
 
   try {
-    const response = await MSTREAMAPI.albums({
-      ignoreVPaths: Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
-        return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
-      })
-    });
+    const response = await browseApi('albums', { ignoreVPaths: localIgnoreVPaths() });
 
     let albums = '<div class="album-grid">';
     response.albums.forEach(value => {
@@ -3049,6 +3210,7 @@ async function getAllAlbums() {
 }
 
 function getAlbumsOnClick(el) {
+  adoptPeer(el);
   getAlbumSongs(
     el.hasAttribute('data-album') ? el.getAttribute('data-album') : null,
     el.hasAttribute('data-artist') ? el.getAttribute('data-artist') : null,
@@ -3072,13 +3234,11 @@ async function getAlbumSongs(album, artist, year) {
   document.getElementById('localSearchBar').value = '';
 
   try {
-    const response = await MSTREAMAPI.albumSongs({
+    const response = await browseApi('albumSongs', {
       album,
       artist,
       year,
-      ignoreVPaths: Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
-        return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
-      })
+      ignoreVPaths: localIgnoreVPaths()
     });
   
     //parse through the json array and make an array of corresponding divs
@@ -3124,7 +3284,7 @@ async function getRatedSongs() {
 
       files += createMusicFileHtml(value.filepath,
         value.metadata.title ? value.metadata.title : value.filepath.split('/').pop(),
-        value.metadata['album-art'] ? `src="${MSTREAMAPI.currentServer.host}album-art/${escapeHtml(value.metadata['album-art'])}?compress=s&token=${MSTREAMAPI.currentServer.token}"` : `src="assets/img/default.png"`,
+        artImgAttr(value.metadata['album-art'], 's'),
         rating,
         value.metadata.artist ? value.metadata.artist : '');
     });
@@ -3166,7 +3326,7 @@ async function redoRecentlyPlayed() {
 
       filelist += createMusicFileHtml(el.filepath,
         el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop(),
-        el.metadata['album-art'] ? `src="${MSTREAMAPI.currentServer.host}album-art/${escapeHtml(el.metadata['album-art'])}?compress=s&token=${MSTREAMAPI.currentServer.token}"` : `src="assets/img/default.png"`,
+        artImgAttr(el.metadata['album-art'], 's'),
         undefined,
         el.metadata.artist ? el.metadata.artist : '');
     });
@@ -3216,7 +3376,7 @@ async function redoMostPlayed() {
 
       filelist += createMusicFileHtml(el.filepath,
         el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop(),
-        el.metadata['album-art'] ? `src="${MSTREAMAPI.currentServer.host}album-art/${escapeHtml(el.metadata['album-art'])}?compress=s&token=${MSTREAMAPI.currentServer.token}"` : `src="assets/img/default.png"`,
+        artImgAttr(el.metadata['album-art'], 's'),
         undefined,
         el.metadata.artist ? `${el.metadata.artist} [${el.metadata['play-count']} plays]` : `[${el.metadata['play-count']} plays]`);
     });
@@ -3247,14 +3407,13 @@ function getRecentlyAdded() {
 
 async function redoRecentlyAdded() {
   currentBrowsingList = [];
-  programState = [{ state: 'recentlyAdded'}];
+  programState = [{ state: 'recentlyAdded' }];
 
   try {
-    const response = await MSTREAMAPI.getRecentlyAdded(
-      document.getElementById('recently-added-limit').value,
-      Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
-        return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
-      }));
+    const limit = document.getElementById('recently-added-limit').value;
+    const response = peerContext
+      ? await MSTREAMAPI.peer.recentlyAdded(peerContext.id, limit)
+      : await MSTREAMAPI.getRecentlyAdded(limit, localIgnoreVPaths());
 
     //parse through the json array and make an array of corresponding divs
     let filelist = '<ul class="collection">';
@@ -3266,7 +3425,7 @@ async function redoRecentlyAdded() {
 
       filelist += createMusicFileHtml(el.filepath,
         el.metadata.title ? `${el.metadata.title}`: el.filepath.split("/").pop(),
-        el.metadata['album-art'] ? `src="${MSTREAMAPI.currentServer.host}album-art/${escapeHtml(el.metadata['album-art'])}?compress=s&token=${MSTREAMAPI.currentServer.token}"` : `src="assets/img/default.png"`,
+        artImgAttr(el.metadata['album-art'], 's'),
         undefined,
         el.metadata.artist ? el.metadata.artist : '');
     });
@@ -3545,6 +3704,9 @@ async function revokeSubsonicApiKey(id) {
 
 //////////////////////////  Share playlists
 async function submitShareForm() {
+  // A share serves LOCAL paths to an anonymous visitor with no federation
+  // key of their own — there is no way to hand a peer's track through it.
+  if (refuseMixedQueue('share.cannotShareMixed')) { return; }
   try {
     document.getElementById('share_it').disabled = true;
     const shareTimeInDays = document.getElementById('share_time').value;
@@ -5009,7 +5171,7 @@ function runLocalSearch(el) {
 
 //////////////////////// Search
 const searchToggles = (() => {
-  const defaults = { albums: true, artists: true, files: false, titles: true, lyrics: true };
+  const defaults = { albums: true, artists: true, files: false, titles: true, lyrics: true, federated: false };
   try {
     const saved = JSON.parse(localStorage.getItem('mstream-search-toggles'));
     // Merge OVER defaults so a toggle added in a later release (e.g. `lyrics`)
@@ -5095,6 +5257,12 @@ function setupSearchPanel(searchTerm) {
         <span>Lyrics</span>
       </label>
     </div>
+    ${federatedSearchOffered() ? `<div class="flex">
+      <label class="grow" for="search-federated">
+        <input ${(searchToggles.federated === true ? 'checked' : '')} id="search-federated" class="filled-in" type="checkbox">
+        <span>${escapeHtml(t('search.federated'))}</span>
+      </label>
+    </div>` : ''}
     <div id="search-results"></div>`;
 
   document.getElementById('search_folders').value = '';
@@ -5103,6 +5271,14 @@ function setupSearchPanel(searchTerm) {
   if (searchTerm) {
     submitSearchForm();
   }
+}
+
+// The multi-server search is offered only while pointed at THIS server:
+// asking a peer to search its peers is not something federation does (and
+// the proxy is deliberately not chainable), so from a federated server the
+// search box searches that server alone.
+function federatedSearchOffered() {
+  return MSTREAMAPI.currentServer.federationBrowse === true && !peerContext;
 }
 
 async function submitSearchForm() {
@@ -5126,61 +5302,283 @@ async function submitSearchForm() {
     searchToggles.titles = document.getElementById("search-in-titles").checked;
     if (document.getElementById("search-in-lyrics") && document.getElementById("search-in-lyrics").checked === false) { postObject.noLyrics = true; }
     searchToggles.lyrics = document.getElementById("search-in-lyrics").checked;
+    const fedBox = document.getElementById("search-federated");
+    if (fedBox) { searchToggles.federated = fedBox.checked; }
 
     try { localStorage.setItem('mstream-search-toggles', JSON.stringify(searchToggles)); } catch (_e) {}
 
-    const res = await MSTREAMAPI.search(postObject);
+    // Searching a federated server searches THAT server; ignoreVPaths is
+    // dropped for it by peerReq, since it names libraries in our config.
+    const res = await browseApi('search', postObject);
 
     if (programState[0].state === 'searchPanel') {
       programState[0].searchTerm = postObject.search;
     }
 
-    let noResultsFlag = true;
-
     // Reset the per-search metadata lookup the search-result handlers read.
     searchResultMetadata = {};
 
-    // Populate list
-    let searchList = '<ul class="collection">';
-    Object.keys(res).forEach((key) => {
-      res[key].forEach((value, i) => {
-        noResultsFlag = false;
+    // Only label the local block when there is something to tell it apart
+    // FROM — a plain single-server search should not grow a header.
+    const fanOut = federatedSearchOffered() && searchToggles.federated === true;
+    const localHtml = renderSearchResults(res, null);
+    const localHeader = (fanOut && localHtml) ? serverResultHeader(t('search.onThisServer')) : '';
 
-        // Track-level hits (title/files/lyrics) now carry the full metadata
-        // object inline — stash it so searchFileClick/searchPlayNow can
-        // enqueue without a second /api/v1/db/metadata round-trip.
-        if (value.filepath && value.metadata) {
-          searchResultMetadata[value.filepath] = value.metadata;
-        }
+    // Three slots: this server's results, a block per peer as each answers,
+    // and an empty-state that any result — local or remote — hides.
+    document.getElementById('search-results').innerHTML =
+      `<div id="search-results-local">${localHeader}${localHtml}</div>` +
+      '<div id="search-results-peers"></div>' +
+      `<div id="search-results-empty" class="${localHtml ? 'super-hide' : ''}"><h5>${t('search.noResults')}</h5></div>`;
 
-        // perform some operation on a value;
-        searchList += `<li class="collection-item">
-          <div onclick="${searchMap[key].func}(this);" data-${searchMap[key].data}="${escapeHtml(value.filepath ? value.filepath : value.name)}" class="${searchMap[key].class} left">
-            <b>${searchMap[key].name}:</b> ${escapeHtml(value.name)}${key === 'lyrics' && value.snippet ? `<br><small class="grey-text">${escapeHtml(value.snippet)}</small>` : ''}
-          </div>
-          ${
-            key === 'files' || key === 'title' || key === 'lyrics' ? `<div class="song-button-box">
-            <span title="Play Now" onclick="searchPlayNow(this);" data-file_location="${escapeHtml(value.filepath)}" class="songDropdown">
-              <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M15.5 5H11l5 7-5 7h4.5l5-7z"/><path d="M8.5 5H4l5 7-5 7h4.5l5-7z"/></svg>
-            </span>
-            <span title="Add To Playlist" onclick="createPopper3(this);" data-file_location="${escapeHtml(value.filepath)}" class="fileAddToPlaylist">
-              <svg class="pop-f" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 292.362 292.362"><path class="pop-f" d="M286.935 69.377c-3.614-3.617-7.898-5.424-12.848-5.424H18.274c-4.952 0-9.233 1.807-12.85 5.424C1.807 72.998 0 77.279 0 82.228c0 4.948 1.807 9.229 5.424 12.847l127.907 127.907c3.621 3.617 7.902 5.428 12.85 5.428s9.233-1.811 12.847-5.428L286.935 95.074c3.613-3.617 5.427-7.898 5.427-12.847 0-4.948-1.814-9.229-5.427-12.85z"/></svg>
-            </span>
-          </div>` : ''
-          }
-        </li>`;
-      });
-    });
-
-    searchList += '</ul>'
-    
-    if (noResultsFlag === true) {
-      searchList = '<h5>No Results Found</h5>';
-    }
-
-    document.getElementById('search-results').innerHTML = searchList;
+    // The same query, asked of every paired server. Fire-and-forget: this
+    // server's results are already on screen, so a slow or dead peer costs
+    // nothing but its own block.
+    if (fanOut) { searchPeers(postObject); }
   }catch(err) {
     boilerplateFailure(err);
+  }
+}
+
+// Render one search response as a collection. `peer` null = this server;
+// otherwise every row carries the peer, so the queue handlers stream it
+// over the federation bridge instead of resolving the path locally.
+function renderSearchResults(res, peer) {
+  let rows = '';
+  Object.keys(res || {}).forEach((key) => {
+    // A peer may run a different version and answer with a category this
+    // build has no renderer for. Skip it rather than throw away the rest.
+    if (!searchMap[key]) { return; }
+    (res[key] || []).forEach((value) => {
+      // Track-level hits (title/files/lyrics) carry the full metadata object
+      // inline — stash it so searchFileClick/searchPlayNow can enqueue
+      // without a second metadata round-trip.
+      if (value.filepath && value.metadata) {
+        searchResultMetadata[searchKey(peer && peer.id, value.filepath)] = value.metadata;
+      }
+      rows += renderSearchRow(key, value, peer);
+    });
+  });
+  return rows ? `<ul class="collection">${rows}</ul>` : '';
+}
+
+function renderSearchRow(key, value, peer) {
+  const attr = peerAttr(peer || null);
+  const isTrack = key === 'files' || key === 'title' || key === 'lyrics';
+  return `<li class="collection-item">
+    <div onclick="${searchMap[key].func}(this);" data-${searchMap[key].data}="${escapeHtml(value.filepath ? value.filepath : value.name)}"${attr} class="${searchMap[key].class} left">
+      <b>${searchMap[key].name}:</b> ${escapeHtml(value.name)}${key === 'lyrics' && value.snippet ? `<br><small class="grey-text">${escapeHtml(value.snippet)}</small>` : ''}
+    </div>
+    ${isTrack ? `<div class="song-button-box">
+      <span title="Play Now" onclick="searchPlayNow(this);" data-file_location="${escapeHtml(value.filepath)}"${attr} class="songDropdown">
+        <svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M15.5 5H11l5 7-5 7h4.5l5-7z"/><path d="M8.5 5H4l5 7-5 7h4.5l5-7z"/></svg>
+      </span>
+      <span title="Add To Playlist" onclick="createPopper3(this);" data-file_location="${escapeHtml(value.filepath)}"${attr} class="fileAddToPlaylist">
+        <svg class="pop-f" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 292.362 292.362"><path class="pop-f" d="M286.935 69.377c-3.614-3.617-7.898-5.424-12.848-5.424H18.274c-4.952 0-9.233 1.807-12.85 5.424C1.807 72.998 0 77.279 0 82.228c0 4.948 1.807 9.229 5.424 12.847l127.907 127.907c3.621 3.617 7.902 5.428 12.85 5.428s9.233-1.811 12.847-5.428L286.935 95.074c3.613-3.617 5.427-7.898 5.427-12.847 0-4.948-1.814-9.229-5.427-12.85z"/></svg>
+      </span>
+    </div>` : ''}
+  </li>`;
+}
+
+// Which server a result block came from. Every block gets one whenever the
+// search spans more than one server, this one included — an unlabelled block
+// next to labelled ones would be the ambiguous case.
+function serverResultHeader(title, note) {
+  return `<div style="padding:12px 12px 2px;font-size:13px;font-weight:600;color:#8bb7f0;">
+    ${escapeHtml(title)}${note ? ` <span style="color:#999;font-weight:400;">&mdash; ${escapeHtml(note)}</span>` : ''}
+  </div>`;
+}
+
+function peerSearchHeader(peer, note) {
+  return serverResultHeader(t('peers.searchHeader', { name: peer.name }), note);
+}
+
+// Ask every paired server the query the user just ran, and append each
+// answer under its own header. Never merged into one list: where a result
+// lives decides whether it can be queued as a local file, added to a
+// playlist, rated, or used as a Sonic Path seed — so the answer is always
+// on screen next to the result.
+async function searchPeers(postObject) {
+  // Fast bail before the peer lookup: the search panel is not on screen.
+  if (!document.getElementById('search-results-peers')) { return; }
+
+  let peers = [];
+  try {
+    peers = (await MSTREAMAPI.federationPeers()).peers || [];
+    peers.forEach(rememberPeer);
+  } catch (err) {
+    console.warn('federation peers unavailable for search', err);
+    return;
+  }
+  if (peers.length === 0) { return; }
+
+  // ignoreVPaths names libraries in OUR config; a peer's namespace is its
+  // own, and it already scopes every answer to what our key was granted.
+  const body = { ...postObject };
+  delete body.ignoreVPaths;
+  const term = postObject.search;
+
+  await Promise.all(peers.map(async (peer) => {
+    let res;
+    try {
+      res = await MSTREAMAPI.peer.search(peer.id, body);
+    } catch (err) {
+      console.warn(`federation search failed on peer ${peer.id}`, err);
+      // One unreachable peer is a footnote on the results, not a failed
+      // search — say which peer is missing rather than come up silently
+      // short.
+      peerResultSlot(term)?.insertAdjacentHTML('beforeend', peerSearchHeader(peer, t('peers.unreachable')));
+      return;
+    }
+
+    // The user may have moved on — a new query, or a different panel.
+    const slot = peerResultSlot(term);
+    if (!slot) { return; }
+    const html = renderSearchResults(res, peer);
+    if (!html) { return; }
+
+    const empty = document.getElementById('search-results-empty');
+    if (empty) { empty.classList.add('super-hide'); }
+    slot.insertAdjacentHTML('beforeend', peerSearchHeader(peer) + html);
+  }));
+}
+
+// Where a late-arriving peer answer should land, or null if it should be
+// dropped. Looked up FRESH each time: submitSearchForm rebuilds the results
+// DOM on every run, so a node captured before the fetch may already be
+// detached — and re-running the same term would otherwise pass a
+// value-only guard and append into nothing.
+function peerResultSlot(term) {
+  const input = document.getElementById('search-term');
+  if (!input || input.value !== term) { return null; }
+  return document.getElementById('search-results-peers');
+}
+
+///////////////////// Federation: the server switcher
+//
+// The app points at ONE server at a time. The top-bar dropdown chooses it;
+// everything else — the nav, the panels, the queue handlers — follows from
+// `peerContext`. There is no "peers" destination to visit: browsing a
+// federated server IS the normal app, pointed somewhere else.
+//
+// A federated server is READ-ONLY (a federation key carries no write
+// permission, and the peer's allowlist stops at reads) and answers only for
+// its own library — none of our playlists, none of our per-user stats. Nav
+// entries that depend on either are marked `.local-only` in index.html and
+// hidden while a peer is selected, so the UI never offers something that
+// cannot work. The left-nav note says why.
+//
+// The dropdown appears only when the ping's federationBrowse flag says
+// there is somewhere else to go (federation on, at least one peer).
+
+// Every top-level panel, keyed by the programState name it sets.
+const PANELS_BY_STATE = {
+  fileExplorer: () => loadFileExplorer(),
+  allPlaylists: () => getAllPlaylists(),
+  allAlbums: () => getAllAlbums(),
+  allArtists: () => getAllArtists(),
+  allGenres: () => getAllGenres(),
+  recentlyAdded: () => getRecentlyAdded(),
+  recentlyPlayed: () => getRecentlyPlayed(),
+  mostPlayed: () => getMostPlayed(),
+  allRated: () => getRatedSongs(),
+  searchPanel: () => setupSearchPanel(),
+};
+
+// Which of those a federated server can actually answer: its library, and
+// nothing that lives in our own user rows. Playlists and the three stats
+// panels are ours alone; the rest map onto routes on the peer's allowlist.
+const PEER_CAPABLE_STATES = new Set([
+  'fileExplorer', 'allAlbums', 'allArtists', 'allGenres', 'recentlyAdded', 'searchPanel',
+]);
+
+// Fill the top-bar dropdown. Called once from init(), only when the ping
+// advertised federationBrowse.
+async function loadServerSwitcher() {
+  const wrap = document.getElementById('server-select-wrap');
+  const select = document.getElementById('server-select');
+  if (!wrap || !select) { return; }
+
+  let peers = [];
+  try {
+    peers = (await MSTREAMAPI.federationPeers()).peers || [];
+  } catch (err) {
+    // Federation off or the route unreachable: leave the dropdown hidden
+    // and the app exactly as it was.
+    console.warn('federation peers unavailable for the server switcher', err);
+    return;
+  }
+  if (peers.length === 0) { return; }
+
+  peers.forEach(rememberPeer);
+  let html = `<option value="">${escapeHtml(t('server.thisServer'))}</option>`;
+  peers.forEach(p => {
+    html += `<option value="${escapeHtml(p.id)}">${escapeHtml(p.name)}</option>`;
+  });
+  select.innerHTML = html;
+  wrap.classList.remove('super-hide');
+}
+
+function onServerChange(el) {
+  switchServer(el.value === '' ? null : Number(el.value));
+}
+
+// Point the app at a server. `peerId` null = this one.
+function switchServer(peerId) {
+  const next = peerId === null
+    ? null
+    : (knownPeers.get(Number(peerId)) || { id: Number(peerId), name: 'peer' });
+  if ((next ? next.id : null) === (peerContext ? peerContext.id : null)) { return; }
+
+  peerContext = next;
+  applyServerContext();
+
+  // Stay on the same panel when the new server can answer it; otherwise
+  // fall back to the file explorer, which every server has.
+  const previous = programState[0];
+  const current = previous ? previous.state : 'fileExplorer';
+  const keep = PANELS_BY_STATE[current] && (!peerContext || PEER_CAPABLE_STATES.has(current));
+  const landing = keep ? current : 'fileExplorer';
+
+  // The explorer's breadcrumb is a path in the OLD server's namespace.
+  fileExplorerArray = [];
+  highlightNavPanel(landing);
+
+  // Carry a query across: switching servers with a search on screen means
+  // "run that again over there", not "start over with an empty box".
+  if (landing === 'searchPanel' && previous && previous.searchTerm) {
+    setupSearchPanel(previous.searchTerm);
+    return;
+  }
+  PANELS_BY_STATE[landing]();
+}
+
+// Move the sidebar's selected marker onto the entry that owns a panel, so a
+// server switch that had to change panels doesn't leave the old one lit.
+function highlightNavPanel(state) {
+  const target = document.querySelector(`.side-nav-item[data-panel="${state}"]`);
+  if (!target) { return; }
+  document.querySelectorAll('.side-nav-item').forEach(el => el.classList.remove('select'));
+  target.classList.add('select');
+}
+
+// Sync the chrome to `peerContext`: the dropdown's selection, the nav
+// entries a federated server cannot serve, and the read-only note. Derives
+// everything from the current context, so it is safe to call at any time.
+function applyServerContext() {
+  const select = document.getElementById('server-select');
+  const want = peerContext ? String(peerContext.id) : '';
+  if (select && select.value !== want) { select.value = want; }
+
+  // One class does the whole job (see spa.css): it hides every .local-only
+  // nav entry and reveals the read-only note. A body class rather than a
+  // per-item toggle, so it composes with the flag gates that already hide
+  // some entries (Sonic Path) instead of un-hiding them on the way back.
+  document.body.classList.toggle('on-federated-server', !!peerContext);
+
+  const note = document.getElementById('nav-readonly-note');
+  if (note && peerContext) {
+    note.textContent = t('server.readOnlyNote', { name: peerContext.name });
   }
 }
 

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -2557,6 +2557,11 @@ async function addToPlaylistUI(playlist) {
 
 /////////////// Download Playlist
 function downloadPlaylist() {
+  // A peer track's rawFilePath resolves only on the peer; posting it to our
+  // local /download/zip would silently drop it, yielding a dishonest archive.
+  // Refuse a mixed queue outright, as savePlaylist/submitShareForm do.
+  if (refuseMixedQueue('download.cannotDownloadMixed')) { return; }
+
   // Loop through array and add each file to the playlist
   const downloadFiles = [];
   for (let i = 0; i < MSTREAMPLAYER.playlist.length; i++) {
@@ -3128,7 +3133,7 @@ async function getAllGenres() {
     response.genres.forEach(value => {
       html += `<li class="collection-item">
         <div data-genre="${escapeHtml(value.name)}"${peerAttr()} class="artistz" onclick="getGenreSongsList(this)">
-          ${escapeHtml(value.name)} <span style="color:#888;font-size:13px;">(${value.track_count})</span>
+          ${escapeHtml(value.name)} <span style="color:#888;font-size:13px;">(${escapeHtml(value.track_count)})</span>
         </div>
       </li>`;
       currentBrowsingList.push({ type: 'genre', name: value.name });
@@ -3518,6 +3523,10 @@ function toggleTranscoding(el, manual){
 
   // Convert playlist
   for (let i = 0; i < MSTREAMPLAYER.playlist.length; i++) {
+    // Peer tracks stream through the federation proxy: there is no transcode
+    // route on the peer, and their URL carries a 'media/' segment this replace
+    // would corrupt into an un-allowlisted path. Leave them untouched.
+    if (MSTREAMPLAYER.playlist[i].federation) { continue; }
     MSTREAMPLAYER.playlist[i].url = MSTREAMPLAYER.playlist[i].url.replace(a, b);
   }
 
@@ -5321,7 +5330,9 @@ async function submitSearchForm() {
     // Only label the local block when there is something to tell it apart
     // FROM — a plain single-server search should not grow a header.
     const fanOut = federatedSearchOffered() && searchToggles.federated === true;
-    const localHtml = renderSearchResults(res, null);
+    // browseApi('search') fetched from peerContext (null = this server), so the
+    // rows must carry that same peer or clicks queue peer paths as local.
+    const localHtml = renderSearchResults(res, peerContext);
     const localHeader = (fanOut && localHtml) ? serverResultHeader(t('search.onThisServer')) : '';
 
     // Three slots: this server's results, a block per peer as each answers,

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -121,6 +121,13 @@ let curFileTracker;
 // leave the context alone — playing a peer track from a mixed search list
 // must not move the browser onto that peer.
 let peerContext = null;
+
+// Bumped whenever the app changes which server it points at (switchServer /
+// adoptPeer). A panel loader captures it before its await and bails if it
+// changed while the request was in flight, so a slow response from the old
+// server can't overwrite the new panel or get its rows stamped with the new
+// server's peer id.
+let browseGeneration = 0;
 // id -> { id, name }. addFederationSongWizard wants a display name for the
 // queue row and a row only carries the id. Filled by loadServerSwitcher()
 // and by anything else that learns a peer's name (e.g. search attribution).
@@ -157,7 +164,7 @@ function adoptPeer(el) {
   const next = peerOf(el);
   const changed = (next ? next.id : null) !== (peerContext ? peerContext.id : null);
   peerContext = next;
-  if (changed) { applyServerContext(); }
+  if (changed) { browseGeneration++; applyServerContext(); }
   return peerContext;
 }
 
@@ -393,10 +400,12 @@ async function senddir(root) {
   const directoryString = root === true ? '~' : getFileExplorerPath();
   document.getElementById('filelist').innerHTML = getLoadingSvg();
 
+  const gen = browseGeneration;
   try {
     const response = peerContext
       ? await MSTREAMAPI.peer.dirparser(peerContext.id, directoryString)
       : await MSTREAMAPI.dirparser(directoryString);
+    if (gen !== browseGeneration) { return; }
     document.getElementById('directoryName').innerHTML = escapeHtml(response.path);
 
     if(root === true && response.path.length > 1) {
@@ -3082,8 +3091,10 @@ async function getAllArtists() {
   document.getElementById('filelist').innerHTML = getLoadingSvg();
   programState = [{ state: 'allArtists' }];
 
+  const gen = browseGeneration;
   try {
     const response = await browseApi('artists', { ignoreVPaths: localIgnoreVPaths() });
+    if (gen !== browseGeneration) { return; }
 
     // parse through the json array and make an array of corresponding divs
     let artists = '<ul class="collection">';
@@ -3118,8 +3129,10 @@ async function getArtistsAlbums(artist) {
   document.getElementById('directoryName').innerHTML = t('label.artist') + ' ' + escapeHtml(artist);
   document.getElementById('filelist').innerHTML = getLoadingSvg();
 
+  const gen = browseGeneration;
   try {
     const response = await browseApi('artistAlbums', { artist: artist, ignoreVPaths: localIgnoreVPaths() });
+    if (gen !== browseGeneration) { return; }
 
     let albums = '<div class="album-grid">';
     response.albums.forEach(value => {
@@ -3142,8 +3155,10 @@ async function getAllGenres() {
   document.getElementById('filelist').innerHTML = getLoadingSvg();
   programState = [{ state: 'allGenres' }];
 
+  const gen = browseGeneration;
   try {
     const response = await browseApi('genres', {});
+    if (gen !== browseGeneration) { return; }
 
     let html = '<ul class="collection">';
     response.genres.forEach(value => {
@@ -3179,8 +3194,10 @@ async function getGenreSongs(genre) {
   document.getElementById('directoryName').innerHTML = t('label.genre') + ' ' + escapeHtml(genre);
   document.getElementById('filelist').innerHTML = getLoadingSvg();
 
+  const gen = browseGeneration;
   try {
     const response = await browseApi('genreSongs', { genre: genre });
+    if (gen !== browseGeneration) { return; }
 
     let songs = '<ul class="collection">';
     response.forEach(song => {
@@ -3208,8 +3225,10 @@ async function getAllAlbums() {
   
   programState = [{ state: 'allAlbums' }];
 
+  const gen = browseGeneration;
   try {
     const response = await browseApi('albums', { ignoreVPaths: localIgnoreVPaths() });
+    if (gen !== browseGeneration) { return; }
 
     let albums = '<div class="album-grid">';
     response.albums.forEach(value => {
@@ -3254,6 +3273,7 @@ async function getAlbumSongs(album, artist, year) {
 
   document.getElementById('localSearchBar').value = '';
 
+  const gen = browseGeneration;
   try {
     const response = await browseApi('albumSongs', {
       album,
@@ -3261,7 +3281,8 @@ async function getAlbumSongs(album, artist, year) {
       year,
       ignoreVPaths: localIgnoreVPaths()
     });
-  
+    if (gen !== browseGeneration) { return; }
+
     //parse through the json array and make an array of corresponding divs
     let files = '<ul class="collection">';
     response.forEach(song => {
@@ -3283,12 +3304,14 @@ async function getRatedSongs() {
   document.getElementById('filelist').innerHTML = getLoadingSvg();
   programState = [{ state: 'allRated' }];
 
+  const gen = browseGeneration;
   try {
     const response = await MSTREAMAPI.getRated({
       ignoreVPaths: Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
         return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
       })
     });
+    if (gen !== browseGeneration) { return; }
     //parse through the json array and make an array of corresponding divs
     let files = '';
     response.forEach(value => {
@@ -3330,12 +3353,14 @@ async function redoRecentlyPlayed() {
   currentBrowsingList = [];
   programState = [{ state: 'recentlyPlayed'}];
 
+  const gen = browseGeneration;
   try {
     const response = await MSTREAMAPI.getRecentlyPlayed(
       document.getElementById('recently-played-limit').value,
       Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
         return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
       }));
+    if (gen !== browseGeneration) { return; }
 
     //parse through the json array and make an array of corresponding divs
     let filelist = '<ul class="collection">';
@@ -3380,12 +3405,14 @@ async function redoMostPlayed() {
   currentBrowsingList = [];
   programState = [{ state: 'mostPlayed'}];
 
+  const gen = browseGeneration;
   try {
     const response = await MSTREAMAPI.getMostPlayed(
       document.getElementById('most-played-limit').value,
       Object.keys(MSTREAMPLAYER.ignoreVPaths).filter((vpath) => {
         return MSTREAMPLAYER.ignoreVPaths[vpath] === true;
       }));
+    if (gen !== browseGeneration) { return; }
 
     //parse through the json array and make an array of corresponding divs
     let filelist = '<ul class="collection">';
@@ -3430,11 +3457,13 @@ async function redoRecentlyAdded() {
   currentBrowsingList = [];
   programState = [{ state: 'recentlyAdded' }];
 
+  const gen = browseGeneration;
   try {
     const limit = document.getElementById('recently-added-limit').value;
     const response = peerContext
       ? await MSTREAMAPI.peer.recentlyAdded(peerContext.id, limit)
       : await MSTREAMAPI.getRecentlyAdded(limit, localIgnoreVPaths());
+    if (gen !== browseGeneration) { return; }
 
     //parse through the json array and make an array of corresponding divs
     let filelist = '<ul class="collection">';
@@ -5559,6 +5588,8 @@ function switchServer(peerId) {
   if ((next ? next.id : null) === (peerContext ? peerContext.id : null)) { return; }
 
   peerContext = next;
+  // Any browse load still in flight belongs to the old server; supersede it.
+  browseGeneration++;
   applyServerContext();
 
   // Stay on the same panel when the new server can answer it; otherwise

--- a/webapp/alpha/spa.css
+++ b/webapp/alpha/spa.css
@@ -2367,3 +2367,16 @@ body.on-federated-server .side-nav-note {
   cursor: pointer;
   text-decoration: underline;
 }
+
+/* Header above each server's block in a multi-server search result. */
+.search-server-header {
+  padding: 12px 12px 2px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #8bb7f0;
+}
+
+.search-server-note {
+  color: #999;
+  font-weight: 400;
+}

--- a/webapp/alpha/spa.css
+++ b/webapp/alpha/spa.css
@@ -2302,3 +2302,55 @@ select {
 .hotkey-btn { cursor: pointer; font-size: 12px; text-transform: uppercase; opacity: 0.7; min-width: 52px; text-align: right; }
 .hotkey-btn:hover { opacity: 1; }
 .hotkeys-disabled { opacity: 0.4; pointer-events: none; }
+
+/* ── Federation: the server picker + read-only chrome ──────────────────────
+   The app points at one server at a time. `body.on-federated-server` is the
+   single switch: it hides every nav entry a federated server cannot serve
+   and reveals the read-only note. Driven by a BODY class rather than by
+   toggling .super-hide on each item, so it composes with the flag gates
+   that already hide some entries (Sonic Path) instead of fighting them. */
+.nav-server-wrap {
+  display: flex;
+  align-items: center;
+  margin-right: 12px;
+}
+
+.nav-server-select {
+  padding: 6px 10px;
+  background-color: #262a33;
+  color: #F5F7FA;
+  border: 1px solid #444c56;
+  border-radius: 4px;
+  font-family: 'Jura', sans-serif;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  min-width: 150px;
+  display: block;
+  height: auto;
+}
+
+.nav-server-select:hover,
+.nav-server-select:focus {
+  border-color: #657ee4;
+  outline: none;
+}
+
+body.on-federated-server .side-nav-item.local-only {
+  display: none !important;
+}
+
+.side-nav-note {
+  display: none;
+  padding: 8px 14px;
+  margin: 4px 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #d6b45f;
+  background-color: rgba(214, 180, 95, 0.1);
+  border-left: 3px solid #d6b45f;
+}
+
+body.on-federated-server .side-nav-note {
+  display: block;
+}

--- a/webapp/alpha/spa.css
+++ b/webapp/alpha/spa.css
@@ -2354,3 +2354,16 @@ body.on-federated-server .side-nav-item.local-only {
 body.on-federated-server .side-nav-note {
   display: block;
 }
+
+/* The escape hatch back to this server, shown inside the read-only note. It
+   lives in the side-nav so it survives top-bar-hidden (which hides the top-bar
+   switcher), the one state where a federated search hit could otherwise strand
+   you on a peer with no visible way home. */
+.nav-note-back {
+  display: inline-block;
+  margin-top: 6px;
+  color: #657ee4;
+  font-weight: bold;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -1,6 +1,26 @@
 const VUEPLAYERCORE = (() => {
   const mstreamModule = {};
 
+  // A playlist lives on THIS server and stores paths in ITS namespace, so a
+  // federated track can never be saved into one. Every live-playlist re-save
+  // rebuilds from the whole queue, which may hold peer tracks — drop them,
+  // and say so once so the user knows the saved playlist is not exactly what
+  // is on screen. Once per page load on purpose: this fires on every drag,
+  // remove and insert, and a toast per drag would be noise.
+  let warnedMixedQueue = false;
+  function localQueueFilepaths() {
+    const all = MSTREAMPLAYER.playlist;
+    const local = all.filter(song => !song.federation);
+    if (local.length !== all.length && !warnedMixedQueue) {
+      warnedMixedQueue = true;
+      iziToast.info({ title: t('playlist.federatedSkipped'), position: 'topCenter', timeout: 4000 });
+    }
+    return local.map(song => song.filepath);
+  }
+  // m.js starts and clears live playlists too, and every one of those paths
+  // re-saves the whole queue — they all have to go through the same filter.
+  mstreamModule.localQueueFilepaths = localQueueFilepaths;
+
   mstreamModule.livePlaylist = {
     name: false
   };
@@ -239,11 +259,7 @@ const VUEPLAYERCORE = (() => {
         document.getElementById("pop").style.visibility = "hidden";
         MSTREAMPLAYER.resetPositionCache();
         if (mstreamModule.livePlaylist.name) {
-          const songs = [];
-          for (let i = 0; i < MSTREAMPLAYER.playlist.length; i++) {
-            songs.push(MSTREAMPLAYER.playlist[i].filepath);
-          }
-          MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name,songs, true);
+          MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
         }
       },
       clearRating: async function () {
@@ -464,11 +480,7 @@ const VUEPLAYERCORE = (() => {
       removeSong: function (event) {
         MSTREAMPLAYER.removeSongAtPosition(this.index, false);
         if (mstreamModule.livePlaylist.name) {
-          const songs = [];
-          for (let i = 0; i < MSTREAMPLAYER.playlist.length; i++) {
-            songs.push(MSTREAMPLAYER.playlist[i].filepath);
-          }
-          MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name,songs, true);
+          MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
         }
       },
       downloadSong: function (event) {
@@ -604,6 +616,12 @@ const VUEPLAYERCORE = (() => {
     props: ['index', 'playlist'],
     methods: {
       addToPlaylist: async function(event) { 
+        // Same rule as the browse rows' add-to-playlist button (m.js): a
+        // peer path would save as a row that resolves to nothing here.
+        if (cps && cps.federation) {
+          iziToast.info({ title: t('peers.noPlaylist'), position: 'topCenter', timeout: 2500 });
+          return;
+        }
         try {
           await MSTREAMAPI.addToPlaylist(this.playlist.name, cps.filepath);
           iziToast.success({
@@ -948,11 +966,7 @@ const VUEPLAYERCORE = (() => {
     if (position) {
       MSTREAMPLAYER.insertSongAt(newSong, position, true);
       if (mstreamModule.livePlaylist.name) {
-        const songs = [];
-        for (let i = 0; i < MSTREAMPLAYER.playlist.length; i++) {
-          songs.push(MSTREAMPLAYER.playlist[i].filepath);
-        }
-        MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name,songs, true);
+        MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
       }
     } else {
       MSTREAMPLAYER.addSong(newSong, autoPlayOff);
@@ -1008,29 +1022,34 @@ const VUEPLAYERCORE = (() => {
   // resolves paths against the LOCAL library, and this path lives in the
   // peer's vpath namespace. The `federation` marker on the song object is
   // what the degrade guards key on (waveform skip, Discover clear).
-  mstreamModule.addFederationSongWizard = (peer, remotePath, metadata, autoPlayOff) => {
+  // `position` (added for the peer-browse panels) inserts and plays, the
+  // way addSongWizard's own position argument does — without it a peer row
+  // could only ever be appended, so "Play Now" did nothing on peer tracks.
+  mstreamModule.addFederationSongWizard = (peer, remotePath, metadata, autoPlayOff, position) => {
     let escaped = remotePath.replace(/\%/g, '%25').replace(/\#/g, '%23').replace(/\?/g, '%3F');
     if (escaped.charAt(0) === '/') { escaped = escaped.substr(1); }
     let url = `${MSTREAMAPI.currentServer.host}api/v1/federation/peers/${peer.id}/stream/${escaped}?`;
     if (MSTREAMAPI.currentServer.token) { url += 'token=' + MSTREAMAPI.currentServer.token; }
-    MSTREAMPLAYER.addSong({
+    const newSong = {
       url: url,
       rawFilePath: remotePath,
       filepath: remotePath,
       metadata: metadata || {},
       authToken: MSTREAMAPI.currentServer.token,
       federation: { peerId: peer.id, peerName: peer.name || 'peer' },
-    }, autoPlayOff);
+    };
+
+    if (position) {
+      MSTREAMPLAYER.insertSongAt(newSong, position, true);
+      return;
+    }
+    MSTREAMPLAYER.addSong(newSong, autoPlayOff);
   };
 
   mstreamModule.clearQueue = async() => {
     MSTREAMPLAYER.clearPlaylist();
     if (mstreamModule.livePlaylist.name) {
-      const songs = [];
-      for (let i = 0; i < MSTREAMPLAYER.playlist.length; i++) {
-        songs.push(MSTREAMPLAYER.playlist[i].filepath);
-      }
-      MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name,songs, true);
+      MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
     }
   }
 

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -21,6 +21,16 @@ const VUEPLAYERCORE = (() => {
   // re-saves the whole queue — they all have to go through the same filter.
   mstreamModule.localQueueFilepaths = localQueueFilepaths;
 
+  // Re-persist the live playlist to the local-only tracks now queued. THE one
+  // place every queue mutation re-saves, so a new mutation site can't forget
+  // the federation filter the way the live-playlist START once did.
+  function saveLiveQueue() {
+    if (mstreamModule.livePlaylist.name) {
+      MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
+    }
+  }
+  mstreamModule.saveLiveQueue = saveLiveQueue;
+
   mstreamModule.livePlaylist = {
     name: false
   };
@@ -268,9 +278,7 @@ const VUEPLAYERCORE = (() => {
       checkMove: function (event) {
         document.getElementById("pop").style.visibility = "hidden";
         MSTREAMPLAYER.resetPositionCache();
-        if (mstreamModule.livePlaylist.name) {
-          MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
-        }
+        saveLiveQueue();
       },
       clearRating: async function () {
         try {
@@ -489,9 +497,7 @@ const VUEPLAYERCORE = (() => {
       },
       removeSong: function (event) {
         MSTREAMPLAYER.removeSongAtPosition(this.index, false);
-        if (mstreamModule.livePlaylist.name) {
-          MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
-        }
+        saveLiveQueue();
       },
       downloadSong: function (event) {
         const link = document.createElement("a");
@@ -985,9 +991,7 @@ const VUEPLAYERCORE = (() => {
 
     if (position) {
       MSTREAMPLAYER.insertSongAt(newSong, position, true);
-      if (mstreamModule.livePlaylist.name) {
-        MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
-      }
+      saveLiveQueue();
     } else {
       MSTREAMPLAYER.addSong(newSong, autoPlayOff);
       if (mstreamModule.livePlaylist.name && livePlaylist !== false) {
@@ -1071,9 +1075,7 @@ const VUEPLAYERCORE = (() => {
 
   mstreamModule.clearQueue = async() => {
     MSTREAMPLAYER.clearPlaylist();
-    if (mstreamModule.livePlaylist.name) {
-      MSTREAMAPI.savePlaylist(mstreamModule.livePlaylist.name, localQueueFilepaths(), true);
-    }
+    saveLiveQueue();
   }
 
   // ── WAVEFORM ────────────────────────────────────────────────────────────────

--- a/webapp/alpha/vp.js
+++ b/webapp/alpha/vp.js
@@ -200,7 +200,9 @@ const VUEPLAYERCORE = (() => {
         if (!this.meta['album-art']) {
           return 'assets/img/default.png';
         }
-        return MSTREAMAPI.currentServer.host + `album-art/${this.meta['album-art']}?compress=l&token=${MSTREAMPLAYER.getCurrentSong().authToken}`;
+        // The playing track may live on a peer while the app is pointed home;
+        // songArtUrl branches on the song's own federation, not peerContext.
+        return songArtUrl(this.meta['album-art'], MSTREAMPLAYER.getCurrentSong(), 'l');
       },
       // "A minor (8A)" / "8A" / "A minor" depending on what's
       // resolvable from the raw key tag. AUTODJ.toCamelot accepts
@@ -247,12 +249,20 @@ const VUEPLAYERCORE = (() => {
       goToArtist: function() {
         const el = document.createElement('DIV');
         el.setAttribute('data-artist', this.meta.artist);
+        // The now-playing track may be a peer's; carry its peer so getArtistz's
+        // adoptPeer looks the artist up on the right server, not the local one.
+        const song = MSTREAMPLAYER.getCurrentSong();
+        if (song && song.federation) { el.setAttribute('data-peer', song.federation.peerId); }
         getArtistz(el);
       },
       goToAlbum: function() {
         const el = document.createElement('DIV');
         el.setAttribute('data-album', this.meta.album);
         el.setAttribute('data-year', this.meta.year);
+        // Carry the playing track's peer (if any) so the album resolves on that
+        // server; without it adoptPeer flips the app home and finds nothing.
+        const song = MSTREAMPLAYER.getCurrentSong();
+        if (song && song.federation) { el.setAttribute('data-peer', song.federation.peerId); }
         getAlbumsOnClick(el);
       },
       checkMove: function (event) {
@@ -590,7 +600,7 @@ const VUEPLAYERCORE = (() => {
       },
       albumArt: function () {
         if (this.song.metadata && this.song.metadata['album-art']) {
-          return MSTREAMAPI.currentServer.host + 'album-art/' + this.song.metadata['album-art'] + '?compress=s&token=' + (this.song.authToken || MSTREAMAPI.currentServer.token);
+          return songArtUrl(this.song.metadata['album-art'], this.song, 's');
         }
         return null;
       },
@@ -738,7 +748,9 @@ const VUEPLAYERCORE = (() => {
         if (!this.meta['album-art']) {
           return 'assets/img/default.png';
         }
-        return MSTREAMAPI.currentServer.host + `album-art/${this.meta['album-art']}?compress=l&token=${MSTREAMPLAYER.getCurrentSong().authToken}`;
+        // The playing track may live on a peer while the app is pointed home;
+        // songArtUrl branches on the song's own federation, not peerContext.
+        return songArtUrl(this.meta['album-art'], MSTREAMPLAYER.getCurrentSong(), 'l');
       },
       // Mirrors the queue-item Vue's djKeyLabel — both Vue instances
       // bind `meta` to MSTREAMPLAYER.playerStats.metadata. See the
@@ -797,12 +809,20 @@ const VUEPLAYERCORE = (() => {
       goToArtist: function() {
         const el = document.createElement('DIV');
         el.setAttribute('data-artist', this.meta.artist);
+        // The now-playing track may be a peer's; carry its peer so getArtistz's
+        // adoptPeer looks the artist up on the right server, not the local one.
+        const song = MSTREAMPLAYER.getCurrentSong();
+        if (song && song.federation) { el.setAttribute('data-peer', song.federation.peerId); }
         getArtistz(el);
       },
       goToAlbum: function() {
         const el = document.createElement('DIV');
         el.setAttribute('data-album', this.meta.album);
         el.setAttribute('data-year', this.meta.year);
+        // Carry the playing track's peer (if any) so the album resolves on that
+        // server; without it adoptPeer flips the app home and finds nothing.
+        const song = MSTREAMPLAYER.getCurrentSong();
+        if (song && song.federation) { el.setAttribute('data-peer', song.federation.peerId); }
         getAlbumsOnClick(el);
       },
       goForward: function(seconds) {
@@ -1039,7 +1059,10 @@ const VUEPLAYERCORE = (() => {
       federation: { peerId: peer.id, peerName: peer.name || 'peer' },
     };
 
-    if (position) {
+    // position 0 is a real insert index (Play Now onto an empty queue); a bare
+    // `if (position)` treated it as "no position" and fell through to a paused
+    // append.
+    if (position !== undefined) {
       MSTREAMPLAYER.insertSongAt(newSong, position, true);
       return;
     }

--- a/webapp/assets/js/mstream.player.js
+++ b/webapp/assets/js/mstream.player.js
@@ -52,8 +52,15 @@ const MSTREAMPLAYER = (() => {
   // This is a placeholder function that the API layer can take hold of to implement the scrobble call
   let scrobbleTimer;
   mstreamModule.scrobble = () => {
+    const song = mstreamModule.getCurrentSong();
+    if (!song) { return; }
+    // A federated track's path lives in the PEER's vpath namespace, so
+    // scrobble-by-filepath cannot resolve it against this library — it
+    // just errors 30 seconds into every peer track. Same degrade rule as
+    // the waveform, rating and Sonic Path guards.
+    if (song.federation) { return; }
     MSTREAMAPI.scrobbleByFilePath(
-      mstreamModule.getCurrentSong().rawFilePath, 
+      song.rawFilePath,
       (response, error) => {});
   }
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -478,6 +478,13 @@
     </div>
     <div id="scan-progress-wrap" class="spc-wrap"></div>
     <div class="nav-bar-right">
+      <!-- Server picker — hidden until the ping advertises federationBrowse
+           (federation on, at least one paired peer). Choosing a federated
+           server points the WHOLE app at it; see the switcher in m.js. -->
+      <div id="server-select-wrap" class="nav-server-wrap super-hide">
+        <select id="server-select" class="nav-server-select" onchange="onServerChange(this);"
+          aria-label="Server" title="Server"></select>
+      </div>
       <!-- Quick Connect (Iroh) — hidden until quick-connect.js confirms the
            server publishes a pairing code (GET /api/v1/iroh/code). Demo-only. -->
       <button type="button" id="quick-connect-btn" onclick="QUICKCONNECT.open()"
@@ -562,75 +569,76 @@
     <div style="display: none;" class="side-nav-header">
       <button class="my-waves" data-i18n="nav.nowPlaying">Now Playing</button>
     </div>
+    <div id="nav-readonly-note" class="side-nav-note"></div>
     <div class="side-nav-header">
       <span data-i18n="nav.music">Music</span>
     </div>
-    <div class="side-nav-item select my-waves" onclick="changeView(loadFileExplorer, this)">
+    <div class="side-nav-item select my-waves" onclick="changeView(loadFileExplorer, this)" data-panel="fileExplorer">
       <?xml version="1.0" encoding="utf-8"?><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="6 6 40 40" style="enable-background:new 0 0 48 48"><path d="M16.516 20.688C16.266 21.25 12 31.906 12 31.906V17c0-.55.45-1 1-1h1.334l.35-1.052C14.857 14.427 15.45 14 16 14h5c.55 0 1.143.427 1.316.948l.35 1.052H32c.55 0 1 .45 1 1v3H17.5c-.275 0-.734.125-.984.688zM41 21H19c-.55 0-1.167.418-1.371.929l-5.258 13.143c-.204.51.079.928.629.928h22c.55 0 1.167-.418 1.371-.929l5.258-13.143c.204-.51-.079-.928-.629-.928z"/></svg>
       <span data-i18n="nav.fileExplorer">File Explorer</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(getAllPlaylists, this)">
+    <div class="local-only side-nav-item my-waves" onclick="changeView(getAllPlaylists, this)" data-panel="allPlaylists">
       <?xml version="1.0" encoding="utf-8"?><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="8 5 38 38" style="enable-background:new 0 0 48 48"><path d="M37.192 23.032c-.847.339-.179-.339-.179-.339s1.422-2.092.406-3.786c-.793-1.321-3.338-1.075-4.42-1.669v14.154c0 .037-.016.07-.022.106-.154 1.504-1.607 3.034-3.696 3.712-2.559.829-5.102.063-5.678-1.711-.574-1.774 1.034-3.887 3.595-4.717.66-.189 2.207-.439 2.801-.193V12.607a.609.609 0 0 1 .608-.607h1.785c.336 0 .608.273.608.607v.549c1.542 1.004 6.18 1.455 6.851 4.139.805 3.225-1.813 5.398-2.659 5.737zM12.5 20H28v-3H12.5c-.275 0-.5.225-.5.5v2c0 .275.225.5.5.5zm0 6H28v-3H12.5c-.275 0-.5.225-.5.5v2c0 .275.225.5.5.5zm10.125 3H12.5c-.275 0-.5.225-.5.5v2c0 .275.225.5.5.5h8.551c.176-1.075.728-2.113 1.574-3z"/></svg>
       <span data-i18n="nav.playlists">Playlists</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(getAllAlbums, this)">
+    <div class="side-nav-item my-waves" onclick="changeView(getAllAlbums, this)" data-panel="allAlbums">
       <?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="10 12 28 28" style="enable-background:new 0 0 48 48"><path d="M11 17v14a1 1 0 0 1-1-1V18a1 1 0 0 1 1-1zM37 17v14a1 1 0 0 0 1-1V18a1 1 0 0 0-1-1zM13 16h1v16h-1a1 1 0 0 1-1-1V17a1 1 0 0 1 1-1zM35 16h-1v16h1a1 1 0 0 0 1-1V17a1 1 0 0 0-1-1zM32 15H16c-.55 0-1 .45-1 1v16c0 .55.45 1 1 1h16c.55 0 1-.45 1-1V16c0-.55-.45-1-1-1zm-3 12c0 1.469-2.022 1.71-2.301 1.71-.846 0-1.55-.395-1.752-1.02-.276-.852.461-1.796 1.607-2.218.649-.238 1.446-.155 1.446-.146v-4.407l-6 1.369V28c0 1.813-2.102 2.057-2.417 2.057-.816 0-1.44-.374-1.629-.955-.271-.835.441-1.77 1.603-2.174.646-.225 1.443-.137 1.443-.131v-6.604c0-.245.072-.469.291-.529l7.491-1.854-.039-.01c.218 0 .257.169.257.393V27z"/></svg>
       <span data-i18n="nav.albums">Albums</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(getAllArtists, this)">
+    <div class="side-nav-item my-waves" onclick="changeView(getAllArtists, this)" data-panel="allArtists">
       <?xml version="1.0" encoding="utf-8"?><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000"><path d="M611.4 34.4c92-46.8 206.7-25.7 276.3 58.1 66.9 80.5 71.4 193.8 18.5 278.4-13.2.1-27-2.3-41.2-6.6-56-17.1-114.7-64.1-161.8-122.1-47.3-58.2-82-126-90.1-184.6-1-8-1.6-15.7-1.7-23.2zM146.8 678c-.7 41.6 19.8 64.6 59 71l431.9-297.1C578.1 413.3 527.3 349.7 501 282.7L146.8 678zm14.1 94.3c-35.9 38.4-46.8 78.1-38.3 107.7 3.5 12.1 10.4 22.5 20.2 30.3 10.4 8.3 24.5 13.8 41.6 15.3 58.5 5.1 146-33.6 248.3-150.9 102.8-118 195.4-173.9 271.3-187.5 45.9-8.2 86.3-1.4 119.7 16.6 33.4 18 59.4 47 76.7 83.1 27 56.4 32.6 130.2 12 205.2l-60-17.2c16.3-59.8 12.6-117.4-7.9-160-11.5-24-28.4-43.1-49.8-54.6-21.5-11.5-48.3-15.8-79.9-10.1-63.2 11.4-143 61-235.4 167-117.5 134.9-224.8 178.7-300 172.2-29.6-2.6-54.8-12.8-74.6-28.4-20.4-16.1-34.7-37.9-41.9-63.2-14.3-50.1.3-113.2 53.1-169.7l44.9 44.2zM871.5 412c-69.8-23.6-139.6-79.4-194.4-146.8-49.9-61.3-88.3-133.3-103.8-200.3-41 51.7-57.7 118-48.6 181.6 25.1 77.2 90.1 157.1 162.7 191.2 60.8 18 127.9 10 184.1-25.7z"/></svg>
       <span data-i18n="nav.artists">Artists</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(getAllGenres, this)">
+    <div class="side-nav-item my-waves" onclick="changeView(getAllGenres, this)" data-panel="allGenres">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#FFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
       <span data-i18n="nav.genres">Genres</span>
     </div>
-    <div onclick="changeView(getRecentlyAdded, this)" class="side-nav-item my-waves">
+    <div onclick="changeView(getRecentlyAdded, this)" data-panel="recentlyAdded" class="side-nav-item my-waves">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="22" height="22"><path d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z"/></svg>
       <span data-i18n="nav.recentAdded">Recent Added</span>
     </div>
-    <div onclick="changeView(getRecentlyPlayed, this)" class="side-nav-item my-waves">
+    <div onclick="changeView(getRecentlyPlayed, this)" data-panel="recentlyPlayed" class="local-only side-nav-item my-waves">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="22" height="22"><path d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z"/></svg>
       <span data-i18n="nav.recentlyPlayed">Recently Played</span>
     </div>
-    <div onclick="changeView(getMostPlayed, this)" class="side-nav-item my-waves">
+    <div onclick="changeView(getMostPlayed, this)" data-panel="mostPlayed" class="local-only side-nav-item my-waves">
       <svg xmlns="http://www.w3.org/2000/svg" height="22px" viewBox="0 0 24 24" width="22px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"/></svg>
       <span data-i18n="nav.mostPlayed">Most Played</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(getRatedSongs, this)">
+    <div class="local-only side-nav-item my-waves" onclick="changeView(getRatedSongs, this)" data-panel="allRated">
       <?xml version="1.0" encoding="iso-8859-1"?><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="-3 0 62 62" style="enable-background:new 0 0 53.867 53.867"><path style="fill:#efce4a" d="M26.934 1.318l8.322 16.864 18.611 2.705L40.4 34.013l3.179 18.536-16.645-8.751-16.646 8.751 3.179-18.536L0 20.887l18.611-2.705z"/></svg>
       <span data-i18n="nav.rated">Rated</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(setupSearchPanel, this)">
+    <div class="side-nav-item my-waves" onclick="changeView(setupSearchPanel, this)" data-panel="searchPanel">
       <svg viewBox="-150 -50 1224 1174" height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M960 832L710.875 582.875C746.438 524.812 768 457.156 768 384 768 171.969 596 0 384 0 171.969 0 0 171.969 0 384c0 212 171.969 384 384 384 73.156 0 140.812-21.562 198.875-57L832 960c17.5 17.5 46.5 17.375 64 0l64-64c17.5-17.5 17.5-46.5 0-64zM384 640c-141.375 0-256-114.625-256-256s114.625-256 256-256 256 114.625 256 256-114.625 256-256 256z"></path></svg>
       <span data-i18n="nav.search">Search</span>
     </div>
     <div class="side-nav-header">
       <span data-i18n="nav.system">System</span>
     </div>
-    <div onclick="changeView(getMobilePanel, this);" class="side-nav-item my-waves">
+    <div onclick="changeView(getMobilePanel, this);" class="local-only side-nav-item my-waves">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15.5 1h-8C6.12 1 5 2.12 5 3.5v17C5 21.88 6.12 23 7.5 23h8c1.38 0 2.5-1.12 2.5-2.5v-17C18 2.12 16.88 1 15.5 1zm-4 21c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm4.5-4H7V4h9v14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
       <span data-i18n="nav.apps">Apps</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(setupAddTorrentPanel, this);">
+    <div class="local-only side-nav-item my-waves" onclick="changeView(setupAddTorrentPanel, this);">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#DDD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/><line x1="12" y1="3" x2="12" y2="15"/><path d="M3 17v2a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2"/></svg>
       <span>Add Torrent</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(autoDjPanel, this);">
+    <div class="local-only side-nav-item my-waves" onclick="changeView(autoDjPanel, this);">
       <svg xmlns="http://www.w3.org/2000/svg" fill="#DDD" width="24" height="24" viewBox="0 0 55.334 55.334"><g><circle cx="27.667" cy="27.667" r="3.618"/><path d="M27.667 0C12.387 0 0 12.387 0 27.667s12.387 27.667 27.667 27.667 27.667-12.387 27.667-27.667S42.947 0 27.667 0zM17.118 6.881a23.213 23.213 0 0111.214-2.509c.367.01.619.922.564 2.025l-.282 5.677c-.055 1.103-.289 1.986-.523 1.979a13.577 13.577 0 00-6.027 1.196c-1.007.455-2.212.184-2.774-.767l-2.896-4.897c-.562-.951-.261-2.203.724-2.704zm-1.132 10.414l-4.278-3.742c-.832-.727-.918-1.994-.119-2.756l.057-.053c.802-.76 2.059-.605 2.737.266l3.494 4.484c.679.871.837 1.889.391 2.314-.447.427-1.45.214-2.282-.513zm1.891 10.372c0-5.407 4.383-9.79 9.79-9.79s9.79 4.383 9.79 9.79-4.383 9.79-9.79 9.79-9.79-4.383-9.79-9.79zM38.17 48.476a23.21 23.21 0 01-11.244 2.484c-.409-.013-.692-.929-.632-2.032l.31-5.676c.061-1.103.322-1.981.586-1.972a13.596 13.596 0 005.656-1.01c1.022-.42 2.275-.144 2.877.782l3.101 4.77c.602.925.332 2.155-.654 2.654zm5.449-3.82c-.766.72-2.005.551-2.703-.305l-3.59-4.407c-.698-.856-.876-1.848-.435-2.255.442-.407 1.443-.179 2.274.549l4.28 3.744c.832.727.941 1.954.174 2.674z"/></g></svg>
       <span data-i18n="nav.autoDJ">Auto DJ</span>
     </div>
     <!-- Sonic Path — hidden until the ping advertises discoveryPath
          (server has POST /api/v1/discovery/local/path). -->
-    <div id="nav-sonic-path" class="side-nav-item my-waves super-hide" onclick="changeView(sonicPathPanel, this);">
+    <div id="nav-sonic-path" class="local-only side-nav-item my-waves super-hide" onclick="changeView(sonicPathPanel, this);">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="#DDD" d="M19 15.18V7c0-2.21-1.79-4-4-4s-4 1.79-4 4v10c0 1.1-.9 2-2 2s-2-.9-2-2V8.82C8.16 8.4 9 7.3 9 6c0-1.66-1.34-3-3-3S3 4.34 3 6c0 1.3.84 2.4 2 2.82V17c0 2.21 1.79 4 4 4s4-1.79 4-4V7c0-1.1.9-2 2-2s2 .9 2 2v8.18c-1.16.42-2 1.52-2 2.82 0 1.66 1.34 3 3 3s3-1.34 3-3c0-1.3-.84-2.4-2-2.82z"/></svg>
       <span data-i18n="nav.sonicPath">Sonic Path</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(setupTranscodePanel, this);">
+    <div class="local-only side-nav-item my-waves" onclick="changeView(setupTranscodePanel, this);">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 48 48"><path id="ffmpeg-logo" fill="none" stroke="#DDD" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M8.5 8.5h9l-9 9v11l20-20h11l-31 31h11l20-20v11l-9 9h9"/></svg>
       <span data-i18n="nav.transcode">Transcode</span>
     </div>
-    <div class="side-nav-item my-waves" onclick="changeView(setupJukeboxPanel, this);">
+    <div class="local-only side-nav-item my-waves" onclick="changeView(setupJukeboxPanel, this);">
       <svg v-bind:class="{ 'aux-button-active-2': jukebox.live }" height="24" width="24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 65 65" enable-background="new 0 0 65 65" xml:space="preserve"><g><path d="M36.1,14.4c-1.4-1.4-3.9-1.4-5.3,0L1.1,44.1c-1.4,1.4-1.4,3.8,0,5.3l14.5,14.5c0.7,0.7,1.6,1.1,2.6,1.1   c1,0,1.9-0.4,2.6-1.1l29.7-29.7c1.5-1.4,1.5-3.8,0-5.3L36.1,14.4z M49.5,33.2L19.8,62.9c-0.8,0.8-2.3,0.8-3.2,0L2.1,48.3   c-0.9-0.9-0.9-2.3,0-3.2l29.7-29.7c0.4-0.4,1-0.7,1.6-0.7c0.6,0,1.2,0.2,1.6,0.7L49.5,30C50.4,30.9,50.4,32.3,49.5,33.2z"></path><rect x="32.4" y="19.5" transform="matrix(0.707 0.7072 -0.7072 0.707 24.3992 -18.4628)" width="4.2" height="1.5"></rect><rect x="42.7" y="29.8" transform="matrix(-0.7072 -0.707 0.707 -0.7072 54.8735 83.7577)" width="4.2" height="1.5"></rect><rect x="14.7" y="37.1" transform="matrix(0.7071 0.7071 -0.7071 0.7071 31.7025 -0.8228)" width="4.2" height="1.5"></rect><rect x="25" y="47.4" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 12.2855 101.3977)" width="4.2" height="1.5"></rect><rect x="19.9" y="42.3" transform="matrix(0.7071 0.7071 -0.7071 0.7071 36.8513 -2.9555)" width="4.2" height="1.5"></rect><rect x="11.7" y="40.2" transform="matrix(0.7071 0.7071 -0.7071 0.7071 32.9629 2.2207)" width="4.2" height="1.5"></rect><rect x="22" y="50.5" transform="matrix(-0.707 -0.7072 0.7072 -0.707 4.9277 104.4377)" width="4.2" height="1.5"></rect><rect x="16.8" y="45.3" transform="matrix(0.7071 0.7071 -0.7071 0.7071 38.1117 8.766792e-002)" width="4.2" height="1.5"></rect><rect x="8.6" y="43.2" transform="matrix(0.7071 0.7071 -0.7071 0.7071 34.2235 5.2638)" width="4.2" height="1.5"></rect><rect x="18.9" y="53.5" transform="matrix(-0.7072 -0.707 0.707 -0.7072 -2.4064 107.4868)" width="4.2" height="1.5"></rect><rect x="13.8" y="48.3" transform="matrix(-0.707 -0.7072 0.7072 -0.707 -7.5673 95.0498)" width="4.2" height="1.5"></rect><rect x="10.8" y="51.4" transform="matrix(-0.7072 -0.707 0.707 -0.7072 -14.9034 98.0997)" width="4.2" height="1.5"></rect><path d="M35.4,38.8c-1.1,1.1-2.4,1.7-3.9,1.9l0.2,1.5c1.8-0.2,3.5-1,4.8-2.3c1.3-1.3,2.1-3,2.3-4.8l-1.5-0.2   C37.1,36.4,36.5,37.8,35.4,38.8z"></path><path d="M31.7,26.2l-0.2,1.5c1.5,0.2,2.8,0.8,3.9,1.9c1.1,1.1,1.7,2.4,1.9,3.9l1.5-0.2c-0.2-1.8-1-3.5-2.3-4.8   C35.2,27.2,33.5,26.4,31.7,26.2z"></path><path d="M26.2,29.6c1.1-1.1,2.4-1.7,3.9-1.9l-0.2-1.5c-1.8,0.2-3.5,1-4.8,2.3c-1.3,1.3-2.1,3-2.3,4.8l1.5,0.2   C24.5,32,25.1,30.6,26.2,29.6z"></path><path d="M24.3,34.9l-1.5,0.2c0.2,1.8,1,3.5,2.3,4.8c1.3,1.3,3,2.1,4.8,2.3l0.2-1.5c-1.5-0.2-2.9-0.8-3.9-1.9   C25.1,37.8,24.5,36.4,24.3,34.9z"></path><path d="M43.4,0v1.5c11.1,0,20.1,9,20.1,20.1H65C65,9.7,55.3,0,43.4,0z"></path><path d="M43.4,7.4v1.5c7,0,12.7,5.7,12.7,12.7h1.5C57.6,13.8,51.2,7.4,43.4,7.4z"></path><path d="M48.6,21.6h1.5c0-3.7-3-6.7-6.7-6.7v1.5C46.3,16.4,48.6,18.7,48.6,21.6z"></path></g></svg>
       <span data-i18n="nav.jukebox">Jukebox</span>
     </div>

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -658,6 +658,7 @@
   "search.noResults": "No Results Found",
   "server.thisServer": "This server",
   "server.readOnlyNote": "Browsing {{name}} — read-only. You can play and queue its music, but not change anything.",
+  "server.backToThisServer": "← Back to this server",
   "search.federated": "Search federated servers",
   "search.onThisServer": "On this server",
   "playlist.federatedSkipped": "Federated tracks aren't saved to the live playlist",

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -666,5 +666,6 @@
     "one": "1 track in the queue lives on another server",
     "other": "{{count}} tracks in the queue live on another server"
   },
-  "share.cannotShareMixed": "Can't share a queue with federated tracks"
+  "share.cannotShareMixed": "Can't share a queue with federated tracks",
+  "download.cannotDownloadMixed": "Can't download a queue with federated tracks"
 }

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -650,5 +650,21 @@
   "admin.modal.creating": "Creating ...",
   "admin.modal.inviteExpiry": "Invite tokens expire in 30 min",
   "admin.modal.copyClipboard": "Copy To Clipboard",
-  "admin.modal.nothingToFederate": "Nothing to Federate"
+  "admin.modal.nothingToFederate": "Nothing to Federate",
+  "peers.unreachable": "unreachable",
+  "peers.searchHeader": "On {{name}}",
+  "peers.noPlaylist": "Peer tracks can't be added to playlists",
+  "peers.noDownload": "Peer folders can't be downloaded",
+  "search.noResults": "No Results Found",
+  "server.thisServer": "This server",
+  "server.readOnlyNote": "Browsing {{name}} — read-only. You can play and queue its music, but not change anything.",
+  "search.federated": "Search federated servers",
+  "search.onThisServer": "On this server",
+  "playlist.federatedSkipped": "Federated tracks aren't saved to the live playlist",
+  "playlist.cannotSaveMixed": "Can't save a playlist with federated tracks",
+  "playlist.federatedCount": {
+    "one": "1 track in the queue lives on another server",
+    "other": "{{count}} tracks in the queue live on another server"
+  },
+  "share.cannotShareMixed": "Can't share a queue with federated tracks"
 }


### PR DESCRIPTION
Federation's surface was lopsided. **Inbound**, a paired peer can call 19 allowlisted read routes of ours plus `/media` and `/album-art`. **Outbound**, the webapp had exactly two consumer routes — the Discover aggregator and the stream proxy — and both need a path someone already handed you. Nothing let a user open a peer and look around.

## Server

New `src/api/federation-browse.js`:

| Route | Purpose |
|---|---|
| `GET /api/v1/federation/peers` | Read-only projection — never `api_key`/`endpoint_ticket`; any logged-in user, not admin-only |
| `ALL /api/v1/federation/peers/:id/api/*path` | One allowlisted read, executed on the peer |
| `GET /api/v1/federation/peers/:id/art/*path` | That peer's album art |

Four decisions worth reviewing closely:

- The proxy screens routes against the **shared** inbound allowlist (`isFederationRouteAllowed`, extracted from `federation-auth.js`), so the two directions can't drift — and screens *before* the peer lookup, so an off-allowlist path never reaches the database.
- **Query params are an allowlist, not a filter.** The API proxy forwards none; art forwards only `compress`. The webapp appends this server's `?token=` to every `<img>` and audio URL and that token is our JWT — forwarding it would hand a peer a working credential for this server.
- **`content-length` is deliberately not forwarded** on browse/art: the peer gzips its JSON and `fetch` transparently decompresses, so the peer's length would describe bytes we're no longer sending. (The stream proxy still forwards it — audio isn't compressed and seeking needs it.)
- Both routes stay **off** the federation-key allowlist, so a peer can never chain proxies through us.

New ping flag `federationBrowse` (federation on + at least one peer) reveals the UI — no probing.

## Webapp

The app points at **one server at a time**, chosen from a new top-bar dropdown. Switching re-enters the current panel when the new server can serve it, otherwise falls back to the file explorer; the nav highlight follows and a live search term carries across.

A federated server is read-only and holds none of our playlists or listening stats, so ten nav entries hide behind a single `body.on-federated-server` class — a body class rather than per-item toggling, so it composes with the flag gates that already hide some entries (Sonic Path) instead of un-hiding them on the way back. A left-nav note says why. What survives: File Explorer, Albums, Artists, Genres, Recent Added, Search, Layout, Admin, Log Out.

**Multi-server search** is opt-in through a "Search federated servers" checkbox, offered only from this server — a peer can't fan out on our behalf. When it fans out, every block is labelled with the server it came from, this one included.

**Mixed queues.** Playlists and shares resolve paths against *this* library, and a peer path is indistinguishable by shape (`testlib/Icarus/…` exists on both servers), so the rules key on the `federation` marker rather than the path. Save and share refuse outright; live playlists skip federated tracks and warn once. Sharing federated tracks isn't possible at all — a share serves local paths to an anonymous visitor with no federation key of their own.

Two bugs fixed in passing: `addFederationSongWizard` had no `position` argument, so **Play Now did nothing** on a peer track; and scrobbling was **erroring `scrobble-by-filepath` 500** thirty seconds into every peer track.

## Testing

`test/integration/federation-browse.test.mjs` — 14 tests: the guards (no credential in the peer projection, off-allowlist refusals, unknown-peer 404s, no proxy chaining, federation disabled) plus a **two-spawned-server iroh** section that pairs B with A over a pasted ticket and reads A's file-explorer/db/health through the bridge, with A's grants still enforced.

Full suite green (2500 tests, 0 fail, 21 POSIX-only skips). Live click-through on a two-server rig: dropdown, nav gating, read-only note, panel preservation and fallback, peer playback (206 through the stream proxy), opt-in search with both headers, mixed-queue refusals, and the live-playlist skip verified by reading the saved playlist back over the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
