### PR TITLE
fix(api): restore auth on GET /api/ — the tokenless 401 is client contract

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -942,41 +942,36 @@ paths:
       tags: [System]
       summary: Layered server info (version, capabilities, boot payload)
       description: |
-        One endpoint, three layers, keyed off the credentials presented:
+        The authenticated server-info endpoint, layered by who is asking:
 
-        * **Base** (always): API versions plus `features` — server-wide
-          capability facts. `server` (the version) appears ONLY when the
-          request carries no credentials at all: it is the anonymous
-          probe's payload ("is this an mStream server, which version");
-          authenticated sessions don't re-learn their server's version
-          here. A federated client that wants the version probes without
-          its key header.
-        * **Authenticated** (JWT, public-access mode, jukebox session, or
-          an `x-federation-key`) — adds `user`: identity plus the
-          CALLER-SCOPED half of the ping boot payload (vpaths, permission
-          flags, federationDiscovery, vpathMetaData). Server-wide
-          capabilities (transcode, supportedAudioFiles, discovery,
-          discoveryP2p) live in `features` instead. Unlike ping, no
-          `playlists` (fetch those from the playlist routes), no
-          `allowYoutubeDownload` (velvet-only; always `!noUpload`), and
-          no `discoveryPath` (always identical to `discovery` on servers
-          new enough to have this endpoint).
-        * **Admin** — adds `admin`: cheap support/debug facts (uptime,
-          runtime versions, DB schema version). Never present for
-          federation keys or jukebox sessions — and never while the admin
-          API is locked (`lockAdmin`): an admin account then still shows
+        * **Base** (every authenticated response): `server` (the
+          version), `apiVersions`, and `features` — server-wide
+          capability facts (transcode, supportedAudioFiles, discovery,
+          discoveryP2p, discoveryReady).
+        * **`user`** — identity plus the CALLER-SCOPED half of the ping
+          boot payload (vpaths, permission flags, federationDiscovery,
+          vpathMetaData). Unlike ping, no `playlists` (fetch those from
+          the playlist routes), no `allowYoutubeDownload` (velvet-only;
+          always `!noUpload`), and no `discoveryPath` (always identical
+          to `discovery` on servers new enough to have this endpoint).
+        * **`admin`** — cheap support/debug facts (uptime, runtime
+          versions, DB schema version). Never present for federation
+          keys or jukebox sessions — and never while the admin API is
+          locked (`lockAdmin`): an admin account then still shows
           `user.admin: true` (identity) but no `admin` object, which is
           how a client tells "locked" from "not an admin".
 
-        Credentials that are **present but invalid** get `401` (`403` for
-        a federation key off its route allowlist) — never a silent
-        downgrade to the public layer, so a client with an expired token
-        sees the error and re-authenticates. Share tokens receive the
-        base layer only, without `server` (presented credentials, just
-        not a session).
+        **The 401 is part of the contract**: a request with no (or an
+        invalid) token on a server that has users returns `401` — mobile
+        clients probe this endpoint tokenless to decide whether to show
+        a login form, exactly as they always have with `/api/v1/ping`.
+        On a no-users server (public-access mode) the probe returns
+        `200` with all applicable layers. Share tokens cannot call this
+        route (`401`). Federation keys reach it via their route
+        allowlist and receive the version plus their granted-library
+        view (`403` on any route off that allowlist).
 
         Supersedes `/api/v1/ping` for new clients.
-      security: []
       responses:
         "200":
           description: Layered server info.
@@ -987,10 +982,7 @@ paths:
                 properties:
                   server:
                     type: string
-                    description: >
-                      Server version (from package.json). Present ONLY when
-                      the request carried no credentials — the anonymous
-                      probe's payload.
+                    description: Server version (from package.json).
                   apiVersions:
                     type: array
                     items: { type: string }
@@ -998,9 +990,9 @@ paths:
                     type: object
                     description: >
                       Server-wide capability facts a client can gate UI on
-                      without an extra round-trip. Public — config and
-                      capability facts only: no counts, no library or content
-                      names, no identity.
+                      without an extra round-trip. Config and capability
+                      facts only: no counts, no library or content names,
+                      no identity.
                     properties:
                       discoveryReady:
                         type: boolean
