### PR TITLE
feat(api): layered GET /api/ — public version, authed boot payload, admin facts

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -944,19 +944,23 @@ paths:
       description: |
         One endpoint, three layers, keyed off the credentials presented:
 
-        * **No credentials** — the public base only: server version, API
-          versions, and capability booleans. Deliberately public so a
-          client adding a server can probe "is this an mStream server,
-          which version" before authenticating.
+        * **Base** (always): API versions plus `features` — server-wide
+          capability facts. `server` (the version) appears ONLY when the
+          request carries no credentials at all: it is the anonymous
+          probe's payload ("is this an mStream server, which version");
+          authenticated sessions don't re-learn their server's version
+          here. A federated client that wants the version probes without
+          its key header.
         * **Authenticated** (JWT, public-access mode, jukebox session, or
-          an `x-federation-key`) — adds `user`: identity plus the client
-          boot payload `/api/v1/ping` has always served (vpaths,
-          transcode, permission flags, discovery flags, vpathMetaData),
-          scoped to the caller. Note: unlike ping, no `playlists` (fetch
-          those from the playlist routes), no `allowYoutubeDownload`
-          (velvet-only; always `!noUpload`), and no `discoveryPath`
-          (always identical to `discovery` on servers new enough to have
-          this endpoint).
+          an `x-federation-key`) — adds `user`: identity plus the
+          CALLER-SCOPED half of the ping boot payload (vpaths, permission
+          flags, federationDiscovery, vpathMetaData). Server-wide
+          capabilities (transcode, supportedAudioFiles, discovery,
+          discoveryP2p) live in `features` instead. Unlike ping, no
+          `playlists` (fetch those from the playlist routes), no
+          `allowYoutubeDownload` (velvet-only; always `!noUpload`), and
+          no `discoveryPath` (always identical to `discovery` on servers
+          new enough to have this endpoint).
         * **Admin** — adds `admin`: cheap support/debug facts (uptime,
           runtime versions, DB schema version). Never present for
           federation keys or jukebox sessions.
@@ -965,7 +969,8 @@ paths:
         a federation key off its route allowlist) — never a silent
         downgrade to the public layer, so a client with an expired token
         sees the error and re-authenticates. Share tokens receive the
-        public layer only.
+        base layer only, without `server` (presented credentials, just
+        not a session).
 
         Supersedes `/api/v1/ping` for new clients.
       security: []
@@ -979,37 +984,59 @@ paths:
                 properties:
                   server:
                     type: string
-                    description: Server version (from package.json).
+                    description: >
+                      Server version (from package.json). Present ONLY when
+                      the request carried no credentials — the anonymous
+                      probe's payload.
                   apiVersions:
                     type: array
                     items: { type: string }
                   features:
                     type: object
                     description: >
-                      Capability flags a client can gate UI on without an extra
-                      round-trip. Public — surface existence and readiness
-                      booleans only, never counts or names.
+                      Server-wide capability facts a client can gate UI on
+                      without an extra round-trip. Public — config and
+                      capability facts only: no counts, no library or content
+                      names, no identity.
                     properties:
-                      subsonic:
-                        type: boolean
-                        description: Whether the Subsonic API surface is mounted.
                       discoveryReady:
                         type: boolean
                         description: >
                           Whether a sonic-similarity query would find anything
-                          right now. Distinct from the boot payload's
-                          `discovery` flag, which reports only that the feature
-                          is enabled: a server can have discovery on with an
-                          unfinished scan, in which case similarity queries
-                          fail against an empty pool. A boolean rather than a
-                          count because this layer is public.
+                          right now. Distinct from the `discovery` flag, which
+                          reports only that the feature is enabled: a server
+                          can have discovery on with an unfinished scan, in
+                          which case similarity queries fail against an empty
+                          pool. A boolean rather than a count because this
+                          layer is public.
+                      discovery:
+                        type: boolean
+                        description: Sonic-similarity collection is enabled.
+                      discoveryP2p:
+                        type: boolean
+                        description: The discovery network feature is enabled.
+                      transcode:
+                        description: >
+                          false when unavailable; otherwise the server's
+                          transcode defaults.
+                        oneOf:
+                          - type: boolean
+                            enum: [false]
+                          - type: object
+                            properties:
+                              defaultCodec: { type: string }
+                              defaultBitrate: { type: string }
+                      supportedAudioFiles:
+                        type: object
+                        description: Per-format booleans from config.
+                        additionalProperties: { type: boolean }
                   user:
                     type: object
                     description: >
-                      Present only for authenticated callers. The client boot
-                      payload (see /api/v1/ping's schema for the shared
-                      fields, minus `playlists`) plus the identity fields
-                      below.
+                      Present only for authenticated callers. The
+                      caller-scoped half of the ping boot payload (vpaths,
+                      permission flags, federationDiscovery, vpathMetaData)
+                      plus the identity fields below.
                     properties:
                       username: { type: string }
                       admin: { type: boolean }
@@ -1033,8 +1060,11 @@ paths:
                 server: "6.22.0"
                 apiVersions: ["1"]
                 features:
-                  subsonic: false
                   discoveryReady: true
+                  discovery: true
+                  discoveryP2p: false
+                  transcode: false
+                  supportedAudioFiles: { mp3: true, flac: true }
         "401":
           description: A token or federation key was presented but is invalid.
         "403":
@@ -1049,14 +1079,16 @@ paths:
         Returns everything the webapp needs on load: the user's libraries, their playlists,
         transcode capabilities, and server-level flags. Called once after login.
 
-        **Deprecated**: new clients should read the same payload from the
-        layered `GET /api` endpoint's `user` object (which also carries the
-        server version and public capability flags — but not `playlists`
-        (playlist-route territory), `allowYoutubeDownload` (velvet-only,
-        always `!noUpload`), or `discoveryPath` (always identical to
-        `discovery`)). This route is kept indefinitely for existing
-        clients and shares its payload builder with `GET /api`, so the
-        two cannot drift.
+        **Deprecated**: new clients should use the layered `GET /api`
+        endpoint instead — this flat payload is split there into the
+        caller-scoped `user` object and the public `features` object
+        (transcode, supportedAudioFiles, discovery, discoveryP2p), and
+        three legacy fields exist only here: `playlists` (playlist-route
+        territory), `allowYoutubeDownload` (velvet-only, always
+        `!noUpload`), and `discoveryPath` (always identical to
+        `discovery`). This route is kept indefinitely for existing
+        clients and is composed from the same builders as `GET /api`, so
+        the two cannot drift.
       responses:
         "200":
           description: Bootstrap info.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -940,12 +940,35 @@ paths:
   /api:
     get:
       tags: [System]
-      summary: API version discovery
-      description: Returns the server version and the list of available API versions.
+      summary: Layered server info (version, capabilities, boot payload)
+      description: |
+        One endpoint, three layers, keyed off the credentials presented:
+
+        * **No credentials** — the public base only: server version, API
+          versions, and capability booleans. Deliberately public so a
+          client adding a server can probe "is this an mStream server,
+          which version" before authenticating.
+        * **Authenticated** (JWT, public-access mode, jukebox session, or
+          an `x-federation-key`) — adds `user`: identity plus the client
+          boot payload `/api/v1/ping` has always served (vpaths,
+          transcode, permission flags, discovery flags, vpathMetaData),
+          scoped to the caller. Note: unlike ping, no `playlists` —
+          fetch those from the playlist routes.
+        * **Admin** — adds `admin`: cheap support/debug facts (uptime,
+          runtime versions, DB schema version). Never present for
+          federation keys or jukebox sessions.
+
+        Credentials that are **present but invalid** get `401` (`403` for
+        a federation key off its route allowlist) — never a silent
+        downgrade to the public layer, so a client with an expired token
+        sees the error and re-authenticates. Share tokens receive the
+        public layer only.
+
+        Supersedes `/api/v1/ping` for new clients.
       security: []
       responses:
         "200":
-          description: Version info.
+          description: Layered server info.
           content:
             application/json:
               schema:
@@ -961,7 +984,8 @@ paths:
                     type: object
                     description: >
                       Capability flags a client can gate UI on without an extra
-                      round-trip.
+                      round-trip. Public — surface existence and readiness
+                      booleans only, never counts or names.
                     properties:
                       subsonic:
                         type: boolean
@@ -970,26 +994,64 @@ paths:
                         type: boolean
                         description: >
                           Whether a sonic-similarity query would find anything
-                          right now. Distinct from the ping's `discovery` flag,
-                          which reports only that the feature is enabled: a
-                          server can have discovery on with an unfinished scan,
-                          in which case similarity queries fail against an empty
-                          pool. A boolean rather than a count because this
-                          endpoint is public.
+                          right now. Distinct from the boot payload's
+                          `discovery` flag, which reports only that the feature
+                          is enabled: a server can have discovery on with an
+                          unfinished scan, in which case similarity queries
+                          fail against an empty pool. A boolean rather than a
+                          count because this layer is public.
+                  user:
+                    type: object
+                    description: >
+                      Present only for authenticated callers. The client boot
+                      payload (see /api/v1/ping's schema for the shared
+                      fields, minus `playlists`) plus the identity fields
+                      below.
+                    properties:
+                      username: { type: string }
+                      admin: { type: boolean }
+                      federation:
+                        type: boolean
+                        description: True when authenticated by a federation key.
+                  admin:
+                    type: object
+                    description: Present only for admin callers.
+                    properties:
+                      uptime:
+                        type: integer
+                        description: Server process uptime in whole seconds.
+                      nodeVersion: { type: string }
+                      platform: { type: string }
+                      dbSchemaVersion:
+                        type: integer
+                        description: The live database's PRAGMA user_version.
+                      lockAdmin: { type: boolean }
               example:
                 server: "6.22.0"
                 apiVersions: ["1"]
                 features:
                   subsonic: false
                   discoveryReady: true
+        "401":
+          description: A token or federation key was presented but is invalid.
+        "403":
+          description: Valid federation key, but the route is off its allowlist.
 
   /api/v1/ping:
     get:
       tags: [System]
-      summary: Bootstrap payload
+      summary: Bootstrap payload (deprecated — use GET /api)
+      deprecated: true
       description: |
         Returns everything the webapp needs on load: the user's libraries, their playlists,
         transcode capabilities, and server-level flags. Called once after login.
+
+        **Deprecated**: new clients should read the same payload from the
+        layered `GET /api` endpoint's `user` object (which also carries the
+        server version and public capability flags — but not `playlists`,
+        which stay playlist-route territory). This route is kept
+        indefinitely for existing clients and shares its payload builder
+        with `GET /api`, so the two cannot drift.
       responses:
         "200":
           description: Bootstrap info.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -963,7 +963,10 @@ paths:
           new enough to have this endpoint).
         * **Admin** — adds `admin`: cheap support/debug facts (uptime,
           runtime versions, DB schema version). Never present for
-          federation keys or jukebox sessions.
+          federation keys or jukebox sessions — and never while the admin
+          API is locked (`lockAdmin`): an admin account then still shows
+          `user.admin: true` (identity) but no `admin` object, which is
+          how a client tells "locked" from "not an admin".
 
         Credentials that are **present but invalid** get `401` (`403` for
         a federation key off its route allowlist) — never a silent
@@ -1045,7 +1048,9 @@ paths:
                         description: True when authenticated by a federation key.
                   admin:
                     type: object
-                    description: Present only for admin callers.
+                    description: >
+                      Present only for admin callers, and only while the
+                      admin API is unlocked.
                     properties:
                       uptime:
                         type: integer
