### PR TITLE
fix(federation-requests): crossing guard, orphan-key unwind, and the mid-dial write races

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6292,7 +6292,7 @@ paths:
         "200":
           description: The created request row (state `pending-delivery`).
         "404": { description: Unknown offered library. }
-        "409": { description: "Feature not enabled, peer blocked, or a request to this peer is already live." }
+        "409": { description: "Feature not enabled, peer blocked, a request to this peer is already live, or the peer already has a live request in YOUR inbox (answer it, or let that exchange finish — one exchange per relationship)." }
         "405": { $ref: "#/components/responses/AdminLocked" }
 
   /api/v1/admin/federation/requests/{id}/accept:

--- a/src/state/federation-requests.js
+++ b/src/state/federation-requests.js
@@ -127,6 +127,15 @@ export async function compose({ peerEndpointId, message = null, offeredLibraries
   const existing = reqDb.listRequests().find((r) => r.direction === 'out'
     && r.peer_endpoint_id === peerEndpointId && reqDb.ACTIVE_STATES.includes(r.state));
   if (existing) { throw new Error(`a request to this peer is already ${existing.state}`); }
+  // Crossing guard: if this peer already has a live inbound request here,
+  // composing back would open a SECOND parallel exchange — four keys for
+  // one relationship. The admin UI steers to the inbox for this case; the
+  // engine refuses so every caller gets the same protection. ("already"
+  // keeps the route's 409 mapping.)
+  if (reqDb.hasActiveFromPeer(peerEndpointId)) {
+    throw new Error('this peer already sent you a federation request — '
+      + 'answer it, or let that exchange finish, before composing a new one');
+  }
 
   const peerName = catalog.get(peerEndpointId)?.payload?.name || null;
   const row = reqDb.createRequest({
@@ -288,12 +297,28 @@ async function attempt(id) {
     const payload = await payloadForRow(row);
     if (!payload) { return; }
 
+    // The dial (and the ticket build above) yield: an operator cancel, a
+    // peer withdraw, a TTL sweep — or the reply to this very DM beating its
+    // own delivery ack — can move the row meanwhile. Writing this attempt's
+    // outcome over that would resurrect a dead row or roll an advanced one
+    // back, so every write below first checks the row still sits where the
+    // attempt found it (and uses the fresh read, not the stale one).
+    const stillCurrent = () => {
+      const now = reqDb.getRequestById(id);
+      if (now && now.state === row.state) { return now; }
+      winston.info(`[federation-requests] ${row.uuid} ${payload.type} outcome dropped — `
+        + `row moved '${row.state}' → '${now ? now.state : 'deleted'}' mid-attempt`);
+      return null;
+    };
+
     let outcome;
     try {
       outcome = await p2p.sendDm(row.peer_endpoint_id, payload);
     } catch (err) {
       // Never reached (offline / pre-DM build / timeout): walk the ladder.
-      const failCount = row.fail_count + 1;
+      const live = stillCurrent();
+      if (!live) { return; }
+      const failCount = live.fail_count + 1;
       const delay = BACKOFF_SECONDS[Math.min(failCount - 1, BACKOFF_SECONDS.length - 1)];
       reqDb.updateRequest(id, { failCount, nextAttemptInSeconds: delay });
       winston.info(`[federation-requests] ${row.uuid} ${payload.type} undeliverable `
@@ -302,7 +327,9 @@ async function attempt(id) {
     }
 
     if (outcome.delivered === true) {
-      const patch = advanceAfterDelivery(row);
+      const fresh = stillCurrent();
+      if (!fresh) { return; }
+      const patch = advanceAfterDelivery(fresh);
       if (patch) { reqDb.updateRequest(id, patch); }
       winston.info(`[federation-requests] ${row.uuid} ${payload.type} delivered to `
         + `${row.peer_endpoint_id.slice(0, 12)}… → ${patch ? patch.state : row.state}`);
@@ -313,10 +340,12 @@ async function attempt(id) {
     // (the peer's typed "no"); rate limiting is always transient; and an
     // accept/grant refusal only means the peer's inbox is momentarily off —
     // they asked for this pairing, so keep trying until the TTL says stop.
+    const now = stillCurrent();
+    if (!now) { return; }
     const transient = outcome.reason === 'rate-limited'
       || (payload.type !== 'federation-request' && outcome.reason === 'not-accepting');
     if (transient) {
-      const failCount = row.fail_count + 1;
+      const failCount = now.fail_count + 1;
       const delay = BACKOFF_SECONDS[Math.min(failCount - 1, BACKOFF_SECONDS.length - 1)];
       reqDb.updateRequest(id, { failCount, nextAttemptInSeconds: delay });
       winston.info(`[federation-requests] ${row.uuid} ${payload.type} refused (${outcome.reason}) — retrying in ${delay}s`);
@@ -327,7 +356,7 @@ async function attempt(id) {
       rejectReason: `transport: ${outcome.reason}`,
       nextAttemptInSeconds: null,
     });
-    revokeUndeliveredKey(row, `refused (${outcome.reason})`);
+    revokeUndeliveredKey(now, `refused (${outcome.reason})`);
     winston.warn(`[federation-requests] ${row.uuid} ${payload.type} refused by `
       + `${row.peer_endpoint_id.slice(0, 12)}… (${outcome.reason}) — terminal`);
   } finally {
@@ -480,6 +509,14 @@ async function handleAccept(from, payload) {
   if (['granting', 'completed'].includes(row.state)) { return; } // idempotent re-delivery
   if (!['pending-delivery', 'delivered'].includes(row.state)) {
     winston.warn(`[federation-requests] ${row.uuid} late accept ignored (state '${row.state}')`);
+    // The accepter minted a live key for a request that no longer stands.
+    // Left unanswered they'd hold it until nothing — their sweep only
+    // revokes UNdelivered credentials. Re-send the withdraw (the original
+    // courtesy, if any, may never have landed) so their handleWithdraw
+    // unwinds the key. Old peers ignore the extra withdraw harmlessly.
+    if (['cancelled', 'expired'].includes(row.state)) {
+      sendCourtesy(row, { type: 'federation-withdraw', uuid: row.uuid });
+    }
     return;
   }
   const peerId = await addPeerFromTicket(row, payload.ticket, 'accept');
@@ -488,7 +525,19 @@ async function handleAccept(from, payload) {
   // advanced the row meanwhile — re-read so only one handler mints the
   // grant-back (everything from here to updateRequest is synchronous).
   row = reqDb.getRequestById(row.id);
-  if (!row || !['pending-delivery', 'delivered'].includes(row.state)) { return; }
+  if (!row || !['pending-delivery', 'delivered'].includes(row.state)) {
+    // A duplicate handler advancing the row is fine (granting/completed —
+    // silent). But an operator cancel (or the TTL) winning this race means
+    // the ticket above was already consumed: a peer row now points at an
+    // exchange we just killed — visible in the panel, where testPeer will
+    // say so. Log it and nack the accepter so it unwinds its side too.
+    if (row && ['cancelled', 'expired'].includes(row.state)) {
+      winston.warn(`[federation-requests] ${row.uuid} accept crossed our ${row.state} row — `
+        + `peer id=${peerId} was already added from its ticket; remove it in the Federation panel if unwanted`);
+      sendCourtesy(row, { type: 'federation-withdraw', uuid: row.uuid });
+    }
+    return;
+  }
 
   const wantOffer = payload.wantOffer !== false;
   const grantNames = wantOffer ? row.offered_libraries : [];
@@ -532,6 +581,18 @@ async function handleGrant(from, payload) {
   }
   const peerId = await addPeerFromTicket(row, payload.ticket, 'grant');
   if (peerId === null) { return; }
+  // addPeerFromTicket yielded: a withdraw from this same peer (or the TTL
+  // sweep) may have closed the row meanwhile — completing over that would
+  // resurrect a terminal row and erase the revocation record. Same guard
+  // as handleAccept's re-read.
+  const fresh = reqDb.getRequestById(row.id);
+  if (!fresh || !['granting', 'accepted'].includes(fresh.state)) {
+    if (fresh && ['cancelled', 'expired'].includes(fresh.state)) {
+      winston.warn(`[federation-requests] ${row.uuid} grant crossed our ${fresh.state} row — `
+        + `peer id=${peerId} was already added from its ticket; remove it in the Federation panel if unwanted`);
+    }
+    return;
+  }
   reqDb.updateRequest(row.id, { state: 'completed', createdPeerId: peerId, nextAttemptInSeconds: null });
   winston.info(`[federation-requests] ${row.uuid} completed — mutual pairing with ${from.slice(0, 12)}…`);
 }
@@ -548,9 +609,41 @@ function handleReject(from, payload) {
 function handleWithdraw(from, payload) {
   const row = rowForSender(from, payload.uuid, 'in', 'withdraw');
   if (!row) { return; }
-  if (row.state !== 'received') { return; }
-  reqDb.updateRequest(row.id, { state: 'cancelled', nextAttemptInSeconds: null });
-  winston.info(`[federation-requests] ${row.uuid} withdrawn by its sender`);
+  if (row.state === 'received') {
+    reqDb.updateRequest(row.id, { state: 'cancelled', nextAttemptInSeconds: null });
+    winston.info(`[federation-requests] ${row.uuid} withdrawn by its sender`);
+    return;
+  }
+  // A withdraw can also cross our accept. The sender can only cancel while
+  // its own row is still pending-delivery/delivered — meaning it never
+  // consumed the ticket we minted, so nobody will ever claim that key, and
+  // the TTL sweep would not revoke it either (it only unwinds UNdelivered
+  // credentials). Honor the withdrawal: revoke the key and close the row.
+  // This branch is also the receiving end of the late-accept nack (see
+  // handleAccept). Completed rows stay untouched — severing a finished
+  // pairing is the operator's call, never a DM's.
+  if (['accepted', 'granting'].includes(row.state)) {
+    reqDb.updateRequest(row.id, { state: 'cancelled', nextAttemptInSeconds: null });
+    if (row.minted_key_id) {
+      try {
+        // Forensics before the delete: a bound key means the "sender never
+        // consumed the ticket" premise was violated — it used the key,
+        // then withdrew. Still honor the withdrawal, but say so.
+        const keyRow = fedDb.getFederationKeyById(row.minted_key_id);
+        if (keyRow?.bound_endpoint_id) {
+          winston.warn(`[federation-requests] ${row.uuid} withdrawing peer had already BOUND key `
+            + `id=${row.minted_key_id} — it consumed the ticket before withdrawing`);
+        }
+        if (fedDb.deleteFederationKey(row.minted_key_id)) {
+          winston.info(`[federation-requests] ${row.uuid} withdrawn after our accept — `
+            + `revoked unclaimed key id=${row.minted_key_id}`);
+        }
+      } catch (err) {
+        winston.warn(`[federation-requests] ${row.uuid} failed to revoke key id=${row.minted_key_id} on withdraw: ${err.message}`);
+      }
+    }
+    winston.info(`[federation-requests] ${row.uuid} withdrawn by its sender after our accept — exchange closed`);
+  }
 }
 
 // Parse a received mstrfed1: ticket and add its issuer as a federation

--- a/test/integration/federation-requests.test.mjs
+++ b/test/integration/federation-requests.test.mjs
@@ -21,7 +21,22 @@
  *  - a transport-refused cold request goes terminal ('refused');
  *  - an unreachable peer walks the retry ladder instead of dying;
  *  - the inbox toggle gates NEW requests at the verb level while replies
- *    keep flowing (the open-for-replies transport window).
+ *    keep flowing (the open-for-replies transport window);
+ *  - the crossing guard: compose refuses while the same peer has a live
+ *    inbound request here (one exchange per relationship);
+ *  - a withdraw crossing our accept revokes the unclaimed minted key
+ *    (which nothing else would ever clean up — the TTL sweep only unwinds
+ *    UNdelivered credentials) — while a withdraw on a COMPLETED pairing
+ *    changes nothing (terminals absorb; severing is the operator's call);
+ *  - a same-tick grant+withdraw pair cannot resurrect the cancelled row
+ *    to 'completed' (handleGrant re-reads after its await, like
+ *    handleAccept);
+ *  - a late accept landing on a cancelled request is nacked with a
+ *    re-sent withdraw, so the accepter can unwind even when the original
+ *    courtesy never landed;
+ *  - a rate-limited refusal from a real sidecar stays TRANSIENT: the row
+ *    keeps retrying instead of going terminal (pins the engine's reading
+ *    of the sidecar's literal reason string, end to end).
  *
  * ⚠ SIDECAR-VERSION GATE: needs a DM-capable sidecar (≥v1.0.3) — the
  * suite skips wholesale where no binary exists and probe-skips against a
@@ -392,5 +407,210 @@ const SIDECAR_BIN = resolveSidecarBinary();
     assert.equal(got.state, 'pending-delivery', 'still live — not terminal');
     assert.ok(got.next_attempt_at, 'retry armed');
     engine.cancel(row.id); // leave the table quiet for the other tests
+  });
+
+  test('crossing guard: compose refuses while the peer has a live inbound request', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // Synthetic inbound off the events bus — the guard under test is pure
+    // engine/DB, no wire needed.
+    const crosser = 'ef'.repeat(32);
+    p2p.events.emit('dm', { from: crosser, payload: { type: 'federation-request', uuid: 'cross-guard-01', name: 'Crosser' } });
+    const inRow = await pollUntil(() => reqDb.getRequestByUuid('cross-guard-01'), { what: 'crossing inbox row' });
+
+    await assert.rejects(engine.compose({ peerEndpointId: crosser }), /already sent you/);
+    assert.equal(reqDb.listRequests().filter((r) => r.peer_endpoint_id === crosser).length, 1,
+      'the refused compose left no row behind');
+
+    // A terminal inbound frees the slot: rejecting theirs makes composing
+    // our own legitimate again (the operator changed their mind and leads).
+    await engine.reject(inRow.id);
+    const out = await engine.compose({ peerEndpointId: crosser });
+    assert.equal(out.state, 'pending-delivery');
+
+    // Tidy: both exchanges go nowhere (fake peer).
+    engine.cancel(out.id);
+    reqDb.deleteRequest(out.id);
+    reqDb.deleteRequest(inRow.id);
+    await engine.pushAcceptPolicy();
+  });
+
+  test('withdraw crossing our accept revokes the unclaimed key', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // A fresh identity so this test's DM budget is its own.
+    const erin = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'erin'));
+    try {
+      await erin.ready;
+      await erin.rpc('setDmAccept', { accept: true }); // erin must be able to RECEIVE our accept ticket
+      await p2p.join([erin.ticket]);
+
+      const uuid = 'in-withdraw-001';
+      await erin.rpc('dm', {
+        to: ourTicket,
+        payload: { type: 'federation-request', uuid, name: 'Erin', offer: ['erinshare'] },
+      });
+      const row = await pollUntil(() => reqDb.getRequestByUuid(uuid), { what: 'erin inbox row' });
+
+      await engine.accept(row.id, {
+        libraryIds: [libId], vpathNames: ['music'],
+        limits: { streamKbps: 0, dailyMb: 0, maxStreams: 0 },
+        expiresAt: null, acceptTheirOffer: true,
+      });
+      // The ticket reaches erin and the row settles in 'granting' — the
+      // state whose minted key the TTL sweep deliberately never revokes
+      // (the credential WAS delivered), i.e. the state that used to strand.
+      await erin.waitForEvent('dm', (e) => e.payload?.type === 'federation-accept' && e.payload.uuid === uuid);
+      await pollUntil(() => reqDb.getRequestById(row.id).state === 'granting', { what: 'granting state' });
+      const keyId = reqDb.getRequestById(row.id).minted_key_id;
+      assert.ok(fedDb.getFederationKeyById(keyId), 'the minted key is live before the withdraw');
+
+      // Erin cancelled instead of granting (its cancel can only happen
+      // while its own row never consumed our ticket — the key is claimable
+      // by nobody).
+      await erin.rpc('dm', { to: ourTicket, payload: { type: 'federation-withdraw', uuid } });
+      await pollUntil(() => reqDb.getRequestById(row.id).state === 'cancelled', { what: 'cancelled state' });
+      assert.ok(!fedDb.getFederationKeyById(keyId), 'the unclaimed key was revoked');
+      assert.equal(reqDb.getRequestById(row.id).next_attempt_at, null, 'nothing left owing');
+
+      reqDb.deleteRequest(row.id);
+      await engine.pushAcceptPolicy();
+    } finally {
+      await erin.stop();
+    }
+  });
+
+  test('a withdraw on a completed pairing changes nothing (terminals absorb)', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // The single most dangerous regression surface of the withdraw-cleanup
+    // branch: it must never grow to include 'completed'. Seeded directly —
+    // the guard under test is pure engine/DB.
+    const peer = '12'.repeat(32);
+    const key = fedDb.createFederationKey('terminal-absorb-test', [libId],
+      { streamKbps: 0, dailyMb: 0, maxStreams: 0 }, null);
+    const row = reqDb.createRequest({
+      uuid: 'in-completed-01', direction: 'in', peerEndpointId: peer,
+      state: 'received', ttlSeconds: 3600,
+    });
+    reqDb.updateRequest(row.id, { state: 'completed', mintedKeyId: key.id });
+
+    p2p.events.emit('dm', { from: peer, payload: { type: 'federation-withdraw', uuid: 'in-completed-01' } });
+    // handleWithdraw runs synchronously inside the emit (no awaits on its
+    // path) — assert directly.
+    assert.equal(reqDb.getRequestById(row.id).state, 'completed', 'the terminal row did not move');
+    assert.ok(fedDb.getFederationKeyById(key.id), 'the delivered credential survives a post-completion withdraw');
+
+    fedDb.deleteFederationKey(key.id);
+    reqDb.deleteRequest(row.id);
+    await engine.pushAcceptPolicy();
+  });
+
+  test('RACE: a same-tick grant+withdraw pair cannot resurrect the row', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // The row's own authenticated peer sends grant then withdraw
+    // back-to-back (one pipe chunk → both dm events in one macrotask).
+    // handleGrant suspends at addPeerFromTicket's await; handleWithdraw —
+    // no awaits — runs to completion inside that suspension (cancelled +
+    // key revoked). Without the post-await re-read, handleGrant's resume
+    // would stomp 'cancelled' with 'completed', erasing the revocation
+    // record on a row whose credential is dead.
+    const peer = '34'.repeat(32);
+    const key = fedDb.createFederationKey('grant-race-test', [libId],
+      { streamKbps: 0, dailyMb: 0, maxStreams: 0 }, null);
+    const row = reqDb.createRequest({
+      uuid: 'grant-race-001', direction: 'in', peerEndpointId: peer,
+      state: 'received', ttlSeconds: 3600,
+    });
+    reqDb.updateRequest(row.id, { state: 'granting', mintedKeyId: key.id });
+
+    const payloadGrant = { type: 'federation-grant', uuid: 'grant-race-001', ticket: bobTicket('fedk_grant_race', 'Grant Racer') };
+    p2p.events.emit('dm', { from: peer, payload: payloadGrant });
+    p2p.events.emit('dm', { from: peer, payload: { type: 'federation-withdraw', uuid: 'grant-race-001' } });
+
+    await pollUntil(() => reqDb.getRequestById(row.id).state === 'cancelled', { what: 'cancelled state' });
+    await new Promise((r) => setTimeout(r, 300)); // give a stomping resume time to betray itself
+    assert.equal(reqDb.getRequestById(row.id).state, 'cancelled', 'the withdraw stands — no resurrection to completed');
+    assert.ok(!fedDb.getFederationKeyById(key.id), 'the revocation stands');
+
+    // The grant's ticket may have added its peer before the guard bailed —
+    // deliberate (logged for the operator); tidy it here.
+    const zombie = fedDb.getFederationPeers().find((p) => p.api_key === 'fedk_grant_race');
+    if (zombie) { fedDb.deleteFederationPeer(zombie.id); }
+    reqDb.deleteRequest(row.id);
+    await engine.pushAcceptPolicy();
+  });
+
+  test('a late accept after cancel is nacked so the accepter can unwind', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    const frank = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'frank'));
+    try {
+      await frank.ready;
+      await frank.rpc('setDmAccept', { accept: true }); // frank must be able to RECEIVE the nack
+      await p2p.join([frank.ticket]);
+
+      const row = await engine.compose({ peerEndpointId: frank.endpointId });
+      await frank.waitForEvent('dm', (e) => e.payload?.type === 'federation-request' && e.payload.uuid === row.uuid);
+      await pollUntil(() => reqDb.getRequestById(row.id).state === 'delivered', { what: 'delivered state' });
+
+      // Cancel with the courtesy withdraw LOST (an offline blip): flip the
+      // row terminal directly instead of engine.cancel(), so the only
+      // withdraw frank can ever see is the nack under test.
+      reqDb.updateRequest(row.id, { state: 'cancelled', nextAttemptInSeconds: null });
+
+      const peersBefore = fedDb.getFederationPeers().length;
+      const keysBefore = fedDb.getFederationKeys().length;
+      // Frank accepted before learning of the cancel — the crossing race.
+      await frank.rpc('dm', {
+        to: ourTicket,
+        payload: { type: 'federation-accept', uuid: row.uuid, ticket: bobTicket('fedk_frank_late', 'Frank'), wantOffer: false },
+      });
+
+      // The late accept is ignored AND answered: frank gets a fresh
+      // withdraw for the uuid, telling it to unwind its minted key.
+      await frank.waitForEvent('dm', (e) => e.payload?.type === 'federation-withdraw' && e.payload.uuid === row.uuid);
+      assert.equal(reqDb.getRequestById(row.id).state, 'cancelled', 'the dead row did not move');
+      assert.equal(fedDb.getFederationPeers().length, peersBefore, 'no peer added from the late ticket');
+      assert.equal(fedDb.getFederationKeys().length, keysBefore, 'nothing minted for a dead exchange');
+
+      reqDb.deleteRequest(row.id);
+      await engine.pushAcceptPolicy();
+    } finally {
+      await frank.stop();
+    }
+  });
+
+  test('a rate-limited refusal is transient: the row retries instead of dying', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // The engine matches the sidecar's literal 'rate-limited' reason string
+    // across two repos — this pins the round-trip against the real binary:
+    // exhaust a fresh peer's per-remote budget for OUR sender identity,
+    // then let the engine's own send hit the limiter.
+    const dave = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'dave'));
+    try {
+      await dave.ready;
+      await dave.rpc('setDmAccept', { accept: true });
+      await p2p.join([dave.ticket]);
+
+      let burned = null;
+      for (let i = 0; i < 40; i++) {
+        const r = await p2p.sendDm(dave.endpointId, { type: 'probe', uuid: `burn-${i}-0000` });
+        if (r.delivered === false) { burned = r; break; }
+      }
+      assert.ok(burned, 'the per-remote budget never tripped — did the sidecar drop its limiter?');
+      assert.equal(burned.reason, 'rate-limited', 'the sidecar still spells the refusal the engine matches on');
+
+      // The window is hot: the engine's first delivery attempt gets the
+      // same typed refusal — and must arm a retry, not go terminal.
+      const row = await engine.compose({ peerEndpointId: dave.endpointId });
+      await pollUntil(() => reqDb.getRequestById(row.id).fail_count === 1, { what: 'rate-limited attempt counted' });
+      const got = reqDb.getRequestById(row.id);
+      assert.equal(got.state, 'pending-delivery', 'transient — still live');
+      assert.equal(got.reject_reason, null, 'no terminal refusal recorded');
+      assert.ok(got.next_attempt_at, 'retry armed');
+
+      engine.cancel(row.id); // pending-delivery cancel sends no courtesy — nothing else to rate-limit
+      reqDb.deleteRequest(row.id);
+      await engine.pushAcceptPolicy();
+    } finally {
+      await dave.stop();
+    }
   });
 });

