### PR TITLE
feat(webapp): Auto DJ across federated servers

### DIFF
--- a/src/api/federation-auth.js
+++ b/src/api/federation-auth.js
@@ -66,6 +66,14 @@ const ALLOWED_EXACT = new Set([
   'POST /api/v1/db/album-songs',
   'POST /api/v1/db/recent/added',
   'POST /api/v1/db/search',
+  // Auto DJ across servers (the webapp's federated session, mStream #929):
+  // a peer's picker, and the vector read-out behind its tracks that a
+  // session seeds itself from. random-songs is a read — it picks and
+  // records nothing — scoped by the key's grants like every db route; the
+  // per-user rating filter is skipped for a key (api/random.js), and
+  // ignoreVPaths names OUR libraries, so a caller sends neither.
+  'POST /api/v1/db/random-songs',
+  'POST /api/v1/discovery/local/embeddings',
   'POST /api/v1/file-explorer',
   'POST /api/v1/file-explorer/recursive',
   'POST /api/v1/file-explorer/m3u',

--- a/src/api/random.js
+++ b/src/api/random.js
@@ -686,7 +686,12 @@ export function runRandomSongs(req, body) {
   const baseConditions = [filter.clause];
   const baseParams = [...(req.user?.id ? [req.user.id] : []), ...filter.params];
 
-  if (body.minRating && Number(body.minRating) > 0) {
+  // Ratings are per-user. A caller with no user id — a federation key, whose
+  // synthetic user carries none — has no stars to filter on: trackQuery
+  // joins user_metadata on NULL for it, so this clause could only ever
+  // empty the pool. Skip it rather than starve a federated Auto DJ pick
+  // (the webapp never sends it to a peer; a stray one is harmless now).
+  if (body.minRating && Number(body.minRating) > 0 && req.user?.id) {
     baseConditions.push('um.rating >= ?');
     baseParams.push(Number(body.minRating));
   }

--- a/test/integration/federation-discovery.test.mjs
+++ b/test/integration/federation-discovery.test.mjs
@@ -258,4 +258,87 @@ describe('federation discovery similar (peer side)', () => {
     const r = await similar(offServer, fedHeaders(offKey), { embedding: b64(Q), modelId: 'test-fake' });
     assert.equal(r.status, 403);
   });
+  // ── The webapp's federated Auto DJ: random-songs + embeddings for a key ──────
+  //
+  // A federated session asks each peer's picker with a vector seed, and reads
+  // the vectors behind anchors that live on that peer. Both routes are now on
+  // the key allowlist; these pin that a key sees them scoped to its grants,
+  // exactly like every other db read — the ungranted library's track has the
+  // highest cosine of all and must never surface.
+
+  describe('federation key: random-songs + embeddings (webapp cross-server Auto DJ)', () => {
+    const ALPHA_PATH = 'shared/alpha.mp3';
+    const UNGRANTED_PATH = 'testlib/Icarus/Be Somebody/01 - Be Somebody.mp3';
+
+    async function post(srv, headers, route, body) {
+      const r = await fetch(`${srv.baseUrl}${route}`, { method: 'POST', headers, body: JSON.stringify(body) });
+      return { status: r.status, body: await r.json().catch(() => null) };
+    }
+
+    test('a plain pick with a key draws only from the granted library', async () => {
+      const seen = new Set();
+      for (let i = 0; i < 16; i++) {
+        const { status, body } = await post(server, fedHeaders(fedKey), '/api/v1/db/random-songs', {});
+        assert.equal(status, 200, JSON.stringify(body));
+        seen.add(body.songs[0].metadata.title);
+        assert.ok(body.songs[0].filepath.startsWith('shared/'), `pick '${body.songs[0].filepath}' left the granted library`);
+      }
+      assert.ok(!seen.has('Be Somebody'));
+    });
+
+    test('a vector-seeded pick with a key stays inside the grants and reports the cosine', async () => {
+      // Q's nearest track overall is Be Somebody (cos ≈ 0.98) in the UNGRANTED
+      // library; within `shared` the pool at 0.5 is {Alpha 0.9, Beta 0.6}.
+      const seen = new Set();
+      for (let i = 0; i < 24; i++) {
+        const { status, body } = await post(server, fedHeaders(fedKey), '/api/v1/db/random-songs',
+          { similarToVector: b64(Q), similarToModelId: 'test-fake', minSimilarity: 0.5 });
+        assert.equal(status, 200, JSON.stringify(body));
+        const title = body.songs[0].metadata.title;
+        seen.add(title);
+        assert.ok(['Alpha Song', 'Beta Song'].includes(title), `'${title}' is outside the key's grants`);
+        const expected = title === 'Alpha Song' ? dot(Q, V.alpha) : dot(Q, V.beta);
+        assert.ok(Math.abs(body.sonic.similarity - expected) < 1e-3, `cosine ${body.sonic.similarity} for '${title}'`);
+      }
+      assert.deepEqual([...seen].sort(), ['Alpha Song', 'Beta Song']);
+    });
+
+    test('a model mismatch is the same hard 400 a local user gets', async () => {
+      const { status, body } = await post(server, fedHeaders(fedKey), '/api/v1/db/random-songs',
+        { similarToVector: b64(Q), similarToModelId: 'some-other-model', minSimilarity: 0.5 });
+      assert.equal(status, 400);
+      assert.match(body.error, /some-other-model/);
+    });
+
+    test('a minRating from a key is skipped, not a starved pool or a 500 (a key has no stars)', async () => {
+      const { status, body } = await post(server, fedHeaders(fedKey), '/api/v1/db/random-songs', { minRating: 8 });
+      assert.equal(status, 200, JSON.stringify(body));
+      assert.ok(body.songs[0].filepath.startsWith('shared/'));
+    });
+
+    test('embeddings for a granted path come back; an ungranted path is a uniform 404', async () => {
+      const ok = await post(server, fedHeaders(fedKey), '/api/v1/discovery/local/embeddings', { filePaths: [ALPHA_PATH] });
+      assert.equal(ok.status, 200, JSON.stringify(ok.body));
+      assert.deepEqual(ok.body.model, { id: 'test-fake', version: '1' });
+      assert.equal(ok.body.dim, 4);
+      assert.equal(ok.body.tracks[0].notAnalyzed, false);
+      const raw = Buffer.from(ok.body.tracks[0].embedding, 'base64');
+      const ab = new ArrayBuffer(raw.length); new Uint8Array(ab).set(raw);
+      const v = new Float32Array(ab);
+      for (let i = 0; i < 4; i++) { assert.ok(Math.abs(v[i] - V.alpha[i]) < 1e-6); }
+
+      const denied = await post(server, fedHeaders(fedKey), '/api/v1/discovery/local/embeddings', { filePaths: [UNGRANTED_PATH] });
+      assert.equal(denied.status, 404);
+    });
+
+    test('a discovery-off peer answers 403 to both, so a session can tell "sits out" from "unreachable"', async () => {
+      assert.equal((await post(offServer, fedHeaders(offKey), '/api/v1/discovery/local/embeddings', { filePaths: ['testlib/x.mp3'] })).status, 403);
+      assert.equal((await post(offServer, fedHeaders(offKey), '/api/v1/db/random-songs',
+        { similarToVector: b64(Q), similarToModelId: 'test-fake', minSimilarity: 0.5 })).status, 403);
+      // …while a plain pick there still works: the route is allowlisted, only
+      // the sonic pool needs discovery.
+      assert.equal((await post(offServer, fedHeaders(offKey), '/api/v1/db/random-songs', {})).status, 200);
+    });
+  });
+
 });

--- a/test/unit/auto-dj-client.test.mjs
+++ b/test/unit/auto-dj-client.test.mjs
@@ -1689,3 +1689,279 @@ describe('sonic anchor lifecycle', () => {
     assert.deepEqual(AUTODJ.state.sonicHistory, []);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// Cross-server session helpers (mStream #929 — federated Auto DJ)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('wire vectors — base64 float32 little-endian', () => {
+  test('encode then decode round-trips the exact floats', () => {
+    const v = new Float32Array([0.25, -1.5, 3, 0]);
+    const wire = AUTODJ.encodeWireVector(v);
+    const back = AUTODJ.decodeWireVector(wire, 4);
+    assert.deepEqual([...back], [...v]);
+  });
+
+  test('the wire bytes are what Node writes for float32 LE (the server\'s form)', () => {
+    const v = new Float32Array([1, 0, 0, 0]);
+    const expected = Buffer.from(v.buffer, v.byteOffset, v.byteLength).toString('base64');
+    assert.equal(AUTODJ.encodeWireVector(v), expected);
+    assert.deepEqual([...AUTODJ.decodeWireVector(expected, 4)], [1, 0, 0, 0]);
+  });
+
+  test('a payload of the wrong length, bad base64, or a bad dim decodes to null', () => {
+    const three = AUTODJ.encodeWireVector(new Float32Array([1, 0, 0]));
+    assert.equal(AUTODJ.decodeWireVector(three, 4), null);
+    assert.equal(AUTODJ.decodeWireVector('!!!not-base64!!!', 4), null);
+    assert.equal(AUTODJ.decodeWireVector('', 4), null);
+    assert.equal(AUTODJ.decodeWireVector(three, 0), null);
+    assert.equal(AUTODJ.decodeWireVector(null, 4), null);
+  });
+});
+
+describe('meanUnitVector', () => {
+  const f = (...xs) => new Float32Array(xs);
+
+  test('averages anchors and re-normalizes', () => {
+    const m = AUTODJ.meanUnitVector([f(1, 0, 0, 0), f(0, 1, 0, 0)], 4);
+    const r = 1 / Math.SQRT2;
+    for (const [i, want] of [[0, r], [1, r], [2, 0], [3, 0]]) {
+      assert.ok(Math.abs(m[i] - want) < 1e-6, `component ${i}: ${m[i]} vs ${want}`);
+    }
+  });
+
+  test('scaled anchors still give a unit vector', () => {
+    const m = AUTODJ.meanUnitVector([f(3, 4, 0, 0), f(3, 4, 0, 0)], 4);
+    assert.ok(Math.abs(m[0] - 0.6) < 1e-6 && Math.abs(m[1] - 0.8) < 1e-6);
+  });
+
+  test('cancelling anchors, nothing to average, or a bad dim give null', () => {
+    assert.equal(AUTODJ.meanUnitVector([f(1, 0, 0, 0), f(-1, 0, 0, 0)], 4), null);
+    assert.equal(AUTODJ.meanUnitVector([], 4), null);
+    assert.equal(AUTODJ.meanUnitVector([f(1, 0, 0, 0)], 0), null);
+  });
+
+  test('a vector of the wrong length is skipped, not summed', () => {
+    const m = AUTODJ.meanUnitVector([f(1, 0, 0, 0), f(0, 1, 0)], 4);
+    assert.deepEqual([...m], [1, 0, 0, 0]);
+    assert.equal(AUTODJ.meanUnitVector([f(0, 1, 0)], 4), null);
+  });
+});
+
+describe('sonic history owners', () => {
+  test('a pick records its owner; a local pick records null; the map is pruned with the ring', () => {
+    AUTODJ.setState({ sonicEnabled: true });
+    AUTODJ.pushSonicHistory('music/a.mp3');
+    AUTODJ.pushSonicHistory('/music/b.mp3', 7);
+    assert.deepEqual(AUTODJ.state.sonicHistoryOwners, { 'music/a.mp3': null, 'music/b.mp3': 7 });
+    for (const p of ['c', 'd', 'e', 'f']) { AUTODJ.pushSonicHistory(`music/${p}.mp3`, 3); }
+    // Ring is 5: 'a' fell out, and so did its owner entry.
+    assert.equal(AUTODJ.state.sonicHistory.length, AUTODJ._internals.SONIC_HISTORY_LIMIT);
+    assert.ok(!('music/a.mp3' in AUTODJ.state.sonicHistoryOwners));
+    assert.equal(AUTODJ.state.sonicHistoryOwners['music/b.mp3'], 7);
+  });
+
+  test('a re-pick from another server moves it to most-recent and updates its owner', () => {
+    AUTODJ.pushSonicHistory('music/a.mp3', 7);
+    AUTODJ.pushSonicHistory('music/b.mp3');
+    AUTODJ.pushSonicHistory('music/a.mp3');
+    assert.deepEqual(AUTODJ.state.sonicHistory, ['music/b.mp3', 'music/a.mp3']);
+    assert.equal(AUTODJ.state.sonicHistoryOwners['music/a.mp3'], null);
+  });
+
+  test('clearing history, anchors, a new seed, resetAnchors and reset all drop the owners', () => {
+    for (const clear of [
+      () => AUTODJ.clearSonicHistory(),
+      () => AUTODJ.clearSonicAnchors(),
+      () => AUTODJ.setSonicSeed('music/seed.mp3', 'Seed'),
+      () => AUTODJ.resetAnchors(),
+      () => AUTODJ.reset(),
+    ]) {
+      AUTODJ.pushSonicHistory('music/x.mp3', 2);
+      clear();
+      assert.deepEqual(AUTODJ.state.sonicHistoryOwners, {});
+      assert.deepEqual(AUTODJ.state.sonicHistory, []);
+    }
+  });
+
+  test('owners survive a re-hydrate, and junk in storage hydrates to an empty map', () => {
+    AUTODJ.pushSonicHistory('music/a.mp3', 9);
+    AUTODJ._internals.rehydrate();
+    assert.deepEqual(AUTODJ.state.sonicHistoryOwners, { 'music/a.mp3': 9 });
+    _store.set(`${AUTODJ._internals.LS_PREFIX}sonicHistoryOwners`, JSON.stringify(['not', 'a', 'map']));
+    AUTODJ._internals.rehydrate();
+    assert.deepEqual(AUTODJ.state.sonicHistoryOwners, {});
+  });
+});
+
+describe('resolveSonicOwners', () => {
+  test('history paths take their recorded owner, the playing track its federation marker, the rest this server', () => {
+    AUTODJ.pushSonicHistory('music/hist-local.mp3');
+    AUTODJ.pushSonicHistory('music/hist-peer.mp3', 4);
+    const cur = { rawFilePath: '/music/playing.mp3', federation: { peerId: 8, peerName: 'NAS' } };
+    const out = AUTODJ.resolveSonicOwners(
+      ['music/hist-local.mp3', 'music/hist-peer.mp3', '/music/playing.mp3', 'music/explicit-seed.mp3'], cur);
+    assert.deepEqual(out, [
+      { path: 'music/hist-local.mp3', peerId: null },
+      { path: 'music/hist-peer.mp3', peerId: 4 },
+      { path: 'music/playing.mp3', peerId: 8 },
+      { path: 'music/explicit-seed.mp3', peerId: null },
+    ]);
+  });
+
+  test('a local playing track resolves to this server; empty and junk input resolve to nothing', () => {
+    const out = AUTODJ.resolveSonicOwners(['music/p.mp3'], { rawFilePath: 'music/p.mp3' });
+    assert.deepEqual(out, [{ path: 'music/p.mp3', peerId: null }]);
+    assert.deepEqual(AUTODJ.resolveSonicOwners([], null), []);
+    assert.deepEqual(AUTODJ.resolveSonicOwners([null, '', 42], null), []);
+  });
+});
+
+describe('sonicAnchors + local-only buildSonicParams (cross-server)', () => {
+  const PEER_CUR = { rawFilePath: 'ashared/a.mp3', federation: { peerId: 1, peerName: 'A' } };
+
+  beforeEach(() => { AUTODJ.setState({ sonicEnabled: true }); });
+
+  test('rolling: the snapshot pairs every history path with its owner; the local body keeps only this server\'s', () => {
+    AUTODJ.pushSonicHistory('lib/p1.mp3', null);
+    AUTODJ.pushSonicHistory('ashared/p2.mp3', 1);
+    assert.deepEqual(AUTODJ.sonicAnchors({ rawFilePath: 'lib/cur.mp3' }),
+      [{ path: 'lib/p1.mp3', peerId: null }, { path: 'ashared/p2.mp3', peerId: 1 }]);
+    assert.deepEqual(AUTODJ.buildSonicParams('lib/cur.mp3').similarTo, ['lib/p1.mp3'],
+      'a peer\'s path never reaches this server (it would answer 404)');
+    assert.deepEqual(AUTODJ.sonicAnchors('lib/cur.mp3'), AUTODJ.sonicAnchors({ rawFilePath: 'lib/cur.mp3' }),
+      'a bare path is accepted');
+  });
+
+  test('rolling: a history that lives entirely on peers falls back to the seed, else the playing song when local', () => {
+    AUTODJ.pushSonicHistory('ashared/p1.mp3', 1);
+    AUTODJ.pushSonicHistory('ashared/p2.mp3', 2);
+    assert.equal(AUTODJ.sonicAnchors({ rawFilePath: 'lib/cur.mp3' }).length, 2, 'the federated pick still sees both');
+    assert.deepEqual(AUTODJ.buildSonicParams('lib/cur.mp3').similarTo, ['lib/cur.mp3'], 'no seed: the local playing song');
+    assert.equal(AUTODJ.buildSonicParams(PEER_CUR), null, 'no seed and a peer track playing: nothing local');
+    AUTODJ.setSonicSeed('lib/seed.mp3', 'Seed');
+    AUTODJ.pushSonicHistory('ashared/p1.mp3', 1);
+    assert.deepEqual(AUTODJ.buildSonicParams(PEER_CUR).similarTo, ['lib/seed.mp3'], 'the seed stands in');
+  });
+
+  test('locked: a pin taken from a playing peer track remembers its owner across ring prunes', () => {
+    AUTODJ.setState({ sonicAnchorMode: 'locked' });
+    assert.deepEqual(AUTODJ.sonicAnchors(PEER_CUR), [{ path: 'ashared/a.mp3', peerId: 1 }]);
+    assert.equal(AUTODJ.state.sonicLockedAnchor, 'ashared/a.mp3');
+    for (let i = 0; i < AUTODJ._internals.SONIC_HISTORY_LIMIT + 2; i++) { AUTODJ.pushSonicHistory(`lib/h${i}.mp3`, null); }
+    assert.deepEqual(AUTODJ.sonicAnchors({ rawFilePath: 'lib/other.mp3' }), [{ path: 'ashared/a.mp3', peerId: 1 }],
+      'the pin\'s owner survives the prune even with another song playing');
+    assert.equal(AUTODJ.buildSonicParams({ rawFilePath: 'lib/other.mp3' }), null,
+      'locked on a peer track with no seed: nothing this server can honour');
+    AUTODJ.clearSonicAnchors();
+    assert.equal(AUTODJ.state.sonicLockedAnchor, null);
+    assert.deepEqual(AUTODJ.state.sonicHistoryOwners, {});
+  });
+
+  test('locked: a pin from a local song or the seed stays a plain local anchor', () => {
+    AUTODJ.setState({ sonicAnchorMode: 'locked' });
+    assert.deepEqual(AUTODJ.sonicAnchors({ rawFilePath: 'lib/cur.mp3' }), [{ path: 'lib/cur.mp3', peerId: null }]);
+    assert.deepEqual(AUTODJ.buildSonicParams(PEER_CUR).similarTo, ['lib/cur.mp3'], 'the pin holds whatever plays next');
+    assert.deepEqual(AUTODJ.state.sonicHistoryOwners, {}, 'no owner entry for a local pin');
+  });
+
+  test('sonic off: no anchors, no params', () => {
+    AUTODJ.pushSonicHistory('ashared/p1.mp3', 1);
+    AUTODJ.setState({ sonicEnabled: false });
+    assert.deepEqual(AUTODJ.sonicAnchors({ rawFilePath: 'lib/cur.mp3' }), []);
+    assert.equal(AUTODJ.buildSonicParams('lib/cur.mp3'), null);
+  });
+});
+
+describe('chooseFederatedPick', () => {
+  const song = (filepath) => ({ filepath, metadata: {} });
+
+  test('the highest cosine wins across servers', () => {
+    const best = AUTODJ.chooseFederatedPick([
+      { peerId: null, song: song('music/l.mp3'), similarity: 0.80, blocked: false },
+      { peerId: 2, song: song('music/p2.mp3'), similarity: 0.91, blocked: false },
+      { peerId: 3, song: song('music/p3.mp3'), similarity: 0.85, blocked: false },
+    ], new Set());
+    assert.equal(best.peerId, 2);
+  });
+
+  test('blocked answers and repeats of the anchors / playing track are passed over', () => {
+    const recent = AUTODJ.federatedRecentKeys(
+      [{ path: 'music/anchor.mp3', peerId: 2 }],
+      { rawFilePath: '/music/playing.mp3', federation: { peerId: 3 } });
+    const best = AUTODJ.chooseFederatedPick([
+      { peerId: 2, song: song('music/anchor.mp3'), similarity: 0.99, blocked: false },   // the anchor itself
+      { peerId: 3, song: song('music/playing.mp3'), similarity: 0.98, blocked: false },  // what is playing
+      { peerId: null, song: song('music/best-but-blocked.mp3'), similarity: 0.97, blocked: true },
+      { peerId: null, song: song('music/ok.mp3'), similarity: 0.70, blocked: false },
+    ], recent);
+    assert.equal(best.song.filepath, 'music/ok.mp3');
+    assert.equal(best.peerId, null);
+  });
+
+  test('the same path on a different server is not a repeat — a path only names a row where it lives', () => {
+    const recent = AUTODJ.federatedRecentKeys([{ path: 'music/same.mp3', peerId: 2 }], null);
+    const best = AUTODJ.chooseFederatedPick([
+      { peerId: 5, song: song('music/same.mp3'), similarity: 0.9, blocked: false },
+    ], recent);
+    assert.equal(best.peerId, 5);
+  });
+
+  test('an answer without a score still competes, but never beats a scored one; nothing usable is null', () => {
+    const best = AUTODJ.chooseFederatedPick([
+      { peerId: 1, song: song('music/unscored.mp3'), similarity: -1, blocked: false },
+      { peerId: 2, song: song('music/scored.mp3'), similarity: 0.5, blocked: false },
+    ], new Set());
+    assert.equal(best.peerId, 2);
+    assert.equal(AUTODJ.chooseFederatedPick([
+      { peerId: 1, song: song('music/unscored.mp3'), similarity: -1, blocked: false },
+    ], new Set()).peerId, 1);
+    assert.equal(AUTODJ.chooseFederatedPick([], new Set()), null);
+    assert.equal(AUTODJ.chooseFederatedPick([{ peerId: 1, song: null }], new Set()), null);
+  });
+});
+
+describe('per-peer ignore lists + session exclusions', () => {
+  test('each peer keeps its own list, trimmed to the cap, persisted, and wiped by reset()', () => {
+    AUTODJ.setPeerIgnoreList(2, [1, 2, 3]);
+    AUTODJ.setPeerIgnoreList(3, [9]);
+    assert.deepEqual(AUTODJ.getPeerIgnoreList(2), [1, 2, 3]);
+    assert.deepEqual(AUTODJ.getPeerIgnoreList(3), [9]);
+    assert.deepEqual(AUTODJ.getPeerIgnoreList(4), []);
+    // A copy: mutating the returned list must not touch state.
+    AUTODJ.getPeerIgnoreList(2).push(99);
+    assert.deepEqual(AUTODJ.getPeerIgnoreList(2), [1, 2, 3]);
+
+    const big = Array.from({ length: AUTODJ._internals.IGNORE_LIST_LIMIT + 10 }, (_, i) => i);
+    AUTODJ.setPeerIgnoreList(2, big);
+    assert.equal(AUTODJ.getPeerIgnoreList(2).length, AUTODJ._internals.IGNORE_LIST_LIMIT);
+    assert.equal(AUTODJ.getPeerIgnoreList(2)[0], 10, 'tail-trimmed, newest kept');
+
+    AUTODJ._internals.rehydrate();
+    assert.deepEqual(AUTODJ.getPeerIgnoreList(3), [9]);
+    AUTODJ.setPeerIgnoreList(3, 'junk');
+    assert.deepEqual(AUTODJ.getPeerIgnoreList(3), []);
+
+    AUTODJ.reset();
+    assert.deepEqual(AUTODJ.getPeerIgnoreList(2), []);
+  });
+
+  test('a model-mismatched peer stays excluded for the session, and reset() clears it', () => {
+    assert.equal(AUTODJ.isPeerExcluded(7), false);
+    AUTODJ.excludePeerForSession(7);
+    assert.equal(AUTODJ.isPeerExcluded(7), true);
+    assert.equal(AUTODJ.isPeerExcluded('7'), true);
+    AUTODJ.excludePeerForSession('not-a-peer');
+    assert.equal(AUTODJ.isPeerExcluded(NaN), false);
+    AUTODJ.reset();
+    assert.equal(AUTODJ.isPeerExcluded(7), false);
+  });
+
+  test('federatedEnabled is a persisted preference that survives reset()', () => {
+    AUTODJ.setState({ federatedEnabled: true });
+    AUTODJ.reset();
+    assert.equal(AUTODJ.state.federatedEnabled, true);
+    AUTODJ._internals.rehydrate();
+    assert.equal(AUTODJ.state.federatedEnabled, true);
+  });
+});

--- a/webapp/alpha/api.js
+++ b/webapp/alpha/api.js
@@ -132,6 +132,14 @@ const MSTREAMAPI = (() => {
     });
   };
 
+  // The embeddings behind LOCAL tracks (1–8 paths): the seed a federated
+  // Auto DJ session carries to other servers as a vector, since a filepath
+  // only names a row here (mStream #929). Same degrade contract as the
+  // calls above: {disabled:true} on 403, null on any other failure.
+  mstreamModule.discoveryEmbeddings = (filePaths) => {
+    return discoveryReq('api/v1/discovery/local/embeddings', { filePaths });
+  };
+
   // POST /api/v1/db/genres → { genres: [{ name, track_count }] }.
   // Used by the Auto-DJ panel's genre filter dropdown. POST (not GET)
   // so callers can pass ignoreVPaths in the body to scope the count;
@@ -268,6 +276,16 @@ const MSTREAMAPI = (() => {
     genres: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/genres', postObject || {}),
     genreSongs: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/genre-songs', postObject),
     recentlyAdded: (peerId, limit) => peerReq(peerId, 'POST', 'api/v1/db/recent/added', { limit: limit || 100 }),
+    // Federated Auto DJ (mStream #929). health: the peer's discovery block
+    // (`discovery.modelId`, null when discovery is off there) — a vector
+    // only compares within one model space, so a session screens peers on
+    // it before asking. discoveryEmbeddings: the vectors behind the PEER's
+    // tracks, for anchors that live there. randomSongs: the peer's picker
+    // fed a vector seed; unlike the local call this rejects on a non-2xx
+    // (req()), which the player reads for the model-mismatch 400.
+    health: (peerId) => peerReq(peerId, 'GET', 'api/v1/federation/health'),
+    discoveryEmbeddings: (peerId, filePaths) => peerReq(peerId, 'POST', 'api/v1/discovery/local/embeddings', { filePaths }),
+    randomSongs: (peerId, postObject) => peerReq(peerId, 'POST', 'api/v1/db/random-songs', postObject),
   };
 
   mstreamModule.searchAlbumArt = (postObject) => {

--- a/webapp/alpha/auto-dj.js
+++ b/webapp/alpha/auto-dj.js
@@ -491,6 +491,28 @@
         const v = _read('sonicLockedAnchor', null);
         return typeof v === 'string' ? v : null;
       })(),
+      // Cross-server session (mStream #929): ask this server AND every
+      // federated peer that shares its discovery model, seed as a vector,
+      // best cosine wins. A preference like sonicEnabled; the panel only
+      // offers it when the server advertises federationBrowse.
+      federatedEnabled:   !!_read('federatedEnabled', false),
+      // Which server each sonicHistory path came from — a peer id, or null
+      // for this server. A path only names a row on the server that holds
+      // it, so a cross-server anchor must remember its owner or the seed
+      // read-out asks the wrong server. Pruned with the history ring.
+      sonicHistoryOwners: (() => {
+        const v = _read('sonicHistoryOwners', null);
+        return (v && typeof v === 'object' && !Array.isArray(v)) ? v : {};
+      })(),
+      // Each peer's own ignoreList, by peer id. The list is server-issued
+      // track ids, meaningful only back on the server that issued it, so
+      // one shared list would exclude unrelated tracks everywhere else and
+      // lose the cooldown wherever the winner moved. The local list stays
+      // djIgnoreList. Each list is tail-trimmed like djIgnoreList.
+      djPeerIgnoreLists: (() => {
+        const v = _read('djPeerIgnoreLists', null);
+        return (v && typeof v === 'object' && !Array.isArray(v)) ? v : {};
+      })(),
     };
   }
 