@@ -1055,7 +1060,6 @@ paths:
                       dbSchemaVersion:
                         type: integer
                         description: The live database's PRAGMA user_version.
-                      lockAdmin: { type: boolean }
               example:
                 server: "6.22.0"
                 apiVersions: ["1"]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -952,8 +952,11 @@ paths:
           an `x-federation-key`) — adds `user`: identity plus the client
           boot payload `/api/v1/ping` has always served (vpaths,
           transcode, permission flags, discovery flags, vpathMetaData),
-          scoped to the caller. Note: unlike ping, no `playlists` —
-          fetch those from the playlist routes.
+          scoped to the caller. Note: unlike ping, no `playlists` (fetch
+          those from the playlist routes), no `allowYoutubeDownload`
+          (velvet-only; always `!noUpload`), and no `discoveryPath`
+          (always identical to `discovery` on servers new enough to have
+          this endpoint).
         * **Admin** — adds `admin`: cheap support/debug facts (uptime,
           runtime versions, DB schema version). Never present for
           federation keys or jukebox sessions.
@@ -1048,10 +1051,12 @@ paths:
 
         **Deprecated**: new clients should read the same payload from the
         layered `GET /api` endpoint's `user` object (which also carries the
-        server version and public capability flags — but not `playlists`,
-        which stay playlist-route territory). This route is kept
-        indefinitely for existing clients and shares its payload builder
-        with `GET /api`, so the two cannot drift.
+        server version and public capability flags — but not `playlists`
+        (playlist-route territory), `allowYoutubeDownload` (velvet-only,
+        always `!noUpload`), or `discoveryPath` (always identical to
+        `discovery`)). This route is kept indefinitely for existing
+        clients and shares its payload builder with `GET /api`, so the
+        two cannot drift.
       responses:
         "200":
           description: Bootstrap info.

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -62,44 +62,9 @@ export function setup(mstream) {
       return next();
     }
 
-    const allUsers = db.getAllUsers();
-
     // Handle No Users (public access mode)
-    if (allUsers.length === 0) {
-      const allLibs = db.getAllLibraries();
-      const adminLocked = config.program.lockAdmin === true;
-      // Spread the sentinel's actual users-table row first so per-user
-      // columns (lastfm_user, lastfm_password, listenbrainz_token, …)
-      // are present on req.user exactly the way they are for real-user
-      // requests above. Endpoints that read those columns off req.user
-      // (scrobbler.js, velvet-stubs.js /lastfm/status, etc.) then work
-      // in public mode without per-endpoint DB lookups. Permission
-      // flags below override whatever the sentinel row stored — the
-      // sentinel's own allow_* defaults are 0 (see ensureAnonymousUser),
-      // and we want them driven by adminLocked instead.
-      const sentinel = db.getAnonymousUser() || {};
-      req.user = {
-        ...sentinel,
-        vpaths: allLibs.map(l => l.name),
-        username: 'mstream-user',
-        admin: !adminLocked,
-        // Pin to the always-present anonymous sentinel row in the
-        // users table. Per-user tables (user_metadata, playlists,
-        // cue_points, …) all FK on users(id) NOT NULL, so a null id
-        // here meant every write endpoint crashed in public mode.
-        // The sentinel is filtered out of getAllUsers() so the
-        // empty-check above still means "no real users".
-        id: db.getAnonymousUserId(),
-        allow_upload: adminLocked ? 0 : 1,
-        allow_mkdir: adminLocked ? 0 : 1,
-        allow_file_modify: adminLocked ? 0 : 1,
-        // Mirrors the other permission flags: when the admin API is
-        // locked, the single implicit user is demoted and loses the
-        // write permissions AND server-audio access. When unlocked,
-        // they're effectively admin, so the gate is bypassed anyway —
-        // the value here only matters in the locked case.
-        allow_server_audio: adminLocked ? 0 : 1
-      };
+    if (db.getAllUsers().length === 0) {
+      req.user = buildPublicModeUser();
       return next();
     }
 
@@ -107,58 +72,15 @@ export function setup(mstream) {
     if (!token) { throw new WebError('Authentication Error', 401); }
     req.token = token;
 
-    // jwt.verify throws on a token we can't trust (malformed, bad signature,
-    // expired). That's a 401, not an unhandled error that falls through to a
-    // generic 500. Log the cause — an invalid token at the auth wall is a
-    // probing signal.
-    let decoded;
-    try {
-      decoded = jwt.verify(token, config.program.secret);
-    } catch (err) {
-      winston.warn(`Rejected invalid token from ${req.ip} on ${req.path}: ${err.message}`);
-      throw new WebError('Authentication Error', 401);
-    }
+    const decoded = verifyToken(token, req);
 
     // Handle jukebox tokens
     if (decoded.jukebox === true && decoded.username) {
-      // Verify the token belongs to an active jukebox session
-      if (!isActiveJukeboxToken(token)) {
-        throw new WebError('Jukebox session expired', 401);
-      }
-
-      const user = db.getUserByUsername(decoded.username);
-      if (!user) { throw new WebError('Authentication Error', 401); }
-      const libIds = db.getUserLibraryIds(user);
-      const libraries = db.getAllLibraries().filter(l => libIds.includes(l.id));
-      req.user = {
-        ...user,
-        vpaths: libraries.map(l => l.name),
-        admin: false,
-        allow_upload: 0,
-        allow_mkdir: 0,
-        allow_file_modify: 0,
-        allow_server_audio: 0
-      };
+      req.user = buildJukeboxUser(decoded, token);
       return next();
     }
 
-    if (!decoded.username) {
-      throw new WebError('Authentication Error', 401);
-    }
-
-    const user = db.getUserByUsername(decoded.username);
-    if (!user) {
-      throw new WebError('Authentication Error', 401);
-    }
-
-    // Build user object with vpaths
-    const libIds = db.getUserLibraryIds(user);
-    const libraries = db.getAllLibraries().filter(l => libIds.includes(l.id));
-    req.user = {
-      ...user,
-      vpaths: libraries.map(l => l.name),
-      admin: user.is_admin === 1
-    };
+    req.user = buildRealUser(decoded);
 
     // Handle Shared Tokens
     if (decoded.shareToken && decoded.shareToken === true) {
@@ -178,4 +100,133 @@ export function setup(mstream) {
 
     next();
   });
+}
+
+// ── User builders ───────────────────────────────────────────────────────────
+// Shared by the wall above and resolveOptionalUser below — ONE source of
+// truth for what each credential kind resolves to. Behavior here is the
+// wall's original inline logic, moved verbatim.
+
+// The public-access-mode user (no real users in the DB).
+function buildPublicModeUser() {
+  const allLibs = db.getAllLibraries();
+  const adminLocked = config.program.lockAdmin === true;
+  // Spread the sentinel's actual users-table row first so per-user
+  // columns (lastfm_user, lastfm_password, listenbrainz_token, …)
+  // are present on req.user exactly the way they are for real-user
+  // requests. Endpoints that read those columns off req.user
+  // (scrobbler.js, velvet-stubs.js /lastfm/status, etc.) then work
+  // in public mode without per-endpoint DB lookups. Permission
+  // flags below override whatever the sentinel row stored — the
+  // sentinel's own allow_* defaults are 0 (see ensureAnonymousUser),
+  // and we want them driven by adminLocked instead.
+  const sentinel = db.getAnonymousUser() || {};
+  return {
+    ...sentinel,
+    vpaths: allLibs.map(l => l.name),
+    username: 'mstream-user',
+    admin: !adminLocked,
+    // Pin to the always-present anonymous sentinel row in the
+    // users table. Per-user tables (user_metadata, playlists,
+    // cue_points, …) all FK on users(id) NOT NULL, so a null id
+    // here meant every write endpoint crashed in public mode.
+    // The sentinel is filtered out of getAllUsers() so the
+    // empty-check still means "no real users".
+    id: db.getAnonymousUserId(),
+    allow_upload: adminLocked ? 0 : 1,
+    allow_mkdir: adminLocked ? 0 : 1,
+    allow_file_modify: adminLocked ? 0 : 1,
+    // Mirrors the other permission flags: when the admin API is
+    // locked, the single implicit user is demoted and loses the
+    // write permissions AND server-audio access. When unlocked,
+    // they're effectively admin, so the gate is bypassed anyway —
+    // the value here only matters in the locked case.
+    allow_server_audio: adminLocked ? 0 : 1
+  };
+}
+
+// jwt.verify throws on a token we can't trust (malformed, bad signature,
+// expired). That's a 401, not an unhandled error that falls through to a
+// generic 500. Log the cause — an invalid token at the auth wall is a
+// probing signal.
+function verifyToken(token, req) {
+  try {
+    return jwt.verify(token, config.program.secret);
+  } catch (err) {
+    winston.warn(`Rejected invalid token from ${req.ip} on ${req.path}: ${err.message}`);
+    throw new WebError('Authentication Error', 401);
+  }
+}
+
+// A jukebox session's restricted user: real user's libraries, no writes,
+// never admin. Verifies the token belongs to an ACTIVE jukebox session.
+function buildJukeboxUser(decoded, token) {
+  if (!isActiveJukeboxToken(token)) {
+    throw new WebError('Jukebox session expired', 401);
+  }
+  const user = db.getUserByUsername(decoded.username);
+  if (!user) { throw new WebError('Authentication Error', 401); }
+  const libIds = db.getUserLibraryIds(user);
+  const libraries = db.getAllLibraries().filter(l => libIds.includes(l.id));
+  return {
+    ...user,
+    vpaths: libraries.map(l => l.name),
+    admin: false,
+    allow_upload: 0,
+    allow_mkdir: 0,
+    allow_file_modify: 0,
+    allow_server_audio: 0
+  };
+}
+
+// A real user token → user object with vpaths.
+function buildRealUser(decoded) {
+  if (!decoded.username) {
+    throw new WebError('Authentication Error', 401);
+  }
+  const user = db.getUserByUsername(decoded.username);
+  if (!user) {
+    throw new WebError('Authentication Error', 401);
+  }
+  const libIds = db.getUserLibraryIds(user);
+  const libraries = db.getAllLibraries().filter(l => libIds.includes(l.id));
+  return {
+    ...user,
+    vpaths: libraries.map(l => l.name),
+    admin: user.is_admin === 1
+  };
+}
+
+// ── Optional-auth resolution ────────────────────────────────────────────────
+// For routes mounted BEFORE the wall whose bottom layer is public (the
+// layered GET /api/ in server-info.js). Same branch ORDER as the wall —
+// federation first is load-bearing for exactly the reason documented there.
+//
+// Contract:
+//   - no credentials at all → null (caller serves its public layer);
+//   - share token → null (they exist to fetch one playlist, not to
+//     identify a session; the wall path-gates them, this endpoint just
+//     treats them as anonymous);
+//   - presented-but-invalid token/key → throws the same 401 the wall
+//     throws (403 for a federation key off its allowlist). A bad
+//     credential must surface as an error, never silently downgrade to
+//     the public layer — a client with an expired token needs the 401
+//     to know to re-authenticate.
+export function resolveOptionalUser(req) {
+  const fedKey = req.headers['x-federation-key'];
+  if (typeof fedKey === 'string' && fedKey.length > 0) {
+    return federationAuth.authenticateFederationKey(fedKey, req);
+  }
+
+  if (db.getAllUsers().length === 0) { return buildPublicModeUser(); }
+
+  const token = req.body?.token || req.query?.token || req.headers?.['x-access-token'] || req.cookies?.['x-access-token'];
+  if (!token) { return null; }
+
+  const decoded = verifyToken(token, req);
+  if (decoded.jukebox === true && decoded.username) {
+    return buildJukeboxUser(decoded, token);
+  }
+  if (decoded.shareToken === true) { return null; }
+  return buildRealUser(decoded);
 }

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -68,7 +68,7 @@ export function setup(mstream) {
       return next();
     }
 
-    const token = req.body?.token || req.query?.token || req.headers?.['x-access-token'] || req.cookies?.['x-access-token'];
+    const token = readToken(req);
     if (!token) { throw new WebError('Authentication Error', 401); }
     req.token = token;
 
@@ -100,6 +100,14 @@ export function setup(mstream) {
 
     next();
   });
