### PR TITLE
feat(stats): Stats API v2 ingest — POST /api/v1/stats/plays, V70 tables, the play-event write path

### DIFF
--- a/docs/json_config.md
+++ b/docs/json_config.md
@@ -278,6 +278,25 @@ Each user can have their own lastFM credentials
 }
 ```
 
+## Listening Stats
+
+How a play is counted, and how far back one may be reported. Clients (the
+mobile app, the web player) send complete plays to `POST /api/v1/stats/plays`
+after they happen; the server judges each one against these settings, stores
+the verdict with the play, and only counted plays move a track's play count.
+
+```json
+  "stats": {
+    "playThresholdMs": 30000,
+    "playThresholdFraction": 0.5,
+    "retentionMonths": 24
+  }
+```
+
+- `playThresholdMs` — listening at least this long counts as a play (default 30 s).
+- `playThresholdFraction` — or at least this fraction of the track, when its length is known (default half). `0` disables the fraction rule.
+- `retentionMonths` — plays that started earlier than this many months ago are refused as `bad-time`. `0` accepts anything since 2000.
+
 ## Storage
 
 mStream will write, logs, DB files, and album art to the filesystem.  By default these will be written in the mStream project folder tothe `save` and `image-cache` folders.  Use the `storage` object to choose where to save these files

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2225,6 +2225,91 @@ paths:
                 items: { $ref: "#/components/schemas/Metadata" }
         "401": { $ref: "#/components/responses/Unauthorized" }
 
+  /api/v1/stats/plays:
+    post:
+      tags: [Stats]
+      summary: Record a batch of complete plays (Stats API v2)
+      description: |
+        Clients report plays AFTER they happen, with their own ids and start
+        times. Each play is resolved to a track and judged against the server's
+        play threshold (`stats.playThresholdMs` / `stats.playThresholdFraction`
+        in config); only counted plays move `play-count` and `last-played`.
+        The answer is per play, so an offline outbox can retry safely:
+        `duplicates` are ids this user already sent (nothing moves), `rejected`
+        carry a reason to drop the play — `unknown-track`, `unknown-peer`,
+        `bad-time` (unparsable, over five minutes in the future, or older than
+        `stats.retentionMonths`), `invalid` (a peer play without its `track`
+        snapshot, or an id another user owns).
+
+        A play of a federated peer's track is recorded HERE, as this user's own
+        play (`peerId` = the peer's id on this server, `track` = what the peer
+        reported), never on the peer. Not reachable with a federation key or a
+        guest token.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [plays]
+              properties:
+                client:
+                  type: object
+                  required: [name]
+                  properties:
+                    name: { type: string, maxLength: 64 }
+                    version: { type: string, maxLength: 32 }
+                    instanceId: { type: string, maxLength: 64 }
+                plays:
+                  type: array
+                  minItems: 1
+                  maxItems: 200
+                  items:
+                    type: object
+                    required: [id, filePath, startedAt, playedMs, outcome]
+                    properties:
+                      id: { type: string, maxLength: 128, description: "Client UUID — the idempotency key." }
+                      filePath: { type: string, description: "Virtual path (`<vpath>/<rel>`); for a peer play, the peer's own path." }
+                      peerId: { type: integer, description: "Present for a play of a federated peer's track." }
+                      startedAt: { oneOf: [{ type: string, format: date-time }, { type: integer, description: "epoch ms" }] }
+                      endedAt: { oneOf: [{ type: string, format: date-time }, { type: integer }] }
+                      playedMs: { type: integer, minimum: 0 }
+                      durationMs: { type: integer, minimum: 0, description: "Defaults to the library's duration for a local track." }
+                      outcome: { type: string, enum: [completed, skipped, stopped] }
+                      source: { type: string, enum: [manual, shuffle, autodj, playlist, smart-playlist, auto, carplay, cast, other] }
+                      sessionId: { type: string, maxLength: 128 }
+                      pauseCount: { type: integer, minimum: 0, default: 0 }
+                      track:
+                        type: object
+                        description: Snapshot for a peer play (ignored for a local track).
+                        properties:
+                          title: { type: string }
+                          artist: { type: string }
+                          album: { type: string }
+                          durationMs: { type: integer }
+                          hash: { type: string, description: "The peer-reported track hash; counters key on it." }
+                          artFile: { type: string }
+      responses:
+        "200":
+          description: Per-play outcome.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted: { type: array, items: { type: string } }
+                  duplicates: { type: array, items: { type: string } }
+                  rejected:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        reason: { type: string, enum: [unknown-track, unknown-peer, bad-time, invalid] }
+        "400": { description: "Validation failed (an unknown key, a bad enum value, an empty or oversized batch)." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: "A federation key or guest token — stats are never recorded for those." }
+
   # ── Playlists ────────────────────────────────────────────────────────────
 
   /api/v1/playlist/load:

--- a/src/api/stats.js
+++ b/src/api/stats.js
@@ -1,0 +1,86 @@
+// Stats API v2 — the write side.
+//
+//   POST /api/v1/stats/plays   record a batch of complete plays
+//
+// Clients (the mobile app's outbox, the web player) send plays AFTER they
+// happen, with their own ids and start times. The server resolves each path
+// to a track, decides whether it counts (config `stats.playThreshold*`), and
+// answers per play — accepted / duplicates / rejected with a reason — so an
+// outbox knows what to drop and what to retry. Rules in src/stats/ingest.js,
+// the write in src/stats/store.js.
+//
+// Never reachable with a federation key or a guest token: the wall's
+// allowlist does not carry this route, and the synthetic user those tokens
+// build has no id to record against. The read side (summary, top,
+// timeseries, history) follows in its own change; nothing advertises the
+// route in `features` until the surface is complete.
+
+import Joi from 'joi';
+import * as db from '../db/manager.js';
+import * as fedDb from '../db/federation.js';
+import * as config from '../state/config.js';
+import WebError from '../util/web-error.js';
+import { joiValidate } from '../util/validation.js';
+import { ingestPlays, MAX_BATCH } from '../stats/ingest.js';
+import { OUTCOMES, SOURCES } from '../stats/store.js';
+
+const instant = Joi.alternatives().try(Joi.string().isoDate(), Joi.number().integer().min(0));
+
+// 'legacy' is reserved for the server's own scrobble shim.
+const CLIENT_SOURCES = [...SOURCES].filter((s) => s !== 'legacy');
+
+// What a client knows about a track this library can't look up — required
+// for a federated peer's track, ignored for a local one (the library is the
+// truth there).
+const trackSnapshot = Joi.object({
+  title: Joi.string().max(512).allow(''),
+  artist: Joi.string().max(512).allow(''),
+  album: Joi.string().max(512).allow(''),
+  durationMs: Joi.number().integer().min(0),
+  hash: Joi.string().max(128),
+  artFile: Joi.string().max(512),
+});
+
+const playSchema = Joi.object({
+  id: Joi.string().min(1).max(128).required(),
+  filePath: Joi.string().min(1).max(2048).required(),
+  peerId: Joi.number().integer().min(1),
+  startedAt: instant.required(),
+  endedAt: instant,
+  playedMs: Joi.number().integer().min(0).required(),
+  durationMs: Joi.number().integer().min(0),
+  outcome: Joi.string().valid(...OUTCOMES).required(),
+  source: Joi.string().valid(...CLIENT_SOURCES),
+  sessionId: Joi.string().max(128),
+  pauseCount: Joi.number().integer().min(0).default(0),
+  track: trackSnapshot,
+});
+
+const bodySchema = Joi.object({
+  client: Joi.object({
+    name: Joi.string().min(1).max(64).required(),
+    version: Joi.string().max(32).allow(''),
+    instanceId: Joi.string().max(64),
+  }),
+  plays: Joi.array().items(playSchema).min(1).max(MAX_BATCH).required(),
+});
+
+// `name/version`, the form stored on every row and shown in history.
+export function clientLabel(c) {
+  if (!c) { return null; }
+  return `${c.name}${c.version ? `/${c.version}` : ''}`.slice(0, 128);
+}
+
+export function setup(mstream) {
+  mstream.post('/api/v1/stats/plays', (req, res) => {
+    if (!req.user?.id || req.user.federation) { throw new WebError('Forbidden', 403); }
+    const { value } = joiValidate(bodySchema, req.body || {});
+    const result = ingestPlays(db.getDB(), req.user, value, {
+      config: config.program.stats,
+      now: new Date(),
+      peers: fedDb.getFederationPeers(),
+      client: clientLabel(value.client),
+    });
+    res.json(result);
+  });
+}

--- a/src/db/hash-migration.js
+++ b/src/db/hash-migration.js
@@ -52,6 +52,9 @@ export function migrateHashReferences(db, oldHash, newHash, { schemeRekey = fals
   // collision. Same merge semantics as the V52 repair migration:
   // play_count sums, starred_at keeps the earliest, last_played the
   // latest, rating prefers the target row's.
+  // The Rust scanner's port (rust-parser/src/main.rs migrate_hash_references)
+  // still merges only the four original columns — see the follow-up noted in
+  // the V70 change.
   let metadata = 0;
   for (const o of db.prepare(
     'SELECT * FROM user_metadata WHERE track_hash = ?').all(oldHash)) {
@@ -64,12 +67,18 @@ export function migrateHashReferences(db, oldHash, newHash, { schemeRekey = fals
     } else {
       const minNonNull = (a, b) => (a == null) ? b : (b == null) ? a : (a < b ? a : b);
       const maxNonNull = (a, b) => (a == null) ? b : (b == null) ? a : (a > b ? a : b);
+      // V70 counters follow the same shape: skips and listened time sum
+      // (every play happened), first_played keeps the earliest.
       db.prepare(`UPDATE user_metadata SET play_count = ?, starred_at = ?,
-                  last_played = ?, rating = ? WHERE user_id = ? AND track_hash = ?`)
+                  last_played = ?, rating = ?, skip_count = ?, listened_ms = ?,
+                  first_played = ? WHERE user_id = ? AND track_hash = ?`)
         .run((n.play_count || 0) + (o.play_count || 0),
           minNonNull(n.starred_at, o.starred_at),
           maxNonNull(n.last_played, o.last_played),
           n.rating ?? o.rating,
+          (n.skip_count || 0) + (o.skip_count || 0),
+          (n.listened_ms || 0) + (o.listened_ms || 0),
+          minNonNull(n.first_played, o.first_played),
           o.user_id, newHash);
       db.prepare('DELETE FROM user_metadata WHERE user_id = ? AND track_hash = ?')
         .run(o.user_id, oldHash);

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -84,7 +84,7 @@ import { HASH_GENERATION } from './audio-hash.js';
 // V69 drops the velvet-only tables (smart_playlists, user_settings,
 // cue_points, play_events) and users.listenbrainz_token — the velvet UI and
 // the API modules that existed only for it were removed. See SCHEMA_V69.
