### PR TITLE
feat(stats): Stats API v2 reads — summary, top, timeseries, history, tracks, periods

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -494,6 +494,21 @@ components:
             type: string
           description: Libraries (vpaths) to exclude from the query.
 
+    StatsPeriod:
+      type: object
+      description: The resolved range a stats read covered.
+      properties:
+        label: { type: string }
+        from: { type: string, format: date-time }
+        to: { type: string, format: date-time, description: "Exclusive." }
+        tz: { type: string }
+
+    StatsOriginSlice:
+      type: object
+      properties:
+        plays: { type: integer }
+        listenedMs: { type: integer }
+
     SearchArtistOrAlbumItem:
       type: object
       description: |
@@ -2309,6 +2324,290 @@ paths:
         "400": { description: "Validation failed (an unknown key, a bad enum value, an empty or oversized batch)." }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { description: "A federation key or guest token — stats are never recorded for those." }
+
+  # ── Stats API v2 (read side) ─────────────────────────────────────────────
+  # Every read is scoped to the caller's own plays and visible libraries.
+  # A range is a preset `period` (+ `offset` <= 0) or an explicit `from`/`to`
+  # pair; `tz` (IANA, default UTC) sets where days, weeks and months begin.
+  # `origin` keeps local plays, federated-peer plays (recorded on this server
+  # as the caller's own plays of a peer's track), or both. Never reachable
+  # with a federation key.
+
+  /api/v1/stats/summary:
+    get:
+      tags: [Stats]
+      summary: Listening summary for a period
+      description: |
+        The period's totals as data (the former Wrapped view without its copy):
+        events, counted plays, uniques, listened time, skip and completion rates,
+        discoveries (tracks whose first counted play ever falls in the period),
+        library coverage, derived sessions (30-minute gap), day streaks, the top
+        listening day, peak hour and weekday, and the local/peer split.
+        Calendar facts (streaks, top day, peaks) come from the per-user hourly
+        rollup and are not narrowed by `ignoreVPaths` or `origin`.
+      parameters:
+        - { name: period, in: query, schema: { type: string, enum: [week, month, quarter, half, year, all], default: month } }
+        - { name: offset, in: query, schema: { type: integer, maximum: 0, default: 0 }, description: "Whole periods back from the current one." }
+        - { name: from, in: query, schema: { type: string, format: date-time }, description: "With `to`, replaces `period`/`offset`." }
+        - { name: to, in: query, schema: { type: string, format: date-time } }
+        - { name: tz, in: query, schema: { type: string, default: UTC }, description: "IANA timezone for period and day boundaries." }
+        - { name: origin, in: query, schema: { type: string, enum: [all, local, peers], default: all } }
+        - { name: ignoreVPaths, in: query, style: form, explode: true, schema: { type: array, items: { type: string } } }
+      responses:
+        "200":
+          description: Summary.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  period: { $ref: "#/components/schemas/StatsPeriod" }
+                  events: { type: integer }
+                  plays: { type: integer, description: "Events the server counted as plays." }
+                  uniqueTracks: { type: integer }
+                  uniqueArtists: { type: integer }
+                  uniqueAlbums: { type: integer }
+                  listenedMs: { type: integer }
+                  skips: { type: integer }
+                  skipRate: { type: number }
+                  completionRate: { type: number }
+                  pauses: { type: integer }
+                  discoveries: { type: integer }
+                  libraryCoveragePct: { type: number }
+                  sessions:
+                    type: object
+                    properties:
+                      count: { type: integer }
+                      avgMs: { type: integer, nullable: true }
+                      longest:
+                        type: object
+                        nullable: true
+                        properties:
+                          startedAt: { type: string, format: date-time }
+                          endedAt: { type: string, format: date-time }
+                          tracks: { type: integer }
+                          plays: { type: integer }
+                          listenedMs: { type: integer }
+                  streakDays:
+                    type: object
+                    properties: { current: { type: integer }, longest: { type: integer } }
+                  topDay:
+                    type: object
+                    nullable: true
+                    properties: { date: { type: string }, plays: { type: integer }, listenedMs: { type: integer } }
+                  peakHour: { type: integer, nullable: true }
+                  peakWeekday: { type: integer, nullable: true, description: "0 = Sunday." }
+                  origins:
+                    type: object
+                    properties:
+                      local: { $ref: "#/components/schemas/StatsOriginSlice" }
+                      peers: { $ref: "#/components/schemas/StatsOriginSlice" }
+        "400": { description: "Validation failed: unknown parameter, bad timezone, unpaired from/to, or an invalid cursor." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/stats/top:
+    get:
+      tags: [Stats]
+      summary: Top tracks, artists, albums or genres for a period
+      description: |
+        Ranked by counted plays or by listened time. A track row carries the
+        library's metadata object when the track still resolves, otherwise the
+        snapshot recorded at ingest (always the case for a federated peer's
+        track, which also carries `peerId`). Artists and albums merge by name
+        across origins; genres come from the library only.
+      parameters:
+        - { name: entity, in: query, schema: { type: string, enum: [tracks, artists, albums, genres], default: tracks } }
+        - { name: metric, in: query, schema: { type: string, enum: [plays, time], default: plays } }
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 200, default: 20 } }
+        - { name: period, in: query, schema: { type: string, enum: [week, month, quarter, half, year, all], default: month } }
+        - { name: offset, in: query, schema: { type: integer, maximum: 0, default: 0 } }
+        - { name: from, in: query, schema: { type: string, format: date-time } }
+        - { name: to, in: query, schema: { type: string, format: date-time } }
+        - { name: tz, in: query, schema: { type: string, default: UTC } }
+        - { name: origin, in: query, schema: { type: string, enum: [all, local, peers], default: all } }
+        - { name: ignoreVPaths, in: query, style: form, explode: true, schema: { type: array, items: { type: string } } }
+      responses:
+        "200":
+          description: Ranked rows.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  period: { $ref: "#/components/schemas/StatsPeriod" }
+                  entity: { type: string }
+                  metric: { type: string }
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        rank: { type: integer }
+                        plays: { type: integer }
+                        listenedMs: { type: integer }
+                        events: { type: integer }
+                        share: { type: number, description: "Fraction of the period's total for the chosen metric." }
+                        name: { type: string, description: "artists / albums / genres only." }
+                        artist: { type: string, nullable: true, description: "albums only." }
+                        tracks: { type: integer, description: "Distinct tracks behind the row (artists / albums / genres)." }
+                        lastPlayed: { type: string, format: date-time, description: "tracks only." }
+                        origin: { type: string, enum: [local, peer], description: "tracks only." }
+                        peerId: { type: integer, nullable: true, description: "tracks only." }
+                        track: { $ref: "#/components/schemas/Metadata" }
+        "400": { description: "Validation failed: unknown parameter, bad timezone, unpaired from/to, or an invalid cursor." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/stats/timeseries:
+    get:
+      tags: [Stats]
+      summary: Plays and listening time per bucket
+      description: |
+        From the per-user hourly rollup, re-bucketed into `tz`. Calendar buckets
+        (`hour`, `day`, `week` — Monday-first, `month`) return only buckets with
+        data, keyed `YYYY-MM-DDTHH`, `YYYY-MM-DD`, the Monday's date, `YYYY-MM`.
+        Profile buckets (`hourOfDay` 0-23, `weekday` 0-6 with Sunday 0) return
+        every bucket. Not narrowed by `ignoreVPaths` or `origin`.
+      parameters:
+        - { name: bucket, in: query, schema: { type: string, enum: [hour, day, week, month, hourOfDay, weekday], default: day } }
+        - { name: period, in: query, schema: { type: string, enum: [week, month, quarter, half, year, all], default: month } }
+        - { name: offset, in: query, schema: { type: integer, maximum: 0, default: 0 } }
+        - { name: from, in: query, schema: { type: string, format: date-time } }
+        - { name: to, in: query, schema: { type: string, format: date-time } }
+        - { name: tz, in: query, schema: { type: string, default: UTC } }
+      responses:
+        "200":
+          description: Buckets in ascending order.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  period: { $ref: "#/components/schemas/StatsPeriod" }
+                  bucket: { type: string }
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        bucket: { type: string }
+                        events: { type: integer }
+                        plays: { type: integer }
+                        skips: { type: integer }
+                        listenedMs: { type: integer }
+        "400": { description: "Validation failed: unknown parameter, bad timezone, unpaired from/to, or an invalid cursor." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/stats/history:
+    get:
+      tags: [Stats]
+      summary: The listening log, newest first
+      description: |
+        Cursor-paginated: pass the previous page's `next` as `before`. `track`
+        filters to one canonical track hash. Each item carries the play's own
+        facts and a `track` object (library metadata, or the ingest snapshot).
+      parameters:
+        - { name: before, in: query, schema: { type: string }, description: "Opaque cursor from a previous page." }
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 200, default: 50 } }
+        - { name: track, in: query, schema: { type: string }, description: "Canonical track hash." }
+        - { name: origin, in: query, schema: { type: string, enum: [all, local, peers], default: all } }
+        - { name: ignoreVPaths, in: query, style: form, explode: true, schema: { type: array, items: { type: string } } }
+      responses:
+        "200":
+          description: A page of plays.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string, description: "The client's event id." }
+                        startedAt: { type: string, format: date-time }
+                        endedAt: { type: string, format: date-time, nullable: true }
+                        playedMs: { type: integer }
+                        durationMs: { type: integer, nullable: true }
+                        outcome: { type: string, enum: [completed, skipped, stopped] }
+                        counted: { type: boolean }
+                        source: { type: string, nullable: true }
+                        sessionId: { type: string, nullable: true }
+                        pauseCount: { type: integer }
+                        client: { type: string, nullable: true }
+                        origin: { type: string, enum: [local, peer] }
+                        peerId: { type: integer, nullable: true }
+                        track: { $ref: "#/components/schemas/Metadata" }
+                  next: { type: string, nullable: true }
+        "400": { description: "Validation failed: unknown parameter, bad timezone, unpaired from/to, or an invalid cursor." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/stats/tracks:
+    post:
+      tags: [Stats]
+      summary: Per-track counters for a batch of tracks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: At least one of the two lists.
+              properties:
+                filePaths: { type: array, maxItems: 500, items: { type: string }, description: "Virtual paths (`<vpath>/<rel>`)." }
+                hashes: { type: array, maxItems: 500, items: { type: string }, description: "Canonical track hashes." }
+      responses:
+        "200":
+          description: One item per track that has counters; unknown tracks are omitted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        hash: { type: string }
+                        filePath: { type: string, description: "Present for rows requested by path." }
+                        plays: { type: integer }
+                        skips: { type: integer }
+                        listenedMs: { type: integer }
+                        firstPlayed: { type: string, format: date-time, nullable: true }
+                        lastPlayed: { type: string, format: date-time, nullable: true }
+        "400": { description: "Validation failed: unknown parameter, bad timezone, unpaired from/to, or an invalid cursor." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/stats/periods:
+    get:
+      tags: [Stats]
+      summary: Periods that have listening data
+      parameters:
+        - { name: tz, in: query, schema: { type: string, default: UTC } }
+      responses:
+        "200":
+          description: The log's bounds and the preset periods that overlap them.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  earliest: { type: string, format: date-time, nullable: true }
+                  latest: { type: string, format: date-time, nullable: true }
+                  tz: { type: string }
+                  periods:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        period: { type: string }
+                        offset: { type: integer }
+                        label: { type: string }
+                        from: { type: string, format: date-time }
+                        to: { type: string, format: date-time }
+        "400": { description: "Validation failed: unknown parameter, bad timezone, unpaired from/to, or an invalid cursor." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
 
   # ── Playlists ────────────────────────────────────────────────────────────
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2503,12 +2503,12 @@ paths:
       summary: The listening log, newest first
       description: |
         Cursor-paginated: pass the previous page's `next` as `before`. `track`
-        filters to one canonical track hash. Each item carries the play's own
+        filters to one track by any hash the client knows it by. Each item carries the play's own
         facts and a `track` object (library metadata, or the ingest snapshot).
       parameters:
         - { name: before, in: query, schema: { type: string }, description: "Opaque cursor from a previous page." }
         - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 200, default: 50 } }
-        - { name: track, in: query, schema: { type: string }, description: "Canonical track hash." }
+        - { name: track, in: query, schema: { type: string }, description: "A track hash: the canonical `audio-hash`, the file `hash` (resolved through the library), or a peer's reported hash." }
         - { name: origin, in: query, schema: { type: string, enum: [all, local, peers], default: all } }
         - { name: ignoreVPaths, in: query, style: form, explode: true, schema: { type: array, items: { type: string } } }
       responses:

--- a/src/api/stats.js
+++ b/src/api/stats.js
@@ -4,7 +4,8 @@
 //   GET  /api/v1/stats/summary     the period's numbers (the old Wrapped view, as data)
 //   GET  /api/v1/stats/top         ranked tracks / artists / albums / genres
 //   GET  /api/v1/stats/timeseries  plays and listening time per bucket, in the caller's zone
-//   GET  /api/v1/stats/history     the listening log, newest first, cursor-paginated
+//   GET  /api/v1/stats/history     the listening log, newest first, cursor-paginated,
+//                                  filterable by any hash a client knows a track by
 //   POST /api/v1/stats/tracks      per-track counters for a batch of paths / hashes
 //   GET  /api/v1/stats/periods     which periods have data
 //

--- a/src/api/stats.js
+++ b/src/api/stats.js
@@ -1,19 +1,32 @@
-// Stats API v2 — the write side.
+// Stats API v2.
 //
-//   POST /api/v1/stats/plays   record a batch of complete plays
+//   POST /api/v1/stats/plays       record a batch of complete plays (the write side)
+//   GET  /api/v1/stats/summary     the period's numbers (the old Wrapped view, as data)
+//   GET  /api/v1/stats/top         ranked tracks / artists / albums / genres
+//   GET  /api/v1/stats/timeseries  plays and listening time per bucket, in the caller's zone
+//   GET  /api/v1/stats/history     the listening log, newest first, cursor-paginated
+//   POST /api/v1/stats/tracks      per-track counters for a batch of paths / hashes
+//   GET  /api/v1/stats/periods     which periods have data
 //
-// Clients (the mobile app's outbox, the web player) send plays AFTER they
-// happen, with their own ids and start times. The server resolves each path
-// to a track, decides whether it counts (config `stats.playThreshold*`), and
-// answers per play — accepted / duplicates / rejected with a reason — so an
-// outbox knows what to drop and what to retry. Rules in src/stats/ingest.js,
-// the write in src/stats/store.js.
+// Write side: clients (the mobile app's outbox, the web player) send plays
+// AFTER they happen, with their own ids and start times. The server resolves
+// each path to a track, decides whether it counts (config
+// `stats.playThreshold*`), and answers per play — accepted / duplicates /
+// rejected with a reason — so an outbox knows what to drop and what to
+// retry. Rules in src/stats/ingest.js, the write in src/stats/store.js.
+//
+// Read side: every read is scoped to the caller — their events, their
+// visible libraries (`ignoreVPaths` narrows further), and their timezone
+// (`tz`, an IANA name, default UTC — day, week and month boundaries follow
+// it). A range is either a preset `period` (+ `offset` ≤ 0) or an explicit
+// `from` / `to` pair of ISO instants; `origin` keeps local plays, federated
+// plays, or both. Queries in src/stats/queries.js, period arithmetic in
+// src/stats/time.js.
 //
 // Never reachable with a federation key or a guest token: the wall's
-// allowlist does not carry this route, and the synthetic user those tokens
-// build has no id to record against. The read side (summary, top,
-// timeseries, history) follows in its own change; nothing advertises the
-// route in `features` until the surface is complete.
+// allowlist does not carry these routes, and the synthetic user those tokens
+// build has no id to record against or read for. Nothing advertises the
+// surface in `features` until the scrobble shim and the flag land with it.
 
 import Joi from 'joi';
 import * as db from '../db/manager.js';
@@ -21,8 +34,17 @@ import * as fedDb from '../db/federation.js';
 import * as config from '../state/config.js';
 import WebError from '../util/web-error.js';
 import { joiValidate } from '../util/validation.js';
+import { getVPathInfo } from '../util/vpath.js';
+import * as q from '../stats/queries.js';
 import { ingestPlays, MAX_BATCH } from '../stats/ingest.js';
 import { OUTCOMES, SOURCES } from '../stats/store.js';
+import {
+  isValidTimeZone, isBucket, periodRange, customRange, toSqlite, fromSqlite, toIso,
+} from '../stats/time.js';
+
+const d = () => db.getDB();
+
+// ── Write side ────────────────────────────────────────────────────────────
 
 const instant = Joi.alternatives().try(Joi.string().isoDate(), Joi.number().integer().min(0));
 
@@ -71,9 +93,84 @@ export function clientLabel(c) {
   return `${c.name}${c.version ? `/${c.version}` : ''}`.slice(0, 128);
 }
 
+// ── Read side ─────────────────────────────────────────────────────────────
+
+const PERIOD_VALUES = ['week', 'month', 'quarter', 'half', 'year', 'all'];
+const ORIGIN_VALUES = ['all', 'local', 'peers'];
+
+// Express parses a repeated key into an array; a single value arrives as a
+// string, which may itself be a comma list. Both shapes are accepted.
+const ignoreVPathsSchema = Joi.alternatives().try(
+  Joi.array().items(Joi.string().max(256)).max(100),
+  Joi.string().max(4096));
+function normIgnore(v) {
+  if (v == null) { return undefined; }
+  const list = Array.isArray(v) ? v : String(v).split(',');
+  return list.map((s) => s.trim()).filter(Boolean);
+}
+
+const rangeKeys = {
+  period: Joi.string().valid(...PERIOD_VALUES),
+  offset: Joi.number().integer().max(0).min(-1000).default(0),
+  from: Joi.string().isoDate(),
+  to: Joi.string().isoDate(),
+  tz: Joi.string().max(64).default('UTC'),
+  ignoreVPaths: ignoreVPathsSchema,
+  origin: Joi.string().valid(...ORIGIN_VALUES).default('all'),
+};
+
+function resolveRange(v) {
+  if (!isValidTimeZone(v.tz)) { throw new WebError(`Unknown timezone '${v.tz}'`, 400); }
+  if ((v.from == null) !== (v.to == null)) { throw new WebError('from and to must be given together', 400); }
+  let r;
+  try {
+    r = v.from != null
+      ? customRange(v.from, v.to)
+      : periodRange({ period: v.period || 'month', offset: v.offset, tz: v.tz });
+  } catch (err) {
+    throw new WebError(err.message, 400);
+  }
+  return { ...r, tz: v.tz, fromText: toSqlite(r.from), toText: toSqlite(r.to) };
+}
+
+const periodOut = (r) => ({ label: r.label, from: r.from.toISOString(), to: r.to.toISOString(), tz: r.tz });
+
+// History cursor: opaque to clients, (started_at, id) underneath so a page
+// boundary inside one second stays exact.
+function encodeCursor(next) {
+  return next ? Buffer.from(JSON.stringify({ s: next.startedAt, i: next.id })).toString('base64url') : null;
+}
+function decodeCursor(text) {
+  if (text == null) { return null; }
+  try {
+    const v = JSON.parse(Buffer.from(String(text), 'base64url').toString('utf8'));
+    if (typeof v?.s !== 'string' || !fromSqlite(v.s) || !Number.isInteger(v?.i)) { throw new Error('shape'); }
+    return { startedAt: v.s, id: v.i };
+  } catch (_) {
+    throw new WebError('Invalid cursor', 400);
+  }
+}
+
+// The canonical per-track key for a library path, as user_metadata keys it.
+function hashForPath(filePath, user) {
+  let info;
+  try { info = getVPathInfo(filePath, user); } catch (_) { return null; }
+  const lib = db.getLibraryByName(info.vpath);
+  if (!lib) { return null; }
+  const row = d().prepare('SELECT audio_hash, file_hash FROM tracks WHERE filepath = ? AND library_id = ?')
+    .get(info.relativePath, lib.id);
+  return row ? (row.audio_hash || row.file_hash || null) : null;
+}
+
+// A federation key or a guest token builds a user with no id; stats are
+// never recorded against or read for one.
+function requireAccount(req) {
+  if (!req.user?.id || req.user.federation) { throw new WebError('Forbidden', 403); }
+}
+
 export function setup(mstream) {
   mstream.post('/api/v1/stats/plays', (req, res) => {
-    if (!req.user?.id || req.user.federation) { throw new WebError('Forbidden', 403); }
+    requireAccount(req);
     const { value } = joiValidate(bodySchema, req.body || {});
     const result = ingestPlays(db.getDB(), req.user, value, {
       config: config.program.stats,
@@ -82,5 +179,115 @@ export function setup(mstream) {
       client: clientLabel(value.client),
     });
     res.json(result);
+  });
+
+  mstream.get('/api/v1/stats/summary', (req, res) => {
+    requireAccount(req);
+    const { value: v } = joiValidate(Joi.object(rangeKeys), req.query);
+    const r = resolveRange(v);
+    const body = q.summary(d(), {
+      user: req.user,
+      from: r.fromText, to: r.toText, fromDate: r.from, toDate: r.to,
+      tz: r.tz, origin: v.origin, ignoreVPaths: normIgnore(v.ignoreVPaths),
+    });
+    res.json({ period: periodOut(r), ...body });
+  });
+
+  mstream.get('/api/v1/stats/top', (req, res) => {
+    requireAccount(req);
+    const { value: v } = joiValidate(Joi.object({
+      ...rangeKeys,
+      entity: Joi.string().valid('tracks', 'artists', 'albums', 'genres').default('tracks'),
+      metric: Joi.string().valid('plays', 'time').default('plays'),
+      limit: Joi.number().integer().min(1).max(200).default(20),
+    }), req.query);
+    const r = resolveRange(v);
+    const args = {
+      user: req.user, userId: req.user.id,
+      from: r.fromText, to: r.toText,
+      scope: q.eventScope(req.user, normIgnore(v.ignoreVPaths)),
+      origin: v.origin, metric: v.metric, limit: v.limit, entity: v.entity,
+    };
+    const items = v.entity === 'tracks' ? q.topTracks(d(), args) : q.topGroups(d(), args);
+    res.json({ period: periodOut(r), entity: v.entity, metric: v.metric, items });
+  });
+
+  mstream.get('/api/v1/stats/timeseries', (req, res) => {
+    requireAccount(req);
+    const { value: v } = joiValidate(Joi.object({
+      ...rangeKeys,
+      bucket: Joi.string().valid('hour', 'day', 'week', 'month', 'hourOfDay', 'weekday').default('day'),
+    }), req.query);
+    const r = resolveRange(v);
+    if (!isBucket(v.bucket)) { throw new WebError('Unknown bucket', 400); }
+    const rows = q.hourRows(d(), { userId: req.user.id, from: r.from, to: r.to });
+    res.json({ period: periodOut(r), bucket: v.bucket, items: q.rebucket(rows, v.bucket, r.tz) });
+  });
+
+  mstream.get('/api/v1/stats/history', (req, res) => {
+    requireAccount(req);
+    const { value: v } = joiValidate(Joi.object({
+      before: Joi.string().max(512),
+      limit: Joi.number().integer().min(1).max(200).default(50),
+      track: Joi.string().max(128),
+      origin: Joi.string().valid(...ORIGIN_VALUES).default('all'),
+      ignoreVPaths: ignoreVPathsSchema,
+    }), req.query);
+    const { items, next } = q.history(d(), {
+      user: req.user, origin: v.origin, ignoreVPaths: normIgnore(v.ignoreVPaths),
+      trackHash: v.track ?? null, before: decodeCursor(v.before), limit: v.limit,
+    });
+    res.json({ items, next: encodeCursor(next) });
+  });
+
+  mstream.post('/api/v1/stats/tracks', (req, res) => {
+    requireAccount(req);
+    const { value: v } = joiValidate(Joi.object({
+      filePaths: Joi.array().items(Joi.string().max(2048)).max(500),
+      hashes: Joi.array().items(Joi.string().max(128)).max(500),
+    }).or('filePaths', 'hashes'), req.body || {});
+    // Resolve every path to its canonical hash first, so one lookup answers
+    // both lists and a path is reported under the key the client sent.
+    const byPath = new Map();
+    for (const p of v.filePaths || []) { byPath.set(p, hashForPath(p, req.user)); }
+    const wanted = [...new Set([...(v.hashes || []), ...[...byPath.values()].filter(Boolean)])];
+    const stats = q.trackStats(d(), req.user.id, wanted);
+    const render = (hash, filePath) => {
+      const s = stats.get(hash);
+      if (!s) { return null; }
+      return {
+        hash,
+        ...(filePath != null ? { filePath } : {}),
+        plays: s.play_count || 0,
+        skips: s.skip_count || 0,
+        listenedMs: s.listened_ms || 0,
+        firstPlayed: toIso(s.first_played),
+        lastPlayed: toIso(s.last_played),
+      };
+    };
+    const items = [];
+    for (const [p, h] of byPath) { const it = h && render(h, p); if (it) { items.push(it); } }
+    for (const h of v.hashes || []) { const it = render(h); if (it) { items.push(it); } }
+    res.json({ items });
+  });
+
+  mstream.get('/api/v1/stats/periods', (req, res) => {
+    requireAccount(req);
+    const { value: v } = joiValidate(Joi.object({ tz: Joi.string().max(64).default('UTC') }), req.query);
+    if (!isValidTimeZone(v.tz)) { throw new WebError(`Unknown timezone '${v.tz}'`, 400); }
+    const b = q.bounds(d(), req.user.id);
+    const periods = [];
+    if (b.earliest) {
+      const earliest = new Date(b.earliest);
+      const now = new Date();
+      for (const [period, maxBack] of [['week', 12], ['month', 12], ['quarter', 8], ['half', 6], ['year', 5]]) {
+        for (let offset = 0; offset >= -maxBack; offset--) {
+          const r = periodRange({ period, offset, tz: v.tz, now });
+          if (r.to <= earliest) { break; }
+          periods.push({ period, offset, label: r.label, from: r.from.toISOString(), to: r.to.toISOString() });
+        }
+      }
+    }
+    res.json({ ...b, tz: v.tz, periods });
   });
 }

--- a/src/stats/queries.js
+++ b/src/stats/queries.js
@@ -463,10 +463,23 @@ export function summary(d, { user, from, to, fromDate, toDate, tz, origin, ignor
 
 // ── History ──────────────────────────────────────────────────────────────
 
+// The key events are stored under, for any hash a client may know a track
+// by. The metadata object's `audio-hash` is the canonical key, but a client
+// holding only `hash` (the file hash) must still find the plays — and a
+// peer's reported hash, which no local row carries, must pass through. A
+// library hit resolves to its canonical key; anything else is used as sent.
+// Both probes are indexed (idx_tracks_audio_hash, idx_tracks_hash).
+export function canonicalHash(d, hash) {
+  if (typeof hash !== 'string' || hash.length === 0) { return hash; }
+  const row = d.prepare('SELECT audio_hash, file_hash FROM tracks WHERE audio_hash = ? OR file_hash = ? LIMIT 1')
+    .get(hash, hash);
+  return row ? (row.audio_hash || row.file_hash || hash) : hash;
+}
+
 export function history(d, { user, origin, ignoreVPaths, trackHash = null, before = null, limit }) {
   const scope = eventScope(user, ignoreVPaths);
   const extra = [];
-  if (trackHash) { extra.push(['pe.track_hash = ?', trackHash]); }
+  if (trackHash) { extra.push(['pe.track_hash = ?', canonicalHash(d, trackHash)]); }
   if (before) {
     extra.push(['(pe.started_at < ? OR (pe.started_at = ? AND pe.id < ?))', before.startedAt, before.startedAt, before.id]);
   }

--- a/src/stats/queries.js
+++ b/src/stats/queries.js
@@ -1,0 +1,527 @@
+// Read queries for the stats API (src/api/stats.js).
+//
+// Every function takes the DB handle and a RESOLVED request — the user, a
+// [from, to) range as stored text, the caller's library scope, an origin
+// filter — and returns plain data. Period arithmetic lives in ./time.js,
+// validation and rendering in the HTTP layer.
+//
+// Two sources, deliberately:
+//   play_events      lists, top-N, uniques, discoveries, sessions — anything
+//                    that needs the track or the outcome. Scoped by library
+//                    and origin. Bounded by raw retention.
+//   user_hour_stats  the time-series, streaks, peak hour / weekday, top day.
+//                    Per-user totals re-bucketed into the caller's zone;
+//                    NOT library- or origin-scoped (a rollup has neither),
+//                    and the part of the history that outlives pruning.
+
+import { libraryFilter, renderMetadataByIds, enrichRowsWithGenres } from '../api/db.js';
+import { fromSqlite, toIso, hourKey, bucketKeyFor, localDay, dayKeyPlus } from './time.js';
+
+export const SESSION_GAP_MS = 30 * 60 * 1000;
+const GENRE_SEP = String.fromCharCode(31);
+
+// ── Scoping ──────────────────────────────────────────────────────────────
+
+// Library scope for EVENT rows. A play of a local track counts when its
+// library is visible to the caller (and not ignored); a federated play
+// always passes — it has no local library, and it is the caller's own play.
+export function eventScope(user, ignoreVPaths) {
+  const f = libraryFilter(user, ignoreVPaths);
+  if (f.coversAllLibraries) { return { clause: '', params: [], libIds: null }; }
+  if (f.params.length === 0) { return { clause: 'pe.peer_id IS NOT NULL', params: [], libIds: new Set() }; }
+  return {
+    clause: `(pe.peer_id IS NOT NULL OR pe.library_id IN (${f.params.map(() => '?').join(',')}))`,
+    params: f.params,
+    libIds: new Set(f.params),
+  };
+}
+
+function whereEvents({ userId, from = null, to = null, scope = null, origin = 'all', extra = [] }) {
+  const clauses = ['pe.user_id = ?'];
+  const params = [userId];
+  if (from != null) { clauses.push('pe.started_at >= ?'); params.push(from); }
+  if (to != null) { clauses.push('pe.started_at < ?'); params.push(to); }
+  if (origin === 'local') { clauses.push('pe.peer_id IS NULL'); }
+  else if (origin === 'peers') { clauses.push('pe.peer_id IS NOT NULL'); }
+  if (scope?.clause) { clauses.push(scope.clause); params.push(...scope.params); }
+  for (const [clause, ...p] of extra) { clauses.push(clause); params.push(...p); }
+  return { sql: clauses.join(' AND '), params };
+}
+
+// ── Track resolution ─────────────────────────────────────────────────────
+
+// hash → the track row it names (the lowest id when a library holds the
+// same audio twice), restricted to [libIds] when given. Two index-driven
+// probes (idx_tracks_audio_hash, idx_tracks_hash) rather than a COALESCE
+// join the planner can't seek. Chunked under SQLite's bind-variable limit.
+export function resolveTracks(d, hashes, libIds = null) {
+  const out = new Map();
+  const uniq = [...new Set(hashes.filter((h) => typeof h === 'string' && h.length > 0))];
+  const lib = libIds ? [...libIds] : null;
+  const libClause = lib ? ` AND t.library_id IN (${lib.map(() => '?').join(',')})` : '';
+  const CHUNK = 400;
+  const cols = `t.id, t.library_id, t.artist_id, t.album_id, t.audio_hash, t.file_hash,
+                t.title, a.name AS artist, al.name AS album`;
+  const joins = 'FROM tracks t LEFT JOIN artists a ON a.id = t.artist_id LEFT JOIN albums al ON al.id = t.album_id';
+  for (let i = 0; i < uniq.length; i += CHUNK) {
+    const slice = uniq.slice(i, i + CHUNK);
+    const ph = slice.map(() => '?').join(',');
+    const rows = d.prepare(`
+      SELECT ${cols} ${joins} WHERE t.audio_hash IN (${ph})${libClause}
+      UNION ALL
+      SELECT ${cols} ${joins} WHERE t.file_hash IN (${ph}) AND t.audio_hash IS NULL${libClause}
+      ORDER BY 1`).all(...slice, ...(lib || []), ...slice, ...(lib || []));
+    for (const r of rows) {
+      const h = r.audio_hash ?? r.file_hash;
+      if (!out.has(h)) { out.set(h, r); }
+    }
+  }
+  return out;
+}
+
+function parseSnapshot(text) {
+  if (!text) { return {}; }
+  try { const v = JSON.parse(text); return v && typeof v === 'object' ? v : {}; } catch (_) { return {}; }
+}
+
+const basename = (p) => String(p || '').split('/').filter(Boolean).pop() || null;
+
+// A Metadata-shaped object for a row this library can't join — a federated
+// play, or a local track deleted since. Built from the snapshot the client
+// sent at ingest, falling back to the stored filepath.
+export function snapshotTrack(row) {
+  const snap = parseSnapshot(row.snapshot);
+  return {
+    filepath: row.filepath,
+    metadata: {
+      title: snap.title ?? basename(row.filepath),
+      artist: snap.artist ?? null,
+      album: snap.album ?? null,
+      hash: snap.hash ?? row.hash ?? null,
+      duration: typeof snap.durationMs === 'number' ? snap.durationMs / 1000 : null,
+      'album-art': snap.artFile ?? null,
+      genres: [],
+    },
+  };
+}
+
+// Attach a `track` object to every aggregate/event row: the library's own
+// metadata object for a local track that still resolves, the snapshot
+// otherwise. One resolve + one render per call, however many rows.
+export function attachTracks(d, rows, user, libIds) {
+  const localHashes = rows.filter((r) => r.peer_id == null && r.hash).map((r) => r.hash);
+  const resolved = resolveTracks(d, localHashes, libIds);
+  const rendered = renderMetadataByIds([...resolved.values()].map((t) => t.id), user);
+  for (const r of rows) {
+    const t = r.peer_id == null && r.hash ? resolved.get(r.hash) : null;
+    r.track = (t && rendered.get(t.id)) || snapshotTrack(r);
+  }
+  return rows;
+}
+
+// ── Aggregates over events ───────────────────────────────────────────────
+
+// Per-track aggregates over the events in [w]. Group key: the canonical
+// hash for a local row; (peer, hash-or-path) for a federated one.
+function trackAggregates(d, w, { metric = 'plays', limit = null } = {}) {
+  const order = metric === 'time' ? 'listened_ms DESC, plays DESC' : 'plays DESC, listened_ms DESC';
+  const having = metric === 'time' ? 'listened_ms > 0' : 'plays > 0';
+  return d.prepare(`
+    SELECT pe.track_hash AS hash, pe.peer_id AS peer_id,
+           MAX(pe.filepath) AS filepath, MAX(pe.snapshot) AS snapshot,
+           SUM(pe.counted) AS plays, SUM(pe.played_ms) AS listened_ms,
+           COUNT(*) AS events, MAX(pe.started_at) AS last_played
+      FROM play_events pe
+     WHERE ${w.sql}
+     GROUP BY COALESCE(pe.peer_id, 0), COALESCE(pe.track_hash, pe.filepath)
+    HAVING ${having}
+     ORDER BY ${order}, last_played DESC
+     ${limit != null ? 'LIMIT ?' : ''}`).all(...w.params, ...(limit != null ? [limit] : []));
+}
+
+function totalsOf(rows) {
+  let plays = 0;
+  let ms = 0;
+  for (const r of rows) { plays += r.plays || 0; ms += r.listened_ms || 0; }
+  return { plays, ms };
+}
+
+const share = (part, whole) => (whole > 0 ? Math.round((part / whole) * 1000) / 1000 : 0);
+
+export function topTracks(d, { user, userId, from, to, scope, origin, metric, limit }) {
+  const w = whereEvents({ userId, from, to, scope, origin });
+  const all = trackAggregates(d, w, { metric });
+  const totals = totalsOf(all);
+  const rows = attachTracks(d, all.slice(0, limit), user, scope?.libIds ?? null);
+  return rows.map((r, i) => ({
+    rank: i + 1,
+    plays: r.plays,
+    listenedMs: r.listened_ms,
+    events: r.events,
+    share: metric === 'time' ? share(r.listened_ms, totals.ms) : share(r.plays, totals.plays),
+    lastPlayed: toIso(r.last_played),
+    origin: r.peer_id == null ? 'local' : 'peer',
+    peerId: r.peer_id ?? null,
+    track: r.track,
+  }));
+}
+
+// artists / albums / genres: group the per-track aggregates by the entity.
+// Local rows join the library; federated rows contribute by the names in
+// their snapshot (no genres there). Artists and albums merge by name across
+// origins — a peer's "Radiohead" is the same artist as yours.
+export function topGroups(d, { userId, from, to, scope, origin, entity, metric, limit }) {
+  const w = whereEvents({ userId, from, to, scope, origin });
+  const all = trackAggregates(d, w, { metric });
+  const totals = totalsOf(all);
+  const local = all.filter((r) => r.peer_id == null && r.hash);
+  const resolved = resolveTracks(d, local.map((r) => r.hash), scope?.libIds ?? null);
+  let genresById = null;
+  if (entity === 'genres') {
+    const idRows = [...new Set([...resolved.values()].map((t) => t.id))].map((id) => ({ id }));
+    genresById = new Map(enrichRowsWithGenres(d, idRows).map((r) => [r.id, r.genres_concat]));
+  }
+
+  const groups = new Map();
+  const add = (key, fields, r) => {
+    let g = groups.get(key);
+    if (!g) { g = { ...fields, plays: 0, listenedMs: 0, events: 0, tracks: new Set() }; groups.set(key, g); }
+    g.plays += r.plays || 0;
+    g.listenedMs += r.listened_ms || 0;
+    g.events += r.events || 0;
+    g.tracks.add(`${r.peer_id ?? 0}:${r.hash ?? r.filepath}`);
+  };
+  const norm = (s) => String(s ?? '').trim().toLowerCase();
+
+  for (const r of all) {
+    const t = r.peer_id == null && r.hash ? resolved.get(r.hash) : null;
+    if (r.peer_id == null && !t) { continue; } // a local track that no longer resolves
+    const snap = t ? null : parseSnapshot(r.snapshot);
+    const artist = t ? t.artist : snap.artist;
+    const album = t ? t.album : snap.album;
+    switch (entity) {
+      case 'artists':
+        if (!artist) { break; }
+        add(norm(artist), { name: artist }, r);
+        break;
+      case 'albums':
+        if (!album) { break; }
+        add(`${norm(album)}|${norm(artist)}`, { name: album, artist: artist ?? null }, r);
+        break;
+      case 'genres': {
+        if (!t) { break; }
+        const gc = genresById.get(t.id);
+        if (!gc) { break; }
+        for (const name of gc.split(GENRE_SEP)) { if (name) { add(norm(name), { name }, r); } }
+        break;
+      }
+      default: break;
+    }
+  }
+
+  const sorted = [...groups.values()].sort((a, b) =>
+    (metric === 'time' ? b.listenedMs - a.listenedMs || b.plays - a.plays : b.plays - a.plays || b.listenedMs - a.listenedMs)
+    || a.name.localeCompare(b.name));
+  return sorted.slice(0, limit).map((g, i) => ({
+    rank: i + 1,
+    name: g.name,
+    ...(entity === 'albums' ? { artist: g.artist } : {}),
+    plays: g.plays,
+    listenedMs: g.listenedMs,
+    events: g.events,
+    tracks: g.tracks.size,
+    share: metric === 'time' ? share(g.listenedMs, totals.ms) : share(g.plays, totals.plays),
+  }));
+}
+
+// ── Rollups ──────────────────────────────────────────────────────────────
+
+// Rollup rows overlapping [from, to). A bound that is not on the hour (a
+// half-hour zone's midnight) includes its partial hour — the rollup can't
+// split it, and losing thirty minutes of listening is worse than gaining.
+export function hourRows(d, { userId, from, to }) {
+  const lo = hourKey(from);
+  const hi = hourKey(to);
+  const partial = to.getUTCMinutes() !== 0 || to.getUTCSeconds() !== 0 || to.getUTCMilliseconds() !== 0;
+  return d.prepare(`
+    SELECT hour, events, plays, skips, listened_ms
+      FROM user_hour_stats
+     WHERE user_id = ? AND hour >= ? AND hour ${partial ? '<=' : '<'} ?
+     ORDER BY hour`).all(userId, lo, hi);
+}
+
+const range = (n) => Array.from({ length: n }, (_, i) => String(i));
+
+// Fold UTC-hour rows into [bucket] keys in [tz]. Profile buckets (hourOfDay,
+// weekday) come back dense with zeros; calendar buckets only where data is.
+export function rebucket(rows, bucket, tz) {
+  const acc = new Map();
+  const seed = bucket === 'hourOfDay' ? range(24) : bucket === 'weekday' ? range(7) : [];
+  for (const k of seed) { acc.set(k, { bucket: k, events: 0, plays: 0, skips: 0, listenedMs: 0 }); }
+  for (const r of rows) {
+    const k = bucketKeyFor(r.hour, bucket, tz);
+    if (k == null) { continue; }
+    let b = acc.get(k);
+    if (!b) { b = { bucket: k, events: 0, plays: 0, skips: 0, listenedMs: 0 }; acc.set(k, b); }
+    b.events += r.events || 0;
+    b.plays += r.plays || 0;
+    b.skips += r.skips || 0;
+    b.listenedMs += r.listened_ms || 0;
+  }
+  const out = [...acc.values()];
+  if (bucket === 'hourOfDay' || bucket === 'weekday') { out.sort((a, b) => Number(a.bucket) - Number(b.bucket)); }
+  else { out.sort((a, b) => (a.bucket < b.bucket ? -1 : a.bucket > b.bucket ? 1 : 0)); }
+  return out;
+}
+
+// ── Sessions ─────────────────────────────────────────────────────────────
+
+// Sessions are runs of events with no gap over [gapMs] between one event's
+// end and the next one's start. Derived, not declared: a client session id
+// is a hint at best (an app process can span days), and clients that never
+// send one get the same numbers. Rows must be ordered by started_at.
+export function foldSessions(rows, gapMs = SESSION_GAP_MS) {
+  const sessions = [];
+  let cur = null;
+  for (const r of rows) {
+    const start = fromSqlite(r.started_at);
+    if (!start) { continue; }
+    const played = r.played_ms || 0;
+    const end = fromSqlite(r.ended_at) || new Date(start.getTime() + played);
+    if (cur && start.getTime() - cur.end.getTime() <= gapMs) {
+      cur.tracks += 1;
+      cur.plays += r.counted ? 1 : 0;
+      cur.listenedMs += played;
+      if (end > cur.end) { cur.end = end; }
+    } else {
+      cur = { start, end, tracks: 1, plays: r.counted ? 1 : 0, listenedMs: played };
+      sessions.push(cur);
+    }
+  }
+  return sessions;
+}
+
+// ── Streaks / days ───────────────────────────────────────────────────────
+
+// Consecutive local days with at least one counted play. `current` is the
+// run that reaches today or yesterday (a day without plays yet is not a
+// broken streak); `longest` is the best run in the rows given.
+export function streaks(dayKeys, todayKey) {
+  const days = [...new Set(dayKeys)].sort();
+  let longest = 0;
+  let run = 0;
+  let prev = null;
+  for (const day of days) {
+    run = prev && dayKeyPlus(prev, 1) === day ? run + 1 : 1;
+    if (run > longest) { longest = run; }
+    prev = day;
+  }
+  const last = days[days.length - 1];
+  const current = last && (last === todayKey || dayKeyPlus(last, 1) === todayKey) ? run : 0;
+  return { current, longest };
+}
+
+export function dayTotals(rows, tz) {
+  const days = new Map();
+  for (const r of rows) {
+    const k = bucketKeyFor(r.hour, 'day', tz);
+    if (k == null) { continue; }
+    let v = days.get(k);
+    if (!v) { v = { date: k, plays: 0, listenedMs: 0 }; days.set(k, v); }
+    v.plays += r.plays || 0;
+    v.listenedMs += r.listened_ms || 0;
+  }
+  return days;
+}
+
+function peakOf(items) {
+  let best = null;
+  for (const it of items) {
+    if (it.plays > 0 && (!best || it.plays > best.plays)) { best = it; }
+  }
+  return best ? Number(best.bucket) : null;
+}
+
+// ── Summary ──────────────────────────────────────────────────────────────
+
+export function summary(d, { user, from, to, fromDate, toDate, tz, origin, ignoreVPaths, now = new Date() }) {
+  const userId = user.id;
+  const scope = eventScope(user, ignoreVPaths);
+  const w = whereEvents({ userId, from, to, scope, origin });
+
+  const core = d.prepare(`
+    SELECT COUNT(*) AS events,
+           COALESCE(SUM(pe.counted), 0) AS plays,
+           COALESCE(SUM(pe.played_ms), 0) AS listened_ms,
+           COALESCE(SUM(CASE WHEN pe.outcome = 'skipped' THEN 1 ELSE 0 END), 0) AS skips,
+           COALESCE(SUM(CASE WHEN pe.outcome = 'completed' THEN 1 ELSE 0 END), 0) AS completed,
+           COALESCE(SUM(pe.pause_count), 0) AS pauses,
+           COALESCE(SUM(CASE WHEN pe.peer_id IS NULL THEN pe.counted ELSE 0 END), 0) AS local_plays,
+           COALESCE(SUM(CASE WHEN pe.peer_id IS NULL THEN pe.played_ms ELSE 0 END), 0) AS local_ms,
+           COALESCE(SUM(CASE WHEN pe.peer_id IS NOT NULL THEN pe.counted ELSE 0 END), 0) AS peer_plays,
+           COALESCE(SUM(CASE WHEN pe.peer_id IS NOT NULL THEN pe.played_ms ELSE 0 END), 0) AS peer_ms
+      FROM play_events pe
+     WHERE ${w.sql}`).get(...w.params);
+
+  // Distinct counted tracks in range, resolved for artist / album uniques.
+  const countedRows = d.prepare(`
+    SELECT COALESCE(pe.peer_id, 0) AS peer, pe.track_hash AS hash, MAX(pe.snapshot) AS snapshot
+      FROM play_events pe
+     WHERE ${w.sql} AND pe.counted = 1
+     GROUP BY COALESCE(pe.peer_id, 0), COALESCE(pe.track_hash, pe.filepath)`).all(...w.params);
+  const resolved = resolveTracks(d, countedRows.filter((r) => r.peer === 0).map((r) => r.hash), scope.libIds);
+  const artists = new Set();
+  const albums = new Set();
+  for (const r of countedRows) {
+    if (r.peer === 0) {
+      const t = resolved.get(r.hash);
+      if (!t) { continue; }
+      if (t.artist_id != null) { artists.add(`id:${t.artist_id}`); }
+      if (t.album_id != null) { albums.add(`id:${t.album_id}`); }
+    } else {
+      const snap = parseSnapshot(r.snapshot);
+      if (snap.artist) { artists.add(`name:${String(snap.artist).trim().toLowerCase()}`); }
+      if (snap.album) { albums.add(`name:${String(snap.album).trim().toLowerCase()}`); }
+    }
+  }
+
+  // Discoveries: tracks whose FIRST counted play ever falls in the range.
+  const wAll = whereEvents({ userId, scope, origin, extra: [['pe.counted = 1']] });
+  const discoveries = d.prepare(`
+    SELECT COUNT(*) AS n FROM (
+      SELECT MIN(pe.started_at) AS first
+        FROM play_events pe
+       WHERE ${wAll.sql}
+       GROUP BY COALESCE(pe.peer_id, 0), COALESCE(pe.track_hash, pe.filepath)
+      HAVING first >= ? AND first < ?)`).get(...wAll.params, from, to)?.n || 0;
+
+  // Library coverage: local tracks ever counted / tracks the caller can see.
+  const lf = libraryFilter(user, ignoreVPaths);
+  const totalTracks = d.prepare(`SELECT COUNT(*) AS n FROM tracks t WHERE ${lf.clause}`).get(...lf.params)?.n || 0;
+  const everHashes = d.prepare(`
+    SELECT DISTINCT pe.track_hash AS hash FROM play_events pe
+     WHERE ${wAll.sql} AND pe.peer_id IS NULL AND pe.track_hash IS NOT NULL`).all(...wAll.params).map((r) => r.hash);
+  const everPlayed = resolveTracks(d, everHashes, scope.libIds).size;
+  const coverage = totalTracks > 0 ? Math.min(100, Math.round((everPlayed / totalTracks) * 1000) / 10) : 0;
+
+  // Sessions from the ordered events in range.
+  const sessionRows = d.prepare(`
+    SELECT pe.started_at, pe.ended_at, pe.played_ms, pe.counted
+      FROM play_events pe WHERE ${w.sql} ORDER BY pe.started_at, pe.id`).all(...w.params);
+  const sessions = foldSessions(sessionRows);
+  let longest = null;
+  let totalSessionMs = 0;
+  for (const s of sessions) {
+    totalSessionMs += s.listenedMs;
+    if (!longest || s.listenedMs > longest.listenedMs) { longest = s; }
+  }
+
+  // Calendar facts from the rollup (per-user totals; see the header).
+  const rows = hourRows(d, { userId, from: fromDate, to: toDate });
+  const days = dayTotals(rows, tz);
+  const playedDays = [...days.values()].filter((v) => v.plays > 0).map((v) => v.date);
+  let topDay = null;
+  for (const v of days.values()) {
+    if (v.listenedMs > 0 && (!topDay || v.listenedMs > topDay.listenedMs)) { topDay = v; }
+  }
+
+  const events = core?.events || 0;
+  return {
+    events,
+    plays: core?.plays || 0,
+    uniqueTracks: countedRows.length,
+    uniqueArtists: artists.size,
+    uniqueAlbums: albums.size,
+    listenedMs: core?.listened_ms || 0,
+    skips: core?.skips || 0,
+    skipRate: events > 0 ? Math.round(((core?.skips || 0) / events) * 1000) / 1000 : 0,
+    completionRate: events > 0 ? Math.round(((core?.completed || 0) / events) * 1000) / 1000 : 0,
+    pauses: core?.pauses || 0,
+    discoveries,
+    libraryCoveragePct: coverage,
+    sessions: {
+      count: sessions.length,
+      avgMs: sessions.length > 0 ? Math.round(totalSessionMs / sessions.length) : null,
+      longest: longest ? {
+        startedAt: longest.start.toISOString(),
+        endedAt: longest.end.toISOString(),
+        tracks: longest.tracks,
+        plays: longest.plays,
+        listenedMs: longest.listenedMs,
+      } : null,
+    },
+    streakDays: streaks(playedDays, localDay(now, tz)),
+    topDay,
+    peakHour: peakOf(rebucket(rows, 'hourOfDay', tz)),
+    peakWeekday: peakOf(rebucket(rows, 'weekday', tz)),
+    origins: {
+      local: { plays: core?.local_plays || 0, listenedMs: core?.local_ms || 0 },
+      peers: { plays: core?.peer_plays || 0, listenedMs: core?.peer_ms || 0 },
+    },
+  };
+}
+
+// ── History ──────────────────────────────────────────────────────────────
+
+export function history(d, { user, origin, ignoreVPaths, trackHash = null, before = null, limit }) {
+  const scope = eventScope(user, ignoreVPaths);
+  const extra = [];
+  if (trackHash) { extra.push(['pe.track_hash = ?', trackHash]); }
+  if (before) {
+    extra.push(['(pe.started_at < ? OR (pe.started_at = ? AND pe.id < ?))', before.startedAt, before.startedAt, before.id]);
+  }
+  const w = whereEvents({ userId: user.id, scope, origin, extra });
+  const rows = d.prepare(`
+    SELECT pe.id, pe.event_id, pe.track_hash AS hash, pe.filepath, pe.library_id, pe.peer_id,
+           pe.snapshot, pe.client, pe.session_id, pe.source, pe.outcome, pe.counted,
+           pe.played_ms, pe.duration_ms, pe.pause_count, pe.started_at, pe.ended_at
+      FROM play_events pe
+     WHERE ${w.sql}
+     ORDER BY pe.started_at DESC, pe.id DESC
+     LIMIT ?`).all(...w.params, limit + 1);
+  const more = rows.length > limit;
+  if (more) { rows.pop(); }
+  attachTracks(d, rows, user, scope.libIds);
+  const last = rows[rows.length - 1];
+  return {
+    items: rows.map((r) => ({
+      id: r.event_id,
+      startedAt: toIso(r.started_at),
+      endedAt: toIso(r.ended_at),
+      playedMs: r.played_ms,
+      durationMs: r.duration_ms,
+      outcome: r.outcome,
+      counted: r.counted === 1,
+      source: r.source,
+      sessionId: r.session_id,
+      pauseCount: r.pause_count,
+      client: r.client,
+      origin: r.peer_id == null ? 'local' : 'peer',
+      peerId: r.peer_id ?? null,
+      track: r.track,
+    })),
+    next: more && last ? { startedAt: last.started_at, id: last.id } : null,
+  };
+}
+
+// ── Per-track counters ───────────────────────────────────────────────────
+
+export function trackStats(d, userId, hashes) {
+  const out = new Map();
+  const uniq = [...new Set(hashes.filter(Boolean))];
+  const CHUNK = 500;
+  for (let i = 0; i < uniq.length; i += CHUNK) {
+    const slice = uniq.slice(i, i + CHUNK);
+    const rows = d.prepare(`
+      SELECT track_hash, play_count, skip_count, listened_ms, first_played, last_played
+        FROM user_metadata
+       WHERE user_id = ? AND track_hash IN (${slice.map(() => '?').join(',')})`).all(userId, ...slice);
+    for (const r of rows) { out.set(r.track_hash, r); }
+  }
+  return out;
+}
+
+export function bounds(d, userId) {
+  const r = d.prepare('SELECT MIN(started_at) AS earliest, MAX(started_at) AS latest FROM play_events WHERE user_id = ?').get(userId);
+  return { earliest: toIso(r?.earliest), latest: toIso(r?.latest) };
+}

--- a/test/integration/stats-api.test.mjs
+++ b/test/integration/stats-api.test.mjs
@@ -1,0 +1,270 @@
+/**
+ * Stats API v2 read routes (src/api/stats.js) against a real server.
+ *
+ * Pattern mirrors test/integration/db-stats.test.mjs: boot mStream in
+ * public/no-users mode with an empty library, stop it, seed tracks and plays
+ * straight into the DB through the store primitive every writer uses
+ * (src/stats/store.js), boot again, hit the HTTP API. No media fixtures, so
+ * no ffmpeg dependency.
+ *
+ * Locks in: the summary's counts and derived facts, top-N by both metrics
+ * with the federated snapshot path, timezone-correct day bucketing, the
+ * history cursor, per-track counters by path, the periods listing, and the
+ * 400s for a bad timezone / unknown parameter.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+import { recordPlayEvents } from '../../src/stats/store.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref(); srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => { const { port } = srv.address(); srv.close(() => resolve(port)); });
+  });
+}
+
+async function waitForReady(baseUrl, timeoutMs = 90_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try { const r = await fetch(`${baseUrl}/api/`); if (r.status < 500) return; } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+
+async function boot(tmpDir, musicDir) {
+  const port = await findFreePort();
+  const config = {
+    port, address: '127.0.0.1',
+    dlna: { mode: 'disabled' },
+    folders: { testlib: { root: musicDir } },
+    storage: {
+      albumArtDirectory: path.join(tmpDir, 'image-cache'),
+      dbDirectory: path.join(tmpDir, 'db'),
+      logsDirectory: path.join(tmpDir, 'logs'),
+    },
+    scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+  };
+  for (const dir of Object.values(config.storage)) await fs.mkdir(dir, { recursive: true });
+  const configPath = path.join(tmpDir, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify(config));
+  const proc = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', configPath],
+    { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForReady(baseUrl);
+  } catch (err) {
+    try { proc.kill('SIGKILL'); } catch { /* already gone */ }
+    throw err;
+  }
+  return { proc, baseUrl };
+}
+
+async function kill(proc) { if (proc.exitCode == null) { proc.kill('SIGKILL'); await new Promise((r) => proc.once('exit', r)); } }
+
+async function get(baseUrl, route) {
+  const r = await fetch(`${baseUrl}${route}`);
+  return { status: r.status, body: r.status === 200 ? await r.json() : await r.text() };
+}
+async function post(baseUrl, route, body) {
+  const r = await fetch(`${baseUrl}${route}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  return { status: r.status, body: r.status === 200 ? await r.json() : await r.text() };
+}
+
+// Three local tracks (C has NULL audio_hash → canonical = file_hash), one
+// federated peer, six plays spread over August/September 2026 — one of them
+// at 22:30Z so a Berlin day boundary can be checked against UTC.
+function seed(dbPath) {
+  const db = new DatabaseSync(dbPath); db.exec('PRAGMA foreign_keys = ON');
+  assert.ok(db.prepare('PRAGMA user_version').get().user_version >= 70, 'V70+ applied at boot');
+  const lib = db.prepare("SELECT id FROM libraries WHERE name='testlib'").get().id;
+  const aid = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist')").run().lastInsertRowid);
+  const alid = Number(db.prepare("INSERT INTO albums (name, artist_id, year) VALUES ('Alb', ?, 2020)").run(aid).lastInsertRowid);
+  const insT = db.prepare(`INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, file_hash, audio_hash, duration, modified, scan_id)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, 180, ?, 'seed')`);
+  const gJazz = Number(db.prepare("INSERT INTO genres (name) VALUES ('Jazz')").run().lastInsertRowid);
+  const insTG = db.prepare('INSERT INTO track_genres (track_id, genre_id) VALUES (?, ?)');
+  const ts = 1700000000000;
+  const idA = Number(insT.run('Song A.mp3', lib, 'Song A', aid, alid, 'fhA', 'ahA', ts).lastInsertRowid);
+  insT.run('Song B.mp3', lib, 'Song B', aid, alid, 'fhB', 'ahB', ts + 1);
+  insT.run('Song C.mp3', lib, 'Song C', aid, alid, 'fhC', null, ts + 2);
+  insTG.run(idA, gJazz);
+  const peer = Number(db.prepare("INSERT INTO federation_peers (name, endpoint_ticket, api_key) VALUES ('Bob', 't', 'fedk_bob')").run().lastInsertRowid);
+  const uid = db.prepare('SELECT id FROM users WHERE is_anonymous_sentinel = 1').get().id;
+
+  const ev = (over) => ({
+    userId: uid, libraryId: lib, outcome: 'completed', counted: true, playedMs: 180_000, durationMs: 180_000,
+    source: 'manual', client: 'test', ...over,
+  });
+  recordPlayEvents(db, [
+    ev({ eventId: 'aug-A', trackHash: 'ahA', filepath: 'Song A.mp3', startedAt: '2026-08-15 10:00:00', endedAt: '2026-08-15 10:03:00' }),
+    ev({ eventId: 'sep1-A', trackHash: 'ahA', filepath: 'Song A.mp3', startedAt: '2026-09-01 10:00:00', endedAt: '2026-09-01 10:03:00' }),
+    ev({ eventId: 'sep2-B', trackHash: 'ahB', filepath: 'Song B.mp3', outcome: 'skipped', counted: false, playedMs: 10_000,
+      startedAt: '2026-09-02 10:05:00', endedAt: '2026-09-02 10:05:10' }),
+    ev({ eventId: 'sep2-A', trackHash: 'ahA', filepath: 'Song A.mp3', startedAt: '2026-09-02 22:30:00', endedAt: '2026-09-02 22:33:00' }),
+    ev({ eventId: 'sep3-C', trackHash: 'fhC', filepath: 'Song C.mp3', startedAt: '2026-09-03 10:00:00', endedAt: '2026-09-03 10:03:00' }),
+    ev({ eventId: 'sep3-peer', trackHash: 'ph1', filepath: 'music/peer.flac', libraryId: null, peerId: peer,
+      snapshot: { title: 'Peer Song', artist: 'Peer Artist', album: 'Peer Album', hash: 'ph1', durationMs: 240_000 },
+      playedMs: 240_000, durationMs: 240_000, startedAt: '2026-09-03 11:00:00', endedAt: '2026-09-03 11:04:00' }),
+  ]);
+  db.close();
+  return { peer };
+}
+
+const SEP = 'from=2026-09-01T00:00:00Z&to=2026-09-04T00:00:00Z';
+
+describe('stats API v2 — reads', () => {
+  let tmpDir, server, seeded;
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-stats-'));
+    const musicDir = path.join(tmpDir, 'music'); await fs.mkdir(musicDir, { recursive: true });
+    server = await boot(tmpDir, musicDir);
+    await kill(server.proc); await sleep(200);
+    seeded = seed(path.join(tmpDir, 'db', 'mstream.db'));
+    server = await boot(tmpDir, musicDir);
+  });
+  after(async () => {
+    if (server?.proc) await kill(server.proc);
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('summary: counts, uniques, discoveries, sessions, streak, origins', async () => {
+    const r = await get(server.baseUrl, `/api/v1/stats/summary?${SEP}`);
+    assert.equal(r.status, 200, r.body);
+    const s = r.body;
+    assert.equal(s.period.from, '2026-09-01T00:00:00.000Z');
+    assert.equal(s.period.tz, 'UTC');
+    assert.equal(s.events, 5);
+    assert.equal(s.plays, 4);
+    assert.equal(s.skips, 1);
+    assert.equal(s.uniqueTracks, 3);          // A, C, peer
+    assert.equal(s.uniqueArtists, 2);         // Artist + Peer Artist
+    assert.equal(s.uniqueAlbums, 2);
+    assert.equal(s.listenedMs, 180_000 * 3 + 10_000 + 240_000);
+    assert.equal(s.skipRate, 0.2);
+    assert.equal(s.completionRate, 0.8);
+    assert.equal(s.discoveries, 2);           // C and the peer track; A's first play was in August
+    assert.equal(s.libraryCoveragePct, 66.7); // A and C of three local tracks, ever
+    assert.equal(s.sessions.count, 5);
+    assert.equal(s.sessions.longest.listenedMs, 240_000);
+    assert.deepEqual(s.streakDays, { current: 0, longest: 3 });
+    assert.equal(s.topDay.date, '2026-09-03');
+    assert.equal(s.peakHour, 10);
+    assert.deepEqual(s.origins, { local: { plays: 3, listenedMs: 550_000 }, peers: { plays: 1, listenedMs: 240_000 } });
+  });
+
+  test('summary: origin=local drops the peer play; a Berlin day moves the 22:30Z play', async () => {
+    const local = await get(server.baseUrl, `/api/v1/stats/summary?${SEP}&origin=local`);
+    assert.equal(local.body.plays, 3);
+    assert.equal(local.body.uniqueTracks, 2);
+    const berlin = await get(server.baseUrl, `/api/v1/stats/summary?${SEP}&tz=Europe/Berlin`);
+    assert.equal(berlin.body.period.tz, 'Europe/Berlin');
+    assert.equal(berlin.body.topDay.date, '2026-09-03'); // 22:30Z Sep 2 = 00:30 Sep 3 local → three plays that day
+  });
+
+  test('top tracks by plays, with a federated snapshot row', async () => {
+    const r = await get(server.baseUrl, `/api/v1/stats/top?${SEP}&entity=tracks&limit=10`);
+    assert.equal(r.status, 200, r.body);
+    assert.deepEqual(r.body.items.map((i) => i.track.metadata.title), ['Song A', 'Peer Song', 'Song C']);
+    const [a, peer, c] = r.body.items;
+    assert.deepEqual([a.rank, a.plays, a.origin, a.share], [1, 2, 'local', 0.5]);
+    assert.equal(a.track.metadata.artist, 'Artist');
+    assert.deepEqual(a.track.metadata.genres, ['Jazz']);
+    assert.equal(peer.origin, 'peer');
+    assert.equal(peer.peerId, seeded.peer);
+    assert.equal(peer.track.metadata.artist, 'Peer Artist');
+    assert.equal(peer.track.metadata.hash, 'ph1');
+    assert.equal(c.track.metadata.title, 'Song C'); // file_hash canonical resolves
+  });
+
+  test('top by time, and grouped entities', async () => {
+    const byTime = await get(server.baseUrl, `/api/v1/stats/top?${SEP}&metric=time&limit=1`);
+    assert.equal(byTime.body.items[0].track.metadata.title, 'Song A'); // 360 s beats the peer's 240 s
+    const artists = await get(server.baseUrl, `/api/v1/stats/top?${SEP}&entity=artists`);
+    // Song B's only play was an uncounted skip, so 'Artist' has two counted tracks behind three plays.
+    assert.deepEqual(artists.body.items.map((i) => [i.name, i.plays, i.tracks]), [['Artist', 3, 2], ['Peer Artist', 1, 1]]);
+    const albums = await get(server.baseUrl, `/api/v1/stats/top?${SEP}&entity=albums`);
+    assert.deepEqual(albums.body.items.map((i) => [i.name, i.artist, i.plays]), [['Alb', 'Artist', 3], ['Peer Album', 'Peer Artist', 1]]);
+    const genres = await get(server.baseUrl, `/api/v1/stats/top?${SEP}&entity=genres`);
+    assert.deepEqual(genres.body.items.map((i) => [i.name, i.plays]), [['Jazz', 2]]);
+  });
+
+  test('timeseries: day buckets follow the timezone; profile buckets are dense', async () => {
+    const utc = await get(server.baseUrl, `/api/v1/stats/timeseries?${SEP}&bucket=day`);
+    assert.deepEqual(utc.body.items.map((b) => [b.bucket, b.events, b.plays]),
+      [['2026-09-01', 1, 1], ['2026-09-02', 2, 1], ['2026-09-03', 2, 2]]);
+    const berlin = await get(server.baseUrl, `/api/v1/stats/timeseries?${SEP}&bucket=day&tz=Europe/Berlin`);
+    assert.deepEqual(berlin.body.items.map((b) => [b.bucket, b.plays]),
+      [['2026-09-01', 1], ['2026-09-02', 0], ['2026-09-03', 3]]);
+    const hod = await get(server.baseUrl, `/api/v1/stats/timeseries?${SEP}&bucket=hourOfDay`);
+    assert.equal(hod.body.items.length, 24);
+    assert.equal(hod.body.items[10].plays, 2);
+    assert.equal(hod.body.items[11].plays, 1);
+    const wd = await get(server.baseUrl, `/api/v1/stats/timeseries?period=all&bucket=weekday`);
+    assert.equal(wd.body.items.length, 7);
+  });
+
+  test('history: newest first, cursor pagination, track filter', async () => {
+    const p1 = await get(server.baseUrl, '/api/v1/stats/history?limit=2');
+    assert.equal(p1.status, 200, p1.body);
+    assert.deepEqual(p1.body.items.map((i) => i.id), ['sep3-peer', 'sep3-C']);
+    assert.equal(p1.body.items[0].origin, 'peer');
+    assert.equal(p1.body.items[0].track.metadata.title, 'Peer Song');
+    assert.equal(p1.body.items[0].startedAt, '2026-09-03T11:00:00.000Z');
+    assert.ok(p1.body.next);
+    const p2 = await get(server.baseUrl, `/api/v1/stats/history?limit=2&before=${encodeURIComponent(p1.body.next)}`);
+    assert.deepEqual(p2.body.items.map((i) => i.id), ['sep2-A', 'sep2-B']);
+    assert.equal(p2.body.items[1].counted, false);
+    const p3 = await get(server.baseUrl, `/api/v1/stats/history?limit=2&before=${encodeURIComponent(p2.body.next)}`);
+    assert.deepEqual(p3.body.items.map((i) => i.id), ['sep1-A', 'aug-A']);
+    assert.equal(p3.body.next, null);
+    const onlyA = await get(server.baseUrl, '/api/v1/stats/history?track=ahA');
+    assert.deepEqual(onlyA.body.items.map((i) => i.id), ['sep2-A', 'sep1-A', 'aug-A']);
+    const bad = await get(server.baseUrl, '/api/v1/stats/history?before=not-a-cursor');
+    assert.equal(bad.status, 400);
+  });
+
+  test('tracks: counters by path and by hash; unknown tracks omitted', async () => {
+    const r = await post(server.baseUrl, '/api/v1/stats/tracks', { filePaths: ['testlib/Song A.mp3', 'testlib/Nope.mp3'], hashes: ['fhC', 'zzz'] });
+    assert.equal(r.status, 200, r.body);
+    assert.deepEqual(r.body.items.map((i) => [i.hash, i.filePath ?? null, i.plays, i.skips]),
+      [['ahA', 'testlib/Song A.mp3', 3, 0], ['fhC', null, 1, 0]]);
+    assert.equal(r.body.items[0].firstPlayed, '2026-08-15T10:00:00.000Z');
+    assert.equal(r.body.items[0].lastPlayed, '2026-09-02T22:30:00.000Z');
+    const empty = await post(server.baseUrl, '/api/v1/stats/tracks', {});
+    assert.equal(empty.status, 400);
+  });
+
+  test('periods: bounds and the presets that overlap them', async () => {
+    const r = await get(server.baseUrl, '/api/v1/stats/periods?tz=Europe/Berlin');
+    assert.equal(r.status, 200, r.body);
+    assert.equal(r.body.earliest, '2026-08-15T10:00:00.000Z');
+    assert.equal(r.body.latest, '2026-09-03T11:00:00.000Z');
+    assert.ok(r.body.periods.some((p) => p.period === 'month' && p.offset === 0));
+    assert.ok(r.body.periods.every((p) => new Date(p.to) > new Date(r.body.earliest)));
+  });
+
+  test('400 on an unknown timezone, an unpaired from, or an unknown parameter', async () => {
+    assert.equal((await get(server.baseUrl, '/api/v1/stats/summary?tz=Nope/Zone')).status, 400);
+    assert.equal((await get(server.baseUrl, '/api/v1/stats/summary?from=2026-09-01T00:00:00Z')).status, 400);
+    const unknown = await get(server.baseUrl, '/api/v1/stats/summary?bogus=1');
+    assert.equal(unknown.status, 400);
+    assert.match(unknown.body, /bogus.* is not allowed/); // the Joi message the app's ServerCapabilities parses
+  });
+});

--- a/test/integration/stats-api.test.mjs
+++ b/test/integration/stats-api.test.mjs
@@ -9,7 +9,8 @@
  *
  * Locks in: the summary's counts and derived facts, top-N by both metrics
  * with the federated snapshot path, timezone-correct day bucketing, the
- * history cursor, per-track counters by path, the periods listing, and the
+ * history cursor and its either-hash track filter, per-track counters by
+ * path, the periods listing, and the
  * 400s for a bad timezone / unknown parameter.
  */
 
@@ -236,6 +237,12 @@ describe('stats API v2 — reads', () => {
     assert.equal(p3.body.next, null);
     const onlyA = await get(server.baseUrl, '/api/v1/stats/history?track=ahA');
     assert.deepEqual(onlyA.body.items.map((i) => i.id), ['sep2-A', 'sep1-A', 'aug-A']);
+    // The file hash resolves to the same canonical key; a peer's hash has no
+    // library row and filters the events directly.
+    const byFileHash = await get(server.baseUrl, '/api/v1/stats/history?track=fhA');
+    assert.deepEqual(byFileHash.body.items.map((i) => i.id), ['sep2-A', 'sep1-A', 'aug-A']);
+    const peerOnly = await get(server.baseUrl, '/api/v1/stats/history?track=ph1');
+    assert.deepEqual(peerOnly.body.items.map((i) => i.id), ['sep3-peer']);
     const bad = await get(server.baseUrl, '/api/v1/stats/history?before=not-a-cursor');
     assert.equal(bad.status, 400);
   });


### PR DESCRIPTION
## Summary

The read side of **Stats API v2**, on top of the write side that landed in #968 (S2 in the app repo's `PLAY_HISTORY_PLAN.md`). Six reads over the V70 listening log, every one scoped to the caller: their own plays, their visible libraries (`ignoreVPaths` narrows further), and **their timezone** — period and day boundaries follow the `tz` the client sends, never the server's clock, which is the wrapped-era bug class this replaces.

## The routes

| Route | Returns |
|---|---|
| `GET /api/v1/stats/summary` | the period's numbers as data: events, counted plays, unique tracks/artists/albums, listened time, skip and completion rates, discoveries (first counted play ever falls in the period), library coverage, sessions derived from 30-minute gaps, day streaks, the top day, peak hour and weekday, and the local/peer split |
| `GET /api/v1/stats/top?entity=tracks\|artists\|albums\|genres&metric=plays\|time` | ranked rows with share of the period; a track row carries the library's metadata object when it still resolves, otherwise the snapshot recorded at ingest (always for a federated peer's track, which also carries `peerId`); artists and albums merge by name across origins |
| `GET /api/v1/stats/timeseries?bucket=hour\|day\|week\|month\|hourOfDay\|weekday` | the per-user hourly rollup re-bucketed into the caller's zone |
| `GET /api/v1/stats/history` | the log newest first, cursor-paginated, filterable by track hash and origin |
| `POST /api/v1/stats/tracks` | per-track counters for a batch of paths or hashes (Song Info, badges) |
| `GET /api/v1/stats/periods` | the preset periods that overlap the log's bounds |

All take either `period=week|month|quarter|half|year|all` + `offset` or an explicit `from`/`to`, plus `tz`, `origin=all|local|peers`, `ignoreVPaths`.

## How

- `src/stats/queries.js` holds the SQL. Hashes resolve to tracks through two index-driven probes (`idx_tracks_audio_hash`, `idx_tracks_hash`) rather than a COALESCE join the planner can't seek. Time-series facts come from `user_hour_stats` (per-user totals, not narrowed by library or origin — a rollup has neither — and the part of the history that outlives retention); everything track-shaped comes from `play_events`.
- Period arithmetic is the `src/stats/time.js` half that #968 carried in advance: local midnights in the caller's IANA zone, Monday-first weeks, whole-period offsets, exact re-bucketing of UTC hours for any whole-hour zone (half-hour zones get half-hour error, documented).
- The shared route module `src/api/stats.js` gains a `requireAccount` guard on every route: a federation key or a guest token builds a user with no id, and stats are never read for one.
- OpenAPI: the six reads plus two shared schemas under the Stats tag.

## Verification

- `test/integration/stats-api.test.mjs`: boots a server, seeds tracks and plays through the store primitive, and checks the summary's counts and derived facts, top by both metrics with the federated snapshot path, timezone-correct day bucketing (a 22:30Z play moving to the next Berlin day), cursor pagination, per-track counters by path and hash, the periods listing, and the 400s. 9/9.
- The #968 ingest suite still passes on this branch (4/4); `eslint` clean; the OpenAPI file parses.
- The full review pass is in the app repo's `PLAY_HISTORY_PLAN.md` §3.4.

## Not in this PR

Still nothing advertises the surface in `features` — the `scrobble-by-filepath` shim, the retention sweep and the `stats` flag are the next change (S3), so clients never see a partial API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