--- a/test/integration/federation-requests.test.mjs
+++ b/test/integration/federation-requests.test.mjs
@@ -33,7 +33,10 @@
  *    handleAccept);
  *  - a late accept landing on a cancelled request is nacked with a
  *    re-sent withdraw, so the accepter can unwind even when the original
- *    courtesy never landed;
+ *    courtesy never landed — and the SECOND nack site too: a cancel that
+ *    wins the race inside the accept handler's own await window (ticket
+ *    already consumed → the documented zombie peer, but no grant-back,
+ *    no resurrection, and the nack still goes out);
  *  - a rate-limited refusal from a real sidecar stays TRANSIENT: the row
  *    keeps retrying instead of going terminal (pins the engine's reading
  *    of the sidecar's literal reason string, end to end).
@@ -574,6 +577,59 @@ const SIDECAR_BIN = resolveSidecarBinary();
       await engine.pushAcceptPolicy();
     } finally {
       await frank.stop();
+    }
+  });
+
+  test('RACE: a cancel inside the accept handler\'s await window is nacked too', { timeout: 60000 }, async (t) => {
+    if (gate(t)) { return; }
+    // The OTHER nack site: the accept passes handleAccept's early state
+    // check, suspends at addPeerFromTicket's await — and the operator's
+    // cancel (zero awaits) completes inside that suspension. The handler
+    // has already consumed the ticket, so the documented zombie peer is
+    // added; the re-read must then stop everything else and still nack.
+    const grace = new RawSidecar(SIDECAR_BIN, path.join(tmpDir, 'grace'));
+    try {
+      await grace.ready;
+      await grace.rpc('setDmAccept', { accept: true }); // grace must be able to RECEIVE the nack
+      await p2p.join([grace.ticket]);
+
+      // Seed the OUT row directly (no request DM ever sent): cancel from
+      // 'pending-delivery' sends no courtesy, so the ONLY withdraw grace
+      // can ever see is the nack from inside the handler.
+      const uuid = 'nack-race-0001';
+      const row = reqDb.createRequest({
+        uuid, direction: 'out', peerEndpointId: grace.endpointId,
+        offeredLibraries: ['music'], state: 'pending-delivery', ttlSeconds: 3600,
+      });
+      const peersBefore = fedDb.getFederationPeers().length;
+      const keysBefore = fedDb.getFederationKeys().length;
+
+      // Same-tick: the emit's handler suspends at the dynamic import; the
+      // cancel runs to completion before microtasks resume it.
+      p2p.events.emit('dm', {
+        from: grace.endpointId,
+        payload: { type: 'federation-accept', uuid, ticket: bobTicket('fedk_nack_race', 'Grace'), wantOffer: true },
+      });
+      engine.cancel(row.id);
+      assert.equal(reqDb.getRequestById(row.id).state, 'cancelled', 'the cancel won synchronously');
+
+      // The resumed handler must nack over the real wire…
+      await grace.waitForEvent('dm', (e) => e.payload?.type === 'federation-withdraw' && e.payload.uuid === uuid);
+      await new Promise((r) => setTimeout(r, 300)); // give a wrong late write time to betray itself
+      // …and leave the dead exchange dead: no resurrection, no grant-back
+      // minted (the row offered 'music', so a stomp would mint), and the
+      // one deliberate leftover is the logged zombie peer.
+      assert.equal(reqDb.getRequestById(row.id).state, 'cancelled', 'no resurrection past the cancel');
+      assert.equal(fedDb.getFederationKeys().length, keysBefore, 'no grant-back key for a dead exchange');
+      assert.equal(fedDb.getFederationPeers().length, peersBefore + 1,
+        'the consumed ticket left the documented (logged) zombie peer');
+
+      const zombie = fedDb.getFederationPeers().find((p) => p.api_key === 'fedk_nack_race');
+      if (zombie) { fedDb.deleteFederationPeer(zombie.id); }
+      reqDb.deleteRequest(row.id);
+      await engine.pushAcceptPolicy();
+    } finally {
+      await grace.stop();
     }
   });
 


