### PR TITLE
iroh: tickets carry only this machine's addresses — fixes the first-dial handshake stall (#940)

### DIFF
--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -31,7 +31,7 @@ import {
   delay,
   bridgeStreamToBackend,
   buildEnvelope,
-  parseEnvelope, describeAddr, handshakeTrace } from './iroh-common.js';
+  parseEnvelope, describeAddr, handshakeTrace, ticketAddr } from './iroh-common.js';
 import * as fedDb from '../db/federation.js';
 import { verifyGuestToken } from './federation-guest.js';
 
@@ -429,7 +429,7 @@ export function getEndpointAddr() {
 // or null when the endpoint isn't running.
 export function getEndpointTicket() {
   if (!endpoint || !irohMod) { return null; }
-  return irohMod.EndpointTicket.fromAddr(endpoint.addr()).toString();
+  return irohMod.EndpointTicket.fromAddr(ticketAddr(irohMod, endpoint)).toString();
 }
 
 export async function stop() {

--- a/src/state/federation.js
+++ b/src/state/federation.js
@@ -31,8 +31,7 @@ import {
   delay,
   bridgeStreamToBackend,
   buildEnvelope,
-  parseEnvelope,
-} from './iroh-common.js';
+  parseEnvelope, describeAddr, handshakeTrace } from './iroh-common.js';
 import * as fedDb from '../db/federation.js';
 import { verifyGuestToken } from './federation-guest.js';
 
@@ -201,9 +200,11 @@ export function clearHandshakeBackoff() {
 // OK is already severable by closeConnectionsForKey — with registration
 // after the reply, an admin revoking the key (or anything else acting on
 // the client-visible OK) races the registry update and severs nothing.
-async function authenticateConnection(conn, remote, onAuthorized) {
+async function authenticateConnection(conn, remote, onAuthorized, tr) {
   const authBi = await conn.acceptBi();
+  tr?.stage('read');
   const sent = Buffer.from(await authBi.recv.readToEnd(HANDSHAKE_LIMIT)).toString('utf8');
+  tr?.stage(`reply (${sent.length} bytes)`);
 
   let keyRow = null;
   let ok = false;
@@ -318,12 +319,16 @@ async function runAcceptLoop(ep, targetHost, targetPort) {
     }
     if (incoming === null) { break; } // endpoint closed
     (async () => {
+      const tr = handshakeTrace('[federation]');
       let remote = '(unknown)';
       try {
         const accepting = await incoming.accept();
+        tr.stage('connect');
         const conn = await accepting.connect();
         try { remote = conn.remoteId().toString(); } catch (_err) { /* noop */ }
+        tr.stage('stream', remote);
         if (isBackedOff(remote)) {
+          tr.end('backed off', 'warn');
           try { conn.close(1n, Array.from(Buffer.from('backoff'))); } catch (_err) { /* noop */ }
           return;
         }
@@ -331,15 +336,16 @@ async function runAcceptLoop(ep, targetHost, targetPort) {
         // (see authenticateConnection's contract); a null return means the
         // callback never ran, so the failure path has nothing to untrack.
         const authed = await authenticateConnection(conn, remote,
-          (row) => trackConn(row.id, conn));
+          (row) => trackConn(row.id, conn), tr);
         if (!authed) {
+          tr.end('rejected', 'warn');
           recordHandshakeFailure(remote);
           try { conn.close(1n, Array.from(Buffer.from('unauthorized'))); } catch (_err) { /* noop */ }
           return;
         }
         const { keyRow, via } = authed;
         failedHandshakes.delete(remote);
-        winston.info(`[federation] ${via} connection authorized: key '${keyRow.name}' from ${remote}`);
+        tr.end(`authorized (${via}, key '${keyRow.name}')`);
         try {
           await acceptConnection(conn, targetHost, targetPort);
         } finally {
@@ -347,7 +353,7 @@ async function runAcceptLoop(ep, targetHost, targetPort) {
         }
         winston.info(`[federation] ${via} connection closed: key '${keyRow.name}' (${remote})`);
       } catch (err) {
-        winston.debug(`[federation] incoming connection dropped (${remote}): ${err?.message}`);
+        tr.end(`dropped: ${err?.message}`, 'warn');
       }
     })();
   }
@@ -381,7 +387,9 @@ export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, a
   endpointIdStr = ep.id().toString();
 
   if (awaitOnline) {
-    await Promise.race([ep.online().catch(() => {}), delay(8000)]);
+    const t0 = Date.now();
+    const online = await Promise.race([ep.online().then(() => true).catch(() => false), delay(8000).then(() => false)]);
+    winston.info(`[federation] endpoint ${online ? 'online' : 'NOT online'} after ${Date.now() - t0}ms: ${describeAddr(ep)}`);
   }
   // stop() ran while we waited for the relay (see state/iroh.js): ep is
   // closed and the state cleared — the reboot's own start() takes over.

--- a/src/state/iroh-common.js
+++ b/src/state/iroh-common.js
@@ -46,8 +46,56 @@ export async function loadIroh() {
       } catch { /* fall back to the loader's default resolution */ }
     }
     irohMod = await import('@number0/iroh');
+    // MSTREAM_IROH_LOG=trace|debug|info|warn turns on iroh's own tracing
+    // (stderr) — the transport-level view the accept loops cannot give.
+    const lvl = process.env.MSTREAM_IROH_LOG;
+    if (lvl && typeof irohMod.setLogLevel === 'function') {
+      const name = lvl[0].toUpperCase() + lvl.slice(1).toLowerCase();
+      try { irohMod.setLogLevel(name); winston.info(`[iroh] native tracing at ${name}`); } catch (err) { winston.warn(`[iroh] setLogLevel(${name}) failed: ${err?.message}`); }
+    }
   }
   return irohMod;
+}
+
+// Where an endpoint stands: its home relay and how many direct addresses it
+// has learned — what a pairing code or federation ticket carries at that
+// moment (mStream#940: a code handed out too early may carry too little).
+export function describeAddr(ep) {
+  try {
+    const a = ep.addr();
+    const direct = a.directAddresses();
+    return `relay ${a.relayUrl() ?? 'none'}, ${direct.length} direct addr(s) [${direct.join(' ')}]`;
+  } catch (err) {
+    return `addr unavailable (${err?.message})`;
+  }
+}
+
+// Per-connection handshake trace for the accept loops (mStream#940). Stage
+// lines print only under MSTREAM_IROH_TRACE=1; a handshake still in flight
+// after STALL_WARN_MS warns regardless, naming the stage it sits in — the
+// phone's dials time out at 10 s and the server used to say nothing at all.
+const TRACE = process.env.MSTREAM_IROH_TRACE === '1';
+const STALL_WARN_MS = 5000;
+export function handshakeTrace(tag) {
+  const t0 = Date.now();
+  let stage = 'accept';
+  let remote = '?';
+  let done = false;
+  const timer = setTimeout(() => {
+    if (!done) { winston.warn(`${tag} handshake from ${remote} still at '${stage}' after ${Date.now() - t0}ms`); }
+  }, STALL_WARN_MS);
+  return {
+    stage(name, r) {
+      stage = name;
+      if (r) { remote = r; }
+      if (TRACE) { winston.info(`${tag} handshake ${remote}: ${name} +${Date.now() - t0}ms`); }
+    },
+    end(outcome, level = 'info') {
+      done = true;
+      clearTimeout(timer);
+      winston[level](`${tag} handshake ${remote}: ${outcome} at '${stage}' after ${Date.now() - t0}ms`);
+    },
+  };
 }
 
 // Smoke check for the `iroh-selftest` worker (build CI + local build

--- a/src/state/iroh-common.js
+++ b/src/state/iroh-common.js
@@ -17,6 +17,7 @@
 //    connect() take Array<number>, NOT Buffers. reset()/stop() take bigint.
 
 import net from 'net';
+import os from 'os';
 import crypto from 'crypto';
 import winston from 'winston';
 import { existsSync, readdirSync } from 'node:fs';
@@ -68,6 +69,57 @@ export function describeAddr(ep) {
   } catch (err) {
     return `addr unavailable (${err?.message})`;
   }
+}
+
+// ---------------------------------------------------------------------------
+// What a ticket advertises (mStream#940)
+// ---------------------------------------------------------------------------
+// endpoint.addr() lists every direct address iroh knows for us: the ones on
+// this machine's interfaces AND the NAT-reflexive ones (the router's outside
+// IP with a mapped port, learned through the relays). A phone on the SAME
+// LAN that reads a ticket with both dials the public one too; the router
+// hairpins that first packet back in with its own LAN address as the source,
+// the reply makes it back through that NAT state, so the phone's QUIC
+// handshake completes and it selects that "direct" path — and its next
+// packets never arrive. The server's half of the handshake times out 30 s
+// later, the phone's after 10 s, and it retries: measured 8/8 fresh
+// endpoints stalling the first dial, 10/10 stalled connections arriving from
+// 192.168.1.1, every success from the phone's own address. A phone outside
+// the NAT cannot use the reflexive address unsolicited anyway — holepunching
+// goes through the relay, which stays in the ticket — so a ticket carries
+// only the addresses this machine actually has. Pure; unit-tested.
+export function localDirectAddresses(directAddrs, interfaceIps) {
+  const ip = (addr) => {
+    const s = String(addr);
+    if (s.startsWith('[')) { return s.slice(1, s.indexOf(']')); }
+    const i = s.lastIndexOf(':');
+    return i < 0 ? s : s.slice(0, i);
+  };
+  const strip = (a) => String(a).split('%')[0].toLowerCase(); // zone ids off IPv6
+  const local = new Set([...interfaceIps].map(strip));
+  return directAddrs.filter((a) => local.has(strip(ip(a))));
+}
+
+function interfaceIps() {
+  const out = new Set();
+  for (const list of Object.values(os.networkInterfaces())) {
+    for (const i of list ?? []) { if (i?.address) { out.add(i.address); } }
+  }
+  return out;
+}
+
+// The EndpointAddr a ticket is built from: the endpoint's own, with the
+// reflexive direct addresses removed. Keeps everything when the filter would
+// leave nothing (interfaces unreadable) — never worse than before.
+export function ticketAddr(irohMod, ep) {
+  const a = ep.addr();
+  let all = [];
+  try { all = a.directAddresses(); } catch (_err) { return a; }
+  const keep = localDirectAddresses(all, interfaceIps());
+  if (keep.length === all.length || keep.length === 0) { return a; }
+  const dropped = all.filter((x) => !keep.includes(x));
+  winston.info(`[iroh] ticket carries ${keep.length} of ${all.length} direct addresses (not the NAT-reflexive ${dropped.join(' ')})`);
+  return new irohMod.EndpointAddr(a.id(), a.relayUrl(), keep);
 }
 
 // Per-connection handshake trace for the accept loops (mStream#940). Stage

