### PR TITLE
refactor(server-audio): drop dead code, fix the CLI harness image, sync the spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -104,7 +104,10 @@ tags:
   - name: Scrobbler - Last.fm
     description: Last.fm scrobbling integration.
   - name: Server Playback
-    description: Proxy to the bundled Rust audio player.
+    description: >-
+      Server-side playback. Proxies to the mstream-player engine, or to a CLI
+      player (mpv, MPD, VLC, MPlayer) when the engine is unavailable. Every
+      route requires the per-user allow_server_audio flag; admins always pass.
   - name: Jukebox
     description: Remote-control mode via WebSocket-backed REST.
   - name: YouTube DL
@@ -3174,7 +3177,33 @@ paths:
     get:
       tags: [Server Playback]
       summary: Get playback state
-      responses: { "200": { description: Proxied response. } }
+      description: >-
+        The active backend's own status object (playing, paused, position,
+        duration, volume, queue_index, queue_length, shuffle, loop_mode, ...)
+        with two fields added by the proxy that say which backend answered.
+      responses:
+        "200":
+          description: Proxied status.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  backend:
+                    type: string
+                    nullable: true
+                    enum: [rust, cli, null]
+                    description: "`rust` for the mstream-player engine, `cli` for a CLI fallback."
+                  player:
+                    type: string
+                    nullable: true
+                    description: "`mstream-player`, or the CLI player name (`mpv`, `mpd`, `vlc`, `mplayer`)."
+        "503":
+          description: No server-audio backend is running.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
   /api/v1/server-playback/queue:
     get:
       tags: [Server Playback]
@@ -3280,16 +3309,22 @@ paths:
     get:
       tags: [Server Playback]
       summary: Server-audio webapp