-export const SCHEMA_VERSION = 69;
+export const SCHEMA_VERSION = 70;
 
 export const SCHEMA_V1 = `
   -- Users
@@ -2506,6 +2506,75 @@ export const SCHEMA_V69 = `
   ALTER TABLE users DROP COLUMN listenbrainz_token;
 `;
 
+// ── V70: Stats API v2 — the listening log, reborn ──────────────────────────
+//
+// V69 dropped the velvet-era play_events (server-stamped time, no track
+// identity beyond a filepath, no ceiling). This is its replacement, shaped
+// for clients that report COMPLETE plays after the fact:
+//   event_id     the client's UUID — the idempotency key an offline outbox
+//                retries against (INSERT OR IGNORE; see src/stats/store.js)
+//   track_hash   the canonical per-track key (audio_hash, else file_hash —
+//                the same key user_metadata uses), resolved at ingest, so a
+//                rename never orphans a play; filepath + library_id are a
+//                snapshot for display and library scoping
+//   peer_id      set for a play of a federated peer's track — the user's
+//                own play of a track that lives elsewhere; snapshot then
+//                carries the peer-reported title/artist/album/hash/art,
+//                because this library has no row to join
+//   counted      the server's verdict under the play-threshold rule at
+//                ingest time, stored so the rule can change later without
+//                rewriting history; play_count only ever moves by counted
+//   started_at   the CLIENT's start time, UTC, as 'YYYY-MM-DD HH:MM:SS.SSS'
+//                — SQLite's own datetime text (strftime()/date() read it,
+//                TEXT comparison orders it) with milliseconds
+// user_hour_stats is the per-user UTC-hour rollup every time-series read
+// comes from: exact re-bucketing for any whole-hour timezone, and the part
+// of the history that survives when raw events are pruned by retention.
+// user_metadata grows the derived per-track counters (skips, listened time,
+// first play) next to the play_count / last_played it already had — all
+// bumped in the same transaction as the event insert, never recomputed
+// from a scan. Forward-only, no rescan.
+export const SCHEMA_V70 = `
+  CREATE TABLE IF NOT EXISTS play_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    track_hash TEXT,
+    filepath TEXT NOT NULL,
+    library_id INTEGER REFERENCES libraries(id) ON DELETE SET NULL,
+    peer_id INTEGER REFERENCES federation_peers(id) ON DELETE SET NULL,
+    snapshot TEXT,
+    client TEXT,
+    session_id TEXT,
+    source TEXT,
+    outcome TEXT NOT NULL CHECK (outcome IN ('completed', 'skipped', 'stopped')),
+    counted INTEGER NOT NULL DEFAULT 0,
+    played_ms INTEGER NOT NULL DEFAULT 0,
+    duration_ms INTEGER,
+    pause_count INTEGER NOT NULL DEFAULT 0,
+    started_at TEXT NOT NULL,
+    ended_at TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_play_events_user_time ON play_events(user_id, started_at);
+  CREATE INDEX IF NOT EXISTS idx_play_events_user_hash ON play_events(user_id, track_hash);
+  CREATE INDEX IF NOT EXISTS idx_play_events_library ON play_events(library_id);
+  CREATE INDEX IF NOT EXISTS idx_play_events_peer ON play_events(peer_id);
+
+  CREATE TABLE IF NOT EXISTS user_hour_stats (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    hour TEXT NOT NULL,
+    events INTEGER NOT NULL DEFAULT 0,
+    plays INTEGER NOT NULL DEFAULT 0,
+    skips INTEGER NOT NULL DEFAULT 0,
+    listened_ms INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, hour)
+  );
+
+  ALTER TABLE user_metadata ADD COLUMN skip_count INTEGER NOT NULL DEFAULT 0;
+  ALTER TABLE user_metadata ADD COLUMN listened_ms INTEGER NOT NULL DEFAULT 0;
+  ALTER TABLE user_metadata ADD COLUMN first_played TEXT;
+`;
+
 export const SCHEMA_V58 = `
   ALTER TABLE federation_peers ADD COLUMN use_discovery INTEGER NOT NULL DEFAULT 1;
 `;
@@ -2903,4 +2972,6 @@ export const MIGRATIONS = [
   // V69 drops the velvet-only tables + users.listenbrainz_token. Pure
   // DROP TABLE / DROP COLUMN, no rescan. See SCHEMA_V69.
   { version: 69, sql: SCHEMA_V69 },
+  // Stats API v2 tables — see SCHEMA_V70.
+  { version: 70, sql: SCHEMA_V70 },
 ];

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ import { dataRoot, usingFallbackDataRoot } from './util/esm-helpers.js';
 import { installedPlayerPath, playerLoadableHere } from './util/mstream-player-bootstrap.js';
 
 import * as dbApi from './api/db.js';
+import * as statsApi from './api/stats.js';
 import * as discoveryApi from './api/discovery.js';
 import * as searchApi from './api/search.js';
 import * as randomApi from './api/random.js';
@@ -557,6 +558,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   discoveryP2pApi.setup(mstream);
   discoveryFederationApi.setup(mstream);
   dbApi.setup(mstream);
+  statsApi.setup(mstream);
   searchApi.setup(mstream);
   randomApi.setup(mstream);
   playlistApi.setup(mstream);

--- a/src/state/config.js
+++ b/src/state/config.js
@@ -378,6 +378,18 @@ const rpnOptions = Joi.object({
   url: Joi.string().optional()
 });
 
+// Listening stats (Stats API v2). What counts as a play, and how far back a
+// client may report one. Clients send complete plays to POST
+// /api/v1/stats/plays; the server judges each against these, stores the
+// verdict on the row, and only counted plays move play_count. The sweep that
+// prunes raw events past retentionMonths is a separate job; ingest already
+// refuses anything older, so the log's age is bounded from the first row.
+const statsOptions = Joi.object({
+  playThresholdMs: Joi.number().integer().min(0).default(30000),
+  playThresholdFraction: Joi.number().min(0).max(1).default(0.5),
+  retentionMonths: Joi.number().integer().min(0).default(24)
+});
+
 const lastFMOptions = Joi.object({
   apiKey: Joi.string().default('25627de528b6603d6471cd331ac819e0'),
   apiSecret: Joi.string().default('a9df934fc504174d4cb68853d9feb143')
@@ -694,6 +706,7 @@ const schema = Joi.object({
     "opus": true, "m3u": false
   }),
   lastFM: lastFMOptions.default(lastFMOptions.validate({}).value),
+  stats: statsOptions.default(statsOptions.validate({}).value),
   scanOptions: scanOptions.default(scanOptions.validate({}).value),
   noUpload: Joi.boolean().default(false),
   noMkdir: Joi.boolean().default(false),

--- a/src/stats/ingest.js
+++ b/src/stats/ingest.js
@@ -1,0 +1,212 @@
+// Stats API v2 — the ingest core.
+//
+// Clients report COMPLETE plays after the fact; the server decides what
+// counts. One batch in, three lists out:
+//   accepted    stored; counters and the hourly rollup bumped
+//   duplicates  an id this user already sent — acknowledged, nothing moved.
+//               This is what makes an offline outbox safe to retry forever.
+//   rejected    { id, reason } — the client should drop the play:
+//               unknown-track  the path names no scanned track in a library
+//                              this user can see
+//               unknown-peer   peerId is not a peer this server lists
+//               bad-time       startedAt / endedAt unparsable, more than five
+//                              minutes ahead of the server clock, or older
+//                              than the retention window
+//               invalid        a peer play without its snapshot, or an id
+//                              another user already owns
+//
+// The write itself is src/stats/store.js (recordPlayEvent), the one path
+// every writer shares; this module resolves, judges and batches. The library
+// resolver is injectable so the whole thing runs on an in-memory database in
+// tests — the default goes through getVPathInfo, which needs the live
+// manager.
+
+import * as db from '../db/manager.js';
+import { getVPathInfo } from '../util/vpath.js';
+import { recordPlayEvent } from './store.js';
+import { fromSqlite } from './time.js';
+
+export const REASONS = Object.freeze({
+  unknownTrack: 'unknown-track',
+  unknownPeer: 'unknown-peer',
+  badTime: 'bad-time',
+  invalid: 'invalid',
+});
+
+export const MAX_BATCH = 200;
+export const FUTURE_SKEW_MS = 5 * 60 * 1000;
+export const DEFAULTS = Object.freeze({
+  playThresholdMs: 30000,
+  playThresholdFraction: 0.5,
+  retentionMonths: 24,
+});
+
+// The play-threshold rule: at least playThresholdMs listened, or at least
+// playThresholdFraction of a known duration. The verdict is stored on the
+// row, so changing the config later never rewrites history.
+export function decideCounted(playedMs, durationMs, cfg = DEFAULTS) {
+  const thresholdMs = cfg?.playThresholdMs ?? DEFAULTS.playThresholdMs;
+  const fraction = cfg?.playThresholdFraction ?? DEFAULTS.playThresholdFraction;
+  if (!Number.isInteger(playedMs) || playedMs < 0) { return false; }
+  if (playedMs >= thresholdMs) { return true; }
+  if (Number.isInteger(durationMs) && durationMs > 0 && fraction > 0) {
+    return playedMs >= durationMs * fraction;
+  }
+  return false;
+}
+
+// A client instant: ISO 8601, the stored SQLite text, or epoch milliseconds.
+export function parseInstant(v) {
+  if (v instanceof Date) { return Number.isNaN(v.getTime()) ? null : v; }
+  if (Number.isInteger(v)) { return v >= 0 ? new Date(v) : null; }
+  if (typeof v === 'string' && v.length > 0) {
+    const d = fromSqlite(v) || new Date(v);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+// The oldest start still accepted: retentionMonths back from now, to the
+// hour, or 2000-01-01 when retention is off.
+export function retentionFloor(now, retentionMonths) {
+  if (!(retentionMonths > 0)) { return new Date(Date.UTC(2000, 0, 1)); }
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - retentionMonths,
+    now.getUTCDate(), now.getUTCHours()));
+}
+
+// The start instant, or null when it is unparsable, more than futureSkewMs
+// ahead of the server clock, or before the retention floor.
+export function checkStartedAt(value, {
+  now = new Date(), retentionMonths = DEFAULTS.retentionMonths, futureSkewMs = FUTURE_SKEW_MS,
+} = {}) {
+  const d = parseInstant(value);
+  if (!d) { return null; }
+  if (d.getTime() > now.getTime() + futureSkewMs) { return null; }
+  if (d.getTime() < retentionFloor(now, retentionMonths).getTime()) { return null; }
+  return d;
+}
+
+const stripSlash = (p) => (typeof p === 'string' && p.startsWith('/') ? p.slice(1) : p);
+
+// A scanned track by (library, relative path): the canonical key (audio
+// hash, else file hash), the library id, the path, and the library's own
+// duration for when the client sent none. A row with no hash at all (a
+// failed parse) resolves with trackHash null — the event is kept for
+// history, but there is no counter row to bump.
+export function lookupTrack(d, libraryId, relativePath) {
+  const row = d.prepare('SELECT audio_hash, file_hash, duration FROM tracks WHERE filepath = ? AND library_id = ?')
+    .get(relativePath, libraryId);
+  if (!row) { return null; }
+  return {
+    trackHash: row.audio_hash || row.file_hash || null,
+    libraryId,
+    filepath: relativePath,
+    durationMs: typeof row.duration === 'number' && row.duration > 0 ? Math.round(row.duration * 1000) : null,
+  };
+}
+
+// The production resolver: a vpath-prefixed path, scoped to the user's
+// libraries by getVPathInfo (which also refuses dot-segments).
+export function resolveLocalTrack(d, filePath, user) {
+  let info;
+  try { info = getVPathInfo(filePath, user); } catch (_) { return null; }
+  const lib = db.getLibraryByName(info.vpath);
+  if (!lib) { return null; }
+  return lookupTrack(d, lib.id, info.relativePath);
+}
+
+// Ingest one validated batch for [user]. Rejections are per play; the
+// accepted plays commit together, so a database failure rolls the whole
+// batch back and throws. Options: config (the `stats` block), now, peers
+// (this server's federation_peers rows), client (stored on every row),
+// resolveLocal (injectable for tests).
+export function ingestPlays(d, user, body, {
+  config = DEFAULTS, now = new Date(), peers = [], client = null, resolveLocal = resolveLocalTrack,
+} = {}) {
+  const accepted = [];
+  const duplicates = [];
+  const rejected = [];
+  const seen = new Set();
+  const prepared = [];
+  const retentionMonths = config?.retentionMonths ?? DEFAULTS.retentionMonths;
+
+  for (const play of body?.plays || []) {
+    const id = play.id;
+    if (seen.has(id)) { duplicates.push(id); continue; }
+    seen.add(id);
+
+    const startedAt = checkStartedAt(play.startedAt, { now, retentionMonths });
+    if (!startedAt) { rejected.push({ id, reason: REASONS.badTime }); continue; }
+    let endedAt = null;
+    if (play.endedAt != null) {
+      endedAt = parseInstant(play.endedAt);
+      if (!endedAt) { rejected.push({ id, reason: REASONS.badTime }); continue; }
+    }
+    if (!endedAt || endedAt < startedAt) {
+      endedAt = new Date(startedAt.getTime() + (play.playedMs || 0));
+    }
+
+    let track;
+    if (play.peerId != null) {
+      if (!peers.some((p) => p.id === play.peerId)) { rejected.push({ id, reason: REASONS.unknownPeer }); continue; }
+      if (!play.track || typeof play.track !== 'object') { rejected.push({ id, reason: REASONS.invalid }); continue; }
+      const snap = play.track;
+      track = {
+        trackHash: typeof snap.hash === 'string' && snap.hash.length > 0 ? snap.hash : null,
+        libraryId: null,
+        peerId: play.peerId,
+        filepath: stripSlash(play.filePath),
+        snapshot: snap,
+        durationMs: play.durationMs ?? (Number.isInteger(snap.durationMs) ? snap.durationMs : null),
+      };
+    } else {
+      const t = resolveLocal(d, play.filePath, user);
+      if (!t) { rejected.push({ id, reason: REASONS.unknownTrack }); continue; }
+      track = { ...t, peerId: null, snapshot: null, durationMs: play.durationMs ?? t.durationMs ?? null };
+    }
+
+    prepared.push({
+      id,
+      event: {
+        eventId: id,
+        userId: user.id,
+        trackHash: track.trackHash,
+        filepath: track.filepath,
+        libraryId: track.libraryId,
+        peerId: track.peerId,
+        snapshot: track.snapshot,
+        client,
+        sessionId: play.sessionId ?? null,
+        source: play.source ?? null,
+        outcome: play.outcome,
+        counted: decideCounted(play.playedMs, track.durationMs, config),
+        playedMs: play.playedMs,
+        durationMs: track.durationMs,
+        pauseCount: play.pauseCount ?? 0,
+        startedAt,
+        endedAt,
+      },
+    });
+  }
+
+  if (prepared.length > 0) {
+    d.exec('BEGIN IMMEDIATE');
+    try {
+      const owner = d.prepare('SELECT user_id FROM play_events WHERE event_id = ?');
+      for (const { id, event } of prepared) {
+        const existing = owner.get(id);
+        if (existing) {
+          if (existing.user_id === user.id) { duplicates.push(id); } else { rejected.push({ id, reason: REASONS.invalid }); }
+          continue;
+        }
+        recordPlayEvent(d, event);
+        accepted.push(id);
+      }
+      d.exec('COMMIT');
+    } catch (err) {
+      try { d.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
+      throw err;
+    }
+  }
+  return { accepted, duplicates, rejected };
+}

--- a/src/stats/store.js
+++ b/src/stats/store.js
@@ -1,0 +1,160 @@
+// The one write path into the listening log.
+//
+// Every writer — the Stats API v2 ingest route, the legacy scrobble shim,
+// test seeding — records a play through here, so the three stores can never
+// disagree:
+//   play_events      the event itself; its client id is the idempotency key
+//   user_hour_stats  the per-user UTC-hour rollup the time-series reads
+//   user_metadata    the per-track counters every metadata join surfaces
+// Takes the DB handle explicitly (node:sqlite, or the Bun adapter — the same
+// prepare().run() surface) so db tests can drive it on an in-memory database.
+//
+// Resolution — a filePath into a track_hash + library_id, a peer id into a
+// peer row, the play-threshold verdict — is the INGEST route's job. This
+// module trusts a fully-resolved event and only guarantees the bookkeeping.
+
+import { toSqlite, fromSqlite, hourKey } from './time.js';
+
+export const OUTCOMES = new Set(['completed', 'skipped', 'stopped']);
+export const SOURCES = new Set(['manual', 'shuffle', 'autodj', 'playlist',
+  'smart-playlist', 'auto', 'carplay', 'cast', 'legacy', 'other']);
+const SNAPSHOT_KEYS = new Set(['title', 'artist', 'album', 'durationMs', 'hash', 'artFile']);
+
+const isInt = (v) => Number.isInteger(v);
+
+function asStoredTime(value, name) {
+  if (value instanceof Date) { return toSqlite(value); }
+  if (typeof value === 'string') {
+    const d = fromSqlite(value) || new Date(value);
+    if (!Number.isNaN(d.getTime())) { return toSqlite(d); }
+  }
+  if (isInt(value)) { return toSqlite(new Date(value)); }
+  throw new TypeError(`${name} must be a Date, epoch ms, or a datetime string`);
+}
+
+// Validate + shape one event into a play_events row. Throws TypeError on a
+// contract violation — callers that take client input validate first (Joi)
+// and treat this as a programming-error backstop.
+export function normalizeEvent(ev) {
+  if (!ev || typeof ev !== 'object') { throw new TypeError('event must be an object'); }
+  const {
+    eventId, userId, trackHash = null, filepath, libraryId = null, peerId = null,
+    snapshot = null, client = null, sessionId = null, source = null, outcome,
+    counted = false, playedMs = 0, durationMs = null, pauseCount = 0, startedAt, endedAt = null,
+  } = ev;
+  if (typeof eventId !== 'string' || eventId.length === 0 || eventId.length > 128) { throw new TypeError('eventId'); }
+  if (!isInt(userId) || userId <= 0) { throw new TypeError('userId'); }
+  if (trackHash != null && typeof trackHash !== 'string') { throw new TypeError('trackHash'); }
+  if (typeof filepath !== 'string') { throw new TypeError('filepath'); }
+  if (libraryId != null && !isInt(libraryId)) { throw new TypeError('libraryId'); }
+  if (peerId != null && !isInt(peerId)) { throw new TypeError('peerId'); }
+  if (!OUTCOMES.has(outcome)) { throw new TypeError('outcome'); }
+  if (source != null && !SOURCES.has(source)) { throw new TypeError('source'); }
+  if (!isInt(playedMs) || playedMs < 0) { throw new TypeError('playedMs'); }
+  if (durationMs != null && (!isInt(durationMs) || durationMs < 0)) { throw new TypeError('durationMs'); }
+  if (!isInt(pauseCount) || pauseCount < 0) { throw new TypeError('pauseCount'); }
+  let snapshotJson = null;
+  if (snapshot != null) {
+    if (typeof snapshot !== 'object') { throw new TypeError('snapshot'); }
+    const clean = {};
+    for (const k of Object.keys(snapshot)) {
+      if (SNAPSHOT_KEYS.has(k) && snapshot[k] != null) { clean[k] = snapshot[k]; }
+    }
+    snapshotJson = JSON.stringify(clean);
+  }
+  return {
+    event_id: eventId,
+    user_id: userId,
+    track_hash: trackHash,
+    filepath,
+    library_id: libraryId,
+    peer_id: peerId,
+    snapshot: snapshotJson,
+    client: client == null ? null : String(client).slice(0, 128),
+    session_id: sessionId == null ? null : String(sessionId).slice(0, 128),
+    source,
+    outcome,
+    counted: counted ? 1 : 0,
+    played_ms: playedMs,
+    duration_ms: durationMs,
+    pause_count: pauseCount,
+    started_at: asStoredTime(startedAt, 'startedAt'),
+    ended_at: endedAt == null ? null : asStoredTime(endedAt, 'endedAt'),
+  };
+}
+
+const INSERT_EVENT = `
+  INSERT OR IGNORE INTO play_events
+    (event_id, user_id, track_hash, filepath, library_id, peer_id, snapshot, client,
+     session_id, source, outcome, counted, played_ms, duration_ms, pause_count, started_at, ended_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+const BUMP_HOUR = `
+  INSERT INTO user_hour_stats (user_id, hour, events, plays, skips, listened_ms)
+  VALUES (?, ?, 1, ?, ?, ?)
+  ON CONFLICT (user_id, hour) DO UPDATE SET
+    events = events + 1,
+    plays = plays + excluded.plays,
+    skips = skips + excluded.skips,
+    listened_ms = listened_ms + excluded.listened_ms`;
+
+// last_played / first_played move only on a COUNTED play — a two-second
+// skip is not "the last time I played this". Listened time and skips
+// accumulate for every event. MAX/MIN over the stored text is exact: one
+// format, lexicographically ordered.
+const BUMP_TRACK = `
+  INSERT INTO user_metadata (user_id, track_hash, play_count, last_played, first_played, listened_ms, skip_count)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT (user_id, track_hash) DO UPDATE SET
+    play_count = play_count + excluded.play_count,
+    last_played = CASE WHEN excluded.play_count > 0
+                       THEN MAX(COALESCE(last_played, ''), excluded.last_played)
+                       ELSE last_played END,
+    first_played = CASE WHEN excluded.play_count > 0
+                        THEN MIN(COALESCE(first_played, excluded.first_played), excluded.first_played)
+                        ELSE first_played END,
+    listened_ms = listened_ms + excluded.listened_ms,
+    skip_count = skip_count + excluded.skip_count`;
+
+// Insert one event and bump the derived stores. True when the row was new;
+// false when event_id already existed, in which case NOTHING else moves —
+// that is what makes an outbox replay safe. Not transactional on its own:
+// wrap a batch in recordPlayEvents (or manager.transaction) so a mid-batch
+// failure can't leave an event without its rollup.
+export function recordPlayEvent(d, ev) {
+  const row = normalizeEvent(ev);
+  const r = d.prepare(INSERT_EVENT).run(
+    row.event_id, row.user_id, row.track_hash, row.filepath, row.library_id, row.peer_id,
+    row.snapshot, row.client, row.session_id, row.source, row.outcome, row.counted,
+    row.played_ms, row.duration_ms, row.pause_count, row.started_at, row.ended_at);
+  if (Number(r.changes) === 0) { return false; }
+  const skipped = row.outcome === 'skipped' ? 1 : 0;
+  d.prepare(BUMP_HOUR).run(row.user_id, hourKey(fromSqlite(row.started_at)), row.counted, skipped, row.played_ms);
+  if (row.track_hash) {
+    const when = row.counted ? row.started_at : null;
+    d.prepare(BUMP_TRACK).run(row.user_id, row.track_hash, row.counted, when, when, row.played_ms, skipped);
+  }
+  return true;
+}
+
+// Record a batch atomically. Returns { inserted, duplicates }. Pass
+// transactional:false from inside an outer transaction (manager.transaction).
+export function recordPlayEvents(d, events, { transactional = true } = {}) {
+  let inserted = 0;
+  let duplicates = 0;
+  const run = () => {
+    for (const ev of events) {
+      if (recordPlayEvent(d, ev)) { inserted++; } else { duplicates++; }
+    }
+  };
+  if (!transactional) { run(); return { inserted, duplicates }; }
+  d.exec('BEGIN IMMEDIATE');
+  try {
+    run();
+    d.exec('COMMIT');
+  } catch (err) {
+    try { d.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
+    throw err;
+  }
+  return { inserted, duplicates };
+}

--- a/src/stats/time.js
+++ b/src/stats/time.js
@@ -1,0 +1,219 @@
+// Period and timezone arithmetic for the stats API (src/api/stats.js).
+//
+// Every bound the API hands to SQL is computed here, in the CALLER's IANA
+// timezone, and rendered in the one text format play_events.started_at and
+// user_hour_stats.hour use — so "this month" is the caller's month, not the
+// server's, and TEXT comparison against the stored rows is exact. This
+// replaces the wrapped-era bug class: bounds built in server-local time and
+// compared as ISO 'T' strings against SQLite's space-separated text, which
+// silently dropped every play made on a period's first day.
+//
+// Pure — no DB, no config. Unit-tested in test/unit/stats-time.test.mjs.
+
+const PERIODS = new Set(['week', 'month', 'quarter', 'half', 'year', 'all']);
+export function isPeriod(p) { return PERIODS.has(p); }
+
+const BUCKETS = new Set(['hour', 'day', 'week', 'month', 'hourOfDay', 'weekday']);
+export function isBucket(b) { return BUCKETS.has(b); }
+
+// One formatter per zone: Intl.DateTimeFormat construction is the expensive
+// part (the 2026-07 audit's 8.4 s hour loop was a fresh formatter per row).
+const fmtCache = new Map();
+function formatter(tz) {
+  let f = fmtCache.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hourCycle: 'h23',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      weekday: 'short',
+    });
+    fmtCache.set(tz, f);
+  }
+  return f;
+}
+
+export function isValidTimeZone(tz) {
+  if (typeof tz !== 'string' || tz.length === 0 || tz.length > 64) { return false; }
+  try { formatter(tz); return true; } catch (_) { return false; }
+}
+
+const WEEKDAYS = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+
+// Wall-clock parts of [date] in [tz]. month is 1-12; weekday 0 = Sunday.
+export function zonedParts(date, tz) {
+  const out = {};
+  for (const { type, value } of formatter(tz).formatToParts(date)) {
+    switch (type) {
+      case 'year': out.year = Number(value); break;
+      case 'month': out.month = Number(value); break;
+      case 'day': out.day = Number(value); break;
+      case 'hour': out.hour = Number(value); break;
+      case 'minute': out.minute = Number(value); break;
+      case 'second': out.second = Number(value); break;
+      case 'weekday': out.weekday = WEEKDAYS[value]; break;
+      default: break;
+    }
+  }
+  return out;
+}
+
+// The instant at which the wall clock in [tz] reads [parts] (month 1-12).
+// Two-pass offset solve: guess the UTC instant with the same digits, read
+// the zone's wall clock back at that guess, correct by the difference, and
+// check once more so a DST-edge guess settles. A wall time inside a
+// spring-forward gap (one that never happens on the clock) resolves to a
+// nearby instant; period bounds are midnights, which no supported zone
+// skips, so callers never land there in practice.
+export function zonedToUtc({ year, month, day = 1, hour = 0, minute = 0, second = 0 }, tz) {
+  const wanted = Date.UTC(year, month - 1, day, hour, minute, second);
+  let guess = wanted;
+  for (let i = 0; i < 2; i++) {
+    const p = zonedParts(new Date(guess), tz);
+    const seen = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+    const diff = seen - wanted;
+    if (diff === 0) { break; }
+    guess -= diff;
+  }
+  return new Date(guess);
+}
+
+// ── Stored text formats ──────────────────────────────────────────────────
+// play_events.started_at / ended_at: 'YYYY-MM-DD HH:MM:SS.SSS', UTC.
+// user_hour_stats.hour: 'YYYY-MM-DDTHH', UTC.
+const pad = (n, w = 2) => String(n).padStart(w, '0');
+
+export function toSqlite(value) {
+  const d = value instanceof Date ? value : new Date(value);
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} `
+    + `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`
+    + `.${pad(d.getUTCMilliseconds(), 3)}`;
+}
+
+// Reads the stored shape with or without milliseconds — datetime('now')
+// rows elsewhere in the schema have none — and tolerates a 'T' separator
+// and a trailing 'Z'. Null for anything else.
+export function fromSqlite(text) {
+  if (text == null) { return null; }
+  const m = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z?$/.exec(String(text));
+  if (!m) { return null; }
+  const ms = m[7] ? Number(m[7].padEnd(3, '0')) : 0;
+  const d = new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6], ms));
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function toIso(value) {
+  const d = value instanceof Date ? value : fromSqlite(value);
+  return d ? d.toISOString() : null;
+}
+
+export function hourKey(value) {
+  const d = value instanceof Date ? value : new Date(value);
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}T${pad(d.getUTCHours())}`;
+}
+
+export function fromHourKey(key) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})$/.exec(String(key));
+  return m ? new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4])) : null;
+}
+
+export const isoDate = (d) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+
+// ── Periods ──────────────────────────────────────────────────────────────
+const daysSinceMonday = (weekday) => (weekday + 6) % 7;
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
+  'August', 'September', 'October', 'November', 'December'];
+
+function periodLabel(period, startWall) {
+  const y = startWall.getUTCFullYear();
+  const m = startWall.getUTCMonth();
+  switch (period) {
+    case 'month': return `${MONTHS[m]} ${y}`;
+    case 'quarter': return `Q${Math.floor(m / 3) + 1} ${y}`;
+    case 'half': return `H${m < 6 ? 1 : 2} ${y}`;
+    case 'year': return String(y);
+    default: return '';
+  }
+}
+
+// [from, to) for a preset period in [tz], shifted by [offset] whole periods
+// (0 = the one containing [now], -1 = the previous, …). Bounds are local
+// midnights; weeks start on Monday. 'all' is an open range from 2000.
+export function periodRange({ period, offset = 0, tz = 'UTC', now = new Date() }) {
+  if (!isPeriod(period)) { throw new RangeError(`unknown period '${period}'`); }
+  if (period === 'all') {
+    return {
+      from: new Date(Date.UTC(2000, 0, 1)),
+      to: new Date(now.getTime() + 86_400_000),
+      label: 'All time',
+    };
+  }
+  const p = zonedParts(now, tz);
+  const wall = (d) => zonedToUtc({ year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() }, tz);
+
+  if (period === 'week') {
+    // Wall dates as UTC-midnight Dates so day arithmetic normalises itself.
+    const start = new Date(Date.UTC(p.year, p.month - 1, p.day - daysSinceMonday(p.weekday) + offset * 7));
+    const end = new Date(start.getTime() + 7 * 86_400_000);
+    return { from: wall(start), to: wall(end), label: `Week of ${isoDate(start)}` };
+  }
+
+  let months = 1;
+  let m = p.month;
+  switch (period) {
+    case 'quarter': months = 3; m -= (m - 1) % 3; break;
+    case 'half': months = 6; m = m <= 6 ? 1 : 7; break;
+    case 'year': months = 12; m = 1; break;
+    default: break;
+  }
+  const startWall = new Date(Date.UTC(p.year, m - 1 + offset * months, 1));
+  const endWall = new Date(Date.UTC(p.year, m - 1 + (offset + 1) * months, 1));
+  return { from: wall(startWall), to: wall(endWall), label: periodLabel(period, startWall) };
+}
+
+// An explicit [from, to) from two ISO instants.
+export function customRange(fromIso, toIso) {
+  const from = new Date(fromIso);
+  const to = new Date(toIso);
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    throw new RangeError('from/to must be ISO 8601 instants');
+  }
+  if (!(from < to)) { throw new RangeError('from must be before to'); }
+  return { from, to, label: `${isoDate(from)} to ${isoDate(to)}` };
+}
+
+// ── Re-bucketing the UTC-hour rollup into the caller's zone ──────────────
+// hour → 'YYYY-MM-DDTHH' local; day → 'YYYY-MM-DD'; week → the Monday's
+// 'YYYY-MM-DD'; month → 'YYYY-MM'; hourOfDay → '0'..'23'; weekday →
+// '0'..'6' with Sunday = 0. Null for a malformed key or unknown bucket.
+export function bucketKeyFor(hourKeyUtc, bucket, tz) {
+  const instant = fromHourKey(hourKeyUtc);
+  if (!instant || !isBucket(bucket)) { return null; }
+  const p = zonedParts(instant, tz);
+  switch (bucket) {
+    case 'hour': return `${p.year}-${pad(p.month)}-${pad(p.day)}T${pad(p.hour)}`;
+    case 'day': return `${p.year}-${pad(p.month)}-${pad(p.day)}`;
+    case 'week': return isoDate(new Date(Date.UTC(p.year, p.month - 1, p.day - daysSinceMonday(p.weekday))));
+    case 'month': return `${p.year}-${pad(p.month)}`;
+    case 'hourOfDay': return String(p.hour);
+    case 'weekday': return String(p.weekday);
+    default: return null;
+  }
+}
+
+// The local calendar day of an instant (or stored text), for streaks and
+// the top listening day.
+export function localDay(value, tz) {
+  const d = value instanceof Date ? value : fromSqlite(value);
+  if (!d) { return null; }
+  const p = zonedParts(d, tz);
+  return `${p.year}-${pad(p.month)}-${pad(p.day)}`;
+}
+
+// Day arithmetic on 'YYYY-MM-DD' keys (UTC-midnight Dates underneath).
+export function dayKeyPlus(dayKey, days) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dayKey));
+  if (!m) { return null; }
+  return isoDate(new Date(Date.UTC(+m[1], +m[2] - 1, +m[3] + days)));
+}

