### PR TITLE
feat(random-songs): `limit` — return up to 25 songs per call

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1546,10 +1546,11 @@ paths:
   /api/v1/db/random-songs:
     post:
       tags: [Library]
-      summary: Get a random song (Auto-DJ)
+      summary: Get random songs (Auto-DJ)
       description: |
-        Returns one random song. With no body fields set, behaves like the
-        pre-V32 route — pick a random track from everything the user can see.
+        Returns one random song by default, or up to `limit` of them. With
+        no body fields set, behaves like the pre-V32 route — pick a random
+        track from everything the user can see.
 
         When any BPM / key / artist filter is set the server runs a
         fallback waterfall that progressively relaxes constraints until
@@ -1574,10 +1575,21 @@ paths:
           5b. similar (drop `ignoreArtists` cooldown — only if set)
           6-10. the non-similar chain above
 
-        After the SQL-side waterfall, a tier filter sorts the surviving
+        After the SQL-side waterfall, a tier ranking sorts the surviving
         rows so an in-range pick wins over an unknown-tag pick wins over
-        a known-wrong pick. The route always returns exactly one song
-        (or 400 if scope is empty).
+        a known-wrong pick. With `limit` omitted the route returns exactly
+        one song (or 400 if scope is empty).
+
+        **Batches.** `limit` (1..25, default 1) asks for several songs in
+        one call. They are distinct, served from the front of the same
+        ranking — best tier first, then songs not in the `ignoreList`
+        before repeats — and every one of them is appended to the returned
+        `ignoreList`. A batch can be SHORTER than `limit`: when fewer
+        candidates are in scope, or when the waterfall step that wins holds
+        fewer matches. The chain deliberately never pads a batch from a
+        more relaxed step, so the tail of a batch satisfies the same
+        constraints as its head. The always-on filters (`genres`, the
+        duration window, the sonic pool) apply to every song in a batch.
 
         `genres` and the `minDuration` / `maxDuration` window are
         ALWAYS-ON base conditions rather than waterfall steps: every
@@ -1601,14 +1613,14 @@ paths:
         or `BPM` / `KEY` / `INITIALKEY` (Vorbis) tags.
 
         `ignoreList` is a round-trip cursor — the server returns an