-      description: Static HTML for the server-audio player mode.
-      security: []
+      description: >-
+        index.html with the browser player swapped for the server-audio
+        client. Sits behind the same auth wall and per-user allow_server_audio
+        gate as the /api/v1/server-playback/* routes.
       responses:
         "200":
           description: HTML.
           content:
             text/html:
               schema: { type: string }
+        "403": { $ref: "#/components/responses/Forbidden" }
         "503":
-          description: Rust audio server unavailable.
+          description: No server-audio backend is running (an HTML error page with a retry link).
+          content:
+            text/html:
+              schema: { type: string }
 
   # ── Jukebox ──────────────────────────────────────────────────────────────
 
@@ -4293,7 +4328,12 @@ paths:
   /api/v1/admin/config/auto-boot-server-audio:
     post:
       tags: [Admin - Config]
-      summary: Toggle auto-start of the Rust audio server
+      summary: Choose the server-audio backend preference
+      description: >-
+        true prefers the mstream-player engine (fetching it on first use where a
+        build is published) and falls back to a CLI player if it is missing or
+        dies during startup; false skips the engine and uses a CLI player only,
+        MPD first. Server audio is re-booted immediately either way.
       requestBody:
         required: true
         content:
@@ -4322,6 +4362,64 @@ paths:
                 rustPlayerPort: { type: integer, minimum: 1, maximum: 65535 }
       responses:
         "200": { $ref: "#/components/responses/EmptySuccess" }
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/server-audio/info:
+    get:
+      tags: [Admin - Config]
+      summary: Active server-audio backend and what else is available
+      description: >-
+        Reads the CLI-detection snapshot taken at boot, on every autoBoot
+        change, and by /api/v1/admin/server-audio/detect. Never probes.
+      responses:
+        "200":
+          description: Backend status.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  backend:
+                    type: string
+                    nullable: true
+                    enum: [rust, cli, null]
+                    description: null when no backend is running.
+                  player:
+                    type: string
+                    nullable: true
+                    description: mstream-player, or the active CLI player's name.
+                  detectedCliPlayers:
+                    type: array
+                    items: { type: string, enum: [mpv, mpd, vlc, mplayer] }
+                    description: Installed or reachable CLI players, in fallback priority order.
+                  binaryFetchable:
+                    type: boolean
+                    description: >-
+                      Whether a missing mstream-player binary can be downloaded for
+                      this platform. npm and source installs fetch it on the first
+                      autoBoot; musl hosts have no build and report false.
+        "405": { $ref: "#/components/responses/AdminLocked" }
+
+  /api/v1/admin/server-audio/detect:
+    post:
+      tags: [Admin - Config]
+      summary: Re-run CLI player detection
+      description: >-
+        Probes for mpv, MPD, VLC and MPlayer again and refreshes the snapshot
+        that /api/v1/admin/server-audio/info reports. Use it after installing
+        or removing a player without restarting the server. Does not change
+        the active backend.
+      responses:
+        "200":
+          description: Fresh detection result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detectedCliPlayers:
+                    type: array
+                    items: { type: string, enum: [mpv, mpd, vlc, mplayer] }
         "405": { $ref: "#/components/responses/AdminLocked" }
 
   /api/v1/admin/config/secret:

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -17,6 +17,7 @@ import * as discoveryExport from '../db/discovery-export.js';
 import { EMBEDDING_MODELS } from '../db/discovery-features-lib.js';
 import * as discoveryP2p from '../state/discovery-p2p.js';
 import * as sidecarBootstrap from '../util/p2p-sidecar-bootstrap.js';
+import * as playerBootstrap from '../util/mstream-player-bootstrap.js';
 import * as discoveryCatalog from '../state/discovery-catalog.js';
 import * as discoverySeeds from '../state/discovery-seeds.js';
 import * as discoveryStack from '../state/discovery-p2p-stack.js';
@@ -25,7 +26,7 @@ import * as logger from '../logger.js';
 import { joiValidate } from '../util/validation.js';
 import { isAdminAllowed } from '../util/admin-network.js';
 import WebError from '../util/web-error.js';
-import { bootRustPlayer, killRustPlayer, getActiveBackend, getDetectedCliPlayers, refreshDetectedCliPlayers, playerBinaryFetchable } from './server-playback.js';
+import { bootRustPlayer, killRustPlayer, getActiveBackend, getDetectedCliPlayers, refreshDetectedCliPlayers } from './server-playback.js';
 import * as lyricsLrclib from './lyrics-cache.js';
 import { warmScrobbleUser } from './scrobbler.js';
 // Torrent admin endpoints live in their own module — see
@@ -1655,7 +1656,7 @@ export function setup(mstream) {
       // Whether a missing player binary could be fetched for this platform
       // (npm/source installs download it on first autoBoot; musl hosts
       // have no build and report false).
-      binaryFetchable: playerBinaryFetchable(),
+      binaryFetchable: playerBootstrap.canAutoFetch(),
     });
   });
 

--- a/src/api/cli-audio/base.js
+++ b/src/api/cli-audio/base.js
@@ -13,8 +13,7 @@ import WebError from '../../util/web-error.js';
 const LOOP_MODES = ['none', 'one', 'all'];
 
 export class BaseCliAdapter {
-  constructor(playerName) {
-    this.playerName = playerName;
+  constructor() {
     this.queue = [];
     this.queueIndex = 0;
     this.shuffle = false;

--- a/src/api/cli-audio/index.js
+++ b/src/api/cli-audio/index.js
@@ -88,7 +88,6 @@ let activeAdapter = null;
 let activePlayerName = null;
 
 export function getActivePlayerName() { return activePlayerName; }
-export function getActiveAdapter() { return activeAdapter; }
 export function isCliActive() { return activeAdapter !== null; }
 
 /**

--- a/src/api/cli-audio/mpd.js
+++ b/src/api/cli-audio/mpd.js
@@ -71,7 +71,7 @@ export function probeMpd({ target, timeoutMs = 1000 } = {}) {
 
 export class MpdAdapter extends BaseCliAdapter {
   constructor(hostArg) {
-    super('mpd');
+    super();
     const envHost = process.env.MSTREAM_MPD_HOST;
     this.target = parseMpdHost(hostArg || envHost || '');
     this._sock = null;

--- a/src/api/cli-audio/mplayer.js
+++ b/src/api/cli-audio/mplayer.js
@@ -14,7 +14,7 @@ import { BaseCliAdapter } from './base.js';
 
 export class MplayerAdapter extends BaseCliAdapter {
   constructor(binary = 'mplayer') {
-    super('mplayer');
+    super();
     this.binary = binary;
     this._proc = null;
     this._stdoutBuf = '';

--- a/src/api/cli-audio/mpv.js
+++ b/src/api/cli-audio/mpv.js
@@ -25,7 +25,7 @@ function socketPath() {
 
 export class MpvAdapter extends BaseCliAdapter {
   constructor(binary = 'mpv') {
-    super('mpv');
+    super();
     this.binary = binary;
     this._sockPath = socketPath();
     this._proc = null;

--- a/src/api/cli-audio/vlc.js
+++ b/src/api/cli-audio/vlc.js
@@ -19,7 +19,7 @@ function pickPort() {
 
 export class VlcAdapter extends BaseCliAdapter {
   constructor(binary = 'vlc') {
-    super('vlc');
+    super();
     this.binary = binary;
     this._port = pickPort();
     this._proc = null;

--- a/src/api/server-playback.js
+++ b/src/api/server-playback.js
@@ -40,13 +40,6 @@ export function getActiveBackend() {
   return { backend: null, player: null };
 }
 
-// Can a missing player binary be fetched for this platform? Surfaced on the
-// admin info endpoint so the UI can tell "one download away" apart from
-// "not available here" (musl hosts).
-export function playerBinaryFetchable() {
-  return canAutoFetch();
-}
-
 function getRustPort() {
   return config.program.rustPlayerPort || 3333;
 }
@@ -76,7 +69,7 @@ function findRustBinary() {
       // downstream spawn will surface the real error if exec is truly
       // blocked (noexec mount, SELinux). Matches the rust-parser's fix in
       // src/db/task-queue.js.
-      try { fs.chmodSync(bin, 0o755); } catch (_) {}
+      try { fs.chmodSync(bin, 0o755); } catch (_err) { /* read-only volume: the spawn surfaces the real error */ }
       return bin;
     }
   }