--- a/test/db/db-stats-ingest.test.mjs
+++ b/test/db/db-stats-ingest.test.mjs
@@ -1,0 +1,173 @@
+/**
+ * src/stats/ingest.js against a real V70 database (in-memory node:sqlite).
+ *
+ * Seeds two users, one library with three tracks (audio-hashed, file-hash
+ * only, hashless) and one federation peer, then drives ingestPlays with a
+ * resolver that mirrors getVPathInfo over the seeded library. Locks in:
+ *  - accepted plays land as events, hourly rollups and per-track counters,
+ *    with the verdict of the threshold rule stored on the row;
+ *  - the library's duration fills in when the client sent none;
+ *  - duplicates within a batch and across calls are acknowledged and inert;
+ *    an id another user owns is `invalid`;
+ *  - unknown paths, unknown peers, missing snapshots and out-of-window times
+ *    reject only their own play — the rest of the batch commits;
+ *  - a peer play stores its snapshot and keys counters on the reported hash;
+ *  - a hashless track keeps the event but moves no counter.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+import { ingestPlays, lookupTrack, REASONS } from '../../src/stats/ingest.js';
+
+const NOW = new Date('2026-09-09T12:00:00Z');
+
+function seed() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA recursive_triggers = ON');
+  applyAllMigrations(db);
+  const alice = Number(db.prepare("INSERT INTO users (username, password, salt) VALUES ('alice', 'h', 's')").run().lastInsertRowid);
+  const bob = Number(db.prepare("INSERT INTO users (username, password, salt) VALUES ('bob', 'h', 's')").run().lastInsertRowid);
+  const lib = Number(db.prepare("INSERT INTO libraries (name, root_path) VALUES ('music', '/srv/music')").run().lastInsertRowid);
+  const ins = db.prepare(`INSERT INTO tracks (filepath, library_id, title, file_hash, audio_hash, duration, modified, scan_id)
+                          VALUES (?, ?, ?, ?, ?, ?, 1, 'seed')`);
+  ins.run('Radiohead/Let Down.flac', lib, 'Let Down', 'fhA', 'ahA', 299.4);
+  ins.run('Portishead/Glory Box.mp3', lib, 'Glory Box', 'fhC', null, 302);
+  ins.run('broken.mp3', lib, 'Broken', '', null, null);
+  const peer = Number(db.prepare("INSERT INTO federation_peers (name, endpoint_ticket, api_key) VALUES ('Bob', 't', 'fedk_bob')").run().lastInsertRowid);
+  return { db, alice: { id: alice, vpaths: ['music'] }, bob: { id: bob, vpaths: ['music'] }, lib, peer };
+}
+
+// getVPathInfo's split over the seeded library, without the live manager.
+function resolver(d, filePath, user) {
+  const p = filePath.startsWith('/') ? filePath.slice(1) : filePath;
+  const [vpath, ...rest] = p.split('/');
+  if (user.vpaths && !user.vpaths.includes(vpath)) { return null; }
+  const lib = d.prepare('SELECT id FROM libraries WHERE name = ?').get(vpath);
+  return lib ? lookupTrack(d, lib.id, rest.join('/')) : null;
+}
+
+const play = (over = {}) => ({
+  id: 'p1', filePath: 'music/Radiohead/Let Down.flac', startedAt: '2026-09-09T11:00:00Z',
+  playedMs: 240000, outcome: 'completed', source: 'manual', pauseCount: 1, ...over,
+});
+
+function ingest(ctx, user, plays, extra = {}) {
+  return ingestPlays(ctx.db, user, { plays }, {
+    now: NOW, peers: [{ id: ctx.peer }], client: 'test/1', resolveLocal: resolver, ...extra,
+  });
+}
+
+describe('ingestPlays', () => {
+  test('a counted play: event, rollup, counters, verdict', () => {
+    const c = seed();
+    const r = ingest(c, c.alice, [play()]);
+    assert.deepEqual(r, { accepted: ['p1'], duplicates: [], rejected: [] });
+    const ev = c.db.prepare('SELECT * FROM play_events').get();
+    assert.equal(ev.track_hash, 'ahA');
+    assert.equal(ev.library_id, c.lib);
+    assert.equal(ev.filepath, 'Radiohead/Let Down.flac');
+    assert.equal(ev.counted, 1);
+    assert.equal(ev.duration_ms, 299400);          // the library's duration, client sent none
+    assert.equal(ev.started_at, '2026-09-09 11:00:00.000');
+    assert.equal(ev.ended_at, '2026-09-09 11:04:00.000'); // start + playedMs when the client sent none
+    assert.equal(ev.client, 'test/1');
+    assert.equal(ev.pause_count, 1);
+    const um = c.db.prepare('SELECT play_count, listened_ms, skip_count, first_played, last_played FROM user_metadata WHERE user_id = ? AND track_hash = ?').get(c.alice.id, 'ahA');
+    assert.deepEqual([um.play_count, um.listened_ms, um.skip_count], [1, 240000, 0]);
+    assert.equal(um.last_played, '2026-09-09 11:00:00.000');
+    const hour = c.db.prepare('SELECT * FROM user_hour_stats').get();
+    assert.deepEqual([hour.hour, hour.events, hour.plays], ['2026-09-09T11', 1, 1]);
+  });
+
+  test('the verdict follows the rule and the config; a short skip is kept but not counted', () => {
+    const c = seed();
+    const r = ingest(c, c.alice, [
+      play({ id: 'skip', outcome: 'skipped', playedMs: 8000 }),
+      play({ id: 'half', filePath: 'music/Portishead/Glory Box.mp3', playedMs: 151000 }), // half of 302 s
+      play({ id: 'low', playedMs: 12000 }),
+    ], { config: { playThresholdMs: 10000, playThresholdFraction: 0.5, retentionMonths: 24 } });
+    assert.deepEqual(r.accepted, ['skip', 'half', 'low']);
+    const counted = Object.fromEntries(c.db.prepare('SELECT event_id, counted FROM play_events').all().map((e) => [e.event_id, e.counted]));
+    assert.deepEqual(counted, { skip: 0, half: 1, low: 1 });
+    const um = c.db.prepare('SELECT play_count, skip_count, listened_ms FROM user_metadata WHERE track_hash = ?').get('ahA');
+    assert.deepEqual([um.play_count, um.skip_count, um.listened_ms], [1, 1, 20000]);
+    assert.equal(c.db.prepare('SELECT play_count FROM user_metadata WHERE track_hash = ?').get('fhC').play_count, 1);
+  });
+
+  test('duplicates: within the batch, across calls, and never for another user', () => {
+    const c = seed();
+    const first = ingest(c, c.alice, [play(), play({ playedMs: 1 })]);
+    assert.deepEqual(first, { accepted: ['p1'], duplicates: ['p1'], rejected: [] });
+    const again = ingest(c, c.alice, [play({ playedMs: 999 }), play({ id: 'p2' })]);
+    assert.deepEqual(again, { accepted: ['p2'], duplicates: ['p1'], rejected: [] });
+    const other = ingest(c, c.bob, [play()]);
+    assert.deepEqual(other, { accepted: [], duplicates: [], rejected: [{ id: 'p1', reason: REASONS.invalid }] });
+    assert.equal(c.db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n, 2);
+    assert.equal(c.db.prepare('SELECT play_count FROM user_metadata WHERE user_id = ? AND track_hash = ?').get(c.alice.id, 'ahA').play_count, 2);
+  });
+
+  test('rejections are per play; the rest of the batch commits', () => {
+    const c = seed();
+    const r = ingest(c, c.alice, [
+      play({ id: 'ok' }),
+      play({ id: 'nope', filePath: 'music/Nobody/Nothing.mp3' }),
+      play({ id: 'elsewhere', filePath: 'other/Let Down.flac' }),
+      play({ id: 'future', startedAt: '2026-09-09T12:06:00Z' }),
+      play({ id: 'ancient', startedAt: '2020-01-01T00:00:00Z' }),
+      play({ id: 'garbled', startedAt: 'yesterday' }),
+      play({ id: 'badend', endedAt: 'later' }),
+      play({ id: 'ghost', peerId: 999, track: { title: 'x' } }),
+      play({ id: 'blind', peerId: c.peer }),
+    ]);
+    assert.deepEqual(r.accepted, ['ok']);
+    assert.deepEqual(r.rejected, [
+      { id: 'nope', reason: REASONS.unknownTrack },
+      { id: 'elsewhere', reason: REASONS.unknownTrack },
+      { id: 'future', reason: REASONS.badTime },
+      { id: 'ancient', reason: REASONS.badTime },
+      { id: 'garbled', reason: REASONS.badTime },
+      { id: 'badend', reason: REASONS.badTime },
+      { id: 'ghost', reason: REASONS.unknownPeer },
+      { id: 'blind', reason: REASONS.invalid },
+    ]);
+    assert.equal(c.db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n, 1);
+  });
+
+  test("a peer's track: snapshot kept, counters keyed on the reported hash, no library", () => {
+    const c = seed();
+    const r = ingest(c, c.alice, [play({
+      id: 'peer1', filePath: '/music/Portishead/Glory Box.mp3', peerId: c.peer, playedMs: 200000,
+      track: { title: 'Glory Box', artist: 'Portishead', album: 'Dummy', durationMs: 302000, hash: 'peerhash', artFile: 'a.jpg', extra: 'dropped' },
+    })]);
+    assert.deepEqual(r.accepted, ['peer1']);
+    const ev = c.db.prepare('SELECT * FROM play_events').get();
+    assert.equal(ev.peer_id, c.peer);
+    assert.equal(ev.library_id, null);
+    assert.equal(ev.track_hash, 'peerhash');
+    assert.equal(ev.filepath, 'music/Portishead/Glory Box.mp3');
+    assert.equal(ev.duration_ms, 302000);
+    assert.deepEqual(JSON.parse(ev.snapshot), { title: 'Glory Box', artist: 'Portishead', album: 'Dummy', durationMs: 302000, hash: 'peerhash', artFile: 'a.jpg' });
+    assert.equal(c.db.prepare('SELECT play_count FROM user_metadata WHERE track_hash = ?').get('peerhash').play_count, 1);
+  });
+
+  test('a hashless track keeps the event and moves no counter', () => {
+    const c = seed();
+    const r = ingest(c, c.alice, [play({ id: 'h', filePath: 'music/broken.mp3' })]);
+    assert.deepEqual(r.accepted, ['h']);
+    const ev = c.db.prepare('SELECT track_hash, counted, duration_ms FROM play_events').get();
+    assert.equal(ev.track_hash, null);
+    assert.equal(ev.counted, 1);          // 240 s listened is a play, whatever the file is
+    assert.equal(ev.duration_ms, null);
+    assert.equal(c.db.prepare('SELECT COUNT(*) AS n FROM user_metadata').get().n, 0);
+    assert.equal(c.db.prepare('SELECT plays FROM user_hour_stats').get().plays, 1);
+  });
+
+  test('an empty or missing batch is a no-op', () => {
+    const c = seed();
+    assert.deepEqual(ingest(c, c.alice, []), { accepted: [], duplicates: [], rejected: [] });
+    assert.deepEqual(ingestPlays(c.db, c.alice, {}, { now: NOW }), { accepted: [], duplicates: [], rejected: [] });
+  });
+});

--- a/test/db/db-v70-stats-tables.test.mjs
+++ b/test/db/db-v70-stats-tables.test.mjs
@@ -1,0 +1,186 @@
+/**
+ * V70: the Stats API v2 tables, and the store primitive that writes them.
+ *
+ *  - a fresh database ends with the new play_events shape (V69 dropped the
+ *    velvet-era one), user_hour_stats, and the three user_metadata columns;
+ *  - recordPlayEvents inserts the event and bumps the hourly rollup and the
+ *    per-track counters in lock-step; last/first played move only on a
+ *    counted play; listened time and skips accumulate on every event;
+ *  - a replayed event id is a no-op end to end (the outbox contract);
+ *  - a federated play keeps its snapshot and survives the peer's deletion
+ *    (peer_id → NULL); a user's plays die with the user.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+
+import { SCHEMA_VERSION, MIGRATIONS } from '../../src/db/schema.js';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+import { recordPlayEvents, recordPlayEvent, normalizeEvent } from '../../src/stats/store.js';
+
+function freshDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA recursive_triggers = ON');
+  applyAllMigrations(db);
+  return db;
+}
+const columns = (db, table) => db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
+
+function seedUser(db, name = 'alice') {
+  return Number(db.prepare("INSERT INTO users (username, password, salt) VALUES (?, 'h', 's')").run(name).lastInsertRowid);
+}
+function seedPeer(db) {
+  return Number(db.prepare("INSERT INTO federation_peers (name, endpoint_ticket, api_key) VALUES ('Bob', 't', 'fedk_bob')").run().lastInsertRowid);
+}
+
+const base = (over = {}) => ({
+  eventId: 'e1', userId: 1, trackHash: 'ah1', filepath: 'Artist/song.flac', libraryId: null,
+  outcome: 'completed', counted: true, playedMs: 200_000, durationMs: 210_000,
+  startedAt: new Date('2026-09-04T19:04:00.500Z'), endedAt: new Date('2026-09-04T19:07:20.500Z'),
+  source: 'manual', client: 'mstream-music/0.36', sessionId: 's1', ...over,
+});
+
+describe('V70 stats tables', () => {
+  test('registered, no rescan, covered by SCHEMA_VERSION', () => {
+    const v70 = MIGRATIONS.find((m) => m.version === 70);
+    assert.ok(v70, 'missing v70 migration');
+    assert.match(v70.sql, /CREATE TABLE IF NOT EXISTS play_events/);
+    assert.match(v70.sql, /CREATE TABLE IF NOT EXISTS user_hour_stats/);
+    assert.ok(!v70.rescanRequired);
+    assert.ok(SCHEMA_VERSION >= 70);
+  });
+
+  test('a fresh database has the v2 shape', () => {
+    const db = freshDb();
+    const pe = columns(db, 'play_events');
+    for (const c of ['event_id', 'track_hash', 'peer_id', 'snapshot', 'client', 'counted', 'played_ms', 'duration_ms', 'started_at']) {
+      assert.ok(pe.includes(c), `play_events.${c}`);
+    }
+    assert.deepEqual(columns(db, 'user_hour_stats'), ['user_id', 'hour', 'events', 'plays', 'skips', 'listened_ms']);
+    const um = columns(db, 'user_metadata');
+    for (const c of ['skip_count', 'listened_ms', 'first_played']) { assert.ok(um.includes(c), `user_metadata.${c}`); }
+    const idx = db.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'play_events'").all().map((r) => r.name);
+    for (const i of ['idx_play_events_user_time', 'idx_play_events_user_hash', 'idx_play_events_library', 'idx_play_events_peer']) {
+      assert.ok(idx.includes(i), i);
+    }
+    db.close();
+  });
+});
+
+describe('recordPlayEvents', () => {
+  test('one counted play: event + rollup + counters, times stored as SQLite text', () => {
+    const db = freshDb();
+    const uid = seedUser(db);
+    const r = recordPlayEvents(db, [base({ userId: uid })]);
+    assert.deepEqual(r, { inserted: 1, duplicates: 0 });
+
+    const ev = db.prepare('SELECT * FROM play_events').get();
+    assert.equal(ev.started_at, '2026-09-04 19:04:00.500');
+    assert.equal(ev.ended_at, '2026-09-04 19:07:20.500');
+    assert.equal(ev.counted, 1);
+    assert.equal(ev.client, 'mstream-music/0.36');
+
+    const hour = db.prepare('SELECT * FROM user_hour_stats').get();
+    assert.equal(hour.hour, '2026-09-04T19');
+    assert.deepEqual([hour.events, hour.plays, hour.skips, hour.listened_ms], [1, 1, 0, 200_000]);
+
+    const um = db.prepare('SELECT * FROM user_metadata WHERE user_id = ? AND track_hash = ?').get(uid, 'ah1');
+    assert.deepEqual([um.play_count, um.skip_count, um.listened_ms], [1, 0, 200_000]);
+    assert.equal(um.first_played, '2026-09-04 19:04:00.500');
+    assert.equal(um.last_played, '2026-09-04 19:04:00.500');
+    db.close();
+  });
+
+  test('a skip that is not counted moves skips and listened time, never play_count or last_played', () => {
+    const db = freshDb();
+    const uid = seedUser(db);
+    recordPlayEvents(db, [
+      base({ userId: uid, eventId: 'e1', startedAt: '2026-09-01 10:00:00' }),
+      base({ userId: uid, eventId: 'e2', outcome: 'skipped', counted: false, playedMs: 8_000,
+        startedAt: '2026-09-02 10:00:00', endedAt: null }),
+    ]);
+    const um = db.prepare('SELECT * FROM user_metadata WHERE track_hash = ?').get('ah1');
+    assert.deepEqual([um.play_count, um.skip_count, um.listened_ms], [1, 1, 208_000]);
+    assert.equal(um.last_played, '2026-09-01 10:00:00.000');
+    assert.equal(um.first_played, '2026-09-01 10:00:00.000');
+    // node:sqlite rows are null-prototype objects; spread them for deepEqual.
+    const hours = db.prepare('SELECT hour, plays, skips FROM user_hour_stats ORDER BY hour').all().map((r) => ({ ...r }));
+    assert.deepEqual(hours, [
+      { hour: '2026-09-01T10', plays: 1, skips: 0 },
+      { hour: '2026-09-02T10', plays: 0, skips: 1 },
+    ]);
+    db.close();
+  });
+
+  test('first_played keeps the earliest, last_played the latest, whatever order plays arrive', () => {
+    const db = freshDb();
+    const uid = seedUser(db);
+    recordPlayEvents(db, [
+      base({ userId: uid, eventId: 'later', startedAt: '2026-09-03 10:00:00' }),
+      base({ userId: uid, eventId: 'earlier', startedAt: '2026-08-01 10:00:00' }),
+    ]);
+    const um = db.prepare('SELECT * FROM user_metadata WHERE track_hash = ?').get('ah1');
+    assert.equal(um.first_played, '2026-08-01 10:00:00.000');
+    assert.equal(um.last_played, '2026-09-03 10:00:00.000');
+    assert.equal(um.play_count, 2);
+    db.close();
+  });
+
+  test('a replayed event id is a complete no-op', () => {
+    const db = freshDb();
+    const uid = seedUser(db);
+    assert.equal(recordPlayEvent(db, base({ userId: uid })), true);
+    assert.equal(recordPlayEvent(db, base({ userId: uid, playedMs: 999 })), false);
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n, 1);
+    assert.equal(db.prepare('SELECT plays FROM user_hour_stats').get().plays, 1);
+    assert.equal(db.prepare('SELECT play_count FROM user_metadata').get().play_count, 1);
+    const again = recordPlayEvents(db, [base({ userId: uid }), base({ userId: uid, eventId: 'e2' })]);
+    assert.deepEqual(again, { inserted: 1, duplicates: 1 });
+    db.close();
+  });
+
+  test('a bad event in a batch rolls the whole batch back', () => {
+    const db = freshDb();
+    const uid = seedUser(db);
+    assert.throws(() => recordPlayEvents(db, [base({ userId: uid }), base({ userId: uid, eventId: 'e2', outcome: 'vanished' })]), TypeError);
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n, 0);
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_hour_stats').get().n, 0);
+    db.close();
+  });
+
+  test('a federated play keeps its snapshot and outlives the peer row', () => {
+    const db = freshDb();
+    const uid = seedUser(db);
+    const peer = seedPeer(db);
+    recordPlayEvents(db, [base({
+      userId: uid, eventId: 'p1', peerId: peer, trackHash: 'peerhash', filepath: 'music/x.flac',
+      snapshot: { title: 'Peer Song', artist: 'Peer Artist', album: 'Peer Album', hash: 'peerhash', secret: 'dropped' },
+    })]);
+    const ev = db.prepare('SELECT peer_id, snapshot FROM play_events').get();
+    assert.equal(ev.peer_id, peer);
+    assert.deepEqual(JSON.parse(ev.snapshot), { title: 'Peer Song', artist: 'Peer Artist', album: 'Peer Album', hash: 'peerhash' });
+    db.prepare('DELETE FROM federation_peers WHERE id = ?').run(peer);
+    assert.equal(db.prepare('SELECT peer_id FROM play_events').get().peer_id, null);
+    db.close();
+  });
+
+  test("a user's plays and rollups die with the user", () => {
+    const db = freshDb();
+    const uid = seedUser(db);
+    recordPlayEvents(db, [base({ userId: uid })]);
+    db.prepare('DELETE FROM users WHERE id = ?').run(uid);
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n, 0);
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_hour_stats').get().n, 0);
+    db.close();
+  });
+
+  test('normalizeEvent rejects contract violations', () => {
+    assert.throws(() => normalizeEvent(base({ eventId: '' })), TypeError);
+    assert.throws(() => normalizeEvent(base({ playedMs: -1 })), TypeError);
+    assert.throws(() => normalizeEvent(base({ source: 'radio' })), TypeError);
+    assert.throws(() => normalizeEvent(base({ startedAt: 'not a time' })), TypeError);
+    assert.equal(normalizeEvent(base({ startedAt: Date.UTC(2026, 8, 4, 19, 4) })).started_at, '2026-09-04 19:04:00.000');
+  });
+});

--- a/test/db/hash-migration.test.mjs
+++ b/test/db/hash-migration.test.mjs
@@ -30,7 +30,10 @@ function mkDb() {
       play_count INTEGER DEFAULT 0,
       last_played TEXT,
       rating INTEGER,
-      starred_at TEXT
+      starred_at TEXT,
+      skip_count INTEGER NOT NULL DEFAULT 0,
+      listened_ms INTEGER NOT NULL DEFAULT 0,
+      first_played TEXT
     );
     CREATE TABLE user_bookmarks (
       user_id INTEGER NOT NULL,
@@ -116,6 +119,26 @@ describe('hash migration helper', () => {
     // Old-hash rows gone.
     const orphaned = db.prepare('SELECT COUNT(*) AS n FROM user_metadata WHERE track_hash = ?').get('oldhash');
     assert.equal(orphaned.n, 0);
+  });
+
+  test('a collision merges the V70 counters: skips and listened time sum, first_played keeps the earliest', () => {
+    const db = mkDb();
+    // The user already holds the NEW identity (stars keyed on the audio hash)…
+    db.prepare(`INSERT INTO user_metadata (user_id, track_hash, play_count, last_played, skip_count, listened_ms, first_played)
+                VALUES (1, 'newhash', 2, '2026-09-01 10:00:00', 1, 100000, '2026-08-01 10:00:00')`).run();
+    // …and plays keyed on the OLD one.
+    db.prepare(`INSERT INTO user_metadata (user_id, track_hash, play_count, last_played, skip_count, listened_ms, first_played)
+                VALUES (1, 'oldhash', 5, '2026-09-05 10:00:00', 3, 250000, '2026-07-01 10:00:00')`).run();
+
+    assert.equal(migrateHashReferences(db, 'oldhash', 'newhash').metadata, 1);
+
+    const row = db.prepare('SELECT * FROM user_metadata WHERE user_id = 1 AND track_hash = ?').get('newhash');
+    assert.equal(row.play_count, 7);
+    assert.equal(row.last_played, '2026-09-05 10:00:00');
+    assert.equal(row.skip_count, 4);
+    assert.equal(row.listened_ms, 350000);
+    assert.equal(row.first_played, '2026-07-01 10:00:00');
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_metadata WHERE track_hash = ?').get('oldhash').n, 0);
   });
 
   test('migrates user_bookmarks rows', () => {

--- a/test/integration/stats-ingest.test.mjs
+++ b/test/integration/stats-ingest.test.mjs
@@ -1,0 +1,161 @@
+/**
+ * POST /api/v1/stats/plays against a real server (src/api/stats.js).
+ *
+ * Pattern mirrors test/integration/db-stats.test.mjs: boot mStream in
+ * public/no-users mode with an empty library, stop it, seed tracks straight
+ * into the DB, boot again, hit the HTTP API. No media fixtures, so no ffmpeg.
+ *
+ * Locks in: the per-play answer shape, that counted plays reach the legacy
+ * most-played / recently-played reads (the counters they run on), that a
+ * replay is acknowledged and inert, that a short skip is kept without
+ * counting, the Joi 400s (unknown key, empty batch, bad enum), and that the
+ * route is not on the federation allowlist.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+import { isFederationRouteAllowed } from '../../src/api/federation-auth.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref(); srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => { const { port } = srv.address(); srv.close(() => resolve(port)); });
+  });
+}
+
+async function waitForReady(baseUrl, timeoutMs = 90_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try { const r = await fetch(`${baseUrl}/api/`); if (r.status < 500) return; } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+
+async function boot(tmpDir, musicDir) {
+  const port = await findFreePort();
+  const config = {
+    port, address: '127.0.0.1',
+    dlna: { mode: 'disabled' },
+    folders: { testlib: { root: musicDir } },
+    storage: {
+      albumArtDirectory: path.join(tmpDir, 'image-cache'),
+      dbDirectory: path.join(tmpDir, 'db'),
+      logsDirectory: path.join(tmpDir, 'logs'),
+    },
+    scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+    stats: { playThresholdMs: 30000, playThresholdFraction: 0.5, retentionMonths: 0 },
+  };
+  for (const dir of Object.values(config.storage)) await fs.mkdir(dir, { recursive: true });
+  const configPath = path.join(tmpDir, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify(config));
+  const proc = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', configPath],
+    { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
+  return { proc, baseUrl };
+}
+
+async function kill(proc) { if (proc.exitCode == null) { proc.kill('SIGKILL'); await new Promise((r) => proc.once('exit', r)); } }
+
+async function post(baseUrl, route, body) {
+  const r = await fetch(`${baseUrl}${route}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  return { status: r.status, body: r.status === 200 ? await r.json() : await r.text() };
+}
+
+function seed(dbPath) {
+  const db = new DatabaseSync(dbPath); db.exec('PRAGMA foreign_keys = ON');
+  assert.ok(db.prepare('PRAGMA user_version').get().user_version >= 70, 'V70+ applied at boot');
+  const lib = db.prepare("SELECT id FROM libraries WHERE name='testlib'").get().id;
+  const aid = Number(db.prepare("INSERT INTO artists (name) VALUES ('Radiohead')").run().lastInsertRowid);
+  const alid = Number(db.prepare("INSERT INTO albums (name, artist_id, year) VALUES ('OK Computer', ?, 1997)").run(aid).lastInsertRowid);
+  const ins = db.prepare(`INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, file_hash, audio_hash, duration, modified, scan_id)
+                          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 'seed')`);
+  ins.run('Let Down.flac', lib, 'Let Down', aid, alid, 'fhA', 'ahA', 299);
+  ins.run('Karma Police.flac', lib, 'Karma Police', aid, alid, 'fhB', 'ahB', 264);
+  db.close();
+}
+
+const play = (over = {}) => ({
+  id: 'p1', filePath: 'testlib/Let Down.flac', startedAt: '2026-09-09T11:00:00Z',
+  playedMs: 240000, outcome: 'completed', source: 'manual', ...over,
+});
+
+describe('POST /api/v1/stats/plays', () => {
+  let tmpDir, server;
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-ingest-'));
+    const musicDir = path.join(tmpDir, 'music'); await fs.mkdir(musicDir, { recursive: true });
+    server = await boot(tmpDir, musicDir);
+    await kill(server.proc); await sleep(200);
+    seed(path.join(tmpDir, 'db', 'mstream.db'));
+    server = await boot(tmpDir, musicDir);
+  });
+  after(async () => {
+    if (server?.proc) await kill(server.proc);
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('a batch is answered per play and reaches the counters the legacy reads run on', async () => {
+    const r = await post(server.baseUrl, '/api/v1/stats/plays', {
+      client: { name: 'mstream-music', version: '0.36.0' },
+      plays: [
+        play(),
+        play({ id: 'p2', filePath: 'testlib/Karma Police.flac', playedMs: 8000, outcome: 'skipped', startedAt: '2026-09-09T11:05:00Z' }),
+        play({ id: 'p3', startedAt: '2026-09-09T11:06:00Z' }),
+        play({ id: 'p4', filePath: 'testlib/Nope.flac' }),
+      ],
+    });
+    assert.equal(r.status, 200, r.body);
+    assert.deepEqual(r.body, { accepted: ['p1', 'p2', 'p3'], duplicates: [], rejected: [{ id: 'p4', reason: 'unknown-track' }] });
+
+    const most = await post(server.baseUrl, '/api/v1/db/stats/most-played', { limit: 10 });
+    assert.equal(most.status, 200, most.body);
+    assert.deepEqual(most.body.map((x) => [x.metadata.title, x.metadata['play-count']]), [['Let Down', 2]]);
+    const recent = await post(server.baseUrl, '/api/v1/db/stats/recently-played', { limit: 10 });
+    assert.deepEqual(recent.body.map((x) => x.metadata.title), ['Let Down']); // the skip never set last_played
+    assert.equal(recent.body[0].metadata['last-played'], '2026-09-09 11:06:00.000');
+  });
+
+  test('a replay is acknowledged and moves nothing', async () => {
+    const r = await post(server.baseUrl, '/api/v1/stats/plays', { plays: [play({ playedMs: 1 }), play({ id: 'p3' })] });
+    assert.equal(r.status, 200, r.body);
+    assert.deepEqual(r.body, { accepted: [], duplicates: ['p1', 'p3'], rejected: [] });
+    const most = await post(server.baseUrl, '/api/v1/db/stats/most-played', { limit: 10 });
+    assert.equal(most.body[0].metadata['play-count'], 2);
+  });
+
+  test('validation: an unknown key, an empty batch and a bad enum are 400s the app can parse', async () => {
+    const unknown = await post(server.baseUrl, '/api/v1/stats/plays', { plays: [play({ bogus: 1 })] });
+    assert.equal(unknown.status, 400);
+    assert.match(unknown.body, /bogus.* is not allowed/);
+    assert.equal((await post(server.baseUrl, '/api/v1/stats/plays', { plays: [] })).status, 400);
+    assert.equal((await post(server.baseUrl, '/api/v1/stats/plays', { plays: [play({ outcome: 'vanished' })] })).status, 400);
+    assert.equal((await post(server.baseUrl, '/api/v1/stats/plays', { plays: [play({ source: 'legacy' })] })).status, 400);
+    assert.equal((await post(server.baseUrl, '/api/v1/stats/plays', {})).status, 400);
+  });
+
+  test('the route is not on the federation allowlist', () => {
+    assert.equal(isFederationRouteAllowed('POST', '/api/v1/stats/plays'), false);
+  });
+});

--- a/test/unit/stats-ingest.test.mjs
+++ b/test/unit/stats-ingest.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * src/stats/ingest.js — the pure judgements the ingest route applies.
+ *
+ *  - decideCounted: the play-threshold rule at its boundaries, with and
+ *    without a known duration, and under a changed config;
+ *  - parseInstant / checkStartedAt: ISO, epoch-ms and stored-text inputs,
+ *    the five-minute future skew, the retention floor (and retention off);
+ *  - clientLabel: the `name/version` stored on every row.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  decideCounted, parseInstant, checkStartedAt, retentionFloor, DEFAULTS, FUTURE_SKEW_MS,
+} from '../../src/stats/ingest.js';
+import { clientLabel } from '../../src/api/stats.js';
+
+describe('decideCounted', () => {
+  test('30 seconds counts; a hair under does not', () => {
+    assert.equal(decideCounted(30000, 300000), true);
+    assert.equal(decideCounted(29999, 300000), false);
+  });
+  test('half of a short track counts before 30 seconds', () => {
+    assert.equal(decideCounted(20000, 40000), true);
+    assert.equal(decideCounted(19999, 40000), false);
+  });
+  test('unknown or zero duration falls back to the time rule alone', () => {
+    assert.equal(decideCounted(25000, null), false);
+    assert.equal(decideCounted(25000, 0), false);
+    assert.equal(decideCounted(30000, undefined), true);
+  });
+  test('the config moves the bar; a fraction of 0 disables that rule', () => {
+    assert.equal(decideCounted(10000, 300000, { playThresholdMs: 10000, playThresholdFraction: 0.5 }), true);
+    assert.equal(decideCounted(20000, 40000, { playThresholdMs: 30000, playThresholdFraction: 0 }), false);
+    assert.equal(decideCounted(20000, 40000, {}), true); // missing keys → defaults
+  });
+  test('garbage never counts', () => {
+    assert.equal(decideCounted(-1, 100), false);
+    assert.equal(decideCounted('30000', 100), false);
+  });
+});
+
+describe('parseInstant', () => {
+  test('accepts ISO, epoch ms, stored text and Dates', () => {
+    assert.equal(parseInstant('2026-09-04T19:04:00.500Z').toISOString(), '2026-09-04T19:04:00.500Z');
+    assert.equal(parseInstant(Date.UTC(2026, 8, 4, 19, 4)).toISOString(), '2026-09-04T19:04:00.000Z');
+    assert.equal(parseInstant('2026-09-04 19:04:00').toISOString(), '2026-09-04T19:04:00.000Z');
+    assert.equal(parseInstant(new Date(0)).getTime(), 0);
+  });
+  test('rejects nonsense', () => {
+    assert.equal(parseInstant('yesterday'), null);
+    assert.equal(parseInstant(-5), null);
+    assert.equal(parseInstant(1.5), null);
+    assert.equal(parseInstant(''), null);
+    assert.equal(parseInstant(null), null);
+  });
+});
+
+describe('checkStartedAt', () => {
+  const now = new Date('2026-09-09T12:00:00Z');
+  test('a recent play passes; the future is allowed only within the skew', () => {
+    assert.ok(checkStartedAt('2026-09-09T11:00:00Z', { now }));
+    assert.ok(checkStartedAt(now.getTime() + FUTURE_SKEW_MS, { now }));
+    assert.equal(checkStartedAt(now.getTime() + FUTURE_SKEW_MS + 1, { now }), null);
+  });
+  test('retention is the floor, to the hour', () => {
+    assert.equal(retentionFloor(now, 24).toISOString(), '2024-09-09T12:00:00.000Z');
+    assert.ok(checkStartedAt('2024-09-09T12:00:00Z', { now, retentionMonths: 24 }));
+    assert.equal(checkStartedAt('2024-09-09T11:59:59Z', { now, retentionMonths: 24 }), null);
+    assert.ok(checkStartedAt('2010-01-01T00:00:00Z', { now, retentionMonths: 0 }));
+    assert.equal(checkStartedAt('1999-12-31T23:59:59Z', { now, retentionMonths: 0 }), null);
+  });
+  test('unparsable is null', () => {
+    assert.equal(checkStartedAt('soon', { now }), null);
+  });
+  test('defaults match the config defaults', () => {
+    assert.equal(DEFAULTS.playThresholdMs, 30000);
+    assert.equal(DEFAULTS.playThresholdFraction, 0.5);
+    assert.equal(DEFAULTS.retentionMonths, 24);
+  });
+});
+
+describe('clientLabel', () => {
+  test('name/version, version optional', () => {
+    assert.equal(clientLabel({ name: 'mstream-music', version: '0.36.0' }), 'mstream-music/0.36.0');
+    assert.equal(clientLabel({ name: 'web' }), 'web');
+    assert.equal(clientLabel({ name: 'web', version: '' }), 'web');
+    assert.equal(clientLabel(null), null);
+  });
+});

--- a/test/unit/stats-time.test.mjs
+++ b/test/unit/stats-time.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * src/stats/time.js — period and timezone arithmetic for the stats API.
+ *
+ * Pins the contract the read routes rely on:
+ *  - stored-text round trips (SQLite datetime text with milliseconds, the
+ *    no-ms form datetime('now') writes, and the ISO/Z tolerance);
+ *  - zonedToUtc solves wall-clock midnights in the caller's zone, on both
+ *    sides of a DST change and in a half-hour zone;
+ *  - periodRange produces [from, to) as LOCAL midnights, Monday-first weeks,
+ *    whole-period offsets, and the labels;
+ *  - bucketKeyFor re-buckets a UTC hour into the caller's calendar.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  toSqlite, fromSqlite, toIso, hourKey, fromHourKey, isValidTimeZone, zonedParts,
+  zonedToUtc, periodRange, customRange, bucketKeyFor, localDay, dayKeyPlus,
+} from '../../src/stats/time.js';
+
+const iso = (d) => d.toISOString();
+
+describe('stored text formats', () => {
+  test('toSqlite writes UTC with milliseconds; fromSqlite reads it back', () => {
+    const d = new Date('2026-09-04T19:04:00.123Z');
+    assert.equal(toSqlite(d), '2026-09-04 19:04:00.123');
+    assert.equal(iso(fromSqlite('2026-09-04 19:04:00.123')), '2026-09-04T19:04:00.123Z');
+  });
+
+  test("fromSqlite accepts datetime('now') rows, a T separator and a Z", () => {
+    assert.equal(iso(fromSqlite('2026-09-04 19:04:00')), '2026-09-04T19:04:00.000Z');
+    assert.equal(iso(fromSqlite('2026-09-04T19:04:00Z')), '2026-09-04T19:04:00.000Z');
+    assert.equal(fromSqlite('yesterday'), null);
+    assert.equal(fromSqlite(null), null);
+    assert.equal(toIso('2026-09-04 19:04:00'), '2026-09-04T19:04:00.000Z');
+  });
+
+  test('hourKey / fromHourKey', () => {
+    assert.equal(hourKey(new Date('2026-09-04T19:59:59.999Z')), '2026-09-04T19');
+    assert.equal(iso(fromHourKey('2026-09-04T19')), '2026-09-04T19:00:00.000Z');
+    assert.equal(fromHourKey('2026-09-04'), null);
+  });
+});
+
+describe('timezones', () => {
+  test('isValidTimeZone', () => {
+    assert.equal(isValidTimeZone('Europe/Berlin'), true);
+    assert.equal(isValidTimeZone('UTC'), true);
+    assert.equal(isValidTimeZone('Mars/Olympus'), false);
+    assert.equal(isValidTimeZone(''), false);
+    assert.equal(isValidTimeZone(undefined), false);
+  });
+
+  test('zonedParts reads the wall clock in the zone', () => {
+    const p = zonedParts(new Date('2026-09-05T23:30:00Z'), 'Europe/Berlin');
+    assert.deepEqual([p.year, p.month, p.day, p.hour, p.minute, p.weekday], [2026, 9, 6, 1, 30, 0]);
+  });
+
+  test('zonedToUtc: UTC identity, summer and winter offsets, half-hour zone', () => {
+    assert.equal(iso(zonedToUtc({ year: 2026, month: 7, day: 1 }, 'UTC')), '2026-07-01T00:00:00.000Z');
+    assert.equal(iso(zonedToUtc({ year: 2026, month: 7, day: 1 }, 'Europe/Berlin')), '2026-06-30T22:00:00.000Z');
+    assert.equal(iso(zonedToUtc({ year: 2026, month: 1, day: 1 }, 'Europe/Berlin')), '2025-12-31T23:00:00.000Z');
+    assert.equal(iso(zonedToUtc({ year: 2026, month: 9, day: 6 }, 'Asia/Kolkata')), '2026-09-05T18:30:00.000Z');
+  });
+
+  test('zonedToUtc across the US spring-forward day', () => {
+    // 2026-03-08: clocks jump 02:00 → 03:00 in New York. Midnight before
+    // and 03:00 after are both real wall times.
+    assert.equal(iso(zonedToUtc({ year: 2026, month: 3, day: 8 }, 'America/New_York')), '2026-03-08T05:00:00.000Z');
+    assert.equal(iso(zonedToUtc({ year: 2026, month: 3, day: 8, hour: 3 }, 'America/New_York')), '2026-03-08T07:00:00.000Z');
+    assert.equal(iso(zonedToUtc({ year: 2026, month: 3, day: 9 }, 'America/New_York')), '2026-03-09T04:00:00.000Z');
+  });
+});
+
+describe('periodRange', () => {
+  // A Sunday, midday UTC, in a summer-time zone one hour ahead.
+  const now = new Date('2026-09-06T12:00:00Z');
+  const tz = 'Europe/Berlin';
+
+  test('month, current and previous, as local midnights', () => {
+    const cur = periodRange({ period: 'month', tz, now });
+    assert.equal(iso(cur.from), '2026-08-31T22:00:00.000Z');
+    assert.equal(iso(cur.to), '2026-09-30T22:00:00.000Z');
+    assert.equal(cur.label, 'September 2026');
+    const prev = periodRange({ period: 'month', offset: -1, tz, now });
+    assert.equal(iso(prev.from), '2026-07-31T22:00:00.000Z');
+    assert.equal(iso(prev.to), '2026-08-31T22:00:00.000Z');
+    assert.equal(prev.label, 'August 2026');
+  });
+
+  test('week is Monday-first', () => {
+    const cur = periodRange({ period: 'week', tz, now });
+    assert.equal(iso(cur.from), '2026-08-30T22:00:00.000Z'); // Mon 2026-08-31 local
+    assert.equal(iso(cur.to), '2026-09-06T22:00:00.000Z');
+    assert.equal(cur.label, 'Week of 2026-08-31');
+    const prev = periodRange({ period: 'week', offset: -1, tz, now });
+    assert.equal(iso(prev.from), '2026-08-23T22:00:00.000Z');
+    assert.equal(prev.label, 'Week of 2026-08-24');
+  });
+
+  test('quarter, half, year — and a year boundary crosses the winter offset', () => {
+    const q = periodRange({ period: 'quarter', tz, now });
+    assert.equal(iso(q.from), '2026-06-30T22:00:00.000Z');
+    assert.equal(iso(q.to), '2026-09-30T22:00:00.000Z');
+    assert.equal(q.label, 'Q3 2026');
+    const h = periodRange({ period: 'half', tz, now });
+    assert.equal(iso(h.from), '2026-06-30T22:00:00.000Z');
+    assert.equal(iso(h.to), '2026-12-31T23:00:00.000Z');
+    assert.equal(h.label, 'H2 2026');
+    const y = periodRange({ period: 'year', tz, now });
+    assert.equal(iso(y.from), '2025-12-31T23:00:00.000Z');
+    assert.equal(iso(y.to), '2026-12-31T23:00:00.000Z');
+    assert.equal(y.label, '2026');
+    const lastYear = periodRange({ period: 'year', offset: -1, tz, now });
+    assert.equal(lastYear.label, '2025');
+    assert.equal(iso(lastYear.to), '2025-12-31T23:00:00.000Z');
+  });
+
+  test("'all' is open-ended and unknown periods throw", () => {
+    const all = periodRange({ period: 'all', tz, now });
+    assert.equal(iso(all.from), '2000-01-01T00:00:00.000Z');
+    assert.ok(all.to > now);
+    assert.equal(all.label, 'All time');
+    assert.throws(() => periodRange({ period: 'fortnight', tz, now }), RangeError);
+  });
+
+  test('customRange validates order and instants', () => {
+    const r = customRange('2026-09-01T00:00:00Z', '2026-09-04T00:00:00Z');
+    assert.equal(r.label, '2026-09-01 to 2026-09-04');
+    assert.throws(() => customRange('2026-09-04T00:00:00Z', '2026-09-01T00:00:00Z'), RangeError);
+    assert.throws(() => customRange('soon', '2026-09-01T00:00:00Z'), RangeError);
+  });
+});
+
+describe('re-bucketing', () => {
+  test('a UTC hour lands in the local calendar', () => {
+    // 23:00Z on Saturday 2026-09-05 is 01:00 on Sunday 2026-09-06 in Berlin.
+    const k = '2026-09-05T23';
+    assert.equal(bucketKeyFor(k, 'hour', 'Europe/Berlin'), '2026-09-06T01');
+    assert.equal(bucketKeyFor(k, 'day', 'Europe/Berlin'), '2026-09-06');
+    assert.equal(bucketKeyFor(k, 'week', 'Europe/Berlin'), '2026-08-31');
+    assert.equal(bucketKeyFor(k, 'month', 'Europe/Berlin'), '2026-09');
+    assert.equal(bucketKeyFor(k, 'hourOfDay', 'Europe/Berlin'), '1');
+    assert.equal(bucketKeyFor(k, 'weekday', 'Europe/Berlin'), '0');
+    assert.equal(bucketKeyFor(k, 'day', 'UTC'), '2026-09-05');
+    assert.equal(bucketKeyFor(k, 'fortnight', 'UTC'), null);
+    assert.equal(bucketKeyFor('nope', 'day', 'UTC'), null);
+  });
+
+  test('localDay and dayKeyPlus', () => {
+    assert.equal(localDay('2026-09-05 23:30:00', 'Europe/Berlin'), '2026-09-06');
+    assert.equal(localDay(new Date('2026-09-05T23:30:00Z'), 'UTC'), '2026-09-05');
+    assert.equal(dayKeyPlus('2026-08-31', 1), '2026-09-01');
+    assert.equal(dayKeyPlus('2026-03-01', -1), '2026-02-28');
+    assert.equal(dayKeyPlus('bad', 1), null);
+  });
+});


### PR DESCRIPTION
## Summary

The write side of **Stats API v2**, the first server step of the play-history feature (S1 in the app repo's `PLAY_HISTORY_PLAN.md`, whose app half is IrosTheBeggar/mstream_music#157). V69 dropped the velvet-era listening log with the UI that owned it; this brings the log back in a shape built for clients that report **complete plays after the fact**, and gives them one route to send them to.

## What's in it

**`POST /api/v1/stats/plays`** — up to 200 plays per call, each with the client's own id and start time. Per play the server:
- resolves the path to a track through `getVPathInfo` (the user's own libraries only), or takes a **federated peer's** track with the metadata snapshot the client carries — recorded *here*, as this user's own play, never on the peer;
- decides whether it **counts** under the play-threshold rule (`stats.playThresholdMs` / `stats.playThresholdFraction`, default 30 s or half the track) and stores the verdict on the row, so changing the rule later never rewrites history;
- answers per play: `accepted`, `duplicates` (an id this user already sent — nothing moves, which is what makes an offline outbox safe to retry forever), or `rejected` with a reason the client can act on: `unknown-track`, `unknown-peer`, `bad-time` (unparsable, over five minutes in the future, or older than `stats.retentionMonths`), `invalid` (a peer play without its snapshot, or an id another user owns).

**Schema V70**: `play_events` keyed by the client id (UNIQUE), the canonical track hash resolved at ingest (rename-proof), `peer_id` + `snapshot` for a peer's track, `counted`, the client label, and the client's start time as SQLite's own datetime text with milliseconds; `user_hour_stats`, a per-user UTC-hour rollup the time-series reads will run on and that outlives raw retention; three derived counters on `user_metadata` (`skip_count`, `listened_ms`, `first_played`). No backfill — the old log died with V69.

**`src/stats/store.js`** — the one write primitive (event + rollup + counters in lock-step, a replayed id a complete no-op) that this route, the future scrobble shim and test seeding all go through. **`src/stats/ingest.js`** — resolve, judge, batch; the library resolver is injectable so the whole thing runs on an in-memory DB in tests. **`src/stats/time.js`** — stored-text helpers plus the period/timezone helpers the read side needs next.

Also: the `stats` config block (documented in `docs/json_config.md`), the route in `docs/openapi.yaml`, and the hash-rekey merge (`hash-migration.js`) now carrying the three new counters like it carries `play_count`.

## Verification

- `npm run test:unit` / `npm run test:db`: 0 failures (the crossed-out entries are the usual no-ffmpeg / no-binaries cancellations).
- New: 58 unit + db tests (`stats-time`, `stats-ingest`, `db-v70-stats-tables`, `db-stats-ingest`, the hash-migration merge case) and a 4-test integration file that boots a server, seeds tracks, posts a batch, and reads the counters back through the existing `most-played` / `recently-played` routes, checks replay, the Joi 400s the app parses, and that the route is off the federation allowlist.
- `eslint` clean.

## Deliberately not in this PR

- **No `features.stats` flag yet** — the read side (summary / top / timeseries / history), the `scrobble-by-filepath` shim and the flag follow as their own changes, so a partial surface is never advertised. The reads are already written on `claude/stats-api-reads` and will be rebased onto this.
- **Last.fm forwarding** with the event's own time (S5), the **retention sweep** (S3; ingest already refuses anything older than retention, so the log's age is bounded from its first row).
- **Rust scanner parity**: `rust-parser/src/main.rs` `migrate_hash_references` still merges the original four `user_metadata` columns; a rekey by the Rust engine would drop the three new counters on a collision. Small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