@@ -580,10 +602,14 @@
       camelotAnchor: null,
       djCountedFilepaths: [],
       sonicHistory: [],
+      sonicHistoryOwners: {},
       sonicLockedAnchor: null,
+      djPeerIgnoreLists: {},
       // sonicSeed survives — like the toggles it's a choice, not
       // session state, so a DJ off/on cycle keeps the picked seed.
+      // federatedEnabled survives for the same reason.
     });
+    _federatedExcluded.clear();
   }
 
   // ── BPM history + anchor ─────────────────────────────────────────
@@ -663,6 +689,7 @@
       // Manual pick = new lane: the sonic session re-anchors on the new
       // song, and any explicit seed from the old lane is consumed.
       sonicHistory: [],
+      sonicHistoryOwners: {},
       sonicLockedAnchor: null,
       sonicSeed: null,
     });
@@ -693,6 +720,7 @@
     setState({
       sonicSeed: { filepath: norm, title: String(title || norm) },
       sonicHistory: [],
+      sonicHistoryOwners: {},
       sonicLockedAnchor: null,
     });
     return true;
@@ -710,56 +738,277 @@
   // last. Re-picking a path already in the window moves it to the
   // most-recent slot instead of duplicating it (a duplicate would
   // double-weight that song in the server's centroid).
