### PR TITLE
feat(discovery): portable sonic seeds — read a vector out, take one in

### DIFF
--- a/src/api/discovery.js
+++ b/src/api/discovery.js
@@ -144,11 +144,87 @@ export function resolveVisible(uid, filter, canonHash, { withGenres = true } = {
   return row;
 }
 
+// Decode a client-supplied embedding into a unit vector this index can be
+// queried with. Extracted from the federation peer route so the two callers
+// that accept a foreign vector — federation/discovery/similar and the Auto-DJ
+// picker's vector seed — validate it identically; a divergence here would be
+// one route quietly accepting a vector the other rejects.
+//
+// Deliberately does NOT check modelId: the two callers differ on what a
+// mismatch means (federation answers a soft `modelMismatch`, the picker
+// refuses), so that policy stays with them.
+export function decodeSeedVector(index, base64) {
+  const raw = Buffer.from(base64, 'base64');
+  if (raw.length !== index.dim * 4) {
+    throw new WebError(`embedding must be ${index.dim} float32 values (little-endian), got ${raw.length} bytes`, 400);
+  }
+  // Aligned copy — a Buffer's byteOffset isn't guaranteed 4-byte aligned.
+  const ab = new ArrayBuffer(raw.length);
+  new Uint8Array(ab).set(raw);
+  const q = new Float32Array(ab);
+
+  let sumSq = 0;
+  for (let i = 0; i < q.length; i++) {
+    if (!Number.isFinite(q[i])) { throw new WebError('embedding contains non-finite values', 400); }
+    sumSq += q[i] * q[i];
+  }
+  const norm = Math.sqrt(sumSq);
+  if (norm === 0) { throw new WebError('embedding is a zero vector', 400); }
+  // The index vectors are L2-normalized at write time; "similarity" only
+  // means cosine if the query is normalized too. Callers should send unit
+  // vectors, but a scaled one costs nothing to fix here.
+  for (let i = 0; i < q.length; i++) { q[i] /= norm; }
+  return q;
+}
+
 function modelBlock(index) {
   return { id: index.modelId, version: index.modelVersion };
 }
 
 export function setup(mstream) {
+
+  // The embedding itself, for a client that needs to carry a seed somewhere
+  // this server can't reach — Auto-DJ spanning several servers averages the
+  // vectors of what is playing and hands the result to each of them, which
+  // only works if it can read them out in the first place.
+  //
+  // Batched because the rolling anchor seeds from the last few picks; one
+  // round trip per pick beats eight. Capped at 8 to match similarTo.
+  //
+  // Same failure semantics as the rest of this file: a uniform 404 for a path
+  // that can't be resolved, and notAnalyzed for one that resolves but has no
+  // vector yet — the caller can tell "wrong path" from "wait for the worker".
+  mstream.post('/api/v1/discovery/local/embeddings', (req, res) => {
+    const schema = Joi.object({
+      filePaths: Joi.array().items(Joi.string()).min(1).max(8).required(),
+    });
+    const { value: body } = joiValidate(schema, req.body);
+
+    const index = requireIndex();
+
+    const tracks = [];
+    for (const filePath of body.filePaths) {
+      const row = resolveSeedTrack(req, filePath, 'discovery/local/embeddings');
+      const canonHash = row.audio_hash || row.file_hash;
+      const entry = canonHash ? index.byHash.get(canonHash) : null;
+      if (!entry) {
+        tracks.push({ filePath, audioHash: canonHash ?? null, notAnalyzed: true, embedding: null });
+        continue;
+      }
+      // entry.vec is a subarray of the index's shared matrix — copy the
+      // bytes rather than handing Buffer a view over the whole thing.
+      const bytes = Buffer.from(
+        entry.vec.buffer, entry.vec.byteOffset, entry.vec.length * 4);
+      tracks.push({
+        filePath,
+        audioHash: canonHash,
+        notAnalyzed: false,
+        embedding: Buffer.from(bytes).toString('base64'),
+      });
+    }
+
+    res.json({ model: modelBlock(index), dim: index.dim, tracks });
+  });
 
   mstream.post('/api/v1/discovery/local/similar/tracks', (req, res) => {
     const schema = Joi.object({

--- a/src/api/federation-discovery.js
+++ b/src/api/federation-discovery.js
@@ -23,10 +23,9 @@
 import Joi from 'joi';
 import * as sim from '../db/discovery-similarity.js';
 import * as discoveryDb from '../db/discovery-db.js';
-import { requireIndex, resolveVisible } from './discovery.js';
+import { requireIndex, resolveVisible, decodeSeedVector } from './discovery.js';
 import { renderMetadataObj, libraryFilter } from './db.js';
 import { joiValidate } from '../util/validation.js';
-import WebError from '../util/web-error.js';
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
@@ -55,26 +54,7 @@ export function setup(mstream) {
       return res.json({ model, results: [] });
     }
 
-    const raw = Buffer.from(body.embedding, 'base64');
-    if (raw.length !== index.dim * 4) {
-      throw new WebError(`embedding must be ${index.dim} float32 values (little-endian), got ${raw.length} bytes`, 400);
-    }
-    // Aligned copy — a Buffer's byteOffset isn't guaranteed 4-byte aligned.
-    const ab = new ArrayBuffer(raw.length);
-    new Uint8Array(ab).set(raw);
-    const q = new Float32Array(ab);
-
-    let sumSq = 0;
-    for (let i = 0; i < q.length; i++) {
-      if (!Number.isFinite(q[i])) { throw new WebError('embedding contains non-finite values', 400); }
-      sumSq += q[i] * q[i];
-    }
-    const norm = Math.sqrt(sumSq);
-    if (norm === 0) { throw new WebError('embedding is a zero vector', 400); }
-    // The index vectors are L2-normalized at write time; "similarity" below
-    // only means cosine if the query is normalized too. Callers should send
-    // unit vectors, but a scaled one costs nothing to fix here.
-    for (let i = 0; i < q.length; i++) { q[i] /= norm; }
+    const q = decodeSeedVector(index, body.embedding);
 
     const filter = libraryFilter(req.user);
     const uid = req.user?.id;

--- a/src/api/random.js
+++ b/src/api/random.js
@@ -42,11 +42,13 @@
 // separate PR — there's no library-aware Last.fm proxy yet, so wiring
 // it here would only test the SQL path.
 
+import { createHash } from 'node:crypto';
+
 import Joi from 'joi';
 import * as db from '../db/manager.js';
 import * as sim from '../db/discovery-similarity.js';
 import { renderMetadataObj, libraryFilter, trackQuery, fetchGenresForTrack } from './db.js';
-import { requireIndex, resolveSeedTrack } from './discovery.js';
+import { requireIndex, resolveSeedTrack, decodeSeedVector } from './discovery.js';
 import { joiValidate } from '../util/validation.js';
 import WebError from '../util/web-error.js';
 
@@ -580,18 +582,47 @@ function buildSonicPool(req, body) {
 
   const vecs = [];
   const seedHashes = [];
-  for (const p of body.similarTo) {
-    const row = resolveSeedTrack(req, p, 'random-songs sonic');
-    const canonHash = row.audio_hash || row.file_hash;
-    const entry = canonHash ? index.byHash.get(canonHash) : null;
-    if (!entry) {
-      throw new WebError('Sonic seed track has not been analyzed yet', 400);
+  let seedKey;
+
+  if (body.similarToVector) {
+    // A seed from somewhere this server can't see — the caller averaged the
+    // vectors of what is playing (possibly across several servers) and sent
+    // the result. Nothing downstream of the pool cares where a vector came
+    // from, so only the decode and the model check are new.
+    //
+    // A mismatch is a hard 400 here, unlike the federation peer route's soft
+    // `modelMismatch`. That route answers a RANKING, where "no results" is a
+    // truthful empty answer; this one answers "what do I play next", and
+    // comparing across model spaces would return confident nonsense — tracks
+    // with no real relationship to the seed. The caller is expected to have
+    // read this server's model id first and skip it when it disagrees, so
+    // reaching here at all is a bug worth surfacing.
+    if (body.similarToModelId !== index.modelId) {
+      throw new WebError(
+        `Sonic seed is from model '${body.similarToModelId}', this library is indexed with '${index.modelId}'`, 400);
     }
-    vecs.push(entry.vec);
-    seedHashes.push(canonHash);
+    if (index.dim === null) {
+      throw new WebError('No tracks have been analyzed yet', 400);
+    }
+    vecs.push(decodeSeedVector(index, body.similarToVector));
+    // Content-addressed so the pool cache behaves exactly as it does for the
+    // filepath form: the same vector and threshold hit the same entry.
+    seedKey = `vec:${createHash('sha1').update(body.similarToVector).digest('hex')}`;
+  } else {
+    for (const p of body.similarTo) {
+      const row = resolveSeedTrack(req, p, 'random-songs sonic');
+      const canonHash = row.audio_hash || row.file_hash;
+      const entry = canonHash ? index.byHash.get(canonHash) : null;
+      if (!entry) {
+        throw new WebError('Sonic seed track has not been analyzed yet', 400);
+      }
+      vecs.push(entry.vec);
+      seedHashes.push(canonHash);
+    }
+    seedKey = [...seedHashes].sort().join('|');
   }
 
-  const cacheKey = `${[...seedHashes].sort().join('|')}@${body.minSimilarity}`;
+  const cacheKey = `${seedKey}@${body.minSimilarity}`;
   let perIndex = sonicPoolCache.get(index);
   if (!perIndex) { perIndex = new Map(); sonicPoolCache.set(index, perIndex); }
   const hit = perIndex.get(cacheKey);
@@ -605,6 +636,10 @@ function buildSonicPool(req, body) {
   // The seeds are the session's recent picks (rolling anchor) or the
   // currently-playing song (locked anchor) — Auto-DJ must never answer
   // "what's next" with "the song you just played".
+  //
+  // A vector seed carries no hashes, so this protection does not apply to it
+  // and `ignoreList` becomes the only thing keeping the DJ off the song that
+  // is playing. Callers using similarToVector MUST send one.
   for (const h of seedHashes) { allowed.delete(h); }
   // The JSON form is what the SQL pool constraint binds (json_each) —
   // stringified once here so locked-anchor picks don't re-serialize a
@@ -642,7 +677,8 @@ export function runRandomSongs(req, body) {
 
   // Sonic pool first — it can 403/404/400 on its own and there's no point
   // running SQL when the seed itself is bad.
-  const sonic = (Array.isArray(body.similarTo) && body.similarTo.length > 0)
+  const sonic = ((Array.isArray(body.similarTo) && body.similarTo.length > 0)
+      || body.similarToVector)
     ? buildSonicPool(req, body)
     : null;
 
@@ -1125,9 +1161,34 @@ export function setup(mstream) {
       //                    (EffNet reality: same-artist ≈ .6-.9, cross ≈
       //                    .3-.7 — the client maps a perceptual slider onto
       //                    this; the API takes the raw value.)
+      //   • similarToVector / similarToModelId: the same seed as a raw
+      //                    vector, for a caller whose seed lives on a
+      //                    DIFFERENT server — a filepath means nothing here,
+      //                    but a vector does. Base64 of dim × float32
+      //                    little-endian, same wire form the federation peer
+      //                    route takes. The model id is required and must
+      //                    match this library's: vectors only compare within
+      //                    one model space, and a silent cross-space compare
+      //                    returns confident nonsense.
       similarTo: Joi.array().items(Joi.string()).min(1).max(8).optional(),
+      similarToVector: Joi.string().base64().optional(),
+      similarToModelId: Joi.string().optional(),
       minSimilarity: Joi.number().min(0).max(1).optional(),
-    }).and('similarTo', 'minSimilarity')
+      // One seed form or the other, never both — they would disagree.
+      // Each form carries its own required peers; `.and()` can't express that
+      // (it would demand the peers of BOTH forms at once), so this is .with()
+      // one way plus an explicit check that a threshold never arrives without
+      // a seed to apply it to.
+    }).oxor('similarTo', 'similarToVector')
+      .with('similarTo', 'minSimilarity')
+      .with('similarToVector', ['similarToModelId', 'minSimilarity'])
+      .custom((v, helpers) => {
+        if (v.minSimilarity !== undefined
+            && v.similarTo === undefined && v.similarToVector === undefined) {
+          return helpers.error('any.custom', { message: 'minSimilarity needs a seed: similarTo or similarToVector' });
+        }
+        return v;
+      }, 'sonic seed pairing')
       // Backwards duration window ({minDuration: 600, maxDuration: 60}) is
       // the same class of typo as a backwards bpmRange: it produces a
       // clause that matches nothing, and because the duration filter is

--- a/test/discovery-seed-vector.test.mjs
+++ b/test/discovery-seed-vector.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * decodeSeedVector — the shared front door for a client-supplied embedding.
+ *
+ * Two routes accept a vector from somewhere else: the federation peer route
+ * (a peer's track) and the Auto-DJ picker's `similarToVector` (a seed the
+ * caller carried from another server). They used to be one implementation
+ * and a copy waiting to happen; these pin the behaviour both rely on.
+ *
+ * The interesting cases are all rejections. A vector that decodes to the
+ * wrong length, or holds NaN, or is all zeros, cannot produce a meaningful
+ * cosine — and because the pool is a hard constraint on what Auto-DJ may
+ * play, a bad seed that is quietly tolerated becomes "the DJ picked nonsense
+ * for the rest of the session" rather than a visible error.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { decodeSeedVector } from '../src/api/discovery.js';
+
+const DIM = 8;
+const index = { dim: DIM };
+
+/** base64 of a float32 little-endian vector, the wire form both routes take. */
+function b64(values) {
+  const f = Float32Array.from(values);
+  return Buffer.from(f.buffer, f.byteOffset, f.byteLength).toString('base64');
+}
+
+test('decodes a well-formed vector to the right length', () => {
+  const v = decodeSeedVector(index, b64([1, 0, 0, 0, 0, 0, 0, 0]));
+  assert.equal(v.length, DIM);
+  assert.ok(v instanceof Float32Array);
+});
+
+test('returns a unit vector even when the input is scaled', () => {
+  // The index is L2-normalized at write time, so a dot product is only a
+  // cosine if the query is normalized too. A caller that averaged vectors
+  // without re-normalizing must not silently get inflated similarities.
+  const v = decodeSeedVector(index, b64([3, 4, 0, 0, 0, 0, 0, 0]));
+  const norm = Math.hypot(...v);
+  assert.ok(Math.abs(norm - 1) < 1e-6, `expected unit length, got ${norm}`);
+  assert.ok(Math.abs(v[0] - 0.6) < 1e-6);
+  assert.ok(Math.abs(v[1] - 0.8) < 1e-6);
+});
+
+test('leaves an already-normalized vector alone', () => {
+  const v = decodeSeedVector(index, b64([0, 1, 0, 0, 0, 0, 0, 0]));
+  assert.ok(Math.abs(v[1] - 1) < 1e-6);
+});
+
+test('rejects a vector of the wrong length', () => {
+  assert.throws(
+    () => decodeSeedVector(index, b64([1, 0, 0])),
+    (err) => err.status === 400 && /1280|8 float32|float32 values/.test(err.message),
+  );
+});
+
+test('rejects non-finite values', () => {
+  assert.throws(
+    () => decodeSeedVector(index, b64([NaN, 0, 0, 0, 0, 0, 0, 0])),
+    (err) => err.status === 400 && /non-finite/.test(err.message),
+  );
+  assert.throws(
+    () => decodeSeedVector(index, b64([Infinity, 0, 0, 0, 0, 0, 0, 0])),
+    (err) => err.status === 400 && /non-finite/.test(err.message),
+  );
+});
+
+test('rejects a zero vector', () => {
+  // Normalizing this would divide by zero and yield NaNs that then compare
+  // against every track in the index.
+  assert.throws(
+    () => decodeSeedVector(index, b64([0, 0, 0, 0, 0, 0, 0, 0])),
+    (err) => err.status === 400 && /zero vector/.test(err.message),
+  );
+});
+
+test('handles a buffer whose byteOffset is not 4-byte aligned', () => {
+  // Buffer.from(base64) can hand back a view into a shared pool at an
+  // arbitrary offset; constructing a Float32Array over it directly throws.
+  // The decoder copies into a fresh ArrayBuffer for exactly this reason, so
+  // decoding many vectors in a row must stay stable.
+  for (let i = 0; i < 64; i++) {
+    const v = decodeSeedVector(index, b64([i + 1, 1, 0, 0, 0, 0, 0, 0]));
+    assert.equal(v.length, DIM);
+    assert.ok(Math.abs(Math.hypot(...v) - 1) < 1e-6);
+  }
+});

--- a/test/integration/random-sonic.test.mjs
+++ b/test/integration/random-sonic.test.mjs
@@ -374,3 +374,169 @@ describe('sonic seed edge cases', () => {
     assert.ok(second.body.sonic.similarity >= 0.75 - 1e-6, 'pick is inside the requested range');
   });
 });
+
+// ── portable seeds: reading a vector out, taking one in ─────────────────────
+//
+// A client with several servers can't hand server B a filepath that only
+// names a row on server A. These pin the two halves that let the seed travel
+// as a vector instead: /discovery/local/embeddings reads it out, and
+// random-songs' similarToVector takes it in. Same handcrafted 4-d space as
+// above, so every pool is known in advance.
+
+const b64v = (v) => blob(v).toString('base64');
+const TITLE_VEC = { 'Be Somebody': V.seed, 'Rise': V.near, 'Highway': V.mid, 'Neon': V.far, 'Lib2 Song': V.lib2 };
+
+async function embeddings(filePaths, user = 'admin', srv = server) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (user && tokens[user]) { headers['x-access-token'] = tokens[user]; }
+  const r = await fetch(`${srv.baseUrl}/api/v1/discovery/local/embeddings`, {
+    method: 'POST', headers, body: JSON.stringify({ filePaths }),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+
+function decodeB64(s) {
+  const raw = Buffer.from(s, 'base64');
+  const ab = new ArrayBuffer(raw.length);
+  new Uint8Array(ab).set(raw);
+  return new Float32Array(ab);
+}
+
+describe('discovery/local/embeddings — reading a seed out', () => {
+  test('returns the vector behind a path as base64 float32 LE, with the model block', async () => {
+    const { status, body } = await embeddings([SEED_PATH]);
+    assert.equal(status, 200, JSON.stringify(body));
+    assert.deepEqual(body.model, { id: 'test-fake', version: '1' });
+    assert.equal(body.dim, 4);
+    assert.equal(body.tracks.length, 1);
+    const t = body.tracks[0];
+    assert.equal(t.filePath, SEED_PATH);
+    assert.equal(t.notAnalyzed, false);
+    assert.ok(typeof t.audioHash === 'string' && t.audioHash.length > 0);
+    assert.equal(Buffer.from(t.embedding, 'base64').length, 4 * 4, 'dim × float32');
+    const v = decodeB64(t.embedding);
+    for (let i = 0; i < 4; i++) {
+      assert.ok(Math.abs(v[i] - V.seed[i]) < 1e-6, `component ${i}: ${v[i]} vs ${V.seed[i]}`);
+    }
+  });
+
+  test('a scanned but un-embedded path is notAnalyzed with a null embedding, beside analyzed ones', async () => {
+    const { status, body } = await embeddings([SEED_PATH, UNSEEDED_PATH]);
+    assert.equal(status, 200);
+    assert.equal(body.tracks.length, 2);
+    assert.equal(body.tracks[0].notAnalyzed, false);
+    assert.ok(typeof body.tracks[0].embedding === 'string');
+    assert.equal(body.tracks[1].filePath, UNSEEDED_PATH);
+    assert.equal(body.tracks[1].notAnalyzed, true);
+    assert.equal(body.tracks[1].embedding, null);
+  });
+
+  test('unknown path → 404; more than 8 paths or none → 400', async () => {
+    assert.equal((await embeddings(['testlib/nope/missing.mp3'])).status, 404);
+    assert.equal((await embeddings(Array(9).fill(SEED_PATH))).status, 400, '9 paths > cap');
+    assert.equal((await embeddings([])).status, 400, 'empty list');
+  });
+
+  test("other users' vpaths are unreadable (uniform 404)", async () => {
+    const { status } = await embeddings([LIB2_PATH], 'bob');
+    assert.equal(status, 404);
+  });
+
+  test('403 when discovery is disabled', async () => {
+    const { status } = await embeddings([SEED_PATH], null, offServer);
+    assert.equal(status, 403);
+  });
+});
+
+describe('sonic vector seed — taking a seed in', () => {
+  const seedBody = (extra = {}) => ({
+    similarToVector: b64v(V.seed), similarToModelId: 'test-fake', minSimilarity: 0.85, ...extra,
+  });
+
+  test('a vector seed pools like the filepath form, except the seed track itself stays eligible', async () => {
+    // A vector carries no hashes, so nothing is excluded by contract: at
+    // 0.85 the pool is {Be Somebody 1.0, Rise 0.95, Lib2 Song 0.9} — one
+    // wider than the filepath form's {Rise, Lib2 Song}.
+    const { status, body: probe } = await pick(seedBody());
+    assert.equal(status, 200, JSON.stringify(probe));
+    assert.equal(probe.sonic.poolSize, 3);
+    const titles = await pickTitles(seedBody(), 64);
+    assert.deepEqual([...titles].sort(), ['Be Somebody', 'Lib2 Song', 'Rise']);
+
+    // ignoreList — server-issued track ids, a SOFT cooldown that yields to
+    // the full pool once it covers every candidate — is what keeps the DJ
+    // off the song already playing. With the pool at three and one id sent,
+    // two candidates stay fresh, so the seed track is never picked here.
+    const mdb = new DatabaseSync(path.join(server.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+    let seedId;
+    try { seedId = mdb.prepare("SELECT id FROM tracks WHERE title = 'Be Somebody'").get().id; } finally { mdb.close(); }
+    const guarded = await pickTitles(seedBody({ ignoreList: [seedId] }), 40);
+    assert.deepEqual([...guarded].sort(), ['Lib2 Song', 'Rise']);
+  });
+
+  test("the reported similarity is the pick's exact cosine against the vector", async () => {
+    const { body } = await pick(seedBody());
+    const expected = dot(V.seed, TITLE_VEC[body.songs[0].metadata.title]);
+    assert.ok(Math.abs(body.sonic.similarity - expected) < 1e-3,
+      `reported ${body.sonic.similarity} for '${body.songs[0].metadata.title}', exact ${expected}`);
+  });
+
+  test('round trip: a vector read out of this server seeds the same pool as its filepath (plus the seed)', async () => {
+    const { body: out } = await embeddings([SEED_PATH]);
+    const viaVector = await pick({ similarToVector: out.tracks[0].embedding, similarToModelId: 'test-fake', minSimilarity: 0.85 });
+    const viaPath = await pick({ similarTo: [SEED_PATH], minSimilarity: 0.85 });
+    assert.equal(viaVector.status, 200);
+    assert.equal(viaPath.status, 200);
+    assert.equal(viaVector.body.sonic.poolSize, viaPath.body.sonic.poolSize + 1,
+      'the only difference is the seed track itself, which the path form excludes');
+  });
+
+  test('a caller-averaged, un-normalized seed reaches the centroid pool', async () => {
+    // What a multi-server client sends: the mean of two anchors, here left
+    // scaled ×3 — the server re-normalizes, so the pool is the same one the
+    // filepath centroid test reaches (Highway ≈ 0.993, Lib2 Song ≈ 0.997,
+    // Rise ≈ 0.979 at 0.97; the anchors themselves sit at 0.866, out).
+    const mean = new Float32Array(4);
+    for (let i = 0; i < 4; i++) { mean[i] = 3 * (V.seed[i] + V.far[i]) / 2; }
+    const body = { similarToVector: b64v(mean), similarToModelId: 'test-fake', minSimilarity: 0.97 };
+    const { status, body: probe } = await pick(body);
+    assert.equal(status, 200, JSON.stringify(probe));
+    assert.equal(probe.sonic.poolSize, 3);
+    const titles = await pickTitles(body, 64);
+    assert.deepEqual([...titles].sort(), ['Highway', 'Lib2 Song', 'Rise']);
+  });
+
+  test('a model-space mismatch is a hard 400 that names both models', async () => {
+    const { status, body } = await pick(seedBody({ similarToModelId: 'some-other-model' }));
+    assert.equal(status, 400);
+    assert.match(body.error, /some-other-model/);
+    assert.match(body.error, /test-fake/);
+  });
+
+  test('validation: exclusive with similarTo; needs its model id and a threshold; malformed vectors refused', async () => {
+    assert.equal((await pick(seedBody({ similarTo: [SEED_PATH] }))).status, 400, 'both seed forms');
+    assert.equal((await pick({ similarToVector: b64v(V.seed), minSimilarity: 0.85 })).status, 400, 'no model id');
+    assert.equal((await pick({ similarToVector: b64v(V.seed), similarToModelId: 'test-fake' })).status, 400, 'no threshold');
+    const short = await pick(seedBody({ similarToVector: b64v(vec(1, 0, 0)) }));
+    assert.equal(short.status, 400, 'wrong length');
+    assert.match(short.body.error, /float32 values/);
+    const zero = await pick(seedBody({ similarToVector: Buffer.alloc(16).toString('base64') }));
+    assert.equal(zero.status, 400, 'zero vector');
+    assert.match(zero.body.error, /zero vector/);
+    assert.equal((await pick(seedBody({ similarToVector: '!!!not-base64!!!' }))).status, 400, 'not base64');
+  });
+
+  test('restricted user never receives other-library picks from a vector seed', async () => {
+    const titles = await pickTitles(seedBody(), 16, 'bob');
+    for (const t of titles) {
+      assert.ok(['Be Somebody', 'Rise'].includes(t), `'${t}' is outside bob's libraries`);
+    }
+  });
+
+  test('403 when discovery is disabled', async () => {
+    const r = await fetch(`${offServer.baseUrl}${ROUTE}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(seedBody()),
+    });
+    assert.equal(r.status, 403);
+  });
+});


### PR DESCRIPTION
## Why

Auto-DJ's sonic mode seeds from **filepaths**, which name a row in *this* server's database. A client with several servers therefore can't ask them all for "something like what's playing" — the path means nothing anywhere else.

These two additions let the seed travel as what it actually is: a vector. Together they're what the app needs for a cross-server Auto DJ session.

## What's here

**`POST /api/v1/discovery/local/embeddings`** — the embedding for 1–8 paths, base64 float32 little-endian, with the model block. Batched because the rolling anchor seeds from the last few picks; one round trip per pick beats eight. Same failure semantics as its neighbours: uniform 404 for an unresolvable path, `notAnalyzed` for one the worker hasn't reached yet.

**`random-songs`: `similarToVector` + `similarToModelId`** — the same seed as a raw vector instead of paths. Nothing downstream of the sonic pool cared where a vector came from, so the change is confined to building it: the pool, the waterfall, the LRU cache and the reported cosine all work unmodified.

## Design notes

**A model-id mismatch is a hard 400**, deliberately unlike the federation peer route's soft `modelMismatch`. That route answers a *ranking*, where an empty result is truthful. This one answers "what do I play next", and comparing across model spaces returns confident nonsense — tracks with no real relationship to the seed. Callers are expected to read the model id first and skip a server that disagrees, so arriving here at all means a bug worth surfacing.

**The decode half of the federation route is now shared** as `decodeSeedVector`: dim, non-finite and zero-vector checks, the aligned copy a `Buffer`'s `byteOffset` makes necessary, and the defensive re-normalization without which a caller-averaged seed would inflate every similarity it produced. Two routes accepting foreign vectors through one front door beats a copy that drifts.

> [!IMPORTANT]
> **Note for callers.** The filepath form removes its seed hashes from the pool so the DJ never answers "what's next" with the song already playing. A vector carries no hashes, so that protection doesn't apply — `ignoreList` becomes load-bearing rather than merely helpful. Commented in both repos.

## Testing

**Two servers, disjoint libraries** (ports 3366/3377, synthetic tracks). A vector read from one and handed to the other returns *that server's own* tracks with a real cosine:

```
Change A: model=effnet-discogs v1 dim=1280 analyzed=true b64=6828 chars
Change B: pick "Alpha Track" | cosine 0.7974 | poolSize 3
          across 8 calls: Alpha×4, Gamma×3, Beta×1
Guard   : foreign model  -> 400 "Sonic seed is from model 'some-other-model', this library is indexed with 'effnet-discogs'"
Guard   : wrong length   -> 400 "embedding must be 1280 float32 values (little-endian), got 64 bytes"
Guard   : both forms     -> 400 conflict between exclusive peers
Regress : filepath seed still works -> "Gamma Track" | cosine 0.7929
```

**Unit tests** — 7 new, covering `decodeSeedVector`: well-formed decode, scaled input normalized to unit length, wrong length, non-finite, zero vector, and repeated decodes exercising the byte-alignment copy.

**Full suite** — `2509 tests, 2472 pass, 15 fail, 22 skipped`. Master baseline on the same machine is `2502 / 2461 / 15 / 22`: the same 15 failures, in `admin-mdns` (untracked WIP) and DLNA/discovery-seed timeouts. They're flaky rather than fixed — the failing names differ between runs, and `dlna-surface.test.mjs` passes 20/20 when run alone both with and without this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)