### PR TITLE
feat(discovery): fetch byte ceiling + model-compat gate for auto-fetch

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1076,7 +1076,10 @@ export function setup(mstream) {
 
     let addressing;
     let label;
+    let maxBytes;
     if (req.body.ticket) {
+      // Ticket = a manual hand-off from someone the admin already trusts;
+      // no announced size exists to bound it, so it stays uncapped.
       addressing = { ticket: req.body.ticket };
       label = `ticket ${req.body.ticket.slice(0, 32)}…`;
     } else {
@@ -1086,11 +1089,15 @@ export function setup(mstream) {
       }
       addressing = { hash: entry.payload.hash, provider: entry.from };
       label = `peer ${req.body.endpointId.slice(0, 12)}…`;
+      // The catalog flow rides the peer's own announcement, so hold the
+      // transfer to the size it claimed — the same ceiling fetchPeer uses
+      // (sidecars ≥ v1.0.4 abort past it; older ones ignore the param).
+      maxBytes = entry.payload.size > 0 ? entry.payload.size : undefined;
     }
 
     const outDir = path.join(config.program.storage.dbDirectory, 'discovery-peers');
     try {
-      res.json(await discoveryP2p.fetch(addressing, outDir));
+      res.json(await discoveryP2p.fetch(addressing, outDir, maxBytes));
     } catch (err) {
       winston.warn(`discovery P2P fetch failed for admin '${req.user?.username}' (${label}): ${err.message}`);
       throw new WebError(`fetch failed: ${err.message}`, 500);

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1097,7 +1097,11 @@ export function setup(mstream) {
 
     const outDir = path.join(config.program.storage.dbDirectory, 'discovery-peers');
     try {
-      res.json(await discoveryP2p.fetch(addressing, outDir, maxBytes));
+      // No hold: this raw route delivers a file, not a shelf membership —
+      // nothing here would ever forget() the blob, so rooting it in the
+      // sidecar store would pin those bytes forever. Un-held store copies
+      // age out with GC; the exported file is the deliverable.
+      res.json(await discoveryP2p.fetch(addressing, outDir, { maxBytes }));
     } catch (err) {
       winston.warn(`discovery P2P fetch failed for admin '${req.user?.username}' (${label}): ${err.message}`);
       throw new WebError(`fetch failed: ${err.message}`, 500);

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -488,6 +488,12 @@ const discoveryP2pOptions = Joi.object({
   // below still applies — the shelf stops at whichever limit hits first.
   autoFetch: Joi.boolean().default(true),
   autoFetchCount: Joi.number().integer().min(0).max(50).default(6),
+  // Auto-fetch only pulls snapshots whose announced embedding model matches
+  // ours — the similarity search reads nothing else, so an incompatible
+  // snapshot is dead weight that still costs disk and a download. Flip on
+  // to opt back in (migration readiness, or seeding the swarm with blobs
+  // you can't search); the manual admin fetch always works regardless.
+  autoFetchIncompatibleModels: Joi.boolean().default(false),
   maxPeerDbStorageMb: Joi.number().integer().min(10).max(100000).default(500),
   // Sidecar memory watchdog: when the p2p-sidecar's resident set exceeds
   // this many MB, the mesh-health watch kills it and lets crash recovery

--- a/src/state/discovery-p2p-stack.js
+++ b/src/state/discovery-p2p-stack.js
@@ -167,6 +167,13 @@ export async function startDiscoveryP2pStack() {
     seeds.resolveBootstrap().then((full) => p2p.join(full)).catch((err) => {
       winston.warn(`[discovery-seeds] community list refresh failed: ${err.message}`);
     });
+    // Re-root the shelf in the (fresh) sidecar store BEFORE the first
+    // holds beacon can go out — advertised holds must be servable from the
+    // first broadcast, and a new sidecar process starts with whatever its
+    // store kept (pre-v1.0.4: nothing fetched survived GC). Internally
+    // per-entry fault-tolerant, never fatal to the start.
+    const peerDbs = await import('./discovery-peer-dbs.js');
+    await peerDbs.reseedShelf();
     try {
       // Builds the export first when the collected dataset is ahead of
       // (or has never had) a snapshot — a server whose embeddings
@@ -182,7 +189,6 @@ export async function startDiscoveryP2pStack() {
     // so the /api/v1/discovery/p2p/similar surface has data to search the
     // moment users ask. Event-driven + periodic; all failures are per-peer
     // logged, never fatal.
-    const peerDbs = await import('./discovery-peer-dbs.js');
     peerDbs.startAutoFetch();
     // Retention pruning: forget catalog peers not heard from in
     // discoveryP2p.peerRetentionDays. The shelf is the pin-set — a peer

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -403,16 +403,24 @@ export async function publish(filePath) {
 // Fetch a blob into outDir. Returns { hash, size, path }. Addressing is
 // either { ticket } (full self-contained address) or { hash, provider }
 // (the catalog flow — provider resolves via the sidecar's address book /
-// discovery). maxBytes (optional) is the transfer's byte ceiling: sidecars
-// ≥ v1.0.4 abort the download the moment it's crossed, so a peer that
-// announced a small snapshot can't stream an arbitrarily large blob into
-// the store (disk-fill DoS). Older sidecars ignore the extra key (the
-// request struct tolerates unknown fields), so the caller must keep its
-// own post-download size check as the fallback bound.
-export async function fetch(addressing, outDir, maxBytes) {
+// discovery). Options, both understood by sidecars ≥ v1.0.4 and IGNORED by
+// older ones (the request struct tolerates unknown keys):
+//
+//   maxBytes  transfer byte ceiling — the sidecar aborts the download the
+//             moment it's crossed, so a peer that announced a small
+//             snapshot can't stream an arbitrarily large blob into the
+//             store (disk-fill DoS). Callers must keep their own
+//             post-download size check as the pre-1.0.4 fallback bound.
+//   hold      root the fetched blob in the sidecar store (persistent tag)
+//             so this server keeps SEEDING it — required for anything the
+//             holds beacon will advertise, because an unrooted blob is
+//             GC-swept within ~15min. forget() releases it. Leave off for
+//             one-off pulls where only the exported file matters.
+export async function fetch(addressing, outDir, { maxBytes, hold } = {}) {
   await start();
   const params = { ...addressing, outDir };
   if (Number.isFinite(maxBytes) && maxBytes > 0) { params.maxBytes = Math.floor(maxBytes); }
+  if (hold === true) { params.hold = true; }
   return rpc('fetch', params, FETCH_TIMEOUT_MS);
 }
 

--- a/src/state/discovery-p2p.js
+++ b/src/state/discovery-p2p.js
@@ -403,10 +403,17 @@ export async function publish(filePath) {
 // Fetch a blob into outDir. Returns { hash, size, path }. Addressing is
 // either { ticket } (full self-contained address) or { hash, provider }
 // (the catalog flow — provider resolves via the sidecar's address book /
-// discovery).
-export async function fetch(addressing, outDir) {
+// discovery). maxBytes (optional) is the transfer's byte ceiling: sidecars
+// ≥ v1.0.4 abort the download the moment it's crossed, so a peer that
+// announced a small snapshot can't stream an arbitrarily large blob into
+// the store (disk-fill DoS). Older sidecars ignore the extra key (the
+// request struct tolerates unknown fields), so the caller must keep its
+// own post-download size check as the fallback bound.
+export async function fetch(addressing, outDir, maxBytes) {
   await start();
-  return rpc('fetch', { ...addressing, outDir }, FETCH_TIMEOUT_MS);
+  const params = { ...addressing, outDir };
+  if (Number.isFinite(maxBytes) && maxBytes > 0) { params.maxBytes = Math.floor(maxBytes); }
+  return rpc('fetch', params, FETCH_TIMEOUT_MS);
 }
 
 export async function status() {

--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -7,12 +7,14 @@
 //
 // Auto-fetch turns the catalog into a working library shelf without admin
 // babysitting: on boot (and as announcements arrive) reconcile() downloads
-// as many of the most useful peers as fit — model-compatible first, then
-// online-now, then biggest — and re-fetches a peer whose announced
-// snapshotSeq moved past our copy. The monotonic seq (not wall clocks) is
-// what makes "is our copy stale?" a safe comparison. Guardrails: peer-count
-// target, total-storage cap, a free-disk floor, and the blockedPeers config
-// list.
+// as many of the most useful peers as fit — model-compatible only (see
+// modelCompatible; incompatible snapshots are unsearchable dead weight
+// unless the config opts back in), then online-now first, then biggest —
+// and re-fetches a peer whose announced snapshotSeq moved past our copy.
+// The monotonic seq (not wall clocks) is what makes "is our copy stale?" a
+// safe comparison. Guardrails: peer-count target, total-storage cap, a
+// free-disk floor, the blockedPeers config list, and a per-fetch byte
+// ceiling that treats the announced size as a claim, not a fact.
 //
 // Rotation (rotatePeerDbs, hourly) keeps the shelf's MEMBERSHIP fresh once
 // it's full: swap the least-useful long-held snapshot (rotationDays age,
@@ -33,7 +35,7 @@ import * as config from './config.js';
 import * as discoveryDb from '../db/discovery-db.js';
 import * as discoveryP2p from './discovery-p2p.js';
 import * as discoveryCatalog from './discovery-catalog.js';
-import { candidateOrder, planRotation } from './discovery-peer-rotation.js';
+import { candidateOrder, modelCompatible, planRotation } from './discovery-peer-rotation.js';
 
 const REGISTRY_FILE = 'peer-dbs.json';
 const SNAPSHOT_FORMAT_VERSION = 1; // must match discovery-export.js
@@ -252,12 +254,52 @@ export async function fetchPeer(endpointId, { pinned = false } = {}) {
   const providerSet = new Set([endpointId, ...discoveryCatalog.holdersOf(entry.payload.hash)]);
   providerSet.delete(discoveryP2p.getEndpointId());
   const providers = [...providerSet].filter((p) => !blocked.has(p));
+  // Byte ceiling for the transfer itself. Everything above trusted the
+  // ANNOUNCED size, which the announcer controls — the blob behind the hash
+  // can be arbitrarily larger, and the sidecar's blob store lives on the
+  // same volume as everything else, so an uncapped transfer is a disk-fill
+  // handed to any catalog peer (this box already died of a full disk once).
+  // An honest announcement is byte-exact (it's the stat of the published
+  // file), so the announced size IS the cap; a legacy size-less
+  // announcement falls back to the storage headroom this fetch was
+  // admitted under. Sidecars ≥ v1.0.4 abort the transfer at the ceiling;
+  // v1.0.3 ignores the extra param, which is why the on-disk re-check
+  // below stays load-bearing.
+  const maxFetchBytes = announcedSize > 0
+    ? announcedSize
+    : storageCapBytes() - (totalBytes() - (existing ? existing.sizeBytes : 0));
   const fetched = await discoveryP2p.fetch(
     providers.length > 1
       ? { hash: entry.payload.hash, providers }
       : { hash: entry.payload.hash, provider: endpointId },
     peerDbDir(),
+    maxFetchBytes,
   );
+
+  // The bytes on disk are the only size that counts. Re-run the admission
+  // checks against them: an over-announced blob (actual > claimed) is a
+  // lying peer, and an actual total past the storage cap must not be kept
+  // no matter what the claim was. Same-blob refreshes are exempt from the
+  // delete (fetched.path IS the held file when the hash didn't change —
+  // removing it would orphan the live registry entry).
+  let actualBytes;
+  try {
+    actualBytes = fs.statSync(fetched.path).size;
+  } catch (_statErr) {
+    actualBytes = Number(fetched.size) || 0;
+  }
+  const overAnnounced = announcedSize > 0 && actualBytes > announcedSize;
+  const projectedActual = totalBytes() - (existing ? existing.sizeBytes : 0) + actualBytes;
+  if (overAnnounced || projectedActual > storageCapBytes()) {
+    if (!(existing && existing.hash === fetched.hash)) {
+      try { fs.rmSync(fetched.path, { force: true }); } catch (_rmErr) { /* best effort */ }
+      discoveryP2p.forget(fetched.hash)
+        .catch((err) => winston.debug(`[discovery-peer-dbs] forget oversized blob: ${err.message}`));
+    }
+    throw new Error(overAnnounced
+      ? `peer announced ${announcedSize} bytes but sent ${actualBytes} — rejecting the snapshot`
+      : `snapshot is ${actualBytes} bytes on disk — over the peer-DB storage cap; rejecting`);
+  }
 
   let inspected;
   try {
@@ -287,7 +329,7 @@ export async function fetchPeer(endpointId, { pinned = false } = {}) {
     modelId: inspected.modelId,
     modelVersion: inspected.modelVersion,
     rowCount: inspected.rowCount,
-    sizeBytes: fetched.size,
+    sizeBytes: actualBytes,
     name: entry.payload.name || '',
     fetchedAt: new Date().toISOString(),
     // The MEMBERSHIP clock (rotation's aging signal) — carried over on a
@@ -495,14 +537,21 @@ export async function reconcile() {
     if (room > 0) {
       const localModel = discoveryDb.openDiscoveryDbIfExists()
         ? discoveryDb.getMeta('embedding_model_id') : null;
+      const allowIncompat = config.program.discoveryP2p.autoFetchIncompatibleModels;
       const capBytes = storageCapBytes();
       let projectedBytes = totalBytes();
       let picked = 0;
       let skippedForSpace = 0;
+      let skippedForModel = 0;
       for (const c of discoveryCatalog.list()
         .filter((x) => !registry.has(x.from) && !isBlocked(x.from))
         .sort(candidateOrder(localModel))) {
         if (picked >= room) { break; }
+        // Auto-fetch only, not a fetch failure: an incompatible snapshot is
+        // unsearchable here, so skipping it burns no backoff and the manual
+        // admin fetch stays available. (Stale-refreshes above are exempt —
+        // what's already ON the shelf keeps refreshing until removed.)
+        if (!modelCompatible(c.payload, localModel, allowIncompat)) { skippedForModel += 1; continue; }
         const announced = c.payload.size || 0;
         if (projectedBytes + announced > capBytes) { skippedForSpace += 1; continue; }
         projectedBytes += announced;
@@ -512,6 +561,10 @@ export async function reconcile() {
       if (skippedForSpace > 0) {
         winston.debug(`[discovery-peer-dbs] skipped ${skippedForSpace} catalog peer(s) whose announced `
           + `size does not fit under the ${config.program.discoveryP2p.maxPeerDbStorageMb}MB cap`);
+      }
+      if (skippedForModel > 0) {
+        winston.debug(`[discovery-peer-dbs] skipped ${skippedForModel} catalog peer(s) announcing a `
+          + `different embedding model (autoFetchIncompatibleModels is off)`);
       }
     }
 
@@ -603,6 +656,7 @@ export async function rotatePeerDbs() {
       autoFetch: cfg.autoFetch,
       autoFetchCount: cfg.autoFetchCount,
       capBytes: storageCapBytes(),
+      allowIncompatibleModels: cfg.autoFetchIncompatibleModels,
       isBlocked,
       inBackoff: inFetchBackoff,
       seederCountOf: (hash) => discoveryCatalog.seederCount(hash),

--- a/src/state/discovery-peer-dbs.js
+++ b/src/state/discovery-peer-dbs.js
@@ -268,12 +268,16 @@ export async function fetchPeer(endpointId, { pinned = false } = {}) {
   const maxFetchBytes = announcedSize > 0
     ? announcedSize
     : storageCapBytes() - (totalBytes() - (existing ? existing.sizeBytes : 0));
+  // hold: shelf snapshots are what the holds beacon advertises, so the
+  // sidecar must keep the blob GC-rooted for as long as we claim to seed
+  // it. Every removal path (replace-on-update, removePeerDb, the reject
+  // below) releases it via forget().
   const fetched = await discoveryP2p.fetch(
     providers.length > 1
       ? { hash: entry.payload.hash, providers }
       : { hash: entry.payload.hash, provider: endpointId },
     peerDbDir(),
-    maxFetchBytes,
+    { maxBytes: maxFetchBytes, hold: true },
   );
 
   // The bytes on disk are the only size that counts. Re-run the admission
@@ -305,8 +309,16 @@ export async function fetchPeer(endpointId, { pinned = false } = {}) {
   try {
     inspected = inspectSnapshot(fetched.path);
   } catch (err) {
-    // Failed validation = not a snapshot we can use; don't leave it around.
-    try { fs.rmSync(fetched.path, { force: true }); } catch (_rmErr) { /* best effort */ }
+    // Failed validation = not a snapshot we can use; don't leave it around
+    // — neither the exported file nor the held blob in the sidecar store
+    // (the fetch above rooted it with hold:true; without the forget it
+    // would stay pinned forever). Same-blob refreshes keep both: the file
+    // IS the held copy.
+    if (!(existing && existing.hash === fetched.hash)) {
+      try { fs.rmSync(fetched.path, { force: true }); } catch (_rmErr) { /* best effort */ }
+      discoveryP2p.forget(fetched.hash)
+        .catch((fErr) => winston.debug(`[discovery-peer-dbs] forget invalid blob: ${fErr.message}`));
+    }
     throw new Error(`peer sent an invalid snapshot: ${err.message}`, { cause: err });
   }
 
@@ -392,6 +404,68 @@ export function pushHolds() {
   }
   discoveryP2p.setHolds([...hashes])
     .catch((err) => winston.debug(`[discovery-peer-dbs] holds push failed: ${err.message}`));
+}
+
+// Re-root every shelf snapshot in the sidecar's blob store, then beacon the
+// hold-set. Two truths this restores at every stack start:
+//
+//  - A fresh sidecar process serves only what its store still holds, and
+//    before sidecar v1.0.4 fetched blobs had NO GC root at all — an
+//    upgraded server's held snapshots are typically gone from the store
+//    while the holds beacon advertises them, so peers' swarm fetches from
+//    us dial in and fail. publish() re-imports the exported file
+//    (content-addressed: same bytes, same hash, now tagged — on every
+//    sidecar version) at the price of one file hash per entry per start.
+//  - A server with a shelf but no own snapshot never reached the
+//    announce-path pushHolds, so its beacon stayed silent all session.
+//
+// Deliberately reads peer-dbs.json ITSELF instead of going through
+// ensureLoaded()/pushHolds(): this runs at stack start, and tripping the
+// lazy registry latch this early would freeze a pre-boot view of the shelf
+// before anything else (the similarity suite hand-seeds it post-boot) had
+// written it. The file is byte-for-byte what the lazy load reads later, and
+// save() rewrites it on every mutation, so disk is never behind memory.
+//
+// Never throws: a per-entry failure is logged and skipped — a snapshot we
+// can't re-import is one we quietly stop advertising, which is exactly the
+// honest outcome. A file that no longer hashes to its registry entry
+// (on-disk drift) is likewise not advertised, and the accidental re-import
+// is released again.
+export async function reseedShelf() {
+  let entries = [];
+  try {
+    entries = JSON.parse(fs.readFileSync(registryPath(), 'utf8'));
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      winston.warn(`discovery peer-db registry unreadable for reseed (${err.message})`);
+    }
+  }
+  const held = [];
+  for (const e of Array.isArray(entries) ? entries : []) {
+    if (!e || !e.hash || !e.path || !fs.existsSync(e.path)) { continue; }
+    try {
+      const pub = await discoveryP2p.publish(e.path);
+      if (pub.hash === e.hash) {
+        held.push(e.hash);
+      } else {
+        winston.warn(`[discovery-peer-dbs] held snapshot ${String(e.endpointId).slice(0, 12)}… drifted `
+          + `on disk (file is ${String(pub.hash).slice(0, 12)}…, registry says ${e.hash.slice(0, 12)}…) `
+          + `— not advertising it`);
+        discoveryP2p.forget(pub.hash)
+          .catch((fErr) => winston.debug(`[discovery-peer-dbs] forget drifted reseed: ${fErr.message}`));
+      }
+    } catch (err) {
+      winston.warn(`[discovery-peer-dbs] reseed of held snapshot ${String(e.endpointId).slice(0, 12)}… `
+        + `failed (it stays on the shelf but won't be served): ${err.message}`);
+    }
+  }
+  if (held.length > 0) {
+    winston.info(`[discovery-peer-dbs] re-seeded ${held.length} held snapshot(s) into the sidecar store`);
+    const own = discoveryP2p.getOwnSnapshotHash();
+    discoveryP2p.setHolds([...new Set(own ? [own, ...held] : held)])
+      .catch((err) => winston.debug(`[discovery-peer-dbs] holds push after reseed failed: ${err.message}`));
+  }
+  return held.length;
 }
 
 function openPeerDb(entry) {

--- a/src/state/discovery-peer-rotation.js
+++ b/src/state/discovery-peer-rotation.js
@@ -29,6 +29,20 @@
 // re-broadcast every ~15s; 90s tolerates a few missed rounds.
 export const ONLINE_WINDOW_MS = 90 * 1000;
 
+// Is a candidate's announced embedding space one we can actually search?
+// The similarity route only ever reads rows WHERE model_id = ours, so a
+// snapshot from another model (or from a server that never embedded — empty
+// modelId) is pure dead weight on the shelf. AUTO paths (reconcile top-up,
+// rotation) therefore skip incompatible candidates by default; the config
+// escape hatch (discoveryP2p.autoFetchIncompatibleModels) and the manual
+// admin fetch both exist for the deliberate cases — migration readiness,
+// or seeding the swarm with snapshots we can't search ourselves. No local
+// model established yet = no compatibility signal; everyone passes.
+export function modelCompatible(payload, localModel, allowIncompatible = false) {
+  if (allowIncompatible || !localModel) { return true; }
+  return (payload.modelId || '') === localModel;
+}
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 // Missing/garbage timestamps parse to 0 = "the beginning of time". For
@@ -42,10 +56,10 @@ function ts(value) {
 }
 
 // Sort candidates by usefulness: peers whose announced embedding model
-// matches ours first (an incompatible snapshot is dead weight for the
-// similar search until a migration lands — still fetchable, just last in
-// line), then peers we can hear right now, then by library size. No local
-// model established yet = no compatibility signal; everyone ties.
+// matches ours first, then peers we can hear right now, then by library
+// size. The model term only bites when incompatible candidates are in the
+// pool at all — i.e. when autoFetchIncompatibleModels opted back in, or no
+// local model exists yet (no compatibility signal; everyone ties).
 export function candidateOrder(localModel, now = Date.now()) {
   return (a, b) => {
     if (localModel) {
@@ -110,6 +124,9 @@ function evictionOrder(catalogByFrom, seederCountOf, now) {
 //   autoFetch/autoFetchCount   rotation is an auto-fetch behavior: a paused
 //                  shelf (feature off, or count 0) must not keep swapping
 //   capBytes       the storage cap; a candidate must fit AFTER the eviction
+//   allowIncompatibleModels    config escape hatch: rotation is an AUTO
+//                  fetch, so model-incompatible candidates are not
+//                  candidates unless the operator opted back in
 //   isBlocked / inBackoff / seederCountOf   injected lookups (pure-testable)
 //
 // evictFirst is true when the incoming snapshot only fits once the evictee's
@@ -120,6 +137,7 @@ function evictionOrder(catalogByFrom, seederCountOf, now) {
 export function planRotation({
   shelf, catalog, ledger, localModel, now,
   rotationDays, autoFetch, autoFetchCount, capBytes,
+  allowIncompatibleModels = false,
   isBlocked = () => false,
   inBackoff = () => false,
   seederCountOf = () => 0,
@@ -139,6 +157,7 @@ export function planRotation({
     || seederCountOf(c.payload.hash || '') > 0;
   const candidates = catalog
     .filter((c) => !held.has(c.from) && !isBlocked(c.from) && !inBackoff(c.from)
+      && modelCompatible(c.payload, localModel, allowIncompatibleModels)
       && fetchable(c))
     .sort(rotationCandidateOrder(ledger, localModel, now));
   if (candidates.length === 0) { return null; }

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -871,6 +871,96 @@ describe('discovery p2p — similarity search + novelty filter', () => {
   });
 });
 
+// ── Announced size is a claim, not a fact ────────────────────────────────────
+// The storage-cap and disk-floor pre-checks trust the ANNOUNCED size; the
+// blob behind the hash can be arbitrarily larger. fetchPeer must reject a
+// snapshot whose real bytes exceed the claim (and ≥v1.0.4 sidecars abort
+// the transfer itself at the maxBytes ceiling — either failure mode ends
+// here). An honest byte-exact announcement must keep fetching fine.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — announced-size lie', () => {
+  let server;
+  let peer;
+  let dir;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      extraConfig: { discoveryP2p: { enabled: true, autoFetch: false } },
+    });
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-lie-'));
+    peer = new RawSidecar(SIDECAR_BIN, path.join(dir, 'sidecar'));
+    await peer.ready;
+  });
+  after(async () => {
+    if (peer) { await peer.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('honest exact size fetches; an under-announced blob is rejected and the old copy survives', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    await peer.rpc('join', { bootstrap: [status.ticket] });
+    await peer.waitForEvent('neighbor', (e) => e.up === true);
+
+    const manualFetch = () => fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/peer-dbs/fetch`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpointId: peer.endpointId }),
+    });
+    const catalogHash = (hash) => pollUntil(async () => {
+      const c = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`)).json();
+      const entry = c.peers.find((p) => p.from === peer.endpointId);
+      return entry?.payload.hash === hash ? entry : null;
+    }, { what: `catalog to carry announcement for ${hash.slice(0, 12)}…` });
+
+    // Round 1 — honest: announced size is the publish stat, byte-exact.
+    const honest = makeSnapshotFile(path.join(dir, 'honest.db'), {
+      tracks: [{ artist: 'Honest Artist', title: 'True Size', vec: [1, 0, 0, 0] }],
+    });
+    const pub1 = await peer.rpc('publish', { path: honest });
+    await peer.rpc('announce', {
+      payload: { hash: pub1.hash, size: pub1.size, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Sizer' },
+    });
+    await catalogHash(pub1.hash);
+    const ok = await manualFetch();
+    assert.equal(ok.status, 200, 'a byte-exact announcement must not trip the ceiling');
+    const record = await ok.json();
+    assert.equal(record.hash, pub1.hash);
+    assert.equal(record.sizeBytes, pub1.size, 'the shelf records the bytes on disk');
+
+    // Round 2 — the lie: a bigger valid snapshot announced as 100 bytes.
+    // A capped sidecar aborts the transfer; an uncapped one delivers and
+    // the on-disk re-check rejects. Both must refuse the swap.
+    const big = makeSnapshotFile(path.join(dir, 'big.db'), {
+      tracks: Array.from({ length: 60 }, (_, i) => (
+        { artist: `Filler ${i}`, title: `Pad Track ${i}`, vec: [0, 1, 0, 0] })),
+    });
+    const pub2 = await peer.rpc('publish', { path: big });
+    assert.ok(pub2.size > 100, 'the lie needs a blob genuinely bigger than the claim');
+    await peer.rpc('announce', {
+      payload: { hash: pub2.hash, size: 100, rowCount: 60,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 2, name: 'Sizer' },
+    });
+    await catalogHash(pub2.hash);
+    const refused = await manualFetch();
+    assert.equal(refused.status, 500);
+    assert.match((await refused.json()).error, /maxBytes|announced \d+ bytes but sent/i,
+      'the refusal names the size mismatch (sidecar ceiling or on-disk re-check)');
+
+    // The held seq-1 snapshot survives the refused refresh untouched, and
+    // the liar's bytes are not on disk.
+    const shelf = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+    assert.equal(shelf.peerDbs.length, 1);
+    assert.equal(shelf.peerDbs[0].rowCount, 1, 'the old copy stays on the shelf');
+    assert.equal(shelf.peerDbs[0].sizeBytes, pub1.size, 'shelf accounting still describes the old bytes');
+    const liarFile = path.join(server.tmpDir, 'db', 'discovery-peers', `${pub2.hash.slice(0, 16)}.db`);
+    assert.ok(!fs.existsSync(liarFile), 'the over-announced blob must not be left on disk');
+  });
+});
+
 // ── Shelf rotation: membership cycles instead of freezing ───────────────────
 // A FULL shelf (registry pre-crafted with two long-held snapshots, count=2)
 // must SWAP its oldest unpinned entry for a newly announced peer — the

--- a/test/integration/discovery-p2p.test.mjs
+++ b/test/integration/discovery-p2p.test.mjs
@@ -961,6 +961,206 @@ describe('discovery p2p — similarity search + novelty filter', () => {
   });
 });
 
+// ── Boot re-seed: advertised holds must be servable ─────────────────────────
+// A fresh sidecar process serves only what its blob store still holds, and
+// fetched blobs used to have no GC root at all — so a rebooted server's
+// holds beacon advertised snapshots its store had already swept. The stack
+// now re-imports every shelf file at start (reseedShelf) and beacons the
+// hold-set. Proof shape: the ORIGIN of a held snapshot is long gone; a
+// third party fetching {hash, provider: server} can only succeed if the
+// re-import actually rooted the bytes in the server's own store.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — boot reseed serves held snapshots', () => {
+  let server;
+  let helper;   // publishes the blob to learn its content hash, then leaves
+  let leecher;  // fetches from the SERVER after boot
+  let dir;
+  let heldFile;
+  let heldHash;
+  const HELD_ID = 'a'.repeat(64);
+
+  before(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-reseed-'));
+    const stateDir = path.join(dir, 'state');
+    const dbDir = path.join(stateDir, 'db');
+
+    // Build the snapshot ONCE and learn its content hash from a throwaway
+    // sidecar (content addressing: same bytes = same hash everywhere).
+    const original = makeSnapshotFile(path.join(dir, 'origin.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Held Artist', title: 'Survivor', vec: [1, 0, 0, 0] }],
+    });
+    helper = new RawSidecar(SIDECAR_BIN, path.join(dir, 'helper'));
+    await helper.ready;
+    const pub = await helper.rpc('publish', { path: original });
+    heldHash = pub.hash;
+    await helper.stop();
+    helper = null; // the origin is now GONE from the network
+
+    // Pre-seed the server's shelf with that exact file, then boot.
+    heldFile = path.join(dbDir, 'discovery-peers', `${heldHash.slice(0, 16)}.db`);
+    fs.mkdirSync(path.dirname(heldFile), { recursive: true });
+    fs.copyFileSync(original, heldFile);
+    fs.mkdirSync(path.join(dbDir, 'discovery-p2p'), { recursive: true });
+    fs.writeFileSync(path.join(dbDir, 'discovery-p2p', 'peer-dbs.json'), JSON.stringify([{
+      endpointId: HELD_ID, hash: heldHash, path: heldFile, snapshotSeq: 1,
+      modelId: 'test-model', modelVersion: '1', rowCount: 1,
+      sizeBytes: fs.statSync(heldFile).size, name: 'Held Peer',
+      fetchedAt: new Date().toISOString(), firstFetchedAt: new Date().toISOString(),
+      pinned: true,
+    }], null, 2));
+
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: false,
+      extraConfig: {
+        storage: {
+          albumArtDirectory: path.join(stateDir, 'image-cache'),
+          dbDirectory: dbDir,
+          logsDirectory: path.join(stateDir, 'logs'),
+          syncConfigDirectory: path.join(stateDir, 'sync'),
+          waveformCacheDirectory: path.join(stateDir, 'waveform-cache'),
+        },
+        discoveryP2p: { enabled: true, autoFetch: false },
+      },
+    });
+    leecher = new RawSidecar(SIDECAR_BIN, path.join(dir, 'leecher'));
+    await leecher.ready;
+  });
+  after(async () => {
+    if (helper) { await helper.stop(); }
+    if (leecher) { await leecher.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('a third party can fetch a held snapshot FROM the server after a cold boot', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    await leecher.rpc('join', { bootstrap: [status.ticket] });
+    await leecher.waitForEvent('neighbor', (e) => e.up === true);
+
+    // The core proof: the origin is gone, so these bytes can only come out
+    // of the server's own store — i.e. the boot re-import worked.
+    const got = await leecher.rpc('fetch', {
+      hash: heldHash, provider: status.endpointId, outDir: path.join(dir, 'leeched'),
+    });
+    assert.equal(got.hash, heldHash);
+    assert.deepEqual(fs.readFileSync(got.path), fs.readFileSync(heldFile),
+      'served bytes must be the held snapshot, byte for byte');
+
+    // And the hold is ADVERTISED: this server has no own snapshot, so the
+    // only pusher of the beacon is reseedShelf — heard within one 60s
+    // re-beacon period of meshing.
+    const beacon = await leecher.waitForEvent('holds',
+      (e) => e.from === status.endpointId && Array.isArray(e.holds) && e.holds.includes(heldHash),
+      75000);
+    assert.ok(beacon, 'the reseeded hold must appear in the holds beacon');
+  });
+});
+
+// ── Auto-fetch model gate: incompatible announcements are not downloaded ────
+// With a LOCAL embedding model established, reconcile must skip catalog
+// peers announcing a different model (their rows are unsearchable — WHERE
+// model_id = ours) while still fetching matching ones from the same pass.
+// The manual admin fetch stays the deliberate escape hatch. Policy details
+// are unit-tested (modelCompatible/planRotation); this proves the reconcile
+// wiring: getMeta('embedding_model_id') → skip → no shelf entry.
+(SIDECAR_BIN ? describe : describe.skip)('discovery p2p — auto-fetch model gate', () => {
+  let server;
+  let alien;   // announces modelId 'alien-model' — must NOT be auto-fetched
+  let match;   // announces modelId 'test-model'  — must be auto-fetched
+  let dir;
+
+  before(async () => {
+    server = await startServer({
+      dlnaMode: 'disabled', waitForScan: true,
+      env: { MSTREAM_TEST_DISCOVERY_DEBOUNCE_MS: '750' },
+      extraConfig: {
+        discoveryP2p: { enabled: true },
+        scanOptions: { collectDiscoveryData: true },
+      },
+    });
+    // Establish the local model the gate compares against (the embedding
+    // worker's job in production — direct meta write per the similarity
+    // suite's seeding precedent).
+    const ddb = new DatabaseSync(path.join(server.tmpDir, 'db', 'discovery.db'));
+    ddb.prepare("INSERT OR REPLACE INTO discovery_meta (key, value) VALUES ('embedding_model_id', 'test-model')").run();
+    ddb.close();
+
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-p2p-gate-'));
+    alien = new RawSidecar(SIDECAR_BIN, path.join(dir, 'alien'));
+    match = new RawSidecar(SIDECAR_BIN, path.join(dir, 'match'));
+    await alien.ready;
+    await match.ready;
+  });
+  after(async () => {
+    if (alien) { await alien.stop(); }
+    if (match) { await match.stop(); }
+    if (server) { await server.stop(); }
+    if (dir) { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('one reconcile pass: matching model fetched, alien model skipped; manual fetch still works', async () => {
+    const status = await pollUntil(async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/status`)).json();
+      return s.running && s.ticket ? s : null;
+    }, { what: 'server sidecar to boot' });
+    await alien.rpc('join', { bootstrap: [status.ticket] });
+    await match.rpc('join', { bootstrap: [status.ticket] });
+    await alien.waitForEvent('neighbor', (e) => e.up === true);
+    await match.waitForEvent('neighbor', (e) => e.up === true);
+
+    const alienSnap = makeSnapshotFile(path.join(dir, 'alien.db'), {
+      modelId: 'alien-model',
+      tracks: [{ artist: 'Alien Artist', title: 'Other Space', vec: [1, 0, 0, 0] }],
+    });
+    const alienPub = await alien.rpc('publish', { path: alienSnap });
+    await alien.rpc('announce', {
+      payload: { hash: alienPub.hash, size: alienPub.size, rowCount: 1,
+        modelId: 'alien-model', modelVersion: '1', snapshotSeq: 1, name: 'Alien' },
+    });
+    const matchSnap = makeSnapshotFile(path.join(dir, 'match.db'), {
+      modelId: 'test-model',
+      tracks: [{ artist: 'Match Artist', title: 'Same Space', vec: [0, 1, 0, 0] }],
+    });
+    const matchPub = await match.rpc('publish', { path: matchSnap });
+    await match.rpc('announce', {
+      payload: { hash: matchPub.hash, size: matchPub.size, rowCount: 1,
+        modelId: 'test-model', modelVersion: '1', snapshotSeq: 1, name: 'Match' },
+    });
+
+    // Both are in the catalog before the debounced reconcile fires. The
+    // admin route HIDES incompatible-model peers once a local model exists
+    // (its own suite covers that), so the alien registers as a bump in
+    // hiddenIncompatible rather than a visible row.
+    await pollUntil(async () => {
+      const c = await (await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/catalog`)).json();
+      const froms = c.peers.map((p) => p.from);
+      const alienHeard = froms.includes(alien.endpointId) || c.hiddenIncompatible >= 1;
+      return froms.includes(match.endpointId) && alienHeard ? c : null;
+    }, { what: 'both announcements in the catalog' });
+
+    // …and the pass that downloads the match must leave the alien alone.
+    const shelfIds = async () => {
+      const s = await (await fetch(`${server.baseUrl}/api/v1/discovery/p2p/peer-dbs`)).json();
+      return s.peerDbs.map((p) => p.endpointId);
+    };
+    await pollUntil(async () => (await shelfIds()).includes(match.endpointId) || null,
+      { timeoutMs: 30000, what: 'auto-fetch to download the matching-model peer' });
+    assert.ok(!(await shelfIds()).includes(alien.endpointId),
+      'the alien-model peer must not be auto-fetched');
+
+    // The deliberate escape hatch: a manual admin fetch of the alien works.
+    const manual = await fetch(`${server.baseUrl}/api/v1/admin/discovery/p2p/peer-dbs/fetch`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpointId: alien.endpointId }),
+    });
+    assert.equal(manual.status, 200, 'manual fetch must bypass the model gate');
+    assert.ok((await shelfIds()).includes(alien.endpointId));
+  });
+});
+
 // ── Shelf rotation: membership cycles instead of freezing ───────────────────
 // A FULL shelf (registry pre-crafted with two long-held snapshots, count=2)
 // must SWAP its oldest unpinned entry for a newly announced peer — the

--- a/test/unit/discovery-peer-rotation.test.mjs
+++ b/test/unit/discovery-peer-rotation.test.mjs
@@ -24,6 +24,7 @@ import {
   planRotation,
   candidateOrder,
   rotationCandidateOrder,
+  modelCompatible,
   ONLINE_WINDOW_MS,
 } from '../../src/state/discovery-peer-rotation.js';
 
@@ -200,14 +201,51 @@ describe('planRotation — candidate choice', () => {
   });
 
   test('novelty ties fall through to the usefulness order (model-compatible first)', () => {
+    // allowIncompatibleModels keeps the other-model candidate in the POOL,
+    // so this exercises the ordering — without it the model gate would
+    // remove 'd' before the sort ever ran.
     const plan = planRotation(inputs({
       localModel: 'model-x',
+      allowIncompatibleModels: true,
       catalog: [
         cat('d', { modelId: 'other-model', rowCount: 99999 }),
         cat('e', { modelId: 'model-x', rowCount: 1 }),
       ],
     }));
     assert.equal(plan.fetchId, id('e'));
+  });
+});
+
+describe('planRotation — model gate', () => {
+  test('an incompatible candidate is not a candidate at all by default', () => {
+    assert.equal(planRotation(inputs({
+      localModel: 'model-x',
+      catalog: [cat('d', { modelId: 'other-model', rowCount: 99999 })],
+    })), null, 'rotation must not swap a searchable snapshot for dead weight');
+  });
+
+  test('a peer that never embedded (empty modelId) counts as incompatible', () => {
+    assert.equal(planRotation(inputs({
+      localModel: 'model-x',
+      catalog: [cat('d', { modelId: '' })],
+    })), null);
+  });
+
+  test('allowIncompatibleModels opts back in', () => {
+    const plan = planRotation(inputs({
+      localModel: 'model-x',
+      allowIncompatibleModels: true,
+      catalog: [cat('d', { modelId: 'other-model' })],
+    }));
+    assert.equal(plan?.fetchId, id('d'));
+  });
+
+  test('no local model = no compatibility signal; every candidate passes', () => {
+    const plan = planRotation(inputs({
+      localModel: null,
+      catalog: [cat('d', { modelId: 'other-model' })],
+    }));
+    assert.equal(plan?.fetchId, id('d'));
   });
 });
 
@@ -303,5 +341,17 @@ describe('order helpers', () => {
 
   test('the online window matches the announce cadence', () => {
     assert.equal(ONLINE_WINDOW_MS, 90 * 1000);
+  });
+
+  test('modelCompatible: match, mismatch, empty, no-signal, escape hatch', () => {
+    assert.equal(modelCompatible({ modelId: 'model-x' }, 'model-x'), true);
+    assert.equal(modelCompatible({ modelId: 'other' }, 'model-x'), false);
+    assert.equal(modelCompatible({ modelId: '' }, 'model-x'), false,
+      'a never-embedded peer is incompatible with any established model');
+    assert.equal(modelCompatible({}, 'model-x'), false);
+    assert.equal(modelCompatible({ modelId: 'other' }, null), true,
+      'no local model = no signal, everyone passes');
+    assert.equal(modelCompatible({ modelId: 'other' }, 'model-x', true), true,
+      'allowIncompatible overrides the gate');
   });
 });


### PR DESCRIPTION
Two hardenings from the 2026-08-28 live discovery-network audit.

## 1. Arbitrary-volume download (the size lie)

`fetchPeer`'s storage-cap and disk-free-floor checks ran on the peer-**announced** size, but nothing bounded the transfer itself: a malicious catalog peer could announce `size: 20480` and serve a multi-GB blob — an unbounded write onto the volume (prod has already crash-looped on a full disk once).

- `discoveryP2p.fetch()` now carries `maxBytes` = announced size (byte-exact for honest peers — it's the publisher's own stat), or the storage-cap headroom for size-less announcements. Sidecars **≥ v1.0.4** abort the transfer at the ceiling (companion PR: IrosTheBeggar/mstream-p2p-sidecar#, see below); v1.0.3 tolerates and ignores the extra key.
- `fetchPeer` re-runs the admission checks on the **actual bytes on disk** after download: over-announced ⇒ reject, delete, forget the blob, normal failure backoff. Same-hash refreshes are exempt from the delete (the file IS the held copy). This on-disk re-check is the load-bearing bound until the sidecar pin bumps to v1.0.4.
- The raw admin catalog-fetch route (`POST /p2p/fetch` by endpointId) gets the same announced-size ceiling; its ticket mode stays uncapped (manual hand-off from someone the admin already trusts, no announcement to bound it).

## 2. Block auto-fetch of model-incompatible snapshots (default)

The similarity search reads only `WHERE model_id = ours`, so a snapshot announced under another model — or none at all (a server that never embedded, e.g. the empty 'Cypher' DB prod auto-fetched) — is unsearchable dead weight. `candidateOrder` only *deprioritized* them; reconcile still fetched them whenever the shelf had room.

- New pure predicate `modelCompatible` gates reconcile's top-up **and** rotation's candidate pool once a local model exists. No local model ⇒ no signal ⇒ everyone passes (unchanged).
- Escape hatches: `discoveryP2p.autoFetchIncompatibleModels` (config, default **false**), the manual admin fetch (ungated), and stale-refreshes of snapshots already on the shelf (ungated — what you hold keeps refreshing until removed).

## Tests

- Unit: model-gate + `modelCompatible` cases; full unit dir 607/607.
- New integration suite **“announced-size lie”**: honest byte-exact announce fetches fine; an under-announced blob is refused (500), the held seq-1 copy survives untouched, and the liar's bytes are not left in `discovery-peers/`. Written to pass under both v1.0.3 semantics (post-check) and v1.0.4 (transfer abort).
- Full discovery integration suite 50/50, run locally against a patched v1.0.4 dev sidecar build.

## Not in this PR

- The sidecar-side transfer abort ships separately (mstream-p2p-sidecar `feat/fetch-max-bytes` → v1.0.4); the manifest pin bump follows the usual release ritual after that publishes.
- Prod's existing empty Cypher shelf entry predates the gate — remove it via the admin shelf UI if unwanted (the gate stops *new* auto-fetches, it doesn't evict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)