-  function pushSonicHistory(filepath) {
+  //
+  // `ownerPeerId` is the server the pick came from — a peer id, or null
+  // (the default, and every single-server pick) for this server. The
+  // owners map is pruned with the ring so it never outgrows it.
+  function pushSonicHistory(filepath, ownerPeerId = null) {
     const norm = _normSonicPath(filepath);
     if (!norm) { return; }
     const next = state.sonicHistory.filter(p => p !== norm);
     next.push(norm);
     while (next.length > SONIC_HISTORY_LIMIT) { next.shift(); }
-    setState({ sonicHistory: next });
+    const owners = {};
+    for (const p of next) {
+      if (p === norm) { owners[p] = ownerPeerId === null || ownerPeerId === undefined ? null : Number(ownerPeerId); }
+      else if (p in state.sonicHistoryOwners) { owners[p] = state.sonicHistoryOwners[p]; }
+    }
+    // The locked anchor is pinned outside the ring; its owner (recorded
+    // by sonicAnchors when the pin came from a playing peer track) rides
+    // along until the pin is cleared.
+    const pin = state.sonicLockedAnchor;
+    if (pin && !(pin in owners) && pin in state.sonicHistoryOwners) { owners[pin] = state.sonicHistoryOwners[pin]; }
+    setState({ sonicHistory: next, sonicHistoryOwners: owners });
   }
 
   function clearSonicHistory() {
-    setState({ sonicHistory: [] });
+    setState({ sonicHistory: [], sonicHistoryOwners: {} });
   }
 
   // Clear the per-session sonic anchors (history + locked pin) while
   // keeping the explicit seed. Used when the feature is toggled off in
   // the panel — mirrors clearBpmHistory/clearCamelotAnchor semantics.
   function clearSonicAnchors() {
-    setState({ sonicHistory: [], sonicLockedAnchor: null });
+    setState({ sonicHistory: [], sonicHistoryOwners: {}, sonicLockedAnchor: null });
   }
 
-  // The `similarTo`/`minSimilarity` fields for the next random-songs
-  // body, or null when sonic mode is off OR no anchor is resolvable
-  // (empty queue, no explicit seed — the caller decides how to surface
-  // that; the player toasts a "pick a seed" pointer).
+  // ── Cross-server session (mStream #929) ─────────────────────────
+  //
+  // With `federatedEnabled`, the player asks this server AND every paired
+  // peer that shares its discovery model. The pure parts live here so
+  // they can be unit-tested; the network round trips stay in the player
+  // (webapp/assets/js/mstream.player.js, _autoDjFederatedPick).
+  //
+  // The seed travels as a VECTOR: a filepath only names a row on the
+  // server that holds it, so the anchor's embeddings are read from their
+  // owning servers, averaged client-side, and sent as `similarToVector`
+  // (base64 of dim × float32 little-endian — the server's wire form).
+
+  // Peers dropped for the rest of the session — a model-space 400 from a
+  // peer means its library is indexed with a different model, and only a
+  // rescan changes that, so it is not re-asked every pick. Session-only,
+  // deliberately not persisted; reset() clears it.
+  const _federatedExcluded = new Set();
+
+  function excludePeerForSession(peerId) {
+    const id = Number(peerId);
+    if (Number.isFinite(id)) { _federatedExcluded.add(id); }
+  }
+
+  function isPeerExcluded(peerId) {
+    return _federatedExcluded.has(Number(peerId));
+  }
+
+  // Which server each anchor path lives on: the owners map for history
+  // paths, the playing song's own `federation` marker for the current
+  // track (a peer pick the user is listening to), and this server for
+  // anything else (the explicit seed is always picked from a local
+  // search). Returns [{ path, peerId }] in the order given, peerId null
+  // for this server.
+  function _currentSongOwner(currentSong) {
+    return currentSong && currentSong.federation && Number.isFinite(Number(currentSong.federation.peerId))
+      ? Number(currentSong.federation.peerId) : null;
+  }
+
+  function resolveSonicOwners(paths, currentSong) {
+    const curPath = _normSonicPath(currentSong && currentSong.rawFilePath);
+    const curPeer = _currentSongOwner(currentSong);
+    const out = [];
+    for (const raw of (Array.isArray(paths) ? paths : [])) {
+      const path = _normSonicPath(raw);
+      if (!path) { continue; }
+      let peerId = null;
+      if (Object.prototype.hasOwnProperty.call(state.sonicHistoryOwners, path)) {
+        const v = state.sonicHistoryOwners[path];
+        peerId = v === null || v === undefined ? null : Number(v);
+      } else if (curPath && path === curPath) {
+        peerId = curPeer;
+      }
+      out.push({ path, peerId });
+    }
+    return out;
+  }
+
+  // "<owner>|<path>" keys for everything a federated pick must not answer
+  // with: the anchors and the playing track. A vector seed carries no
+  // hashes for a server to exclude (the filepath form's seeds are dropped
+  // from the pool server-side), and ignoreList is only a soft cooldown that
+  // yields to the full pool once it covers every candidate — so the guard
+  // is here, and an answer that repeats is passed over for the next best.
+  function federatedKey(peerId, path) {
+    return `${peerId === null || peerId === undefined ? 'local' : Number(peerId)}|${_normSonicPath(path)}`;
+  }
+
+  function federatedRecentKeys(anchors, currentSong) {
+    const keys = new Set();
+    for (const a of (Array.isArray(anchors) ? anchors : [])) {
+      if (a && a.path) { keys.add(federatedKey(a.peerId, a.path)); }
+    }
+    const curPath = _normSonicPath(currentSong && currentSong.rawFilePath);
+    if (curPath) {
+      const curPeer = currentSong.federation && Number.isFinite(Number(currentSong.federation.peerId))
+        ? Number(currentSong.federation.peerId) : null;
+      keys.add(federatedKey(curPeer, curPath));
+    }
+    return keys;
+  }
+
+  // Best answer across servers: highest reported cosine among the answers
+  // that are neither blocked (keyword / genre / duration / continuity —
+  // the same client-side checks the single-server loop applies) nor a
+  // repeat of what is playing or anchoring. Null when nothing qualifies,
+  // which sends the player back to the single-server pick.
+  //   answers: [{ peerId|null, song, res, similarity, blocked }]
+  function chooseFederatedPick(answers, recentKeys) {
+    const recent = recentKeys instanceof Set ? recentKeys : new Set(recentKeys || []);
+    let best = null;
+    for (const a of (Array.isArray(answers) ? answers : [])) {
+      if (!a || !a.song || a.blocked) { continue; }
+      if (recent.has(federatedKey(a.peerId, a.song.filepath))) { continue; }
+      const sim = Number.isFinite(a.similarity) ? a.similarity : -1;
+      if (!best || sim > best.similarity) { best = { ...a, similarity: sim }; }
+    }
+    return best;
+  }
+
+  // Per-peer ignoreList bookkeeping (see djPeerIgnoreLists above).
+  function getPeerIgnoreList(peerId) {
+    const list = state.djPeerIgnoreLists[String(Number(peerId))];
+    return Array.isArray(list) ? [...list] : [];
+  }
+
+  function setPeerIgnoreList(peerId, list) {
+    const id = Number(peerId);
+    if (!Number.isFinite(id)) { return; }
+    const trimmed = !Array.isArray(list) ? []
+      : (list.length > IGNORE_LIST_LIMIT ? list.slice(-IGNORE_LIST_LIMIT) : list);
+    setState({ djPeerIgnoreLists: { ...state.djPeerIgnoreLists, [String(id)]: trimmed } });
+  }
+
+  // Wire vectors — base64 of dim × float32 little-endian, read and written
+  // through a DataView so the bytes are the same on any host.
+  function decodeWireVector(base64, dim) {
+    if (typeof base64 !== 'string' || !Number.isInteger(dim) || dim <= 0) { return null; }
+    let bytes;
+    try {
+      const bin = atob(base64);
+      bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) { bytes[i] = bin.charCodeAt(i); }
+    } catch (_e) {
+      return null;
+    }
+    if (bytes.length !== dim * 4) { return null; }
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const out = new Float32Array(dim);
+    for (let i = 0; i < dim; i++) { out[i] = view.getFloat32(i * 4, true); }
+    return out;
+  }
+
+  function encodeWireVector(vector) {
+    const buf = new ArrayBuffer(vector.length * 4);
+    const view = new DataView(buf);
+    for (let i = 0; i < vector.length; i++) { view.setFloat32(i * 4, vector[i], true); }
+    const bytes = new Uint8Array(buf);
+    let bin = '';
+    for (let i = 0; i < bytes.length; i++) { bin += String.fromCharCode(bytes[i]); }
+    return btoa(bin);
+  }
+
+  // The unit-length mean of the anchors' vectors, or null when there is
+  // nothing to average or the mean collapses (near-opposite anchors — the
+  // server would refuse a zero vector, so don't spend the round trip). A
+  // vector of the wrong length is skipped rather than poisoning the sum.
+  function meanUnitVector(vectors, dim) {
+    if (!Number.isInteger(dim) || dim <= 0) { return null; }
+    const sum = new Float64Array(dim);
+    let n = 0;
+    for (const v of (vectors || [])) {
+      if (!v || v.length !== dim) { continue; }
+      for (let i = 0; i < dim; i++) { sum[i] += v[i]; }
+      n++;
+    }
+    if (n === 0) { return null; }
+    let sumSq = 0;
+    for (let i = 0; i < dim; i++) { sum[i] /= n; sumSq += sum[i] * sum[i]; }
+    const norm = Math.sqrt(sumSq);
+    if (!(norm > 0) || !Number.isFinite(norm)) { return null; }
+    const out = new Float32Array(dim);
+    for (let i = 0; i < dim; i++) { out[i] = sum[i] / norm; }
+    return out;
+  }
+
+  // The anchors a sonic pick averages over, each paired with the server
+  // that owns it (resolveSonicOwners) — [{ path, peerId }], empty when
+  // sonic mode is off or nothing is resolvable (empty queue, no explicit
+  // seed). One synchronous read: a song change between reading the ring
+  // and reading the owners map would have pruned an evicted path's owner,
+  // and a peer path then reads as this server's — which answers a
+  // uniform 404 for any path it can't resolve.
   //
   // Anchor resolution:
   //   locked  → the pinned path; lazily pinned on the session's first