@@ -1070,7 +1062,10 @@ paths:
                   transcode: false
                   supportedAudioFiles: { mp3: true, flac: true }
         "401":
-          description: A token or federation key was presented but is invalid.
+          description: >
+            No token (on a server with users), an invalid token or
+            federation key, or a share token. The tokenless 401 is the
+            login-required signal clients probe for.
         "403":
           description: Valid federation key, but the route is off its allowlist.
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -102,10 +102,7 @@ export function setup(mstream) {
   });
 }
 
-// The token slots, in precedence order. ONE definition — the wall,
-// resolveOptionalUser, and credentialsPresented must always agree on
-// where a token can ride, or "present but invalid" and "absent" drift
-// apart between the wall and the optional-auth endpoint.
+// The token slots, in precedence order.
 function readToken(req) {
   return req.body?.token || req.query?.token || req.headers?.['x-access-token'] || req.cookies?.['x-access-token'];
 }
@@ -205,48 +202,9 @@ function buildRealUser(decoded) {
   };
 }
 
-// ── Optional-auth resolution ────────────────────────────────────────────────
-// For routes mounted BEFORE the wall whose bottom layer is public (the
-// layered GET /api/ in server-info.js). Same branch ORDER as the wall —
-// federation first is load-bearing for exactly the reason documented there.
-//
-// Contract:
-//   - no credentials at all → null (caller serves its public layer);
-//   - share token → null (they exist to fetch one playlist, not to
-//     identify a session; the wall path-gates them, this endpoint just
-//     treats them as anonymous);
-//   - presented-but-invalid token/key → throws the same 401 the wall
-//     throws (403 for a federation key off its allowlist). A bad
-//     credential must surface as an error, never silently downgrade to
-//     the public layer — a client with an expired token needs the 401
-//     to know to re-authenticate.
-export function resolveOptionalUser(req) {
-  const fedKey = req.headers['x-federation-key'];
-  if (typeof fedKey === 'string' && fedKey.length > 0) {
-    return federationAuth.authenticateFederationKey(fedKey, req);
-  }
-
-  if (db.getAllUsers().length === 0) { return buildPublicModeUser(); }
-
-  const token = readToken(req);
-  if (!token) { return null; }
-
-  const decoded = verifyToken(token, req);
-  if (decoded.jukebox === true && decoded.username) {
-    return buildJukeboxUser(decoded, token);
-  }
-  if (decoded.shareToken === true) { return null; }
-  return buildRealUser(decoded);
-}
-
-// Whether the request PRESENTED any credential (a federation key or a
-// token in any slot), regardless of validity or what it resolves to.
-// The layered /api/ uses this for its "the version is the anonymous
-// probe's payload" rule: `server` appears only when this is false. Note
-// the deliberate asymmetry with resolveOptionalUser: a share token
-// resolves to null (anonymous data-wise) but still counts as presented.
-export function credentialsPresented(req) {
-  const fedKey = req.headers['x-federation-key'];
-  if (typeof fedKey === 'string' && fedKey.length > 0) { return true; }
-  return Boolean(readToken(req));
-}
+// NOTE (history, do not repeat): #932 briefly exported an optional-auth
+// resolver here so GET /api/ could serve an anonymous public layer from
+// before the wall. That broke third-party clients, which probe /api/
+// tokenless and read the 401 as "this server requires login". The
+// endpoint lives behind the wall again; if some future route genuinely
+// needs optional auth, it must not be one that clients auth-probe.

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -1,47 +1,47 @@
-// GET /api/ — the layered server-info endpoint.
+// GET /api/ — the layered server-info endpoint. Sits BEHIND the auth
+// wall, and that placement is a CLIENT-FACING API CONTRACT, not an
+// accident of mounting order:
 //
-// One endpoint, three layers, built ADDITIVELY (base → +user → +admin).
-// Never build this response by filtering a full object down: an additive
-// bug omits a field, a filtering bug discloses everything.
+//   ⚠ Tokenless GET /api/ on a server with users MUST return 401.
+//   Third-party mobile clients probe this endpoint (like ping before it)
+//   with no token to decide whether to show a login form — 401 means
+//   "authenticate first", 200 means public-access mode. #932 briefly
+//   mounted this route before the wall with an anonymous base layer and
+//   broke exactly that detection (every server answered 200, so every
+//   server looked public). Do not make this endpoint anonymous again.
 //
