### PR TITLE
fix(ffmpeg): pin month-end BtbN builds; fall back to latest when a pin is pruned

### DIFF
--- a/.github/workflows/update-ffmpeg-manifest.yml
+++ b/.github/workflows/update-ffmpeg-manifest.yml
@@ -4,12 +4,17 @@
 # review PR when the pins moved. A human merges; nothing lands on master
 # automatically.
 #
-# Why monthly: pins exist so Windows users keep a stable unsigned-binary
-# hash that accrues SmartScreen / Smart App Control reputation — churning
-# weekly would defeat that — while BtbN's bounded retention of dated
-# releases means a pin left for a year could 404 for fresh installs.
-# Monthly threads that needle. The 3rd-of-month at an odd minute dodges
-# GitHub's first-of-month/on-the-hour cron congestion.
+# Why monthly, and why the 3rd: pins exist so Windows users keep a stable
+# unsigned-binary hash that accrues SmartScreen / Smart App Control
+# reputation — churning weekly would defeat that. BtbN's prune keeps only
+# the 14 newest dailies plus each month's FINAL build (24 months back), so
+# the script pins the previous month's final build — the one that outlives
+# any mStream release; a "newest daily" pin 404'd for fresh installs two
+# weeks after being committed. Running on the 3rd means last month is
+# complete and its final build is known; the odd minute dodges GitHub's
+# first-of-month/on-the-hour cron congestion. A pruned pin no longer strands
+# an install: the bootstrap falls back to BtbN's rolling `latest`
+# (checksum-verified) until a manifest with a live pin ships.
 name: Update ffmpeg manifest
 
 on:
@@ -18,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'BtbN tag to pin (autobuild-YYYY-MM-DD-HH-MM); empty = newest dated autobuild'
+        description: 'BtbN tag to pin (autobuild-YYYY-MM-DD-HH-MM); empty = the final build of the last completed month (the one BtbN retains)'
         required: false
         default: ''
 

--- a/bin/ffmpeg/README.md
+++ b/bin/ffmpeg/README.md
@@ -9,12 +9,27 @@ Updating the pins is a small text PR:
 
     node scripts/update-ffmpeg-manifest.mjs [autobuild-YYYY-MM-DD-HH-MM]
 
-(no argument = newest dated BtbN autobuild; the rolling `latest` tag is
-refused — pins exist so Windows users keep a stable binary hash that can
-accrue SmartScreen / Smart App Control reputation, and so the build we ship
-is a reviewed choice, not whatever upstream published that week). Run it a
-few times a year: BtbN retains dated releases in bulk but not forever, and a
-pruned tag would 404 for fresh installs.
+(no argument = the final BtbN autobuild of the last completed month; the
+rolling `latest` tag is refused — pins exist so Windows users keep a stable
+binary hash that can accrue SmartScreen / Smart App Control reputation, and
+so the build we ship is a reviewed choice, not whatever upstream published
+that week). Why month-end builds: BtbN's prune (`util/prunetags.sh`) keeps
+only the 14 newest dailies plus each month's last build for 24 months, so a
+daily pin 404s for fresh installs about two weeks after it is committed —
+the 2026-08-19 pin died on 2026-09-02 — while a month-end pin outlives any
+mStream release. The monthly workflow (`update-ffmpeg-manifest.yml`, the 3rd
+of each month) pins the previous month's final build; a hand-picked daily
+tag is accepted with a warning.
+
+If a pinned BtbN asset has been pruned anyway (an old mStream build being
+installed fresh), the bootstrap falls back to the same-platform stable-branch
+build from BtbN's rolling `latest` release (`ffmpeg-n9.0-latest-…`, or the
+master snapshot if no branch build is listed), verified against that
+release's `checksums.sha256` — an integrity check, not a reviewed pin, and
+logged as a warning. The receipt marks such an install as a fallback, so the
+next manifest with a live pin converges it back onto a reviewed build.
+macOS pins (martin-riedl versioned paths) are not pruned and have no
+fallback.
 
 Installs made by mStream record a `.fetched.json` receipt and are refreshed
 when the committed pins change (checked locally — no network polling). Set
@@ -24,5 +39,6 @@ touched — mStream only updates builds it installed itself.
 
 Air-gapped hosts: `MSTREAM_FFMPEG_MIRROR` replaces the download base with a
 flat namespace (the BtbN archive under its pinned file name; the macOS
-binaries as `ffmpeg.zip` / `ffprobe.zip`). The sha256 pins are enforced
-regardless of the source.
+binaries as `ffmpeg.zip` / `ffprobe.zip`; the pruned-pin fallback under
+`latest/checksums.sha256` + `latest/<asset name>`). The sha256 pins are
+enforced regardless of the source.

