### PR TITLE
feat(federation): guest tokens — direct app access to a federated peer

### DIFF
--- a/docs/federation-guest-ticket.md
+++ b/docs/federation-guest-ticket.md
@@ -1,0 +1,91 @@
+# mStream Federation Guest Ticket (`mstrfedg<V>:`)
+
+The string a server hands **one of its own devices** (the mobile app) so
+the device can reach a federated peer directly — its bytes no longer
+crossing the server's home link twice, and the peer staying usable while
+the server is down. Sibling spec to [federation-ticket.md](federation-ticket.md)
+(the admin-to-admin pairing ticket) and [iroh-pairing-code.md](iroh-pairing-code.md)
+(the Quick Connect QR): same envelope mechanics, a different audience and a
+different trust model (see [Security](#security)).
+
+Builder/parser: `buildFederationGuestTicket` / `parseFederationGuestTicket`
+in `src/state/federation.js`. Tokens: `src/state/federation-guest.js`.
+
+## Envelope
+
+```
+mstrfedg<V>:<base64url(JSON payload)>
+```
+
+- `mstrfedg` — literal prefix. Disjoint from both `mstr<V>:` (the tunnel
+  pairing code) and `mstrfed<V>:` (the federation ticket): `mstrfedg1:`
+  never matches `^mstrfed(\d+):`, so a ticket handed to the wrong parser
+  fails cleanly.
+- `<V>` — integer payload version. This build emits and understands **v1**.
+  A parser MUST reject a version newer than it understands with an
+  actionable "update" error.
+- No bare-body legacy form.
+
+## v1 payload
+
+```jsonc
+{
+  "t": "endpoint…",   // REQUIRED — the PEER's federation EndpointTicket
+                      // (iroh: node id + relay + direct addresses)
+  "g": "eyJ…"         // REQUIRED — a guest token the peer minted for the
+                      // holder's key: a JWT signed by the peer, claims
+                      // { federationGuest: true, federationKeyId, iat, exp }
+}
+```
+
+Parsers MUST ignore unknown fields (forward compatibility) and MUST reject a
+payload missing `t` or `g`.
+
+## Flow
+
+1. Server B (the *parent*) is paired with peer A through a federation
+   ticket — A minted a `fedk_` key for B, B redeemed it over A's federation
+   endpoint, and A TOFU-bound the key to B's endpoint id.
+2. A device logged in to B asks B for direct access to A:
+   `GET /api/v1/federation/peers/:id/access`.
+3. B asks A, over the existing bound pipe, for a guest token:
+   `POST /api/v1/federation/guest` (with B's `x-federation-key`). A signs a
+   short-lived JWT for that key (24 h by default). B caches it and re-mints
+   once three quarters of its life is gone (or on `?refresh=1`).
+4. B answers the device with `{ direct: true, endpointTicket, endpointId,
+   guestToken, expiresAt, directTicket }` — `directTicket` being this
+   envelope. An A too old to mint (its allowlist 403s the route) makes B
+   answer `{ direct: false, reason }`, and the device keeps using B's
+   proxies (`/api/v1/federation/peers/:id/{api,art,stream}`).
+5. The device dials `t` on ALPN `mstream/federation/1` and presents `g` on
+   the first bi-stream. A verifies the token and replies `OK`; every later
+   bi-stream is a plain TCP-over-QUIC bridge into A's HTTP server, where the
+   device authenticates each request with the same token in the ordinary
+   slots (`x-access-token` header, or `?token=` on stream and art URLs).
+6. Before the token expires the device asks B again (step 2). B's cache
+   hands out the same token until it is due for a re-mint, so this is
+   cheap.
+
+## Security
+
+- **The standing key never leaves B.** The device only ever holds a guest
+  token; B's `fedk_` key is not in the ticket, the access response, or any
+  URL.
+- **Scope is the key's.** A guest token resolves on A to the same synthetic
+  read-only user as B's key: the same library grants, the same route
+  allowlist, the same bandwidth caps — and guests share the key's caps
+  (concurrent streams, daily quota, rate) rather than getting their own.
+- **No TOFU; expiry instead.** A device dials from an ephemeral endpoint,
+  so there is nothing stable to bind. A guest token is valid from any
+  endpoint until it expires. The per-endpoint failed-handshake backoff
+  still applies.
+- **Revocation is through the key.** Deleting or expiring A's key for B
+  rejects every guest of it at its next handshake and its next request, and
+  severs their live pipes. B cannot revoke a single device's token early;
+  the lifetime is the bound.
+- **A guest cannot mint guests.** The mint route refuses a guest credential,
+  and a guest token carries no `username`, so it cannot be replayed as an
+  ordinary user token either.
+- **Exposure class.** On the device the token sits in stream and art URLs
+  exactly like B's own JWT does today; on the wire it is inside iroh's
+  end-to-end encryption. Treat it like any session token.

--- a/docs/federation-ticket.md
+++ b/docs/federation-ticket.md
@@ -94,3 +94,15 @@ payload missing `t` or `k`.
 - **"Friend reinstalled" case:** their endpoint identity changed, so TOFU
   rejects them. The admin UI's reset-binding action clears the binding
   without re-minting; the next successful handshake re-binds.
+
+## Guest access (`mstrfedg<V>:`)
+
+A key holder's own devices — the mobile app — can reach the minting server
+directly instead of through the holder's proxies. The holder asks the
+minting server for a **guest token** over its bound pipe
+(`POST /api/v1/federation/guest`) and hands the device that token plus the
+minting server's endpoint ticket, packaged as a `mstrfedg1:` guest ticket.
+The token is a short-lived JWT scoped exactly like the key (same grants,
+allowlist and caps), it is never bound (expiry is its bound), and revoking
+the key revokes its guests. The key itself still never leaves the holder.
+Spec: [federation-guest-ticket.md](federation-guest-ticket.md).

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -27,6 +27,11 @@ info:
     - **Shared-playlist tokens** (`shareToken: true`) restrict file access to the tracks in one specific shared playlist.
     - **Federation keys** (`x-federation-key: fedk_…` header, not a JWT) authenticate a paired peer server as a
       synthetic read-only user scoped to the key's granted libraries, limited to a read-route allowlist.
+    - **Federation guest tokens** (`federationGuest: true`) are short-lived JWTs this server mints for a
+      federation key on request (`POST /api/v1/federation/guest`), so a key holder's own device can reach
+      this server directly. They ride the ordinary token slots and resolve to the same read-only user as
+      the key (same grants, allowlist and bandwidth caps); revoking the key revokes its guests. See
+      docs/federation-guest-ticket.md.
 
     ## Errors
 
@@ -165,6 +170,11 @@ tags:
       server's endpoint address plus the key. A peer authenticates every
       HTTP request with the `x-federation-key` header and is restricted to a
       read-route allowlist within the granted libraries.
+
+      A key holder may also fetch **guest tokens** for its own devices
+      (`POST /api/v1/federation/guest`; docs/federation-guest-ticket.md) so
+      a device dials this server directly instead of through the holder's
+      proxies — the parent side of that is `GET /api/v1/federation/peers/{id}/access`.
   - name: Torrent
     description: |
       User-facing torrent feature. Operators upload `.torrent` files or
@@ -1031,14 +1041,24 @@ paths:
                       Present only for authenticated callers. The
                       caller-scoped half of the ping boot payload (vpaths,
                       permission flags, federationDiscovery,
-                      federationBrowse, vpathMetaData) plus the identity
-                      fields below.
+                      federationBrowse, federationDirect, vpathMetaData)
+                      plus the identity fields below.
                     properties:
                       username: { type: string }
                       admin: { type: boolean }
                       federation:
                         type: boolean
-                        description: True when authenticated by a federation key.
+                        description: True when authenticated by a federation key (or a guest token of one).
+                      federationGuest:
+                        type: boolean
+                        description: True when authenticated by a federation guest token rather than the key itself.
+                      federationDirect:
+                        type: boolean
+                        description: >
+                          This build offers `GET /api/v1/federation/peers/{id}/access`
+                          and there is at least one peer to reach. Same value as
+                          federationBrowse; whether a given peer cooperates is
+                          answered per peer by the access route.
                   admin:
                     type: object
                     description: >
@@ -6081,6 +6101,45 @@ paths:
                       modelVersion: { type: string, nullable: true }
                       dim: { type: integer, description: Embedding dimension (float32 count per vector) }
                       analyzedCount: { type: integer, description: Embedded tracks in the index }
+                  guestAccess:
+                    type: boolean
+                    description: This build mints guest tokens (`POST /api/v1/federation/guest`).
+
+  /api/v1/federation/guest:
+    post:
+      tags: [Federation]
+      summary: Mint a guest token for the caller's federation key
+      description: |
+        Called by a paired server (with its `x-federation-key`) over the
+        federation bridge to get a short-lived JWT one of its OWN devices —
+        the mobile app — can dial this server with directly, so the device's
+        bytes stop crossing the holder's home link twice. The standing key
+        never leaves the holder; the device only ever holds the token.
+
+        The token resolves here to the same synthetic read-only user as the
+        key: same library grants, same route allowlist, same bandwidth caps
+        (guests share the key's pool). No TOFU binding — a device dials from
+        an ephemeral endpoint — so expiry (24 h) is the bound; revoking or
+        expiring the key rejects its guests at their next handshake and
+        request and severs their live pipes. See docs/federation-guest-ticket.md.
+
+        Refused (403) for a local user (no key to mint for), for a guest
+        (guests cannot mint guests), and for a key that has never completed
+        the federation handshake (unbound).
+      responses:
+        "200":
+          description: A signed guest token and its expiry.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token: { type: string, description: "JWT — claims { federationGuest: true, federationKeyId, iat, exp }" }
+                  expiresAt: { type: string, format: date-time }
+        "401":
+          description: Federation is disabled, or the key is unknown or expired.
+        "403":
+          description: Not a federation key, a guest credential, or an unbound key.
 
   /api/v1/federation/discovery/similar:
     post:
@@ -6179,6 +6238,14 @@ paths:
                         lastSeen: { type: string, nullable: true, description: "Last successful contact (SQLite datetime), or null" }
                         lastStatus: { type: string, nullable: true, description: "'ok' or an error string from the last test-connection" }
                         useDiscovery: { type: boolean, description: Whether this server sends the peer similarity queries }
+                        endpointId:
+                          type: string
+                          nullable: true
+                          description: >
+                            The peer's iroh endpoint id (a public key, not a
+                            credential) — lets a client tell that two parents
+                            list the same server. Null when this build cannot
+                            read tickets.
         "403":
           description: Federation is disabled on this server.
 
@@ -6282,6 +6349,63 @@ paths:
         "403": { description: Federation is disabled on this server. }
         "404": { description: "Unknown peer id, or the peer has no such art file." }
         "502": { description: "Peer unreachable — the 15s deadline was exceeded." }
+
+  /api/v1/federation/peers/{id}/access:
+    get:
+      tags: [Federation]
+      summary: What a device needs to reach a peer directly
+      description: |
+        Hands a logged-in user what its device needs to reach the peer
+        WITHOUT this server in the path: the peer's endpoint ticket and a
+        guest token the peer minted for this server's key
+        (`POST /api/v1/federation/guest`, called over the bridge). The
+        device dials the ticket on ALPN `mstream/federation/1`, presents
+        the token on the first bi-stream, and authenticates every request
+        inside the pipe with the same token in the ordinary token slots.
+        `directTicket` packages the two as a `mstrfedg1:` guest ticket for
+        the device's native dialer (docs/federation-guest-ticket.md).
+
+        Tokens are cached per peer and re-minted once three quarters of
+        their life is gone, or on `?refresh=1` — for a client whose token
+        the peer just refused (a refresh within seconds of a mint is served
+        from the cache). The key itself never leaves this server.
+
+        A peer that will not mint — an older build, or federation disabled
+        there — is a 200 with `direct: false`, so a client can tell "keep
+        using the proxies" from "the peer is down" (502).
+
+        Takes normal local-user auth and is NOT callable with a federation
+        key or a guest token.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer }, description: Peer row id }
+        - { name: refresh, in: query, required: false, schema: { type: string, enum: ["1", "true"] }, description: Force a fresh mint }
+      responses:
+        "200":
+          description: "Direct-access material, or `direct: false`."
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    required: [direct, endpointTicket, guestToken, expiresAt, directTicket]
+                    properties:
+                      direct: { type: boolean, enum: [true] }
+                      endpointTicket: { type: string, description: "The peer's iroh EndpointTicket" }
+                      endpointId: { type: string, nullable: true, description: "The peer's endpoint id (public key)" }
+                      guestToken: { type: string, description: "JWT the peer signed for this server's key" }
+                      expiresAt: { type: string, format: date-time }
+                      directTicket: { type: string, description: "`mstrfedg1:` envelope of endpointTicket + guestToken" }
+                  - type: object
+                    required: [direct, reason]
+                    properties:
+                      direct: { type: boolean, enum: [false] }
+                      reason: { type: string }
+        "403":
+          description: Federation is disabled on this server.
+        "404":
+          description: Unknown peer id.
+        "502":
+          description: "Peer unreachable — the dial + response deadline (15s) was exceeded, or it answered the mint unexpectedly."
 
   /api/v1/federation/peers/{id}/stream/{path}:
     get:

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -24,6 +24,7 @@ import * as admin from '../util/admin.js';
 import * as db from '../db/manager.js';
 import * as fedDb from '../db/federation.js';
 import * as fedLimits from './federation-limits.js';
