### PR TITLE
feat(api): album items carry album_artist, artists, compilation and the V70 aggregates; album-songs takes an album_artist selector

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -470,18 +470,50 @@ components:
 
     Album:
       type: object
+      description: |
+        One album card. Rows sharing (name, year, album_art_file) are collapsed into
+        one item — an album with no ALBUMARTIST tag and several track artists is one
+        card — so the credit fields describe the group: `album_artist` is its single
+        credit and null when the collapsed rows disagree, `artists` the union of their
+        main credits, `compilation` true when any of them is one. Send `name`, `year`
+        and `album_artist` back to `/db/album-songs` to open exactly this card.
       properties:
         name:
           type: string
-        artist:
-          type: string
           nullable: true
+          description: Null only on the singles entry `/db/artists-albums` appends (tracks with no album).
         year:
           type: integer
           nullable: true
+          description: The album's aggregate year (its most common track year).
         album_art_file:
           type: string
           nullable: true
+        album_artist:
+          type: string
+          nullable: true
+          description: The ALBUMARTIST display string, else the primary album artist; null when the collapsed rows disagree.
+        artists:
+          type: array
+          items: { type: string }
+          description: Main album credits in tag order (the primary artist when a row carries none), de-duplicated across the group.
+        compilation:
+          type: boolean
+        year_min:
+          type: integer
+          nullable: true
+          description: Earliest track year across the group (V70 aggregate; null on the singles entry).
+        year_max:
+          type: integer
+          nullable: true
+        track_count:
+          type: integer
+          nullable: true
+          description: Tracks in the album(s) — the scan-time aggregate over every library, not the caller's visible subset; null on the singles entry.
+        duration:
+          type: number
+          nullable: true
+          description: Total seconds, same aggregate basis as `track_count`.
 
     Library:
       type: object
@@ -1536,9 +1568,22 @@ paths:
             schema:
               allOf:
                 - type: object
-                  required: [album]
                   properties:
-                    album: { type: string }
+                    album:
+                      type: string
+                      nullable: true
+                      description: |
+                        The album name exactly as a list response gave it. Null or absent selects
+                        the singles bucket — tracks with no album — narrowed by `artist` / `album_artist`.
+                    album_artist:
+                      type: string
+                      nullable: true
+                      description: |
+                        Narrows a named album to one album artist when two albums share a name: send
+                        back the `album_artist` (or one of the `artists`) a list response gave you.
+                        Matched on the normalised artist name against the album's primary artist and
+                        its main credits, or verbatim against the display string. Without `album` (the
+                        singles bucket) it matches the track artist, like `artist`.
                     artist:
                       type: string
                       description: |