--- a/bin/ffmpeg/manifest.json
+++ b/bin/ffmpeg/manifest.json
@@ -3,26 +3,26 @@
   "schema": 1,
   "btbn": {
     "repo": "BtbN/FFmpeg-Builds",
-    "tag": "autobuild-2026-08-19-19-21"
+    "tag": "autobuild-2026-08-31-13-27"
   },
   "assets": {
     "linux-x64": {
       "source": "btbn",
-      "file": "ffmpeg-N-126217-ge1e325235e-linux64-gpl.tar.xz",
-      "sha256": "c3df9379d32a16f6923681411c97880ee8d45b0bae03a55a6fc8262f2f653ba6",
-      "size": 128000068
+      "file": "ffmpeg-N-126342-gf88b741dbf-linux64-gpl.tar.xz",
+      "sha256": "d1cf19f669510448f18a4cffcdbd8fa9592ee7c15c92feb5b96ad7e9ccc30114",
+      "size": 128065756
     },
     "linux-arm64": {
       "source": "btbn",
-      "file": "ffmpeg-N-126217-ge1e325235e-linuxarm64-gpl.tar.xz",
-      "sha256": "e184dbde7d57d8f1ffa616795d9c4f6f368b211bc9e6fd86b60fea511a21f430",
-      "size": 109603608
+      "file": "ffmpeg-N-126342-gf88b741dbf-linuxarm64-gpl.tar.xz",
+      "sha256": "b65dfcc901e081ea76f8fd25c8fe2f3318f458f1d52d7d6c5423aef95b693da6",
+      "size": 109726420
     },
     "win32-x64": {
       "source": "btbn",
-      "file": "ffmpeg-N-126217-ge1e325235e-win64-gpl.zip",
-      "sha256": "fe5a8f090b9fbc77d5e64c7d8b404b8837e05a09663ed9768ba19284cf929b20",
-      "size": 170644098
+      "file": "ffmpeg-N-126342-gf88b741dbf-win64-gpl.zip",
+      "sha256": "b4da332540eaebc6939181b59e267f163dd57407ef6596f7f3452845921d1d91",
+      "size": 170732198
     },
     "darwin-x64": {
       "source": "martinriedl",

--- a/scripts/btbn-retention.mjs
+++ b/scripts/btbn-retention.mjs
@@ -1,0 +1,60 @@
+// BtbN/FFmpeg-Builds release retention, as their util/prunetags.sh enforces
+// it after every build: of the dated `autobuild-YYYY-MM-DD-HH-MM` releases,
+// only the KEEP_LATEST newest and the newest build of each of the KEEP_MONTHLY
+// most recent months survive — every other release is deleted, tag and
+// assets, and its download URLs answer 404 from then on. So a pin is durable
+// only when it is the FINAL build of a COMPLETED month: the current month's
+// newest build is superseded (and, two weeks later, pruned) by tomorrow's.
+//
+// Pure helpers shared by scripts/update-ffmpeg-manifest.mjs and its tests.
+export const KEEP_LATEST = 14;
+export const KEEP_MONTHLY = 24;
+
+const TAG_RE = /^autobuild-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})$/;
+
+export function parseAutobuildTag(tag) {
+  const m = TAG_RE.exec(tag || '');
+  if (!m) { return null; }
+  return { tag, year: Number(m[1]), month: Number(m[2]), day: Number(m[3]), hour: Number(m[4]), minute: Number(m[5]) };
+}
+
+// Zero-padded dated tags sort chronologically as strings.
+function newest(parsed) {
+  return parsed.slice().sort((a, b) => (a.tag < b.tag ? 1 : a.tag > b.tag ? -1 : 0))[0] || null;
+}
+
+function monthIndex(year, month) {
+  return year * 12 + (month - 1);
+}
+
+function currentMonthIndex(now) {
+  return monthIndex(now.getUTCFullYear(), now.getUTCMonth() + 1);
+}
+
+/**
+ * The newest autobuild tag from the most recent COMPLETED (UTC) month — the
+ * pin BtbN keeps for ~KEEP_MONTHLY months. `tags` is any mix of release tag
+ * names (non-autobuild names are ignored); `now` is the reference time.
+ * Returns null when no completed month has a build.
+ */
+export function pickRetainedTag(tags, now = new Date()) {
+  const cutoff = currentMonthIndex(now);
+  const eligible = tags.map(parseAutobuildTag).filter((t) => t && monthIndex(t.year, t.month) < cutoff);
+  const pick = newest(eligible);
+  return pick ? pick.tag : null;
+}
+
+/**
+ * Whether `tag` is the final build of a completed month among `tags` — the
+ * only kind of pin BtbN retains long-term. A current-month tag is never
+ * final (tomorrow's build supersedes it), and a tag with a later sibling in
+ * its month has already lost that month's slot.
+ */
+export function isRetainedTag(tag, tags, now = new Date()) {
+  const t = parseAutobuildTag(tag);
+  if (!t) { return false; }
+  if (monthIndex(t.year, t.month) >= currentMonthIndex(now)) { return false; }
+  const sameMonth = tags.map(parseAutobuildTag).filter((o) => o && o.year === t.year && o.month === t.month);
+  const top = newest(sameMonth);
+  return !!top && top.tag === tag;
+}

--- a/scripts/update-ffmpeg-manifest.mjs
+++ b/scripts/update-ffmpeg-manifest.mjs
@@ -4,10 +4,17 @@
 // Usage:
 //   node scripts/update-ffmpeg-manifest.mjs [autobuild-YYYY-MM-DD-HH-MM] [--verify]
 //
-// With no tag argument, pins the newest dated BtbN autobuild. NEVER pins the
-// rolling "latest" tag — its assets are replaced in place, which would break
-// both the sha256 pins and the Smart-App-Control-reputation goal (a stable
-// hash accrues reputation; a rolling one resets weekly).
+// With no tag argument, pins the final BtbN autobuild of the most recent
+// COMPLETED month — the only dated release BtbN keeps: their prune retains
+// the 14 newest dailies plus each month's last build (24 months back) and
+// deletes everything else, so a "newest daily" pin 404s for fresh installs
+// about two weeks after it is committed (the 2026-08-19 pin died on
+// 2026-09-02). A month-end pin outlives any mStream release. See
+// scripts/btbn-retention.mjs. NEVER pins the rolling "latest" tag — its
+// assets are replaced in place, which would break both the sha256 pins and
+// the Smart-App-Control-reputation goal (a stable hash accrues reputation;
+// a rolling one resets weekly). The runtime bootstrap does use `latest` as a
+// checksum-verified FALLBACK when a pinned asset has been pruned anyway.
 //
 // --verify: after assembling, DOWNLOAD every pinned asset and hash it against
 // its pin (~500 MB total). This is the load-bearing check for the monthly
@@ -19,9 +26,8 @@
 // Sources:
 //   - BtbN/FFmpeg-Builds (linux x64/arm64, win x64): the release's own
 //     checksums.sha256 provides the digests; asset sizes come from the
-//     GitHub API. Dated releases are retained in bulk but NOT forever —
-//     re-run this and ship the small manifest PR a few times a year so
-//     fresh installs never chase a pruned tag.
+//     GitHub API. Only month-end releases survive their prune (above), so
+//     the monthly refresh on the 3rd pins the previous month's final build.
 //   - ffmpeg.martin-riedl.de (macOS x64/arm64): /redirect/latest/... 307s
 //     to a versioned /download/... path where a sibling .sha256 lives; the
 //     manifest pins that resolved path + digest so installs never depend on