@@ -121,9 +114,9 @@ async function bootCliFallback(reason, preferredPlayer = null) {
  *                                to other installed CLI players if MPD isn't
  *                                available.
  *
- * Name is kept for backwards-compatibility with existing callers in
- * src/server.js and src/api/admin.js. Returns a Promise; callers that don't
- * need to await may fire-and-forget.
+ * Still named for the Rust-first preference it implements; it boots whichever
+ * backend applies. Returns a Promise; callers that don't need to await may
+ * fire-and-forget.
  */
 export async function bootRustPlayer() {
   if (rustPlayerProcess) { return; }
@@ -206,8 +199,8 @@ export function killRustPlayer() {
 }
 
 // Proxy a request to the Rust binary and pipe the response back.
-// Exported: cli-audio/index.js's proxyToCli is its drop-in counterpart.
-export function proxyToRust(method, rustPath, body) {
+// cli-audio/index.js's proxyToCli is its drop-in counterpart.
+function proxyToRust(method, rustPath, body) {
   return new Promise((resolve, reject) => {
     const postData = body ? JSON.stringify(body) : '';
     const options = {
@@ -258,7 +251,7 @@ function proxyPlayback(method, rustPath, body) {
 }
 
 // Resolve a virtual path (e.g. "55/song.mp3") to an absolute filesystem path
-export function resolveFilePath(filePath, user) {
+function resolveFilePath(filePath, user) {
   const info = vpath.getVPathInfo(filePath, user);
   return info.fullPath;
 }
@@ -273,7 +266,7 @@ export function isWithin(child, root) {
 }
 
 // Reverse: convert an absolute path back to a virtual path (e.g. "55/song.mp3")
-export function absoluteToVpath(absolutePath) {
+function absoluteToVpath(absolutePath) {
   const normalized = path.normalize(absolutePath);
   const libraries = db.getAllLibraries();
   for (const lib of libraries) {
@@ -285,6 +278,35 @@ export function absoluteToVpath(absolutePath) {
   }
   // If no vpath matches, return the filename as fallback
   return path.basename(absolutePath);
+}
+
+// The /server-remote page is index.html with the browser player swapped for
+// the server-audio client. Pure and exported so a unit test can pin it against
+// the REAL index.html: every step is an exact-string or regex match that
+// silently no-ops when the markup drifts (three visualizer-script strips sat
+// here as dead code for months for exactly that reason). Hiding the sidebar
+// items and buttons that make no sense in this mode is the client's job —
+// mstream.server-audio.js injects that CSS at parse time.
+export function rewriteIndexForServerAudio(page) {
+  return page
+    // Swap mstream.player.js for mstream.server-audio.js, which implements the
+    // same MSTREAMPLAYER interface but routes every command through the
+    // server-playback API. The flag must be set before the client script runs.
+    .replace(
+      '<script src="assets/js/mstream.player.js"></script>',
+      '<script>var serverAudioMode = true;</script>\n  <script src="assets/js/mstream.server-audio.js"></script>'
+    )
+    // Scripts with no role in server-audio mode: the jukebox remote, the QR
+    // pairing code, and the visualizer loader (the client stubs VIZ).
+    .replace('<script src="assets/js/mstream.jukebox.js"></script>', '')
+    .replace('<script defer src="assets/js/lib/qr.js"></script>', '')
+    .replace('<script src="assets/js/t.js"></script>', '')
+    // Replace the visualizer button (the equalizer SVG inside div.grow.flex-center)
+    // with a "Server Audio" badge so the player bar keeps its layout spacer.
+    .replace(
+      /(<div class="grow flex-center">)\s*<svg v-on:click="fadeOverlay"[^]*?<\/svg>\s*(<\/div>)/,
+      '$1<span style="background:#264679;color:#fff;padding:3px 10px;border-radius:4px;font-size:11px;opacity:0.85;">Server Audio</span>$2'
+    );
 }
 
 // Single source of truth for "may this user touch server audio?" — shared
@@ -455,10 +477,10 @@ export function setup(mstream) {
 
   // ── /server-remote page (serves the webapp with serverAudioMode flag) ──
   //
-  // Previously lived in setupBeforeAuth() so anyone could hit the page, but
-  // that let unauthenticated users probe whether server audio was running.
-  // The page only makes sense for users who can actually control playback,
-  // so it now sits behind the same auth + permission checks as the APIs.
+  // Previously registered ahead of the auth wall so anyone could hit the
+  // page, but that let unauthenticated users probe whether server audio was
+  // running. The page only makes sense for users who can actually control
+  // playback, so it sits behind the same auth + permission checks as the APIs.
   mstream.get('/server-remote', async (req, res) => {
     if (!userCanUseServerAudio(req.user)) {
       return res.status(403).json({ error: 'Server audio access disabled for this user' });
@@ -488,44 +510,11 @@ export function setup(mstream) {
     }
 
     try {
-      let page = await fsPromises.readFile(path.join(config.program.webAppDirectory, 'index.html'), 'utf-8');
-      // Replace the browser audio player with the server audio player.
-      // This swaps mstream.player.js for mstream.server-audio.js which
-      // implements the same MSTREAMPLAYER interface but routes all commands
-      // to the Rust audio binary via the server-playback API.
-      // Swap browser audio player for server audio player
-      page = page.replace(
-        '<script src="assets/js/mstream.player.js"></script>',
-        '<script>var serverAudioMode = true;</script>\n  <script src="assets/js/mstream.server-audio.js"></script>'
-      );
-
-      // Strip out scripts not needed in server audio mode
-      page = page.replace('<script src="assets/js/mstream.jukebox.js"></script>', '');
-      page = page.replace('<script defer src="assets/js/lib/qr.js"></script>', '');
-      page = page.replace('<script src="assets/js/t.js"></script>', '');
-      page = page.replace('<script async src="assets/js/lib/butterchurn.min.js"></script>', '');
-      page = page.replace('<script async src="assets/js/lib/butterchurn-presets.min.js"></script>', '');
-      page = page.replace('<script async src="assets/js/lib/butterchurn-presets-extra.js"></script>', '');
-
-      // Remove sidebar items not relevant to server audio mode (Auto DJ, Transcode, Jukebox)
-      page = page.replace(/\s*<div[^>]*onclick="changeView\(autoDjPanel[^]*?<\/span>\s*<\/div>/i, '');
-      page = page.replace(/\s*<div[^>]*onclick="changeView\(setupTranscodePanel[^]*?<\/span>\s*<\/div>/i, '');
-      page = page.replace(/\s*<div[^>]*onclick="changeView\(setupJukeboxPanel[^]*?<\/span>\s*<\/div>/i, '');
-
-      // Replace the visualizer button (div.grow.flex-center with the equalizer SVG)
-      // with a "Server Audio" badge to preserve the layout spacer
-      page = page.replace(
-        /(<div class="grow flex-center">)\s*<svg v-on:click="fadeOverlay"[^]*?<\/svg>\s*(<\/div>)/,
-        '$1<span style="background:#264679;color:#fff;padding:3px 10px;border-radius:4px;font-size:11px;opacity:0.85;">Server Audio</span>$2'
-      );
-
-      res.send(page);
-    } catch (_e) {
+      const page = await fsPromises.readFile(path.join(config.program.webAppDirectory, 'index.html'), 'utf-8');
+      res.send(rewriteIndexForServerAudio(page));
+    } catch (err) {
+      winston.warn(`[server-audio] failed to serve /server-remote: ${err.message}`);
       res.status(500).json({ error: 'Failed to serve server-remote page' });
     }
   });
 }
-
-// Retained so existing call sites in src/server.js keep compiling — /server-
-// remote was moved into setup() so it sits behind auth now.
-export function setupBeforeAuth() {}

--- a/src/server.js
+++ b/src/server.js
@@ -524,9 +524,6 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     }
   });
 
-  // Server-remote route (must be before static middleware to intercept /server-remote)
-  serverPlaybackApi.setupBeforeAuth(mstream);
-
   // Give access to public folder.
   mstream.use('/', express.static(config.program.webAppDirectory));
 

--- a/src/util/mstream-player-bootstrap.js
+++ b/src/util/mstream-player-bootstrap.js
@@ -22,7 +22,7 @@
  *   - Binaries the OPERATOR placed (anything without our install receipt)
  *     are never overwritten or second-guessed; a dev cargo build of the
  *     player repo wins before this module is consulted (see
- *     src/api/server-playback.js resolvePlayerBinary()).
+ *     src/api/server-playback.js findRustBinary()).
  *
  * There is no musl build of the player (server audio is opt-in and needs a
  * sound device — not an Alpine-container feature). On musl hosts the key

--- a/test/cli-audio/Dockerfile
+++ b/test/cli-audio/Dockerfile
@@ -34,6 +34,9 @@ WORKDIR /app
 RUN npm init -y >/dev/null && npm install --omit=dev --no-audit --no-fund winston >/dev/null
 
 COPY src/api/cli-audio ./src/api/cli-audio
+# base.js and mplayer.js import WebError from src/util; the image carries
+# only what is COPYed here, so without this line the harness dies at import.
+COPY src/util/web-error.js ./src/util/web-error.js
 COPY test/cli-audio/test-routing.mjs ./test/cli-audio/test-routing.mjs
 COPY test/cli-audio/mpd.conf        ./test/cli-audio/mpd.conf
 COPY test/cli-audio/entrypoint.sh   ./test/cli-audio/entrypoint.sh

--- a/test/unit/cli-audio-error-codes.test.mjs
+++ b/test/unit/cli-audio-error-codes.test.mjs
@@ -21,32 +21,32 @@ class StubAdapter extends BaseCliAdapter {
 }
 
 test('happy path returns 200', async () => {
-  const a = new StubAdapter('stub');
+  const a = new StubAdapter();
   assert.equal((await a.handleRequest('POST', '/pause', {})).status, 200);
 });
 
 test('missing required body → 400', async () => {
-  const a = new StubAdapter('stub');
+  const a = new StubAdapter();
   assert.equal((await a.handleRequest('POST', '/play', {})).status, 400);
   assert.equal((await a.handleRequest('POST', '/queue/add', {})).status, 400);
   assert.equal((await a.handleRequest('POST', '/queue/add-many', {})).status, 400);
 });
 
 test('out-of-range queue index → 400', async () => {
-  const a = new StubAdapter('stub');
+  const a = new StubAdapter();
   assert.equal((await a.handleRequest('POST', '/queue/play-index', { index: 5 })).status, 400);
   assert.equal((await a.handleRequest('POST', '/queue/remove', { index: 5 })).status, 400);
 });
 
 test('queue-state conflicts → 409', async () => {
-  const a = new StubAdapter('stub');
+  const a = new StubAdapter();
   // empty queue: nothing to advance to / nothing to step back from
   assert.equal((await a.handleRequest('POST', '/next', {})).status, 409);
   assert.equal((await a.handleRequest('POST', '/previous', {})).status, 409);
 });
 
 test('unknown route → 404', async () => {
-  const a = new StubAdapter('stub');
+  const a = new StubAdapter();
   assert.equal((await a.handleRequest('GET', '/does-not-exist', {})).status, 404);
   assert.equal((await a.handleRequest('POST', '/play/extra', {})).status, 404);
 });
@@ -55,7 +55,7 @@ test('an unexpected (non-WebError) failure → 500, not 400', async () => {
   class Boom extends StubAdapter {
     async _loadFile() { throw new Error('kaboom'); }
   }
-  const a = new Boom('boom');
+  const a = new Boom();
   const r = await a.handleRequest('POST', '/play', { file: '/x.mp3' });
   assert.equal(r.status, 500);
   assert.equal(r.data.error, 'kaboom');

--- a/test/unit/server-remote-rewrite.test.mjs
+++ b/test/unit/server-remote-rewrite.test.mjs
@@ -1,0 +1,59 @@
+/**
+ * /server-remote serves webapp/index.html with the browser player swapped for
+ * the server-audio client (src/api/server-playback.js
+ * rewriteIndexForServerAudio).
+ *
+ * Every step of that rewrite is an exact-string or regex match against the
+ * committed index.html, and a miss is silent: the page still renders, just
+ * with the wrong player or a stray script. Three replacements had been
+ * no-ops for months after the visualizer scripts left index.html. This pins
+ * the rewrite to the REAL index.html so markup drift fails here instead of
+ * on somebody's remote.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { rewriteIndexForServerAudio } from '../../src/api/server-playback.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const indexHtml = fs.readFileSync(path.join(here, '..', '..', 'webapp', 'index.html'), 'utf8');
+
+describe('rewriteIndexForServerAudio', () => {
+  const out = rewriteIndexForServerAudio(indexHtml);
+
+  test('swaps the browser player for the server-audio client, flag first', () => {
+    assert.ok(indexHtml.includes('assets/js/mstream.player.js'), 'index.html must load the browser player');
+    assert.ok(!out.includes('assets/js/mstream.player.js'), 'the browser player must be gone');
+    const flag = out.indexOf('var serverAudioMode = true');
+    const client = out.indexOf('assets/js/mstream.server-audio.js');
+    assert.ok(flag > 0, 'serverAudioMode must be set');
+    assert.ok(client > flag, 'the client script must load after the flag is set');
+  });
+
+  test('drops the scripts that have no role in server-audio mode', () => {
+    for (const src of ['assets/js/mstream.jukebox.js', 'assets/js/lib/qr.js', 'assets/js/t.js']) {
+      assert.ok(indexHtml.includes(src), `${src} must exist in index.html for the strip to mean anything`);
+      assert.ok(!out.includes(src), `${src} must be stripped`);
+    }
+  });
+
+  test('replaces the visualizer button with the Server Audio badge', () => {
+    assert.ok(indexHtml.includes('v-on:click="fadeOverlay"'), 'index.html must carry the visualizer button');
+    assert.ok(!out.includes('v-on:click="fadeOverlay"'), 'the visualizer button must be gone');
+    assert.ok(out.includes('>Server Audio</span>'), 'the badge must take its place');
+  });
+
+  test('leaves everything else alone', () => {
+    // The sidebar items this mode hides stay in the markup — the client's
+    // injected CSS owns hiding them, so the server must not strip them.
+    for (const panel of ['autoDjPanel', 'setupTranscodePanel', 'setupJukeboxPanel']) {
+      assert.ok(out.includes(`changeView(${panel}`), `${panel} sidebar item must survive the rewrite`);
+    }
+    assert.equal(rewriteIndexForServerAudio('<html></html>'), '<html></html>', 'no anchors, no change');
+    assert.equal(rewriteIndexForServerAudio(indexHtml), out, 'pure function of its input');
+  });
+});

--- a/webapp/assets/js/mstream.server-audio.js
+++ b/webapp/assets/js/mstream.server-audio.js
@@ -392,7 +392,9 @@ var MSTREAMPLAYER = (function () {
 
   // ── Hide irrelevant UI elements ───────────────────────────────────────
   // Use CSS injection so elements are hidden immediately, even if Vue
-  // components mount after DOMContentLoaded.
+  // components mount after DOMContentLoaded. This is the one place that
+  // hides UI for server-audio mode: the /server-remote handler only swaps
+  // scripts and replaces the visualizer button with a badge.
 
   var hideCSS = document.createElement('style');
   hideCSS.textContent =
@@ -412,28 +414,6 @@ var MSTREAMPLAYER = (function () {
     '#livePlaylist { display: none !important; }';
   document.head.appendChild(hideCSS);
 
-  function hideElements() {
-    // Badge is now inline in the player bar (replaces visualizer button server-side)
-  }
-
-  // Some elements are rendered by Vue after mount, so we need to retry
-  // hiding them until they appear in the DOM.
-  var hideRetries = 0;
-  function hideVueElements() {
-    var hidden = 0;
-
-    // Visualizer button (Vue v-on:click="fadeOverlay" — no onclick attr to target via CSS)
-    var allSvgs = document.querySelectorAll('#mstream-player svg[viewBox="0 0 512 512"]');
-    allSvgs.forEach(function (svg) {
-      if (svg.parentElement) { svg.parentElement.style.display = 'none'; hidden++; }
-    });
-
-    hideRetries++;
-    if (hidden === 0 && hideRetries < 20) {
-      setTimeout(hideVueElements, 250);
-    }
-  }
-
   // Stub out the visualizer
   window.VIZ = {
     toggleDom: function () {},
@@ -441,10 +421,8 @@ var MSTREAMPLAYER = (function () {
     get: function () { return null; }
   };
 
-  // Start polling and hide UI when DOM is ready
+  // Start polling when DOM is ready
   function init() {
-    hideElements();
-    hideVueElements();
     startPolling();
     // Wait for MSTREAMAPI to be available before loading queue
     function tryLoadQueue() {


### PR DESCRIPTION
## Summary

Step 1 of a structure-first cleanup of the server-side audio feature (`src/api/server-playback.js`, `src/api/cli-audio/`, `src/util/mstream-player-bootstrap.js`). Everything here is behaviour-neutral: dead code, a broken test harness, one lint error, and spec drift. The lifecycle split with the boot-race fix follows in a stacked PR.

### Dead code
- The empty `setupBeforeAuth()` stub and its call in `server.js`. It was "kept so callers keep compiling", but both ends live in this repo.
- `proxyToRust` was exported for the Subsonic jukebox handler, which went away in a17eefc1; nothing imports it. The vpath helpers are un-exported too, since only `isWithin` has an importer (its unit test).
- `getActiveAdapter`, the `playerBinaryFetchable` pass-through (admin.js now calls `canAutoFetch()` on the bootstrap directly, the way the sidecar endpoint does), and the write-only `BaseCliAdapter.playerName`.

### /server-remote rewrite
- Three `page.replace` calls stripped visualizer `<script>` tags that left `index.html` when `t.js` took over lazy-loading them. They have been silent no-ops since.
- The sidebar regexes duplicated the client's injected CSS (`[onclick*="autoDjPanel"]` and friends, applied at parse time), and the client's `hideVueElements` retry loop hunted an SVG the server had already replaced. One owner each now: the server swaps scripts and places the badge, the client hides.
- The rewrite is a pure exported function, `rewriteIndexForServerAudio`, with a unit test that runs it against the real `webapp/index.html`, so the next markup drift fails a test.

### Harness, lint, spec
- `npm run test:cli-audio` has been import-broken since June: the Dockerfile copied only `src/api/cli-audio`, but `base.js` and `mplayer.js` import `src/util/web-error.js` (d3c60f6f). One `COPY` line.
- `no-empty` in `findRustBinary`; two stale comments (a `resolvePlayerBinary` that never existed, the "kept for callers" note).
- OpenAPI: `/server-remote` moved behind auth in April but still said `security: []`; status's `backend`/`player` fields and `/api/v1/admin/server-audio/info` + `/detect` were undocumented; the tag and autoBoot copy still described a Rust-only world.

## Test plan
- [x] `test/unit/server-remote-rewrite.test.mjs` (new, 4 cases) plus `server-playback-vpath`, `cli-audio-error-codes`, `mstream-player-fetch`: 30/30
- [x] whole `test/unit`: 675 pass, 0 fail, 3 pre-existing skips
- [x] `api-server-info` + `admin-access` integration suites (server boots, admin routes load): 25/25
- [x] ESLint on changed files: 0 errors (remaining warnings are the pre-existing `require-await` on the async adapter hooks)
- [x] `docs/openapi.yaml` parses; new paths present
- [x] Docker harness: Docker Desktop was not running locally, so the Dockerfile's `COPY` set was replayed into a scratch dir and the adapters imported. Old set fails on `web-error.js`, new set imports. `npm run test:cli-audio` on a Docker host is the real check.
- [ ] `full-ci` label: 9-job matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