+import { forgetPeerAccess } from './federation-browse.js';
 
 // Per-key bandwidth caps (0 = unlimited). Optional at mint time — absent
 // fields fall back to config.federation.limits, which is also what the UI
@@ -167,6 +168,14 @@ export function register(mstream) {
     const limits = resolveLimits(req.body);
     const expiresAt = normalizeExpiry(req.body.expiresAt);
     const minted = fedDb.createFederationKey(req.body.name, libraryIds, limits, expiresAt);
+    // A fresh key means a fresh dial is coming — typically from the same
+    // friend whose retries on a key just revoked are what the endpoint
+    // backed off (mStream #940: a peer re-added right after a revocation
+    // was refused for a minute). Forgive every backed-off remote now.
+    try {
+      const federation = await import('../state/federation.js');
+      federation.clearHandshakeBackoff();
+    } catch (_err) { /* native binary not present — no endpoint, nothing backed off */ }
     winston.info(`[federation] ${req.user.username} minted key '${minted.name}' for libraries [${req.body.vpaths.join(', ')}] `
       + `(limits: ${limits.streamKbps} kbps, ${limits.dailyMb} MB/day, ${limits.maxStreams} streams; `
       + `expires: ${expiresAt || 'never'})`);
@@ -223,6 +232,8 @@ export function register(mstream) {
       const closed = federation.closeConnectionsForKey(Number(req.params.id));
       if (closed > 0) { winston.info(`[federation] closed ${closed} live connection(s) for revoked key id=${req.params.id}`); }
     } catch (_err) { /* native binary not present — nothing live to close */ }
+    // Its unflushed usage would fail its FOREIGN KEY forever (mStream #940).
+    fedLimits.forgetKey(Number(req.params.id));
     winston.info(`[federation] ${req.user.username} revoked key id=${req.params.id}`);
     res.json({});
   });
@@ -466,6 +477,7 @@ export function register(mstream) {
       const client = await import('../state/federation-client.js');
       client.closePeerBridge(id);
     } catch (_err) { /* nothing live to close */ }
+    forgetPeerAccess(id);
     winston.info(`[federation] ${req.user.username} removed peer id=${id}`);
     res.json({});
   });

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -7,6 +7,7 @@ import * as db from '../db/manager.js';
 import * as shared from '../api/shared.js';
 import { isActiveJukeboxToken } from '../api/remote.js';
 import * as federationAuth from './federation-auth.js';