-        updated list with the just-picked index appended, and clients
-        echo it back on the next call to deduplicate across a session.
-        The server trims older entries automatically when the list
-        exceeds ~half the candidate-pool size; clients don't need to
-        prune it themselves. Capped at 500 entries. Entries are
-        server-issued track ids, meaningful only on the server that
-        issued them, and the cooldown is soft: once the list covers every
-        candidate the server picks from the full pool again rather than
+        updated list with every just-served track id appended (newest
+        last), and clients echo it back on the next call to deduplicate
+        across a session. The server keeps only the newest 50 entries;
+        clients don't need to prune it themselves. Accepted up to 500
+        entries. Entries are server-issued track ids, meaningful only on
+        the server that issued them, and the cooldown is soft: once the
+        list covers every candidate (or leaves fewer than a batch needs)
+        the server fills in from the full pool again rather than
         answering 400.
 
         **Sonic similarity** (`similarTo` or `similarToVector`, with
@@ -1648,15 +1660,27 @@ paths:
               allOf:
                 - type: object
                   properties:
+                    limit:
+                      type: integer
+                      minimum: 1
+                      maximum: 25
+                      default: 1
+                      description: |
+                        How many songs to return. Distinct, best tier
+                        first, fresh before repeats; may come back short
+                        when fewer candidates are in scope or the winning
+                        waterfall step holds fewer matches (see above).
+                        Every served song is appended to `ignoreList`.
                     minRating: { type: integer, minimum: 0, maximum: 10 }
                     ignoreList:
                       type: array
                       maxItems: 500
                       items: { type: integer, minimum: 0 }
                       description: |
-                        Indices of recently-picked tracks to skip. Echo
-                        back the `ignoreList` from the previous response
-                        unchanged; the server appends + trims.
+                        Server-issued track ids of recently served songs
+                        to skip. Echo back the `ignoreList` from the
+                        previous response unchanged; the server appends +
+                        trims.
                     bpmRanges:
                       type: array
                       maxItems: 16
@@ -1836,7 +1860,7 @@ paths:
                 - { $ref: "#/components/schemas/IgnoreVPaths" }
       responses:
         "200":
-          description: One random song that satisfies the (possibly relaxed) constraints.
+          description: Up to `limit` random songs (one by default) that satisfy the (possibly relaxed) constraints.
           content:
             application/json:
               schema:
@@ -1845,25 +1869,32 @@ paths:
                   songs:
                     type: array
                     items: { $ref: "#/components/schemas/Metadata" }
+                    description: |
+                      One entry by default, up to `limit` — possibly
+                      fewer, never more (see the batch notes above).
                   ignoreList:
                     type: array
                     items: { type: integer }
                     description: |
                       Updated cursor: previous request's `ignoreList`
-                      with the just-picked index appended, plus any
-                      server-side trimming. Echo back unchanged on the
-                      next call.
+                      with every served track id appended (newest last),
+                      trimmed to the newest 50. Echo back unchanged on
+                      the next call.
                   sonic:
                     type: object
                     description: |
                       Present only when a sonic seed was given: how close
-                      the pick actually is, and how large the pool was
+                      the picks actually are, and how large the pool was
                       before the other filters cut it down.
                     properties:
                       similarity:
                         type: number
                         nullable: true
-                        description: Cosine similarity of the picked track to the seed centroid, rounded to 4 decimals (`null` if the pick has no vector).
+                        description: Cosine similarity of the first song in `songs` to the seed centroid, rounded to 4 decimals (`null` if it has no vector). Kept for single-pick callers; equals `similarities[0]`.
+                      similarities:
+                        type: array
+                        items: { type: number, nullable: true }
+                        description: One cosine similarity per entry of `songs`, in the same order, rounded to 4 decimals.
                       poolSize:
                         type: integer
                         description: Analyzed tracks at or above `minSimilarity`, before rating / genre / BPM / key filtering.

--- a/src/api/random.js
+++ b/src/api/random.js
@@ -37,6 +37,16 @@
 // match no candidate row and age out of the capped list within a few
 // picks.
 //
+// `limit` (default 1, capped at PICK_LIMIT_MAX) asks for a batch instead
+// of a single pick. A batch is served from the same bounded pool a pick
+// is: distinct rows, best tier first, fresh (not in the cooldown) before
+// repeats, and every song served advances the ignoreList. It can fall
+// short of `limit` — when fewer candidates are in scope, or when the
+// waterfall step that wins holds fewer matches. The chain deliberately
+// does NOT cascade into a more relaxed step to fill the remainder: the
+// tail of the batch would then break the constraint its head satisfied,
+// and the caller couldn't tell which songs are which.
+//
 // This is step B of the Auto-DJ velvet port. Similar-artists support
 // (the `artists` / `ignoreArtists` filters) is step D and lands in a
 // separate PR — there's no library-aware Last.fm proxy yet, so wiring
@@ -378,7 +388,10 @@ export function buildArtistFilter(opts) {
 // in JS so an in-range row wins over an unknown row wins over a wrong
 // row. Without this, "drop constraint" steps would feed garbage picks
 // to the client.
-function classifyRow(row, opts) {
+//
+// Exported for tests — the SQL twin (buildTierOrderExpr) is checked
+// row-for-row against this classifier.
+export function classifyRow(row, opts) {
   const bpmRanges = opts.bpmRanges;
   const keySet    = opts.keySet;
 
@@ -408,36 +421,37 @@ function classifyRow(row, opts) {
   return 2;
 }
 
-export function applyTierFilter(rows, opts) {
+// Stable sort by tier against the ORIGINAL request constraints: Tier 0
+// rows first, then Tier 1, then Tier 2, each keeping its input order.
+// The waterfall may have dropped the BPM/key constraint at the SQL layer,
+// so a batch is handed out from the front of this ranking — in-range
+// rows before unknown-tag rows before known-wrong rows — and a single
+// pick takes the best row present, exactly as the old best-tier-only
+// filter did. Input order carries the fresh-before-cooled priority (see
+// finalisePick), which the stable sort preserves within a tier.
+export function rankByTier(rows, opts) {
   const haveBpm = Array.isArray(opts.bpmRanges) && opts.bpmRanges.length > 0;
   const haveKey = Array.isArray(opts.musicalKeys) && opts.musicalKeys.length > 0;
-  // No active constraint → no filtering needed.
+  // No active constraint → nothing to rank on.
   if (!haveBpm && !haveKey) { return rows; }
 
   const keySet = haveKey ? new Set(expandCamelotCodes(opts.musicalKeys)) : null;
   const classifyOpts = { bpmRanges: opts.bpmRanges, keySet };
 
-  const tier0 = [];
-  const tier1 = [];
-  const tier2 = [];
+  const tiers = [[], [], []];
   for (const row of rows) {
-    const t = classifyRow(row, classifyOpts);
-    if (t === 0) { tier0.push(row); }
-    else if (t === 1) { tier1.push(row); }
-    else { tier2.push(row); }
+    tiers[classifyRow(row, classifyOpts)].push(row);
   }
-  if (tier0.length > 0) { return tier0; }
-  if (tier1.length > 0) { return tier1; }
-  return tier2;
+  return [...tiers[0], ...tiers[1], ...tiers[2]];
 }
 
 // SQL twin of classifyRow, built against the ORIGINAL request constraints
-// (exactly what the JS applyTierFilter call at the end of runRandomSongs
-// classifies with — tight ranges + expanded key names). Used as the leading
-// ORDER BY term of every bounded waterfall query: rows sort best-tier-first
-// before the RANDOM() tiebreak, so a LIMIT-sized pool provably contains the
-// best tier present in scope and sampling can't starve the tier filter.
-// The JS filter stays the authority — this only shapes what gets sampled.
+// (exactly what the JS rankByTier call in finalisePick classifies with —
+// tight ranges + expanded key names). Used as the leading ORDER BY term of
+// every bounded waterfall query: rows sort best-tier-first before the
+// RANDOM() tiebreak, so a LIMIT-sized pool provably contains the best tier
+// present in scope and sampling can't starve the tier ranking. The JS
+// ranking stays the authority — this only shapes what gets sampled.
 //
 // Emission order matters: params are pushed by the emit* helpers as the
 // template literal evaluates left-to-right, keeping placeholder order and
@@ -518,17 +532,20 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
   // to JS per pick). When the request carries BPM/key constraints,
   // `tierOrder` leads the ORDER BY so the pool always contains the best
   // tier present (see buildTierOrderExpr); the id cooldown is excluded in
-  // SQL first, and when that alone empties the step, the SAME step retries
-  // without it so cooldown exhaustion falls back to repeats WITHIN this
-  // step's constraints (matching finalisePick's fallback).
+  // SQL first, and when that alone leaves the step short of `limit` fresh
+  // rows (with one song asked: empty), the SAME step retries without it so
+  // cooldown exhaustion falls back to repeats WITHIN this step's
+  // constraints (matching finalisePick's fallback). The fresh rows stay in
+  // front of the merged result so the repeats only fill what's left.
   //
   // The retry is skipped for artist-cooldown-ENFORCING steps
-  // (allowRepeatRetry false): their all-cooled rows would be rejected
-  // by the step loop's id-fresh rule anyway (see runRandomSongs), so
-  // returning empty lets the waterfall advance toward the
-  // drop-cooldown step without paying for a query whose result is
-  // discarded.
-  const { ignoreIds, allowRepeatRetry, tierOrder } = bounded;
+  // (allowRepeatRetry false) that came back with NO fresh row: their
+  // all-cooled rows would be rejected by the step loop's id-fresh rule
+  // anyway (see runRandomSongs), so returning empty lets the waterfall
+  // advance toward the drop-cooldown step without paying for a query
+  // whose result is discarded. An enforcing step that has SOME fresh rows
+  // wins regardless, so its batch is topped up like any other step's.
+  const { ignoreIds, allowRepeatRetry, tierOrder, limit } = bounded;
   const orderBy = tierOrder
     ? `ORDER BY ${tierOrder.expr}, RANDOM()`
     : 'ORDER BY RANDOM()';
@@ -541,8 +558,9 @@ function runWaterfallQuery(d, baseSql, baseParams, filterOpts, bounded) {
       .all(...baseParams, ...params, ...(exclude ? ignoreIds : []), ...tierParams);
   };
   const rows = attempt(true);
-  if (rows.length > 0 || ignoreIds.length === 0 || !allowRepeatRetry) { return rows; }
-  return attempt(false);
+  if (rows.length >= limit || ignoreIds.length === 0) { return rows; }
+  if (rows.length === 0 && !allowRepeatRetry) { return rows; }
+  return mergeRows(rows, attempt(false));
 }
 
 // ── Sonic similarity pool (discovery embeddings) ────────────────────────────
@@ -660,10 +678,21 @@ function buildSonicPool(req, body) {
 // (The Joi wire cap of 500 stays as defense-in-depth headroom.)
 const IGNORE_COOLDOWN_MAX = 50;
 
-// Candidate-pool size for the bounded simple-mode query. The pick is one
-// song; 50 keeps the pool comfortably larger than the cooldown so
-// consecutive picks stay varied even right after a fallback.
-const SIMPLE_POOL_LIMIT = 50;
+// Candidate-pool size for every bounded candidate query (simple mode and
+// each waterfall step). 50 keeps the pool comfortably larger than the
+// cooldown so consecutive picks stay varied even right after a fallback.
+// Exported for the invariant test on PICK_LIMIT_MAX.
+export const SIMPLE_POOL_LIMIT = 50;
+
+// Most songs one request may ask for (`limit`). Two invariants keep a
+// batch cheap and coherent, both pinned by test/integration/random-route.test.mjs:
+//   • ≤ SIMPLE_POOL_LIMIT — one bounded pool always holds a full batch,
+//     so no query grows with the request, and a pool that comes back
+//     short has provably shown every fresh candidate in scope.
+//   • ≤ IGNORE_COOLDOWN_MAX / 2 — a maximal batch still leaves the whole
+//     previous batch in the ignoreList, so back-to-back batches never
+//     repeat each other.
+export const PICK_LIMIT_MAX = 25;
 
 // Sanitize the client's round-tripped ignoreList to track ids we can bind
 // into SQL / compare against rows. Joi already enforces integers >= 0;
@@ -673,9 +702,39 @@ function ignoreIdsFrom(body) {
   return list.filter((n) => Number.isInteger(n) && n >= 0);
 }
 
+// How many songs the request asks for. Joi defaults `limit` to 1 and caps
+// it at PICK_LIMIT_MAX; the clamp here is the same defence-in-depth as
+// ignoreIdsFrom for callers that bypass the route schema.
+function pickLimitFrom(body) {
+  const n = Number(body.limit);
+  if (!Number.isInteger(n) || n < 1) { return 1; }
+  return Math.min(n, PICK_LIMIT_MAX);
+}
+
+// Union of a cooldown-excluding query and its no-exclusion retry over the
+// SAME candidate set: the fresh rows first, then whatever the retry added
+// (all cooled — a first query that came back short of `limit` rows already
+// returned every fresh row in scope, see PICK_LIMIT_MAX). Order matters:
+// finalisePick hands out the front of the list, so repeats only ever fill
+// what fresh rows couldn't.
+function mergeRows(fresh, more) {
+  const seen = new Set(fresh.map((r) => r.id));
+  const out = [...fresh];
+  for (const r of more) {
+    if (seen.has(r.id)) { continue; }
+    seen.add(r.id);
+    out.push(r);
+  }
+  return out;
+}
+
 export function runRandomSongs(req, body) {
   const d = db.getDB();
   if (!d) { throw new WebError('Database not ready', 400); }
+
+  // Batch size — every bounded query's top-up rule and the final pick
+  // honour it (see the header comment).
+  const limit = pickLimitFrom(body);
 
   // Sonic pool first — it can 403/404/400 on its own and there's no point
   // running SQL when the seed itself is bad.
@@ -747,9 +806,9 @@ export function runRandomSongs(req, body) {
   }
 
   // Skip the trackQuery `tg_agg` aggregation for the candidate-set
-  // query — only the picked row's genres survive to the response, and
+  // query — only the picked rows' genres survive to the response, and
   // SQLite MATERIALIZEs the aggregation over the full tracks table
-  // before applying the WHERE clause. finalisePick enriches the
+  // before applying the WHERE clause. finalisePick enriches each
   // chosen row via fetchGenresForTrack so `metadata.genres` is still
   // populated on the wire. Measured ~80% SQL speedup on the smoke DB
   // (52 rows) and extrapolates to ~460ms saved per request at 100k
@@ -785,11 +844,12 @@ export function runRandomSongs(req, body) {
       ).all(...baseParams, ...(exclude ? ignoreIds : []));
     };
     let rows = bounded(true);
-    if (rows.length === 0 && ignoreIds.length > 0) {
-      // Cooldown covers everything in scope — allow repeats rather
-      // than stalling the session (same contract as the waterfall's
-      // drop-cooldown steps).
-      rows = bounded(false);
+    if (rows.length < limit && ignoreIds.length > 0) {
+      // The cooldown leaves fewer fresh songs in scope than asked for
+      // (with one song asked: none at all) — fill the rest with repeats
+      // rather than stalling the session (same contract as the
+      // waterfall's drop-cooldown steps). Fresh rows stay in front.
+      rows = mergeRows(rows, bounded(false));
     }
     if (rows.length === 0) {
       throw new WebError(sonic
@@ -972,7 +1032,7 @@ export function runRandomSongs(req, body) {
     // step).
     const candidate = runWaterfallQuery(
       d, baseSql, baseParams, opts,
-      { ignoreIds, allowRepeatRetry: !enforcesCooldown, tierOrder },
+      { ignoreIds, allowRepeatRetry: !enforcesCooldown, tierOrder, limit },
     );
     if (candidate.length === 0) { continue; }
     if (enforcesCooldown && candidate.every((r) => ignoreSet.has(r.id))) { continue; }
@@ -986,56 +1046,78 @@ export function runRandomSongs(req, body) {
       : 'No songs that match criteria', 400);
   }
 
-  // Apply tier filter against the ORIGINAL request constraints so that
-  // even after the chain drops the SQL filter, in-range rows still win.
-  rows = applyTierFilter(rows, {
+  // Ranked against the ORIGINAL request constraints inside finalisePick,
+  // so that even after the chain drops the SQL filter, in-range rows are
+  // served first.
+  return finalisePick(rows, body, sonic, {
     bpmRanges: body.bpmRanges,
     musicalKeys: body.musicalKeys,
   });
-
-  return finalisePick(rows, body, sonic);
 }
 
-function finalisePick(rows, body, sonic) {
+// Turn the winning candidate rows into the response: the first `limit`
+// rows in priority order, the advanced cooldown, and (sonic mode) the
+// picks' similarities.
+//
+// Priority is tier first, freshness second. The cooldown is soft —
+// best-effort variety — while the tier ranking guards the BPM/key promise
+// the request made, so a recently-served in-range row outranks a never-
+// served unknown-tag row. Within a tier, rows not served recently come
+// first; when the cooldown covers the whole candidate set (tiny library /
+// narrow filters / long session) the repeats fill in — they beat stalling
+// the session. Simple mode already excluded the cooled ids in SQL, so its
+// fresh partition only matters after a repeat top-up; the waterfall passes
+// `tierOpts` so its relaxed steps still serve in-range rows first. Every
+// query behind `rows` ends in RANDOM(), so the front of the ordering is a
+// uniform sample and a single pick is as random as it ever was.
+function finalisePick(rows, body, sonic, tierOpts = null) {
+  const limit = pickLimitFrom(body);
   const sent = ignoreIdsFrom(body);
   const ignoreSet = new Set(sent);
-  // Cooldown: prefer candidates not served recently. When the cooldown
-  // covers the whole candidate set (tiny library / narrow filters / long
-  // session), fall back to the full set — repeats beat stalling the
-  // session. Simple mode already excluded the ids in SQL, so the filter
-  // is a no-op there; waterfall and sonic sets are filtered here.
-  const fresh = rows.filter((r) => !ignoreSet.has(r.id));
-  const pool = fresh.length > 0 ? fresh : rows;
-  const picked = pool[Math.floor(Math.random() * pool.length)];
+  let ordered = [
+    ...rows.filter((r) => !ignoreSet.has(r.id)),
+    ...rows.filter((r) => ignoreSet.has(r.id)),
+  ];
+  if (tierOpts) { ordered = rankByTier(ordered, tierOpts); }
+  const picked = ordered.slice(0, limit);
 
-  // Move-to-end + trim: newest last, bounded, no duplicate of the pick.
+  // Move-to-end + trim: newest last, bounded, no duplicate of any pick.
   // Stale entries (deleted tracks, a pre-rework index-based list) age
   // out through the cap as new picks append.
-  const nextIgnore = sent.filter((id) => id !== picked.id);
-  nextIgnore.push(picked.id);
+  const pickedIds = picked.map((r) => r.id);
+  const pickedSet = new Set(pickedIds);
+  const nextIgnore = sent.filter((id) => !pickedSet.has(id));
+  nextIgnore.push(...pickedIds);
   while (nextIgnore.length > IGNORE_COOLDOWN_MAX) { nextIgnore.shift(); }
 
-  // Enrich the picked row with `genres_concat` so renderMetadataObj
+  // Enrich each picked row with `genres_concat` so renderMetadataObj
   // emits a populated `metadata.genres` field. The candidate-set
-  // query above skipped the LEFT JOIN aggregation for speed; this
-  // single targeted SELECT costs ~10µs and keeps the wire shape
+  // query above skipped the LEFT JOIN aggregation for speed; these
+  // targeted SELECTs cost ~10µs apiece and keep the wire shape
   // contractually identical.
-  const { genres_concat } = fetchGenresForTrack(db.getDB(), picked.id);
-  picked.genres_concat = genres_concat;
+  const d = db.getDB();
+  for (const row of picked) {
+    row.genres_concat = fetchGenresForTrack(d, row.id).genres_concat;
+  }
 
   const out = {
-    songs: [renderMetadataObj(picked)],
+    songs: picked.map((row) => renderMetadataObj(row)),
     ignoreList: nextIgnore,
   };
 
-  // Sonic mode: report the pick's actual cosine vs the seed/centroid (UI
+  // Sonic mode: report each pick's actual cosine vs the seed/centroid (UI
   // display + slider tuning) and how many analyzed tracks are inside the
   // range at all (before the other filters cut it down further).
+  // `similarities` is aligned with `songs`; `similarity` stays the first
+  // song's value so single-pick callers keep reading one number.
   if (sonic) {
-    const similarity = sim.similarityToHash(
-      sonic.index, sonic.seedVec, picked.audio_hash || picked.file_hash);
+    const similarities = picked.map((row) => {
+      const s = sim.similarityToHash(sonic.index, sonic.seedVec, row.audio_hash || row.file_hash);
+      return s === null ? null : Math.round(s * 10000) / 10000;
+    });
     out.sonic = {
-      similarity: similarity === null ? null : Math.round(similarity * 10000) / 10000,
+      similarity: similarities[0],
+      similarities,
       poolSize: sonic.allowed.size,
     };
   }
@@ -1087,6 +1169,14 @@ export function setup(mstream) {
     //                    16 is room for future tolerance-window UIs.
     //   • musicalKeys:   24 possible Camelot codes; the cap matches.
     const schema = Joi.object({
+      // How many songs to return — 1 (the default, and the pre-batch wire
+      // shape) up to PICK_LIMIT_MAX. Songs in a batch are distinct, served
+      // best-tier-first and fresh-before-repeats from the same bounded pool
+      // a single pick uses, and every one of them advances the ignoreList.
+      // `songs.length` can fall short of `limit` when fewer candidates are
+      // in scope, or when the waterfall step that wins holds fewer matches
+      // — the chain never cascades into a relaxed step to fill a batch.
+      limit: Joi.number().integer().min(1).max(PICK_LIMIT_MAX).default(1),
       ignoreList: Joi.array().items(Joi.number().integer().min(0)).max(500).optional(),
       ignoreVPaths: Joi.array().items(Joi.string()).max(50).optional(),
       // minRating accepts 0..10 — the alpha-UI rating dropdown

--- a/test/db/discovery-hot-loops.test.mjs
+++ b/test/db/discovery-hot-loops.test.mjs
@@ -198,7 +198,7 @@ describe('pathBetween equivalence with the old full-sort walk', () => {
 // ── buildTierOrderExpr ⇄ classifyRow lockstep ──────────────────────────────
 
 describe('buildTierOrderExpr mirrors the JS tier classifier', () => {
-  test('SQL tier ordering matches applyTierFilter tiers for every row shape', () => {
+  test('SQL tier ordering matches classifyRow tiers for every row shape', () => {
     const mem = new DatabaseSync(':memory:');
     mem.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, bpm REAL, musical_key TEXT)');
     const ins = mem.prepare('INSERT INTO t (bpm, musical_key) VALUES (?, ?)');
@@ -223,12 +223,11 @@ describe('buildTierOrderExpr mirrors the JS tier classifier', () => {
       `SELECT id, ${tier.expr} AS tier FROM t ORDER BY id`
     ).all(...tier.params).map((r) => r.tier);
 
-    // The JS authority, tier by tier.
+    // The JS authority, row by row — classifyRow takes the expanded key
+    // set, exactly as rankByTier hands it over.
     const all = mem.prepare('SELECT id, bpm, musical_key FROM t ORDER BY id').all();
-    const t0 = new Set(random.applyTierFilter(all, body).map((r) => r.id));
-    const rest = all.filter((r) => !t0.has(r.id));
-    const t1 = new Set(random.applyTierFilter(rest, body).map((r) => r.id));
-    const jsTiers = all.map((r) => (t0.has(r.id) ? 0 : t1.has(r.id) ? 1 : 2));
+    const keySet = new Set(random.expandCamelotCodes(body.musicalKeys));
+    const jsTiers = all.map((r) => random.classifyRow(r, { bpmRanges: body.bpmRanges, keySet }));
 
     assert.deepEqual(sqlTiers, jsTiers, 'SQL CASE and classifyRow must agree row-for-row');
     mem.close();

--- a/test/integration/random-route.test.mjs
+++ b/test/integration/random-route.test.mjs
@@ -32,7 +32,9 @@ import {
   buildBpmKeyFilter,
   buildGenreFilter,
   buildDurationFilter,
-  applyTierFilter,
+  rankByTier,
+  PICK_LIMIT_MAX,
+  SIMPLE_POOL_LIMIT,
 } from '../../src/api/random.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -200,77 +202,88 @@ describe('buildBpmKeyFilter', () => {
   });
 });
 
-describe('applyTierFilter', () => {
+describe('rankByTier', () => {
   // Row helper — sparse fields only since classifyRow only reads bpm + musical_key.
   const r = (bpm, musical_key, id = 0) => ({ id, bpm, musical_key });
+  const ids = (rows) => rows.map((x) => x.id);
+  const inRange = { bpmRanges: [{ min: 120, max: 130 }] };
 
   test('no constraints → identity (returns rows unchanged)', () => {
     const rows = [r(120, 'Am'), r(null, null), r(80, 'C')];
-    assert.deepEqual(applyTierFilter(rows, {}), rows);
+    assert.deepEqual(rankByTier(rows, {}), rows);
   });
 
-  test('BPM in range → Tier 0; out of range → Tier 2 (dropped if Tier 0 exists)', () => {
+  test('keeps every row — it ranks, it does not filter', () => {
+    // A batch is served from the front of the ranking, so lower tiers
+    // must survive for the tail; a single pick only ever reads row 0.
+    const rows = [r(80, null, 1), r(125, null, 2), r(null, null, 3)];
+    const ranked = rankByTier(rows, inRange);
+    assert.equal(ranked.length, rows.length);
+    assert.deepEqual([...ids(ranked)].sort(), [1, 2, 3]);
+  });
+
+  test('BPM in range (Tier 0) ranks ahead of out of range (Tier 2)', () => {
     const rows = [
-      r(125, null, 1),   // Tier 0: BPM good, key NA
-      r(80,  null, 2),   // Tier 2: BPM wrong, key NA
+      r(80,  null, 1),   // Tier 2: BPM wrong, key NA
+      r(125, null, 2),   // Tier 0: BPM good, key NA
     ];
-    const filtered = applyTierFilter(rows, {
-      bpmRanges: [{ min: 120, max: 130 }],
-    });
-    assert.equal(filtered.length, 1);
-    assert.equal(filtered[0].id, 1);
+    assert.deepEqual(ids(rankByTier(rows, inRange)), [2, 1]);
   });
 
-  test('unknown BPM passes through as Tier 1 when no Tier 0 exists', () => {
+  test('unknown BPM (Tier 1) ranks between in-range and known-wrong', () => {
     const rows = [
-      r(80,  null, 1),    // Tier 2: BPM wrong
+      r(80,   null, 1),   // Tier 2: BPM wrong
       r(null, null, 2),   // Tier 1: BPM unknown
+      r(125,  null, 3),   // Tier 0: BPM good
     ];
-    const filtered = applyTierFilter(rows, {
-      bpmRanges: [{ min: 120, max: 130 }],
-    });
-    // No Tier 0 → fall back to Tier 1 (unknown BPM).
-    assert.equal(filtered.length, 1);
-    assert.equal(filtered[0].id, 2);
+    assert.deepEqual(ids(rankByTier(rows, inRange)), [3, 2, 1]);
   });
 
-  test('all rows Tier 2 → return them (no Tier 0/1 to prefer)', () => {
-    const rows = [
-      r(80,  null, 1),
-      r(200, null, 2),
-    ];
-    const filtered = applyTierFilter(rows, {
-      bpmRanges: [{ min: 120, max: 130 }],
-    });
-    assert.equal(filtered.length, 2);
+  test('stable within a tier — input order is the tiebreak', () => {
+    // finalisePick relies on this: it puts fresh rows ahead of cooled
+    // rows and expects the ranking to keep that order inside each tier.
+    const rows = [r(80, null, 1), r(125, null, 2), r(200, null, 3), r(128, null, 4)];
+    assert.deepEqual(ids(rankByTier(rows, inRange)), [2, 4, 1, 3]);
   });
 
-  test('combined BPM+key: good BPM + good key = Tier 0', () => {
+  test('combined BPM+key: one wrong dimension sinks the row to Tier 2', () => {
     const rows = [
-      r(125, 'A minor', 1), // bpm good, key good → Tier 0
-      r(125, 'Cmaj',    2), // bpm good, key wrong → Tier 2
-      r(80,  'A minor', 3), // bpm wrong, key good → Tier 2 (one wrong sinks it)
+      r(125, 'Cmaj',    1), // bpm good, key wrong → Tier 2
+      r(80,  'A minor', 2), // bpm wrong, key good → Tier 2 (one wrong sinks it)
+      r(125, 'A minor', 3), // bpm good, key good → Tier 0
     ];
-    const filtered = applyTierFilter(rows, {
+    const ranked = rankByTier(rows, {
       bpmRanges:   [{ min: 120, max: 130 }],
       musicalKeys: ['8A'], // expands to A minor / Am / Amin / 8A
     });
-    assert.equal(filtered.length, 1);
-    assert.equal(filtered[0].id, 1);
+    assert.deepEqual(ids(ranked), [3, 1, 2]);
   });
 
-  test('one good + one unknown = both Tier 0/1, picks Tier 0', () => {
-    // Per classifyRow: bpm=good and key=na → Tier 0. So if there's no
-    // key constraint, a known-good BPM row is Tier 0 regardless of key.
+  test('good BPM with no key constraint is Tier 0 regardless of key', () => {
+    // Per classifyRow: bpm=good and key=na → Tier 0.
     const rows = [
-      r(125, 'whatever', 1), // BPM good, no key constraint → Tier 0
-      r(null, 'whatever', 2), // BPM unknown → Tier 1
+      r(null, 'whatever', 1), // BPM unknown → Tier 1
+      r(125,  'whatever', 2), // BPM good, no key constraint → Tier 0
     ];
-    const filtered = applyTierFilter(rows, {
-      bpmRanges: [{ min: 120, max: 130 }],
-    });
-    assert.equal(filtered.length, 1);
-    assert.equal(filtered[0].id, 1);
+    assert.deepEqual(ids(rankByTier(rows, inRange)), [2, 1]);
+  });
+});
+
+describe('batch size invariants', () => {
+  test('PICK_LIMIT_MAX fits inside one bounded pool', () => {
+    // Every candidate query is `ORDER BY ... RANDOM() LIMIT SIMPLE_POOL_LIMIT`.
+    // If a batch could exceed that, a request would come back short while
+    // fresh candidates were still in scope — and the top-up logic assumes a
+    // short pool has already shown every fresh row.
+    assert.ok(PICK_LIMIT_MAX <= SIMPLE_POOL_LIMIT,
+      `PICK_LIMIT_MAX ${PICK_LIMIT_MAX} > SIMPLE_POOL_LIMIT ${SIMPLE_POOL_LIMIT}`);
+  });
+
+  test('two maximal batches fit in the cooldown', () => {
+    // The route caps the returned ignoreList at 50 (pinned by 'returned
+    // list is capped at 50, newest last' below). A maximal batch must leave
+    // the whole previous batch in it, or back-to-back batches could repeat.
+    assert.ok(PICK_LIMIT_MAX * 2 <= 50, `PICK_LIMIT_MAX ${PICK_LIMIT_MAX} > half the cooldown`);
   });
 });
 
@@ -701,6 +714,126 @@ describe('POST /api/v1/db/random-songs — BPM/key waterfall', () => {
     assert.equal(r.body.ignoreList.length, 50);
     assert.equal(r.body.ignoreList.at(-1), ids[pickedTitle(r)], 'picked id lands at the end');
     assert.equal(r.body.ignoreList[0], 900001, 'oldest entry shifted out');
+  });
+
+  // ── limit — batch picks ───────────────────────────────────────────
+  //
+  // `limit` returns up to N distinct songs from the same bounded pool a
+  // single pick uses. Fresh rows come first, repeats fill in only when
+  // the cooldown leaves fewer fresh candidates than asked for, and every
+  // song served lands in the returned ignoreList (newest last). A batch
+  // can come back short: fewer candidates in scope, or a waterfall step
+  // that wins with fewer matches — the chain never pads a batch from a
+  // more relaxed step.
+
+  const titlesOf = (r) => r.body.songs.map((s) => s.metadata.title);
+
+  test('limit omitted → one song (the pre-batch wire shape is unchanged)', async () => {
+    const r = await randomReq(server.baseUrl, { ignoreList: [] });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.songs.length, 1);
+    assert.equal(r.body.ignoreList.length, 1);
+  });
+
+  test('limit: 5 → five distinct songs, every served id in the cooldown in order', async () => {
+    const ids = trackIdsByTitle();
+    const r = await randomReq(server.baseUrl, { limit: 5, ignoreList: [] });
+    assert.equal(r.status, 200);
+    const titles = titlesOf(r);
+    assert.equal(titles.length, 5);
+    assert.equal(new Set(titles).size, 5, 'no duplicates within a batch');
+    assert.deepEqual(r.body.ignoreList, titles.map((t) => ids[t]),
+      'ignoreList gains every served id, in serving order');
+  });
+
+  test('limit beyond the in-scope pool returns everything in scope, once', async () => {
+    const r = await randomReq(server.baseUrl, { limit: PICK_LIMIT_MAX });
+    assert.equal(r.status, 200);
+    assert.deepEqual([...titlesOf(r)].sort(), ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8']);
+    assert.equal(r.body.ignoreList.length, 8);
+  });
+
+  test('a batch serves fresh songs first, then tops up with repeats', async () => {
+    const ids = trackIdsByTitle();
+    // Cool down everything except t3 and t6, ask for five.
+    const cooled = Object.entries(ids).filter(([t]) => t !== 't3' && t !== 't6');
+    const r = await randomReq(server.baseUrl, {
+      limit: 5, ignoreList: cooled.map(([, id]) => id),
+    });
+    assert.equal(r.status, 200);
+    const titles = titlesOf(r);
+    assert.equal(titles.length, 5, 'topped up to the requested size');
+    assert.deepEqual([...titles.slice(0, 2)].sort(), ['t3', 't6'], 'the two fresh songs lead');
+    for (const t of titles.slice(2)) {
+      assert.ok(cooled.some(([c]) => c === t), `repeat '${t}' came from the cooled set`);
+    }
+    assert.equal(new Set(titles).size, 5, 'repeats are still distinct rows');
+    // Move-to-end for every served id: 6 sent − 3 re-served + 5 served = 8.
+    assert.equal(r.body.ignoreList.length, 8);
+    assert.deepEqual(r.body.ignoreList.slice(-5), titles.map((t) => ids[t]));
+  });
+
+  test('a batch honours the always-on filters and enriches every row', async () => {
+    // Funk is t1 + t3. Asking for five yields exactly those two, each
+    // carrying its genres — per-row enrichment, not just the first pick's.
+    const r = await randomReq(server.baseUrl, { limit: 5, genres: ['Funk'] });
+    assert.equal(r.status, 200);
+    assert.deepEqual([...titlesOf(r)].sort(), ['t1', 't3']);
+    for (const s of r.body.songs) {
+      assert.ok(s.metadata.genres.includes('Funk'), `${s.metadata.title} lost its genres`);
+    }
+  });
+
+  test('waterfall batch: the winning step is served whole, never padded from a relaxed step', async () => {
+    // 124-128 BPM holds t1, t2, t3, t7. Asking for six returns those four
+    // — the chain does not fall through to off-range songs to make six.
+    const r = await randomReq(server.baseUrl, { limit: 6, bpmRanges: [{ min: 124, max: 128 }] });
+    assert.equal(r.status, 200);
+    assert.deepEqual([...titlesOf(r)].sort(), ['t1', 't2', 't3', 't7']);
+    for (const s of r.body.songs) {
+      assert.ok(s.metadata.bpm >= 124 && s.metadata.bpm <= 128, `${s.metadata.title} is off-range`);
+    }
+  });
+
+  test('waterfall batch: tier ranking orders a relaxed step (unknown BPM before known-wrong)', async () => {
+    // Nothing is at 300-310 BPM, so every constrained step is empty and
+    // the unrestricted step wins with all eight rows. The batch must lead
+    // with the two unknown-BPM rows (Tier 1) before any known-wrong row.
+    const r = await randomReq(server.baseUrl, { limit: 4, bpmRanges: [{ min: 300, max: 310 }] });
+    assert.equal(r.status, 200);
+    const bpms = r.body.songs.map((s) => s.metadata.bpm);
+    assert.equal(bpms.length, 4);
+    assert.deepEqual(bpms.slice(0, 2), [null, null], 'unknown-BPM rows lead');
+    assert.ok(bpms.slice(2).every((b) => typeof b === 'number'), 'known-wrong rows trail');
+  });
+
+  test('waterfall batch: the id cooldown tops up within the winning step', async () => {
+    const ids = trackIdsByTitle();
+    // 124-125 BPM is {t1, t2, t7}; cool down t1 + t2 and ask for three:
+    // t7 leads and the two repeats come from the same step, never from
+    // outside the BPM window.
+    const r = await randomReq(server.baseUrl, {
+      limit: 3, bpmRanges: [{ min: 124, max: 125 }], ignoreList: [ids.t1, ids.t2],
+    });
+    assert.equal(r.status, 200);
+    const titles = titlesOf(r);
+    assert.equal(titles[0], 't7', 'the fresh song leads');
+    assert.deepEqual([...titles].sort(), ['t1', 't2', 't7']);
+  });
+
+  test('artist-cooldown batch flows through the bounded waterfall', async () => {
+    const r = await randomReq(server.baseUrl, { limit: 3, ignoreArtists: ['No Such Artist'] });
+    assert.equal(r.status, 200);
+    assert.equal(new Set(titlesOf(r)).size, 3);
+  });
+
+  test('limit validation: an integer from 1 to PICK_LIMIT_MAX', async () => {
+    for (const limit of [0, PICK_LIMIT_MAX + 1, 2.5, 'many', -1]) {
+      const r = await randomReq(server.baseUrl, { limit });
+      assert.equal(r.status, 400, `expected 400 for limit=${JSON.stringify(limit)}`);
+    }
+    assert.equal((await randomReq(server.baseUrl, { limit: 1 })).status, 200);
+    assert.equal((await randomReq(server.baseUrl, { limit: PICK_LIMIT_MAX })).status, 200);
   });
 
   // ── Bounded waterfall (no-BPM/key sessions) ───────────────────────

--- a/test/integration/random-sonic.test.mjs
+++ b/test/integration/random-sonic.test.mjs
@@ -244,6 +244,29 @@ describe('sonic threshold pool', () => {
     assert.deepEqual([...titles].sort(), ['Highway', 'Lib2 Song', 'Rise']);
   });
 
+  test('a batch reports one similarity per song, aligned with songs', async () => {
+    // Pool at 0.75 = {Rise .95, Lib2 Song .9, Highway .8}. Asking for five
+    // returns exactly those three — the pool is a hard constraint, so the
+    // batch is not padded from outside it — each with its own exact
+    // cosine. The single `similarity` stays the first song's value so
+    // one-pick callers keep reading one number.
+    const { status, body } = await pick({ similarTo: [SEED_PATH], minSimilarity: 0.75, limit: 5 });
+    assert.equal(status, 200);
+    const titles = body.songs.map((s) => s.metadata.title);
+    assert.deepEqual([...titles].sort(), ['Highway', 'Lib2 Song', 'Rise']);
+    assert.equal(body.sonic.poolSize, 3);
+    assert.equal(body.sonic.similarities.length, 3, 'one entry per served song');
+    assert.equal(body.sonic.similarity, body.sonic.similarities[0]);
+    const expected = {
+      'Rise': dot(V.seed, V.near), 'Lib2 Song': dot(V.seed, V.lib2), 'Highway': dot(V.seed, V.mid),
+    };
+    titles.forEach((t, i) => {
+      assert.ok(Math.abs(body.sonic.similarities[i] - expected[t]) < 1e-3,
+        `similarities[${i}] = ${body.sonic.similarities[i]} is '${t}'s exact cosine`);
+    });
+    assert.equal(body.ignoreList.length, 3, 'every served song advances the cooldown');
+  });
+
   test('empty pool → 400 with the similarity-range message', async () => {
     const { status, body } = await pick({ similarTo: [SEED_PATH], minSimilarity: 0.99 });
     assert.equal(status, 400);

--- a/test/unit/auto-dj-client.test.mjs
+++ b/test/unit/auto-dj-client.test.mjs
@@ -575,6 +575,46 @@ describe('setState round-trip', () => {
     AUTODJ._internals.rehydrate();
     assert.equal(AUTODJ.state.djMinRating, 10);
   });
+
+  test('djLimit defaults to 1 and hydrates to an integer in 1..DJ_LIMIT_MAX', () => {
+    assert.equal(AUTODJ.state.djLimit, 1);
+    localStorage.setItem('mstream-dj-djLimit', '99');
+    AUTODJ._internals.rehydrate();
+    assert.equal(AUTODJ.state.djLimit, AUTODJ._internals.DJ_LIMIT_MAX);
+
+    localStorage.setItem('mstream-dj-djLimit', '0');
+    AUTODJ._internals.rehydrate();
+    assert.equal(AUTODJ.state.djLimit, 1);
+
+    // A fractional value would 400 on the server (Joi integer()).
+    localStorage.setItem('mstream-dj-djLimit', '2.7');
+    AUTODJ._internals.rehydrate();
+    assert.equal(AUTODJ.state.djLimit, 3);
+  });
+});
+
+describe('setLimit (songs per fetch)', () => {
+  test('stores an integer in 1..LIMIT_MAX, persists it, and returns it', () => {
+    assert.equal(AUTODJ.setLimit(5), 5);
+    assert.equal(AUTODJ.state.djLimit, 5);
+    assert.equal(JSON.parse(localStorage.getItem('mstream-dj-djLimit')), 5);
+  });
+
+  test('clamps, rounds, and falls back to 1 on junk', () => {
+    assert.equal(AUTODJ.setLimit('99'), AUTODJ.LIMIT_MAX);
+    assert.equal(AUTODJ.LIMIT_MAX, AUTODJ._internals.DJ_LIMIT_MAX);
+    assert.equal(AUTODJ.setLimit(0), 1);
+    assert.equal(AUTODJ.setLimit(-4), 1);
+    assert.equal(AUTODJ.setLimit('2.5'), 3);
+    assert.equal(AUTODJ.setLimit(''), 1);
+    assert.equal(AUTODJ.setLimit('abc'), 1);
+  });
+
+  test('survives reset() — a preference, not session state', () => {
+    AUTODJ.setLimit(7);
+    AUTODJ.reset();
+    assert.equal(AUTODJ.state.djLimit, 7);
+  });
 });
 
 describe('reset()', () => {
@@ -1918,6 +1958,53 @@ describe('chooseFederatedPick', () => {
     ], new Set()).peerId, 1);
     assert.equal(AUTODJ.chooseFederatedPick([], new Set()), null);
     assert.equal(AUTODJ.chooseFederatedPick([{ peerId: 1, song: null }], new Set()), null);
+  });
+});
+
+describe('chooseFederatedPicks (a batch across servers)', () => {
+  const song = (filepath) => ({ filepath, metadata: {} });
+  const answers = [
+    { peerId: null, song: song('music/l1.mp3'), similarity: 0.80, blocked: false },
+    { peerId: null, song: song('music/l2.mp3'), similarity: 0.60, blocked: false },
+    { peerId: 2, song: song('music/p2a.mp3'), similarity: 0.91, blocked: false },
+    { peerId: 2, song: song('music/p2b.mp3'), similarity: 0.95, blocked: true },
+    { peerId: 3, song: song('music/p3.mp3'), similarity: 0.85, blocked: false },
+  ];
+  const paths = (picks) => picks.map((p) => p.song.filepath);
+
+  test('the n highest cosines across every server, best first', () => {
+    assert.deepEqual(paths(AUTODJ.chooseFederatedPicks(answers, new Set(), 3)),
+      ['music/p2a.mp3', 'music/p3.mp3', 'music/l1.mp3']);
+  });
+
+  test('blocked and recent answers are passed over; fewer than n come back when that is all there is', () => {
+    const recent = AUTODJ.federatedRecentKeys([{ path: 'music/p3.mp3', peerId: 3 }], null);
+    assert.deepEqual(paths(AUTODJ.chooseFederatedPicks(answers, recent, 10)),
+      ['music/p2a.mp3', 'music/l1.mp3', 'music/l2.mp3']);
+  });
+
+  test('a server|path appears once even when two rounds of asks both offered it', () => {
+    const twice = [...answers, { peerId: 2, song: song('music/p2a.mp3'), similarity: 0.91, blocked: false }];
+    const picks = AUTODJ.chooseFederatedPicks(twice, new Set(), 10);
+    assert.equal(picks.filter((p) => p.peerId === 2 && p.song.filepath === 'music/p2a.mp3').length, 1);
+    assert.equal(picks.length, 4);
+  });
+
+  test('ties keep answer order, so the local server (asked first) wins them', () => {
+    const tied = [
+      { peerId: 4, song: song('music/peer.mp3'), similarity: 0.9, blocked: false },
+      { peerId: null, song: song('music/local.mp3'), similarity: 0.9, blocked: false },
+    ];
+    assert.deepEqual(paths(AUTODJ.chooseFederatedPicks(tied, new Set(), 2)), ['music/peer.mp3', 'music/local.mp3']);
+    assert.deepEqual(paths(AUTODJ.chooseFederatedPicks([tied[1], tied[0]], new Set(), 2)), ['music/local.mp3', 'music/peer.mp3']);
+  });
+
+  test('n defaults to one, and chooseFederatedPick is exactly the first pick', () => {
+    assert.equal(AUTODJ.chooseFederatedPicks(answers, new Set()).length, 1);
+    assert.deepEqual(AUTODJ.chooseFederatedPick(answers, new Set()),
+      AUTODJ.chooseFederatedPicks(answers, new Set(), 1)[0]);
+    assert.deepEqual(AUTODJ.chooseFederatedPicks([], new Set(), 3), []);
+    assert.deepEqual(AUTODJ.chooseFederatedPicks([{ peerId: 1, song: null }], new Set(), 3), []);
   });
 });
 

--- a/webapp/alpha/auto-dj.js
+++ b/webapp/alpha/auto-dj.js
@@ -323,6 +323,7 @@
   const DURATION_MAX_SECONDS = 86400;   // mirrors src/api/random.js Joi.number().max(86400) — 24h
   const GENRES_CACHE_TTL_MS = 5 * 60 * 1000;  // 5 min — popover dropdown content
   const GENRE_MODES = Object.freeze(['whitelist', 'blacklist']);
+  const DJ_LIMIT_MAX = 25;              // mirrors src/api/random.js PICK_LIMIT_MAX — songs one fetch may ask for
 
   // Safe-ish localStorage shim — Node tests + private-mode browsers
   // can both end up without a real one. Returning `null` for misses
@@ -382,6 +383,13 @@
       harmonicMixing: !!_read('harmonicMixing', false),
       bpmTolerance:   _readNumber('bpmTolerance', DEFAULT_BPM_TOLERANCE, 1, 20),
       djMinRating:    _readNumber('djMinRating', 0, 0, 10),
+      // Songs per fetch — how many songs one Auto DJ turn asks the server
+      // for (`limit` on random-songs, mStream #966). A preference like
+      // djMinRating, so it survives reset(). Rounded because the server's
+      // Joi wants an integer: a fractional value left in LS would 400
+      // every pick. The player only puts `limit` on the wire above 1, so
+      // the default keeps the pre-batch request byte-identical.
+      djLimit:        Math.round(_readNumber('djLimit', 1, 1, DJ_LIMIT_MAX)),
       // Vpath inclusion set — array of vpath names this DJ session is
       // allowed to pick from. Empty means "every vpath the user can
       // see"; the player computes the inverted `ignoreVPaths` payload.
@@ -855,22 +863,35 @@
     return keys;
   }
 
-  // Best answer across servers: highest reported cosine among the answers
-  // that are neither blocked (keyword / genre / duration / continuity —
-  // the same client-side checks the single-server loop applies) nor a
-  // repeat of what is playing or anchoring. Null when nothing qualifies,
-  // which sends the player back to the single-server pick.
+  // Best answers across servers: the `n` highest reported cosines among
+  // the answers that are neither blocked (keyword / genre / duration /
+  // continuity — the same client-side checks the single-server loop
+  // applies) nor a repeat of what is playing or anchoring, one entry per
+  // distinct server|path (a server never repeats itself within one
+  // answer, but two rounds of asks can offer the same song twice). Best
+  // first; equal cosines keep answer order, so the local server — asked
+  // first — wins ties. Empty when nothing qualifies, which sends the
+  // player back to the single-server pick.
   //   answers: [{ peerId|null, song, res, similarity, blocked }]
-  function chooseFederatedPick(answers, recentKeys) {
+  function chooseFederatedPicks(answers, recentKeys, n) {
     const recent = recentKeys instanceof Set ? recentKeys : new Set(recentKeys || []);
-    let best = null;
+    const want = Number.isInteger(n) && n > 0 ? n : 1;
+    const seen = new Set();
+    const eligible = [];
     for (const a of (Array.isArray(answers) ? answers : [])) {
       if (!a || !a.song || a.blocked) { continue; }
-      if (recent.has(federatedKey(a.peerId, a.song.filepath))) { continue; }
-      const sim = Number.isFinite(a.similarity) ? a.similarity : -1;
-      if (!best || sim > best.similarity) { best = { ...a, similarity: sim }; }
+      const key = federatedKey(a.peerId, a.song.filepath);
+      if (recent.has(key) || seen.has(key)) { continue; }
+      seen.add(key);
+      eligible.push({ ...a, similarity: Number.isFinite(a.similarity) ? a.similarity : -1 });
     }
-    return best;
+    eligible.sort((x, y) => y.similarity - x.similarity);   // stable: ties keep answer order
+    return eligible.slice(0, want);
+  }
+
+  // The single best answer, or null — chooseFederatedPicks for one song.
+  function chooseFederatedPick(answers, recentKeys) {
+    return chooseFederatedPicks(answers, recentKeys, 1)[0] || null;
   }
 
   // Per-peer ignoreList bookkeeping (see djPeerIgnoreLists above).
@@ -1249,6 +1270,20 @@
     return { min, max };
   }
 
+  // ── Songs per fetch ─────────────────────────────────────────────
+  //
+  // One place owns the rules — an integer from 1 to DJ_LIMIT_MAX — so a
+  // typed "99", "0", "2.5" or "" can never reach the wire: the server's
+  // Joi rejects a non-integer or out-of-range `limit` and would 400 every
+  // pick until the field was fixed. Returns what was stored so the panel
+  // can write it back into the input.
+  function setLimit(raw) {
+    const n = Math.round(Number(raw));
+    const val = Number.isFinite(n) ? Math.max(1, Math.min(DJ_LIMIT_MAX, n)) : 1;
+    setState({ djLimit: val });
+    return val;
+  }
+
   // ── Genres-list fetch cache ─────────────────────────────────────
   //
   // The popover/dropdown content (the SET of genres in the library)
@@ -1351,6 +1386,7 @@
     resolveSonicOwners,
     federatedRecentKeys,
     chooseFederatedPick,
+    chooseFederatedPicks,
     getPeerIgnoreList,
     setPeerIgnoreList,
     excludePeerForSession,
@@ -1382,6 +1418,11 @@
     // constrain each other).
     setDurationBounds,
 
+    // Songs per fetch (state.djLimit — set through the clamping setter;
+    // LIMIT_MAX is the ceiling the panel renders and the server enforces).
+    setLimit,
+    LIMIT_MAX: DJ_LIMIT_MAX,
+
     // Library genres-list cache (5-min TTL; populated by m.js's
     // panel-open lifecycle from /api/v1/db/genres).
     getCachedGenresList,
@@ -1407,6 +1448,7 @@
       GENRES_CACHE_TTL_MS,
       GENRE_MODES,
       DURATION_MAX_SECONDS,
+      DJ_LIMIT_MAX,
       // Re-read state from localStorage (tests seed LS then probe).
       rehydrate: _rehydrate,
     },

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -4516,6 +4516,20 @@ async function autoDjPanel() {
           <select class="autodj-select browser-default" id="dj-min-rating">${ratingOptions}</select>
         </div>
 
+        <div class="autodj-opt-row">
+          <div>
+            <div class="autodj-opt-label" id="dj-limit-label">${t('autoDJ.limitLabel')}</div>
+            <div class="autodj-opt-hint">${t('autoDJ.limitHint', { max: AUTODJ.LIMIT_MAX })}</div>
+          </div>
+          <input
+            type="number"
+            class="autodj-select browser-default dj-limit-num"
+            id="dj-limit"
+            min="1" max="${AUTODJ.LIMIT_MAX}" step="1" inputmode="numeric"
+            value="${AUTODJ.state.djLimit}"
+            aria-labelledby="dj-limit-label">
+        </div>
+
         <h4 class="autodj-section-heading">${t('autoDJ.sectionContinuity')}</h4>
         ${similarRow}
         ${bpmContinuityRow}
@@ -4583,6 +4597,13 @@ async function autoDjPanel() {
     const val = Math.max(0, Math.min(10, parseInt(e.target.value, 10)));
     AUTODJ.setState({ djMinRating: val });
   };
+
+  // Songs per fetch. `change` (blur / Enter), not `input`, so "12" isn't
+  // clamped the moment the user types "1". AUTODJ owns the integer +
+  // range rule and hands back what it stored, which is written into the
+  // field so it always shows what the next request will send.
+  const limitEl = document.getElementById('dj-limit');
+  limitEl.onchange = () => { limitEl.value = AUTODJ.setLimit(limitEl.value); };
 
   // Similar-artists toggle (no-op while disabled, but the event still
   // fires on label-click in some browsers).

--- a/webapp/alpha/spa.css
+++ b/webapp/alpha/spa.css
@@ -1957,6 +1957,16 @@ select {
 .dj-duration-num {
   -moz-appearance: textfield;
 }
+
+/* Songs-per-fetch — a short numeric field on the right of its row,
+   dressed as .autodj-select so the two "how much" controls at the top
+   of the panel match. Native spinners stay: step=1 is meaningful here. */
+.dj-limit-num {
+  width: 5.5em;
+  min-width: 0;
+  text-align: center;
+  cursor: text;
+}
 /* Unknown-length row — same shape as .dj-filter-head (caption left,
    .toggle-sw switch right) so it reads as one of the panel's toggles
    rather than a stray control. The switch itself needs no rules here;

--- a/webapp/assets/js/mstream.player.js
+++ b/webapp/assets/js/mstream.player.js
@@ -145,6 +145,13 @@ const MSTREAMPLAYER = (() => {
       ignoreVPaths,
     };
 
+    // Songs per fetch (mStream #966). Only on the wire when it changes
+    // anything: at the default of 1 the request stays byte-identical to
+    // the pre-batch shape, and a server from before `limit` existed
+    // (Joi, no unknown keys) never sees a field it would reject.
+    const limit = autodjLoaded ? Number(AUTODJ.state.djLimit) : 1;
+    if (Number.isInteger(limit) && limit > 1) { body.limit = limit; }
+
     // Current song's metadata — used for BPM anchor / Camelot anchor /
     // similar-artist source. May be undefined on the very first DJ
     // pick of a session.
@@ -414,6 +421,23 @@ const MSTREAMPLAYER = (() => {
   }
 
   // One federated pick. True when a song was queued.
+  // A peer's random-songs, with one concession to age: a peer from before
+  // batch picks (mStream #966) rejects `limit` outright — Joi, no unknown
+  // keys — and would otherwise sit out every round while the setting is
+  // above 1. Ask such a peer for one song instead, the way the app's
+  // capability learner does, rather than dropping it from the session.
+  function _askPeerRandomSongs(peer, body) {
+    return MSTREAMAPI.peer.randomSongs(peer.id, body).catch((err) => {
+      const msg = (err && err.body && err.body.error) || '';
+      if (body.limit !== undefined && err && err.status === 400 && /"limit" is not allowed/i.test(msg)) {
+        const single = { ...body };
+        delete single.limit;
+        return MSTREAMAPI.peer.randomSongs(peer.id, single);
+      }
+      throw err;
+    });
+  }
+
   async function _autoDjFederatedPick(signal) {
     // The anchors and their owners in one synchronous read, before
     // anything is awaited (see AUTODJ.sonicAnchors): a song change during
@@ -475,26 +499,32 @@ const MSTREAMPLAYER = (() => {
     // own ignoreList. Every server is asked at once — a session that waited
     // for each in turn would stall the queue on the slowest one.
     //
-    // A server answers with a random row from its pool, so when every
+    // A server answers with random rows from its pool, so when every
     // answer is a repeat or blocked the ask is repeated a couple of times
     // with each server's own returned ignoreList fed back (the way the
     // single-server loop retries) before the pick is left to that loop —
     // otherwise a strict slider, whose pools are small, would keep turning
     // the session local-only. The fed-back lists stay transient: only the
-    // winner's cooldown advances, its pick is the one being played.
+    // cooldowns of servers whose songs get queued advance.
+    //
+    // Songs per fetch applies across all servers: every server is asked
+    // for the whole batch (`limit` rides along in `shared`) and the best
+    // `want` cosines overall are queued, so one server with the closest
+    // matches can supply the entire batch.
     const { similarTo, ignoreVPaths, minRating, ignoreList, ...shared } = body;
     const eligible = peers.filter(p => p.modelId === modelId);
     const retryLists = new Map([['local', ignoreList]]);
     for (const p of eligible) { retryLists.set(String(p.id), AUTODJ.getPeerIgnoreList(p.id)); }
     const recentKeys = AUTODJ.federatedRecentKeys(anchors, curSong);
+    const want = Number.isInteger(shared.limit) && shared.limit > 1 ? shared.limit : 1;
     const MAX_ASKS = 3;
-    let best = null;
-    for (let attempt = 0; attempt < MAX_ASKS && !best; attempt++) {
+    let chosen = [];
+    for (let attempt = 0; attempt < MAX_ASKS && chosen.length === 0; attempt++) {
       const asks = [
         MSTREAMAPI.getRandomSong({ ...shared, ignoreVPaths, minRating, ignoreList: retryLists.get('local'), ...vectorSeed }, { signal })
           .then(res => ({ peer: null, res }), err => ({ peer: null, err })),
         ...eligible.filter(p => !AUTODJ.isPeerExcluded(p.id)).map(p =>
-          MSTREAMAPI.peer.randomSongs(p.id, { ...shared, ignoreList: retryLists.get(String(p.id)), ...vectorSeed })
+          _askPeerRandomSongs(p, { ...shared, ignoreList: retryLists.get(String(p.id)), ...vectorSeed })
             .then(res => ({ peer: p, res }), err => ({ peer: p, err }))),
       ];
       const answers = await Promise.all(asks);
@@ -509,41 +539,58 @@ const MSTREAMPLAYER = (() => {
           }
           continue;
         }
-        const song = a.res && a.res.songs && a.res.songs[0];
-        if (!song) { continue; }
+        const songs = a.res && Array.isArray(a.res.songs) ? a.res.songs : [];
+        if (songs.length === 0) { continue; }
         if (Array.isArray(a.res.ignoreList)) { retryLists.set(a.peer ? String(a.peer.id) : 'local', a.res.ignoreList); }
-        const sim = a.res.sonic && Number.isFinite(a.res.sonic.similarity) ? a.res.sonic.similarity : -1;
-        scored.push({
-          peerId: a.peer ? a.peer.id : null,
-          peer: a.peer,
-          song,
-          res: a.res,
-          similarity: sim,
-          blocked: _autoDjSongBlocked(song.metadata, refBpm, refNeighbours),
+        // One cosine per song (`sonic.similarities`, aligned with `songs`);
+        // a peer from before batches reports only the first song's value.
+        const sims = a.res.sonic && Array.isArray(a.res.sonic.similarities) ? a.res.sonic.similarities : [];
+        songs.forEach((song, i) => {
+          let sim = -1;
+          if (Number.isFinite(sims[i])) { sim = sims[i]; }
+          else if (i === 0 && a.res.sonic && Number.isFinite(a.res.sonic.similarity)) { sim = a.res.sonic.similarity; }
+          scored.push({
+            peerId: a.peer ? a.peer.id : null,
+            peer: a.peer,
+            song,
+            res: a.res,
+            similarity: sim,
+            blocked: _autoDjSongBlocked(song.metadata, refBpm, refNeighbours),
+          });
         });
       }
       // Nobody answered — asking again would not change that.
       if (scored.length === 0) { break; }
-      best = AUTODJ.chooseFederatedPick(scored, recentKeys);
+      chosen = AUTODJ.chooseFederatedPicks(scored, recentKeys, want);
     }
-    if (!best) { return false; }
+    if (chosen.length === 0) { return false; }
 
-    // Only the winner's cooldown advances — its pick is the one being
-    // played, the others' were not.
-    if (best.peerId === null) {
-      AUTODJ.setIgnoreList(Array.isArray(best.res.ignoreList) ? best.res.ignoreList : []);
-      autoDjIgnoreArray = AUTODJ.getIgnoreList();
-    } else {
-      AUTODJ.setPeerIgnoreList(best.peerId, best.res.ignoreList);
+    // Only the cooldowns of servers whose songs are being queued advance —
+    // the others' answers were not played. A contributing server's list
+    // also carries the ids of its songs that lost to a better cosine
+    // elsewhere; the cooldown is soft variety and they cycle back out.
+    const advanced = new Set();
+    for (const pick of chosen) {
+      const key = pick.peerId === null ? 'local' : String(pick.peerId);
+      if (advanced.has(key)) { continue; }
+      advanced.add(key);
+      if (pick.peerId === null) {
+        AUTODJ.setIgnoreList(Array.isArray(pick.res.ignoreList) ? pick.res.ignoreList : []);
+        autoDjIgnoreArray = AUTODJ.getIgnoreList();
+      } else {
+        AUTODJ.setPeerIgnoreList(pick.peerId, pick.res.ignoreList);
+      }
     }
 
-    const meta = { ...(best.song.metadata || {}), _djPicked: true };
-    if (meta.artist) { AUTODJ.pushArtistHistory(meta.artist); }
-
-    if (best.peerId === null) {
-      await VUEPLAYERCORE.addSongWizard(best.song.filepath, meta);
-    } else {
-      VUEPLAYERCORE.addFederationSongWizard(best.peer, best.song.filepath, meta, false);
+    // Queue best first so the playlist order is the ranking.
+    for (const pick of chosen) {
+      const meta = { ...(pick.song.metadata || {}), _djPicked: true };
+      if (meta.artist) { AUTODJ.pushArtistHistory(meta.artist); }
+      if (pick.peerId === null) {
+        await VUEPLAYERCORE.addSongWizard(pick.song.filepath, meta);
+      } else {
+        VUEPLAYERCORE.addFederationSongWizard(pick.peer, pick.song.filepath, meta, false);
+      }
     }
     return true;
   }
@@ -657,41 +704,48 @@ const MSTREAMPLAYER = (() => {
       // blocked retry doesn't re-pick the same song.
       if (Array.isArray(res?.ignoreList)) { ignoreList = res.ignoreList; }
 
-      const song = res.songs && res.songs[0];
-      if (!song) { break; }
+      const songs = Array.isArray(res.songs) ? res.songs : [];
+      if (songs.length === 0) { break; }
 
       // Client-side post-fetch guard. Velvet's `_djSongBlocked` —
-      // the server's tier filter already prefers in-range rows, but
-      // in degraded fallback cases (step 5, step 10) the candidate
+      // the server's tier ranking already prefers in-range rows, but
+      // in degraded fallback cases (step 5, step 10) a candidate
       // can still be off-target. Retry-on-blocked closes the gap.
       // Songs with NULL bpm/key pass through (server already
-      // exhausted the tagged options).
-      const blocked = _autoDjSongBlocked(song.metadata, refBpm, refNeighbours);
-      if (!blocked) { picked = song; break; }
+      // exhausted the tagged options). A batch keeps whatever part
+      // of it passes; only an answer blocked in full is retried.
+      const accepted = songs.filter((s) => !_autoDjSongBlocked(s.metadata, refBpm, refNeighbours));
+      if (accepted.length > 0) { picked = accepted; break; }
     }
 
     // If every retry was blocked, fall through with whatever the
     // last response was so the session doesn't stall completely.
     // The server's fallback chain is already exhausting all viable
     // alternatives; refusing here just means the DJ stops.
-    if (!picked && lastResponse?.songs?.[0]) {
-      picked = lastResponse.songs[0];
+    if (!picked && Array.isArray(lastResponse?.songs) && lastResponse.songs.length > 0) {
+      picked = lastResponse.songs;
     }
     if (!picked) {
       throw new Error('no song in response');
     }
 
-    // Mark as a DJ pick so the song-change handler later knows to
+    // Mark as DJ picks so the song-change handler later knows to
     // push to BPM history (vs. resetting anchors on a manual pick).
-    // `_djPicked` is the only metadata flag the song carries; the
+    // `_djPicked` is the only metadata flag a song carries; the
     // "have we counted this song's BPM yet" state lives in AUTODJ
     // proper (state.djCountedFilepaths), not on the metadata.
-    const meta = { ...(picked.metadata || {}), _djPicked: true };
+    const queued = picked.map((song) => ({
+      filepath: song.filepath,
+      meta: { ...(song.metadata || {}), _djPicked: true },
+    }));
 
-    // Persist updated ignoreList + push picked artist to cooldown.
+    // Persist updated ignoreList + push every picked artist to the
+    // cooldown — all of them are about to be queued.
     if (autodjLoaded) {
       AUTODJ.setIgnoreList(ignoreList);
-      if (meta.artist) { AUTODJ.pushArtistHistory(meta.artist); }
+      for (const { meta } of queued) {
+        if (meta.artist) { AUTODJ.pushArtistHistory(meta.artist); }
+      }
     }
     // Legacy bridge — keep the old global in sync until everywhere
     // else has migrated off it.
@@ -708,10 +762,13 @@ const MSTREAMPLAYER = (() => {
     // via the dev console but the user gets the gist.
     _showSimilarArtistsInfoStrip();
 
-    // Await so async failures inside addSongWizard surface through
-    // the outer try/catch and trigger the iziToast warning instead
-    // of becoming a silent unhandled rejection.
-    await VUEPLAYERCORE.addSongWizard(picked.filepath, meta);
+    // Await each so async failures inside addSongWizard surface through
+    // the outer try/catch and trigger the iziToast warning instead of
+    // becoming a silent unhandled rejection — and so the queue keeps
+    // the server's order (best tier first).
+    for (const { filepath, meta } of queued) {
+      await VUEPLAYERCORE.addSongWizard(filepath, meta);
+    }
   }
 
   // Info strip helper — fires an iziToast.info if similar-mode is on
@@ -1605,11 +1662,13 @@ const MSTREAMPLAYER = (() => {
   // (No mstreamModule.minRating init — the legacy global is dead;
   // the rewritten autoDJ() reads djMinRating from AUTODJ.state.)
 
-  // Queue N Auto-DJ picks sequentially. The autoDJ() function is
-  // guarded against re-entrancy (a second call while the first is
-  // in flight returns the same in-flight promise), so we must await
-  // each pick before requesting the next — calling autoDJ() twice in
-  // a row collapses to a single pick.
+  // Queue Auto-DJ fetches until at least N songs have been added. The
+  // autoDJ() function is guarded against re-entrancy (a second call
+  // while the first is in flight returns the same in-flight promise),
+  // so each fetch is awaited before the next — calling autoDJ() twice
+  // in a row collapses to a single fetch. One fetch adds up to
+  // AUTODJ.state.djLimit songs: at the default of 1 that is two fetches
+  // here, at any larger setting a single fetch already covers the runway.
   //
   // Used on STARTUP paths (toggleAutoDJ, clearPlaylist) to bootstrap
   // a 2-deep lookahead. The downstream "queue one ahead" triggers in
@@ -1623,13 +1682,14 @@ const MSTREAMPLAYER = (() => {
   // Re-checks `mstreamModule.playerStats.autoDJ` between picks so a
   // user toggling Auto-DJ off mid-bootstrap aborts cleanly.
   async function _autoDjQueueN(n) {
-    for (let i = 0; i < n; i++) {
+    const start = mstreamModule.playlist.length;
+    while (mstreamModule.playlist.length - start < n) {
       if (mstreamModule.playerStats.autoDJ !== true) { return; }
       const before = mstreamModule.playlist.length;
       try {
         await autoDJ();
       } catch (_) { /* autoDJ already toasts; don't stack errors */ }
-      // A pick that added nothing failed (autoDJ toasted why) — the
+      // A fetch that added nothing failed (autoDJ toasted why) — the
       // next bootstrap attempt would fail the same way; stop instead
       // of stacking a duplicate toast + duplicate server round-trip.
       if (mstreamModule.playlist.length === before) { return; }

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -215,6 +215,8 @@
   "autoDJ.sectionFilters": "Filters",
   "autoDJ.sectionContinuity": "Continuity",
   "autoDJ.ratingAny": "Any",
+  "autoDJ.limitLabel": "Songs per fetch",
+  "autoDJ.limitHint": "How many songs Auto DJ queues each time it runs (1–{{max}}). Continuity filters judge the whole batch against the song playing when it was fetched.",
   "autoDJ.similarLabel": "Similar artists (Last.fm)",
   "autoDJ.similarHint": "Bias picks toward artists Last.fm says are similar to the current song.",
   "autoDJ.similarHintNoKey": "No Last.fm API key configured on the server.",


### PR DESCRIPTION
## Summary

`POST /api/v1/db/random-songs` can now return more than one song per call via a new `limit` field (integer 1..25, default 1), and the webapp's Auto DJ panel exposes it as **"Songs per fetch"**. The response already carried a `songs` array, so the server change is additive and wire-compatible: every existing client (webapp at its default, Flutter app, federation peers) reads `songs[0]` and is unaffected.

Two commits: the server API (bdae7411) and the webapp control on top of it.

## Server — `src/api/random.js`
- `limit` in the Joi schema, default 1, max `PICK_LIMIT_MAX` (25).
- `applyTierFilter` → `rankByTier`: a stable sort by tier that keeps every row. A batch is sliced off the front (in-range → unknown-tag → known-wrong); a single pick still takes the best row present, exactly as before.
- Both cooldown fallbacks (the simple-mode bounded query and the waterfall's same-step retry) now top up whenever fresh rows fall short of the batch, keeping fresh rows ahead of repeats. An artist-cooldown-enforcing step still skips the retry only when it has no fresh row at all (its all-cooled result would be discarded anyway).
- `finalisePick` serves the first `limit` rows in (tier, freshness) order, appends every served id to `ignoreList` (still capped at 50, newest last), enriches genres per row, and in sonic mode emits `sonic.similarities` aligned with `songs` while keeping `sonic.similarity` as the first song's value.
- Two pinned invariants on `PICK_LIMIT_MAX`: ≤ `SIMPLE_POOL_LIMIT` (one bounded pool always holds a full batch, so no query grows with the request) and ≤ half the cooldown (a maximal batch still leaves the previous batch in the ignoreList).

**Semantics worth knowing**
- A batch can come back **shorter than `limit`**: when fewer candidates are in scope, or when the waterfall step that wins holds fewer matches. The chain deliberately does **not** cascade into a more relaxed step to pad a batch — the tail would then break the constraint the head satisfied, and the caller couldn't tell which songs are which. The always-on filters (genres, duration window, sonic pool) apply to every song in a batch.
- Priority within a batch is tier first, freshness second: the cooldown is best-effort variety, the tier ranking guards the BPM/key promise. For `limit: 1` the result is what it was before (a single pick never mixed fresh and cooled rows).
- Songs within a batch are always distinct rows.

## Webapp — "Songs per fetch" in the Auto DJ panel
- **State** (`webapp/alpha/auto-dj.js`): a persisted `djLimit` preference, hydrated as an integer clamped to 1..25 (a fractional LS value would 400 every pick); `setLimit()` owns the clamp/round rule and returns what it stored; survives `reset()` like the other preferences. `chooseFederatedPicks(answers, recentKeys, n)` returns the n highest cosines across servers, one per distinct server|path; `chooseFederatedPick` is its n=1 form.
- **Request** (`webapp/assets/js/mstream.player.js`): `limit` goes on the wire only above 1, so the default request is byte-identical to before and pre-`limit` servers never see the field. The single-server loop keeps every unblocked song of an answer and queues them in the server's order (best tier first). The federated pick asks every server for the batch, scores each song by its own `sonic.similarities[i]` (old peers: first song's `similarity`), queues the best N overall, and advances only contributing servers' cooldowns. A peer that rejects `limit` as an unknown key is asked again for one song rather than sitting out the round. The startup bootstrap now fetches until at least two songs are queued: one fetch at any setting above 1, two at the default (unchanged).
- **Panel** (`webapp/alpha/m.js`, `spa.css`, `locales/en.json`): a compact number input beside the minimum-rating select, committed on blur/Enter with the clamped value written back; two English strings (other locales fall back to English like the existing Auto DJ keys).

## Tests
- `test/integration/random-route.test.mjs`: `rankByTier` ordering + the two invariants (unit); ten new route tests — distinct rows, ignoreList grows by every served id in order, limit beyond scope returns everything once, fresh-first-then-repeats top-up, per-row filter + genre enrichment, winning step served whole (never padded), tier ordering in a relaxed step, id-cooldown top-up inside the winning step, artist-cooldown batch, Joi bounds.
- `test/integration/random-sonic.test.mjs`: a batch returns one similarity per song, aligned, with `similarity === similarities[0]`.
- `test/db/discovery-hot-loops.test.mjs`: the SQL tier-expression lockstep test now compares row-for-row against the (newly exported) `classifyRow`.
- `test/unit/auto-dj-client.test.mjs`: `djLimit` hydration clamping; `setLimit` clamp / round / junk / survives reset; `chooseFederatedPicks` top-n across servers, blocked + recent skipped, dedupe across rounds, tie order, and `chooseFederatedPick` ≡ first pick.

## Docs
`docs/openapi.yaml`: `limit`, the batch rules, `sonic.similarities`, and a fix for the stale wording that called `ignoreList` entries "indices" (they have been track ids since 527f6504). `redocly lint`: valid, 0 errors.

## Verification

| Suite | Result |
|---|---|
| random-route | 132/132 |
| random-sonic | 29/29 |
| random-similar-artists | 16/16 |
| federation-discovery | 14/14 |
| discovery-hot-loops | 10/10 |
| auto-dj-client (unit) | 212/212 |

`npx eslint` clean on every changed server/test file (the webapp tree is eslint-ignored by project config; `node --check` passes on the three changed scripts).

**Browser smoke** of the webapp against a booted server with a 24-track fixture library (public mode): limit 5 + Start → one request, five distinct songs queued, five cooldown ids, genres on every row; reaching the fifth song fired exactly one more request for five more (ten distinct); reload hydrated the field to 5 with the interpolated hint; clamps 0→1, 99→25, 2.5→3; limit 1 on an empty queue → two requests and two songs (the pre-existing bootstrap contract). No console errors. The federated path with a real second server was not browser-smoked; its selection is unit-tested and reduces to the previous behaviour at the default.

## Not in this PR
- Flutter app: needs none of this to keep working. To *send* `limit` it needs a version-floor entry in `lib/util/server_version.dart` (the server rejects unknown keys), and that release must be tagged 6.26.0.
- Federation: the route stays on the read allowlist and the body passes through; the webapp handles an older peer's rejection of `limit` by re-asking for one song.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