-//   Base (always): `apiVersions` + `features` — server-wide capability
-//     facts (see buildFeatures). `server` (the version) is included ONLY
-//     when the request carries no credentials at all: the anonymous
-//     probe surface ("is this an mStream server, which version") is the
-//     one place a client needs it, and an authenticated session doesn't
-//     re-learn its server's version on every call. This layer is
-//     deliberately public and must stay allocation-cheap: config reads
-//     and the guarded one-row discovery probe, nothing an anonymous
-//     caller can use to make the server do work. Rule for what may
-//     appear here: config/capability facts only — no counts, no
-//     library or content names, no identity.
+// For authenticated callers (valid JWT, public-access mode, jukebox
+// session, or a federation key — the wall resolves all of them), the
+// response is built ADDITIVELY in three layers. Never build it by
+// filtering a full object down: an additive bug omits a field, a
+// filtering bug discloses everything.
 //
-//   Layer 2 (valid JWT, public-access mode, jukebox session, or a
-//   federation key): adds `user` — identity plus the CALLER-SCOPED boot
-//   payload (vpaths, permission flags, federationDiscovery,
-//   vpathMetaData). Server-wide capabilities live in `features`, not
-//   here; ping's frozen contract still carries both halves flat (see
-//   buildClientBootPayload).
+//   Base: `server` (the version), `apiVersions`, and `features` —
+//     server-wide capability facts (see buildFeatures). Visible to every
+//     authenticated caller including federated peers; rule for what may
+//     appear: config/capability facts only — no counts, no library or
+//     content names, no identity.
 //
-//   Layer 3 (admin only — never federation, never jukebox): adds `admin`
-//   — cheap support/debug facts. Mostly a framework hook today.
+//   `user`: identity plus the CALLER-SCOPED boot payload (vpaths,
+//     permission flags, federationDiscovery, vpathMetaData), scoped
+//     exactly as ping scopes it.
 //
-// Auth contract: a request with NO credentials gets the base (with
-// `server`); a request with PRESENT-but-invalid credentials gets 401
-// (403 for a federation key off its allowlist) — a bad token is an error
-// the client must see, never a silent downgrade to the public layer (a
-// webapp with an expired cookie needs the 401 to know to re-login).
-// Share tokens get the base layer, without `server` (they are presented
-// credentials, just not a session). A federated client that wants the
-// version probes WITHOUT its key header — the anonymous base — and sends
-// the key when it wants its scoped view.
+//   `admin`: cheap support/debug facts. Admin callers only — never
+//     federation keys or jukebox sessions — and never while lockAdmin
+//     is on: a locked admin API serves no admin params, so an is_admin
+//     account under the lock sees user.admin=true (identity) with no
+//     admin object, which is how a client tells "locked" from "not an
+//     admin". In public-access mode (no users, lockAdmin off) the layer
+//     is visible to tokenless callers — deliberate: public mode IS
+//     admin on every other route, and lockAdmin is the hardening lever.
 //
-// Mounted BEFORE the auth wall (see server.js) so it owns its auth via
-// resolveOptionalUser(); /api/v1/ping stays behind the wall unchanged and
-// composes its frozen flat payload from the two builders below — one
-// source of truth, zero drift between the two routes. Ping is deprecated
-// in favor of this endpoint but kept indefinitely: older mobile clients,
-// CI liveness probes, and the torrent/velvet webapps still call it.
+// Federation keys reach this route via their allowlist ('GET /api' +
+// 'GET /api/' in federation-auth.js) and get the version plus their
+// granted-library view — the mobile app's "what can this peer do" call.
+// Share tokens get the wall's path-gating and cannot call this (401),
+// same as ping. /api/v1/ping is deprecated in favor of this endpoint
+// but kept indefinitely; it composes its frozen flat payload from the
+// two builders below — one source of truth, zero drift.
 
 import packageJson from '../../package.json' with { type: 'json' };
 import * as config from '../state/config.js';