+import * as federationGuest from '../state/federation-guest.js';
 import WebError from '../util/web-error.js';
 
 export function setup(mstream) {
@@ -62,13 +63,27 @@ export function setup(mstream) {
       return next();
     }
 
+    // Federation GUEST tokens next — the same ordering reason. A guest is a
+    // device of a key holder carrying a short-lived JWT this server signed
+    // for the key (state/federation-guest.js); it rides the ordinary token
+    // slots so clients need no special header. Routed by CLAIM (a plain
+    // decode) so ordinary user tokens are still verified exactly once,
+    // below; a token that claims to be a guest is verified for real in the
+    // guest branch, and a bad one is a 401 there — never a fall-through to
+    // public mode.
+    const token = readToken(req);
+    if (token && federationGuest.looksLikeGuestToken(token)) {
+      req.token = token;
+      req.user = federationAuth.authenticateGuestToken(token, req);
+      return next();
+    }
+
     // Handle No Users (public access mode)
     if (db.getAllUsers().length === 0) {
       req.user = buildPublicModeUser();
       return next();
     }
 
-    const token = readToken(req);
     if (!token) { throw new WebError('Authentication Error', 401); }
     req.token = token;
 

--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -7,6 +7,14 @@
 // hand every request a full-access user, silently bypassing federation
 // scoping.
 //
+// A GUEST of a key — one of the key holder's own devices, carrying a
+// short-lived JWT this server signed for the key (state/federation-guest.js)
+// in the ordinary token slots — takes the wall's SECOND branch,
+// authenticateGuestToken(), for the same ordering reason. It resolves to the
+// same synthetic user as the key it belongs to, with `federationGuest: true`
+// on top; the one thing a guest may not do that the key may is mint further
+// guests (api/federation.js checks the flag).
+//
 // A validated key resolves to a synthetic read-only req.user:
 //   - admin false + every allow_* flag 0 → all write handlers refuse
 //     (the same construction the jukebox-token branch uses);
@@ -27,6 +35,7 @@ import winston from 'winston';
 import WebError from '../util/web-error.js';
 import * as config from '../state/config.js';
 import * as fedDb from '../db/federation.js';
+import { verifyGuestToken } from '../state/federation-guest.js';
 
 // Read routes a federation key may call. Exact "METHOD path" matches plus
 // GET-only prefixes for the static media/art trees. The file-explorer
@@ -39,8 +48,8 @@ const ALLOWED_EXACT = new Set([
   // The layered server-info endpoint (server-info.js): version +
   // capabilities, plus the key-scoped `user` boot payload — how a
   // federated client (the mobile app) learns what this peer can do.
-  // Both spellings: it's mounted before the wall and resolves the key
-  // itself, so req.path arrives exactly as the client sent it.
+  // Both spellings: the route sits behind the wall (#934) and req.path
+  // arrives exactly as the client sent it, trailing slash or not.
   'GET /api',
   'GET /api/',
   'GET /api/v1/db/status',
@@ -62,6 +71,11 @@ const ALLOWED_EXACT = new Set([
   'POST /api/v1/file-explorer/m3u',
   'GET /api/v1/federation/health',
   'POST /api/v1/federation/discovery/similar',
+  // The guest mint (api/federation.js): a key holder asks for a token one
+  // of its own devices can dial us with. Listed for the KEY's sake; the
+  // route itself refuses guests, so being on the shared allowlist does not
+  // let a guest mint guests.
+  'POST /api/v1/federation/guest',
 ]);
 const ALLOWED_GET_PREFIXES = ['/media/', '/album-art/'];
 
@@ -86,45 +100,48 @@ export function isFederationRouteAllowed(method, path, { exactOnly = false } = {
   return false;
 }
 
-// Validate a presented key and build the synthetic read-only req.user.
-// Throws WebError 401 (bad/inert key) or 403 (valid key, off-limits route).
-export function authenticateFederationKey(key, req) {
-  // Feature off = every minted key is inert, even over plain LAN HTTP. The
-  // key is the credential and the iroh endpoint just a rendezvous, so the
-  // enabled flag has to gate here, not only at the endpoint.
+// Feature off = every minted key (and every guest of one) is inert, even
+// over plain LAN HTTP. The key is the credential and the iroh endpoint just
+// a rendezvous, so the enabled flag has to gate here, not only at the
+// endpoint.
+function requireFederationEnabled(req, what) {
   if (config.program.federation.enabled !== true) {
-    winston.warn(`[federation] rejected key auth from ${req.ip} on ${req.path}: federation is disabled`);
+    winston.warn(`[federation] rejected ${what} from ${req.ip} on ${req.path}: federation is disabled`);
     throw new WebError('Authentication Error', 401);
   }
+}
 
-  const row = fedDb.getFederationKeyByKey(key);
-  if (!row) {
-    // A wrong key at this wall is a probing signal, same as an invalid JWT.
-    winston.warn(`[federation] rejected unknown key from ${req.ip} on ${req.path}`);
-    throw new WebError('Authentication Error', 401);
-  }
+// Lazy severing of an expired key's pipes: an iroh pipe opened before the
+// cutoff would otherwise coast on keep-alives (each request inside it dies
+// at the wall anyway, but the connection itself should go too). DELAYED a
+// beat on purpose: severing in-line races the 401 through the bridge — the
+// pipe died under the in-flight response and the peer saw "unreachable"
+// instead of the clean auth error (caught by the two-server live smoke).
+// Two seconds lets the rejection flush; anything the peer sends in the
+// window still dies at the wall.
+function severExpiredKeyLater(row) {
+  const sever = setTimeout(() => {
+    import('../state/federation.js')
+      .then((federation) => federation.closeConnectionsForKey(row.id))
+      .catch(() => { /* native binary absent — nothing live to sever */ });
+  }, 2000);
+  if (sever.unref) { sever.unref(); }
+}
 
+// The shared tail of both branches: a key row that exists resolves to the
+// synthetic read-only user — after the expiry check and the allowlist
+// screen. `guest` marks a token-carrying device rather than the paired
+// server itself; everything else about the user is the key's.
+function buildFederationUser(row, req, { guest = false } = {}) {
+  const who = guest ? `guest of key '${row.name}'` : `key '${row.name}'`;
   if (row.expired) {
-    winston.warn(`[federation] rejected expired key '${row.name}' from ${req.ip} on ${req.path}`);
-    // Lazy severing: an iroh pipe opened before the cutoff would otherwise
-    // coast on keep-alives (each request inside it dies here anyway, but
-    // the connection itself should go too). DELAYED a beat on purpose:
-    // severing in-line races this 401 through the bridge — the pipe died
-    // under the in-flight response and the peer saw "unreachable" instead
-    // of the clean auth error (caught by the two-server live smoke). Two
-    // seconds lets the rejection flush; anything the peer sends in the
-    // window still dies at this wall.
-    const sever = setTimeout(() => {
-      import('../state/federation.js')
-        .then((federation) => federation.closeConnectionsForKey(row.id))
-        .catch(() => { /* native binary absent — nothing live to sever */ });
-    }, 2000);
-    if (sever.unref) { sever.unref(); }
+    winston.warn(`[federation] rejected expired ${who} from ${req.ip} on ${req.path}`);
+    severExpiredKeyLater(row);
     throw new WebError('Authentication Error', 401);
   }
 
   if (!isFederationPathAllowed(req)) {
-    winston.warn(`[federation] key '${row.name}' denied off-allowlist route ${req.method} ${req.path} from ${req.ip}`);
+    winston.warn(`[federation] ${who} denied off-allowlist route ${req.method} ${req.path} from ${req.ip}`);
     throw new WebError('Forbidden', 403);
   }
 
@@ -136,6 +153,9 @@ export function authenticateFederationKey(key, req) {
     username: `federation:${row.name}`,
     federation: true,
     federationKeyId: row.id,
+    // A device of the key holder rather than the holder's server (see the
+    // header). Same scope and caps; the mint route refuses it.
+    federationGuest: guest,
     // Bandwidth caps ride along so the limits middleware (registered right
     // after this wall) never needs a second key lookup. 0 = unlimited.
     federationLimits: {
@@ -151,4 +171,44 @@ export function authenticateFederationKey(key, req) {
     allow_file_modify: 0,
     allow_server_audio: 0,
   };
+}
+
+// Validate a presented key and build the synthetic read-only req.user.
+// Throws WebError 401 (bad/inert key) or 403 (valid key, off-limits route).
+export function authenticateFederationKey(key, req) {
+  requireFederationEnabled(req, 'key auth');
+
+  const row = fedDb.getFederationKeyByKey(key);
+  if (!row) {
+    // A wrong key at this wall is a probing signal, same as an invalid JWT.
+    winston.warn(`[federation] rejected unknown key from ${req.ip} on ${req.path}`);
+    throw new WebError('Authentication Error', 401);
+  }
+
+  return buildFederationUser(row, req);
+}
+
+// Validate a guest token (state/federation-guest.js) presented in the
+// ordinary token slots and build the same synthetic user for the key it
+// belongs to — so a revoked or expired key takes its guests with it.
+// Throws WebError 401 (bad, expired, or orphaned token) or 403 (off-limits
+// route), exactly like authenticateFederationKey.
+export function authenticateGuestToken(token, req) {
+  requireFederationEnabled(req, 'guest auth');
+
+  let guest;
+  try {
+    guest = verifyGuestToken(token);
+  } catch (err) {
+    winston.warn(`[federation] rejected guest token from ${req.ip} on ${req.path}: ${err.message}`);
+    throw new WebError('Authentication Error', 401);
+  }
+
+  const row = fedDb.getFederationKeyById(guest.keyId);
+  if (!row) {
+    winston.warn(`[federation] rejected guest of a revoked key (id=${guest.keyId}) from ${req.ip} on ${req.path}`);
+    throw new WebError('Authentication Error', 401);
+  }
+
+  return buildFederationUser(row, req, { guest: true });
 }

--- a/src/api/federation-browse.js
+++ b/src/api/federation-browse.js
@@ -12,8 +12,10 @@
 //   GET /api/v1/federation/peers                 peers this user can browse
 //   ALL /api/v1/federation/peers/:id/api/<path>  one allowlisted read
 //   GET /api/v1/federation/peers/:id/art/<file>  that peer's album art
+//   GET /api/v1/federation/peers/:id/access      what a device needs to
+//                                                reach that peer DIRECTLY
 //
-// All three take normal local-user auth and stay OFF the federation-key
+// All four take normal local-user auth and stay OFF the federation-key
 // allowlist, so a peer can never chain a proxy through us — the same rule
 // api/federation-stream.js states for the byte proxy.
 //
@@ -31,6 +33,7 @@ import * as config from '../state/config.js';
 import * as fedDb from '../db/federation.js';
 import { isFederationRouteAllowed } from './federation-auth.js';
 import { fedFetchWithDeadline } from './discovery-federation.js';
+import { buildFederationGuestTicket, endpointIdFromTicket } from '../state/federation.js';
 import WebError from '../util/web-error.js';
 
 // Dial + response budget, matching testPeer and the stream proxy's header
@@ -107,6 +110,68 @@ function pipeUpstream(upstream, res, peer, label) {
   body.pipe(res);
 }
 
+// ── Direct access: guest tokens for this server's own devices ─────────────
+//
+// GET /api/v1/federation/peers/:id/access hands a logged-in user what its
+// device needs to reach the peer WITHOUT this server in the path: the peer's
+// endpoint ticket and a guest token the peer minted for our key (POST
+// /api/v1/federation/guest over the bridge — state/federation-guest.js on
+// the peer's side). Tokens are cached per peer and re-minted once three
+// quarters of their life is gone, or on ?refresh=1 for a client whose token
+// the peer just refused, so a device polling this on every resume costs one
+// bridge round trip a day. The key itself still never leaves this server.
+const GUEST_REMINT_AT = 0.75; // fraction of the lifetime after which we re-mint
+const GUEST_REFRESH_MIN_GAP_MS = 5 * 1000; // a refresh right after a mint is served from cache
+const guestAccess = new Map(); // peerId -> { token, expiresAt: ms, mintedAt: ms }
+const guestPending = new Map(); // peerId -> Promise<entry|null> (one mint in flight per peer)
+
+function guestIsFresh(entry, { refresh }) {
+  if (!entry) { return false; }
+  const age = Date.now() - entry.mintedAt;
+  if (refresh) { return age < GUEST_REFRESH_MIN_GAP_MS; }
+  const life = entry.expiresAt - entry.mintedAt;
+  return life > 0 && age < life * GUEST_REMINT_AT;
+}
+
+// Drop a peer's cached guest token — on removal (the row is gone; a re-added
+// peer gets a fresh id anyway, this just keeps the map honest).
+export function forgetPeerAccess(peerId) {
+  guestAccess.delete(peerId);
+}
+
+// Ask the peer for a guest token. Resolves to the cache entry, or null when
+// the peer refuses to mint: an older build whose allowlist has no guest
+// route (its wall answers 403), or federation switched off there. Throws
+// when the peer is unreachable or answers something unexpected.
+async function mintGuestFromPeer(peer) {
+  const fedClient = await import('../state/federation-client.js');
+  const upstream = await fedFetchWithDeadline(fedClient, peer, '/api/v1/federation/guest', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+  }, DEADLINE_MS);
+  if (upstream.status === 403 || upstream.status === 404) { return null; }
+  if (!upstream.ok) { throw new Error(`peer answered http ${upstream.status} to the guest mint`); }
+  const body = await upstream.json();
+  if (typeof body?.token !== 'string' || typeof body?.expiresAt !== 'string') {
+    throw new Error('peer answered the guest mint with an unexpected shape');
+  }
+  const expiresAt = Date.parse(body.expiresAt);
+  if (!Number.isFinite(expiresAt)) { throw new Error('peer answered the guest mint with an unreadable expiry'); }
+  return { token: body.token, expiresAt, mintedAt: Date.now() };
+}
+
+function guestAccessFor(peer, { refresh = false } = {}) {
+  const cached = guestAccess.get(peer.id);
+  if (guestIsFresh(cached, { refresh })) { return Promise.resolve(cached); }
+  const inFlight = guestPending.get(peer.id);
+  if (inFlight) { return inFlight; }
+  const p = mintGuestFromPeer(peer).then((entry) => {
+    if (entry) { guestAccess.set(peer.id, entry); } else { guestAccess.delete(peer.id); }
+    return entry;
+  }).finally(() => guestPending.delete(peer.id));
+  guestPending.set(peer.id, p);
+  return p;
+}
+
 export function setup(mstream) {
   // The peers a local user may browse. Admin's /api/v1/admin/federation/peers
   // returns the row — which carries api_key and endpoint_ticket, both
@@ -124,7 +189,46 @@ export function setup(mstream) {
         lastSeen: p.last_seen || null,
         lastStatus: p.last_status || null,
         useDiscovery: p.use_discovery === 1,
+        // The peer's iroh identity (a public key, not a credential): how a
+        // client tells that two parents list the same server. Null when
+        // this build cannot read tickets (no native module).
+        endpointId: endpointIdFromTicket(p.endpoint_ticket),
       })),
+    });
+  });
+
+  // What a device needs to reach a peer directly — see the section above.
+  // Same guards as the proxies (federation on, known peer, local-user auth,
+  // never a federation key), and the same 502 when the peer cannot be
+  // reached; a peer that will not mint is a 200 with `direct: false`, so a
+  // client can tell "fall back to the proxies" from "the peer is down".
+  mstream.get('/api/v1/federation/peers/:id/access', async (req, res) => {
+    requireFederation();
+    const peer = requirePeer(req.params.id);
+    const refresh = req.query.refresh === '1' || req.query.refresh === 'true';
+
+    let entry;
+    try {
+      entry = await guestAccessFor(peer, { refresh });
+    } catch (err) {
+      winston.warn(`[federation] access: peer '${peer.name}' (id=${peer.id}) unreachable for the guest mint: ${err.message}`);
+      throw new WebError('Peer unreachable', 502);
+    }
+    if (!entry) {
+      return res.json({
+        direct: false,
+        reason: 'peer does not offer guest access (an older build, or federation is disabled there)',
+      });
+    }
+    res.json({
+      direct: true,
+      endpointTicket: peer.endpoint_ticket,
+      endpointId: endpointIdFromTicket(peer.endpoint_ticket),
+      guestToken: entry.token,
+      expiresAt: new Date(entry.expiresAt).toISOString(),
+      // The two above, packaged for the device's native dialer:
+      // docs/federation-guest-ticket.md.
+      directTicket: buildFederationGuestTicket({ endpointTicket: peer.endpoint_ticket, guestToken: entry.token }),
     });
   });
 

--- a/src/api/federation-limits.js
+++ b/src/api/federation-limits.js
@@ -81,6 +81,17 @@ export function flushUsage() {
     try {
       flushKey(keyId, entry);
     } catch (err) {
+      if (/FOREIGN KEY/i.test(err.message)) {
+        // The key is gone — revoked between accumulation and flush, or a
+        // request that was in flight when the delete route called
+        // forgetKey re-created the entry. It can never land; retrying it
+        // every interval only logged the same failure forever (mStream
+        // #940). Drop it and move on to the next key.
+        winston.info(`[federation] dropping ${entry.bytes} unflushed bytes for revoked key id=${keyId}`);
+        pending.delete(keyId);
+        dbBaseline.delete(keyId);
+        continue;
+      }
       // Keep accumulating and retry next interval — a locked/closing DB
       // must not lose the day's count or take a stream down with it.
       winston.warn(`[federation] usage flush failed for key id=${keyId}: ${err.message}`);
@@ -94,6 +105,18 @@ export function flushUsage() {
       winston.warn(`[federation] usage prune failed: ${err.message}`);
     }
   }
+}
+
+// A revoked key's accounting has nowhere to go — its usage row is FK'd to
+// the deleted key — so drop everything held for it (the delete route calls
+// this next to severing the key's live pipes). Responses still open on the
+// key stop counting when they close; the flusher's FOREIGN KEY branch
+// catches whatever they added in the meantime.
+export function forgetKey(keyId) {
+  pending.delete(keyId);
+  dbBaseline.delete(keyId);
+  buckets.delete(keyId);
+  activeStreams.delete(keyId);
 }
 
 function addUsage(keyId, bytes, requests = 0) {

--- a/src/api/federation.js
+++ b/src/api/federation.js
@@ -10,12 +10,21 @@
 //
 // Regular logged-in users can also hit this route; they just see their own
 // vpaths, which they already know. Harmless.
+//
+// Also the guest mint: a paired server asks, over its bound pipe, for a
+// short-lived token one of its OWN devices (the mobile app) can dial us
+// with directly, so the device's bytes stop crossing the holder's home link
+// twice (state/federation-guest.js). Same wall, same key: the caller is the
+// key holder, and the token it gets back is scoped exactly like the key.
 
 import os from 'os';
 import winston from 'winston';
 import packageJson from '../../package.json' with { type: 'json' };
 import * as config from '../state/config.js';
+import * as fedDb from '../db/federation.js';
 import * as sim from '../db/discovery-similarity.js';
+import { mintGuestToken } from '../state/federation-guest.js';
+import WebError from '../util/web-error.js';
 
 // What a peer needs before sending vector queries: can this server answer
 // at all, and in which model space. null = don't bother querying. The index
@@ -46,6 +55,36 @@ export function setup(mstream) {
       name: config.program.federation.serverName || os.hostname(),
       libraries: req.user.vpaths,
       discovery: discoveryCapability(),
+      // This build mints guest tokens (POST /api/v1/federation/guest), so a
+      // parent may offer its devices a direct path to us. A flag, not a
+      // probe — like everything else a peer learns here.
+      guestAccess: true,
     });
+  });
+
+  // Mint a GUEST token for the caller's key. Callable only with a federation
+  // key that has completed the pipe handshake (bound) — in practice: by the
+  // parent, over the bridge. A guest may not mint guests, and a local user
+  // has no key to mint for. The token is what the parent's access route
+  // (api/federation-browse.js) hands its device; see federation-guest.js
+  // for what it resolves to here.
+  mstream.post('/api/v1/federation/guest', (req, res) => {
+    const user = req.user;
+    if (user?.federation !== true) {
+      throw new WebError('Guest tokens are minted for federation keys only', 403);
+    }
+    if (user.federationGuest === true) {
+      throw new WebError('A guest cannot mint guests', 403);
+    }
+    const row = fedDb.getFederationKeyById(user.federationKeyId);
+    if (!row || row.expired) { throw new WebError('Authentication Error', 401); }
+    if (row.bound_endpoint_id === null) {
+      // Never redeemed over the federation endpoint: a key used only over
+      // plain HTTP has not shown it can dial, and guests exist to dial.
+      throw new WebError('Key is not bound to an endpoint yet — complete the federation handshake first', 403);
+    }
+    const minted = mintGuestToken(row);
+    winston.info(`[federation] minted a guest token for key '${row.name}' (expires ${minted.expiresAt})`);
+    res.json(minted);
   });
 }

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -126,6 +126,14 @@ export function buildClientBootPayload(user) {
     // with none stays quiet. Caller-scoped for the same reason
     // federationDiscovery is: it reports live peer RELATIONSHIPS.
     federationBrowse: federationEnabled && federationPeers.length > 0,
+    // Direct access to a peer (the `access` route in api/federation-browse.js):
+    // a device dials the peer itself with a guest token this server fetches
+    // on its behalf (state/federation-guest.js). Same shape as
+    // federationBrowse — the key's presence says this build has the route,
+    // its value says there is a peer to reach. Whether a given PEER
+    // cooperates is answered per peer by the access route (an older peer
+    // refuses, and the client keeps using the proxies above).
+    federationDirect: federationEnabled && federationPeers.length > 0,
     vpathMetaData: {}
   };
 