-  //             pick from the explicit seed, else the current song.
+  //             pick from the explicit seed, else the current song (whose
+  //             owner is recorded with the pin when it is a peer track).
   //   rolling → the DJ-pick history; falls back to the explicit seed,
   //             else the current song, for the session's first pick.
-  function buildSonicParams(currentFilepath) {
-    if (!state.sonicEnabled) { return null; }
-    const cur = _normSonicPath(currentFilepath);
+  //
+  // `currentSong` is the playing song object (rawFilePath + the
+  // `federation` marker a peer pick carries); a bare path is accepted too.
+  function sonicAnchors(currentSong) {
+    if (!state.sonicEnabled) { return []; }
+    const song = typeof currentSong === 'string' ? { rawFilePath: currentSong } : currentSong;
+    const cur = _normSonicPath(song && song.rawFilePath);
     const explicit = state.sonicSeed ? _normSonicPath(state.sonicSeed.filepath) : null;
-    const minSimilarity = state.sonicMinSimilarity;
 
     if (state.sonicAnchorMode === 'locked') {
       let anchor = state.sonicLockedAnchor;
       if (!anchor) {
         anchor = explicit || cur;
-        if (anchor) { setState({ sonicLockedAnchor: anchor }); }
+        if (anchor) {
+          const owner = anchor === cur ? _currentSongOwner(song) : null;
+          setState({
+            sonicLockedAnchor: anchor,
+            sonicHistoryOwners: owner === null
+              ? state.sonicHistoryOwners
+              : { ...state.sonicHistoryOwners, [anchor]: owner },
+          });
+        }
       }
-      return anchor ? { similarTo: [anchor], minSimilarity } : null;
+      return anchor ? resolveSonicOwners([anchor], song) : [];
     }
 
     if (state.sonicHistory.length > 0) {
-      return { similarTo: [...state.sonicHistory], minSimilarity };
+      return resolveSonicOwners([...state.sonicHistory], song);
     }
     const seed = explicit || cur;
-    return seed ? { similarTo: [seed], minSimilarity } : null;
+    return seed ? resolveSonicOwners([seed], song) : [];
+  }
+
+  // The `similarTo`/`minSimilarity` fields for the next random-songs
+  // body sent to THIS server, or null when sonic mode is off OR no anchor
+  // this server holds remains (the caller decides how to surface that;
+  // the player toasts a "pick a seed" pointer).
+  //
+  // Anchors a peer owns are left out — a filepath only names a row on the
+  // server that holds it. When every anchor lives elsewhere (a federated
+  // session that has wandered onto peers, now asking this server alone),
+  // the explicit seed stands in; in rolling mode the playing song does
+  // too when it is this server's. A locked pin on a peer track with no
+  // seed yields null rather than quietly re-anchoring somewhere else.
+  function buildSonicParams(currentSong) {
+    const song = typeof currentSong === 'string' ? { rawFilePath: currentSong } : currentSong;
+    const anchors = sonicAnchors(song);
+    if (anchors.length === 0) { return null; }
+    const minSimilarity = state.sonicMinSimilarity;
+    let local = anchors.filter(a => a.peerId === null).map(a => a.path);
+    if (local.length === 0) {
+      const explicit = state.sonicSeed ? _normSonicPath(state.sonicSeed.filepath) : null;
+      const cur = _normSonicPath(song && song.rawFilePath);
+      const curLocal = cur && resolveSonicOwners([cur], song)[0].peerId === null ? cur : null;
+      local = explicit ? [explicit]
+        : (state.sonicAnchorMode !== 'locked' && curLocal ? [curLocal] : []);
+    }
+    return local.length > 0 ? { similarTo: local, minSimilarity } : null;
   }
 
   // ── Counted-filepath tracking ────────────────────────────────────
@@ -1078,6 +1327,7 @@
     clearSonicHistory,
     clearSonicAnchors,
     buildSonicParams,
+    sonicAnchors,
 
     // Counted-filepath tracking (used by the song-change handler to
     // avoid double-counting BPM history when the user navigates back
@@ -1093,6 +1343,19 @@
     // ignoreList passthrough
     setIgnoreList,
     getIgnoreList,
+
+    // Cross-server session (toggle on state.federatedEnabled; the player
+    // does the round trips, these are the pure parts + bookkeeping).
+    resolveSonicOwners,
+    federatedRecentKeys,
+    chooseFederatedPick,
+    getPeerIgnoreList,
+    setPeerIgnoreList,
+    excludePeerForSession,
+    isPeerExcluded,
+    decodeWireVector,
+    encodeWireVector,
+    meanUnitVector,
 
     // Keyword filter (toggle lives on state.djFilterEnabled,
     // mutated via setState; helpers here marshall the word list).
@@ -1135,6 +1398,7 @@
       FILTER_WORDS_LIMIT,
       DEFAULT_BPM_TOLERANCE,
       SONIC_HISTORY_LIMIT,
+      IGNORE_LIST_LIMIT,
       SONIC_ANCHOR_MODES,
       DEFAULT_SONIC_MIN_SIMILARITY,
       GENRE_LIST_LIMIT,

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -4610,6 +4610,17 @@ async function autoDjPanel() {
           <button type="button" class="dj-genre-mode-btn dj-sonic-anchor-btn" data-anchor="locked" aria-pressed="${anchorMode === 'locked'}">${t('autoDJ.sonicAnchorLocked')}</button>
         </div>
       </div>
+      ${MSTREAMAPI.currentServer.federationBrowse === true ? `
+      <div class="autodj-opt-row">
+        <div>
+          <div class="autodj-opt-label" id="dj-federated-label">${t('autoDJ.federatedLabel')}</div>
+          <div class="autodj-opt-hint">${t('autoDJ.federatedHint')}</div>
+        </div>
+        <label class="toggle-sw">
+          <input type="checkbox" id="dj-federated-on" aria-labelledby="dj-federated-label" ${AUTODJ.state.federatedEnabled ? 'checked' : ''}>
+          <span class="toggle-sw-track"><span class="toggle-sw-thumb"></span></span>
+        </label>
+      </div>` : ''}
       <div class="autodj-opt-row autodj-opt-col">
         <div>
           <div class="autodj-opt-label">${t('autoDJ.sonicSeedLabel')}</div>
@@ -4805,6 +4816,15 @@ async function autoDjPanel() {
         t(mode === 'locked' ? 'autoDJ.sonicAnchorLockedHint' : 'autoDJ.sonicAnchorRollingHint');
     };
   });