--- a/src/api/db.js
+++ b/src/api/db.js
@@ -638,6 +638,104 @@ export function setup(mstream) {
   mstream.get('/api/v1/db/artists', (req, res) => res.json(getArtists(req)));
   mstream.post('/api/v1/db/artists', (req, res) => res.json(getArtists(req)));
 
+  // ── Album items ─────────────────────────────────────────────────────────
+  // What /db/albums and /db/artists-albums return per album: the legacy trio
+  // (name, year, album_art_file) plus, since the album-API series, the credit
+  // fields (album_artist, artists, compilation) and the V70 aggregates
+  // (year_min, year_max, track_count, duration).
+  //
+  // The DISTINCT collapse over exactly (name, year, album_art_file) is a
+  // client-visible contract and stays: an album with no ALBUMARTIST tag and
+  // several track artists is N album rows and ONE card, and album-songs'
+  // name + year match returns every fragment's tracks. So the new fields are
+  // GROUP aggregates: `album_artist` is the group's single credit and null
+  // when its rows disagree, `artists` is the union of the rows' 'main'
+  // credits, `compilation` is true when any row is one.
+  //
+  // Aggregation is at ALBUM granularity: the library filter is an EXISTS
+  // probe per album over idx_tracks_album, never a tracks join that GROUP BY
+  // then has to fold — so the cost scales with the number of albums, not
+  // tracks (the 2026-07 audit's lesson for every list route). The credit
+  // names come from a second, id-chunked query like enrichRowsWithGenres,
+  // not a GROUP_CONCAT whose element order SQLite does not guarantee.
+  //
+  // The aggregate columns are the album rows' own (the scan-end refresh over
+  // ALL of an album's tracks), like `year` always was — a library filter
+  // hides albums, it does not recount the ones it shows.
+  //
+  // The select list expects `albums al LEFT JOIN artists pa` in the FROM.
+  const ALBUM_ITEM_COLUMNS = `
+             al.name, al.year, al.album_art_file,
+             GROUP_CONCAT(al.id) AS ids,
+             COUNT(DISTINCT COALESCE(al.album_artist, pa.name)) AS credit_variants,
+             MIN(COALESCE(al.album_artist, pa.name)) AS credit,
+             MAX(al.compilation) AS compilation,
+             MIN(COALESCE(al.year_min, al.year)) AS year_min,
+             MAX(COALESCE(al.year_max, al.year)) AS year_max,
+             SUM(al.track_count) AS track_count,
+             SUM(al.duration_total) AS duration_total`;
+  const ALBUM_ITEM_GROUP = 'GROUP BY al.name, al.year, al.album_art_file';
+
+  // The 'main' album credits of a set of album ids, in tag order, plus each
+  // row's primary artist as the fallback for rows without credits (legacy
+  // and fixture rows — both scanners write a credit for every album they
+  // touch). One query per id chunk; ORDER BY names the compound's columns.
+  function fetchAlbumCredits(d, ids) {
+    const out = new Map();
+    if (ids.length === 0) { return out; }
+    const ph = ids.map(() => '?').join(',');
+    const rows = d.prepare(`
+      SELECT aa.album_id AS album_id, a.name AS name, aa.position AS position, 0 AS fallback
+        FROM album_artists aa JOIN artists a ON a.id = aa.artist_id
+       WHERE aa.role = 'main' AND aa.album_id IN (${ph})
+      UNION ALL
+      SELECT al.id, pa.name, 0, 1
+        FROM albums al JOIN artists pa ON pa.id = al.artist_id
+       WHERE al.id IN (${ph})
+       ORDER BY album_id, fallback, position, name COLLATE NOCASE
+    `).all(...ids, ...ids);
+    for (const r of rows) {
+      let e = out.get(r.album_id);
+      if (!e) { e = { credits: [], fallback: [] }; out.set(r.album_id, e); }
+      (r.fallback ? e.fallback : e.credits).push(r.name);
+    }
+    return out;
+  }
+
+  // ALBUM_ITEM_SELECT rows → wire items, in row order. A group's `artists`
+  // walks its rows by id (deterministic across plans) and de-duplicates.
+  function albumItems(d, rows) {
+    const idsOf = (r) => String(r.ids).split(',').map(Number).sort((x, y) => x - y);
+    const all = [...new Set(rows.flatMap(idsOf))];
+    const credits = new Map();
+    const CHUNK = 500;
+    for (let i = 0; i < all.length; i += CHUNK) {
+      for (const [id, c] of fetchAlbumCredits(d, all.slice(i, i + CHUNK))) { credits.set(id, c); }
+    }
+    return rows.map((r) => {
+      const names = [];
+      for (const id of idsOf(r)) {
+        const c = credits.get(id);
+        if (!c) { continue; }
+        for (const n of (c.credits.length ? c.credits : c.fallback)) {
+          if (!names.includes(n)) { names.push(n); }
+        }
+      }
+      return {
+        name: r.name,
+        year: r.year,
+        album_art_file: r.album_art_file || null,
+        album_artist: r.credit_variants === 1 ? r.credit : null,
+        artists: names,
+        compilation: Number(r.compilation) > 0,
+        year_min: r.year_min ?? null,
+        year_max: r.year_max ?? null,
+        track_count: r.track_count ?? 0,
+        duration: r.duration_total ?? 0,
+      };
+    });
+  }
+
   // ── Artist Albums ───────────────────────────────────────────────────────
 
   mstream.post('/api/v1/db/artists-albums', (req, res) => {
@@ -678,30 +776,46 @@ export function setup(mstream) {
     // page unasked. `roles` (array of role names) replaces that set.
     const roles = parseRoles(req.body?.roles);
     const rolePh = roles.map(() => '?').join(',');
+    // The card is the ALBUM, the same item /db/albums returns, not the
+    // artist's fragment of it: `reach` is the (name, year, art) groups the
+    // artist's visible rows fall in, and the aggregate then runs over every
+    // visible row of those groups — so an untagged album split across two
+    // artists shows one card with a null album_artist on both artists' pages,
+    // and sending that card back to album-songs still plays the whole album.
+    // (Aggregating over the reached rows alone would have credited the
+    // fragment to this artist and narrowed playback to their tracks.) The
+    // group join is on idx_albums_name; IS makes null years and art match
+    // themselves. The trailing `al.album_art_file` completes the tie pin: two
+    // same-name, same-year albums differing only in art are distinct cards
+    // whose relative order must not depend on the plan either.
     const albumRows = d().prepare(`
-      SELECT DISTINCT al.name, al.year, al.album_art_file
-      FROM albums al
-      WHERE al.id IN (
-        SELECT id FROM albums WHERE artist_id IN (SELECT id FROM artists WHERE name_key = ?)
-        UNION ALL
-        SELECT album_id FROM album_artists
-          WHERE artist_id IN (SELECT id FROM artists WHERE name_key = ?)
-        UNION ALL
-        SELECT t2.album_id FROM track_artists ta
-          JOIN tracks t2 ON t2.id = ta.track_id
-          WHERE ta.artist_id IN (SELECT id FROM artists WHERE name_key = ?)
-            AND ta.role IN (${rolePh})
-            AND t2.album_id IS NOT NULL
+      WITH reach AS (
+        SELECT DISTINCT al.name, al.year, al.album_art_file
+        FROM albums al
+        WHERE al.id IN (
+          SELECT id FROM albums WHERE artist_id IN (SELECT id FROM artists WHERE name_key = ?)
+          UNION ALL
+          SELECT album_id FROM album_artists
+            WHERE artist_id IN (SELECT id FROM artists WHERE name_key = ?)
+          UNION ALL
+          SELECT t2.album_id FROM track_artists ta
+            JOIN tracks t2 ON t2.id = ta.track_id
+            WHERE ta.artist_id IN (SELECT id FROM artists WHERE name_key = ?)
+              AND ta.role IN (${rolePh})
+              AND t2.album_id IS NOT NULL
+        )
+        AND EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND ${filter.clause})
       )
-      AND EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND ${filter.clause})
-      ORDER BY al.year DESC, al.name COLLATE NOCASE
-    `).all(artistKey, artistKey, artistKey, ...roles, ...filter.params);
+      SELECT ${ALBUM_ITEM_COLUMNS}
+      FROM reach r
+      JOIN albums al ON al.name = r.name AND al.year IS r.year AND al.album_art_file IS r.album_art_file
+      LEFT JOIN artists pa ON pa.id = al.artist_id
+      WHERE EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND ${filter.clause})
+      ${ALBUM_ITEM_GROUP}
+      ORDER BY al.year DESC, al.name COLLATE NOCASE, al.album_art_file
+    `).all(artistKey, artistKey, artistKey, ...roles, ...filter.params, ...filter.params);
 
-    const albums = albumRows.map(r => ({
-      name: r.name,
-      year: r.year,
-      album_art_file: r.album_art_file || null
-    }));
+    const albums = albumItems(d(), albumRows);
 
     // Check for tracks with no album (null album_id) by this artist
     // V72: the same `roles` apply to the singles bucket — a credit in one
@@ -718,10 +832,22 @@ export function setup(mstream) {
     `).get(...filter.params, artistKey, ...roles, artistKey);
 
     if (nullAlbumRow) {
+      // The singles bucket is the requested artist's by definition, so its
+      // credit fields name them — in the canonical spelling the key resolves
+      // to. It has no album row, so the aggregates are null, not zero.
+      const canonical = d().prepare('SELECT name FROM artists WHERE name_key = ?').get(artistKey)?.name
+        ?? String(req.body.artist);
       albums.push({
         name: null,
         year: null,
-        album_art_file: nullAlbumRow.album_art_file || null
+        album_art_file: nullAlbumRow.album_art_file || null,
+        album_artist: canonical,
+        artists: [canonical],
+        compilation: false,
+        year_min: null,
+        year_max: null,
+        track_count: null,
+        duration: null,
       });
     }
 
@@ -732,19 +858,21 @@ export function setup(mstream) {
 
   function getAlbums(req) {
     const filter = libraryFilter(req.user, req.body?.ignoreVPaths);
+    // `, al.year DESC, al.album_art_file` pins the order among same-name
+    // albums, which `ORDER BY al.name` alone left to the plan (the rewrite
+    // changed the plan, and the UI renders response order — see the
+    // artists-albums tiebreak note). Newest first among namesakes; a one-time
+    // reorder for libraries that hold two albums of one name.
     const rows = d().prepare(`
-      SELECT DISTINCT al.name, al.year, al.album_art_file
+      SELECT ${ALBUM_ITEM_COLUMNS}
       FROM albums al
-      JOIN tracks t ON t.album_id = al.id
-      WHERE ${filter.clause}
-      ORDER BY al.name COLLATE NOCASE
+      LEFT JOIN artists pa ON pa.id = al.artist_id
+      WHERE EXISTS (SELECT 1 FROM tracks t WHERE t.album_id = al.id AND ${filter.clause})
+      ${ALBUM_ITEM_GROUP}
+      ORDER BY al.name COLLATE NOCASE, al.year DESC, al.album_art_file
     `).all(...filter.params);
 
-    return { albums: rows.map(r => ({
-      name: r.name,
-      year: r.year,
-      album_art_file: r.album_art_file || null
-    }))};
+    return { albums: albumItems(d(), rows) };
   }
 
   mstream.get('/api/v1/db/albums', (req, res) => res.json(getAlbums(req)));
@@ -854,6 +982,15 @@ export function setup(mstream) {
   // ── Album Songs ─────────────────────────────────────────────────────────
 
   mstream.post('/api/v1/db/album-songs', (req, res) => {
+    // `.unknown(true)` and a nullable field on purpose: this route never had
+    // a schema, the webapp sends `album: null, artist: null, year: null` for
+    // the singles bucket, and federated peers and the Flutter app forward
+    // whatever they hold. Only the new field is validated.
+    const schema = Joi.object({
+      album_artist: Joi.string().allow('', null).optional(),
+    }).unknown(true);
+    joiValidate(schema, req.body);
+
     const filter = libraryFilter(req.user, req.body?.ignoreVPaths);
     const conditions = [filter.clause];
     const params = [...filter.params];
@@ -876,6 +1013,34 @@ export function setup(mstream) {
          WHERE ta.role IN (${PERFORMER_ROLES_SQL})
            AND ta.artist_id IN (SELECT id FROM artists WHERE name_key = ?)))`);
       params.push(key, key);
+    }
+
+    // `album_artist` narrows a named album to one credit. Two albums that
+    // share a name (and overlapping years) are one `album` + `year` match
+    // here, so a client that holds the album artist a list response gave it
+    // sends it back. Matched three ways, so any spelling a client can hold
+    // resolves: the primary album artist's normalised key, a 'main' album
+    // credit's key, or the display string verbatim (a joined "A & B" tag has
+    // no artist row of its own). The singles bucket has no album to credit:
+    // there the album artist IS the track artist, matched like `artist`.
+    const albumArtist = typeof req.body.album_artist === 'string' ? req.body.album_artist.trim() : '';
+    let albumArtistJoin = '';
+    if (albumArtist) {
+      const key = nameKey(albumArtist);
+      if (req.body.album) {
+        albumArtistJoin = 'LEFT JOIN artists pa ON pa.id = al.artist_id';
+        conditions.push(`(pa.name_key = ? OR COALESCE(al.album_artist, pa.name) = ? OR al.id IN (
+          SELECT aa.album_id FROM album_artists aa
+           WHERE aa.role = 'main'
+             AND aa.artist_id IN (SELECT id FROM artists WHERE name_key = ?)))`);
+        params.push(key, albumArtist, key);
+      } else {
+        conditions.push(`(a.name_key = ? OR t.id IN (
+          SELECT ta.track_id FROM track_artists ta
+           WHERE ta.role IN (${PERFORMER_ROLES_SQL})
+             AND ta.artist_id IN (SELECT id FROM artists WHERE name_key = ?)))`);
+        params.push(key, key);
+      }
     }
 
     // V70 dropped the year from album identity, so one album can span
@@ -903,6 +1068,7 @@ export function setup(mstream) {
 
     const rows = d().prepare(`
       ${trackQuery(req.user?.id, { includeGenres: false })}
+      ${albumArtistJoin}
       WHERE ${conditions.join(' AND ')}
       ORDER BY ${ALBUM_TRACK_ORDER}, t.filepath
     `).all(...allParams);

--- a/test/db/db-album-fields.test.mjs
+++ b/test/db/db-album-fields.test.mjs
@@ -1,0 +1,367 @@
+/**
+ * The album-API fields (album-API series, PR 4): /db/albums and
+ * /db/artists-albums items carry `album_artist`, `artists`, `compilation` and
+ * the V70 aggregates (`year_min`, `year_max`, `track_count`, `duration`) next
+ * to the legacy trio, and /db/album-songs takes an `album_artist` selector.
+ *
+ * What is pinned here:
+ *   - the DISTINCT collapse over (name, year, album_art_file) survives, and the
+ *     new fields describe the GROUP: one credit when the rows agree, null when
+ *     they disagree, the union of the rows' main credits, MAX(compilation);
+ *   - rows without album credits fall back to their primary artist;
+ *   - the legacy keys keep their values and stay first in each item;
+ *   - same-name albums come back newest first (the pinned tie order);
+ *   - library visibility is still an EXISTS probe — a hidden-library album
+ *     drops out, and the counts are the album rows' own aggregates;
+ *   - the singles entry names the requested artist and nulls the aggregates;
+ *   - album-songs `album_artist` narrows a namesake album by primary-artist
+ *     key, by main credit, or by the verbatim display string; without `album`
+ *     it matches the track artist; null bodies are still accepted.
+ *
+ * Same bare-express harness as db-read-paths: `req.user` is driven directly
+ * so the library gate can be varied per call.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import express from 'express';
+
+let testRoot, server, base;
+let config, manager, dbApi;
+let LIB_A, LIB_B;
+let asUser = null;
+
+const LEGACY_KEYS = ['name', 'year', 'album_art_file'];
+const NEW_KEYS = ['album_artist', 'artists', 'compilation', 'year_min', 'year_max', 'track_count', 'duration'];
+
+before(async () => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-af-'));
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+      waveformCacheDirectory: path.join(testRoot, 'waveforms'),
+    },
+    port: 0,
+  }, null, 2));
+
+  config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  manager = await import('../../src/db/manager.js');
+  manager.initDB();
+  dbApi = await import('../../src/api/db.js');
+
+  const d = manager.getDB();
+  d.exec('BEGIN');
+  for (const name of ['libA', 'libB']) {
+    d.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks)
+               VALUES (?, ?, 'music', 0)`).run(name, path.join(testRoot, name));
+  }
+  manager.invalidateCache();
+  LIB_A = d.prepare("SELECT id FROM libraries WHERE name='libA'").get().id;
+  LIB_B = d.prepare("SELECT id FROM libraries WHERE name='libB'").get().id;
+
+  const insArtist = d.prepare('INSERT INTO artists (name) VALUES (?)');
+  for (const n of ['Ann', 'Bob', 'Cid', 'Solo Singer']) { insArtist.run(n); }
+  const artistId = (n) => d.prepare('SELECT id FROM artists WHERE name = ?').get(n).id;
+  const VA = artistId('Various Artists');   // seeded by the V17 migration
+
+  // (name, artist_id, year, art, album_artist, compilation, year_min, year_max, track_count, duration_total)
+  const insAlbum = d.prepare(`INSERT INTO albums
+    (name, artist_id, year, album_art_file, album_artist, compilation, year_min, year_max, track_count, duration_total, agg_dirty)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`);
+  // One credit, one row.
+  insAlbum.run('Solo', artistId('Ann'), 2001, 'solo.jpg', 'Ann', 0, 2001, 2001, 2, 300.5);
+  // A joined display string with two main credits.
+  insAlbum.run('Duet', artistId('Ann'), 2002, 'duet.jpg', 'Ann & Bob', 0, 2001, 2003, 3, 450);
+  // A compilation credited to Various Artists.
+  insAlbum.run('Mix', VA, 2005, 'mix.jpg', 'Various Artists', 1, 1999, 2005, 4, 800);
+  // Two rows that collapse into one card and DISAGREE on the credit.
+  insAlbum.run('Twin', artistId('Ann'), 2003, 'twin.jpg', 'Ann', 0, 2003, 2003, 3, 100.5);
+  insAlbum.run('Twin', artistId('Bob'), 2003, 'twin.jpg', 'Bob', 0, 2003, 2004, 2, 200);
+  // Two rows that collapse and AGREE (the tag names Ann on both; the primary
+  // artist differs, which is what the tag is for).
+  insAlbum.run('Same', artistId('Ann'), 2004, 'same.jpg', 'Ann', 0, 2004, 2004, 1, 60);
+  insAlbum.run('Same', artistId('Bob'), 2004, 'same.jpg', 'Ann', 0, 2004, 2004, 1, 60);
+  // No tag, no credits: falls back to the primary artist.
+  insAlbum.run('Legacy', artistId('Cid'), 2006, null, null, 0, 2006, 2006, 1, 30);
+  // Namesakes with different years and art: the pinned order is newest first.
+  insAlbum.run('Tie', artistId('Ann'), 2010, 'tie-a.jpg', 'Ann', 0, 2010, 2010, 1, 10);
+  insAlbum.run('Tie', artistId('Bob'), 2009, 'tie-b.jpg', 'Bob', 0, 2009, 2009, 1, 10);
+  // Lives only in libB.
+  insAlbum.run('Hidden', artistId('Cid'), 2007, null, 'Cid', 0, 2007, 2007, 1, 30);
+  const albumIds = (n) => d.prepare('SELECT id FROM albums WHERE name = ? ORDER BY id').all(n).map((r) => r.id);
+  const albumId = (n, i = 0) => albumIds(n)[i];
+
+  const insTrack = d.prepare(`INSERT INTO tracks
+    (filepath, library_id, title, artist_id, album_id, year, created_at, audio_hash)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
+  let n = 0;
+  const addTrack = (lib, album, artist, year = null) =>
+    insTrack.run(`t${n}.mp3`, lib, `Track ${n}`, artist, album, year, '2024-01-01 00:00:00', `h-${n++}`);
+
+  addTrack(LIB_A, albumId('Solo'), artistId('Ann'), 2001);
+  addTrack(LIB_A, albumId('Solo'), artistId('Ann'), 2001);
+  addTrack(LIB_A, albumId('Duet'), artistId('Ann'), 2002);
+  addTrack(LIB_A, albumId('Mix'), artistId('Ann'), 1999);
+  addTrack(LIB_A, albumId('Mix'), artistId('Bob'), 2005);
+  addTrack(LIB_A, albumId('Twin', 0), artistId('Ann'), 2003);
+  addTrack(LIB_A, albumId('Twin', 1), artistId('Bob'), 2003);
+  addTrack(LIB_A, albumId('Same', 0), artistId('Ann'), 2004);
+  addTrack(LIB_A, albumId('Same', 1), artistId('Bob'), 2004);
+  addTrack(LIB_A, albumId('Legacy'), artistId('Cid'), 2006);
+  addTrack(LIB_A, albumId('Tie', 0), artistId('Ann'), 2010);
+  addTrack(LIB_A, albumId('Tie', 1), artistId('Bob'), 2009);
+  addTrack(LIB_B, albumId('Hidden'), artistId('Cid'), 2007);
+  // Singles: one by Ann (the primary artist), one where Ann is only featured.
+  addTrack(LIB_A, null, artistId('Ann'), 2020);
+  addTrack(LIB_A, null, artistId('Solo Singer'), 2021);
+
+  // Main album credits, in tag order. 'Legacy' and the second 'Twin' row get none.
+  const insCredit = d.prepare('INSERT INTO album_artists (album_id, artist_id, role, position) VALUES (?, ?, ?, ?)');
+  insCredit.run(albumId('Solo'), artistId('Ann'), 'main', 0);
+  insCredit.run(albumId('Duet'), artistId('Ann'), 'main', 0);
+  insCredit.run(albumId('Duet'), artistId('Bob'), 'main', 1);
+  insCredit.run(albumId('Mix'), VA, 'main', 0);
+  insCredit.run(albumId('Twin', 0), artistId('Ann'), 'main', 0);
+  insCredit.run(albumId('Same', 0), artistId('Ann'), 'main', 0);
+  insCredit.run(albumId('Same', 1), artistId('Ann'), 'main', 0);
+  insCredit.run(albumId('Tie', 0), artistId('Ann'), 'main', 0);
+  insCredit.run(albumId('Tie', 1), artistId('Bob'), 'main', 0);
+  insCredit.run(albumId('Hidden'), artistId('Cid'), 'main', 0);
+  // Track credits (the scanners write one per track; the fixture only needs
+  // two): Bob's main credit on the compilation puts Mix on his page through
+  // the track_artists arm, and a featured credit on Solo Singer's single lets
+  // the singles bucket be reached through a performer credit.
+  const insTrackCredit = d.prepare('INSERT INTO track_artists (track_id, artist_id, role, position) VALUES (?, ?, ?, ?)');
+  const bobOnMix = d.prepare('SELECT id FROM tracks WHERE album_id = ? AND artist_id = ?').get(albumId('Mix'), artistId('Bob')).id;
+  insTrackCredit.run(bobOnMix, artistId('Bob'), 'main', 0);
+  const featSingle = d.prepare('SELECT id FROM tracks WHERE album_id IS NULL AND artist_id = ?').get(artistId('Solo Singer')).id;
+  insTrackCredit.run(featSingle, artistId('Ann'), 'featured', 1);
+  d.exec('COMMIT');
+
+  const app = express();
+  app.use(express.json({ limit: '10mb' }));
+  app.use((req, _res, next) => { req.user = asUser ?? undefined; next(); });
+  dbApi.setup(app);
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  try { if (server) { server.close(); } } catch (_e) { /* closed */ }
+  try { manager.close(); } catch (_e) { /* closed */ }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_e) { /* win locks */ }
+  setImmediate(() => process.exit(0));
+});
+
+async function post(route, body = {}) {
+  const r = await fetch(`${base}${route}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+async function get(route) {
+  const r = await fetch(`${base}${route}`);
+  return { status: r.status, body: await r.json().catch(() => null) };
+}
+const scopeTo = (ids) => { asUser = ids ? { id: null, libraryIds: ids } : null; };
+const byName = (albums, name) => albums.filter((a) => a.name === name);
+
+// ── /db/albums ──────────────────────────────────────────────────────────────
+
+describe('/db/albums items', () => {
+  test('carry the legacy trio first, then the credit and aggregate fields', async () => {
+    scopeTo(null);
+    const r = await get('/api/v1/db/albums');
+    assert.equal(r.status, 200);
+    const solo = byName(r.body.albums, 'Solo');
+    assert.equal(solo.length, 1);
+    assert.deepEqual(Object.keys(solo[0]), [...LEGACY_KEYS, ...NEW_KEYS]);
+    assert.deepEqual(solo[0], {
+      name: 'Solo', year: 2001, album_art_file: 'solo.jpg',
+      album_artist: 'Ann', artists: ['Ann'], compilation: false,
+      year_min: 2001, year_max: 2001, track_count: 2, duration: 300.5,
+    });
+  });
+
+  test('a joined ALBUMARTIST keeps its display string and lists every main credit in tag order', async () => {
+    scopeTo(null);
+    const [duet] = byName((await get('/api/v1/db/albums')).body.albums, 'Duet');
+    assert.equal(duet.album_artist, 'Ann & Bob');
+    assert.deepEqual(duet.artists, ['Ann', 'Bob']);
+    assert.equal(duet.compilation, false);
+    assert.deepEqual([duet.year_min, duet.year_max], [2001, 2003]);
+  });
+
+  test('a compilation is flagged and credited to Various Artists', async () => {
+    scopeTo(null);
+    const [mix] = byName((await get('/api/v1/db/albums')).body.albums, 'Mix');
+    assert.equal(mix.compilation, true);
+    assert.equal(mix.album_artist, 'Various Artists');
+    assert.deepEqual(mix.artists, ['Various Artists']);
+  });
+
+  test('collapsed rows that disagree yield a null album_artist, the union of credits and summed counts', async () => {
+    scopeTo(null);
+    const twin = byName((await get('/api/v1/db/albums')).body.albums, 'Twin');
+    assert.equal(twin.length, 1, 'the (name, year, art) collapse is preserved');
+    assert.equal(twin[0].album_artist, null);
+    // Row one is credited to Ann; row two has no credit and falls back to Bob.
+    assert.deepEqual(twin[0].artists, ['Ann', 'Bob']);
+    assert.equal(twin[0].track_count, 5);
+    assert.equal(twin[0].duration, 300.5);
+    assert.deepEqual([twin[0].year_min, twin[0].year_max], [2003, 2004]);
+  });
+
+  test('collapsed rows that agree keep the shared credit', async () => {
+    scopeTo(null);
+    const same = byName((await get('/api/v1/db/albums')).body.albums, 'Same');
+    assert.equal(same.length, 1);
+    assert.equal(same[0].album_artist, 'Ann');
+    assert.deepEqual(same[0].artists, ['Ann']);
+    assert.equal(same[0].track_count, 2);
+  });
+
+  test('a row without tag or credits falls back to its primary artist', async () => {
+    scopeTo(null);
+    const [legacy] = byName((await get('/api/v1/db/albums')).body.albums, 'Legacy');
+    assert.equal(legacy.album_artist, 'Cid');
+    assert.deepEqual(legacy.artists, ['Cid']);
+    assert.equal(legacy.album_art_file, null);
+  });
+
+  test('namesakes come back newest first, the list otherwise by name', async () => {
+    scopeTo(null);
+    const names = (await get('/api/v1/db/albums')).body.albums.map((a) => `${a.name}/${a.year}`);
+    assert.deepEqual(names, [
+      'Duet/2002', 'Hidden/2007', 'Legacy/2006', 'Mix/2005', 'Same/2004', 'Solo/2001',
+      'Tie/2010', 'Tie/2009', 'Twin/2003',
+    ]);
+  });
+
+  test('a hidden-library album drops out for a scoped caller; the rest is unchanged', async () => {
+    scopeTo([LIB_A]);
+    const r = await post('/api/v1/db/albums', {});
+    assert.equal(byName(r.body.albums, 'Hidden').length, 0);
+    assert.equal(byName(r.body.albums, 'Solo')[0].track_count, 2);
+    scopeTo(null);
+  });
+});
+
+// ── /db/artists-albums ──────────────────────────────────────────────────────
+
+describe('/db/artists-albums items', () => {
+  test('the same item shape, and the singles entry names the requested artist', async () => {
+    scopeTo(null);
+    const r = await post('/api/v1/db/artists-albums', { artist: 'ann' });
+    assert.equal(r.status, 200);
+    const solo = byName(r.body.albums, 'Solo');
+    assert.deepEqual(Object.keys(solo[0]), [...LEGACY_KEYS, ...NEW_KEYS]);
+    assert.equal(solo[0].album_artist, 'Ann');
+    // Duet reaches Ann through both the primary artist and a credit: one card.
+    assert.equal(byName(r.body.albums, 'Duet').length, 1);
+    const singles = r.body.albums.filter((a) => a.name === null);
+    assert.equal(singles.length, 1, 'Ann has album-less tracks');
+    assert.deepEqual(singles[0], {
+      name: null, year: null, album_art_file: null,
+      album_artist: 'Ann', artists: ['Ann'], compilation: false,
+      year_min: null, year_max: null, track_count: null, duration: null,
+    });
+  });
+
+  test('order is year DESC, then name, then art — the Tie pair keeps its years apart', async () => {
+    scopeTo(null);
+    const r = await post('/api/v1/db/artists-albums', { artist: 'Bob' });
+    const got = r.body.albums.filter((a) => a.name !== null).map((a) => `${a.name}/${a.year}`);
+    assert.deepEqual(got, ['Tie/2009', 'Mix/2005', 'Same/2004', 'Twin/2003', 'Duet/2002']);
+  });
+
+  test('a card is the whole album, not the artist\'s fragment of it', async () => {
+    scopeTo(null);
+    // Bob reaches only the second Twin row, but the card aggregates every
+    // visible row of the (name, year, art) group — the same object
+    // /db/albums returns — so sending it back to album-songs plays the album.
+    const [viaBob] = byName((await post('/api/v1/db/artists-albums', { artist: 'Bob' })).body.albums, 'Twin');
+    const [viaList] = byName((await get('/api/v1/db/albums')).body.albums, 'Twin');
+    assert.deepEqual(viaBob, viaList);
+    assert.equal(viaBob.album_artist, null);
+    assert.deepEqual(viaBob.artists, ['Ann', 'Bob']);
+    assert.equal(viaBob.track_count, 5);
+  });
+
+  test('a scoped caller only reaches an album through its own visible rows', async () => {
+    // Cid's only album in libA is Legacy; Hidden lives in libB. With libA
+    // alone visible, Hidden is gone from his page, and Legacy is intact.
+    scopeTo([LIB_A]);
+    const names = (await post('/api/v1/db/artists-albums', { artist: 'Cid' })).body.albums.map((a) => a.name);
+    assert.deepEqual(names, ['Legacy']);
+    scopeTo(null);
+  });
+});
+
+// ── /db/album-songs album_artist ────────────────────────────────────────────
+
+describe('/db/album-songs album_artist', () => {
+  const titles = (r) => r.body.map((t) => t.metadata.title).sort();
+
+  test('without it, a namesake album returns every fragment (the pre-series contract)', async () => {
+    scopeTo(null);
+    const r = await post('/api/v1/db/album-songs', { album: 'Twin', year: 2003 });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.length, 2);
+  });
+
+  test('narrows by the primary artist, matched on the normalised key', async () => {
+    scopeTo(null);
+    const r = await post('/api/v1/db/album-songs', { album: 'Twin', year: 2003, album_artist: ' BOB ' });
+    assert.equal(r.body.length, 1);
+    assert.equal(r.body[0].metadata.artist, 'Bob');
+  });
+
+  test('narrows by a main credit and by the verbatim display string', async () => {
+    scopeTo(null);
+    const viaCredit = await post('/api/v1/db/album-songs', { album: 'Duet', album_artist: 'Bob' });
+    assert.equal(viaCredit.body.length, 1, 'Bob is a main credit on Duet, not its primary artist');
+    const viaDisplay = await post('/api/v1/db/album-songs', { album: 'Duet', album_artist: 'Ann & Bob' });
+    assert.equal(viaDisplay.body.length, 1);
+    const nobody = await post('/api/v1/db/album-songs', { album: 'Duet', album_artist: 'Cid' });
+    assert.deepEqual(nobody.body, []);
+  });
+
+  test('the collapsed card that agrees opens fully with its shared credit', async () => {
+    scopeTo(null);
+    const r = await post('/api/v1/db/album-songs', { album: 'Same', year: 2004, album_artist: 'Ann' });
+    assert.equal(r.body.length, 2, 'both rows carry the Ann tag');
+  });
+
+  test('without an album it matches the track artist, performer credits included', async () => {
+    scopeTo(null);
+    const r = await post('/api/v1/db/album-songs', { album: null, album_artist: 'Ann' });
+    assert.deepEqual(titles(r), ['Track 13', 'Track 14'], 'her own single plus the one she is featured on');
+  });
+
+  test('null fields and unknown keys are still accepted; an empty selector is ignored', async () => {
+    scopeTo(null);
+    const nulls = await post('/api/v1/db/album-songs', { album: 'Solo', artist: null, year: null, album_artist: null, extra: 1 });
+    assert.equal(nulls.status, 200);
+    assert.equal(nulls.body.length, 2);
+    const empty = await post('/api/v1/db/album-songs', { album: 'Solo', album_artist: '' });
+    assert.equal(empty.body.length, 2);
+  });
+
+  test('a hidden-library album stays hidden with the selector too', async () => {
+    scopeTo([LIB_A]);
+    const r = await post('/api/v1/db/album-songs', { album: 'Hidden', album_artist: 'Cid' });
+    assert.deepEqual(r.body, []);
+    scopeTo(null);
+  });
+});

--- a/test/db/db-read-paths.test.mjs
+++ b/test/db/db-read-paths.test.mjs
@@ -347,7 +347,10 @@ describe('artists-albums', () => {
       ORDER BY al.year DESC
     `).all('Solo', 'Solo', 'Solo', LIB_A, LIB_B)
       .map((r) => ({ name: r.name, year: r.year, album_art_file: r.album_art_file || null }));
-    const got = (await post('/api/v1/db/artists-albums', { artist: 'Solo' })).body.albums;
+    // The album-API series added credit and aggregate fields to the items;
+    // this oracle is about the legacy trio and the collapse, so compare those.
+    const got = (await post('/api/v1/db/artists-albums', { artist: 'Solo' })).body.albums
+      .map(({ name, year, album_art_file }) => ({ name, year, album_art_file }));
     assert.deepEqual([...got].sort((a, b) => String(a.name).localeCompare(b.name)),
       [...oracle].sort((a, b) => String(a.name).localeCompare(b.name)));
   });


### PR DESCRIPTION
PR 4 of the album-API series, stacked on #955 (V72). The change the series was started for: album items carry their artist, and a client can open exactly the card it was shown. Server, tests and spec only; the webapp (PR 5) and the Flutter app (PR 6) follow.

## What changes on the wire (all additive)

**`/db/albums` and `/db/artists-albums` items** keep `name`, `year`, `album_art_file` first and unchanged, and gain:

- `album_artist` — the ALBUMARTIST display string, else the primary album artist; **null when the collapsed rows disagree**.
- `artists` — the main album credits in tag order (the primary artist for a row without credits), de-duplicated across the group.
- `compilation` — true when any row of the group is one.
- `year_min`, `year_max`, `track_count`, `duration` — the V70 aggregates, summed / min-maxed over the group. Null on the singles entry.

The DISTINCT collapse over `(name, year, album_art_file)` is a client-visible contract (an untagged album with several track artists is N rows and ONE card, and album-songs' name + year match plays every fragment) and stays exactly as it was; the new fields describe the group. On an artist's page the card is the **album**, the same object `/db/albums` returns, not that artist's fragment of it — otherwise a client sending the card back would have narrowed playback to the artist's tracks.

**`/db/album-songs`** gains an optional `album_artist`: with `album`, it narrows a namesake album to one credit, matched on the normalised key of the primary album artist or of a main credit, or verbatim against the display string (a joined "A & B" tag has no artist row). Without `album` it matches the track artist like `artist` does. The route gets its first Joi schema, `.unknown(true)` with nullable fields, because the webapp sends `artist: null, year: null` and peers forward what they hold.

**OpenAPI:** the `Album` schema loses the `artist` field the server never emitted (added aspirationally in 02cc9962) and documents the new ones; `album` on album-songs is nullable (the singles bucket), `album_artist` documented. `redocly lint` warning count unchanged (252 → 252).

Deliberately not on the wire: an album `id` (collapsed groups span rows), an artist filter on `/db/albums` (artists-albums covers it), any Subsonic / DLNA / federation change (routes unchanged, allow-list untouched).

## How

Aggregation at **album granularity** with an EXISTS visibility probe per album over `idx_tracks_album`, never a tracks join that GROUP BY then folds, so cost scales with albums, not tracks. The credit names come from a second, id-chunked query in the `enrichRowsWithGenres` shape (GROUP_CONCAT's element order is not guaranteed). Same-name albums are now ordered newest first, then by art: the old `ORDER BY name` left namesake order to the plan, and the rewrite changed the plan — a one-time reorder for libraries holding two albums of one name.

## Tests

- New `test/db/db-album-fields.test.mjs` (17 tests on the bare-Express, driven-`req.user` harness): item shape and key order, agree / disagree / fallback / compilation / summed groups, namesake ordering, hidden-library exclusion, the singles entry, the artist-page card equalling the list card, and every `album_artist` match path on album-songs plus null-body tolerance.
- `db-read-paths` oracle compares the legacy trio only (it asserts the collapse, not the item shape).
- Local: db + unit + integration suites green (numbers in the PR checks).

## Measured (synthetic 2,500 albums / 25,000 tracks, this machine)

| | old | new |
|---|---|---|
| `/db/albums` list SQL, all libraries | 9–24 ms | 12–14 ms |
| credits lookup, all 2,500 albums | — | 11–14 ms |
| `/db/albums` end to end (HTTP + JSON) | — | 47–64 ms |
| `/db/artists-albums`, `/db/album-songs` | — | 2–9 ms |

The list route roughly doubles at that size and stays well inside the budget of a whole-library call; the credits query is the candidate if a 25,000-album library ever needs it faster (a per-chunk-size statement memo, as discovery.js does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