@@ -49,11 +49,9 @@ import * as db from '../db/manager.js';
 import * as fedDb from '../db/federation.js';
 import * as sim from '../db/discovery-similarity.js';
 import * as transcode from './transcode.js';
-import * as authApi from './auth.js';
 
-// Server-wide capability facts — the public `features` object. Everything
-// here is a config/capability fact safe for anonymous eyes (the public
-// rule above); nothing is caller-scoped.
+// Server-wide capability facts — the `features` object. Everything here
+// is a config/capability fact (the rule above); nothing is caller-scoped.
 export function buildFeatures() {
   // Signal "transcoding available" only when ffmpeg actually resolved
   // (bundled binaries ready OR system-PATH fallback succeeded).
@@ -73,9 +71,8 @@ export function buildFeatures() {
     // similarTo/minSimilarity, every pick 400s on the empty pool, and the
     // queue silently stops advancing.
     //
-    // A boolean, not a count: this layer is public, and how many tracks
-    // are analysed is library-size information. Clients only need to know
-    // whether to offer the feature.
+    // A boolean, not a count: how many tracks are analysed is
+    // library-size information no client needs.
     discoveryReady: sim.hasEmbeddings(),
     // The Discover panel has a server to talk to (no /api/v1/discovery/*
     // probes needed — flags, never probes, is the house rule).
@@ -92,7 +89,7 @@ export function buildFeatures() {
 
 // The CALLER-SCOPED half of the old ping payload: what this user (or
 // federation key, or public-mode caller) may see and do. Server-wide
-// capabilities moved to buildFeatures(); ping composes both halves (plus
+// capabilities live in buildFeatures(); ping composes both halves (plus
 // its legacy fields) back into its frozen flat shape:
 //   - `playlists`            — a resource (the playlist routes), not a
 //                              server capability;
@@ -114,8 +111,7 @@ export function buildClientBootPayload(user) {
     // "From your peers" in the Discover panel: needs local embeddings (the
     // seed vector comes from our discovery.db) plus at least one federated
     // peer that hasn't opted out of discovery. Caller-scoped by nature —
-    // it reflects this server's live peer RELATIONSHIPS, which is not a
-    // fact for the anonymous features object.
+    // it reflects this server's live peer RELATIONSHIPS.
     federationDiscovery: config.program.federation.enabled === true
       && config.program.scanOptions.collectDiscoveryData === true
       && fedDb.getFederationPeers().some((p) => p.use_discovery === 1),
@@ -135,21 +131,18 @@ export function buildClientBootPayload(user) {
 
 export function setup(mstream) {
   mstream.get('/api/', (req, res) => {
-    // Throws 401 on a presented-but-bad token/key (403 for a federation
-    // key off its allowlist); returns null for "no credentials at all"
-    // and for share tokens.
-    const user = authApi.resolveOptionalUser(req);
+    // Behind the wall: req.user is always resolved (or the wall already
+    // threw the 401 the tokenless-probe contract depends on).
+    const user = req.user;
 
-    // ── Base layer: always ─────────────────────────────────────────────
+    // ── Base ───────────────────────────────────────────────────────────
     const info = {
-      // The version is the anonymous probe's payload — see the header.
-      ...(authApi.credentialsPresented(req) ? {} : { server: packageJson.version }),
+      server: packageJson.version,
       apiVersions: ["1"],
       features: buildFeatures(),
     };
-    if (!user) { return res.json(info); }
 
-    // ── Layer 2: any authenticated caller ──────────────────────────────
+    // ── `user`: caller-scoped ──────────────────────────────────────────
     info.user = {
       username: user.username,
       admin: user.admin === true,
@@ -157,21 +150,8 @@ export function setup(mstream) {
       ...buildClientBootPayload(user),
     };
 
-    // ── Layer 3: admin only, and only while the admin API is usable ────
-    // user.admin is false by construction for federation keys and jukebox
-    // sessions. lockAdmin gates the layer EXPLICITLY: a real is_admin
-    // account keeps user.admin=true under the lock (an identity fact),
-    // but with the admin API refusing everything there are no admin
-    // params to serve — the layer's ABSENCE alongside user.admin=true is
-    // how a client tells "locked" from "not an admin". (The public-mode
-    // user is already demoted to admin=false under the lock.)
-    //
-    // DELIBERATE: in public-access mode (no users, lockAdmin off) this
-    // layer is visible to anonymous callers — public mode IS admin
-    // everywhere else on the server (the whole /admin surface is open),
-    // and /api/ pretending otherwise would be the one inconsistent route.
-    // Operators who expose a no-users server and want this hidden have
-    // the same lever as for everything else: lockAdmin.
+    // ── `admin`: admin only, and only while the admin API is usable ────
+    // (See the header for the lockAdmin and public-mode reasoning.)
     if (user.admin === true && config.program.lockAdmin !== true) {
       info.admin = {
         uptime: Math.floor(process.uptime()),

--- a/src/server.js
+++ b/src/server.js
@@ -598,13 +598,6 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   // http.Server started in the post-boot hook below.
   if (config.program.subsonic.mode === 'same-port') { subsonicApi.setup(mstream); }
 
-  // GET /api/ — the layered server-info endpoint. Mounted BEFORE the wall
-  // because its bottom layer (version + capability booleans) is
-  // deliberately public; it resolves optional credentials itself via
-  // authApi.resolveOptionalUser (see api/server-info.js for the layer
-  // contract).
-  serverInfoApi.setup(mstream);
-
   // Everything below this line requires authentication
   authApi.setup(mstream);
 
@@ -612,6 +605,13 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   // (needs req.user.federation) and before every route/static mount whose
   // responses it meters.
   federationLimitsApi.setup(mstream);
+
+  // GET /api/ — the layered server-info endpoint. Deliberately BEHIND the
+  // wall: tokenless requests on a users-server MUST 401 — third-party
+  // clients probe this to decide whether to show a login form. That 401
+  // is client-facing API surface, not an accident of ordering (see the
+  // header of api/server-info.js before ever moving this).
+  serverInfoApi.setup(mstream);
 
   adminApi.setup(mstream);
   irohApi.setup(mstream);

--- a/test/integration/api-server-info.test.mjs
+++ b/test/integration/api-server-info.test.mjs
@@ -1,25 +1,24 @@
 /**
  * The layered GET /api/ endpoint (src/api/server-info.js) — the auth matrix.
  *
- * The endpoint sits BEFORE the auth wall and resolves credentials itself
- * (authApi.resolveOptionalUser), so this suite pins the full contract
- * against real spawned servers:
+ * The endpoint sits BEHIND the auth wall, and the tokenless 401 is a
+ * CLIENT-FACING CONTRACT: third-party mobile apps probe /api/ (as they
+ * always probed ping) with no token and read 401 as "show the login
+ * form" / 200 as "public server". This suite pins that plus the full
+ * layer matrix against real spawned servers:
  *
- *  - users-server, no credentials  → 200, base layer ONLY, WITH `server`
- *    (the version is the anonymous probe's payload) and the server-wide
- *    capability `features` (no `subsonic` — removed);
- *  - present-but-invalid token     → 401 (an error, never a silent
- *    downgrade to the public layer);
- *  - plain user                    → base WITHOUT `server` (authenticated
- *    sessions don't re-learn the version) + `user` (the caller-scoped
- *    half of the ping payload — capabilities live in `features`), no
- *    `admin`;
+ *  - users-server, no credentials  → 401 (the login-detection signal —
+ *    NEVER an anonymous 200; #932 briefly broke this);
+ *  - present-but-invalid token     → 401;
+ *  - plain user                    → base (`server`, `apiVersions`, the
+ *    capability `features` — no `subsonic`, removed) + `user` (the
+ *    caller-scoped half of the ping payload), no `admin`;
  *  - admin user                    → base + `user` + `admin`;
  *  - ping parity                   → /api/'s `user` object equals
  *    /api/v1/ping's body (minus playlists / identity fields) — the
  *    drift-lock on the shared payload builder;
- *  - share token                   → base only (shares fetch a playlist,
- *    they are not a session);
+ *  - share token                   → 401 (shares fetch a playlist, they
+ *    are not a session — the wall's path gating covers /api/ like ping);
  *  - federation key                → base + `user` scoped to the key's
  *    grants, `federation: true`, never `admin` — the mobile-app
  *    "version and capabilities over federation" deliverable;
@@ -108,11 +107,26 @@ describe('layered /api/ server info', () => {
 
   after(async () => { await srv?.stop(); });
 
-  test('no credentials on a users-server: the base layer ONLY, with the version', async () => {
+  test('no credentials on a users-server: 401 — the login-detection contract', async () => {
+    // THE contract this endpoint must never lose again: third-party
+    // clients probe /api/ tokenless and read 401 as "authenticate first".
+    // An anonymous 200 here makes every server look public (#932's
+    // regression). Public-access mode is the one place tokenless gets a
+    // 200 — pinned in the public-mode suite below.
     const r = await api();
-    assert.equal(r.status, 200, 'the bottom layer is public');
+    assert.equal(r.status, 401, 'tokenless on a users-server MUST 401');
+  });
+
+  test('a presented-but-invalid token is a 401, not a downgrade', async () => {
+    const r = await api({ 'x-access-token': 'not-a-jwt' });
+    assert.equal(r.status, 401);
+  });
+
+  test('plain user: base + user layer, no admin layer', async () => {
+    const r = await api({ 'x-access-token': userToken });
+    assert.equal(r.status, 200);
     const j = await r.json();
-    assert.equal(typeof j.server, 'string', 'the anonymous probe gets the version');
+    assert.equal(typeof j.server, 'string', 'every authenticated response carries the version');
     assert.match(j.server, /^\d+\.\d+\.\d+/);
     assert.deepEqual(j.apiVersions, ['1']);
     assert.ok(!('subsonic' in j.features), 'subsonic flag removed (feature on its way out)');
@@ -121,21 +135,6 @@ describe('layered /api/ server info', () => {
     assert.equal(j.features.discoveryP2p, false);
     assert.ok('transcode' in j.features, 'transcode capability is a server fact');
     assert.equal(typeof j.features.supportedAudioFiles, 'object');
-    assert.ok(!('user' in j), 'no user layer without credentials');
-    assert.ok(!('admin' in j), 'no admin layer without credentials');
-  });
-
-  test('a presented-but-invalid token is a 401, not a downgrade', async () => {
-    const r = await api({ 'x-access-token': 'not-a-jwt' });
-    assert.equal(r.status, 401);
-  });
-
-  test('plain user: base (no version) + user layer, no admin layer', async () => {
-    const r = await api({ 'x-access-token': userToken });
-    assert.equal(r.status, 200);
-    const j = await r.json();
-    assert.ok(!('server' in j), 'authenticated callers do not get the version');
-    assert.ok(j.features, 'capabilities still ride along');
     assert.equal(j.user.username, 'pleb');
     assert.equal(j.user.admin, false);
     assert.equal(j.user.federation, false);
@@ -170,7 +169,7 @@ describe('layered /api/ server info', () => {
     const r = await api({ 'x-access-token': adminToken });
     assert.equal(r.status, 200);
     const j = await r.json();
-    assert.ok(!('server' in j), 'not even admins re-learn the version here');
+    assert.equal(typeof j.server, 'string');
     assert.equal(j.user.username, 'boss');
     assert.equal(j.user.admin, true);
     assert.ok(j.admin, 'admin layer present');
@@ -202,7 +201,7 @@ describe('layered /api/ server info', () => {
       'ping is exactly the two shared builders flattened — any drift is a bug');
   });
 
-  test('share token: base layer only', async () => {
+  test('share token: 401 — shares fetch a playlist, they are not a session', async () => {
     const shareR = await fetch(`${srv.baseUrl}/api/v1/share`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-access-token': userToken },
@@ -212,13 +211,10 @@ describe('layered /api/ server info', () => {
     const { token } = await shareR.json();
     assert.ok(token, 'share creation returns its token');
 
+    // The wall's share-token path gating covers /api/ like it covers
+    // ping: shares can only fetch their playlist's routes.
     const r = await api({ 'x-access-token': token });
-    assert.equal(r.status, 200);
-    const j = await r.json();
-    assert.ok(!('server' in j), 'a share token counts as presented credentials — no version');
-    assert.ok(j.features, 'capabilities still served');
-    assert.ok(!('user' in j), 'a share token is not a session');
-    assert.ok(!('admin' in j));
+    assert.equal(r.status, 401);
   });
 
   test('federation key: scoped user layer, never admin — and the allowlist stays tight', async () => {
@@ -231,13 +227,12 @@ describe('layered /api/ server info', () => {
     const { key } = await mintR.json();
     assert.match(key, /^fedk_/);
 
-    // The deliverable: a federated caller reads capabilities (+ its
-    // scoped view). The VERSION it gets by probing without the key —
-    // the tokenless case above — since keyed calls are authenticated.
+    // The deliverable: a federated caller reads the version and
+    // capabilities with its key, plus its granted-library view.
     const r = await api({ 'x-federation-key': key });
     assert.equal(r.status, 200);
     const j = await r.json();
-    assert.ok(!('server' in j), 'a keyed call is authenticated — no version');
+    assert.equal(typeof j.server, 'string', 'version visible over federation');
     assert.ok(j.features, 'capabilities visible over federation');
     assert.equal(typeof j.features.discovery, 'boolean');
     assert.equal(j.user.federation, true);
@@ -278,7 +273,7 @@ describe('layered /api/ in public-access mode', () => {
     try {
       const j = await (await fetch(`${pub.baseUrl}/api/`)).json();
       assert.equal(typeof j.server, 'string',
-        'no credentials presented → the probe still gets the version, even in public mode');
+        'the tokenless probe gets a 200 + version ONLY in public mode — the "no login needed" answer');
       assert.equal(j.user.username, 'mstream-user');
       assert.equal(j.user.admin, true, 'public mode is effectively admin');
       assert.equal(j.user.federation, false);


### PR DESCRIPTION
Follow-up fix to #932: `GET /api/` goes back **behind the auth wall**, restoring the tokenless-401 contract third-party mobile apps depend on.

## The regression
Third-party clients (like the first-party one) probe `/api/` — as they always probed `/ping` — **with no token** and read the answer as the login decision: `401` → show the login form, `200` → public-access server, proceed. #932 mounted the endpoint before the wall with an anonymous base layer, so every server answered `200` and looked public to that probe, breaking auth handling in existing apps. The tokenless 401 was de-facto API surface all along; this PR makes it *documented* API surface (code comments, OpenAPI, and a regression test that names it) so it can't be "fixed" back to public.

## What changes
- **Mount moves after the wall** (`server.js`) — the wall now answers tokenless/invalid/share-token requests with the same 401s as every other route; the handler reads `req.user` directly.
- **`server` (the version) returns to every response.** The "version only when unauthenticated" rule existed to serve the anonymous probe; with no anonymous responses left, it's meaningless. Federated callers get the version **with their key** — the original mobile-app deliverable, now without the probe-without-key dance.
- **`resolveOptionalUser` + `credentialsPresented` deleted** from `auth.js` (dead code — single call site each). The wall's extracted builder helpers stay: the wall itself uses them, and the refactor stands on its own. A history note in `auth.js` records why the optional-auth resolver must not come back for auth-probed routes.
- **Everything else from #932 stands**: capabilities in `features` (no `subsonic`), caller-scoped `user` (no playlists/legacy fields), `admin` gated by `user.admin && !lockAdmin`, ping frozen, the shared builders untouched — the drift-lock still holds by construction.
- Side effect: the anonymous version-disclosure question from the #932 review is moot — `/api/` discloses nothing tokenless anymore.

## Contract (now explicit in OpenAPI)
| Request | Result |
|---|---|
| no token, server has users | **401 — the login-detection signal** |
| invalid token / bogus federation key | 401 |
| share token | 401 (wall path-gating, same as ping) |
| valid JWT | 200: `server` + `features` + `user` (+ `admin` if admin and unlocked) |
| public-access mode, tokenless | 200 with all applicable layers — the "no login needed" answer |
| federation key | 200: `server` + `features` + key-scoped `user`; other routes still 403 off-allowlist |

## Tests
Matrix rewritten to 12 cases pinning the flip: the tokenless-401 case carries the contract comment by name; share-token → 401; version asserted present on user/admin/federation responses; unchanged pins all still green (drift-lock, disclosure-by-name, allowlist tightness, jukebox dead-session, public-mode ×2, real-admin-under-lockAdmin two-boot test). Suite 12/12; full `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