+
+  // Federated session toggle — present only when the server advertises
+  // federationBrowse (rendered inside the sonic block, so it is already
+  // gated on sonic being on). A pure preference: the player decides per
+  // pick whether a cross-server pick can actually run.
+  const fedOnEl = document.getElementById('dj-federated-on');
+  if (fedOnEl) {
+    fedOnEl.onchange = (e) => { AUTODJ.setState({ federatedEnabled: !!e.target.checked }); };
+  }
 
   // Seed picker — title search against /api/v1/db/search (titles
   // only), debounced; picking a result stores the seed and, if

--- a/webapp/assets/js/mstream.player.js
+++ b/webapp/assets/js/mstream.player.js
@@ -258,10 +258,13 @@ const MSTREAMPLAYER = (() => {
         && AUTODJ.state.sonicEnabled
         && MSTREAMAPI.currentServer.discovery === true) {
       const curSong = mstreamModule.getCurrentSong && mstreamModule.getCurrentSong();
-      const sonic = AUTODJ.buildSonicParams(curSong ? curSong.rawFilePath : null);
+      const sonic = AUTODJ.buildSonicParams(curSong || null);
       if (sonic) {
         body.similarTo = sonic.similarTo;
         body.minSimilarity = sonic.minSimilarity;
+      } else if (opts && opts.sonicOptional) {
+        // The federated pick: its anchors may all live on peers, and the
+        // vector it sends replaces `similarTo` anyway.
       } else {
         // No resolvable anchor: empty queue and no explicit seed. The
         // pick can't honor the "within the similarity range" promise —
@@ -321,14 +324,228 @@ const MSTREAMPLAYER = (() => {
         AUTODJ.setCamelotAnchor(meta['musical-key']);
       }
       // Rolling sonic anchor — each DJ pick joins the last-N window the
-      // next request's `similarTo` centroid averages over.
+      // next request's `similarTo` centroid averages over. A peer pick
+      // records its owner, so a federated session can read that anchor's
+      // vector back from the server that actually holds it.
       if (AUTODJ.state.sonicEnabled) {
-        AUTODJ.pushSonicHistory(filepath);
+        AUTODJ.pushSonicHistory(filepath, curSong.federation ? curSong.federation.peerId : null);
       }
       AUTODJ.markFilepathCounted(filepath);
     } else {
       AUTODJ.resetAnchors();
     }
+  }
+
+  // Client-side post-fetch guard, shared by the single-server retry loop and
+  // the federated pick. Velvet's `_djSongBlocked` — the server's tier
+  // filter already prefers in-range rows, but in degraded fallback cases
+  // (step 5, step 10) the candidate can still be off-target. Songs with NULL
+  // bpm/key pass through (server already exhausted the tagged options).
+  //
+  // Keyword filter — independent of BPM/harmonic toggles. The server doesn't
+  // know about user-supplied skip words (kept entirely client-side per
+  // velvet's design), so this is the only place it gets applied.
+  // Genre + track-length are defence-in-depth against the server's pick:
+  // the server already enforces both, this catches a rescan changing the
+  // row between the server's SELECT and our read.
+  function _autoDjSongBlocked(metadata, refBpm, refNeighbours) {
+    if (typeof AUTODJ === 'undefined' || !AUTODJ.songBlocked) { return false; }
+    return AUTODJ.songBlocked(metadata, {
+      bpmContinuity: AUTODJ.state.bpmContinuity,
+      refBpm,
+      bpmTolerance: AUTODJ.state.bpmTolerance,
+      harmonicMixing: AUTODJ.state.harmonicMixing,
+      refNeighbours,
+      filterEnabled: AUTODJ.state.djFilterEnabled,
+      filterWords: AUTODJ.state.djFilterWords,
+      genreEnabled: AUTODJ.state.djGenreEnabled,
+      genreMode: AUTODJ.state.djGenreMode,
+      genres: AUTODJ.state.djGenres,
+      durationEnabled: AUTODJ.state.djDurationEnabled,
+      minDuration: AUTODJ.state.djMinDuration,
+      maxDuration: AUTODJ.state.djMaxDuration,
+      allowUnknownDuration: AUTODJ.state.djAllowUnknownDuration,
+    });
+  }
+
+  // ── Cross-server session (mStream #929) ─────────────────────────────
+  //
+  // With "play from federated servers" on, a pick is chosen across this
+  // server and every paired peer that shares its discovery model. The
+  // anchor's vectors are read from the servers that OWN them (a path only
+  // names a row where it lives — AUTODJ.resolveSonicOwners), averaged
+  // client-side, and sent to each server as `similarToVector`; the best
+  // reported cosine wins. Peer picks are queued through the federation
+  // wizard, so they stream through the proxy and carry the `federation`
+  // marker every degrade guard keys on.
+  //
+  // Anything that can't run this way — no eligible peer, no usable seed,
+  // nobody answered — returns false, and the single-server loop runs
+  // unchanged: switching this on can never leave the queue empty where it
+  // would otherwise have filled.
+  //
+  // Peers and their model id are learned through the browse proxy (GET
+  // federation/health is allowlisted) and cached for a few minutes; a peer
+  // that still answers a model-space 400 is dropped for the session.
+  let _fedPeersCache = null; // { at, peers: [{ id, name, modelId|null }] }
+  const FED_PEERS_TTL_MS = 5 * 60 * 1000;
+
+  async function _federatedPeers() {
+    if (_fedPeersCache && Date.now() - _fedPeersCache.at < FED_PEERS_TTL_MS) {
+      return _fedPeersCache.peers;
+    }
+    const listed = (await MSTREAMAPI.federationPeers()).peers || [];
+    const peers = await Promise.all(listed
+      // The admin's per-peer discovery opt-in — the same flag the Discover
+      // aggregator honours.
+      .filter(p => p.useDiscovery !== false)
+      .map(async (p) => {
+        try {
+          const health = await MSTREAMAPI.peer.health(p.id);
+          const modelId = health && health.discovery && health.discovery.modelId;
+          return { id: p.id, name: p.name, modelId: modelId || null };
+        } catch (_e) {
+          // Unreachable, or too old to answer: sits this session out.
+          return { id: p.id, name: p.name, modelId: null };
+        }
+      }));
+    _fedPeersCache = { at: Date.now(), peers };
+    return peers;
+  }
+
+  // One federated pick. True when a song was queued.
+  async function _autoDjFederatedPick(signal) {
+    // The anchors and their owners in one synchronous read, before
+    // anything is awaited (see AUTODJ.sonicAnchors): a song change during
+    // the pick prunes the owners map, and a path read after that could
+    // land on the wrong server.
+    const curSong = mstreamModule.getCurrentSong && mstreamModule.getCurrentSong();
+    const anchors = AUTODJ.sonicAnchors(curSong);
+    if (anchors.length === 0) { return false; }
+
+    const peers = (await _federatedPeers()).filter(p => p.modelId && !AUTODJ.isPeerExcluded(p.id));
+    if (peers.length === 0) { return false; }
+
+    // Continuity, filters and our ignoreList; the local `similarTo` is
+    // optional here (every anchor may live on a peer).
+    const { body, refBpm, refNeighbours } = await _buildAutoDjBody({ ignoreList: AUTODJ.getIgnoreList(), sonicOptional: true });
+
+    // The anchors' vectors, each from its own server. The session's model
+    // space is whatever answers first (the local server, when it holds an
+    // anchor); vectors from another space are skipped, never averaged in.
+    const byOwner = new Map();
+    for (const a of anchors) {
+      const key = a.peerId === null ? 'local' : String(a.peerId);
+      if (!byOwner.has(key)) { byOwner.set(key, { peerId: a.peerId, paths: [] }); }
+      byOwner.get(key).paths.push(a.path);
+    }
+    let modelId = null;
+    let dim = null;
+    const vectors = [];
+    for (const { peerId, paths } of byOwner.values()) {
+      let got = null;
+      try {
+        got = peerId === null
+          ? await MSTREAMAPI.discoveryEmbeddings(paths.slice(0, 8))
+          : await MSTREAMAPI.peer.discoveryEmbeddings(peerId, paths.slice(0, 8));
+      } catch (_e) {
+        got = null;
+      }
+      if (!got || got.disabled || !got.model || !Array.isArray(got.tracks)) { continue; }
+      if (modelId === null) { modelId = got.model.id; dim = got.dim; }
+      else if (got.model.id !== modelId || got.dim !== dim) { continue; }
+      for (const trk of got.tracks) {
+        const v = trk && trk.embedding ? AUTODJ.decodeWireVector(trk.embedding, dim) : null;
+        if (v) { vectors.push(v); }
+      }
+    }
+    const seed = modelId ? AUTODJ.meanUnitVector(vectors, dim) : null;
+    if (!seed) { return false; }
+    const vectorSeed = {
+      similarToVector: AUTODJ.encodeWireVector(seed),
+      similarToModelId: modelId,
+      // The pool floor travels with the vector; the local body only
+      // carries it when this server holds an anchor.
+      minSimilarity: Number.isFinite(body.minSimilarity) ? body.minSimilarity : AUTODJ.state.sonicMinSimilarity,
+    };
+
+    // The same body everywhere, minus what only means something on this
+    // server: the filepath seed (the vector replaces it), ignoreVPaths (OUR
+    // library names) and minRating (OUR user's stars); each peer gets its
+    // own ignoreList. Every server is asked at once — a session that waited
+    // for each in turn would stall the queue on the slowest one.
+    //
+    // A server answers with a random row from its pool, so when every
+    // answer is a repeat or blocked the ask is repeated a couple of times
+    // with each server's own returned ignoreList fed back (the way the
+    // single-server loop retries) before the pick is left to that loop —
+    // otherwise a strict slider, whose pools are small, would keep turning
+    // the session local-only. The fed-back lists stay transient: only the
+    // winner's cooldown advances, its pick is the one being played.
+    const { similarTo, ignoreVPaths, minRating, ignoreList, ...shared } = body;
+    const eligible = peers.filter(p => p.modelId === modelId);
+    const retryLists = new Map([['local', ignoreList]]);
+    for (const p of eligible) { retryLists.set(String(p.id), AUTODJ.getPeerIgnoreList(p.id)); }
+    const recentKeys = AUTODJ.federatedRecentKeys(anchors, curSong);
+    const MAX_ASKS = 3;
+    let best = null;
+    for (let attempt = 0; attempt < MAX_ASKS && !best; attempt++) {
+      const asks = [
+        MSTREAMAPI.getRandomSong({ ...shared, ignoreVPaths, minRating, ignoreList: retryLists.get('local'), ...vectorSeed }, { signal })
+          .then(res => ({ peer: null, res }), err => ({ peer: null, err })),
+        ...eligible.filter(p => !AUTODJ.isPeerExcluded(p.id)).map(p =>
+          MSTREAMAPI.peer.randomSongs(p.id, { ...shared, ignoreList: retryLists.get(String(p.id)), ...vectorSeed })
+            .then(res => ({ peer: p, res }), err => ({ peer: p, err }))),
+      ];
+      const answers = await Promise.all(asks);
+      if (signal && signal.aborted) { return false; }
+
+      const scored = [];
+      for (const a of answers) {
+        if (a.err) {
+          if (a.err.name === 'AbortError') { return false; }
+          if (a.peer && a.err.status === 400 && /Sonic seed is from model/i.test((a.err.body && a.err.body.error) || '')) {
+            AUTODJ.excludePeerForSession(a.peer.id);
+          }
+          continue;
+        }
+        const song = a.res && a.res.songs && a.res.songs[0];
+        if (!song) { continue; }
+        if (Array.isArray(a.res.ignoreList)) { retryLists.set(a.peer ? String(a.peer.id) : 'local', a.res.ignoreList); }
+        const sim = a.res.sonic && Number.isFinite(a.res.sonic.similarity) ? a.res.sonic.similarity : -1;
+        scored.push({
+          peerId: a.peer ? a.peer.id : null,
+          peer: a.peer,
+          song,
+          res: a.res,
+          similarity: sim,
+          blocked: _autoDjSongBlocked(song.metadata, refBpm, refNeighbours),
+        });
+      }
+      // Nobody answered — asking again would not change that.
+      if (scored.length === 0) { break; }
+      best = AUTODJ.chooseFederatedPick(scored, recentKeys);
+    }
+    if (!best) { return false; }
+
+    // Only the winner's cooldown advances — its pick is the one being
+    // played, the others' were not.
+    if (best.peerId === null) {
+      AUTODJ.setIgnoreList(Array.isArray(best.res.ignoreList) ? best.res.ignoreList : []);
+      autoDjIgnoreArray = AUTODJ.getIgnoreList();
+    } else {
+      AUTODJ.setPeerIgnoreList(best.peerId, best.res.ignoreList);
+    }
+
+    const meta = { ...(best.song.metadata || {}), _djPicked: true };
+    if (meta.artist) { AUTODJ.pushArtistHistory(meta.artist); }
+
+    if (best.peerId === null) {
+      await VUEPLAYERCORE.addSongWizard(best.song.filepath, meta);
+    } else {
+      VUEPLAYERCORE.addFederationSongWizard(best.peer, best.song.filepath, meta, false);
+    }
+    return true;
   }
 
   // Re-entrancy guard — multiple triggers (song-end, removeSong,
@@ -389,6 +606,19 @@ const MSTREAMPLAYER = (() => {
     let ignoreList = autodjLoaded ? AUTODJ.getIgnoreList() : [];
     const MAX_RETRIES = 5;
 
+    // Cross-server session first (see _autoDjFederatedPick). It returns
+    // false whenever it can't run this way, and the single-server loop
+    // below then runs exactly as before.
+    if (autodjLoaded
+        && AUTODJ.state.sonicEnabled && AUTODJ.state.federatedEnabled
+        && MSTREAMAPI.currentServer.discovery === true
+        && MSTREAMAPI.currentServer.federationBrowse === true) {
+      if (await _autoDjFederatedPick(signal)) {
+        _showSimilarArtistsInfoStrip();
+        return;
+      }
+    }
+
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       const { body, refBpm, refNeighbours } = await _buildAutoDjBody({ ignoreList });
       let res;
@@ -436,39 +666,7 @@ const MSTREAMPLAYER = (() => {
       // can still be off-target. Retry-on-blocked closes the gap.
       // Songs with NULL bpm/key pass through (server already
       // exhausted the tagged options).
-      const blocked = (autodjLoaded && AUTODJ.songBlocked)
-        ? AUTODJ.songBlocked(song.metadata, {
-            bpmContinuity: AUTODJ.state.bpmContinuity,
-            refBpm,
-            bpmTolerance: AUTODJ.state.bpmTolerance,
-            harmonicMixing: AUTODJ.state.harmonicMixing,
-            refNeighbours,
-            // Keyword filter — independent of BPM/harmonic toggles.
-            // Server doesn't know about user-supplied skip words
-            // (kept entirely client-side per velvet's design), so
-            // the retry loop is the only place this gets applied.
-            filterEnabled: AUTODJ.state.djFilterEnabled,
-            filterWords: AUTODJ.state.djFilterWords,
-            // Genre filter — defence-in-depth check against the
-            // server's pick. Server already filters via EXISTS /
-            // NOT EXISTS, so a survivor of the server filter
-            // should never block here under normal operation. The
-            // rare case this handles: a server-returned row whose
-            // track_genres rows were modified by a rescan between
-            // the server SELECT and the client receiving metadata.
-            genreEnabled: AUTODJ.state.djGenreEnabled,
-            genreMode: AUTODJ.state.djGenreMode,
-            genres: AUTODJ.state.djGenres,
-            // Track-length window — same defence-in-depth rationale as
-            // the genre filter: the server already enforces it as a
-            // base condition, this catches a rescan changing the row
-            // between the server's SELECT and our read.
-            durationEnabled: AUTODJ.state.djDurationEnabled,
-            minDuration: AUTODJ.state.djMinDuration,
-            maxDuration: AUTODJ.state.djMaxDuration,
-            allowUnknownDuration: AUTODJ.state.djAllowUnknownDuration,
-          })
-        : false;
+      const blocked = _autoDjSongBlocked(song.metadata, refBpm, refNeighbours);
       if (!blocked) { picked = song; break; }
     }
 

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -281,6 +281,8 @@
   "autoDJ.sonicToastTitle": "Auto DJ — sonic similarity",
   "autoDJ.sonicNoMatch": "No songs are within the similarity range. Loosen the match slider or adjust your filters.",
   "autoDJ.sonicSeedUnanalyzed": "That song hasn't been analyzed yet. Pick another seed or wait for the discovery scan.",
+  "autoDJ.federatedLabel": "Play from federated servers",
+  "autoDJ.federatedHint": "Also ask every federated server that shares this server's discovery model, and play whichever answers closest to the session's sound.",
   "autoDJ.similarInfoTitle": "Auto DJ — similar artists",
   "autoDJ.similarInfoBody": "Picked something close to {{source}}. Considered: {{candidates}}.",
   "autoDJ.similarInfoBodyMore": "Picked something close to {{source}}. Considered: {{candidates}} (+{{extra}} more).",


### PR DESCRIPTION
## Summary

The webapp half of the portable sonic seed (#929): with **Play from federated servers** on, a sonic Auto DJ session asks this server *and* every paired peer that shares its discovery model, and plays whichever answers closest to the session's sound.

Part of #936 — this is its **Scope 2** (a session that spans servers). Scope 1 (Auto DJ while pointed at one peer through the server switcher: nav gating, the peer's libraries in the folder filter) stays open; the allowlist entry, the peer wrapper and the min-rating wrinkle it needed are done here (the rating clause is skipped server-side for a key rather than hidden in the panel).

**Base branch is `claude/portable-sonic-seeds` (#929)**, so this diff shows only the webapp work. #929 stays open and unmerged for now — this PR is the smoke-test vehicle for it.

### How it works

- The anchors' embeddings are read from the servers that **own** them (a filepath only names a row where it lives), averaged client-side, and sent everywhere as `similarToVector`.
- Every server is asked at once; the best reported cosine wins. A peer pick is queued through the federation wizard, so it streams through the proxy and carries the `federation` marker the rest of the player keys on.
- A server answers with a random row from its pool, so when every answer is a repeat or blocked the ask is repeated up to three times with each server's returned `ignoreList` fed back (transient — only the winner's cooldown advances), the way the single-server loop retries.
- Anything that can't run this way (no eligible peer, no usable seed, nobody answered) falls through to the single-server loop unchanged, so switching it on can never leave the queue empty where it would otherwise have filled.

### Server

- `POST /api/v1/db/random-songs` and `POST /api/v1/discovery/local/embeddings` join the federation-key allowlist so the browse proxy can forward them. random-songs is a read scoped by the key's grants like every db route.
- random-songs skips `minRating` for a caller with no user id (a key has no stars; the clause could only empty the pool).

### Webapp

- **api.js** — `discoveryEmbeddings` (local), `peer.health` / `peer.discoveryEmbeddings` / `peer.randomSongs` through the proxy.
- **auto-dj.js** — the pure, unit-tested parts: the sonic history records each pick's owner; `sonicAnchors` pairs every anchor with its owner in one synchronous read; `buildSonicParams` keeps only anchors this server holds for the single-server body (a peer's path in a local request draws the server's uniform 404); `chooseFederatedPick`; per-peer ignore lists (server-issued ids only mean something on the server that issued them); a session-only exclusion set for peers that answer a model-space 400; wire-vector encode/decode + mean.
- **mstream.player.js** — `_autoDjFederatedPick` runs first when sonic + federated are on and the server advertises `federationBrowse`; peers and their model id come from `GET federation/health` through the proxy (cached 5 min, the admin's `useDiscovery` flag honoured).
- **Panel** — a "Play from federated servers" toggle inside the sonic block, shown only when the server advertises `federationBrowse`.

### Smoke (two-server rig, browser)

Two public-mode servers with `test-fake` 4-d vectors, A paired into B with a key over one library. From B's webapp, seeded on a local track:

- fan-out to B and to A through the proxy on every pick, A's picks queued with the federation marker and streamed through the peer stream route;
- an A-owned anchor's vector read back from A;
- A's ids kept in A's own ignore list, B's in B's;
- a repeat-only round retried, then handed to the single-server loop with a local-only `similarTo` (no 404s, no toast);
- turning the toggle off mid-session, with peer paths in the history, keeps the local loop working.

### Tests

- 25 new unit tests (`test/unit/auto-dj-client.test.mjs`) — 203/203.
- 6 new integration tests on `test/integration/federation-discovery.test.mjs` (a key's plain and vector-seeded picks stay inside its grants with exact cosines, model mismatch 400, minRating skipped, embeddings granted / 404, discovery-off 403s) — 14/14; `random-sonic` and `federation-browse` green.

### Known, pre-existing

- The rolling anchor window trails by one song (the pick for the slot after the next song fires at the current song's end); same in the single-server loop.
- A song re-played within the 50-entry counted-filepath ring is not re-pushed into the sonic history; same guard the BPM history uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