### PR DESCRIPTION
The follow-up hardening pass for the federation-requests arc (#925 engine, #926 UI). Five related fixes in the engine, each closing a gap identified in the post-merge review — the fifth found by an adversarial review of this very diff. No schema change, no UI change.

## 1. Server-side crossing-compose guard
`compose()` now refuses (409) when the target peer already has a **live inbound request in your inbox**. The UI already swapped `Federate…` for `Review their request`, but the API allowed both servers to compose at each other — two parallel exchanges and **four keys for one relationship**. The engine now enforces what the UI implied, so non-UI callers get the same protection. `openapi.yaml` documents the new 409 cause.

## 2. Mid-dial state guard in `attempt()`
Every outcome write (delivered / transient-refusal / terminal-refusal / dial-error) re-reads the row and **drops the outcome if the state moved during the awaits**. Previously a cancel, a peer withdraw, a TTL sweep — or the peer's reply beating our own delivery ack — landing mid-dial was silently overwritten:
- a cancelled row could resurrect to `granting`;
- a completed exchange could roll back to `delivered`, blocking re-compose to that peer until the 14-day TTL and holding the transport window open.

## 3. Withdraw unwinds an accepted exchange (the forever-orphan key)
A `federation-withdraw` crossing our accept used to be ignored unless the row was still `received`. The accepter then held a live minted key that **nothing would ever revoke**: the withdrawing sender can only cancel before consuming the ticket (so the key is claimable by nobody), and the TTL sweep deliberately only unwinds *undelivered* credentials. The key sat live forever, visible in the key list.

Now the row closes (`cancelled`) and the unclaimed key is revoked — with a forensic `warn` if the key was already TOFU-bound, i.e. the peer consumed the ticket and *then* withdrew. Completed pairings are explicitly untouched — severing a finished exchange stays the operator's call, never a DM's.

## 4. Late-accept nack
An accept landing on a cancelled/expired request was ignored silently. If the cancel's best-effort courtesy withdraw never landed, the accepter stranded exactly as in (3). The engine now **re-sends the withdraw as the answer** to a late accept, so fix (3) unwinds the far side even when the original courtesy was lost. Old builds ignore the extra withdraw harmlessly — mixed versions behave exactly as today. (No amplification: the nack is 1:1 with inbound accepts, which the sidecar's per-remote limiter caps.)

