### PR TITLE
feat(api): federationInbox on the boot payload — requests waiting on the operator

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1022,7 +1022,8 @@ paths:
                       Present only for authenticated callers. The
                       caller-scoped half of the ping boot payload (vpaths,
                       permission flags, federationDiscovery,
-                      federationBrowse, federationDirect, vpathMetaData)
+                      federationBrowse, federationDirect, federationInbox,
+                      vpathMetaData)
                       plus the identity fields below.
                     properties:
                       username: { type: string }
@@ -1040,6 +1041,16 @@ paths:
                           and there is at least one peer to reach. Same value as
                           federationBrowse; whether a given peer cooperates is
                           answered per peer by the access route.
+                      federationInbox:
+                        type: integer
+                        description: >
+                          Federation requests waiting on this operator: inbound
+                          rows still in the `received` state, the number the
+                          admin panel's Requests badge shows. A number only for
+                          an admin, on an unlocked admin API, of a
+                          federation-enabled server; everyone else reads 0. The
+                          key's presence says the build has the requests
+                          feature (schema V67).
                   admin:
                     type: object
                     description: >

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -47,6 +47,7 @@ import packageJson from '../../package.json' with { type: 'json' };
 import * as config from '../state/config.js';
 import * as db from '../db/manager.js';
 import * as fedDb from '../db/federation.js';
+import * as fedRequestsDb from '../db/federation-requests.js';
 import * as sim from '../db/discovery-similarity.js';
 import * as transcode from './transcode.js';
 
@@ -133,6 +134,17 @@ export function buildClientBootPayload(user) {
     // cooperates is answered per peer by the access route (an older peer
     // refuses, and the client keeps using the proxies above).
     federationDirect: federationEnabled && federationPeers.length > 0,
+    // Federation requests waiting on this operator — inbound rows still in
+    // the `received` state (the V67 inbox), the number the admin panel's
+    // Requests badge shows. A client draws its "N requests waiting" banner
+    // from the value alone, so it is scoped to who can ACT on it: a number
+    // only for an admin, on an unlocked admin API, of a federation-enabled
+    // server (the same three gates the accept/reject routes sit behind);
+    // everyone else reads 0. The key's presence says the build has the
+    // requests feature — an older server omits it and the client shows
+    // nothing.
+    federationInbox: federationEnabled && user.admin === true && config.program.lockAdmin !== true
+      ? fedRequestsDb.countPendingInbound() : 0,
     vpathMetaData: {}
   };
 

--- a/test/integration/api-server-info.test.mjs
+++ b/test/integration/api-server-info.test.mjs
@@ -49,6 +49,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import jwt from 'jsonwebtoken';
 import { startServer } from '../helpers/server.mjs';
+import { DatabaseSync } from 'node:sqlite';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -177,6 +178,42 @@ describe('layered /api/ server info', () => {
     assert.equal(typeof j.admin.platform, 'string');
     assert.ok(Number.isInteger(j.admin.dbSchemaVersion) && j.admin.dbSchemaVersion >= 67,
       'live PRAGMA user_version');
+  });
+
+  test('federationInbox: an admin counts the requests waiting on them, a member reads 0', async () => {
+    // Fresh boot, federation on, nothing in the inbox: the key is present
+    // (this build has the V67 requests feature) and reads 0 for everyone.
+    const empty = await (await api({ 'x-access-token': adminToken })).json();
+    assert.equal(empty.user.federationInbox, 0);
+
+    // A request that arrived over the discovery mesh and is now waiting on
+    // a human — the row the inbound DM handler writes, planted straight
+    // into the server's database (the server counts live, per call).
+    const dbFile = new DatabaseSync(path.join(srv.tmpDir, 'db', 'mstream.db'));
+    dbFile.prepare(`
+      INSERT INTO federation_requests
+        (uuid, direction, peer_endpoint_id, peer_name, message, state, expires_at)
+      VALUES (?, 'in', ?, ?, ?, 'received', datetime('now', '+7 days'))
+    `).run('11111111-2222-4333-8444-555555555555', 'a'.repeat(64), 'Ghost NAS', 'Swap for the vinyl rips?');
+    // An outbound request of ours and a settled inbound one never count.
+    dbFile.prepare(`
+      INSERT INTO federation_requests (uuid, direction, peer_endpoint_id, state, expires_at)
+      VALUES (?, 'out', ?, 'pending-delivery', datetime('now', '+7 days')),
+             (?, 'in', ?, 'accepted', datetime('now', '+7 days'))
+    `).run('11111111-2222-4333-8444-666666666666', 'b'.repeat(64),
+      '11111111-2222-4333-8444-777777777777', 'c'.repeat(64));
+    try {
+      const admin = await (await api({ 'x-access-token': adminToken })).json();
+      assert.equal(admin.user.federationInbox, 1, 'only inbound rows still received count');
+      const member = await (await api({ 'x-access-token': userToken })).json();
+      assert.equal(member.user.federationInbox, 0, 'a member cannot act on requests, so reads 0');
+      // Both boot routes carry it (drift-lock below keeps them equal).
+      const ping = await (await fetch(`${srv.baseUrl}/api/v1/ping`, { headers: { 'x-access-token': adminToken } })).json();
+      assert.equal(ping.federationInbox, 1);
+    } finally {
+      dbFile.prepare('DELETE FROM federation_requests').run();
+      dbFile.close();
+    }
   });
 
   test('drift-lock: ping === /api/ user half + features half (modulo legacy/identity)', async () => {


### PR DESCRIPTION
Adds one caller-scoped number to the boot payload so a client can show "N federation requests waiting" without polling the admin requests route.

## What

`federationInbox` on both routes that carry `buildClientBootPayload` (`GET /api/` under `user`, and flat on `GET /api/v1/ping`): the count of inbound requests still in the `received` state — the number the admin panel's Requests badge shows (`countPendingInbound`, already in `db/federation-requests.js`).

## Scope

A number only for an admin, on an unlocked admin API, of a federation-enabled server — the same three gates the accept/reject routes sit behind. Everyone else reads 0. The key's presence says the build has the requests feature (schema V67); an older server omits it and the client shows nothing. No new route, no new query shape.

## Test

`test/integration/api-server-info.test.mjs`: plants a received inbound row (plus an outbound one and a settled inbound one that must not count) straight into the server's SQLite file, then reads `/api/` as admin (1) and member (0) and `/api/v1/ping` as admin (1). The drift-lock test keeps the two routes equal. File passes 14/14.

## Consumer

The mobile app's home banner + federation-request notification: IrosTheBeggar/mstream_music#165 reads `user.federationInbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