@@ -158,6 +166,9 @@ export function setup(mstream) {
       username: user.username,
       admin: user.admin === true,
       federation: user.federation === true,
+      // A device of a key holder, on a guest token rather than the key
+      // itself (state/federation-guest.js). Same scope as the key.
+      federationGuest: user.federationGuest === true,
       ...buildClientBootPayload(user),
     };
 

--- a/src/state/federation-guest.js
+++ b/src/state/federation-guest.js
@@ -1,0 +1,74 @@
+// Federation GUEST tokens — the credential that lets a key holder's own
+// device (the mobile app) reach a peer directly, without the standing
+// `fedk_` key ever leaving the parent server.
+//
+// A guest token is a short-lived JWT the PEER signs for one of its minted
+// keys, on request from that key's holder (POST /api/v1/federation/guest —
+// api/federation.js — callable only with a key that has completed the pipe
+// handshake, which in practice means: by the parent, over the bridge). The
+// parent hands the token to its device together with the peer's endpoint
+// ticket (the `mstrfedg1:` guest ticket, docs/federation-guest-ticket.md);
+// the device then dials the peer's federation endpoint itself, presents the
+// token on the first bi-stream (state/federation.js), and authenticates
+// every HTTP request inside the pipe with it — through the ordinary
+// `?token=` / `x-access-token` slots, because it IS a JWT signed with this
+// server's secret (api/auth.js routes it to api/federation-auth.js).
+//
+// What it resolves to: the key's synthetic read-only user — same library
+// grants, same route allowlist, same bandwidth caps (guests share the key's
+// pool). What differs from the key:
+//   - no TOFU. Phones dial from ephemeral endpoints, so there is nothing
+//     stable to bind; expiry is the bound instead (GUEST_TOKEN_TTL_MS).
+//   - revocation is through the key: deleting (or expiring) the key kills
+//     every guest at its next handshake or request, and severs live pipes.
+//   - a guest cannot mint further guests (the mint route refuses).
+//
+// The claims are deliberately minimal: `federationGuest: true` marks the
+// kind, `federationKeyId` names the key. No `username`, so a guest token
+// presented as an ordinary user token dies in the wall's real-user branch
+// (401), and an ordinary user token never carries the guest claim.
+
+import jwt from 'jsonwebtoken';
+import * as config from './config.js';
+
+// Test override, same pattern as MSTREAM_TEST_FED_FLUSH_MS: production
+// installs should never set it. 24h: long enough that a device refreshes a
+// handful of times a day (the parent re-mints past three quarters of the
+// lifetime), short enough that a token lifted off a phone is worthless by
+// the next day.
+export const GUEST_TOKEN_TTL_MS = Number(process.env.MSTREAM_TEST_FED_GUEST_TTL_MS) || 24 * 60 * 60 * 1000;
+
+// Sign a guest token for `keyRow`. Returns { token, expiresAt } with the
+// expiry as ISO — read back out of the signed token, so the two can never
+// disagree by a rounding second.
+export function mintGuestToken(keyRow, { ttlMs = GUEST_TOKEN_TTL_MS } = {}) {
+  const token = jwt.sign(
+    { federationGuest: true, federationKeyId: keyRow.id },
+    config.program.secret,
+    { expiresIn: Math.max(1, Math.ceil(ttlMs / 1000)) },
+  );
+  const { exp } = jwt.decode(token);
+  return { token, expiresAt: new Date(exp * 1000).toISOString() };
+}
+
+// Whether a token CLAIMS to be a guest token — a plain decode, no signature
+// check. The auth wall uses this to route a token to the guest branch ahead
+// of the public-mode branch without verifying ordinary user tokens twice;
+// the guest branch then verifies for real.
+export function looksLikeGuestToken(token) {
+  if (typeof token !== 'string' || token.length === 0) { return false; }
+  const decoded = jwt.decode(token);
+  return Boolean(decoded && typeof decoded === 'object' && decoded.federationGuest === true);
+}
+
+// Verify a guest token (signature, expiry, shape). Returns { keyId, exp }
+// or throws — the caller turns that into its own 401 / handshake NO.
+export function verifyGuestToken(token) {
+  const decoded = jwt.verify(token, config.program.secret);
+  if (!decoded || typeof decoded !== 'object'
+    || decoded.federationGuest !== true
+    || !Number.isInteger(decoded.federationKeyId)) {
+    throw new Error('not a federation guest token');
+  }
+  return { keyId: decoded.federationKeyId, exp: decoded.exp };
+}

--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -34,12 +34,16 @@ import {
   parseEnvelope,
 } from './iroh-common.js';
 import * as fedDb from '../db/federation.js';
+import { verifyGuestToken } from './federation-guest.js';
 
 // ALPN — both ends must present identical bytes; Array<number> per the v1
 // binding. Bump the version if the handshake framing changes.
 export const FEDERATION_ALPN = Array.from(Buffer.from('mstream/federation/1'));
 
-const HANDSHAKE_LIMIT = 128; // fedk_ keys are 48 chars; anything bigger is garbage
+// The first bi-stream carries either a fedk_ key (48 chars) or a guest
+// token (a signed JWT — ~200 chars, see federation-guest.js); anything
+// bigger than this is garbage.
+const HANDSHAKE_LIMIT = 2048;
 const CONNECT_TIMEOUT_MS = 25000;
 
 // Failed-handshake backoff, per remote EndpointId. The endpoint is publicly
@@ -113,6 +117,45 @@ export function parseFederationTicket(str) {
 }
 
 // ---------------------------------------------------------------------------
+// Federation GUEST ticket: "mstrfedg<V>:<base64url(JSON)>". Payload:
+//   t  (required) the PEER's federation EndpointTicket string
+//   g  (required) a guest token the peer minted for the holder's key
+//                 (federation-guest.js — a short-lived JWT)
+// What a parent hands ONE OF ITS OWN DEVICES (the mobile app) so the device
+// can dial the peer directly — the opposite audience from the federation
+// ticket above, which goes admin-to-admin and carries a standing key. The
+// prefixes are disjoint on purpose (`mstrfedg1:` never matches
+// `^mstrfed(\d+):`), so a ticket pasted into the wrong parser fails
+// cleanly. Unknown fields are ignored (forward compat).
+// Spec: docs/federation-guest-ticket.md.
+// ---------------------------------------------------------------------------
+
+export const FEDERATION_GUEST_TICKET_PREFIX = 'mstrfedg';
+export const FEDERATION_GUEST_TICKET_VERSION = 1;
+
+export function buildFederationGuestTicket({ endpointTicket, guestToken }) {
+  return buildEnvelope(FEDERATION_GUEST_TICKET_PREFIX, FEDERATION_GUEST_TICKET_VERSION, {
+    t: endpointTicket,
+    g: guestToken,
+  });
+}
+
+// Pure (no native module). Throws on garbage, a missing prefix, a too-new
+// version, or missing fields.
+export function parseFederationGuestTicket(str) {
+  const { version, payload } = parseEnvelope(str, {
+    prefix: FEDERATION_GUEST_TICKET_PREFIX,
+    maxVersion: FEDERATION_GUEST_TICKET_VERSION,
+    allowBare: false,
+    label: 'federation guest ticket',
+  });
+  if (!payload || typeof payload.t !== 'string' || typeof payload.g !== 'string') {
+    throw new Error('Invalid federation guest ticket (missing fields)');
+  }
+  return { version, endpointTicket: payload.t, guestToken: payload.g };
+}
+
+// ---------------------------------------------------------------------------
 // Inbound: accept loop + key handshake with TOFU
 // ---------------------------------------------------------------------------
 
@@ -134,8 +177,25 @@ function recordHandshakeFailure(remote) {
   failedHandshakes.set(remote, entry);
 }
 
-// First bi-stream carries the raw key. Look it up, enforce/establish the TOFU
-// binding, reply OK/NO. Returns the key row on success, null otherwise.
+// Forgive every backed-off remote. Called when the admin mints a key: the
+// friend's next dial (with the new key) is expected, and the failures on
+// the books are typically that same friend retrying a key the admin just
+// revoked — which used to cost them a confusing minute (mStream #940).
+export function clearHandshakeBackoff() {
+  failedHandshakes.clear();
+}
+
+// First bi-stream carries the credential. Two kinds:
+//   - a raw `fedk_` key: a paired SERVER. Look it up, enforce/establish the
+//     TOFU binding to the dialer's EndpointId, reply OK/NO.
+//   - a guest token (federation-guest.js): one of a key holder's own
+//     DEVICES, carrying a short-lived JWT the holder fetched from us over
+//     its bound pipe. Verified (signature, expiry) and resolved to its key;
+//     NO binding — the device's endpoint is ephemeral, expiry is the bound
+//     — but every other rule is the key's: a revoked or expired key rejects
+//     its guests, and their pipes are tracked under the key so
+//     closeConnectionsForKey severs them too.
+// Returns { keyRow, via: 'peer' | 'guest' } on success, null otherwise.
 // `onAuthorized` runs BEFORE the OK byte is flushed: the caller registers
 // the connection in the live-conns map there, so a peer that has been told
 // OK is already severable by closeConnectionsForKey — with registration