+}
+
+// The token slots, in precedence order. ONE definition — the wall,
+// resolveOptionalUser, and credentialsPresented must always agree on
+// where a token can ride, or "present but invalid" and "absent" drift
+// apart between the wall and the optional-auth endpoint.
+function readToken(req) {
+  return req.body?.token || req.query?.token || req.headers?.['x-access-token'] || req.cookies?.['x-access-token'];
 }
 
 // ── User builders ───────────────────────────────────────────────────────────
@@ -220,7 +228,7 @@ export function resolveOptionalUser(req) {
 
   if (db.getAllUsers().length === 0) { return buildPublicModeUser(); }
 
-  const token = req.body?.token || req.query?.token || req.headers?.['x-access-token'] || req.cookies?.['x-access-token'];
+  const token = readToken(req);
   if (!token) { return null; }
 
   const decoded = verifyToken(token, req);
@@ -229,4 +237,16 @@ export function resolveOptionalUser(req) {
   }
   if (decoded.shareToken === true) { return null; }
   return buildRealUser(decoded);
+}
+
+// Whether the request PRESENTED any credential (a federation key or a
+// token in any slot), regardless of validity or what it resolves to.
+// The layered /api/ uses this for its "the version is the anonymous
+// probe's payload" rule: `server` appears only when this is false. Note
+// the deliberate asymmetry with resolveOptionalUser: a share token
+// resolves to null (anonymous data-wise) but still counts as presented.
+export function credentialsPresented(req) {
+  const fedKey = req.headers['x-federation-key'];
+  if (typeof fedKey === 'string' && fedKey.length > 0) { return true; }
+  return Boolean(readToken(req));
 }

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -36,6 +36,13 @@ import * as fedDb from '../db/federation.js';
 // (per-user stats — meaningless and privacy-adjacent for a foreign
 // reader) and every write route.
 const ALLOWED_EXACT = new Set([
+  // The layered server-info endpoint (server-info.js): version +
+  // capabilities, plus the key-scoped `user` boot payload — how a
+  // federated client (the mobile app) learns what this peer can do.
+  // Both spellings: it's mounted before the wall and resolves the key
+  // itself, so req.path arrives exactly as the client sent it.
+  'GET /api',
+  'GET /api/',
   'GET /api/v1/db/status',
   'POST /api/v1/db/metadata',
   'POST /api/v1/db/metadata/batch',

--- a/src/api/playlist.js
+++ b/src/api/playlist.js
@@ -1,8 +1,6 @@
 import Joi from 'joi';
-import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
-import * as fedDb from '../db/federation.js';
-import * as transcode from './transcode.js';
+import { buildClientBootPayload } from './server-info.js';
 import { joiValidate, resolveId } from '../util/validation.js';
 import WebError from '../util/web-error.js';
 
@@ -10,61 +8,21 @@ export function setup(mstream) {
   const d = () => db.getDB();
 
   // ── Ping (initial app load) ─────────────────────────────────────────────
+  //
+  // DEPRECATED in favor of the layered GET /api/ (server-info.js), which
+  // nests this same payload under `user` for authenticated callers. Kept
+  // indefinitely: older mobile clients, CI liveness probes, and the
+  // torrent/velvet webapps still boot off it. The payload itself lives in
+  // buildClientBootPayload — ONE builder for both routes, so the two can
+  // never drift — with `playlists` composed back on top here only (the
+  // frozen ping contract carries them; the layered endpoint deliberately
+  // does not).
 
   mstream.get('/api/v1/ping', (req, res) => {
-    // Signal "transcoding available" only when ffmpeg actually resolved
-    // (bundled binaries ready OR system-PATH fallback succeeded).
-    let transcodeInfo = false;
-    if (transcode.isDownloaded() && config.program.transcode) {
-      transcodeInfo = {
-        defaultCodec: config.program.transcode.defaultCodec,
-        defaultBitrate: config.program.transcode.defaultBitrate
-      };
-    }
-
-    // Get user's library names
-    const vpaths = req.user.vpaths || [];
-
-    const returnThis = {
-      vpaths,
+    res.json({
+      ...buildClientBootPayload(req.user),
       playlists: getPlaylists(req.user.id),
-      transcode: transcodeInfo,
-      noMkdir: config.program.noMkdir || req.user.allow_mkdir === false || req.user.allow_mkdir === 0,
-      noUpload: config.program.noUpload || req.user.allow_upload === false || req.user.allow_upload === 0,
-      noFileModify: config.program.noFileModify || req.user.allow_file_modify === false || req.user.allow_file_modify === 0,
-      // VELVET ONLY: redundant with noUpload — update Velvet UI to use noUpload instead, then remove this
-      allowYoutubeDownload: !(config.program.noUpload || req.user.allow_upload === false || req.user.allow_upload === 0),
-      supportedAudioFiles: config.program.supportedAudioFiles,
-      // Lets the webapp know the Discover panel has a server to talk to
-      // without probing /api/v1/discovery/* (kept collapsed by default, the
-      // panel sends no discovery requests at all until expanded).
-      discovery: config.program.scanOptions.collectDiscoveryData === true,
-      // Sonic path (POST /api/v1/discovery/local/path). Same condition as
-      // `discovery` — the flag's real payload is "this server VERSION has
-      // the route": older builds omit the key entirely, so clients that
-      // never probe (the house rule) simply don't show the feature.
-      discoveryPath: config.program.scanOptions.collectDiscoveryData === true,
-      // Same contract for the panel's "From the network" section
-      // (/api/v1/discovery/p2p/*): no flag, no probes.
-      discoveryP2p: config.program.discoveryP2p.enabled === true,
-      // And again for "From your peers" (/api/v1/discovery/federation/*):
-      // needs local embeddings (the seed vector comes from our discovery.db)
-      // plus at least one federated peer that hasn't opted out of discovery.
-      federationDiscovery: config.program.federation.enabled === true
-        && config.program.scanOptions.collectDiscoveryData === true
-        && fedDb.getFederationPeers().some((p) => p.use_discovery === 1),
-      vpathMetaData: {}
-    };
-
-    // Get library type metadata
-    for (const vpathName of vpaths) {
-      const lib = db.getLibraryByName(vpathName);
-      if (lib) {
-        returnThis.vpathMetaData[vpathName] = { type: lib.type };
-      }
-    }
-
-    res.json(returnThis);
+    });
   });
 
   // ── Delete playlist ─────────────────────────────────────────────────────

--- a/src/api/playlist.js
+++ b/src/api/playlist.js
@@ -14,14 +14,23 @@ export function setup(mstream) {
   // indefinitely: older mobile clients, CI liveness probes, and the
   // torrent/velvet webapps still boot off it. The payload itself lives in
   // buildClientBootPayload — ONE builder for both routes, so the two can
-  // never drift — with `playlists` composed back on top here only (the
-  // frozen ping contract carries them; the layered endpoint deliberately
-  // does not).
+  // never drift — plus three legacy fields the frozen ping contract
+  // carries but the layered endpoint deliberately does not. Both extras
+  // derive from the builder's own output, so no logic is duplicated.
 
   mstream.get('/api/v1/ping', (req, res) => {
+    const boot = buildClientBootPayload(req.user);
     res.json({
-      ...buildClientBootPayload(req.user),
+      ...boot,
+      // A resource (the playlist routes), not a server capability.
       playlists: getPlaylists(req.user.id),
+      // VELVET ONLY: velvet's ping consumer still reads it; leaves with velvet.
+      allowYoutubeDownload: !boot.noUpload,
+      // Historical version-gate ("this server has the sonic-path route") —
+      // identical to `discovery` on every build carrying this code. The
+      // alpha webapp (until it migrates to /api/) and the Flutter app
+      // still read it from ping.
+      discoveryPath: boot.discovery,
     });
   });
 

--- a/src/api/playlist.js
+++ b/src/api/playlist.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import * as db from '../db/manager.js';
-import { buildClientBootPayload } from './server-info.js';
+import { buildClientBootPayload, buildFeatures } from './server-info.js';
 import { joiValidate, resolveId } from '../util/validation.js';
 import WebError from '../util/web-error.js';
 
@@ -9,19 +9,25 @@ export function setup(mstream) {
 
   // ── Ping (initial app load) ─────────────────────────────────────────────
   //
-  // DEPRECATED in favor of the layered GET /api/ (server-info.js), which
-  // nests this same payload under `user` for authenticated callers. Kept
+  // DEPRECATED in favor of the layered GET /api/ (server-info.js). Kept
   // indefinitely: older mobile clients, CI liveness probes, and the
-  // torrent/velvet webapps still boot off it. The payload itself lives in
-  // buildClientBootPayload — ONE builder for both routes, so the two can
-  // never drift — plus three legacy fields the frozen ping contract
-  // carries but the layered endpoint deliberately does not. Both extras
-  // derive from the builder's own output, so no logic is duplicated.
+  // torrent/velvet webapps still boot off it. Ping's FROZEN flat contract
+  // is composed from the same two builders /api/ uses — the caller-scoped
+  // half (buildClientBootPayload → /api/'s `user`) and the server-wide
+  // capabilities (buildFeatures → /api/'s public `features`) — plus three
+  // legacy fields only ping carries. One source of truth, zero drift.
 
   mstream.get('/api/v1/ping', (req, res) => {
     const boot = buildClientBootPayload(req.user);
+    const features = buildFeatures();
     res.json({
       ...boot,
+      // Server-wide capabilities: flat here, under `features` on /api/.
+      // (features.discoveryReady is /api/-only — ping never served it.)
+      transcode: features.transcode,
+      supportedAudioFiles: features.supportedAudioFiles,
+      discovery: features.discovery,
+      discoveryP2p: features.discoveryP2p,
       // A resource (the playlist routes), not a server capability.
       playlists: getPlaylists(req.user.id),
       // VELVET ONLY: velvet's ping consumer still reads it; leaves with velvet.
@@ -30,7 +36,7 @@ export function setup(mstream) {
       // identical to `discovery` on every build carrying this code. The
       // alpha webapp (until it migrates to /api/) and the Flutter app
       // still read it from ping.
-      discoveryPath: boot.discovery,
+      discoveryPath: features.discovery,
     });
   });
 

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -157,10 +157,14 @@ export function setup(mstream) {
       ...buildClientBootPayload(user),
     };
 
-    // ── Layer 3: admin only ────────────────────────────────────────────
-    // user.admin is false by construction for federation keys, jukebox
-    // sessions, and the lockAdmin public-mode user, so gating on the flag
-    // alone is sufficient. Cheap support/debug facts; grows as needed.
+    // ── Layer 3: admin only, and only while the admin API is usable ────
+    // user.admin is false by construction for federation keys and jukebox
+    // sessions. lockAdmin gates the layer EXPLICITLY: a real is_admin
+    // account keeps user.admin=true under the lock (an identity fact),
+    // but with the admin API refusing everything there are no admin
+    // params to serve — the layer's ABSENCE alongside user.admin=true is
+    // how a client tells "locked" from "not an admin". (The public-mode
+    // user is already demoted to admin=false under the lock.)
     //
     // DELIBERATE: in public-access mode (no users, lockAdmin off) this
     // layer is visible to anonymous callers — public mode IS admin
@@ -168,13 +172,12 @@ export function setup(mstream) {
     // and /api/ pretending otherwise would be the one inconsistent route.
     // Operators who expose a no-users server and want this hidden have
     // the same lever as for everything else: lockAdmin.
-    if (user.admin === true) {
+    if (user.admin === true && config.program.lockAdmin !== true) {
       info.admin = {
         uptime: Math.floor(process.uptime()),
         nodeVersion: process.version,
         platform: process.platform,
         dbSchemaVersion: db.getDB().prepare('PRAGMA user_version').get().user_version,
-        lockAdmin: config.program.lockAdmin === true,
       };
     }
 

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -1,0 +1,166 @@
+// GET /api/ — the layered server-info endpoint.
+//
+// One endpoint, three layers, built ADDITIVELY (base → +user → +admin).
+// Never build this response by filtering a full object down: an additive
+// bug omits a field, a filtering bug discloses everything.
+//
+//   Layer 1 (always, no credentials):
+//     { server, apiVersions, features } — version + capability booleans
+//     only. This layer is deliberately public (mobile clients need a
+//     pre-auth "is this an mStream server, which version" probe when
+//     adding a server) and must stay allocation-cheap: config reads and
+//     the guarded one-row discovery probe, nothing an anonymous caller
+//     can use to make the server do work.
+//
+//   Layer 2 (valid JWT, public-access mode, jukebox session, or a
+//   federation key): adds `user` — identity plus the client boot payload
+//   that /api/v1/ping has always served (vpaths, transcode, permission
+//   flags, discovery flags, vpathMetaData), scoped to the caller exactly
+//   as ping scopes it. Playlists are deliberately NOT here — they're a
+//   resource (the playlist routes), not a capability.
+//
+//   Layer 3 (admin only — never federation, never jukebox): adds `admin`
+//   — cheap support/debug facts. Mostly a framework hook today.
+//
+// Auth contract: a request with NO credentials gets layer 1; a request
+// with PRESENT-but-invalid credentials gets 401 (403 for a federation key
+// off its allowlist) — a bad token is an error the client must see, never
+// a silent downgrade to the public layer (a webapp with an expired cookie
+// needs the 401 to know to re-login). Share tokens get layer 1 only.
+//
+// Mounted BEFORE the auth wall (see server.js) so it owns its auth via
+// resolveOptionalUser(); /api/v1/ping stays behind the wall unchanged and
+// is now a thin wrapper over buildClientBootPayload() below — one payload
+// builder, zero drift between the two routes. Ping is deprecated in favor
+// of this endpoint but kept indefinitely: older mobile clients, CI
+// liveness probes, and the torrent/velvet webapps still call it.
+
+import packageJson from '../../package.json' with { type: 'json' };
+import * as config from '../state/config.js';
+import * as db from '../db/manager.js';
+import * as fedDb from '../db/federation.js';
+import * as sim from '../db/discovery-similarity.js';
+import * as transcode from './transcode.js';
+import * as authApi from './auth.js';
+
+// The client boot payload — the object /api/v1/ping has always returned,
+// minus `playlists` (moved here otherwise verbatim). Ping composes
+// playlists back on top to keep its frozen contract; the layered /api/
+// deliberately does NOT serve them — playlist content is its own
+// resource (the playlist routes), not a server capability. Field changes
+// here reach BOTH routes — that is the point.
+export function buildClientBootPayload(user) {
+  // Signal "transcoding available" only when ffmpeg actually resolved
+  // (bundled binaries ready OR system-PATH fallback succeeded).
+  let transcodeInfo = false;
+  if (transcode.isDownloaded() && config.program.transcode) {
+    transcodeInfo = {
+      defaultCodec: config.program.transcode.defaultCodec,
+      defaultBitrate: config.program.transcode.defaultBitrate
+    };
+  }
+
+  // Get user's library names
+  const vpaths = user.vpaths || [];
+
+  const payload = {
+    vpaths,
+    transcode: transcodeInfo,
+    noMkdir: config.program.noMkdir || user.allow_mkdir === false || user.allow_mkdir === 0,
+    noUpload: config.program.noUpload || user.allow_upload === false || user.allow_upload === 0,
+    noFileModify: config.program.noFileModify || user.allow_file_modify === false || user.allow_file_modify === 0,
+    // VELVET ONLY: redundant with noUpload — update Velvet UI to use noUpload instead, then remove this
+    allowYoutubeDownload: !(config.program.noUpload || user.allow_upload === false || user.allow_upload === 0),
+    supportedAudioFiles: config.program.supportedAudioFiles,
+    // Lets the webapp know the Discover panel has a server to talk to
+    // without probing /api/v1/discovery/* (kept collapsed by default, the
+    // panel sends no discovery requests at all until expanded).
+    discovery: config.program.scanOptions.collectDiscoveryData === true,
+    // Sonic path (POST /api/v1/discovery/local/path). Same condition as
+    // `discovery` — the flag's real payload is "this server VERSION has
+    // the route": older builds omit the key entirely, so clients that
+    // never probe (the house rule) simply don't show the feature.
+    discoveryPath: config.program.scanOptions.collectDiscoveryData === true,
+    // Same contract for the panel's "From the network" section
+    // (/api/v1/discovery/p2p/*): no flag, no probes.
+    discoveryP2p: config.program.discoveryP2p.enabled === true,
+    // And again for "From your peers" (/api/v1/discovery/federation/*):
+    // needs local embeddings (the seed vector comes from our discovery.db)
+    // plus at least one federated peer that hasn't opted out of discovery.
+    federationDiscovery: config.program.federation.enabled === true
+      && config.program.scanOptions.collectDiscoveryData === true
+      && fedDb.getFederationPeers().some((p) => p.use_discovery === 1),
+    vpathMetaData: {}
+  };
+
+  // Get library type metadata
+  for (const vpathName of vpaths) {
+    const lib = db.getLibraryByName(vpathName);
+    if (lib) {
+      payload.vpathMetaData[vpathName] = { type: lib.type };
+    }
+  }
+
+  return payload;
+}
+
+export function setup(mstream) {
+  mstream.get('/api/', (req, res) => {
+    // ── Layer 1: always ────────────────────────────────────────────────
+    const info = {
+      server: packageJson.version,
+      apiVersions: ["1"],
+      features: {
+        subsonic: config.program.subsonic.mode !== 'disabled',
+        // Whether a sonic-similarity query would find anything RIGHT NOW.
+        // Distinct from the boot payload's `discovery` flag, which says the
+        // feature is switched on: a server can have it on with an
+        // unfinished scan, and that combination is exactly what makes
+        // clients look broken. Auto DJ sends similarTo/minSimilarity,
+        // every pick 400s on the empty pool, and the queue silently stops
+        // advancing.
+        //
+        // A boolean, not a count: this layer is public, and how many
+        // tracks are analysed is library-size information. Clients only
+        // need to know whether to offer the feature.
+        discoveryReady: sim.hasEmbeddings(),
+      },
+    };
+
+    // Throws 401 on a presented-but-bad token/key (403 for a federation
+    // key off its allowlist); returns null for "no credentials at all".
+    const user = authApi.resolveOptionalUser(req);
+    if (!user) { return res.json(info); }
+
+    // ── Layer 2: any authenticated caller ──────────────────────────────
+    info.user = {
+      username: user.username,
+      admin: user.admin === true,
+      federation: user.federation === true,
+      ...buildClientBootPayload(user),
+    };
+
+    // ── Layer 3: admin only ────────────────────────────────────────────
+    // user.admin is false by construction for federation keys, jukebox
+    // sessions, and the lockAdmin public-mode user, so gating on the flag
+    // alone is sufficient. Cheap support/debug facts; grows as needed.
+    //
+    // DELIBERATE: in public-access mode (no users, lockAdmin off) this
+    // layer is visible to anonymous callers — public mode IS admin
+    // everywhere else on the server (the whole /admin surface is open),
+    // and /api/ pretending otherwise would be the one inconsistent route.
+    // Operators who expose a no-users server and want this hidden have
+    // the same lever as for everything else: lockAdmin.
+    if (user.admin === true) {
+      info.admin = {
+        uptime: Math.floor(process.uptime()),
+        nodeVersion: process.version,
+        platform: process.platform,
+        dbSchemaVersion: db.getDB().prepare('PRAGMA user_version').get().user_version,
+        lockAdmin: config.program.lockAdmin === true,
+      };
+    }
+
+    res.json(info);
+  });
+}

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -4,36 +4,44 @@
 // Never build this response by filtering a full object down: an additive
 // bug omits a field, a filtering bug discloses everything.
 //
-//   Layer 1 (always, no credentials):
-//     { server, apiVersions, features } — version + capability booleans
-//     only. This layer is deliberately public (mobile clients need a
-//     pre-auth "is this an mStream server, which version" probe when
-//     adding a server) and must stay allocation-cheap: config reads and
-//     the guarded one-row discovery probe, nothing an anonymous caller
-//     can use to make the server do work.
+//   Base (always): `apiVersions` + `features` — server-wide capability
+//     facts (see buildFeatures). `server` (the version) is included ONLY
+//     when the request carries no credentials at all: the anonymous
+//     probe surface ("is this an mStream server, which version") is the
+//     one place a client needs it, and an authenticated session doesn't
+//     re-learn its server's version on every call. This layer is
+//     deliberately public and must stay allocation-cheap: config reads
+//     and the guarded one-row discovery probe, nothing an anonymous
+//     caller can use to make the server do work. Rule for what may
+//     appear here: config/capability facts only — no counts, no
+//     library or content names, no identity.
 //
 //   Layer 2 (valid JWT, public-access mode, jukebox session, or a
-//   federation key): adds `user` — identity plus the client boot payload
-//   that /api/v1/ping has always served (vpaths, transcode, permission
-//   flags, discovery flags, vpathMetaData), scoped to the caller exactly
-//   as ping scopes it — minus ping's three legacy fields (playlists /
-//   allowYoutubeDownload / discoveryPath; see buildClientBootPayload).
+//   federation key): adds `user` — identity plus the CALLER-SCOPED boot
+//   payload (vpaths, permission flags, federationDiscovery,
+//   vpathMetaData). Server-wide capabilities live in `features`, not
+//   here; ping's frozen contract still carries both halves flat (see
+//   buildClientBootPayload).
 //
 //   Layer 3 (admin only — never federation, never jukebox): adds `admin`
 //   — cheap support/debug facts. Mostly a framework hook today.
 //
-// Auth contract: a request with NO credentials gets layer 1; a request
-// with PRESENT-but-invalid credentials gets 401 (403 for a federation key
-// off its allowlist) — a bad token is an error the client must see, never
-// a silent downgrade to the public layer (a webapp with an expired cookie
-// needs the 401 to know to re-login). Share tokens get layer 1 only.
+// Auth contract: a request with NO credentials gets the base (with
+// `server`); a request with PRESENT-but-invalid credentials gets 401
+// (403 for a federation key off its allowlist) — a bad token is an error
+// the client must see, never a silent downgrade to the public layer (a
+// webapp with an expired cookie needs the 401 to know to re-login).
+// Share tokens get the base layer, without `server` (they are presented
+// credentials, just not a session). A federated client that wants the
+// version probes WITHOUT its key header — the anonymous base — and sends
+// the key when it wants its scoped view.
 //
 // Mounted BEFORE the auth wall (see server.js) so it owns its auth via
 // resolveOptionalUser(); /api/v1/ping stays behind the wall unchanged and
-// is now a thin wrapper over buildClientBootPayload() below — one payload
-// builder, zero drift between the two routes. Ping is deprecated in favor
-// of this endpoint but kept indefinitely: older mobile clients, CI
-// liveness probes, and the torrent/velvet webapps still call it.
+// composes its frozen flat payload from the two builders below — one
+// source of truth, zero drift between the two routes. Ping is deprecated
+// in favor of this endpoint but kept indefinitely: older mobile clients,
+// CI liveness probes, and the torrent/velvet webapps still call it.
 
 import packageJson from '../../package.json' with { type: 'json' };
 import * as config from '../state/config.js';
@@ -43,18 +51,10 @@ import * as sim from '../db/discovery-similarity.js';
 import * as transcode from './transcode.js';
 import * as authApi from './auth.js';
 
-// The client boot payload — the object /api/v1/ping has always returned,
-// minus three legacy fields ping composes back on top of this to keep
-// its frozen contract (moved here otherwise verbatim):
-//   - `playlists`            — a resource (the playlist routes), not a
-//                              server capability;
-//   - `allowYoutubeDownload` — velvet-only and always === !noUpload;
-//   - `discoveryPath`        — a historical "this server VERSION has the
-//                              sonic-path route" gate, always ===
-//                              `discovery` on any build carrying this
-//                              code, so on /api/ it says nothing.
-// Field changes here reach BOTH routes — that is the point.
-export function buildClientBootPayload(user) {
+// Server-wide capability facts — the public `features` object. Everything
+// here is a config/capability fact safe for anonymous eyes (the public
+// rule above); nothing is caller-scoped.
+export function buildFeatures() {
   // Signal "transcoding available" only when ffmpeg actually resolved
   // (bundled binaries ready OR system-PATH fallback succeeded).
   let transcodeInfo = false;
@@ -65,26 +65,57 @@ export function buildClientBootPayload(user) {
     };
   }
 
+  return {
+    // Whether a sonic-similarity query would find anything RIGHT NOW.
+    // Distinct from `discovery`, which says the feature is switched on: a
+    // server can have it on with an unfinished scan, and that combination
+    // is exactly what makes clients look broken. Auto DJ sends
+    // similarTo/minSimilarity, every pick 400s on the empty pool, and the
+    // queue silently stops advancing.
+    //
+    // A boolean, not a count: this layer is public, and how many tracks
+    // are analysed is library-size information. Clients only need to know
+    // whether to offer the feature.
+    discoveryReady: sim.hasEmbeddings(),
+    // The Discover panel has a server to talk to (no /api/v1/discovery/*
+    // probes needed — flags, never probes, is the house rule).
+    discovery: config.program.scanOptions.collectDiscoveryData === true,
+    // Same contract for the panel's "From the network" section
+    // (/api/v1/discovery/p2p/*).
+    discoveryP2p: config.program.discoveryP2p.enabled === true,
+    // false, or the server's transcode defaults.
+    transcode: transcodeInfo,
+    // Per-format booleans from config.
+    supportedAudioFiles: config.program.supportedAudioFiles,
+  };
+}
+
+// The CALLER-SCOPED half of the old ping payload: what this user (or
+// federation key, or public-mode caller) may see and do. Server-wide
+// capabilities moved to buildFeatures(); ping composes both halves (plus
+// its legacy fields) back into its frozen flat shape:
+//   - `playlists`            — a resource (the playlist routes), not a
+//                              server capability;
+//   - `allowYoutubeDownload` — velvet-only and always === !noUpload;
+//   - `discoveryPath`        — a historical "this server VERSION has the
+//                              sonic-path route" gate, always ===
+//                              `discovery` on any build carrying this
+//                              code, so on /api/ it says nothing.
+// Field changes in these builders reach BOTH routes — that is the point.
+export function buildClientBootPayload(user) {
   // Get user's library names
   const vpaths = user.vpaths || [];
 
   const payload = {
     vpaths,
-    transcode: transcodeInfo,
     noMkdir: config.program.noMkdir || user.allow_mkdir === false || user.allow_mkdir === 0,
     noUpload: config.program.noUpload || user.allow_upload === false || user.allow_upload === 0,
     noFileModify: config.program.noFileModify || user.allow_file_modify === false || user.allow_file_modify === 0,
-    supportedAudioFiles: config.program.supportedAudioFiles,
-    // Lets the webapp know the Discover panel has a server to talk to
-    // without probing /api/v1/discovery/* (kept collapsed by default, the
-    // panel sends no discovery requests at all until expanded).
-    discovery: config.program.scanOptions.collectDiscoveryData === true,
-    // Same contract for the panel's "From the network" section
-    // (/api/v1/discovery/p2p/*): no flag, no probes.
-    discoveryP2p: config.program.discoveryP2p.enabled === true,
-    // And again for "From your peers" (/api/v1/discovery/federation/*):
-    // needs local embeddings (the seed vector comes from our discovery.db)
-    // plus at least one federated peer that hasn't opted out of discovery.
+    // "From your peers" in the Discover panel: needs local embeddings (the
+    // seed vector comes from our discovery.db) plus at least one federated
+    // peer that hasn't opted out of discovery. Caller-scoped by nature —
+    // it reflects this server's live peer RELATIONSHIPS, which is not a
+    // fact for the anonymous features object.
     federationDiscovery: config.program.federation.enabled === true
       && config.program.scanOptions.collectDiscoveryData === true
       && fedDb.getFederationPeers().some((p) => p.use_discovery === 1),
@@ -104,30 +135,18 @@ export function buildClientBootPayload(user) {
 
 export function setup(mstream) {
   mstream.get('/api/', (req, res) => {
-    // ── Layer 1: always ────────────────────────────────────────────────
-    const info = {
-      server: packageJson.version,
-      apiVersions: ["1"],
-      features: {
-        subsonic: config.program.subsonic.mode !== 'disabled',
-        // Whether a sonic-similarity query would find anything RIGHT NOW.
-        // Distinct from the boot payload's `discovery` flag, which says the
-        // feature is switched on: a server can have it on with an
-        // unfinished scan, and that combination is exactly what makes
-        // clients look broken. Auto DJ sends similarTo/minSimilarity,
-        // every pick 400s on the empty pool, and the queue silently stops
-        // advancing.
-        //
-        // A boolean, not a count: this layer is public, and how many
-        // tracks are analysed is library-size information. Clients only
-        // need to know whether to offer the feature.
-        discoveryReady: sim.hasEmbeddings(),
-      },
-    };
-
     // Throws 401 on a presented-but-bad token/key (403 for a federation
-    // key off its allowlist); returns null for "no credentials at all".
+    // key off its allowlist); returns null for "no credentials at all"
+    // and for share tokens.
     const user = authApi.resolveOptionalUser(req);
+
+    // ── Base layer: always ─────────────────────────────────────────────
+    const info = {
+      // The version is the anonymous probe's payload — see the header.
+      ...(authApi.credentialsPresented(req) ? {} : { server: packageJson.version }),
+      apiVersions: ["1"],
+      features: buildFeatures(),
+    };
     if (!user) { return res.json(info); }
 
     // ── Layer 2: any authenticated caller ──────────────────────────────

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -16,8 +16,8 @@
 //   federation key): adds `user` — identity plus the client boot payload
 //   that /api/v1/ping has always served (vpaths, transcode, permission
 //   flags, discovery flags, vpathMetaData), scoped to the caller exactly
-//   as ping scopes it. Playlists are deliberately NOT here — they're a
-//   resource (the playlist routes), not a capability.
+//   as ping scopes it — minus ping's three legacy fields (playlists /
+//   allowYoutubeDownload / discoveryPath; see buildClientBootPayload).
 //
 //   Layer 3 (admin only — never federation, never jukebox): adds `admin`
 //   — cheap support/debug facts. Mostly a framework hook today.
@@ -44,11 +44,16 @@ import * as transcode from './transcode.js';
 import * as authApi from './auth.js';
 
 // The client boot payload — the object /api/v1/ping has always returned,
-// minus `playlists` (moved here otherwise verbatim). Ping composes
-// playlists back on top to keep its frozen contract; the layered /api/
-// deliberately does NOT serve them — playlist content is its own
-// resource (the playlist routes), not a server capability. Field changes
-// here reach BOTH routes — that is the point.
+// minus three legacy fields ping composes back on top of this to keep
+// its frozen contract (moved here otherwise verbatim):
+//   - `playlists`            — a resource (the playlist routes), not a
+//                              server capability;
+//   - `allowYoutubeDownload` — velvet-only and always === !noUpload;
+//   - `discoveryPath`        — a historical "this server VERSION has the
+//                              sonic-path route" gate, always ===
+//                              `discovery` on any build carrying this
+//                              code, so on /api/ it says nothing.
+// Field changes here reach BOTH routes — that is the point.
 export function buildClientBootPayload(user) {
   // Signal "transcoding available" only when ffmpeg actually resolved
   // (bundled binaries ready OR system-PATH fallback succeeded).
@@ -69,18 +74,11 @@ export function buildClientBootPayload(user) {
     noMkdir: config.program.noMkdir || user.allow_mkdir === false || user.allow_mkdir === 0,
     noUpload: config.program.noUpload || user.allow_upload === false || user.allow_upload === 0,
     noFileModify: config.program.noFileModify || user.allow_file_modify === false || user.allow_file_modify === 0,
-    // VELVET ONLY: redundant with noUpload — update Velvet UI to use noUpload instead, then remove this
-    allowYoutubeDownload: !(config.program.noUpload || user.allow_upload === false || user.allow_upload === 0),
     supportedAudioFiles: config.program.supportedAudioFiles,
     // Lets the webapp know the Discover panel has a server to talk to
     // without probing /api/v1/discovery/* (kept collapsed by default, the
     // panel sends no discovery requests at all until expanded).
     discovery: config.program.scanOptions.collectDiscoveryData === true,
-    // Sonic path (POST /api/v1/discovery/local/path). Same condition as
-    // `discovery` — the flag's real payload is "this server VERSION has
-    // the route": older builds omit the key entirely, so clients that
-    // never probe (the house rule) simply don't show the feature.
-    discoveryPath: config.program.scanOptions.collectDiscoveryData === true,
     // Same contract for the panel's "From the network" section
     // (/api/v1/discovery/p2p/*): no flag, no probes.
     discoveryP2p: config.program.discoveryP2p.enabled === true,

--- a/src/server.js
+++ b/src/server.js
@@ -35,7 +35,7 @@ import * as dbManager from './db/manager.js';
 import * as discoveryDb from './db/discovery-db.js';
 import { reapOrphanedScanner } from './db/scan-pidfile.js';
 // scanner.js removed — parser now writes directly to SQLite
-import * as sim from './db/discovery-similarity.js';
+import * as serverInfoApi from './api/server-info.js';
 import * as federationApi from './api/federation.js';
 import * as federationDiscoveryApi from './api/federation-discovery.js';
 import * as federationLimitsApi from './api/federation-limits.js';
@@ -66,7 +66,6 @@ import * as adminUtil from './util/admin.js';
 import * as updateCheck from './util/update-check.js';
 import * as bootWatchdog from './util/boot-watchdog.js';
 
-import packageJson from '../package.json' with { type: 'json' };
 
 let mstream;
 let server;
@@ -599,6 +598,13 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   // http.Server started in the post-boot hook below.
   if (config.program.subsonic.mode === 'same-port') { subsonicApi.setup(mstream); }
 
+  // GET /api/ — the layered server-info endpoint. Mounted BEFORE the wall
+  // because its bottom layer (version + capability booleans) is
+  // deliberately public; it resolves optional credentials itself via
+  // authApi.resolveOptionalUser (see api/server-info.js for the layer
+  // contract).
+  serverInfoApi.setup(mstream);
+
   // Everything below this line requires authentication
   authApi.setup(mstream);
 
@@ -683,30 +689,6 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     cuepointsApi.setup(mstream);
     velvetStubs.setup(mstream);
   }
-
-  // Versioned APIs. Includes a small `features` block for the frontend
-  // to gate UI on without an extra round-trip — currently just whether
-  // the Subsonic API surface is mounted (used by the mobile-clients
-  // panel to conditionally render the Subsonic password / API key UI).
-  // Public — no auth required for this endpoint.
-  mstream.get('/api/', (req, res) => res.json({
-    server: packageJson.version,
-    apiVersions: ["1"],
-    features: {
-      subsonic: config.program.subsonic.mode !== 'disabled',
-      // Whether a sonic-similarity query would find anything RIGHT NOW.
-      // Distinct from the ping's `discovery` flag, which says the feature is
-      // switched on: a server can have it on with an unfinished scan, and
-      // that combination is exactly what makes clients look broken. Auto DJ
-      // sends similarTo/minSimilarity, every pick 400s on the empty pool, and
-      // the queue silently stops advancing.
-      //
-      // A boolean, not a count: this endpoint is public, and how many tracks
-      // are analysed is library-size information. Clients only need to know
-      // whether to offer the feature.
-      discoveryReady: sim.hasEmbeddings(),
-    },
-  }));
 
   // album art folder
   mstream.get('/album-art/:file', albumArtApi.serveAlbumArtFile);

--- a/test/integration/api-server-info.test.mjs
+++ b/test/integration/api-server-info.test.mjs
@@ -10,7 +10,8 @@
  *  - present-but-invalid token     → 401 (an error, never a silent
  *    downgrade to the public layer);
  *  - plain user                    → base + `user` (the ping boot payload,
- *    minus playlists), no `admin`;
+ *    minus the legacy playlists / allowYoutubeDownload / discoveryPath
+ *    fields), no `admin`;
  *  - admin user                    → base + `user` + `admin`;
  *  - ping parity                   → /api/'s `user` object equals
  *    /api/v1/ping's body (minus playlists / identity fields) — the
@@ -97,6 +98,8 @@ describe('layered /api/ server info', () => {
     assert.equal(j.user.federation, false);
     assert.deepEqual(j.user.vpaths, ['testlib']);
     assert.ok(!('playlists' in j.user), 'playlists are a resource, not a capability');
+    assert.ok(!('allowYoutubeDownload' in j.user), 'velvet-only legacy field stays on ping');
+    assert.ok(!('discoveryPath' in j.user), 'redundant-with-discovery legacy field stays on ping');
     assert.equal(typeof j.user.noUpload, 'boolean');
     assert.equal(typeof j.user.noMkdir, 'boolean');
     assert.equal(typeof j.user.noFileModify, 'boolean');
@@ -138,8 +141,13 @@ describe('layered /api/ server info', () => {
     const ping = await pingR.json();
 
     const { username: _u, admin: _a, federation: _f, ...bootFromApi } = fromApi;
-    const { playlists, ...pingRest } = ping;
+    // Ping's frozen contract = the shared builder + three legacy fields.
+    const { playlists, allowYoutubeDownload, discoveryPath, ...pingRest } = ping;
     assert.ok(Array.isArray(playlists), 'ping still carries playlists');
+    assert.equal(allowYoutubeDownload, !ping.noUpload,
+      'ping still carries the velvet field, with its historical value');
+    assert.equal(discoveryPath, ping.discovery,
+      'ping still carries discoveryPath, identical to discovery as always');
     assert.deepEqual(bootFromApi, pingRest,
       'both routes serve the SAME builder output — any drift is a bug');
   });

--- a/test/integration/api-server-info.test.mjs
+++ b/test/integration/api-server-info.test.mjs
@@ -33,15 +33,50 @@
  *  - public mode (no users)        → user + admin layers, matching how
  *    public mode behaves everywhere else (deliberate — public mode IS
  *    admin on every other route; lockAdmin is the hardening lever);
- *  - public mode + lockAdmin       → demoted user layer, no admin layer.
+ *  - public mode + lockAdmin       → demoted user layer, no admin layer;
+ *  - REAL admin + lockAdmin        → user.admin stays true (identity),
+ *    but a locked admin API serves NO admin params — the layer's absence
+ *    beside user.admin=true is how a client tells "locked" from "not an
+ *    admin" (two boots on one data dir: the lock refuses the admin API,
+ *    so the account must predate it).
  */
 
 import { describe, test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import jwt from 'jsonwebtoken';
 import { startServer } from '../helpers/server.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.unref();
+    s.on('error', reject);
+    s.listen(0, '127.0.0.1', () => {
+      const { port } = s.address();
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+async function pollReady(base, getExitCode, timeoutMs = 90_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (getExitCode() !== null) { throw new Error(`server exited with code ${getExitCode()}`); }
+    try {
+      const r = await fetch(`${base}/api/`);
+      if (r.status < 500) { return; }
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`server never became ready within ${timeoutMs}ms`);
+}
 
 describe('layered /api/ server info', () => {
   let srv;
@@ -144,7 +179,6 @@ describe('layered /api/ server info', () => {
     assert.equal(typeof j.admin.platform, 'string');
     assert.ok(Number.isInteger(j.admin.dbSchemaVersion) && j.admin.dbSchemaVersion >= 67,
       'live PRAGMA user_version');
-    assert.equal(j.admin.lockAdmin, false);
   });
 
   test('drift-lock: ping === /api/ user half + features half (modulo legacy/identity)', async () => {
@@ -249,7 +283,6 @@ describe('layered /api/ in public-access mode', () => {
       assert.equal(j.user.admin, true, 'public mode is effectively admin');
       assert.equal(j.user.federation, false);
       assert.ok(j.admin, 'admin layer present in public mode');
-      assert.equal(j.admin.lockAdmin, false);
     } finally {
       await pub.stop();
     }
@@ -264,6 +297,53 @@ describe('layered /api/ in public-access mode', () => {
       assert.ok(!('admin' in j), 'no admin layer under lockAdmin');
     } finally {
       await locked.stop();
+    }
+  });
+
+  test('a REAL admin under lockAdmin: identity stays true, NO admin layer', { timeout: 180000 }, async () => {
+    // lockAdmin refuses the admin API, so the admin account must exist
+    // BEFORE the lock — the real-world shape: a running server gets
+    // locked and rebooted. Boot 1 creates the admin; boot 2 reuses the
+    // same data dir with the lock on.
+    const srv1 = await startServer({
+      waitForScan: false,
+      users: [{ username: 'boss', password: 'pw', admin: true }],
+    });
+    const { tmpDir } = srv1;
+    // Keep the data dir: kill the child directly (the helper's stop()
+    // would delete tmpDir).
+    srv1.proc.kill('SIGKILL');
+    await new Promise((r) => srv1.proc.once('exit', r));
+
+    const cfgPath = path.join(tmpDir, 'config.json');
+    const cfg = JSON.parse(await fs.readFile(cfgPath, 'utf8'));
+    cfg.lockAdmin = true;
+    // Fresh port — Windows can race re-binding a just-killed listener;
+    // the identity lives in the data dir, not the port.
+    cfg.port = await freePort();
+    await fs.writeFile(cfgPath, JSON.stringify(cfg, null, 2));
+
+    const proc2 = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', cfgPath],
+      { cwd: REPO_ROOT, stdio: 'ignore' });
+    const base = `http://127.0.0.1:${cfg.port}`;
+    try {
+      await pollReady(base, () => proc2.exitCode);
+      const loginR = await fetch(`${base}/api/v1/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'boss', password: 'pw' }),
+      });
+      assert.equal(loginR.status, 200, 'login still works under lockAdmin');
+      const { token } = await loginR.json();
+
+      const j = await (await fetch(`${base}/api/`, { headers: { 'x-access-token': token } })).json();
+      assert.equal(j.user.admin, true, 'the identity fact survives the lock');
+      assert.ok(!('admin' in j), 'a locked admin API serves no admin params');
+      assert.ok(j.user, 'the user layer itself is unaffected');
+    } finally {
+      try { proc2.kill('SIGKILL'); } catch { /* already gone */ }
+      await new Promise((r) => { if (proc2.exitCode !== null) { r(); } else { proc2.once('exit', r); } });
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   });
 });

--- a/test/integration/api-server-info.test.mjs
+++ b/test/integration/api-server-info.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * The layered GET /api/ endpoint (src/api/server-info.js) — the auth matrix.
+ *
+ * The endpoint sits BEFORE the auth wall and resolves credentials itself
+ * (authApi.resolveOptionalUser), so this suite pins the full contract
+ * against real spawned servers:
+ *
+ *  - users-server, no credentials  → 200, base layer ONLY (the deliberate
+ *    public surface: version + capability booleans, nothing else);
+ *  - present-but-invalid token     → 401 (an error, never a silent
+ *    downgrade to the public layer);
+ *  - plain user                    → base + `user` (the ping boot payload,
+ *    minus playlists), no `admin`;
+ *  - admin user                    → base + `user` + `admin`;
+ *  - ping parity                   → /api/'s `user` object equals
+ *    /api/v1/ping's body (minus playlists / identity fields) — the
+ *    drift-lock on the shared payload builder;
+ *  - share token                   → base only (shares fetch a playlist,
+ *    they are not a session);
+ *  - federation key                → base + `user` scoped to the key's
+ *    grants, `federation: true`, never `admin` — the mobile-app
+ *    "version and capabilities over federation" deliverable;
+ *  - federation allowlist          → /api/ allowed, but ping (and every
+ *    other unlisted route) still 403s — adding /api loosened nothing;
+ *  - bogus federation key          → 401;
+ *  - jukebox JWT, dead session     → 401 (correctly signed is not enough);
+ *  - disclosure pins               → users-table columns (password, salt,
+ *    scrobbler credentials, …) and the fed user's internal fields are
+ *    asserted ABSENT from the response by name;
+ *  - public mode (no users)        → user + admin layers, matching how
+ *    public mode behaves everywhere else (deliberate — public mode IS
+ *    admin on every other route; lockAdmin is the hardening lever);
+ *  - public mode + lockAdmin       → demoted user layer, no admin layer.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import jwt from 'jsonwebtoken';
+import { startServer } from '../helpers/server.mjs';
+
+describe('layered /api/ server info', () => {
+  let srv;
+  let adminToken, userToken;
+
+  const api = (headers = {}) => fetch(`${srv.baseUrl}/api/`, { headers });
+
+  before(async () => {
+    srv = await startServer({
+      users: [
+        { username: 'boss', password: 'pw', admin: true },
+        { username: 'pleb', password: 'pw', admin: false },
+      ],
+      // Federation ON so a minted key can authenticate at the HTTP wall.
+      extraConfig: { federation: { enabled: true } },
+    });
+    const login = async (username) => {
+      const r = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password: 'pw' }),
+      });
+      assert.equal(r.status, 200, `login for ${username}`);
+      return (await r.json()).token;
+    };
+    adminToken = await login('boss');
+    userToken = await login('pleb');
+  });
+
+  after(async () => { await srv?.stop(); });
+
+  test('no credentials on a users-server: the base layer ONLY', async () => {
+    const r = await api();
+    assert.equal(r.status, 200, 'the bottom layer is public');
+    const j = await r.json();
+    assert.equal(typeof j.server, 'string');
+    assert.match(j.server, /^\d+\.\d+\.\d+/);
+    assert.deepEqual(j.apiVersions, ['1']);
+    assert.equal(typeof j.features.subsonic, 'boolean');
+    assert.equal(j.features.discoveryReady, false, 'discovery off in this config');
+    assert.ok(!('user' in j), 'no user layer without credentials');
+    assert.ok(!('admin' in j), 'no admin layer without credentials');
+  });
+
+  test('a presented-but-invalid token is a 401, not a downgrade', async () => {
+    const r = await api({ 'x-access-token': 'not-a-jwt' });
+    assert.equal(r.status, 401);
+  });
+
+  test('plain user: base + user layer, no admin layer', async () => {
+    const r = await api({ 'x-access-token': userToken });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.user.username, 'pleb');
+    assert.equal(j.user.admin, false);
+    assert.equal(j.user.federation, false);
+    assert.deepEqual(j.user.vpaths, ['testlib']);
+    assert.ok(!('playlists' in j.user), 'playlists are a resource, not a capability');
+    assert.equal(typeof j.user.noUpload, 'boolean');
+    assert.equal(typeof j.user.noMkdir, 'boolean');
+    assert.equal(typeof j.user.noFileModify, 'boolean');
+    assert.ok('testlib' in j.user.vpathMetaData, 'library type metadata rides along');
+    assert.equal(j.user.discovery, false);
+    assert.ok(!('admin' in j), 'no admin layer for a non-admin');
+
+    // The disclosure contract: `user` is built ADDITIVELY from explicit
+    // fields — the resolved req.user internally spreads the full users-table
+    // row (password hash, salt, scrobbler credentials, …) and NONE of it may
+    // reach the response. The drift-lock test can't catch a leak introduced
+    // inside the shared builder (ping would leak identically), so pin the
+    // sensitive columns by name.
+    for (const secret of ['password', 'salt', 'token', 'id',
+      'lastfm_user', 'lastfm_password', 'listenbrainz_token']) {
+      assert.ok(!(secret in j.user), `users-table column '${secret}' must never reach the response`);
+    }
+  });
+
+  test('admin user: all three layers', async () => {
+    const r = await api({ 'x-access-token': adminToken });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.user.username, 'boss');
+    assert.equal(j.user.admin, true);
+    assert.ok(j.admin, 'admin layer present');
+    assert.ok(Number.isInteger(j.admin.uptime) && j.admin.uptime >= 0);
+    assert.equal(typeof j.admin.nodeVersion, 'string');
+    assert.equal(typeof j.admin.platform, 'string');
+    assert.ok(Number.isInteger(j.admin.dbSchemaVersion) && j.admin.dbSchemaVersion >= 67,
+      'live PRAGMA user_version');
+    assert.equal(j.admin.lockAdmin, false);
+  });
+
+  test('drift-lock: /api/ user layer === ping payload (modulo playlists/identity)', async () => {
+    const fromApi = (await (await api({ 'x-access-token': userToken })).json()).user;
+    const pingR = await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: { 'x-access-token': userToken } });
+    assert.equal(pingR.status, 200, 'ping unchanged behind the wall');
+    const ping = await pingR.json();
+
+    const { username: _u, admin: _a, federation: _f, ...bootFromApi } = fromApi;
+    const { playlists, ...pingRest } = ping;
+    assert.ok(Array.isArray(playlists), 'ping still carries playlists');
+    assert.deepEqual(bootFromApi, pingRest,
+      'both routes serve the SAME builder output — any drift is a bug');
+  });
+
+  test('share token: base layer only', async () => {
+    const shareR = await fetch(`${srv.baseUrl}/api/v1/share`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': userToken },
+      body: JSON.stringify({ playlist: ['testlib/anything.mp3'] }),
+    });
+    assert.equal(shareR.status, 200);
+    const { token } = await shareR.json();
+    assert.ok(token, 'share creation returns its token');
+
+    const r = await api({ 'x-access-token': token });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(typeof j.server, 'string');
+    assert.ok(!('user' in j), 'a share token is not a session');
+    assert.ok(!('admin' in j));
+  });
+
+  test('federation key: scoped user layer, never admin — and the allowlist stays tight', async () => {
+    const mintR = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-access-token': adminToken },
+      body: JSON.stringify({ name: 'matrix-key', vpaths: ['testlib'] }),
+    });
+    assert.equal(mintR.status, 200, 'admin minted a federation key');
+    const { key } = await mintR.json();
+    assert.match(key, /^fedk_/);
+
+    // The deliverable: a federated caller reads version + capabilities.
+    const r = await api({ 'x-federation-key': key });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(typeof j.server, 'string', 'version visible over federation');
+    assert.equal(typeof j.features.subsonic, 'boolean');
+    assert.equal(j.user.federation, true);
+    assert.equal(j.user.admin, false);
+    assert.deepEqual(j.user.vpaths, ['testlib'], 'scoped to the key grants');
+    assert.ok(!('playlists' in j.user));
+    assert.ok(!('admin' in j), 'a federation key can never see the admin layer');
+    assert.ok(!('federationLimits' in j.user) && !('federationKeyId' in j.user),
+      'the synthetic fed user\'s internal fields stay internal');
+
+    // Adding /api to the allowlist loosened NOTHING else: ping (and every
+    // other unlisted route) still refuses the key.
+    const ping = await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: { 'x-federation-key': key } });
+    assert.equal(ping.status, 403, 'ping stays off the federation allowlist');
+  });
+
+  test('a bogus federation key is a 401', async () => {
+    const r = await api({ 'x-federation-key': 'fedk_definitely_not_real' });
+    assert.equal(r.status, 401);
+  });
+
+  test('a jukebox token without a live session is a 401', async () => {
+    // A CORRECTLY-SIGNED jukebox JWT whose WebSocket session no longer
+    // exists (or never did) must 401 like the wall does — not downgrade to
+    // the public layer. Signed with the spawned server's own secret, read
+    // back from its generated config.
+    const { secret } = JSON.parse(
+      await fs.readFile(path.join(srv.tmpDir, 'config.json'), 'utf8'));
+    const stale = jwt.sign({ username: 'pleb', jukebox: true }, secret);
+    const r = await api({ 'x-access-token': stale });
+    assert.equal(r.status, 401, 'dead jukebox session → error, not the public layer');
+  });
+});
+
+describe('layered /api/ in public-access mode', () => {
+  test('no users: tokenless callers get user AND admin layers', { timeout: 120000 }, async () => {
+    const pub = await startServer({ waitForScan: false });
+    try {
+      const j = await (await fetch(`${pub.baseUrl}/api/`)).json();
+      assert.equal(j.user.username, 'mstream-user');
+      assert.equal(j.user.admin, true, 'public mode is effectively admin');
+      assert.equal(j.user.federation, false);
+      assert.ok(j.admin, 'admin layer present in public mode');
+      assert.equal(j.admin.lockAdmin, false);
+    } finally {
+      await pub.stop();
+    }
+  });
+
+  test('no users + lockAdmin: demoted user layer, NO admin layer', { timeout: 120000 }, async () => {
+    const locked = await startServer({ waitForScan: false, extraConfig: { lockAdmin: true } });
+    try {
+      const j = await (await fetch(`${locked.baseUrl}/api/`)).json();
+      assert.equal(j.user.admin, false, 'lockAdmin demotes the implicit user');
+      assert.equal(j.user.noUpload, true, 'write permissions forced off');
+      assert.ok(!('admin' in j), 'no admin layer under lockAdmin');
+    } finally {
+      await locked.stop();
+    }
+  });
+});

--- a/test/integration/api-server-info.test.mjs
+++ b/test/integration/api-server-info.test.mjs
@@ -5,13 +5,15 @@
  * (authApi.resolveOptionalUser), so this suite pins the full contract
  * against real spawned servers:
  *
- *  - users-server, no credentials  → 200, base layer ONLY (the deliberate
- *    public surface: version + capability booleans, nothing else);
+ *  - users-server, no credentials  → 200, base layer ONLY, WITH `server`
+ *    (the version is the anonymous probe's payload) and the server-wide
+ *    capability `features` (no `subsonic` — removed);
  *  - present-but-invalid token     → 401 (an error, never a silent
  *    downgrade to the public layer);
- *  - plain user                    → base + `user` (the ping boot payload,
- *    minus the legacy playlists / allowYoutubeDownload / discoveryPath
- *    fields), no `admin`;
+ *  - plain user                    → base WITHOUT `server` (authenticated
+ *    sessions don't re-learn the version) + `user` (the caller-scoped
+ *    half of the ping payload — capabilities live in `features`), no
+ *    `admin`;
  *  - admin user                    → base + `user` + `admin`;
  *  - ping parity                   → /api/'s `user` object equals
  *    /api/v1/ping's body (minus playlists / identity fields) — the
@@ -71,15 +73,19 @@ describe('layered /api/ server info', () => {
 
   after(async () => { await srv?.stop(); });
 
-  test('no credentials on a users-server: the base layer ONLY', async () => {
+  test('no credentials on a users-server: the base layer ONLY, with the version', async () => {
     const r = await api();
     assert.equal(r.status, 200, 'the bottom layer is public');
     const j = await r.json();
-    assert.equal(typeof j.server, 'string');
+    assert.equal(typeof j.server, 'string', 'the anonymous probe gets the version');
     assert.match(j.server, /^\d+\.\d+\.\d+/);
     assert.deepEqual(j.apiVersions, ['1']);
-    assert.equal(typeof j.features.subsonic, 'boolean');
+    assert.ok(!('subsonic' in j.features), 'subsonic flag removed (feature on its way out)');
     assert.equal(j.features.discoveryReady, false, 'discovery off in this config');
+    assert.equal(j.features.discovery, false);
+    assert.equal(j.features.discoveryP2p, false);
+    assert.ok('transcode' in j.features, 'transcode capability is a server fact');
+    assert.equal(typeof j.features.supportedAudioFiles, 'object');
     assert.ok(!('user' in j), 'no user layer without credentials');
     assert.ok(!('admin' in j), 'no admin layer without credentials');
   });
@@ -89,10 +95,12 @@ describe('layered /api/ server info', () => {
     assert.equal(r.status, 401);
   });
 
-  test('plain user: base + user layer, no admin layer', async () => {
+  test('plain user: base (no version) + user layer, no admin layer', async () => {
     const r = await api({ 'x-access-token': userToken });
     assert.equal(r.status, 200);
     const j = await r.json();
+    assert.ok(!('server' in j), 'authenticated callers do not get the version');
+    assert.ok(j.features, 'capabilities still ride along');
     assert.equal(j.user.username, 'pleb');
     assert.equal(j.user.admin, false);
     assert.equal(j.user.federation, false);
@@ -100,11 +108,15 @@ describe('layered /api/ server info', () => {
     assert.ok(!('playlists' in j.user), 'playlists are a resource, not a capability');
     assert.ok(!('allowYoutubeDownload' in j.user), 'velvet-only legacy field stays on ping');
     assert.ok(!('discoveryPath' in j.user), 'redundant-with-discovery legacy field stays on ping');
+    for (const cap of ['transcode', 'supportedAudioFiles', 'discovery', 'discoveryP2p']) {
+      assert.ok(!(cap in j.user), `server-wide capability '${cap}' lives in features, not user`);
+    }
     assert.equal(typeof j.user.noUpload, 'boolean');
     assert.equal(typeof j.user.noMkdir, 'boolean');
     assert.equal(typeof j.user.noFileModify, 'boolean');
+    assert.equal(typeof j.user.federationDiscovery, 'boolean',
+      'peer-relationship-derived flag stays caller-scoped');
     assert.ok('testlib' in j.user.vpathMetaData, 'library type metadata rides along');
-    assert.equal(j.user.discovery, false);
     assert.ok(!('admin' in j), 'no admin layer for a non-admin');
 
     // The disclosure contract: `user` is built ADDITIVELY from explicit
@@ -123,6 +135,7 @@ describe('layered /api/ server info', () => {
     const r = await api({ 'x-access-token': adminToken });
     assert.equal(r.status, 200);
     const j = await r.json();
+    assert.ok(!('server' in j), 'not even admins re-learn the version here');
     assert.equal(j.user.username, 'boss');
     assert.equal(j.user.admin, true);
     assert.ok(j.admin, 'admin layer present');
@@ -134,22 +147,25 @@ describe('layered /api/ server info', () => {
     assert.equal(j.admin.lockAdmin, false);
   });
 
-  test('drift-lock: /api/ user layer === ping payload (modulo playlists/identity)', async () => {
-    const fromApi = (await (await api({ 'x-access-token': userToken })).json()).user;
+  test('drift-lock: ping === /api/ user half + features half (modulo legacy/identity)', async () => {
+    const apiJ = await (await api({ 'x-access-token': userToken })).json();
     const pingR = await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: { 'x-access-token': userToken } });
     assert.equal(pingR.status, 200, 'ping unchanged behind the wall');
     const ping = await pingR.json();
 
-    const { username: _u, admin: _a, federation: _f, ...bootFromApi } = fromApi;
-    // Ping's frozen contract = the shared builder + three legacy fields.
+    // Ping's frozen flat contract = the caller-scoped half (/api/'s
+    // `user` minus identity) + the capabilities half (/api/'s `features`
+    // minus the /api/-only discoveryReady) + three legacy fields.
+    const { username: _u, admin: _a, federation: _f, ...userHalf } = apiJ.user;
+    const { discoveryReady: _dr, ...capsHalf } = apiJ.features;
     const { playlists, allowYoutubeDownload, discoveryPath, ...pingRest } = ping;
     assert.ok(Array.isArray(playlists), 'ping still carries playlists');
     assert.equal(allowYoutubeDownload, !ping.noUpload,
       'ping still carries the velvet field, with its historical value');
     assert.equal(discoveryPath, ping.discovery,
       'ping still carries discoveryPath, identical to discovery as always');
-    assert.deepEqual(bootFromApi, pingRest,
-      'both routes serve the SAME builder output — any drift is a bug');
+    assert.deepEqual(pingRest, { ...userHalf, ...capsHalf },
+      'ping is exactly the two shared builders flattened — any drift is a bug');
   });
 
   test('share token: base layer only', async () => {
@@ -165,7 +181,8 @@ describe('layered /api/ server info', () => {
     const r = await api({ 'x-access-token': token });
     assert.equal(r.status, 200);
     const j = await r.json();
-    assert.equal(typeof j.server, 'string');
+    assert.ok(!('server' in j), 'a share token counts as presented credentials — no version');
+    assert.ok(j.features, 'capabilities still served');
     assert.ok(!('user' in j), 'a share token is not a session');
     assert.ok(!('admin' in j));
   });
@@ -180,12 +197,15 @@ describe('layered /api/ server info', () => {
     const { key } = await mintR.json();
     assert.match(key, /^fedk_/);
 
-    // The deliverable: a federated caller reads version + capabilities.
+    // The deliverable: a federated caller reads capabilities (+ its
+    // scoped view). The VERSION it gets by probing without the key —
+    // the tokenless case above — since keyed calls are authenticated.
     const r = await api({ 'x-federation-key': key });
     assert.equal(r.status, 200);
     const j = await r.json();
-    assert.equal(typeof j.server, 'string', 'version visible over federation');
-    assert.equal(typeof j.features.subsonic, 'boolean');
+    assert.ok(!('server' in j), 'a keyed call is authenticated — no version');
+    assert.ok(j.features, 'capabilities visible over federation');
+    assert.equal(typeof j.features.discovery, 'boolean');
     assert.equal(j.user.federation, true);
     assert.equal(j.user.admin, false);
     assert.deepEqual(j.user.vpaths, ['testlib'], 'scoped to the key grants');
@@ -223,6 +243,8 @@ describe('layered /api/ in public-access mode', () => {
     const pub = await startServer({ waitForScan: false });
     try {
       const j = await (await fetch(`${pub.baseUrl}/api/`)).json();
+      assert.equal(typeof j.server, 'string',
+        'no credentials presented → the probe still gets the version, even in public mode');
       assert.equal(j.user.username, 'mstream-user');
       assert.equal(j.user.admin, true, 'public mode is effectively admin');
       assert.equal(j.user.federation, false);


### PR DESCRIPTION
PR A of the `/api` takeover plan: `GET /api/` becomes the layered server-info endpoint — the successor to `/api/v1/ping` — and joins the federation allowlist so the mobile app can read a peer's version and capabilities. Builds on #879 (`discoveryReady` carries over verbatim). PR B (webapp off `/ping`) follows separately.

## The finding that shaped this
The old `/api/` handler's "Public — no auth required" comment was **stale**: it was registered *after* the auth wall, so on any server with users it 401'd tokenless callers (verified live against prod). Layer 1 below is what makes the endpoint actually public — a deliberate change, discussed in review: the exact version already escapes tokenless via the Subsonic error envelope (`serverVersion` in `errorBody`), SSDP (`mStream/<ver>` + Node version) and mDNS broadcasts, and the pre-wall webapp assets. The layer adds convenience, not new exposure — and lets clients warn about outdated servers, which is the mitigation that actually matters.

## The three layers
| Layer | Who | Adds |
|---|---|---|
| base | everyone | `apiVersions` + `features.{discoveryReady, discovery, discoveryP2p, transcode, supportedAudioFiles}` — server-wide capability facts (config only: no counts, no library/content names, no identity). **`server` (the version) appears ONLY on requests carrying no credentials** — it's the anonymous probe's payload; authed sessions don't re-learn it, and a federated client probes without its key when it wants the version. No `subsonic` flag (feature on its way out; the webapp's only consumer fails closed and hides that UI) |
| `user` | valid JWT · public mode · jukebox · federation key | identity (`username`, `admin`, `federation`) + the **caller-scoped** half of the ping payload: vpaths, permission flags, `federationDiscovery` (peer-relationship-derived, so not public), vpathMetaData — **no `playlists`** (a resource, not a capability; ping keeps them) |
| `admin` | admin only — never federation/jukebox, **never while `lockAdmin` is on** | `uptime`, `nodeVersion`, `platform`, live `dbSchemaVersion` — cheap support facts; framework hook for later. Under the lock a real admin keeps `user.admin: true` (identity) but gets no `admin` object — the absence beside the flag is how a client tells "locked" from "not an admin" |

`/ping`'s flat contract is untouched: it's now composed from the same two builders (`buildClientBootPayload` + `buildFeatures`) plus its three legacy-only fields (`playlists`, `allowYoutubeDownload` ≡ `!noUpload`, `discoveryPath` ≡ `discovery`).

**Contract:** credentials *absent* → base only. Credentials *present but invalid* → `401` (`403` for a federation key off its allowlist) — never a silent downgrade, so an expired webapp cookie surfaces instead of quietly demoting. Share tokens → base only. The response is built **additively** (base → +user → +admin), never by filtering a full object down — an additive bug omits a field, a filtering bug discloses everything.

## How it's wired
- **New `src/api/server-info.js`**, mounted immediately before the wall; it resolves credentials itself via the new `authApi.resolveOptionalUser(req)`.
- **Auth wall refactor** (`src/api/auth.js`): the wall's inline user-building moved *verbatim* into module-scope helpers (`buildPublicModeUser` / `verifyToken` / `buildJukeboxUser` / `buildRealUser`), now shared by the wall and `resolveOptionalUser` — one source of truth, no copied logic. Wall behavior is unchanged: federation-first ordering, share-token path gating, jukebox session checks, `req.token` assignment all preserved.
- **`/api/v1/ping` frozen**: now a thin wrapper over the shared `buildClientBootPayload()` + `playlists`. Deprecated in the OpenAPI, kept indefinitely (older mobile clients, CI liveness probes, the torrent/velvet webapps). The shared builder makes drift between the two routes impossible.
- **Federation allowlist** gains `GET /api` + `GET /api/` (both spellings — the route is pre-wall, so `req.path` arrives exactly as sent).

## Tests — 12-case auth matrix vs real spawned servers
tokenless base-only **with `server`** · bad-token **401-not-downgrade** · user layer (no `server`, no admin, capabilities in `features` not `user`) · admin (all three, still no `server`) · **drift-lock** (ping ≡ user-half + features-half flattened, modulo the three legacy fields, via deepEqual on live responses — plus the two legacy invariants pinned) · share token base-only without `server` · federation key scoped to grants + **ping still 403s the key** (the allowlist loosened nothing) · bogus key 401 · correctly-signed jukebox JWT with a dead session → 401 · **by-name disclosure pins** (users-table columns and the fed user's internal fields asserted absent) · public mode (user+admin, `server` present — no credentials were presented) · public-mode lockAdmin (demoted, no admin layer) · **a real admin under lockAdmin** (two boots on one data dir — the lock refuses user creation, so the account must predate it: `user.admin` stays true, no `admin` object).

## Adversarial review outcome
The wall refactor was diffed line-by-line against the pre-refactor original (verbatim extraction, branch order preserved), and the federation allowlist was probed with **live Express routing experiments** — traversal (`/api/../…`), encoding (`%2e%2e`, `..%2f`), double-slash, and case variants all fail closed (`req.path` is raw and un-normalized; router and allowlist key off the same string, so they cannot disagree). No privilege-escalation, disclosure, or DoS path found; `getAllUsers()` is cache-backed and `hasEmbeddings()` stays a flag-gated `LIMIT 1`. Two deliberate calls, documented in code: public-mode anonymous callers see the admin layer (public mode **is** admin on every other route; `lockAdmin` is the lever, test-pinned), and an empty-string token header counts as absent rather than invalid.

Suite 11/11; full `npm test` green (2537 pass / 0 fail).

## Notes for PR B
The webapp migrates `MSTREAMAPI.ping()` → `GET /api/` and reads `response.user.*`; playlists come from the playlist route instead. Torrent/velvet webapps stay on `/ping` (velvet is slated for removal). Flutter follow-up (separate repo): add-server gains a real tokenless probe; federated mode reads peer capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