## 5. `handleGrant` post-await re-read (found by the adversarial pass on this diff)
With (3) in place, a same-tick `grant`+`withdraw` pair from the row's own authenticated peer could interleave through `addPeerFromTicket`'s suspension: the withdraw lands (row `cancelled`, key revoked) while the grant handler is suspended, and its resume then stomped `cancelled` → `completed`, erasing the revocation record. `handleGrant` now re-reads after its await — the same guard `handleAccept` has carried since #925's double-mint fix.

## Tests (6 new e2e cases, real sidecar over real iroh)
| Case | Pins |
|---|---|
| crossing guard | compose refuses while an inbound is live; rejecting theirs frees the slot |
| withdraw revokes the unclaimed key | the `granting`-state key (the one the TTL sweep never touches) is deleted on withdraw |
| **terminals absorb** | a withdraw on a `completed` pairing changes nothing — the delivered credential survives (the most dangerous regression surface of fix 3) |
| **same-tick grant+withdraw race** | deterministic reproduction of finding 5 — the withdraw stands, no resurrection |
| late-accept nack | the re-sent withdraw actually **arrives** at the accepter; no peer/key created here |
| **second nack site** | a cancel winning the race *inside* `handleAccept`'s await window: the consumed ticket leaves exactly the one logged zombie peer, no grant-back is minted, no resurrection — and the nack still arrives at a real peer. Red-proven against this specific branch (the early-branch nack can't satisfy it — that path adds no peer) |
| rate-limited stays transient | a **real** sidecar refusal (`rate-limited`) arms the retry ladder instead of going terminal — pinning the cross-repo literal reason string end to end |

Suite: 16/16 (9 existing + 7 new). Full `npm test` green.

## Review notes
Adversarial review hunted wrongful credential revocation, stuck rows, nack loops/amplification, and compose-guard deadlocks — none found (fix 3 can only ever delete a key whose ticket the authenticated withdrawer provably never consumed, and repeated/interleaved revocation paths are mutually excluded or idempotent). Both nack sites are now test-pinned. Known deferred: the *true simultaneous* cross (both composes in flight before either lands) remains possible by design — the guard covers the sequential case, which is the one the UI produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