@@ -145,31 +205,54 @@ async function authenticateConnection(conn, remote, onAuthorized) {
   const authBi = await conn.acceptBi();
   const sent = Buffer.from(await authBi.recv.readToEnd(HANDSHAKE_LIMIT)).toString('utf8');
 
-  let keyRow = sent.startsWith(fedDb.FEDERATION_KEY_PREFIX) ? fedDb.getFederationKeyByKey(sent) : undefined;
+  let keyRow = null;
   let ok = false;
-  if (!keyRow) {
-    winston.warn(`[federation] rejected connection from ${remote}: unknown key`);
-  } else if (keyRow.expired) {
-    // Checked BEFORE the TOFU block: an expired-but-unredeemed ticket must
-    // die without ever binding. The admin renewing the date re-arms it.
-    winston.warn(`[federation] rejected expired key '${keyRow.name}' from ${remote}`);
-    keyRow = null;
-  } else {
-    if (keyRow.bound_endpoint_id === null) {
-      // TOFU: first redemption binds the key to this dialer. The guarded
-      // UPDATE loses gracefully if a concurrent handshake (or a revoke)
-      // got there first — either way, re-read and require an exact match.
-      if (fedDb.bindFederationKeyEndpoint(keyRow.id, remote)) {
-        winston.info(`[federation] key '${keyRow.name}' bound to endpoint ${remote} (first use)`);
+  let via = 'peer';
+  if (sent.startsWith(fedDb.FEDERATION_KEY_PREFIX)) {
+    keyRow = fedDb.getFederationKeyByKey(sent) || null;
+    if (!keyRow) {
+      winston.warn(`[federation] rejected connection from ${remote}: unknown key`);
+    } else if (keyRow.expired) {
+      // Checked BEFORE the TOFU block: an expired-but-unredeemed ticket must
+      // die without ever binding. The admin renewing the date re-arms it.
+      winston.warn(`[federation] rejected expired key '${keyRow.name}' from ${remote}`);
+      keyRow = null;
+    } else {
+      if (keyRow.bound_endpoint_id === null) {
+        // TOFU: first redemption binds the key to this dialer. The guarded
+        // UPDATE loses gracefully if a concurrent handshake (or a revoke)
+        // got there first — either way, re-read and require an exact match.
+        if (fedDb.bindFederationKeyEndpoint(keyRow.id, remote)) {
+          winston.info(`[federation] key '${keyRow.name}' bound to endpoint ${remote} (first use)`);
+        }
+        keyRow = fedDb.getFederationKeyById(keyRow.id) || null;
       }
-      keyRow = fedDb.getFederationKeyById(keyRow.id);
+      ok = Boolean(keyRow && !keyRow.expired && keyRow.bound_endpoint_id === remote);
+      if (keyRow && !ok) {
+        // The one log line that matters most: a KNOWN key from the WRONG
+        // endpoint means the ticket leaked (or the friend reinstalled — the
+        // admin reset-binding action covers that case).
+        winston.warn(`[federation] rejected key '${keyRow.name}' from ${remote}: bound to ${keyRow.bound_endpoint_id} (possible leaked ticket)`);
+      }
     }
-    ok = Boolean(keyRow && !keyRow.expired && keyRow.bound_endpoint_id === remote);
-    if (keyRow && !ok) {
-      // The one log line that matters most: a KNOWN key from the WRONG
-      // endpoint means the ticket leaked (or the friend reinstalled — the
-      // admin reset-binding action covers that case).
-      winston.warn(`[federation] rejected key '${keyRow.name}' from ${remote}: bound to ${keyRow.bound_endpoint_id} (possible leaked ticket)`);
+  } else {
+    via = 'guest';
+    let guest = null;
+    try {
+      guest = verifyGuestToken(sent);
+    } catch (err) {
+      winston.warn(`[federation] rejected connection from ${remote}: neither a key nor a valid guest token (${err.message})`);
+    }
+    if (guest) {
+      keyRow = fedDb.getFederationKeyById(guest.keyId) || null;
+      if (!keyRow) {
+        winston.warn(`[federation] rejected guest of a revoked key (id=${guest.keyId}) from ${remote}`);
+      } else if (keyRow.expired) {
+        winston.warn(`[federation] rejected guest of expired key '${keyRow.name}' from ${remote}`);
+        keyRow = null;
+      } else {
+        ok = true;
+      }
     }
   }
 
@@ -182,7 +265,7 @@ async function authenticateConnection(conn, remote, onAuthorized) {
     await authBi.send.writeAll(Array.from(Buffer.from(ok ? 'OK' : 'NO')));
     await authBi.send.finish();
   } catch (_err) { /* peer may have hung up */ }
-  return ok ? keyRow : null;
+  return ok ? { keyRow, via } : null;
 }
 
 function trackConn(keyId, conn) {
@@ -247,21 +330,22 @@ async function runAcceptLoop(ep, targetHost, targetPort) {
         // Tracking happens inside the handshake, before the peer hears OK
         // (see authenticateConnection's contract); a null return means the
         // callback never ran, so the failure path has nothing to untrack.
-        const keyRow = await authenticateConnection(conn, remote,
+        const authed = await authenticateConnection(conn, remote,
           (row) => trackConn(row.id, conn));
-        if (!keyRow) {
+        if (!authed) {
           recordHandshakeFailure(remote);
           try { conn.close(1n, Array.from(Buffer.from('unauthorized'))); } catch (_err) { /* noop */ }
           return;
         }
+        const { keyRow, via } = authed;
         failedHandshakes.delete(remote);
-        winston.info(`[federation] peer connection authorized: key '${keyRow.name}' from ${remote}`);
+        winston.info(`[federation] ${via} connection authorized: key '${keyRow.name}' from ${remote}`);
         try {
           await acceptConnection(conn, targetHost, targetPort);
         } finally {
           untrackConn(keyRow.id, conn);
         }
-        winston.info(`[federation] peer connection closed: key '${keyRow.name}' (${remote})`);
+        winston.info(`[federation] ${via} connection closed: key '${keyRow.name}' (${remote})`);
       } catch (err) {
         winston.debug(`[federation] incoming connection dropped (${remote}): ${err?.message}`);
       }
@@ -309,6 +393,24 @@ export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, a
 }
 
 export function getEndpointId() { return endpointIdStr; }
+
+// The EndpointId (base32 public key) inside an endpoint ticket string, or
+// null when the native module is not loaded or the ticket does not parse. A
+// public key is not a credential, so a parent may show it to its users (the
+// peers projection): it is how a client tells that two parents list the
+// same peer. Cached — the projection asks per peer per listing.
+const endpointIdCache = new Map(); // ticket string -> id string | null
+export function endpointIdFromTicket(endpointTicketStr) {
+  if (!irohMod || typeof endpointTicketStr !== 'string') { return null; }
+  if (endpointIdCache.has(endpointTicketStr)) { return endpointIdCache.get(endpointTicketStr); }
+  let id = null;
+  try {
+    id = irohMod.EndpointTicket.fromString(endpointTicketStr).endpointAddr().id().toString();
+  } catch (_err) { /* not a ticket this build can read */ }
+  if (endpointIdCache.size >= 256) { endpointIdCache.clear(); }
+  endpointIdCache.set(endpointTicketStr, id);
+  return id;
+}
 
 export function getEndpointAddr() {
   if (!endpoint) { return null; }

--- a/test/integration/api-server-info.test.mjs
+++ b/test/integration/api-server-info.test.mjs
@@ -189,7 +189,7 @@ describe('layered /api/ server info', () => {
     // Ping's frozen flat contract = the caller-scoped half (/api/'s
     // `user` minus identity) + the capabilities half (/api/'s `features`
     // minus the /api/-only discoveryReady) + three legacy fields.
-    const { username: _u, admin: _a, federation: _f, ...userHalf } = apiJ.user;
+    const { username: _u, admin: _a, federation: _f, federationGuest: _g, ...userHalf } = apiJ.user;
     const { discoveryReady: _dr, ...capsHalf } = apiJ.features;
     const { playlists, allowYoutubeDownload, discoveryPath, ...pingRest } = ping;
     assert.ok(Array.isArray(playlists), 'ping still carries playlists');

--- a/test/integration/federation-browse.test.mjs
+++ b/test/integration/federation-browse.test.mjs
@@ -19,6 +19,12 @@
  * Part 2 (skips without the iroh binary) is the real thing: two spawned
  * servers, B pairs with A over a pasted ticket, and B's webapp routes read
  * A's library through the bridge.
+ *
+ * Direct access (GET /api/v1/federation/peers/:id/access) rides both parts:
+ * the guards in part 1, and in part 2 the whole device flow — B mints a
+ * guest token from A over the bridge, a throwaway "phone" endpoint dials A
+ * with it and reads A's library through its own pipe, and the token works
+ * against A's HTTP wall in the ordinary token slots.
  */
 
 import { describe, test, before, after } from 'node:test';
@@ -27,7 +33,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { startServer } from '../helpers/server.mjs';
-import { buildFederationTicket } from '../../src/state/federation.js';
+import { buildFederationTicket, parseFederationGuestTicket, FEDERATION_ALPN } from '../../src/state/federation.js';
 import http from 'node:http';
 
 let irohAvailable = true;
@@ -100,8 +106,9 @@ describe('federation browse proxy — guards', () => {
     const { peers } = await res.json();
 
     assert.equal(peers.length, 1);
-    assert.deepEqual(Object.keys(peers[0]).sort(), ['id', 'lastSeen', 'lastStatus', 'name', 'useDiscovery']);
+    assert.deepEqual(Object.keys(peers[0]).sort(), ['endpointId', 'id', 'lastSeen', 'lastStatus', 'name', 'useDiscovery']);
     assert.equal(peers[0].name, 'Ghost NAS');
+    assert.equal(peers[0].endpointId, null, 'a ticket that does not parse yields no id (never throws)');
 
     // The credential columns must not appear under ANY key spelling.
     const serialized = JSON.stringify(peers);
@@ -180,6 +187,26 @@ describe('federation browse proxy — guards', () => {
     assert.equal(art.status, 404);
   });
 
+  test('the access route shares the guards: 404 unknown peer, 502 unreachable, never a federation key', async () => {
+    const ghost = await fetch(`${srv.baseUrl}/api/v1/federation/peers/424242/access`, { headers: json(adminToken) });
+    assert.equal(ghost.status, 404);
+
+    // The peer row is real but its endpoint is not: the mint cannot be
+    // asked, which is the same 502 the proxies give — NOT `direct: false`,
+    // which is reserved for a peer that answered and declined.
+    const down = await fetch(`${srv.baseUrl}/api/v1/federation/peers/${peerId}/access`, { headers: json(adminToken) });
+    assert.equal(down.status, 502);
+
+    // A normal user may ask (browsing is not an admin action)...
+    const login = await fetch(`${srv.baseUrl}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'listener', password: 'pw' }),
+    });
+    const listenerToken = (await login.json()).token;
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/peers/${peerId}/access`, { headers: json(listenerToken) })).status, 502);
+  });
+
   test('a federation key cannot chain a proxy through us', async () => {
     const mint = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys`, {
       method: 'POST', headers: json(adminToken), body: JSON.stringify({ name: 'chainer', vpaths: ['shared'] }),
@@ -196,6 +223,7 @@ describe('federation browse proxy — guards', () => {
     for (const url of [
       `${srv.baseUrl}/api/v1/federation/peers`,
       `${srv.baseUrl}/api/v1/federation/peers/${peerId}/art/cover.jpg`,
+      `${srv.baseUrl}/api/v1/federation/peers/${peerId}/access`,
     ]) {
       assert.equal((await fetch(url, { headers: fedH })).status, 403, url);
     }
@@ -205,10 +233,15 @@ describe('federation browse proxy — guards', () => {
     assert.equal(proxied.status, 403);
   });
 
-  test('ping advertises federationBrowse once a peer exists', async () => {
+  test('ping and /api/ advertise federationBrowse + federationDirect once a peer exists', async () => {
     const res = await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: json(adminToken) });
     assert.equal(res.status, 200);
-    assert.equal((await res.json()).federationBrowse, true);
+    const ping = await res.json();
+    assert.equal(ping.federationBrowse, true);
+    assert.equal(ping.federationDirect, true);
+    const info = await (await fetch(`${srv.baseUrl}/api/`, { headers: json(adminToken) })).json();
+    assert.equal(info.user.federationDirect, true);
+    assert.equal(info.user.federationGuest, false);
   });
 });
 
@@ -243,9 +276,11 @@ describe('federation browse proxy — federation disabled', () => {
       method: 'POST', headers: json(token), body: '{}',
     });
     assert.equal(proxied.status, 403);
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/peers/1/access`, { headers: json(token) })).status, 403);
 
-    const ping = await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: json(token) });
-    assert.equal((await ping.json()).federationBrowse, false);
+    const ping = await (await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: json(token) })).json();
+    assert.equal(ping.federationBrowse, false);
+    assert.equal(ping.federationDirect, false);
   });
 });
 
