### PR TITLE
chore(discovery): pin p2p-sidecar v1.0.4 — capped, hold-rooted fetches

### DIFF
--- a/bin/p2p-sidecar/manifest-musl.json
+++ b/bin/p2p-sidecar/manifest-musl.json
@@ -2,24 +2,24 @@
   "family": "p2p-sidecar",
   "schema": 2,
   "repo": "IrosTheBeggar/mstream-p2p-sidecar",
-  "tag": "v1.0.3",
-  "builtFrom": "150cef8d6fedf008c5343a8864e7f4845708d6db",
-  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/33089369342",
+  "tag": "v1.0.4",
+  "builtFrom": "593e2c4dd7821064ebd456ec180922e3ec59cf02",
+  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/33254927555",
   "assets": {
     "p2p-sidecar-linux-x64-musl": {
       "file": "p2p-sidecar-linux-x64-musl",
-      "sha256": "41d4f7353a416c513e7f437bb59d48c38308326f5be1bc69dfe60646bce25ad3",
-      "size": 8668000
+      "sha256": "5b815f5362b5943c8073ba5ec868d18a5b0079b17ade90fcbe371c3affbfd094",
+      "size": 8688480
     },
     "p2p-sidecar-linux-arm64-musl": {
       "file": "p2p-sidecar-linux-arm64-musl",
-      "sha256": "214ad5b026187d313ee1b5fef1c674011dfddb7aac6268bd4f9cfb44fecca27b",
-      "size": 7299272
+      "sha256": "f6e040780c4aff9a500ce78b33757fa635f6e494bada68c5e83cadcac211b728",
+      "size": 7319752
     },
     "p2p-sidecar-linux-arm-musl": {
       "file": "p2p-sidecar-linux-arm-musl",
-      "sha256": "10087d47f201e4e9a8d3de88f9472d0dbdd082e0d9e3ab6ba2709ff265e8af2f",
-      "size": 7259492
+      "sha256": "acfd0d79dfbb829b6f101654cfc075ac9bf1aa34fe4f11e5454a4732fd9ac32f",
+      "size": 7284068
     }
   }
 }

--- a/bin/p2p-sidecar/manifest.json
+++ b/bin/p2p-sidecar/manifest.json
@@ -2,39 +2,39 @@
   "family": "p2p-sidecar",
   "schema": 2,
   "repo": "IrosTheBeggar/mstream-p2p-sidecar",
-  "tag": "v1.0.3",
-  "builtFrom": "150cef8d6fedf008c5343a8864e7f4845708d6db",
-  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/33089369278",
+  "tag": "v1.0.4",
+  "builtFrom": "593e2c4dd7821064ebd456ec180922e3ec59cf02",
+  "workflowRun": "https://github.com/IrosTheBeggar/mstream-p2p-sidecar/actions/runs/33254927533",
   "assets": {
     "p2p-sidecar-win32-x64.exe": {
       "file": "p2p-sidecar-win32-x64.exe",
-      "sha256": "5913952b63849cf7d77b1b5f6a1a1fd098460dcf9dc4f0aaa8434f8bce532cb8",
-      "size": 7047680
+      "sha256": "ac1c57c982bbd2285b8620d5539e857a818a77740c25d548925007ce52d58538",
+      "size": 7069184
     },
     "p2p-sidecar-darwin-x64": {
       "file": "p2p-sidecar-darwin-x64",
-      "sha256": "f9cee6868ccd03aab9574598a4d126bbc7c3c7d375732d4a7f79dbadc4ace80a",
-      "size": 7387480
+      "sha256": "ccfc14e246c0518261b0e24c40e1cfbc701a104dd92a1bfeb38912a3b93bd518",
+      "size": 7412160
     },
     "p2p-sidecar-darwin-arm64": {
       "file": "p2p-sidecar-darwin-arm64",
-      "sha256": "a3b73658c5756f7b65a6f88e6289be90fdd07a9cbd4d5045045353d71a60d489",
-      "size": 6296128
+      "sha256": "103dd6ea1967457429d45f576ea6d3cf08c11d8b646ea3d4539a367af93a31c2",
+      "size": 6312688
     },
     "p2p-sidecar-linux-x64": {
       "file": "p2p-sidecar-linux-x64",
-      "sha256": "01be5b87838f9d1f46ed640a05a7429956915d52192aff96188762730d3df65e",
-      "size": 8559424
+      "sha256": "6809a30b134459178762fd365ffdac434dc3657d198e321540bfbbd5c5a71d98",
+      "size": 8582120
     },
     "p2p-sidecar-linux-arm64": {
       "file": "p2p-sidecar-linux-arm64",
-      "sha256": "2d8704e7ddeae19acc27e04530e902a3d9d9663cb7efdc5f998c2f37d50799ca",
-      "size": 7533488
+      "sha256": "a527ebd39f2bbc4df9efccb96f6a36284004cdf2f59a764f73c5f22a8a8d3f03",
+      "size": 7553968
     },
     "p2p-sidecar-linux-arm": {
       "file": "p2p-sidecar-linux-arm",
-      "sha256": "ae720f1c2f20fb588d66908da9d3b362bbfd02cc71d2545a90c365c7a7eb180a",
-      "size": 7325536
+      "sha256": "30cfb2ecb675aee5f0709c90818650e30a76094cd72c46b327ff6262069ad362",
+      "size": 7346016
     }
   }
 }


### PR DESCRIPTION
Manifest-only pin bump to [sidecar v1.0.4](https://github.com/IrosTheBeggar/mstream-p2p-sidecar/releases/tag/v1.0.4) (published today; built from `593e2c4d`, both release workflows green, 11 assets, fragment shas byte-verified against the actual assets before the release was published).

The server side of both features merged in #928 and degrades gracefully on v1.0.3; this pin activates the sidecar halves:

- **fetch `maxBytes`** — the transfer itself now aborts past the ceiling derived from the peer's announced size (mid-transfer bound of the disk-fill fix; the on-disk post-check stays as the belt). Smoked at scale on this exact build: a 300 MB blob announced as 20 KB aborts at 32 KB / 9 ms (single-origin) and 64 KB / 375 ms (swarm).
- **fetch `hold`** — fetched shelf snapshots get a persistent GC root, so holds beacons advertise only what the store can actually serve; the boot reseed from #928 keeps healing pre-v1.0.4 stores either way.

**Verified with these exact pins**: `npm run fetch-p2p-sidecar`'s receipt-gated refresh replaced the previously fetched v1.0.3 binary with v1.0.4, checksum-verified it, the binary passes `--print-id`, and its sha256 (`ac1c57c9…`) matches the pinned value. The full discovery integration suite (52/52) ran against this build pre-release.

Prod picks it up on its next image rebuild/restart (it's still on v1.0.2 → this jumps it to v1.0.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)