--- a/src/state/iroh.js
+++ b/src/state/iroh.js
@@ -39,8 +39,7 @@ import {
   delay,
   bridgeStreamToBackend,
   buildEnvelope,
-  parseEnvelope,
-} from './iroh-common.js';
+  parseEnvelope, describeAddr, handshakeTrace } from './iroh-common.js';
 
 // Shared plumbing re-exported for existing consumers.
 export {
@@ -112,9 +111,11 @@ export function parseCompositeTicket(code) {
 // Validate the shared-secret handshake on a freshly-accepted connection. The
 // client's FIRST bi-stream carries the secret; we compare constant-time and
 // reply OK / NO. Returns true iff the secret matched.
-async function authenticateConnection(conn) {
+async function authenticateConnection(conn, tr) {
   const authBi = await conn.acceptBi();
+  tr?.stage('read');
   const sent = Buffer.from(await authBi.recv.readToEnd(HANDSHAKE_LIMIT));
+  tr?.stage(`reply (${sent.length} bytes)`);
   const ok = sent.length === connectSecretBuf.length && crypto.timingSafeEqual(sent, connectSecretBuf);
   try {
     await authBi.send.writeAll(Array.from(Buffer.from(ok ? 'OK' : 'NO')));
@@ -149,22 +150,25 @@ async function runAcceptLoop(ep, targetHost, targetPort) {
     }
     if (incoming === null) { break; } // endpoint closed
     (async () => {
+      const tr = handshakeTrace('[iroh]');
       let remote = '(unknown)';
       try {
         const accepting = await incoming.accept();
+        tr.stage('connect');
         const conn = await accepting.connect();
         try { remote = conn.remoteId().toString(); } catch (_err) { /* noop */ }
-        const authed = await authenticateConnection(conn);
+        tr.stage('stream', remote);
+        const authed = await authenticateConnection(conn, tr);
         if (!authed) {
-          winston.warn(`[iroh] rejected connection from ${remote} (bad connect secret)`);
+          tr.end('rejected (bad connect secret)', 'warn');
           try { conn.close(1n, Array.from(Buffer.from('unauthorized'))); } catch (_err) { /* noop */ }
           return;
         }
-        winston.info(`[iroh] tunnel connection authorized: ${remote}`);
+        tr.end('authorized');
         await acceptConnection(conn, targetHost, targetPort);
         winston.info(`[iroh] tunnel connection closed: ${remote}`);
       } catch (err) {
-        winston.debug(`[iroh] incoming connection dropped (${remote}): ${err?.message}`);
+        tr.end(`dropped: ${err?.message}`, 'warn');
       }
     })();
   }
@@ -196,7 +200,9 @@ export async function start({ targetPort, targetHost = '127.0.0.1', secretKey, c
   endpointIdStr = ep.id().toString();
 
   if (awaitOnline) {
-    await Promise.race([ep.online().catch(() => {}), delay(8000)]);
+    const t0 = Date.now();
+    const online = await Promise.race([ep.online().then(() => true).catch(() => false), delay(8000).then(() => false)]);
+    winston.info(`[iroh] endpoint ${online ? 'online' : 'NOT online'} after ${Date.now() - t0}ms: ${describeAddr(ep)}`);
   }
   // stop() ran while we waited for the relay (a soft reboot lands here when
   // an admin saves right after boot): ep is closed and the state cleared —
@@ -221,6 +227,7 @@ export function getEndpointAddr() {
 export function getTicket() {
   if (!endpoint || !irohMod) { return null; }
   const ticketStr = irohMod.EndpointTicket.fromAddr(endpoint.addr()).toString();
+  if (process.env.MSTREAM_IROH_TRACE === '1') { winston.info(`[iroh] pairing code issued: ${describeAddr(endpoint)}`); }
   return buildCompositeTicket(ticketStr, connectSecretBuf);
 }
 

--- a/src/state/iroh.js
+++ b/src/state/iroh.js
@@ -39,7 +39,7 @@ import {
   delay,
   bridgeStreamToBackend,
   buildEnvelope,
-  parseEnvelope, describeAddr, handshakeTrace } from './iroh-common.js';
+  parseEnvelope, describeAddr, handshakeTrace, ticketAddr } from './iroh-common.js';
 
 // Shared plumbing re-exported for existing consumers.
 export {
@@ -226,7 +226,7 @@ export function getEndpointAddr() {
 // The composite QR string (EndpointTicket + connectSecret), or null if not started.
 export function getTicket() {
   if (!endpoint || !irohMod) { return null; }
-  const ticketStr = irohMod.EndpointTicket.fromAddr(endpoint.addr()).toString();
+  const ticketStr = irohMod.EndpointTicket.fromAddr(ticketAddr(irohMod, endpoint)).toString();
   if (process.env.MSTREAM_IROH_TRACE === '1') { winston.info(`[iroh] pairing code issued: ${describeAddr(endpoint)}`); }
   return buildCompositeTicket(ticketStr, connectSecretBuf);
 }

--- a/test/unit/iroh-ticket-addrs.test.mjs
+++ b/test/unit/iroh-ticket-addrs.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { localDirectAddresses } from '../../src/state/iroh-common.js';
+
+// mStream#940: a ticket must not advertise the NAT-reflexive public addresses
+// iroh learns through the relays — a phone on the same LAN dials them first,
+// the router hairpins the first packet and the path only works one way.
+test('keeps the addresses on this machine, drops the reflexive ones', () => {
+  const addrs = ['73.60.222.134:52111', '73.60.222.134:64140', '192.168.1.120:64140'];
+  assert.deepEqual(localDirectAddresses(addrs, new Set(['192.168.1.120', '127.0.0.1'])), ['192.168.1.120:64140']);
+});
+
+test('a public IP that IS on an interface (a VPS) is kept', () => {
+  const addrs = ['203.0.113.7:4000', '10.0.0.5:4000'];
+  assert.deepEqual(localDirectAddresses(addrs, new Set(['203.0.113.7', '10.0.0.5'])), addrs);
+});
+
+test('IPv6 with brackets and zone ids', () => {
+  const addrs = ['[fe80::1c2b:3d4e:5f60:7a8b]:4000', '[2001:db8::10]:4000', '192.168.1.120:4000'];
+  const ifaces = new Set(['fe80::1c2b:3d4e:5f60:7a8b%en0', '192.168.1.120']);
+  assert.deepEqual(localDirectAddresses(addrs, ifaces), ['[fe80::1c2b:3d4e:5f60:7a8b]:4000', '192.168.1.120:4000']);
+});
+
+test('nothing local → empty (the caller then keeps the original set)', () => {
+  assert.deepEqual(localDirectAddresses(['73.60.222.134:1'], new Set(['192.168.1.120'])), []);
+});


### PR DESCRIPTION
Fixes the last open item of #940: a phone's first dials to a freshly enabled Quick Connect endpoint (and, since the app went direct, to a peer's federation endpoint) stalled in the handshake for 13 s a time, up to six times in a row.

## What it was

`endpoint.addr()` lists every direct address iroh knows for the server: the LAN address **and** the NAT-reflexive public ones learned through the relays. Both went into the pairing code and the federation ticket. A phone on the same LAN dials all of them; the router hairpins the first packet to the public address back in with its own LAN address as the source, the reply makes it back through that NAT state, so the phone's QUIC handshake completes and it selects that "direct" path. Nothing it sends after that arrives. The server's half of the handshake times out after 30 s, the phone's after 10 s, and the phone retries until a dial lands on the LAN address or the relay.

Why it looked like a fresh-endpoint problem: a 15 s wait before the first dial made it disappear, because by then the endpoint's UPnP mapping exists and the hairpin works both ways. Same-host dials (the parent to the peer, the iOS simulator) never stalled because the LAN path always won there.

## Evidence (Galaxy S25 on the LAN, `smoke/android/qc-first-dial.sh` in the app repo)

| Run | Result |
|---|---|
| 8 fresh endpoints, code handed out 0.5 s after enabling | 8 / 8 stalled the first dial, 21 stalls |
| Server trace (`MSTREAM_IROH_LOG=debug`), 3 more endpoints | every stalled connection arrived from `192.168.1.1` (the router), every success from `192.168.1.204` (the phone); the phone reported each stall "on direct path" |
| 15 s warm-up control | 3 / 4 clean, 1 / 4 stalled four times — the wait only changes the odds of which candidate the phone selects first |
| Same server, only the phone relaunched | ran after the fix was in place: 4 / 4 first-dial connects (no longer discriminating, kept for the record) |
| **With this fix**, 6 fresh endpoints, warm-up 0 | **0 / 6 stalled**, every dial connected on the first try in 3.2 s (five direct, one relay), the code handed out 0.5 s after enabling |
| Federation rig, Quick Connect parent, warm-up 0, with this fix | the parent's Quick Connect tunnel and the guest dial to the peer both connected on the first try (`(launch)` / `(server-switch)`, no `retry#`); direct phase, renewal through the re-dialed parent, switch and revocation all pass; one relaunch check tripped on a downloaded copy, a rig-side check fixed in the app repo |

## The change

- `ticketAddr` builds a ticket from an `EndpointAddr` holding only the direct addresses present on this machine's interfaces (a VPS keeps its public IP; IPv6 zone ids handled), falling back to the full set if the filter would leave nothing. Used by the pairing code and the federation endpoint ticket, which the guest ticket embeds. `localDirectAddresses` is pure and unit-tested. A phone outside the NAT never could use the reflexive address unsolicited; holepunching goes through the relay, which stays in the ticket.
- Both accept loops now trace each incoming connection (accept → connect → stream → read → reply), warn when a handshake is still in flight after 5 s naming its stage, and log the outcome with the stage and elapsed time; `start()` logs the online wait's outcome with the relay and direct addresses. `MSTREAM_IROH_TRACE=1` prints the per-stage lines, `MSTREAM_IROH_LOG=debug` turns on iroh's own tracing. This is what found the bug; the server used to say nothing about a stalled handshake.

667 unit tests pass.

## Left for iroh upstream

The path selection that keeps a one-way hairpinned "direct" path selected while the relay path is available is iroh's; this change sidesteps it by not advertising the trap. Worth reporting with the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