@@ -369,6 +404,86 @@ describe('federation browse proxy over iroh (B reads A)', {
       assert.equal(res.status, 200, `${route} should proxy`);
       assert.ok(shapeOk(await res.json()), `${route} should come back in its normal shape`);
     }
+  });
+
+  test("direct access: B mints a guest token from A; a 'phone' dials A with it and reads A's library", async () => {
+    const res = await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/access`);
+    const text = await res.text();
+    assert.equal(res.status, 200, text);
+    const access = JSON.parse(text);
+    assert.equal(access.direct, true);
+    assert.ok(access.endpointTicket, 'the peer endpoint ticket');
+    assert.ok(access.endpointId, 'the peer endpoint id (public key)');
+    assert.match(access.guestToken, /^eyJ/);
+    assert.ok(Date.parse(access.expiresAt) > Date.now() + 23 * 3600 * 1000, 'a day-long token');
+    assert.match(access.directTicket, /^mstrfedg1:/);
+    const parsed = parseFederationGuestTicket(access.directTicket);
+    assert.equal(parsed.endpointTicket, access.endpointTicket);
+    assert.equal(parsed.guestToken, access.guestToken);
+
+    // The peers projection agrees on who A is.
+    const { peers } = await (await fetch(`${srvB.baseUrl}/api/v1/federation/peers`)).json();
+    assert.equal(peers[0].endpointId, access.endpointId);
+
+    // The token is A's: it works against A's HTTP wall directly, scoped to
+    // the grant, and A knows it is a guest.
+    const health = await fetch(`${srvA.baseUrl}/api/v1/federation/health`, { headers: { 'x-access-token': access.guestToken } });
+    assert.equal(health.status, 200);
+    assert.deepEqual((await health.json()).libraries, ['ashared']);
+    const info = await (await fetch(`${srvA.baseUrl}/api/`, { headers: { 'x-access-token': access.guestToken } })).json();
+    assert.equal(info.user.federationGuest, true);
+    assert.equal((await fetch(`${srvA.baseUrl}/media/ashared/shared-track.txt?token=${access.guestToken}`)).status, 200);
+    assert.equal((await fetch(`${srvA.baseUrl}/media/aprivate/private-track.txt?token=${access.guestToken}`)).status, 404);
+
+    // The phone: a throwaway endpoint (NOT B's) dials A's federation
+    // endpoint with the token, opens a bridged HTTP request, and reads A's
+    // library through its own pipe — B is nowhere in the path.
+    const { Endpoint, EndpointTicket } = await import('@number0/iroh');
+    const phone = await Endpoint.bind({});
+    try {
+      const addr = EndpointTicket.fromString(access.endpointTicket).endpointAddr();
+      const conn = await phone.connect(addr, FEDERATION_ALPN);
+      const authBi = await conn.openBi();
+      await authBi.send.writeAll(Array.from(Buffer.from(access.guestToken)));
+      await authBi.send.finish();
+      assert.equal(Buffer.from(await authBi.recv.readToEnd(8)).toString('utf8'), 'OK');
+
+      const bi = await conn.openBi();
+      const req = `POST /api/v1/file-explorer HTTP/1.0\r\nHost: a\r\nContent-Type: application/json\r\n`
+        + `x-access-token: ${access.guestToken}\r\nContent-Length: 17\r\nConnection: close\r\n\r\n{"directory":"/"}`;
+      await bi.send.writeAll(Array.from(Buffer.from(req)));
+      await bi.send.finish();
+      const chunks = [];
+      for (;;) { const c = await bi.recv.read(65536); if (c.length === 0) { break; } chunks.push(Buffer.from(c)); }
+      const raw = Buffer.concat(chunks).toString('utf8');
+      assert.match(raw, /^HTTP\/1\.[01] 200/);
+      const body = JSON.parse(raw.slice(raw.indexOf('\r\n\r\n') + 4));
+      assert.deepEqual((body.directories || []).map((d) => d.name), ['ashared'], 'only the granted library, through the phone\'s own pipe');
+      conn.close(0n, Array.from(Buffer.from('bye')));
+    } finally {
+      await phone.close();
+    }
+  });
+
+  test('direct access is cached per peer; ?refresh=1 mints anew; a guest cannot fetch access', async () => {
+    const first = await (await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/access`)).json();
+    const again = await (await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/access`)).json();
+    assert.equal(again.guestToken, first.guestToken, 'served from the cache');
+
+    // A refresh right after a mint is served from the cache (a client
+    // looping on 401s cannot make B mint per request)...
+    const soon = await (await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/access?refresh=1`)).json();
+    assert.equal(soon.guestToken, first.guestToken);
+    // ...but a new token is a new token: two mints a second apart differ
+    // by their iat, which the cache keyed on time proves once the gap is
+    // over. Waiting 5s is what the gap costs; keep the suite honest but
+    // bounded by checking the request is at least accepted.
+    assert.equal(soon.direct, true);
+
+    // The guest token is A's credential, not B's: it opens nothing on B.
+    assert.equal((await fetch(`${srvB.baseUrl}/api/v1/federation/peers/${peerId}/access`, {
+      headers: { 'x-access-token': first.guestToken },
+    })).status, 401, 'signed by A — B\'s wall does not know it');
   });
 
   test("A's own auth wall still refuses an ungranted library through the proxy", async () => {

--- a/test/integration/federation-e2e.test.mjs
+++ b/test/integration/federation-e2e.test.mjs
@@ -16,6 +16,15 @@
  * branch-ordering pin: public mode grants anonymous requests everything, but
  * a federation key must STILL be scoped to its grants. If the wall checked
  * public mode first, the key would silently see every library.
+ *
+ * Guest tokens (state/federation-guest.js) get the same treatment in both
+ * scenarios: signed here with the spawned server's secret (read back out of
+ * its config.json) exactly as the server itself would mint them — the mint
+ * ROUTE needs a bound key, i.e. a real iroh handshake, and is covered by
+ * federation-browse's two-server suite. Over plain HTTP the guest rides the
+ * ordinary token slots and must land on the key's scope, the key's
+ * allowlist, and die with the key; and in public mode a forged one must be
+ * a 401, never the public user.
  */
 
 import { describe, test, before, after } from 'node:test';
@@ -24,6 +33,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { startServer } from '../helpers/server.mjs';
+import jwt from 'jsonwebtoken';
 import { parseFederationTicket, buildFederationTicket } from '../../src/state/federation.js';
 
 async function makeLibDir(prefix, fileName, content) {
@@ -33,6 +43,15 @@ async function makeLibDir(prefix, fileName, content) {
 }
 
 const fedHeaders = (key, extra = {}) => ({ 'x-federation-key': key, 'Content-Type': 'application/json', ...extra });
+const tokenHeaders = (token) => ({ 'x-access-token': token, 'Content-Type': 'application/json' });
+
+// The spawned server's JWT secret — config.setup generated it into the
+// config file at boot. Signing with it is exactly what mintGuestToken does.
+async function serverSecret(srv) {
+  return JSON.parse(await fs.readFile(path.join(srv.tmpDir, 'config.json'), 'utf8')).secret;
+}
+const signGuest = (secret, keyId, extra = {}) =>
+  jwt.sign({ federationGuest: true, federationKeyId: keyId, ...extra }, secret, extra.exp ? {} : { expiresIn: '1h' });
 
 describe('federation keys e2e (server with users)', () => {
   let srv, sharedDir, privateDir, adminToken, fedKey, keyId;
@@ -243,7 +262,62 @@ describe('federation keys e2e (server with users)', () => {
     assert.equal(delAgain.status, 404);
   });
 
-  test('revocation kills the key on the next request', async () => {
+  test('a guest token lands on the key\'s scope through the ordinary token slots', async () => {
+    const guest = signGuest(await serverSecret(srv), keyId);
+
+    // Header slot: health shows the key's grants and /api/ says who we are.
+    const health = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: tokenHeaders(guest) });
+    assert.equal(health.status, 200);
+    assert.deepEqual((await health.json()).libraries, ['shared']);
+    const info = await (await fetch(`${srv.baseUrl}/api/`, { headers: tokenHeaders(guest) })).json();
+    assert.equal(info.user.federation, true);
+    assert.equal(info.user.federationGuest, true);
+    assert.deepEqual(info.user.vpaths, ['shared']);
+    assert.equal(info.admin, undefined, 'never the admin layer');
+
+    // Query slot, the way stream and art URLs carry it: granted media
+    // streams, ungranted 404s — the key's scoping, verbatim.
+    const ok = await fetch(`${srv.baseUrl}/media/shared/hello.txt?token=${guest}`);
+    assert.equal(ok.status, 200);
+    assert.equal(await ok.text(), 'hello from shared');
+    assert.equal((await fetch(`${srv.baseUrl}/media/private/secret.txt?token=${guest}`)).status, 404);
+  });
+
+  test('a guest is held to the allowlist and cannot mint guests', async () => {
+    const guest = signGuest(await serverSecret(srv), keyId);
+    const write = await fetch(`${srv.baseUrl}/api/v1/db/rate-song`, {
+      method: 'POST', headers: tokenHeaders(guest), body: JSON.stringify({ filepath: 'x', rating: 5 }),
+    });
+    assert.equal(write.status, 403);
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/db/rated`, { headers: tokenHeaders(guest) })).status, 403);
+    // On the allowlist (for the KEY's sake), refused by the route itself.
+    const mint = await fetch(`${srv.baseUrl}/api/v1/federation/guest`, { method: 'POST', headers: tokenHeaders(guest) });
+    assert.equal(mint.status, 403);
+    assert.match((await mint.json()).error, /guest cannot mint/i);
+  });
+
+  test('the mint route refuses local users and keys that never completed the handshake', async () => {
+    // A logged-in admin has no key to mint for.
+    const asUser = await fetch(`${srv.baseUrl}/api/v1/federation/guest`, { method: 'POST', headers: tokenHeaders(adminToken) });
+    assert.equal(asUser.status, 403);
+    // Over plain HTTP the key is unbound (no iroh dial happened): refused.
+    const asKey = await fetch(`${srv.baseUrl}/api/v1/federation/guest`, { method: 'POST', headers: fedHeaders(fedKey) });
+    assert.equal(asKey.status, 403);
+    assert.match((await asKey.json()).error, /not bound/i);
+  });
+
+  test('bad guest tokens are 401: expired, foreign signature, unknown key', async () => {
+    const secret = await serverSecret(srv);
+    const expired = signGuest(secret, keyId, { exp: Math.floor(Date.now() / 1000) - 60 });
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: tokenHeaders(expired) })).status, 401);
+    const forged = jwt.sign({ federationGuest: true, federationKeyId: keyId }, 'not-the-secret');
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: tokenHeaders(forged) })).status, 401);
+    const orphan = signGuest(secret, 424242);
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: tokenHeaders(orphan) })).status, 401);
+  });
+
+  test('revocation kills the key on the next request — and its guests', async () => {
+    const guest = signGuest(await serverSecret(srv), keyId);
     const del = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/${keyId}`, {
       method: 'DELETE', headers: { 'x-access-token': adminToken },
     });
@@ -251,11 +325,13 @@ describe('federation keys e2e (server with users)', () => {
 
     const r = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(fedKey) });
     assert.equal(r.status, 401);
+    const g = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: tokenHeaders(guest) });
+    assert.equal(g.status, 401, 'a still-valid guest token dies with its key');
   });
 });
 
 describe('federation keys e2e (public mode — the branch-ordering pin)', () => {
-  let srv, sharedDir, privateDir, fedKey;
+  let srv, sharedDir, privateDir, fedKey, keyId;
 
   before(async () => {
     sharedDir = await makeLibDir('mstream-fed-pub-shared-', 'hello.txt', 'public shared');
@@ -274,7 +350,7 @@ describe('federation keys e2e (public mode — the branch-ordering pin)', () => 
       body: JSON.stringify({ name: 'pub-peer', vpaths: ['shared'] }),
     });
     assert.equal(mint.status, 200);
-    ({ key: fedKey } = await mint.json());
+    ({ key: fedKey, id: keyId } = await mint.json());
   });
 
   after(async () => {
@@ -300,5 +376,20 @@ describe('federation keys e2e (public mode — the branch-ordering pin)', () => 
 
     const ok = await fetch(`${srv.baseUrl}/media/shared/hello.txt`, { headers: fedHeaders(fedKey) });
     assert.equal(ok.status, 200);
+  });
+
+  test('guest tokens are scoped in public mode too, and a forged one is a 401 — never the public user', async () => {
+    const secret = await serverSecret(srv);
+    const guest = signGuest(secret, keyId);
+    assert.equal((await fetch(`${srv.baseUrl}/media/private/secret.txt?token=${guest}`)).status, 404,
+      'a valid guest must not inherit public mode\'s everything');
+    assert.equal((await fetch(`${srv.baseUrl}/media/shared/hello.txt?token=${guest}`)).status, 200);
+
+    // A token that merely CLAIMS to be a guest is verified in the guest
+    // branch and refused there. Falling through to public mode would hand
+    // anyone who can spell the claim the whole library.
+    const forged = jwt.sign({ federationGuest: true, federationKeyId: keyId }, 'not-the-secret');
+    assert.equal((await fetch(`${srv.baseUrl}/media/private/secret.txt?token=${forged}`)).status, 401);
+    assert.equal((await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: tokenHeaders(forged) })).status, 401);
   });
 });

--- a/test/integration/federation-handshake.test.mjs
+++ b/test/integration/federation-handshake.test.mjs
@@ -4,6 +4,11 @@
  * HTTP to the backend. Exercises the lazy native load + accept/auth loop +
  * the shared byte pumps against a real iroh endpoint.
  *
