### PR TITLE
feat(db)!: V68 drops users.subsonic_password_encrypted

### DIFF
--- a/docs/subsonic-deprecation.md
+++ b/docs/subsonic-deprecation.md
@@ -36,8 +36,9 @@ password column and a second authentication wall in front of the library.
   that used to live there is under **Lyrics**.
 - **Database** — the tables the Subsonic surface populated (per-user stars,
   bookmarks, play queue, API keys) are left in place and are inert. The
-  encrypted Subsonic password column is dropped by a later release; the
-  secret that could decrypt it is already gone from the config.
+  encrypted Subsonic password column is dropped by the V68 migration on
+  first boot; the secret that could decrypt it is removed from the config
+  at the same time.
 
 ## If you need a Subsonic server
 

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -81,7 +81,7 @@ import { HASH_GENERATION } from './audio-hash.js';
 // V63 indexes cue_points.library_id and play_events.library_id so the
 // library-delete cascade seeks instead of scanning. See SCHEMA_V63.
 // V64 indexes tracks.year so the DLNA By-Year browse seeks. See SCHEMA_V64.
-export const SCHEMA_VERSION = 67;
+export const SCHEMA_VERSION = 68;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -1256,6 +1256,9 @@ export const SCHEMA_V34 = `
 //
 // Forward-only, no rescan required, NULL default keeps the migration
 // invisible to anyone not setting a Subsonic password.
+//
+// Dropped again by V68 after the Subsonic API was removed. Kept so a
+// database anywhere in the V35..V67 window still migrates in sequence.
 export const SCHEMA_V35 = `
   ALTER TABLE users ADD COLUMN subsonic_password_encrypted TEXT DEFAULT NULL;
 `;
@@ -2451,6 +2454,24 @@ export const SCHEMA_V67 = `
     ON federation_requests(peer_endpoint_id);
 `;
 
+// V68: drop users.subsonic_password_encrypted. The Subsonic API — and with
+// it the only reader and writer of this column (the protocol's token-auth
+// path and the Subsonic password setters) — was removed, and
+// config.setup() strips `subsonicSecret`, the HKDF input for the column's
+// AES key, from config.json on first boot. What remains is
+// recoverable-password ciphertext nothing can decrypt: the one piece of
+// Subsonic-era schema worth deleting rather than leaving dormant (the
+// star / bookmark / play-queue / api-key tables are generic user state
+// and stay).
+//
+// Plain `ALTER TABLE ... DROP COLUMN` — the same shape as V34 (SQLite
+// ≥3.35; Node ≥22.5 ships ≥3.45). Nothing indexes, references or triggers
+// on the column, so no table rebuild. Forward-only, no rescan. A pre-V68
+// backup restored onto this build simply re-runs the drop.
+export const SCHEMA_V68 = `
+  ALTER TABLE users DROP COLUMN subsonic_password_encrypted;
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2678,7 +2699,7 @@ export const MIGRATIONS = [
   // Subsonic-specific password storage so token-auth Subsonic clients
   // can connect. Main PBKDF2 password unchanged. NULL default keeps
   // existing behavior for anyone who hasn't set a Subsonic password.
-  // See SCHEMA_V35 for the design rationale.
+  // See SCHEMA_V35 for the design rationale; V68 drops the column again.
   { version: 35, sql: SCHEMA_V35 },
   // V36 adds tracks.source — open-enum provenance label. The ytdl
   // handler writes 'ytdl' on insert; the scanner backfills from a
@@ -2840,4 +2861,9 @@ export const MIGRATIONS = [
   // requests over the discovery DM transport. Pure new table + index, no
   // rescan. See SCHEMA_V67.
   { version: 67, sql: SCHEMA_V67 },
+  // V68 drops users.subsonic_password_encrypted — the Subsonic API and
+  // every reader of the column are gone, and the config key that could
+  // decrypt it is stripped on boot. Plain DROP COLUMN, no rescan. See
+  // SCHEMA_V68.
+  { version: 68, sql: SCHEMA_V68 },
 ];

--- a/test/db/db-v48-multi-art.test.mjs
+++ b/test/db/db-v48-multi-art.test.mjs
@@ -83,12 +83,12 @@ function buildV47Fixture(db) {
 
 function finishMigrations(db) {
   // Continue the chain from wherever the fixture left it.
+  // Through the shared helper so per-migration JS hooks run: V59 drops
+  // fts_tracks in SQL and recreates it in its hook, and a chain applied
+  // without hooks leaves the FTS triggers pointing at a missing table —
+  // which the next schema-validating ALTER (V68's DROP COLUMN) refuses.
   const current = db.prepare('PRAGMA user_version').get().user_version;
-  for (const m of MIGRATIONS) {
-    if (m.version <= current) { continue; }
-    db.exec(m.sql);
-    db.exec(`PRAGMA user_version = ${m.version}`);
-  }
+  applyAllMigrations(db, { fromVersion: current });
 }
 
 // ── Schema shape ────────────────────────────────────────────────────────────

--- a/test/db/db-v50-content-hash.test.mjs
+++ b/test/db/db-v50-content-hash.test.mjs
@@ -25,12 +25,12 @@ function freshDb({ upToVersion } = {}) {
 }
 
 function finishMigrations(db) {
+  // Through the shared helper so per-migration JS hooks run: V59 drops
+  // fts_tracks in SQL and recreates it in its hook, and a chain applied
+  // without hooks leaves the FTS triggers pointing at a missing table —
+  // which the next schema-validating ALTER (V68's DROP COLUMN) refuses.
   const current = db.prepare('PRAGMA user_version').get().user_version;
-  for (const m of MIGRATIONS) {
-    if (m.version <= current) { continue; }
-    db.exec(m.sql);
-    db.exec(`PRAGMA user_version = ${m.version}`);
-  }
+  applyAllMigrations(db, { fromVersion: current });
 }
 
 describe('V50 schema shape', () => {

--- a/test/db/db-v68-drop-subsonic-password.test.mjs
+++ b/test/db/db-v68-drop-subsonic-password.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * V68: users.subsonic_password_encrypted is dropped.
+ *
+ * The column (V35) held AES-encrypted, RECOVERABLE Subsonic passwords for
+ * that protocol's token auth. The Subsonic API is gone and config.setup()
+ * strips the `subsonicSecret` that keyed the ciphertext, so what the column
+ * holds is unreadable data. Pins that the drop is registered, that a fresh
+ * database never has the column, and that upgrading a V67 database with a
+ * populated column keeps every other users field intact.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+
+import { SCHEMA_VERSION, MIGRATIONS } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+
+const COLUMN = 'subsonic_password_encrypted';
+
+function freshDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA recursive_triggers = ON');
+  return db;
+}
+const userColumns = (db) => db.prepare('PRAGMA table_info(users)').all().map((c) => c.name);
+
+describe('V68 drops users.subsonic_password_encrypted', () => {
+  test('registered, plain DROP COLUMN, no rescan, covered by SCHEMA_VERSION', () => {
+    const v68 = MIGRATIONS.find((m) => m.version === 68);
+    assert.ok(v68, 'missing v68 migration');
+    assert.match(v68.sql, /ALTER TABLE users DROP COLUMN subsonic_password_encrypted/);
+    assert.ok(!v68.rescanRequired, 'a column drop needs no rescan');
+    assert.ok(!v68.js, 'no procedural hook');
+    assert.ok(SCHEMA_VERSION >= 68);
+  });
+
+  test('a fresh database never has the column', () => {
+    const db = freshDb();
+    applyAllMigrations(db);
+    assert.ok(!userColumns(db).includes(COLUMN));
+    db.close();
+  });
+
+  test('upgrading a V67 database with a populated column keeps every other users field', () => {
+    const db = freshDb();
+    applyAllMigrations(db, { upToVersion: 67 });
+    assert.ok(userColumns(db).includes(COLUMN), 'V35..V67 still carry the column');
+
+    db.prepare(`INSERT INTO users (username, password, salt, ${COLUMN})
+                VALUES ('alice', 'pbkdf2-hash', 'salt', 'v1:iv:ciphertext-nobody-can-read')`).run();
+    const before = db.prepare("SELECT * FROM users WHERE username = 'alice'").get();
+    assert.equal(before[COLUMN], 'v1:iv:ciphertext-nobody-can-read');
+    delete before[COLUMN];
+
+    // The real upgrade path: only migrations above the stored user_version run.
+    applyAllMigrations(db, { fromVersion: 67 });
+    assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
+    assert.ok(!userColumns(db).includes(COLUMN), 'column dropped');
+
+    const after = db.prepare("SELECT * FROM users WHERE username = 'alice'").get();
+    assert.deepEqual(after, before, 'every other users column survives unchanged');
+    db.close();
+  });
+});

--- a/test/scanner/scanner-schema-guard.test.mjs
+++ b/test/scanner/scanner-schema-guard.test.mjs
@@ -20,7 +20,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { MIGRATIONS, SCHEMA_VERSION } from '../../src/db/schema.js';
+import { SCHEMA_VERSION } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
 import {
   writeScannerPidfile, clearScannerPidfile, reapOrphanedScanner,
   looksLikeScanner,
@@ -40,10 +41,10 @@ function makeDb(tmp) {
   const db = new DatabaseSync(dbPath);
   db.exec('PRAGMA journal_mode = WAL');
   db.exec('PRAGMA foreign_keys = ON');
-  for (const m of MIGRATIONS) {
-    db.exec(m.sql);
-    db.exec(`PRAGMA user_version = ${m.version}`);
-  }
+  // Shared helper: runs the per-migration JS hooks the runner runs (V59
+  // recreates fts_tracks in its hook; without it the FTS triggers dangle
+  // and V68's DROP COLUMN refuses the schema).
+  applyAllMigrations(db);
   return { db, dbPath };
 }
 
@@ -227,10 +228,7 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
     const db = new DatabaseSync(dbPath);
     db.exec('PRAGMA journal_mode = WAL');
     // Build the world as it was BEFORE the repair migration...
-    for (const m of MIGRATIONS.filter(m => m.version <= 45)) {
-      db.exec(m.sql);
-      db.exec(`PRAGMA user_version = ${m.version}`);
-    }
+    applyAllMigrations(db, { upToVersion: 45 });
     db.prepare("INSERT INTO libraries (id, name, root_path) VALUES (1, 'l', 'x')").run();
     // ...poison it the way old JS scanners did (fractional mtimeMs → REAL)...
     db.exec(`INSERT INTO tracks (filepath, library_id, scan_id, modified, lyrics_sidecar_mtime)
@@ -238,10 +236,7 @@ describe('stale sweep verify-absence (deleteStaleTracks)', () => {
     db.exec(`INSERT INTO tracks (filepath, library_id, scan_id, modified, lyrics_sidecar_mtime)
              VALUES ('healthy.mp3', 1, 's', 1781126455012, NULL)`);
     // ...then apply the rest of the migrations (V46).
-    for (const m of MIGRATIONS.filter(m => m.version > 45)) {
-      db.exec(m.sql);
-      db.exec(`PRAGMA user_version = ${m.version}`);
-    }
+    applyAllMigrations(db, { fromVersion: 45 });
     const rows = db.prepare(
       `SELECT filepath, modified, typeof(modified) AS tm,
               lyrics_sidecar_mtime AS lsm, typeof(lyrics_sidecar_mtime) AS tl

--- a/test/scanner/waveform-fallback.test.mjs
+++ b/test/scanner/waveform-fallback.test.mjs
@@ -23,7 +23,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { MIGRATIONS } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
 import { run, shouldChain } from '../../src/db/waveform-fallback.js';
 import {
   NUM_BARS, cacheFilePath, failedMarkerPath, deferredMarkerPath,
@@ -103,7 +103,7 @@ async function makeCase(tracks) {
   await fsp.mkdir(cache, { recursive: true });
 
   const db = new DatabaseSync(path.join(root, 'wf.db'));
-  for (const m of MIGRATIONS) { db.exec(m.sql); db.exec(`PRAGMA user_version = ${m.version}`); }
+  applyAllMigrations(db); // shared helper: runs the JS hooks (V59 recreates fts_tracks)
   db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('lib', lib);
 
   for (const t of tracks) {

--- a/test/scanner/waveform-scan.test.mjs
+++ b/test/scanner/waveform-scan.test.mjs
@@ -27,7 +27,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { MIGRATIONS, SCHEMA_VERSION } from '../../src/db/schema.js';
+import { SCHEMA_VERSION } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
 import {
   generateWaveformBars, NUM_BARS, CACHE_EXT, FAILED_EXT,
   cacheFilePath, failedMarkerPath,
@@ -133,7 +134,7 @@ describe('rust-parser --waveform-scan (the enrichment pass)', () => {
 
     const db = new DatabaseSync(dbPath);
     db.exec('PRAGMA journal_mode = WAL');
-    for (const m of MIGRATIONS) { db.exec(m.sql); db.exec(`PRAGMA user_version = ${m.version}`); }
+    applyAllMigrations(db); // shared helper: runs the JS hooks (V59 recreates fts_tracks)
     db.prepare('INSERT INTO libraries (id, name, root_path) VALUES (1, ?, ?)').run('wflib', lib);
     db.close();
 


### PR DESCRIPTION
## Summary

Schema follow-up to the Subsonic removal (#949): migration **V68 drops `users.subsonic_password_encrypted`**, the V35 column that held AES-encrypted, *recoverable* Subsonic passwords for that protocol's token auth.

PR 3 of 3. #947 and #949 are merged; this targets master directly.

## Why drop this one and keep the rest

- The Subsonic API was the only reader and writer of the column, and #949's `config.setup()` strips `subsonicSecret` (the HKDF input for the column's key) from `config.json` on first boot. What is left is ciphertext nothing can decrypt.
- The other Subsonic-era tables (`user_api_keys`, `user_metadata.starred_at`, `user_album_stars` / `user_artist_stars`, `user_bookmarks`, `user_play_queue`, `playlists.public`, `shared_playlists.description`) are generic user state, threaded through the scanner's bail check, orphan-cleanup and hash-migration. They stay; dropping them is a separate decision.

## The migration

Plain `ALTER TABLE users DROP COLUMN subsonic_password_encrypted` — the same shape as V34 (SQLite ≥ 3.35; Node ≥ 22.5 ships ≥ 3.45). Nothing indexes, references or triggers on the column, so no table rebuild. Forward-only, no rescan. `SCHEMA_VERSION` 67 → 68. A pre-V68 backup restored onto this build simply re-runs the drop (backup is a whole-file mirror).

## A latent test-fixture bug this exposed

A `DROP COLUMN` makes SQLite re-validate every trigger in the schema. Five test files built their databases with an inlined migration loop that skipped the per-migration JS hooks, and **V59 recreates `fts_tracks` only in its hook** — so their FTS triggers had been pointing at a missing table all along, unnoticed until V68 refused the schema with `error in trigger artists_au_fts: no such table: main.fts_tracks`. They now go through `test/helpers/apply-migrations.mjs`, which runs the hooks exactly as the runner in `manager.js` does:

- `test/db/db-v48-multi-art.test.mjs`, `test/db/db-v50-content-hash.test.mjs` (own `finishMigrations`)
- `test/scanner/scanner-schema-guard.test.mjs`, `test/scanner/waveform-fallback.test.mjs`, `test/scanner/waveform-scan.test.mjs` (inlined loops)

Production is unaffected: the real runner has always run the hooks.

## Verification

- New `test/db/db-v68-drop-subsonic-password.test.mjs`: registry entry (plain SQL, no rescan, no hook), fresh DB never has the column, and a V67 → V68 upgrade of a populated row keeps every other `users` field byte-identical.
- `test/db` + `test/unit` + `test/scanner` together: **1185 tests, 1179 pass, 0 fail, 6 skipped** (environment skips).
- Real upgrade: booted a server on a file database left at V67 by an earlier session — the runner applied V68, `PRAGMA user_version` reads 68, `PRAGMA table_info(users)` no longer lists the column, no errors in the boot log.
- Full `npm test` locally on Windows: **2276 tests, 2255 pass, 0 fail, 0 cancelled, 21 skipped** (environment skips), exit 0, 6m47s. Neither of the contention flakes seen during #949's runs recurred.

## Follow-ups

- `docs/subsonic-deprecation.md` now says the column is dropped by V68 on first boot (was "a later release").
- Whether to also drop `user_api_keys` (Subsonic-only in practice, but shaped as a generic per-user key table) is left open on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