@@ -33,6 +39,7 @@ import { writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { pickRetainedTag, isRetainedTag, KEEP_LATEST } from './btbn-retention.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT = join(root, 'bin', 'ffmpeg', 'manifest.json');
@@ -71,16 +78,27 @@ function gh(path) {
 }
 
 async function resolveTag(argTag) {
+  if (argTag && !/^autobuild-[0-9-]+$/.test(argTag)) {
+    throw new Error(`refusing tag '${argTag}' — pin a dated autobuild-* tag, never 'latest'`);
+  }
+  // Every dated release BtbN currently serves — the 14 newest dailies plus
+  // the month-end builds — fits one page.
+  const releases = await gh(`/repos/${BTBN_REPO}/releases?per_page=100`);
+  const tags = releases.map((r) => r.tag_name).filter((t) => /^autobuild-/.test(t));
+  if (tags.length === 0) { throw new Error('no dated autobuild release found'); }
   if (argTag) {
-    if (!/^autobuild-[0-9-]+$/.test(argTag)) {
-      throw new Error(`refusing tag '${argTag}' — pin a dated autobuild-* tag, never 'latest'`);
+    if (!isRetainedTag(argTag, tags)) {
+      const durable = pickRetainedTag(tags);
+      console.warn(
+        `WARNING: ${argTag} is not the final build of a completed month. BtbN deletes such dailies once ` +
+        `${KEEP_LATEST} newer builds exist, so this pin would 404 for fresh installs within ~2 weeks ` +
+        `(the runtime then falls back to BtbN's rolling 'latest'). The durable choice is ${durable || 'n/a'}.`);
     }
     return argTag;
   }
-  const releases = await gh(`/repos/${BTBN_REPO}/releases?per_page=10`);
-  const dated = releases.find((r) => /^autobuild-/.test(r.tag_name));
-  if (!dated) { throw new Error('no dated autobuild release found'); }
-  return dated.tag_name;
+  const tag = pickRetainedTag(tags);
+  if (!tag) { throw new Error('no autobuild release from a completed month found'); }
+  return tag;
 }
 
 // The exact build-flavor selector the bootstrap has always used: plain -gpl

--- a/src/util/ffmpeg-bootstrap.js
+++ b/src/util/ffmpeg-bootstrap.js
@@ -5,9 +5,21 @@
  * the PINNED manifest committed at bin/ffmpeg/manifest.json — the same trust
  * model as p2p-sidecar-bootstrap: {tag/path, sha256, size} per platform is
  * reviewed text, a download that doesn't hash to its pin is deleted and
- * refused (no fallback, no retry-with-less-verification), and updates ship
- * as a manifest-bump PR (scripts/update-ffmpeg-manifest.mjs) instead of
- * whatever the upstream's rolling "latest" serves that week.
+ * refused (no retry-with-less-verification), and updates ship as a
+ * manifest-bump PR (scripts/update-ffmpeg-manifest.mjs) instead of whatever
+ * the upstream's rolling "latest" serves that week.
+ *
+ * One deliberate exception — a PRUNED pin. BtbN deletes dated autobuild
+ * releases (their util/prunetags.sh keeps the 14 newest plus each month's
+ * final build for 24 months), so a pin can vanish from under an mStream
+ * build that is still being installed fresh: the 2026-08-19 pin 404'd on
+ * 2026-09-02 for every new Linux and Windows install. A pinned asset that
+ * answers 404/410 therefore falls back to the same-platform stable-branch
+ * build from BtbN's rolling `latest` release, verified against THAT
+ * release's checksums.sha256 — an integrity check, not a reviewed pin, and
+ * logged as such. The install receipt records it as a fallback, so the
+ * update check re-converges onto a reviewed pin as soon as a manifest with
+ * a live one ships (and does not churn while the dead tag is still pinned).
  *
  * Why pins and not upstream's own checksum file (the pre-2026-08 design):
  * a rolling build means every refresh hands Windows users a brand-new
@@ -211,7 +223,7 @@ export function pinnedRelease({ manifestDir = MANIFEST_DIR, key = platformKey() 
     const url = MIRROR
       ? `${MIRROR}/${entry.file}`
       : `https://github.com/${m.btbn.repo}/releases/download/${m.btbn.tag}/${entry.file}`;
-    return { source: 'btbn', tag: m.btbn.tag, file: entry.file, url, sha256: entry.sha256, size: entry.size };
+    return { source: 'btbn', repo: m.btbn.repo, tag: m.btbn.tag, file: entry.file, url, sha256: entry.sha256, size: entry.size };
   }
   if (entry.source === 'martinriedl') {
     const files = {};
@@ -261,11 +273,13 @@ function readReceipt(dir) {
   }
 }
 
-async function writeReceipt(dir, release) {
+// `pins` defaults to the manifest's; a fallback install (see
+// installLatestFallback) records its own identity instead.
+async function writeReceipt(dir, release, pins = pinsOf(release)) {
   await writeJsonAtomic(path.join(dir, RECEIPT_FILE), {
     schema: 1,
     family: 'ffmpeg',
-    pins: pinsOf(release),
+    pins,
     installedAt: new Date().toISOString(),
   });
 }
@@ -308,7 +322,9 @@ export function downloadToFile(url, destPath, { maxBytes = null } = {}) {
         }
         if (res.statusCode !== 200) {
           res.resume();
-          return reject(new Error(`HTTP ${res.statusCode} downloading ${u}`));
+          const httpErr = new Error(`HTTP ${res.statusCode} downloading ${u}`);
+          httpErr.statusCode = res.statusCode; // lets a caller tell "gone" (404/410) from "failed"
+          return reject(httpErr);
         }
         const tmp = destPath + '.tmp';
         const out = fs.createWriteStream(tmp);
@@ -362,6 +378,9 @@ export function computeFileChecksum(filePath) {
 
 // ── Extraction ──────────────────────────────────────────────────────────────
 
+// BtbN archives unpack into a directory named after the asset (sans
+// .tar.xz) — for the dated builds and the rolling `latest` ones alike
+// (ffmpeg-n9.0-latest-linux64-gpl-9.0/bin/ffmpeg, checked 2026-09-04).
 function extractTarXz(tarPath, destDir, asset) {
   const prefix = asset.replace(/\.tar\.xz$/, '');
   return new Promise((resolve, reject) => {
@@ -416,28 +435,31 @@ function extractZipUnix(zipPath, destDir, member) {
 
 // Download one file and verify it against its manifest pin: size cap during
 // transfer (wrong bytes aren't worth the disk or the wait), exact size after,
-// sha256 last. Deletes the file and returns false on any miss — the pin is
-// the only authority, there is no fetch-the-checksum fallback.
+// sha256 last. Deletes the file on any miss. Returns { ok: true }, or
+// { ok: false, gone } where `gone` marks an asset the upstream no longer
+// serves at all (HTTP 404/410 — a pruned release): the ONE failure
+// installInto() may answer with the rolling fallback. Every other miss —
+// network, size, digest — is a plain refusal; the pin stays the authority.
 async function downloadPinned(url, destPath, pin, label) {
   try {
     await downloadToFile(url, destPath, { maxBytes: pin.size });
   } catch (e) {
     winston.error(`[ffmpeg-bootstrap] ${label} download failed: ${e.message}`);
-    return false;
+    return { ok: false, gone: e.statusCode === 404 || e.statusCode === 410 };
   }
   const { size } = await fsp.stat(destPath).catch(() => ({ size: -1 }));
   if (size !== pin.size) {
     await fsp.unlink(destPath).catch(() => {});
     winston.error(`[ffmpeg-bootstrap] ${label} is ${size} bytes, manifest pins ${pin.size} — refusing`);
-    return false;
+    return { ok: false, gone: false };
   }
   const actual = await computeFileChecksum(destPath);
   if (actual !== pin.sha256) {
     await fsp.unlink(destPath).catch(() => {});
     winston.error(`[ffmpeg-bootstrap] ${label} does not match its committed pin! Expected ${pin.sha256}, got ${actual} — refusing (a modified or substituted upstream asset fails closed; see bin/ffmpeg/manifest.json)`);
-    return false;
+    return { ok: false, gone: false };
   }
-  return true;
+  return { ok: true };
 }
 
 // macOS: download one binary's .zip into the staging dir, verify against its
@@ -447,7 +469,9 @@ async function downloadPinned(url, destPath, pin, label) {
 // into place.
 async function installMacBinary(pin, stagingDir, member) {
   const zipPath = path.join(stagingDir, `${member}.zip`);
-  if (!(await downloadPinned(pin.url, zipPath, pin, `${member} (macOS)`))) { return false; }
+  // martin-riedl keeps its versioned download paths, so a miss here is a
+  // plain failure — no rolling fallback on this source.
+  if (!(await downloadPinned(pin.url, zipPath, pin, `${member} (macOS)`)).ok) { return false; }
   try {
     await extractZipUnix(zipPath, stagingDir, member);
   } catch (e) {
@@ -458,6 +482,109 @@ async function installMacBinary(pin, stagingDir, member) {
   await fsp.chmod(path.join(stagingDir, member), 0o755).catch(() => {});
   await fsp.unlink(zipPath).catch(() => {});
   return true;
+}
+
+// ── Pruned-pin fallback (BtbN only) ─────────────────────────────────────────
+
+// No pin records a rolling asset's size, so cap it instead: the win64 zip is
+// ~170 MB, anything past this is wrong bytes. The checksum listing is ~5 KB.
+const FALLBACK_MAX_BYTES = 512 * 1024 * 1024;
+const CHECKSUMS_MAX_BYTES = 64 * 1024;
+
+// BtbN asset names. Pinned: ffmpeg-N-<rev>-g<sha>-<plat>-gpl.<ext>. In the
+// rolling `latest` release: ffmpeg-n<maj>.<min>-latest-<plat>-gpl-<maj>.<min>.<ext>
+// (a release branch, updated in place) and ffmpeg-master-latest-<plat>-gpl.<ext>
+// (the master snapshot). The -shared / -lgpl flavors never match these.
+const PINNED_BTBN_RE = /^ffmpeg-N-[0-9]+-g[0-9a-f]+-(linux64|linuxarm64|win64)-gpl\.(tar\.xz|zip)$/;
+const LATEST_STABLE_RE = /^ffmpeg-n([0-9]+)\.([0-9]+)-latest-(linux64|linuxarm64|win64)-gpl-([0-9]+)\.([0-9]+)\.(tar\.xz|zip)$/;
+const LATEST_MASTER_RE = /^ffmpeg-master-latest-(linux64|linuxarm64|win64)-gpl\.(tar\.xz|zip)$/;
+
+/**
+ * Choose the `latest`-release asset that stands in for a pruned pin: the same
+ * platform and flavor (plain static -gpl, same archive type) as the pin, the
+ * newest release-BRANCH build BtbN lists (ffmpeg-n9.0-latest-…) over the
+ * master snapshot, which is taken only when no branch build is listed.
+ * `checksumsText` is that release's checksums.sha256 — every line's name is
+ * token-validated before it can become a URL, every digest must be hex.
+ * Returns { name, sha256, branch } or null. Pure; exported for the tests.
+ */
+export function pickLatestFallback(checksumsText, pinnedFile) {
+  const pinned = PINNED_BTBN_RE.exec(pinnedFile || '');
+  if (!pinned) { return null; }
+  const [, plat, ext] = pinned;
+  let stable = null;
+  let master = null;
+  for (const line of String(checksumsText || '').split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 2) { continue; }
+    const digest = parts[0].toLowerCase();
+    const name = parts[1];
+    if (!isSha256(digest) || !TOKEN_RE.test(name)) { continue; }
+    const s = LATEST_STABLE_RE.exec(name);
+    if (s) {
+      if (s[3] !== plat || s[6] !== ext || s[1] !== s[4] || s[2] !== s[5]) { continue; }
+      const version = [Number(s[1]), Number(s[2])];
+      if (!stable || version[0] > stable.version[0] || (version[0] === stable.version[0] && version[1] > stable.version[1])) {
+        stable = { name, sha256: digest, branch: `n${s[1]}.${s[2]}`, version };
+      }
+      continue;
+    }
+    const m = LATEST_MASTER_RE.exec(name);
+    if (m && m[1] === plat && m[2] === ext && !master) {
+      master = { name, sha256: digest, branch: 'master' };
+    }
+  }
+  const pick = stable || master;
+  return pick ? { name: pick.name, sha256: pick.sha256, branch: pick.branch } : null;
+}
+
+// Download the fallback archive into the staging dir, verified against the
+// `latest` release's own checksums.sha256. BtbN replaces those assets in
+// place once a day, so a download that straddles the swap hashes to neither
+// listing: the listing is re-read and the download retried once; a second
+// miss is refused like any other. Returns { file, sha256, branch } or null.
+async function installLatestFallback(release, staging) {
+  const base = MIRROR ? `${MIRROR}/latest` : `https://github.com/${release.repo}/releases/download/latest`;
+  winston.warn(
+    `[ffmpeg-bootstrap] ${release.file} is gone from BtbN release ${release.tag}: BtbN prunes dated autobuilds, ` +
+    'and this mStream build\'s pin has aged out. Falling back to the rolling stable-branch build from BtbN\'s ' +
+    '"latest" release, verified against that release\'s checksums.sha256 (an integrity check, not a reviewed ' +
+    'pin). Update mStream to get a reviewed pin again.');
+  const sumsPath = path.join(staging, 'checksums.sha256');
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    let sums;
+    try {
+      await downloadToFile(`${base}/checksums.sha256`, sumsPath, { maxBytes: CHECKSUMS_MAX_BYTES });
+      sums = await fsp.readFile(sumsPath, 'utf8');
+    } catch (e) {
+      winston.error(`[ffmpeg-bootstrap] could not read BtbN's latest checksums.sha256: ${e.message}`);
+      return null;
+    }
+    const pick = pickLatestFallback(sums, release.file);
+    if (!pick) {
+      winston.error(`[ffmpeg-bootstrap] BtbN's latest release lists no build matching ${release.file} — nothing to fall back to`);
+      return null;
+    }
+    const dest = path.join(staging, pick.name);
+    try {
+      await downloadToFile(`${base}/${pick.name}`, dest, { maxBytes: FALLBACK_MAX_BYTES });
+    } catch (e) {
+      winston.error(`[ffmpeg-bootstrap] ${pick.name} download failed: ${e.message}`);
+      return null;
+    }
+    const actual = await computeFileChecksum(dest);
+    if (actual === pick.sha256) {
+      winston.info(`[ffmpeg-bootstrap] Checksum verified against BtbN's latest release (${pick.branch} branch): ${pick.name}`);
+      return { file: pick.name, sha256: pick.sha256, branch: pick.branch };
+    }
+    await fsp.unlink(dest).catch(() => {});
+    if (attempt === 1) {
+      winston.warn(`[ffmpeg-bootstrap] ${pick.name} does not match BtbN's checksums.sha256 — retrying once, the rolling asset may have been replaced mid-download`);
+    } else {
+      winston.error(`[ffmpeg-bootstrap] ${pick.name} does not match BtbN's checksums.sha256 again (expected ${pick.sha256}, got ${actual}) — refusing`);
+    }
+  }
+  return null;
 }
 
 // ── Atomic install swap ─────────────────────────────────────────────────────
@@ -604,6 +731,9 @@ async function installInto(dir) {
   const destFfprobe = path.join(dir, `ffprobe${binaryExt}`);
   const stagedFfmpeg = path.join(staging, `ffmpeg${binaryExt}`);
   const stagedFfprobe = path.join(staging, `ffprobe${binaryExt}`);
+  // Set when the rolling fallback stood in for a pruned pin: the receipt then
+  // records the fallback's identity, not the manifest's (see checkForUpdate).
+  let installedPins = null;
 
   winston.info(`[ffmpeg-bootstrap] Downloading ffmpeg for ${process.platform}/${process.arch}...${MIRROR ? ` (mirror: ${MIRROR})` : ''}`);
 
@@ -614,14 +744,27 @@ async function installInto(dir) {
       if (!(await installMacBinary(release.files.ffprobe, staging, 'ffprobe'))) { return false; }
     } else {
       // BtbN: one archive, verified against its pin before extraction.
-      const archivePath = path.join(staging, release.file);
-      if (!(await downloadPinned(release.url, archivePath, release, release.file))) { return false; }
-      winston.info(`[ffmpeg-bootstrap] Checksum verified against the committed pin (${release.tag})`);
+      let archiveFile = release.file;
+      let archivePath = path.join(staging, release.file);
+      const pinned = await downloadPinned(release.url, archivePath, release, release.file);
+      if (pinned.ok) {
+        winston.info(`[ffmpeg-bootstrap] Checksum verified against the committed pin (${release.tag})`);
+      } else if (pinned.gone) {
+        // The pinned release was pruned upstream (module header): the rolling
+        // stable-branch build beats a fresh install with no ffmpeg at all.
+        const fallback = await installLatestFallback(release, staging);
+        if (!fallback) { return false; }
+        archiveFile = fallback.file;
+        archivePath = path.join(staging, fallback.file);
+        installedPins = { source: 'btbn-latest', forTag: release.tag, file: fallback.file, sha256: fallback.sha256 };
+      } else {
+        return false;
+      }
 
       // Extract
-      if (release.file.endsWith('.tar.xz')) {
-        await extractTarXz(archivePath, staging, release.file);
-      } else if (release.file.endsWith('.zip')) {
+      if (archiveFile.endsWith('.tar.xz')) {
+        await extractTarXz(archivePath, staging, archiveFile);
+      } else if (archiveFile.endsWith('.zip')) {
         await extractZip(archivePath, staging);
       }
 
@@ -657,7 +800,7 @@ async function installInto(dir) {
     // pre-manifest `.checksum` baseline is superseded (its absence alongside
     // a receipt must not read as "operator's"), so drop it.
     try {
-      await writeReceipt(dir, release);
+      await writeReceipt(dir, release, installedPins || pinsOf(release));
       await fsp.rm(path.join(dir, LEGACY_CHECKSUM_FILE), { force: true }).catch(() => {});
     } catch (e) {
       winston.warn(`[ffmpeg-bootstrap] could not write install receipt: ${e.message}`);
@@ -853,6 +996,11 @@ export async function checkForUpdate() {
   // installs (a `.checksum` baseline, or a default-dir install with no
   // marker at all) never match and converge onto the pinned build once.
   if (receipt && JSON.stringify(receipt.pins) === JSON.stringify(pinsOf(release))) return;
+  // A fallback install (the pinned asset had been pruned upstream — see
+  // installLatestFallback) is as current as it can be while the manifest
+  // still pins that same dead tag: trying again would only re-fetch the
+  // rolling build. It converges the moment a manifest with a new tag ships.
+  if (receipt?.pins?.source === 'btbn-latest' && release.source === 'btbn' && receipt.pins.forTag === release.tag) return;
 
   winston.info('[ffmpeg-bootstrap] Manifest pins changed — refreshing the managed ffmpeg install...');
   // The live binaries stay in place (and spawnable) for the whole download:

--- a/test/unit/btbn-retention.test.mjs
+++ b/test/unit/btbn-retention.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * BtbN retention helpers (scripts/btbn-retention.mjs): the manifest refresh
+ * must pin a build BtbN will still serve months from now. Their prune keeps
+ * the 14 newest dailies plus each month's final build (24 months), so the
+ * durable pick is the final build of the most recent COMPLETED month — never
+ * "the newest daily", which is what the 2026-08-19 pin was when it 404'd on
+ * 2026-09-02, two weeks after being committed.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickRetainedTag, isRetainedTag, parseAutobuildTag } from '../../scripts/btbn-retention.mjs';
+
+// What BtbN served on 2026-09-04 (newest first): 14 dailies, then month-ends.
+const LIVE_2026_09_04 = [
+  'autobuild-2026-09-04-14-01', 'autobuild-2026-09-03-13-17', 'autobuild-2026-09-02-13-13',
+  'autobuild-2026-09-01-13-13', 'autobuild-2026-08-31-13-27', 'autobuild-2026-08-30-13-12',
+  'autobuild-2026-08-29-13-12', 'autobuild-2026-08-28-17-08', 'autobuild-2026-08-27-16-45',
+  'autobuild-2026-08-26-13-06', 'autobuild-2026-08-25-13-06', 'autobuild-2026-08-24-13-10',
+  'autobuild-2026-08-23-13-03', 'autobuild-2026-08-22-12-58',
+  'autobuild-2026-07-31-14-10', 'autobuild-2026-06-30-13-34', 'autobuild-2026-05-31-13-22',
+  'autobuild-2024-10-31-12-59',
+];
+const NOW = new Date('2026-09-04T23:00:00Z');
+
+describe('btbn-retention: pickRetainedTag', () => {
+  test('picks the final build of the most recent completed month, not the newest daily', () => {
+    assert.equal(pickRetainedTag(LIVE_2026_09_04, NOW), 'autobuild-2026-08-31-13-27');
+  });
+
+  test('on the 1st, before that day\'s build exists, still picks last month\'s final build', () => {
+    const tags = LIVE_2026_09_04.filter((t) => !t.startsWith('autobuild-2026-09'));
+    assert.equal(pickRetainedTag(tags, new Date('2026-09-01T08:23:00Z')), 'autobuild-2026-08-31-13-27');
+  });
+
+  test('a completed month with no builds is skipped, not chosen empty', () => {
+    const tags = LIVE_2026_09_04.filter((t) => !t.startsWith('autobuild-2026-08'));
+    assert.equal(pickRetainedTag(tags, NOW), 'autobuild-2026-07-31-14-10');
+  });
+
+  test('order of input does not matter and non-autobuild names are ignored', () => {
+    const shuffled = ['latest', 'v1', ...LIVE_2026_09_04].reverse();
+    assert.equal(pickRetainedTag(shuffled, NOW), 'autobuild-2026-08-31-13-27');
+  });
+
+  test('null when only the current month has builds, or nothing dated at all', () => {
+    assert.equal(pickRetainedTag(['autobuild-2026-09-04-14-01', 'autobuild-2026-09-03-13-17'], NOW), null);
+    assert.equal(pickRetainedTag(['latest'], NOW), null);
+    assert.equal(pickRetainedTag([], NOW), null);
+  });
+
+  test('a year boundary counts December as completed in January', () => {
+    const tags = ['autobuild-2027-01-02-13-00', 'autobuild-2026-12-31-13-05', 'autobuild-2026-12-30-13-05'];
+    assert.equal(pickRetainedTag(tags, new Date('2027-01-03T08:23:00Z')), 'autobuild-2026-12-31-13-05');
+  });
+});
+
+describe('btbn-retention: isRetainedTag', () => {
+  test('the final build of a completed month is retained', () => {
+    assert.equal(isRetainedTag('autobuild-2026-08-31-13-27', LIVE_2026_09_04, NOW), true);
+    assert.equal(isRetainedTag('autobuild-2026-07-31-14-10', LIVE_2026_09_04, NOW), true);
+  });
+
+  test('a current-month build is never retained, however new', () => {
+    assert.equal(isRetainedTag('autobuild-2026-09-04-14-01', LIVE_2026_09_04, NOW), false);
+    assert.equal(isRetainedTag('autobuild-2026-09-02-13-13', LIVE_2026_09_04, NOW), false);
+  });
+
+  test('a superseded daily from a completed month is not retained', () => {
+    assert.equal(isRetainedTag('autobuild-2026-08-30-13-12', LIVE_2026_09_04, NOW), false);
+    assert.equal(isRetainedTag('autobuild-2026-08-19-19-21', LIVE_2026_09_04, NOW), false); // the pin that 404'd
+  });
+
+  test('malformed or non-dated tags are never retained', () => {
+    assert.equal(isRetainedTag('latest', LIVE_2026_09_04, NOW), false);
+    assert.equal(isRetainedTag('autobuild-2026-08-31', LIVE_2026_09_04, NOW), false);
+    assert.equal(isRetainedTag(undefined, LIVE_2026_09_04, NOW), false);
+  });
+});
+
+describe('btbn-retention: parseAutobuildTag', () => {
+  test('parses the dated shape and rejects everything else', () => {
+    assert.deepEqual(parseAutobuildTag('autobuild-2026-08-31-13-27'),
+      { tag: 'autobuild-2026-08-31-13-27', year: 2026, month: 8, day: 31, hour: 13, minute: 27 });
+    assert.equal(parseAutobuildTag('autobuild-2026-8-31-13-27'), null);
+    assert.equal(parseAutobuildTag('latest'), null);
+    assert.equal(parseAutobuildTag(''), null);
+  });
+});

--- a/test/unit/ffmpeg-fallback.test.mjs
+++ b/test/unit/ffmpeg-fallback.test.mjs
@@ -1,0 +1,200 @@
+/**
+ * ffmpeg-bootstrap: a PRUNED pin falls back to BtbN's rolling `latest`
+ * release — verified against that release's checksums.sha256 — instead of
+ * leaving a fresh install with no ffmpeg.
+ *
+ * Why: BtbN deletes dated autobuild releases (util/prunetags.sh keeps the 14
+ * newest dailies + each month's final build), and the 2026-08-19 pin 404'd on
+ * 2026-09-02 for every fresh Linux and Windows install. The manifest now pins
+ * month-end builds (see btbn-retention.test.mjs); this is the belt to that
+ * brace.
+ *
+ * Hermetic like ffmpeg-bootstrap.test.mjs: MSTREAM_FFMPEG_MIRROR points at a
+ * loopback server. The pinned asset answers 404 (or 500, for the no-fallback
+ * case); `latest/checksums.sha256` lists a stable-branch build, a master
+ * build, and noise, with digests that either match the fake archive bytes
+ * (the fallback is verified and handed to the extractor, which fails on the
+ * garbage — nothing installs) or never match (retried once, then refused).
+ * What is asserted is which URLs were fetched, and how many times.
+ *
+ * macOS pins come from ffmpeg.martin-riedl.de versioned paths (no prune, no
+ * BtbN, no fallback) and musl skips the download step, so both skip.
+ */
+
+import { describe, before, after, beforeEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const isMusl = process.platform === 'linux' && !(process.report?.getReport?.()?.header?.glibcVersionRuntime);
+const skip = process.platform === 'darwin' ? 'macOS pins are martin-riedl versioned paths — no BtbN, no fallback'
+  : isMusl ? 'musl skips the download step' : false;
+
+const ARCHIVE_BYTES = Buffer.from('not-an-archive-but-hashes-deterministically');
+const ARCHIVE_DIGEST = crypto.createHash('sha256').update(ARCHIVE_BYTES).digest('hex');
+const ZERO_DIGEST = '0'.repeat(64);
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+let server;
+let tmpDir;
+let dirCounter = 0;
+let config;
+let bootstrap;
+let pinnedFile;   // the platform's pinned BtbN file name from the committed manifest
+let plat;         // linux64 | linuxarm64 | win64
+let ext;          // tar.xz | zip
+const hits = [];  // request paths, in order
+let pinnedStatus = 404;   // what the pinned asset answers
+let sumsMatch = true;     // whether latest/checksums.sha256 digests match ARCHIVE_BYTES
+
+function checksumsText() {
+  const d = sumsMatch ? ARCHIVE_DIGEST : ZERO_DIGEST;
+  const other = plat === 'win64' ? 'linux64' : 'win64';
+  const otherExt = plat === 'win64' ? 'tar.xz' : 'zip';
+  return [
+    `${d}  ffmpeg-master-latest-${plat}-gpl.${ext}`,
+    `${d}  ffmpeg-master-latest-${plat}-gpl-shared.${ext}`,
+    `${d}  ffmpeg-n8.1-latest-${plat}-gpl-8.1.${ext}`,
+    `${d}  ffmpeg-n9.0-latest-${plat}-gpl-9.0.${ext}`,
+    `${d}  ffmpeg-n9.0-latest-${plat}-gpl-shared-9.0.${ext}`,
+    `${d}  ffmpeg-n9.0-latest-${other}-gpl-9.0.${otherExt}`,
+    `${d}  ffmpeg-master-latest-${plat}-lgpl.${ext}`,
+    '',
+  ].join('\n');
+}
+
+function count(pathname) {
+  return hits.filter((h) => h === pathname).length;
+}
+
+function freshDir() {
+  const dir = path.join(tmpDir, `ffmpeg-${++dirCounter}`);
+  config.program.transcode.ffmpegDirectory = dir;
+  return dir;
+}
+
+describe('ffmpeg-bootstrap: pruned pin → latest-release fallback', { skip }, () => {
+  before(async () => {
+    server = http.createServer((req, res) => {
+      const { pathname } = new URL(req.url, 'http://x');
+      hits.push(pathname);
+      if (pathname === '/latest/checksums.sha256') {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        return res.end(checksumsText());
+      }
+      if (pathname.startsWith('/latest/')) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        return res.end(ARCHIVE_BYTES);
+      }
+      // The pinned asset: pruned upstream (404) or some other failure (500).
+      res.writeHead(pinnedStatus, { 'content-type': 'text/plain' });
+      res.end(pinnedStatus === 404 ? 'Not Found' : 'Internal Server Error');
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    process.env.MSTREAM_FFMPEG_MIRROR = `http://127.0.0.1:${server.address().port}`;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-ffmpeg-fallback-'));
+    config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    config.program.transcode.ffmpegDirectory = path.join(tmpDir, 'ffmpeg-0');
+    bootstrap = await import('../../src/util/ffmpeg-bootstrap.js');
+
+    const release = bootstrap.pinnedRelease();
+    assert.equal(release?.source, 'btbn', 'this platform must have a BtbN pin in bin/ffmpeg/manifest.json');
+    pinnedFile = release.file;
+    const m = /-(linux64|linuxarm64|win64)-gpl\.(tar\.xz|zip)$/.exec(pinnedFile);
+    assert.ok(m, `pinned file has the BtbN shape: ${pinnedFile}`);
+    [, plat, ext] = m;
+  });
+
+  beforeEach(() => {
+    bootstrap.reset();
+    hits.length = 0;
+    pinnedStatus = 404;
+    sumsMatch = true;
+    freshDir();
+  });
+
+  after(async () => {
+    bootstrap?.reset();
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('pickLatestFallback prefers the newest stable branch, same platform and archive type', () => {
+    const pick = bootstrap.pickLatestFallback(checksumsText(), pinnedFile);
+    assert.deepEqual(pick, { name: `ffmpeg-n9.0-latest-${plat}-gpl-9.0.${ext}`, sha256: ARCHIVE_DIGEST, branch: 'n9.0' });
+  });
+
+  test('pickLatestFallback takes the master snapshot only when no branch build is listed', () => {
+    const masterOnly = `${ARCHIVE_DIGEST}  ffmpeg-master-latest-${plat}-gpl.${ext}\n${ZERO_DIGEST}  ffmpeg-master-latest-${plat}-gpl-shared.${ext}\n`;
+    assert.deepEqual(bootstrap.pickLatestFallback(masterOnly, pinnedFile),
+      { name: `ffmpeg-master-latest-${plat}-gpl.${ext}`, sha256: ARCHIVE_DIGEST, branch: 'master' });
+  });
+
+  test('pickLatestFallback refuses bad digests, other platforms, and non-BtbN pins', () => {
+    assert.equal(bootstrap.pickLatestFallback(`nothex  ffmpeg-n9.0-latest-${plat}-gpl-9.0.${ext}\n`, pinnedFile), null);
+    const other = plat === 'win64' ? 'linux64' : 'win64';
+    assert.equal(bootstrap.pickLatestFallback(`${ARCHIVE_DIGEST}  ffmpeg-n9.0-latest-${other}-gpl-9.0.${ext}\n`, pinnedFile), null);
+    assert.equal(bootstrap.pickLatestFallback(checksumsText(), 'download/macos/arm64/1787073674_9.0.1/ffmpeg.zip'), null);
+    assert.equal(bootstrap.pickLatestFallback('', pinnedFile), null);
+  });
+
+  test('a pruned pin (404) falls back to the latest stable-branch build, verified against its checksums', async () => {
+    const dir = config.program.transcode.ffmpegDirectory;
+    await bootstrap.ensureFfmpeg();
+    assert.equal(count(`/${pinnedFile}`), 1, `pinned asset fetched: ${hits.join(', ')}`);
+    assert.equal(count('/latest/checksums.sha256'), 1, `checksums fetched: ${hits.join(', ')}`);
+    assert.equal(count(`/latest/ffmpeg-n9.0-latest-${plat}-gpl-9.0.${ext}`), 1, `stable-branch asset fetched: ${hits.join(', ')}`);
+    assert.equal(count(`/latest/ffmpeg-master-latest-${plat}-gpl.${ext}`), 0, 'master must not be fetched when a branch build exists');
+    // The bytes verified, then the extractor choked on them: nothing installed.
+    assert.notEqual(bootstrap.getResolvedSource(), 'bundled');
+    assert.equal(fs.existsSync(path.join(dir, '.fetched.json')), false, 'no receipt for a failed install');
+    assert.equal(fs.existsSync(path.join(dir, '.staging')), false, 'staging cleaned up');
+  });
+
+  test('a fallback whose digest never matches is retried once, then refused', async () => {
+    sumsMatch = false;
+    await bootstrap.ensureFfmpeg();
+    assert.equal(count('/latest/checksums.sha256'), 2, `checksums re-read once: ${hits.join(', ')}`);
+    assert.equal(count(`/latest/ffmpeg-n9.0-latest-${plat}-gpl-9.0.${ext}`), 2, `asset fetched twice: ${hits.join(', ')}`);
+    assert.notEqual(bootstrap.getResolvedSource(), 'bundled');
+  });
+
+  test('a non-404 failure of the pinned asset does NOT fall back', async () => {
+    pinnedStatus = 500;
+    await bootstrap.ensureFfmpeg();
+    assert.equal(count(`/${pinnedFile}`), 1);
+    assert.equal(hits.filter((h) => h.startsWith('/latest/')).length, 0, `latest must stay untouched: ${hits.join(', ')}`);
+    assert.notEqual(bootstrap.getResolvedSource(), 'bundled');
+  });
+
+  test('checkForUpdate leaves a fallback install alone while the manifest still pins the dead tag', async () => {
+    const dir = config.program.transcode.ffmpegDirectory;
+    const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'bin', 'ffmpeg', 'manifest.json'), 'utf8'));
+    const binExt = process.platform === 'win32' ? '.exe' : '';
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `ffmpeg${binExt}`), 'stub');
+    fs.writeFileSync(path.join(dir, `ffprobe${binExt}`), 'stub');
+    const receipt = (forTag) => JSON.stringify({
+      schema: 1, family: 'ffmpeg', installedAt: new Date().toISOString(),
+      pins: { source: 'btbn-latest', forTag, file: `ffmpeg-n9.0-latest-${plat}-gpl-9.0.${ext}`, sha256: ARCHIVE_DIGEST },
+    });
+
+    // Same dead tag as the manifest: nothing to converge onto, no network.
+    fs.writeFileSync(path.join(dir, '.fetched.json'), receipt(manifest.btbn.tag));
+    await bootstrap.checkForUpdate();
+    assert.equal(hits.length, 0, `no fetch expected: ${hits.join(', ')}`);
+
+    // A manifest with a NEW tag (here: the receipt naming an older one) is
+    // grounds to try the pin again — and, it being pruned too, to fall back.
+    fs.writeFileSync(path.join(dir, '.fetched.json'), receipt('autobuild-2000-01-01-00-00'));
+    await bootstrap.checkForUpdate();
+    assert.equal(count(`/${pinnedFile}`), 1, `pinned asset retried: ${hits.join(', ')}`);
+    assert.equal(count('/latest/checksums.sha256'), 1, `fallback attempted: ${hits.join(', ')}`);
+  });
+});


### PR DESCRIPTION
Fresh Linux **and Windows** installs have had no ffmpeg since 2026-09-02: the manifest pinned `autobuild-2026-08-19-19-21` and BtbN deleted it. Their [`util/prunetags.sh`](https://github.com/BtbN/FFmpeg-Builds/blob/master/util/prunetags.sh) keeps only the 14 newest dailies plus each month's final build (24 months back) — the live release list is exactly that: dailies from 08-22 on, then only month-end builds back to 2024-10-31. A "newest daily" pin therefore 404s about two weeks after it is committed, and the monthly refresh on the 3rd could never keep up; with the old selection, fresh installs would be ffmpeg-less for roughly half of every month. #942 (a bump to the 2026-09-02 daily) would have died again around 2026-09-16, so it was closed in favour of this. Existing installs were never affected (they keep their binary); macOS pins are martin-riedl versioned paths, which are not pruned and were still current.

**1. Pin what BtbN keeps.** `scripts/update-ffmpeg-manifest.mjs` now picks the final build of the most recent *completed* month (pure logic in the new `scripts/btbn-retention.mjs`); a hand-given daily tag is accepted with a warning naming the durable choice. The manifest moves to `autobuild-2026-08-31-13-27`, every asset downloaded and sha256-verified (`--verify`, ~500 MB), which BtbN retains until roughly 2028. The monthly workflow keeps its cadence — on the 3rd the previous month is complete — with its comments and the dispatch input description updated.

**2. Never strand an install.** When a pinned BtbN asset answers 404/410, `src/util/ffmpeg-bootstrap.js` falls back to the same-platform stable-branch build from BtbN's rolling `latest` release (`ffmpeg-n9.0-latest-…`; the master snapshot only if no branch build is listed), verified against that release's own `checksums.sha256` — an integrity check rather than a reviewed pin, and logged as a warning that says so. A digest miss is retried once (BtbN swaps `latest` assets in place daily, so a download can straddle the swap) and then refused; any non-404 failure of the pin still refuses outright, as before. The install receipt records `{source: 'btbn-latest', forTag}`, so `checkForUpdate()` neither churns while the manifest still pins the dead tag nor fails to converge onto a reviewed pin once a new manifest ships. The `MSTREAM_FFMPEG_MIRROR` seam gains a `latest/` sub-namespace for the fallback (documented in `bin/ffmpeg/README.md`).

**Tests.** `test/unit/btbn-retention.test.mjs` (selection against BtbN's live release list as of 2026-09-04, month boundaries, superseded dailies, malformed tags) and `test/unit/ffmpeg-fallback.test.mjs` (hermetic loopback mirror: a 404 falls back to the stable-branch build, verified and handed to the extractor; a digest miss is retried once then refused; a 500 does not fall back; `checkForUpdate` no-churn and re-convergence). Both skip where they don't apply (macOS, musl). The existing single-flight suite still passes.

**Real-network proof.** With the manifest temporarily pinned to the pruned 08-19 tag, the fallback downloaded, verified, extracted and executed BtbN's n9.0 build on Windows (host Node) and on Linux (`node:24-bookworm` container), wrote a `btbn-latest` receipt, and a following `checkForUpdate()` was a no-op.

Worth knowing: the CI boot smokes pass on a failed ffmpeg download, which is how a two-week outage for fresh installs went unnoticed; asserting the download in the smokes is a sensible follow-up, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