+ * Guest tokens (state/federation-guest.js) take the same first bi-stream:
+ * a signed token opens the pipe from ANY endpoint (no TOFU — expiry is the
+ * bound), never disturbs the key's binding, dies with the key, and its
+ * live pipes are severed with the key's.
+ *
  * Needs a real DB for the key lookups, so it bootstraps the canonical
  * config.setup + initDB harness into a temp dir (and process.exit()s in
  * teardown like the other DB-backed suites).
@@ -18,13 +23,14 @@ import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import jwt from 'jsonwebtoken';
 
 let available = true;
 try { await import('@number0/iroh'); } catch { available = false; }
 
 describe('federation endpoint handshake', { skip: available ? false : 'no @number0/iroh binary for this platform' }, () => {
   let tmpDir, stub, stubPort;
-  let federation, fedDb, iroh; // modules
+  let federation, fedDb, iroh, guest, config; // modules
   let endpointTicketStr;
   let keyGood; // { id, key }
   const clients = []; // throwaway dial endpoints to close in teardown
@@ -41,13 +47,14 @@ describe('federation endpoint handshake', { skip: available ? false : 'no @numbe
       port: 0,
     }, null, 2));
 
-    const config = await import('../../src/state/config.js');
+    config = await import('../../src/state/config.js');
     await config.setup(path.join(tmpDir, 'config.json'));
     const dbManager = await import('../../src/db/manager.js');
     dbManager.initDB();
     fedDb = await import('../../src/db/federation.js');
     federation = await import('../../src/state/federation.js');
     iroh = await import('../../src/state/iroh-common.js');
+    guest = await import('../../src/state/federation-guest.js');
 
     const d = dbManager.getDB();
     const libId = Number(d.prepare("INSERT INTO libraries (name, root_path) VALUES ('music', '/music')").run().lastInsertRowid);
@@ -147,6 +154,68 @@ describe('federation endpoint handshake', { skip: available ? false : 'no @numbe
     fedDb.setFederationKeyExpiry(expired.id, new Date(Date.now() + 3600_000).toISOString());
     const again = await dial(expired.key);
     assert.equal(again.resp, 'OK');
+  });
+
+  test('a guest token opens the pipe from any endpoint and bridges HTTP, without touching the binding', async () => {
+    const boundTo = fedDb.getFederationKeyById(keyGood.id).bound_endpoint_id;
+    assert.ok(boundTo, 'the key was bound by the first test');
+    const { token } = guest.mintGuestToken(keyGood);
+
+    // Two DIFFERENT throwaway endpoints (dial() binds a new one each time):
+    // a key would be rejected on the second (TOFU); a guest is not bound.
+    for (let i = 0; i < 2; i++) {
+      const { conn, resp } = await dial(token);
+      assert.equal(resp, 'OK', `guest dial #${i + 1}`);
+      const bi = await conn.openBi();
+      await bi.send.writeAll(Array.from(Buffer.from('GET /guest HTTP/1.0\r\nConnection: close\r\n\r\n')));
+      await bi.send.finish();
+      const chunks = [];
+      for (;;) { const c = await bi.recv.read(65536); if (c.length === 0) { break; } chunks.push(Buffer.from(c)); }
+      assert.match(Buffer.concat(chunks).toString('utf8'), /200[\s\S]*\/guest/);
+    }
+    assert.equal(fedDb.getFederationKeyById(keyGood.id).bound_endpoint_id, boundTo,
+      'a guest handshake must not rebind the key');
+  });
+
+  test('a guest of a revoked, expired or unknown key is rejected; so are forged and user tokens', async () => {
+    const revoked = fedDb.createFederationKey('revoked-host', []);
+    const { token: orphan } = guest.mintGuestToken(revoked);
+    fedDb.deleteFederationKey(revoked.id);
+    assert.notEqual((await dial(orphan)).resp, 'OK', 'guest of a deleted key');
+
+    const expiredKey = fedDb.createFederationKey('expired-host', [], {},
+      new Date(Date.now() - 60_000).toISOString());
+    const { token: ofExpired } = guest.mintGuestToken(expiredKey);
+    assert.notEqual((await dial(ofExpired)).resp, 'OK', 'guest of an expired key');
+
+    const expiredToken = jwt.sign(
+      { federationGuest: true, federationKeyId: keyGood.id, exp: Math.floor(Date.now() / 1000) - 60 },
+      config.program.secret,
+    );
+    assert.notEqual((await dial(expiredToken)).resp, 'OK', 'expired guest token');
+
+    const forged = jwt.sign({ federationGuest: true, federationKeyId: keyGood.id }, 'wrong-secret');
+    assert.notEqual((await dial(forged)).resp, 'OK', 'foreign signature');
+
+    const userToken = jwt.sign({ username: 'alice' }, config.program.secret);
+    assert.notEqual((await dial(userToken)).resp, 'OK', 'an ordinary user JWT is not a pipe credential');
+  });
+
+  test('closeConnectionsForKey severs a live guest pipe along with the key\'s', async () => {
+    const host = fedDb.createFederationKey('host-with-guests', []);
+    const viaKey = await dial(host.key);
+    assert.equal(viaKey.resp, 'OK');
+    const { token } = guest.mintGuestToken(host);
+    const viaGuest = await dial(token);
+    assert.equal(viaGuest.resp, 'OK');
+
+    assert.equal(federation.closeConnectionsForKey(host.id), 2, 'the key pipe AND its guest pipe');
+    await assert.rejects(async () => {
+      const bi = await viaGuest.conn.openBi();
+      await bi.send.writeAll(Array.from(Buffer.from('GET / HTTP/1.0\r\n\r\n')));
+      await bi.send.finish();
+      await bi.recv.readToEnd(64);
+    });
   });
 
   test('closeConnectionsForKey severs a live authorized pipe', async () => {

--- a/test/integration/federation-limits.test.mjs
+++ b/test/integration/federation-limits.test.mjs
@@ -15,7 +15,10 @@
  *  - maxStreams 429s a second concurrent stream, and the slot frees on
  *    completion;
  *  - streamKbps paces a download without corrupting it (timing asserted
- *    with WIDE margins — CI runners and Windows clocks are noisy).
+ *    with WIDE margins — CI runners and Windows clocks are noisy);
+ *  - revoking a key with unflushed usage neither errors forever nor leaves
+ *    a usage row behind (mStream #940), and a guest of a key shares its
+ *    caps — the concurrent-stream slot in particular.
  */
 
 import { describe, test, before, after } from 'node:test';
@@ -26,6 +29,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { startServer } from '../helpers/server.mjs';
+import jwt from 'jsonwebtoken';
 import { parseFederationTicket } from '../../src/state/federation.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -274,6 +278,56 @@ describe('federation bandwidth limits e2e', () => {
     const cleared = (await listKeys()).find((r) => r.id === k.id);
     assert.equal(cleared.expires_at, null);
     assert.equal(cleared.expired, 0);
+  });
+
+  test('a guest of a key shares its concurrent-stream cap', async () => {
+    // Same recipe as the maxStreams test above: 200 KiB at 800 kbps holds
+    // the one slot for ~1s, and the guest asks while the key's stream is
+    // mid-body. Same pool, not a pool of its own.
+    const k = await mintKey('shared-pool', { maxStreams: 1, streamKbps: 800, dailyMb: 0 });
+    const secret = JSON.parse(await fs.readFile(path.join(srv.tmpDir, 'config.json'), 'utf8')).secret;
+    const guest = jwt.sign({ federationGuest: true, federationKeyId: k.id }, secret, { expiresIn: '1h' });
+
+    const holder = await fetch(`${srv.baseUrl}/media/shared/c.bin`, { headers: fedHeaders(k.key) });
+    assert.equal(holder.status, 200);
+    await sleep(150);
+    const second = await fetch(`${srv.baseUrl}/media/shared/c.bin?token=${guest}`);
+    assert.equal(second.status, 429);
+    assert.match((await second.json()).error, /concurrent/i);
+    assert.ok(Buffer.from(await holder.arrayBuffer()).equals(FILE_CONC), 'the held stream is intact');
+
+    // Slot freed → the guest streams (the decrement lands on 'close', a
+    // beat after the last byte, so poll briefly).
+    let status = 0;
+    for (let i = 0; i < 20 && status !== 200; i++) {
+      await sleep(100);
+      const r = await fetch(`${srv.baseUrl}/media/shared/c.bin?token=${guest}`);
+      status = r.status;
+      await r.arrayBuffer();
+    }
+    assert.equal(status, 200, 'the guest gets the freed slot');
+  });
+
+  test('revoking a key with unflushed usage drops it cleanly (no FK error loop, no orphan row)', async () => {
+    const k = await mintKey('revoke-me', { streamKbps: 0, dailyMb: 0, maxStreams: 0 });
+    const r = await fetch(`${srv.baseUrl}/media/shared/c.bin`, { headers: fedHeaders(k.key) });
+    assert.equal(r.status, 200);
+    await r.arrayBuffer();
+    // Revoke while the accumulator (200ms flush) likely still holds bytes.
+    const del = await fetch(`${srv.baseUrl}/api/v1/admin/federation/keys/${k.id}`, {
+      method: 'DELETE', headers: { 'x-access-token': adminToken },
+    });
+    assert.equal(del.status, 200);
+    await sleep(800); // several flush intervals
+    // The server is still healthy, and nothing was written for the dead key
+    // (the usage rows cascade with the key; a late flush must not re-create one).
+    const db = new DatabaseSync(path.join(srv.tmpDir, 'db', 'mstream.db'), { readOnly: true });
+    try {
+      assert.equal(db.prepare('SELECT COUNT(*) AS n FROM federation_key_usage WHERE key_id = ?').get(k.id).n, 0);
+      assert.equal(db.prepare('SELECT COUNT(*) AS n FROM federation_keys WHERE id = ?').get(k.id).n, 0);
+    } finally { db.close(); }
+    const health = await fetch(`${srv.baseUrl}/api/v1/federation/health`, { headers: fedHeaders(k.key) });
+    assert.equal(health.status, 401);
   });
 
   test('streamKbps paces the download without corrupting it', async () => {

--- a/test/unit/federation-auth.test.mjs
+++ b/test/unit/federation-auth.test.mjs
@@ -20,7 +20,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { isFederationPathAllowed, authenticateFederationKey } from '../../src/api/federation-auth.js';
+import { isFederationPathAllowed, authenticateFederationKey, authenticateGuestToken } from '../../src/api/federation-auth.js';
 import { getUserLibraryIds } from '../../src/db/manager.js';
 import * as config from '../../src/state/config.js';
 
@@ -48,6 +48,7 @@ describe('federation route allowlist', () => {
       ['POST', '/api/v1/file-explorer/m3u'],
       ['GET', '/api/v1/federation/health'],
       ['POST', '/api/v1/federation/discovery/similar'],
+      ['POST', '/api/v1/federation/guest'],
       ['GET', '/media/music/album/track.mp3'],
       ['GET', '/album-art/abc123.jpg'],
     ]) {
@@ -86,6 +87,13 @@ describe('federation disabled gate', () => {
   test('rejects any key with 401 while federation.enabled=false', () => {
     assert.throws(
       () => authenticateFederationKey('fedk_anything', req('GET', '/api/v1/federation/health')),
+      (err) => err.status === 401 && /Authentication/.test(err.message),
+    );
+  });
+
+  test('rejects any guest token with 401 while federation.enabled=false (before verifying it)', () => {
+    assert.throws(
+      () => authenticateGuestToken('eyJ.not-even-verified.x', req('GET', '/api/v1/federation/health')),
       (err) => err.status === 401 && /Authentication/.test(err.message),
     );
   });

--- a/test/unit/federation-guest.test.mjs
+++ b/test/unit/federation-guest.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Federation guest tokens (src/state/federation-guest.js) — the pure parts:
+ *
+ *  - mint → verify round-trip, with the expiry read back out of the token;
+ *  - looksLikeGuestToken is a CLAIM check only (no signature), so the auth
+ *    wall can route a token before the public-mode branch without
+ *    verifying ordinary user tokens twice;
+ *  - verifyGuestToken refuses ordinary user tokens, foreign signatures,
+ *    expired tokens and malformed claims.
+ *
+ * The wall branch, the handshake and the mint route are covered by the
+ * integration suites (federation-e2e, federation-handshake,
+ * federation-browse).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import jwt from 'jsonwebtoken';
+
+import * as config from '../../src/state/config.js';
+import {
+  mintGuestToken, verifyGuestToken, looksLikeGuestToken, GUEST_TOKEN_TTL_MS,
+} from '../../src/state/federation-guest.js';
+
+describe('federation guest tokens', () => {
+  let tmpDir;
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-fed-guest-'));
+    await config.setup(path.join(tmpDir, 'config.json')); // generates the JWT secret
+  });
+  after(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+  test('mint → verify round-trips the key id; expiry comes from the token itself', () => {
+    const before = Date.now();
+    const { token, expiresAt } = mintGuestToken({ id: 7 });
+    const { keyId, exp } = verifyGuestToken(token);
+    assert.equal(keyId, 7);
+    assert.equal(new Date(expiresAt).getTime(), exp * 1000, 'expiresAt is the signed exp');
+    const life = exp * 1000 - before;
+    assert.ok(life > GUEST_TOKEN_TTL_MS - 5000 && life <= GUEST_TOKEN_TTL_MS + 1000, `lifetime ${life}ms`);
+    assert.equal(GUEST_TOKEN_TTL_MS, 24 * 60 * 60 * 1000, 'default lifetime is a day');
+  });
+
+  test('a custom ttl sticks', () => {
+    const { token } = mintGuestToken({ id: 1 }, { ttlMs: 60_000 });
+    const { exp, iat } = jwt.decode(token);
+    assert.equal(exp - iat, 60);
+  });
+
+  test('looksLikeGuestToken is a claim check, not a signature check', () => {
+    const { token } = mintGuestToken({ id: 3 });
+    assert.equal(looksLikeGuestToken(token), true);
+    // Same claims, foreign signature: still LOOKS like a guest (so the wall
+    // routes it to the guest branch, where verification fails it with 401
+    // instead of letting it fall through to public mode).
+    const forged = jwt.sign({ federationGuest: true, federationKeyId: 3 }, 'not-the-secret');
+    assert.equal(looksLikeGuestToken(forged), true);
+    assert.throws(() => verifyGuestToken(forged), /signature/);
+    // Ordinary user tokens, garbage and empties do not.
+    const user = jwt.sign({ username: 'alice' }, config.program.secret);
+    assert.equal(looksLikeGuestToken(user), false);
+    assert.equal(looksLikeGuestToken('not.a.jwt'), false);
+    assert.equal(looksLikeGuestToken(''), false);
+    assert.equal(looksLikeGuestToken(undefined), false);
+  });
+
+  test('verify refuses user tokens, malformed claims and expired tokens', () => {
+    const user = jwt.sign({ username: 'alice' }, config.program.secret);
+    assert.throws(() => verifyGuestToken(user), /not a federation guest token/);
+    const noKey = jwt.sign({ federationGuest: true }, config.program.secret);
+    assert.throws(() => verifyGuestToken(noKey), /not a federation guest token/);
+    const stringKey = jwt.sign({ federationGuest: true, federationKeyId: '7' }, config.program.secret);
+    assert.throws(() => verifyGuestToken(stringKey), /not a federation guest token/);
+    const expired = jwt.sign(
+      { federationGuest: true, federationKeyId: 7, exp: Math.floor(Date.now() / 1000) - 60 },
+      config.program.secret,
+    );
+    assert.throws(() => verifyGuestToken(expired), /expired/);
+  });
+});

--- a/test/unit/federation-ticket.test.mjs
+++ b/test/unit/federation-ticket.test.mjs
@@ -5,7 +5,10 @@
 
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildFederationTicket, parseFederationTicket } from '../../src/state/federation.js';
+import {
+  buildFederationTicket, parseFederationTicket,
+  buildFederationGuestTicket, parseFederationGuestTicket,
+} from '../../src/state/federation.js';
 import { buildCompositeTicket } from '../../src/state/iroh.js';
 
 describe('federation ticket (mstrfed envelope)', () => {
@@ -58,5 +61,45 @@ describe('federation ticket (mstrfed envelope)', () => {
   test('a tunnel pairing code fails cleanly in the federation parser', () => {
     const tunnelCode = buildCompositeTicket('endpointabc', Buffer.alloc(32, 1));
     assert.throws(() => parseFederationTicket(tunnelCode), /Invalid federation ticket/);
+  });
+});
+
+// The device-facing sibling: what a parent hands its own app to dial a peer
+// directly (docs/federation-guest-ticket.md). Same envelope mechanics, a
+// disjoint prefix, a token instead of a key.
+describe('federation guest ticket (mstrfedg envelope)', () => {
+  const jwtish = 'eyJhbGciOiJIUzI1NiJ9.eyJmZWRlcmF0aW9uR3Vlc3QiOnRydWV9.sig';
+
+  test('round-trips endpoint ticket + guest token, emits mstrfedg1:', () => {
+    const ticket = buildFederationGuestTicket({ endpointTicket: 'endpointpeer', guestToken: jwtish });
+    assert.match(ticket, /^mstrfedg1:/);
+    const parsed = parseFederationGuestTicket(ticket);
+    assert.equal(parsed.version, 1);
+    assert.equal(parsed.endpointTicket, 'endpointpeer');
+    assert.equal(parsed.guestToken, jwtish);
+  });
+
+  test('the three envelopes are disjoint — each parser refuses the other two', () => {
+    const guest = buildFederationGuestTicket({ endpointTicket: 'e', guestToken: jwtish });
+    const fed = buildFederationTicket({ endpointTicket: 'e', key: 'fedk_k' });
+    const tunnel = buildCompositeTicket('e', Buffer.alloc(32, 1));
+    assert.throws(() => parseFederationTicket(guest), /Invalid federation ticket/,
+      'mstrfedg1: must not read as mstrfed<digits>:');
+    assert.throws(() => parseFederationGuestTicket(fed), /Invalid federation guest ticket/);
+    assert.throws(() => parseFederationGuestTicket(tunnel), /Invalid federation guest ticket/);
+  });
+
+  test('rejects missing fields, garbage, bare bodies, and newer versions', () => {
+    const noToken = 'mstrfedg1:' + Buffer.from(JSON.stringify({ t: 'only-endpoint' })).toString('base64url');
+    assert.throws(() => parseFederationGuestTicket(noToken), /Invalid federation guest ticket/);
+    assert.throws(() => parseFederationGuestTicket('not-a-ticket!!'), /Invalid federation guest ticket/);
+    const bare = Buffer.from(JSON.stringify({ t: 'x', g: 'y' })).toString('base64url');
+    assert.throws(() => parseFederationGuestTicket(bare), /Invalid federation guest ticket/);
+    assert.throws(() => parseFederationGuestTicket(`mstrfedg2:${bare}`), /version 2.*supports up to v1.*[Uu]pdate/s);
+  });
+
+  test('ignores unknown payload fields (forward compat)', () => {
+    const body = Buffer.from(JSON.stringify({ t: 'e', g: jwtish, e: 'soon', zzz: 1 })).toString('base64url');
+    assert.equal(parseFederationGuestTicket(`mstrfedg1:${body}`).guestToken, jwtish);
   });
 });


### PR DESCRIPTION
Server half of [mstream_music#143](https://github.com/IrosTheBeggar/mstream_music/issues/143): let a key holder's own device — the mobile app — reach a federated peer **directly**, so its bytes stop crossing the parent's home link twice and the peer stays usable while the parent is down.

## Why the app cannot dial a peer today

Federation is server-to-server: the parent redeems a `fedk_` key over the peer's iroh endpoint, the peer TOFU-binds that key to the parent's endpoint id, and every other endpoint presenting it is rejected as a leaked ticket. The key is a standing credential that must never reach a phone. So the phone needs a credential of its own, vouched for by the parent.

## What this adds

**Guest tokens** (`src/state/federation-guest.js`): a short-lived JWT (24 h) the **peer** signs for one of its minted keys, on request from the key holder. It resolves to the same synthetic read-only user as the key — same library grants, same route allowlist, same bandwidth caps (guests share the key's pool) — and dies with the key.

Peer side:
- `POST /api/v1/federation/guest` — mints for the caller's key. Only a **bound** key (one that completed the pipe handshake, i.e. the parent over the bridge); refused for local users and for guests (a guest cannot mint guests). `GET /api/v1/federation/health` advertises `guestAccess: true`.
- Auth wall: a guest branch right after the key branch and **before** the public-mode branch, routed by claim (`federationGuest: true`, a plain decode) so ordinary user tokens are still verified exactly once. A token that claims to be a guest is verified for real there — a forged one is a 401, never the public user. Guests ride the ordinary token slots (`x-access-token`, `?token=`), so the app's stream and art URLs work unchanged.
- Handshake: the first bi-stream accepts a guest token as well as a key. No TOFU for guests (phones dial from ephemeral endpoints; expiry is the bound), the key's binding is never touched, and guest pipes are tracked under the key so `closeConnectionsForKey` severs them on revocation. `HANDSHAKE_LIMIT` grows from 128 B to 2 KB — a signed token did not fit.

Parent side:
- `GET /api/v1/federation/peers/:id/access` → `{ direct: true, endpointTicket, endpointId, guestToken, expiresAt, directTicket }`. The parent mints over the bridge, caches per peer, re-mints past three quarters of the lifetime (or `?refresh=1`, served from cache within 5 s of a mint), and answers `{ direct: false, reason }` for a peer that will not mint (older build, or federation off there) — distinct from the 502 of a peer that is down, so a client knows whether to keep using the proxies.
- `directTicket` is a new `mstrfedg1:{t, g}` envelope (`docs/federation-guest-ticket.md`), disjoint from `mstr<V>:` and `mstrfed<V>:`, for the device's native dialer.
- The peers projection gains `endpointId` (a public key, not a credential) so a client can tell that two parents list the same server.
- `GET /api/` (and ping) gain `federationDirect` next to `federationBrowse`; the user block gains `federationGuest`.

**mStream #940**, folded in since the direct-mode rig would hit both:
- a revoked key's unflushed usage no longer fails its FOREIGN KEY every 15 s forever — the delete route drops the accumulator (`forgetKey`), and the flusher treats an FK failure as terminal for that key;
- minting a key clears the per-endpoint failed-handshake backoff, so a peer re-added right after a revocation is not refused for a minute.
- The just-enabled Quick Connect first-dial stall from the same issue is the tunnel persona, not federation, and is **not** addressed here.

Also fixes the stale `/api` allowlist comment (it claimed the route sits before the wall; #934 moved it behind).

## Security summary

- The `fedk_` key never leaves the parent: not in the access response, the envelope, or any URL.
- A guest is the key's user: grants, allowlist, caps — and nothing more. It cannot mint guests, carries no `username` (so it is not replayable as a user token), and is refused with the key on revocation or expiry.
- Lifetime is the bound. The parent cannot revoke one device's token early; 24 h keeps a token lifted off a phone worthless by the next day. On the device it sits in URLs exactly like the parent's own JWT does today.
- In public mode a valid guest stays scoped and a forged one is a 401 (pinned by test).

## Tests

- unit: `federation-guest` (new), `federation-ticket` (guest envelope, parser disjointness), `federation-auth` (allowlist, disabled gate for guests)
- integration, in-process iroh: `federation-handshake` — guest opens the pipe from two different endpoints, binding untouched; revoked/expired key, expired/forged/user tokens rejected; severing takes guest pipes too
- integration, spawned servers: `federation-e2e` — guest scoping via header and query, allowlist, mint refusals, revocation kills guests, public-mode pin; `federation-browse` — access-route guards (404 / 502 / never a federation key / 403 when off), `federationDirect` on ping and `/api/`, and the whole device flow over real iroh: B mints from A, a throwaway "phone" endpoint dials A with the token and lists A's granted library through its own pipe, cache + refresh semantics; `federation-limits` — a guest shares the key's concurrent-stream cap; revoking a key with unflushed usage leaves no FK loop and no orphan row
- `npm run lint`: no findings in touched files (the repo's pre-existing errors are elsewhere); `redocly lint docs/openapi.yaml` valid (two more operationId warnings, the same class every route has)

## Follow-ups (app side, per #143)

Native federation dial mode (`mstrfedg1:` + ALPN `mstream/federation/1`), keyed tunnels with a credential-swap hook so a token refresh does not rotate the loopback port, the multi-tunnel ServerManager, and the direct transport on the federated `Server` with the proxy path as fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
