### PR TITLE
feat(stats): Stats API v2 lifecycle — features.stats, forget/reset/export/rebuild, retention, the scrobble shim

### DIFF
--- a/docs/json_config.md
+++ b/docs/json_config.md
@@ -295,7 +295,7 @@ the verdict with the play, and only counted plays move a track's play count.
 
 - `playThresholdMs` — listening at least this long counts as a play (default 30 s).
 - `playThresholdFraction` — or at least this fraction of the track, when its length is known (default half). `0` disables the fraction rule.
-- `retentionMonths` — plays that started earlier than this many months ago are refused as `bad-time`. `0` accepts anything since 2000.
+- `retentionMonths` — plays that started earlier than this many months ago are refused as `bad-time`, and a daily sweep prunes stored plays older than that (their totals survive in the per-track counters and the hourly rollup). `0` keeps everything and accepts anything since 2000.
 
 ## Storage
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1000,6 +1000,13 @@ paths:
                       facts only: no counts, no library or content names,
                       no identity.
                     properties:
+                      stats:
+                        type: integer
+                        description: >
+                          The Stats API v2 version this server speaks
+                          (`/api/v1/stats/*`: ingest, reads, management).
+                          Absent on servers without it — gate on this key,
+                          never on the version string.
                       discoveryReady:
                         type: boolean
                         description: >
@@ -2325,6 +2332,22 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { description: "A federation key or guest token — stats are never recorded for those." }
 
+    delete:
+      tags: [Stats]
+      summary: Forget every play in a range
+      parameters:
+        - { name: from, in: query, required: true, schema: { type: string, format: date-time } }
+        - { name: to, in: query, required: true, schema: { type: string, format: date-time }, description: "Exclusive." }
+      responses:
+        "200":
+          description: How many went.
+          content:
+            application/json:
+              schema: { type: object, properties: { deleted: { type: integer } } }
+        "400": { description: "Missing or unordered bounds." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+
   # ── Stats API v2 (read side) ─────────────────────────────────────────────
   # Every read is scoped to the caller's own plays and visible libraries.
   # A range is a preset `period` (+ `offset` <= 0) or an explicit `from`/`to`
@@ -2608,6 +2631,82 @@ paths:
                         to: { type: string, format: date-time }
         "400": { description: "Validation failed: unknown parameter, bad timezone, unpaired from/to, or an invalid cursor." }
         "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/stats/plays/{id}:
+    delete:
+      tags: [Stats]
+      summary: Forget one play
+      description: The event goes, and its track's counters and its hour in the rollup are decremented exactly.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string }, description: "The client's event id." }
+      responses:
+        "200":
+          description: Deleted.
+          content:
+            application/json:
+              schema: { type: object, properties: { deleted: { type: integer } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { description: "No play with that id for this user." }
+
+  /api/v1/stats/reset:
+    post:
+      tags: [Stats]
+      summary: Zero the counters, drop the log, or both
+      description: |
+        `counts` zeroes play/skip counts, listened time and first/last played on every track
+        (stars and ratings stay). `history` deletes the log and its hourly rollup. `all` does both.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [scope]
+              properties:
+                scope: { type: string, enum: [counts, history, all] }
+      responses:
+        "200":
+          description: What was reset.
+          content:
+            application/json:
+              schema: { type: object, properties: { scope: { type: string }, tracks: { type: integer }, events: { type: integer } } }
+        "400": { description: "Unknown scope." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/stats/export:
+    get:
+      tags: [Stats]
+      summary: The whole listening log as NDJSON
+      description: One JSON object per line, oldest first, streamed. A backup, a migration, or a client rebuilding its local copy.
+      responses:
+        "200":
+          description: The log.
+          content:
+            application/x-ndjson:
+              schema:
+                type: string
+                description: "Lines of `{id, startedAt, endedAt, playedMs, durationMs, outcome, counted, source, sessionId, pauseCount, client, filePath, peerId, trackHash, snapshot}`."
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/admin/stats/rebuild:
+    post:
+      tags: [Stats]
+      summary: Recompute the hourly rollup from the log (admin)
+      description: Every hour that still has events is rewritten exactly; hours whose events were pruned by retention keep their rows.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId: { type: integer, description: "Narrow to one user." }
+      responses:
+        "200":
+          description: Hours rewritten.
+          content:
+            application/json:
+              schema: { type: object, properties: { hours: { type: integer } } }
+        "403": { description: "Not an admin." }
 
   # ── Playlists ────────────────────────────────────────────────────────────
 

--- a/src/api/playlist.js
+++ b/src/api/playlist.js
@@ -28,6 +28,8 @@ export function setup(mstream) {
       supportedAudioFiles: features.supportedAudioFiles,
       discovery: features.discovery,
       discoveryP2p: features.discoveryP2p,
+      // Stats API v2 version — the same fact /api/ carries under features.
+      stats: features.stats,
       // A resource (the playlist routes), not a server capability.
       playlists: getPlaylists(req.user.id),
       // Historical version-gate ("this server has the sonic-path route") —

--- a/src/api/scrobbler.js
+++ b/src/api/scrobbler.js
@@ -5,6 +5,8 @@ import Scribble from '../state/lastfm.js';
 import * as db from '../db/manager.js';
 import { joiValidate } from '../util/validation.js';
 import { getVPathInfo } from '../util/vpath.js';
+import { randomUUID } from 'node:crypto';
+import { recordPlayEvent } from '../stats/store.js';
 
 const Scrobbler = new Scribble();
 
@@ -201,7 +203,7 @@ export function setup(mstream) {
     if (!lib) { return res.json({ scrobble: false }); }
 
     const track = d().prepare(`
-      SELECT t.file_hash, t.audio_hash, t.title, a.name AS artist, al.name AS album
+      SELECT t.file_hash, t.audio_hash, t.title, t.duration, a.name AS artist, al.name AS album
       FROM tracks t
       LEFT JOIN artists a ON t.artist_id = a.id
       LEFT JOIN albums al ON t.album_id = al.id
@@ -225,15 +227,29 @@ export function setup(mstream) {
       return res.json({ scrobble: false });
     }
 
-    // Update play count and last played. Sentinel-keyed in public mode
-    // — the operator's listening history. See the header comment above.
-    d().prepare(`
-      INSERT INTO user_metadata (user_id, track_hash, play_count, last_played)
-      VALUES (?, ?, 1, datetime('now'))
-      ON CONFLICT(user_id, track_hash) DO UPDATE SET
-        play_count = play_count + 1,
-        last_played = datetime('now')
-    `).run(req.user.id, trackKey);
+    // The count now goes through the same write as every other play
+    // (src/stats/store.js), as a synthetic event the stats reads can see:
+    // counted by decree — the web player fires this route 30 s into a
+    // track, so 30 s listened is all that is known — and marked
+    // `source: 'legacy'` for the day the route goes. play_count and
+    // last_played move exactly as they always did. Sentinel-keyed in public
+    // mode — the operator's listening history. See the header comment above.
+    const now = Date.now();
+    recordPlayEvent(d(), {
+      eventId: randomUUID(),
+      userId: req.user.id,
+      trackHash: trackKey,
+      filepath: pathInfo.relativePath,
+      libraryId: lib.id,
+      client: 'legacy',
+      source: 'legacy',
+      outcome: 'stopped',
+      counted: true,
+      playedMs: 30000,
+      durationMs: track.duration > 0 ? Math.round(track.duration * 1000) : null,
+      startedAt: new Date(now - 30000),
+      endedAt: new Date(now),
+    });
 
     res.json({});
 

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -85,6 +85,11 @@ export function buildFeatures() {
     transcode: transcodeInfo,
     // Per-format booleans from config.
     supportedAudioFiles: config.program.supportedAudioFiles,
+    // Stats API v2 (/api/v1/stats/*): the version a client should speak.
+    // Absent on older servers, so a client gates on this — never on the
+    // version string. 2 = ingest, reads and management together; a partial
+    // surface was never advertised.
+    stats: 2,
   };
 }
 

--- a/src/api/stats.js
+++ b/src/api/stats.js
@@ -8,6 +8,11 @@
 //                                  filterable by any hash a client knows a track by
 //   POST /api/v1/stats/tracks      per-track counters for a batch of paths / hashes
 //   GET  /api/v1/stats/periods     which periods have data
+//   DELETE /api/v1/stats/plays/:id  forget one play (counters and rollup follow)
+//   DELETE /api/v1/stats/plays?from=&to=  forget every play in a range
+//   POST /api/v1/stats/reset       zero the counters, drop the log, or both
+//   GET  /api/v1/stats/export      the whole log as NDJSON
+//   POST /api/v1/admin/stats/rebuild  recompute the hourly rollup from the log
 //
 // Write side: clients (the mobile app's outbox, the web player) send plays
 // AFTER they happen, with their own ids and start times. The server resolves
@@ -26,8 +31,9 @@
 //
 // Never reachable with a federation key or a guest token: the wall's
 // allowlist does not carry these routes, and the synthetic user those tokens
-// build has no id to record against or read for. Nothing advertises the
-// surface in `features` until the scrobble shim and the flag land with it.
+// build has no id to record against or read for. The surface is advertised
+// as `features.stats` (src/api/server-info.js); clients gate on that, never
+// on the version string.
 
 import Joi from 'joi';
 import * as db from '../db/manager.js';
@@ -38,7 +44,9 @@ import { joiValidate } from '../util/validation.js';
 import { getVPathInfo } from '../util/vpath.js';
 import * as q from '../stats/queries.js';
 import { ingestPlays, MAX_BATCH } from '../stats/ingest.js';
-import { OUTCOMES, SOURCES } from '../stats/store.js';
+import {
+  OUTCOMES, SOURCES, RESET_SCOPES, deletePlayEvents, resetStats, rebuildHourStats,
+} from '../stats/store.js';
 import {
   isValidTimeZone, isBucket, periodRange, customRange, toSqlite, fromSqlite, toIso,
 } from '../stats/time.js';
@@ -270,6 +278,86 @@ export function setup(mstream) {
     for (const [p, h] of byPath) { const it = h && render(h, p); if (it) { items.push(it); } }
     for (const h of v.hashes || []) { const it = render(h); if (it) { items.push(it); } }
     res.json({ items });
+  });
+
+  // ── Management ──
+
+  mstream.delete('/api/v1/stats/plays/:id', (req, res) => {
+    requireAccount(req);
+    const { value } = joiValidate(Joi.object({ id: Joi.string().min(1).max(128).required() }), req.params);
+    const r = deletePlayEvents(d(), req.user.id, { eventIds: [value.id] });
+    if (r.deleted === 0) { throw new WebError('No such play', 404); }
+    res.json(r);
+  });
+
+  mstream.delete('/api/v1/stats/plays', (req, res) => {
+    requireAccount(req);
+    const { value: v } = joiValidate(Joi.object({
+      from: Joi.string().isoDate().required(),
+      to: Joi.string().isoDate().required(),
+    }), req.query);
+    let r;
+    try { r = customRange(v.from, v.to); } catch (err) { throw new WebError(err.message, 400); }
+    res.json(deletePlayEvents(d(), req.user.id, { from: toSqlite(r.from), to: toSqlite(r.to) }));
+  });
+
+  mstream.post('/api/v1/stats/reset', (req, res) => {
+    requireAccount(req);
+    const { value } = joiValidate(Joi.object({
+      scope: Joi.string().valid(...RESET_SCOPES).required(),
+    }), req.body || {});
+    res.json({ scope: value.scope, ...resetStats(d(), req.user.id, value.scope) });
+  });
+
+  // The whole log, one JSON object per line, oldest first — a backup, a
+  // migration, or a client rebuilding its local copy. Streamed in keyset
+  // pages so a long history never sits in memory at once.
+  mstream.get('/api/v1/stats/export', (req, res) => {
+    requireAccount(req);
+    res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('Content-Disposition', 'attachment; filename="listening-history.ndjson"');
+    const page = d().prepare(`
+      SELECT pe.*, l.name AS library_name
+        FROM play_events pe LEFT JOIN libraries l ON l.id = pe.library_id
+       WHERE pe.user_id = ? AND pe.id > ?
+       ORDER BY pe.id LIMIT 500`);
+    let after = 0;
+    for (;;) {
+      const rows = page.all(req.user.id, after);
+      if (rows.length === 0) { break; }
+      for (const r of rows) {
+        let snapshot = null;
+        if (r.snapshot) { try { snapshot = JSON.parse(r.snapshot); } catch (_) { snapshot = null; } }
+        res.write(`${JSON.stringify({
+          id: r.event_id,
+          startedAt: toIso(r.started_at),
+          endedAt: toIso(r.ended_at),
+          playedMs: r.played_ms,
+          durationMs: r.duration_ms,
+          outcome: r.outcome,
+          counted: r.counted === 1,
+          source: r.source,
+          sessionId: r.session_id,
+          pauseCount: r.pause_count,
+          client: r.client,
+          filePath: r.peer_id == null && r.library_name ? `${r.library_name}/${r.filepath}` : r.filepath,
+          peerId: r.peer_id ?? null,
+          trackHash: r.track_hash,
+          snapshot,
+        })}\n`);
+        after = r.id;
+      }
+    }
+    res.end();
+  });
+
+  // Recompute the hourly rollup from the events on hand (every hour that
+  // still has events; older rows are kept — see rebuildHourStats). Admin
+  // only; optional userId narrows it.
+  mstream.post('/api/v1/admin/stats/rebuild', (req, res) => {
+    if (!req.user?.admin) { throw new WebError('Forbidden', 403); }
+    const { value } = joiValidate(Joi.object({ userId: Joi.number().integer().min(1) }), req.body || {});
+    res.json(rebuildHourStats(d(), { userId: value.userId ?? null }));
   });
 
   mstream.get('/api/v1/stats/periods', (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import { installedPlayerPath, playerLoadableHere } from './util/mstream-player-b
 
 import * as dbApi from './api/db.js';
 import * as statsApi from './api/stats.js';
+import { startRetentionSweep, stopRetentionSweep } from './stats/retention.js';
 import * as discoveryApi from './api/discovery.js';
 import * as searchApi from './api/search.js';
 import * as randomApi from './api/random.js';
@@ -559,6 +560,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   discoveryFederationApi.setup(mstream);
   dbApi.setup(mstream);
   statsApi.setup(mstream);
+  startRetentionSweep();
   searchApi.setup(mstream);
   randomApi.setup(mstream);
   playlistApi.setup(mstream);
@@ -1008,6 +1010,8 @@ export function reboot() {
     // them — without this, each reboot left the old boot timeouts
     // pending alongside the new ones.
     backupManager.shutdown();
+    // The stats retention sweep is re-armed by the setup path on reboot.
+    stopRetentionSweep();
 
     // Tear down the Iroh tunnel, the federation endpoint (+ its peer bridges)
     // and the discovery-network gossip stack. Each binds its own sockets

--- a/src/stats/ingest.js
+++ b/src/stats/ingest.js
@@ -24,7 +24,9 @@
 import * as db from '../db/manager.js';
 import { getVPathInfo } from '../util/vpath.js';
 import { recordPlayEvent } from './store.js';
-import { fromSqlite } from './time.js';
+import { fromSqlite, retentionFloor } from './time.js';
+
+export { retentionFloor };
 
 export const REASONS = Object.freeze({
   unknownTrack: 'unknown-track',
@@ -64,14 +66,6 @@ export function parseInstant(v) {
     return Number.isNaN(d.getTime()) ? null : d;
   }
   return null;
-}
-
-// The oldest start still accepted: retentionMonths back from now, to the
-// hour, or 2000-01-01 when retention is off.
-export function retentionFloor(now, retentionMonths) {
-  if (!(retentionMonths > 0)) { return new Date(Date.UTC(2000, 0, 1)); }
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - retentionMonths,
-    now.getUTCDate(), now.getUTCHours()));
 }
 
 // The start instant, or null when it is unparsable, more than futureSkewMs

--- a/src/stats/retention.js
+++ b/src/stats/retention.js
@@ -1,0 +1,54 @@
+// The retention sweep: once a day (and once shortly after boot), prune raw
+// play events older than config `stats.retentionMonths`. Counters and the
+// hourly rollup keep the totals, so what goes is only the per-play detail
+// that the history and top-N reads no longer need to show. Ingest already
+// refuses plays older than the same floor, so the log's age is bounded at
+// both ends. 0 months = keep everything; the sweep is then a no-op.
+//
+// After a prune, an incremental vacuum hands the freed pages back when the
+// database was created in that auto-vacuum mode; otherwise the pages are
+// simply reused by the next writes.
+
+import winston from 'winston';
+import * as db from '../db/manager.js';
+import * as config from '../state/config.js';
+import { sweepRetention } from './store.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const BOOT_DELAY_MS = 60 * 1000;
+
+let bootTimer = null;
+let dailyTimer = null;
+
+export function runRetentionSweep({ now = new Date() } = {}) {
+  const d = db.getDB();
+  if (!d) { return { deleted: 0, cutoff: null }; }
+  const retentionMonths = config.program.stats?.retentionMonths ?? 24;
+  const r = sweepRetention(d, { retentionMonths, now });
+  if (r.deleted > 0) {
+    winston.info(`[stats] retention: pruned ${r.deleted} play event(s) that started before ${r.cutoff}`);
+    try {
+      if (d.prepare('PRAGMA auto_vacuum').get().auto_vacuum === 2) { d.exec('PRAGMA incremental_vacuum'); }
+    } catch (err) {
+      winston.warn(`[stats] retention: incremental vacuum failed: ${err.message}`);
+    }
+  }
+  return r;
+}
+
+function safeRun() {
+  try { runRetentionSweep(); } catch (err) { winston.warn(`[stats] retention sweep failed: ${err.message}`); }
+}
+
+export function startRetentionSweep() {
+  stopRetentionSweep();
+  bootTimer = setTimeout(safeRun, BOOT_DELAY_MS);
+  dailyTimer = setInterval(safeRun, DAY_MS);
+  if (bootTimer.unref) { bootTimer.unref(); }
+  if (dailyTimer.unref) { dailyTimer.unref(); }
+}
+
+export function stopRetentionSweep() {
+  if (bootTimer) { clearTimeout(bootTimer); bootTimer = null; }
+  if (dailyTimer) { clearInterval(dailyTimer); dailyTimer = null; }
+}

--- a/src/stats/store.js
+++ b/src/stats/store.js
@@ -13,7 +13,7 @@
 // peer row, the play-threshold verdict — is the INGEST route's job. This
 // module trusts a fully-resolved event and only guarantees the bookkeeping.
 
-import { toSqlite, fromSqlite, hourKey } from './time.js';
+import { toSqlite, fromSqlite, hourKey, retentionFloor } from './time.js';
 
 export const OUTCOMES = new Set(['completed', 'skipped', 'stopped']);
 export const SOURCES = new Set(['manual', 'shuffle', 'autodj', 'playlist',
@@ -158,3 +158,146 @@ export function recordPlayEvents(d, events, { transactional = true } = {}) {
   }
   return { inserted, duplicates };
 }
+
+// ── Removal ──────────────────────────────────────────────────────────────
+//
+// Deleting an event subtracts exactly what recording it added: its hour row
+// (dropped once it holds no events) and its track's counters. A track's
+// first/last played are then recomputed from the counted events that
+// remain; when none remain but plays predate the log (play_count still
+// above zero — the legacy count routes never wrote events) the dates are
+// left as they are, since the log cannot say when those plays were; and
+// when the count is zero they are cleared.
+
+const EVENT_COLS = 'id, event_id, user_id, track_hash, outcome, counted, played_ms, started_at';
+
+function subtractEvent(d, ev) {
+  const skipped = ev.outcome === 'skipped' ? 1 : 0;
+  const hour = hourKey(fromSqlite(ev.started_at));
+  d.prepare(`
+    UPDATE user_hour_stats
+       SET events = MAX(events - 1, 0), plays = MAX(plays - ?, 0),
+           skips = MAX(skips - ?, 0), listened_ms = MAX(listened_ms - ?, 0)
+     WHERE user_id = ? AND hour = ?`).run(ev.counted, skipped, ev.played_ms, ev.user_id, hour);
+  d.prepare('DELETE FROM user_hour_stats WHERE user_id = ? AND hour = ? AND events <= 0').run(ev.user_id, hour);
+  if (ev.track_hash) {
+    d.prepare(`
+      UPDATE user_metadata
+         SET play_count = MAX(play_count - ?, 0), skip_count = MAX(skip_count - ?, 0),
+             listened_ms = MAX(listened_ms - ?, 0)
+       WHERE user_id = ? AND track_hash = ?`).run(ev.counted, skipped, ev.played_ms, ev.user_id, ev.track_hash);
+  }
+}
+
+function refreshTrackTimes(d, userId, trackHash) {
+  const um = d.prepare('SELECT play_count FROM user_metadata WHERE user_id = ? AND track_hash = ?').get(userId, trackHash);
+  if (!um) { return; }
+  const r = d.prepare(`
+    SELECT MIN(started_at) AS first, MAX(started_at) AS last, COUNT(*) AS n
+      FROM play_events WHERE user_id = ? AND track_hash = ? AND counted = 1`).get(userId, trackHash);
+  if (r.n > 0) {
+    d.prepare('UPDATE user_metadata SET first_played = ?, last_played = ? WHERE user_id = ? AND track_hash = ?')
+      .run(r.first, r.last, userId, trackHash);
+  } else if (!(um.play_count > 0)) {
+    d.prepare('UPDATE user_metadata SET first_played = NULL, last_played = NULL WHERE user_id = ? AND track_hash = ?')
+      .run(userId, trackHash);
+  }
+}
+
+// Delete [userId]'s events by id list, or every event that started in
+// [from, to) (stored-text bounds). Atomic. Returns { deleted }.
+export function deletePlayEvents(d, userId, { eventIds = null, from = null, to = null } = {}) {
+  let rows;
+  if (Array.isArray(eventIds)) {
+    if (eventIds.length === 0) { return { deleted: 0 }; }
+    rows = d.prepare(`SELECT ${EVENT_COLS} FROM play_events WHERE user_id = ? AND event_id IN (${eventIds.map(() => '?').join(',')})`)
+      .all(userId, ...eventIds);
+  } else if (from != null && to != null) {
+    rows = d.prepare(`SELECT ${EVENT_COLS} FROM play_events WHERE user_id = ? AND started_at >= ? AND started_at < ?`)
+      .all(userId, from, to);
+  } else {
+    throw new TypeError('deletePlayEvents needs eventIds or a from/to range');
+  }
+  if (rows.length === 0) { return { deleted: 0 }; }
+  d.exec('BEGIN IMMEDIATE');
+  try {
+    const hashes = new Set();
+    const del = d.prepare('DELETE FROM play_events WHERE id = ?');
+    for (const ev of rows) {
+      subtractEvent(d, ev);
+      del.run(ev.id);
+      if (ev.track_hash) { hashes.add(ev.track_hash); }
+    }
+    for (const h of hashes) { refreshTrackTimes(d, userId, h); }
+    d.exec('COMMIT');
+  } catch (err) {
+    try { d.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
+    throw err;
+  }
+  return { deleted: rows.length };
+}
+
+// ── Reset ────────────────────────────────────────────────────────────────
+//
+// 'counts' zeroes the per-track counters (stars and ratings stay); 'history'
+// drops the log and its hourly rollup; 'all' does both. Counts without
+// history is the legacy reset — the log then says more than the counters,
+// which is what the user asked for.
+export const RESET_SCOPES = new Set(['counts', 'history', 'all']);
+
+export function resetStats(d, userId, scope) {
+  if (!RESET_SCOPES.has(scope)) { throw new TypeError('scope'); }
+  const out = { tracks: 0, events: 0 };
+  d.exec('BEGIN IMMEDIATE');
+  try {
+    if (scope === 'counts' || scope === 'all') {
+      out.tracks = Number(d.prepare(`
+        UPDATE user_metadata
+           SET play_count = 0, skip_count = 0, listened_ms = 0, first_played = NULL, last_played = NULL
+         WHERE user_id = ?`).run(userId).changes);
+    }
+    if (scope === 'history' || scope === 'all') {
+      out.events = Number(d.prepare('DELETE FROM play_events WHERE user_id = ?').run(userId).changes);
+      d.prepare('DELETE FROM user_hour_stats WHERE user_id = ?').run(userId);
+    }
+    d.exec('COMMIT');
+  } catch (err) {
+    try { d.exec('ROLLBACK'); } catch (_) { /* already rolled back */ }
+    throw err;
+  }
+  return out;
+}
+
+// ── Rebuild ──────────────────────────────────────────────────────────────
+//
+// Recompute the hourly rollup from the events on hand: every hour that
+// still has events is rewritten exactly; an hour with none keeps its row,
+// because it may be older than retention — the rollup is the part of the
+// history that outlives the raw events, so a rebuild must never erase it.
+export function rebuildHourStats(d, { userId = null } = {}) {
+  const where = userId != null ? 'WHERE user_id = ?' : '';
+  const params = userId != null ? [userId] : [];
+  const r = d.prepare(`
+    INSERT INTO user_hour_stats (user_id, hour, events, plays, skips, listened_ms)
+    SELECT user_id, strftime('%Y-%m-%dT%H', started_at), COUNT(*), SUM(counted),
+           SUM(CASE WHEN outcome = 'skipped' THEN 1 ELSE 0 END), SUM(played_ms)
+      FROM play_events ${where}
+     GROUP BY 1, 2
+    ON CONFLICT (user_id, hour) DO UPDATE SET
+      events = excluded.events, plays = excluded.plays,
+      skips = excluded.skips, listened_ms = excluded.listened_ms`).run(...params);
+  return { hours: Number(r.changes) };
+}
+
+// ── Retention ────────────────────────────────────────────────────────────
+//
+// Prune raw events that started before the retention floor. Counters and
+// the hourly rollup are deliberately untouched: the totals survive, only
+// the per-play rows go. Returns { deleted, cutoff }.
+export function sweepRetention(d, { retentionMonths, now = new Date() } = {}) {
+  if (!(retentionMonths > 0)) { return { deleted: 0, cutoff: null }; }
+  const cutoff = toSqlite(retentionFloor(now, retentionMonths));
+  const r = d.prepare('DELETE FROM play_events WHERE started_at < ?').run(cutoff);
+  return { deleted: Number(r.changes), cutoff };
+}
+

--- a/src/stats/time.js
+++ b/src/stats/time.js
@@ -120,6 +120,15 @@ export function fromHourKey(key) {
 
 export const isoDate = (d) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
 
+// The oldest start still inside the retention window: [retentionMonths]
+// back from [now], to the hour; 2000-01-01 when retention is off. Ingest
+// refuses anything older; the sweep prunes anything older.
+export function retentionFloor(now, retentionMonths) {
+  if (!(retentionMonths > 0)) { return new Date(Date.UTC(2000, 0, 1)); }
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - retentionMonths,
+    now.getUTCDate(), now.getUTCHours()));
+}
+
 // ── Periods ──────────────────────────────────────────────────────────────
 const daysSinceMonday = (weekday) => (weekday + 6) % 7;
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July',

--- a/test/db/db-stats-lifecycle.test.mjs
+++ b/test/db/db-stats-lifecycle.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * src/stats/store.js — the lifecycle half: removal, reset, rebuild, sweep.
+ *
+ *  - deleting an event subtracts exactly what recording it added (hour row,
+ *    dropped at zero; track counters), and recomputes a track's first/last
+ *    played from what remains — left as they are when only legacy plays
+ *    remain, cleared when nothing does;
+ *  - deletion by id list and by range; an unknown id is a no-op;
+ *  - reset scopes: counts zeroes counters and leaves the log, history drops
+ *    the log and rollup and leaves counters, all does both;
+ *  - rebuild rewrites every hour that has events and never erases an hour
+ *    that has none (it may be older than retention);
+ *  - the retention sweep prunes raw events before the floor only, leaving
+ *    the rollup and counters — and does nothing when retention is off.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { applyAllMigrations } from '../helpers/apply-migrations.mjs';
+import {
+  recordPlayEvents, deletePlayEvents, resetStats, rebuildHourStats, sweepRetention,
+} from '../../src/stats/store.js';
+
+function fresh() {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA recursive_triggers = ON');
+  applyAllMigrations(db);
+  db.prepare("INSERT INTO users (username, password, salt) VALUES ('alice', 'h', 's')").run();
+  db.prepare("INSERT INTO users (username, password, salt) VALUES ('bob', 'h', 's')").run();
+  return db;
+}
+
+const ev = (id, startedAt, over = {}) => ({
+  eventId: id, userId: 1, trackHash: 'ahA', filepath: 'a.flac', outcome: 'completed', counted: true,
+  playedMs: 200000, startedAt, ...over,
+});
+
+function seedPlays(db) {
+  recordPlayEvents(db, [
+    ev('e1', '2026-09-01 10:00:00'),
+    ev('e2', '2026-09-01 10:30:00'),
+    ev('e3', '2026-09-02 12:00:00'),
+    ev('skip', '2026-09-02 12:10:00', { outcome: 'skipped', counted: false, playedMs: 8000 }),
+  ]);
+}
+
+const counters = (db, hash = 'ahA', uid = 1) => {
+  const r = db.prepare('SELECT play_count, skip_count, listened_ms, first_played, last_played FROM user_metadata WHERE user_id = ? AND track_hash = ?').get(uid, hash);
+  return r ? { ...r } : null;
+};
+const hours = (db) => db.prepare('SELECT hour, events, plays, skips, listened_ms FROM user_hour_stats ORDER BY hour').all().map((r) => ({ ...r }));
+
+describe('deletePlayEvents', () => {
+  test('one play: hour row and counters step down, first/last recomputed', () => {
+    const db = fresh(); seedPlays(db);
+    assert.deepEqual(deletePlayEvents(db, 1, { eventIds: ['e2'] }), { deleted: 1 });
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n, 3);
+    assert.deepEqual(hours(db), [
+      { hour: '2026-09-01T10', events: 1, plays: 1, skips: 0, listened_ms: 200000 },
+      { hour: '2026-09-02T12', events: 2, plays: 1, skips: 1, listened_ms: 208000 },
+    ]);
+    const c = counters(db);
+    assert.deepEqual([c.play_count, c.skip_count, c.listened_ms], [2, 1, 408000]);
+    assert.equal(c.first_played, '2026-09-01 10:00:00.000');
+    assert.equal(c.last_played, '2026-09-02 12:00:00.000');
+    db.close();
+  });
+
+  test('an hour that empties loses its row; the skip counts down too', () => {
+    const db = fresh(); seedPlays(db);
+    deletePlayEvents(db, 1, { eventIds: ['e3', 'skip'] });
+    assert.deepEqual(hours(db), [{ hour: '2026-09-01T10', events: 2, plays: 2, skips: 0, listened_ms: 400000 }]);
+    const c = counters(db);
+    assert.deepEqual([c.play_count, c.skip_count, c.listened_ms], [2, 0, 400000]);
+    assert.equal(c.last_played, '2026-09-01 10:30:00.000');
+    db.close();
+  });
+
+  test('by range, an unknown id, and the other user untouched', () => {
+    const db = fresh(); seedPlays(db);
+    recordPlayEvents(db, [ev('bob1', '2026-09-02 12:20:00', { userId: 2 })]);
+    assert.deepEqual(deletePlayEvents(db, 1, { eventIds: ['nope'] }), { deleted: 0 });
+    assert.deepEqual(deletePlayEvents(db, 2, { eventIds: ['e1'] }), { deleted: 0 }); // not bob's
+    assert.deepEqual(deletePlayEvents(db, 1, { from: '2026-09-02 00:00:00.000', to: '2026-09-03 00:00:00.000' }), { deleted: 2 });
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM play_events WHERE user_id = 1').get().n, 2);
+    assert.equal(counters(db, 'ahA', 2).play_count, 1);
+    assert.throws(() => deletePlayEvents(db, 1, {}), TypeError);
+    db.close();
+  });
+
+  test('legacy plays keep their dates; a track with nothing left is cleared', () => {
+    const db = fresh();
+    db.prepare(`INSERT INTO user_metadata (user_id, track_hash, play_count, last_played, first_played)
+                VALUES (1, 'legacy', 5, '2026-05-01 00:00:00', '2026-01-01 00:00:00')`).run();
+    recordPlayEvents(db, [ev('l1', '2026-09-01 10:00:00', { trackHash: 'legacy' }), ev('only', '2026-09-01 11:00:00', { trackHash: 'lone' })]);
+    assert.equal(counters(db, 'legacy').play_count, 6);
+    deletePlayEvents(db, 1, { eventIds: ['l1', 'only'] });
+    const legacy = counters(db, 'legacy');
+    assert.equal(legacy.play_count, 5);
+    // Recording moved last_played to the event; deleting it cannot restore a
+    // date the log never held, so the dates stay as they are rather than
+    // being cleared under a count that is still five.
+    assert.equal(legacy.last_played, '2026-09-01 10:00:00.000');
+    assert.equal(legacy.first_played, '2026-01-01 00:00:00');
+    const lone = counters(db, 'lone');
+    assert.deepEqual([lone.play_count, lone.first_played, lone.last_played], [0, null, null]);
+    db.close();
+  });
+});
+
+describe('resetStats', () => {
+  test('counts / history / all', () => {
+    const db = fresh(); seedPlays(db);
+    assert.deepEqual(resetStats(db, 1, 'counts'), { tracks: 1, events: 0 });
+    assert.deepEqual([counters(db).play_count, counters(db).listened_ms, counters(db).last_played], [0, 0, null]);
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n, 4);
+    assert.deepEqual(resetStats(db, 1, 'history'), { tracks: 0, events: 4 });
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_hour_stats').get().n, 0);
+    assert.ok(counters(db)); // the counter row stays (zeroed earlier)
+    seedPlays(db);
+    assert.deepEqual(resetStats(db, 1, 'all'), { tracks: 1, events: 4 });
+    assert.throws(() => resetStats(db, 1, 'everything'), TypeError);
+    db.close();
+  });
+
+  test('scoped to the user', () => {
+    const db = fresh(); seedPlays(db);
+    recordPlayEvents(db, [ev('bob1', '2026-09-02 12:20:00', { userId: 2 })]);
+    resetStats(db, 2, 'all');
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM play_events WHERE user_id = 1').get().n, 4);
+    assert.equal(counters(db, 'ahA', 1).play_count, 3);
+    db.close();
+  });
+});
+
+describe('rebuildHourStats', () => {
+  test('rewrites hours that have events, keeps hours that do not', () => {
+    const db = fresh(); seedPlays(db);
+    db.prepare("UPDATE user_hour_stats SET plays = 99, listened_ms = 1 WHERE hour = '2026-09-01T10'").run();
+    db.prepare("INSERT INTO user_hour_stats (user_id, hour, events, plays, skips, listened_ms) VALUES (1, '2024-01-01T09', 7, 7, 0, 700000)").run();
+    assert.deepEqual(rebuildHourStats(db), { hours: 2 });
+    assert.deepEqual(hours(db), [
+      { hour: '2024-01-01T09', events: 7, plays: 7, skips: 0, listened_ms: 700000 },
+      { hour: '2026-09-01T10', events: 2, plays: 2, skips: 0, listened_ms: 400000 },
+      { hour: '2026-09-02T12', events: 2, plays: 1, skips: 1, listened_ms: 208000 },
+    ]);
+    recordPlayEvents(db, [ev('bob1', '2026-09-02 12:20:00', { userId: 2 })]);
+    db.prepare('DELETE FROM user_hour_stats WHERE user_id = 2').run();
+    assert.deepEqual(rebuildHourStats(db, { userId: 2 }), { hours: 1 });
+    db.close();
+  });
+});
+
+describe('sweepRetention', () => {
+  test('prunes raw events before the floor; rollup and counters survive; off = no-op', () => {
+    const db = fresh();
+    recordPlayEvents(db, [ev('old', '2026-07-01 10:00:00'), ev('new', '2026-09-01 10:00:00')]);
+    const now = new Date('2026-09-09T12:00:00Z');
+    assert.deepEqual(sweepRetention(db, { retentionMonths: 0, now }), { deleted: 0, cutoff: null });
+    const r = sweepRetention(db, { retentionMonths: 1, now });
+    assert.deepEqual(r, { deleted: 1, cutoff: '2026-08-09 12:00:00.000' });
+    assert.deepEqual(db.prepare('SELECT event_id FROM play_events').all().map((x) => x.event_id), ['new']);
+    assert.equal(hours(db).length, 2);          // the July hour keeps its row
+    assert.equal(counters(db).play_count, 2);   // and the count is still two
+    db.close();
+  });
+});

--- a/test/integration/stats-lifecycle.test.mjs
+++ b/test/integration/stats-lifecycle.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * Stats API v2 lifecycle against a real server: the capability flag, the
+ * scrobble shim through the shared write, the management routes, the
+ * export stream, the admin rebuild and its gate.
+ *
+ * Same pattern as stats-api.test.mjs: boot mStream in public/no-users mode
+ * with an empty library, stop it, seed tracks straight into the DB, boot
+ * again, drive HTTP. The last test creates a user, which ends public mode,
+ * so it stays last.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+import { isFederationRouteAllowed } from '../../src/api/federation-auth.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref(); srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => { const { port } = srv.address(); srv.close(() => resolve(port)); });
+  });
+}
+async function waitForReady(baseUrl, timeoutMs = 90_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try { const r = await fetch(`${baseUrl}/api/`); if (r.status < 500) return; } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+async function boot(tmpDir, musicDir) {
+  const port = await findFreePort();
+  const config = {
+    port, address: '127.0.0.1',
+    dlna: { mode: 'disabled' },
+    folders: { testlib: { root: musicDir } },
+    storage: { albumArtDirectory: path.join(tmpDir, 'image-cache'), dbDirectory: path.join(tmpDir, 'db'), logsDirectory: path.join(tmpDir, 'logs') },
+    scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+    stats: { playThresholdMs: 30000, playThresholdFraction: 0.5, retentionMonths: 0 },
+  };
+  for (const dir of Object.values(config.storage)) await fs.mkdir(dir, { recursive: true });
+  const configPath = path.join(tmpDir, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify(config));
+  const proc = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', configPath],
+    { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try { await waitForReady(baseUrl); } catch (err) { try { proc.kill('SIGKILL'); } catch { /* gone */ } throw err; }
+  return { proc, baseUrl };
+}
+async function kill(proc) { if (proc.exitCode == null) { proc.kill('SIGKILL'); await new Promise((r) => proc.once('exit', r)); } }
+
+const H = { 'Content-Type': 'application/json' };
+async function call(baseUrl, method, route, body, headers = {}) {
+  const r = await fetch(`${baseUrl}${route}`, { method, headers: { ...H, ...headers }, body: body === undefined ? undefined : JSON.stringify(body) });
+  const text = await r.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* not json */ }
+  return { status: r.status, body: json ?? text, text };
+}
+
+function seed(dbPath) {
+  const db = new DatabaseSync(dbPath); db.exec('PRAGMA foreign_keys = ON');
+  const lib = db.prepare("SELECT id FROM libraries WHERE name='testlib'").get().id;
+  const aid = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist')").run().lastInsertRowid);
+  const ins = db.prepare(`INSERT INTO tracks (filepath, library_id, title, artist_id, file_hash, audio_hash, duration, modified, scan_id)
+                          VALUES (?, ?, ?, ?, ?, ?, ?, 1, 'seed')`);
+  ins.run('Song A.flac', lib, 'Song A', aid, 'fhA', 'ahA', 200);
+  ins.run('Song B.flac', lib, 'Song B', aid, 'fhB', 'ahB', 180);
+  db.close();
+}
+
+const play = (id, filePath, startedAt, over = {}) => ({ id, filePath, startedAt, playedMs: 150000, outcome: 'completed', source: 'manual', ...over });
+
+describe('Stats API v2 — lifecycle', () => {
+  let tmpDir, server;
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-stats-life-'));
+    const musicDir = path.join(tmpDir, 'music'); await fs.mkdir(musicDir, { recursive: true });
+    server = await boot(tmpDir, musicDir);
+    await kill(server.proc); await sleep(200);
+    seed(path.join(tmpDir, 'db', 'mstream.db'));
+    server = await boot(tmpDir, musicDir);
+  });
+  after(async () => {
+    if (server?.proc) await kill(server.proc);
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('the capability flag is advertised', async () => {
+    const r = await call(server.baseUrl, 'GET', '/api/');
+    assert.equal(r.status, 200);
+    assert.equal(r.body.features.stats, 2);
+  });
+
+  test('the scrobble shim records a counted legacy event through the shared write, once', async () => {
+    const r = await call(server.baseUrl, 'POST', '/api/v1/lastfm/scrobble-by-filepath', { filePath: 'testlib/Song B.flac' });
+    assert.equal(r.status, 200, r.text);
+    assert.deepEqual(r.body, {});
+    const h = await call(server.baseUrl, 'GET', '/api/v1/stats/history?track=ahB');
+    assert.equal(h.body.items.length, 1);
+    const e = h.body.items[0];
+    assert.equal(e.source, 'legacy');
+    assert.equal(e.client, 'legacy');
+    assert.equal(e.counted, true);
+    assert.equal(e.playedMs, 30000);
+    assert.equal(e.durationMs, 180000);
+    const m = await call(server.baseUrl, 'POST', '/api/v1/db/metadata', { filepath: 'testlib/Song B.flac' });
+    assert.equal(m.body.metadata['play-count'], 1);
+    const unknown = await call(server.baseUrl, 'POST', '/api/v1/lastfm/scrobble-by-filepath', { filePath: 'testlib/Nope.flac' });
+    assert.deepEqual(unknown.body, { scrobble: false });
+  });
+
+  test('delete one play, then a range; counters follow', async () => {
+    const ing = await call(server.baseUrl, 'POST', '/api/v1/stats/plays', { plays: [
+      play('a1', 'testlib/Song A.flac', '2026-09-01T10:00:00Z'),
+      play('a2', 'testlib/Song A.flac', '2026-09-02T10:00:00Z'),
+      play('a3', 'testlib/Song A.flac', '2026-09-03T10:00:00Z'),
+    ] });
+    assert.deepEqual(ing.body.accepted, ['a1', 'a2', 'a3']);
+    const one = await call(server.baseUrl, 'DELETE', '/api/v1/stats/plays/a2');
+    assert.equal(one.status, 200, one.text);
+    assert.deepEqual(one.body, { deleted: 1 });
+    assert.equal((await call(server.baseUrl, 'DELETE', '/api/v1/stats/plays/a2')).status, 404);
+    let m = await call(server.baseUrl, 'POST', '/api/v1/db/metadata', { filepath: 'testlib/Song A.flac' });
+    assert.equal(m.body.metadata['play-count'], 2);
+    assert.equal(m.body.metadata['last-played'], '2026-09-03 10:00:00.000');
+    const range = await call(server.baseUrl, 'DELETE', '/api/v1/stats/plays?from=2026-09-03T00:00:00Z&to=2026-09-04T00:00:00Z');
+    assert.deepEqual(range.body, { deleted: 1 });
+    m = await call(server.baseUrl, 'POST', '/api/v1/db/metadata', { filepath: 'testlib/Song A.flac' });
+    assert.equal(m.body.metadata['play-count'], 1);
+    assert.equal(m.body.metadata['last-played'], '2026-09-01 10:00:00.000');
+    assert.equal((await call(server.baseUrl, 'DELETE', '/api/v1/stats/plays?from=2026-09-04T00:00:00Z&to=2026-09-03T00:00:00Z')).status, 400);
+    assert.equal((await call(server.baseUrl, 'DELETE', '/api/v1/stats/plays')).status, 400);
+  });
+
+  test('export streams the log as NDJSON, oldest first', async () => {
+    const r = await fetch(`${server.baseUrl}/api/v1/stats/export`);
+    assert.equal(r.status, 200);
+    assert.match(r.headers.get('content-type'), /application\/x-ndjson/);
+    const lines = (await r.text()).trim().split('\n').map((l) => JSON.parse(l));
+    assert.deepEqual(lines.map((l) => l.id).slice(-1), ['a1']);
+    const a1 = lines.find((l) => l.id === 'a1');
+    assert.equal(a1.filePath, 'testlib/Song A.flac');
+    assert.equal(a1.trackHash, 'ahA');
+    assert.equal(a1.startedAt, '2026-09-01T10:00:00.000Z');
+    assert.equal(a1.counted, true);
+    const legacy = lines.find((l) => l.source === 'legacy');
+    assert.ok(legacy, 'the shim event is in the export');
+  });
+
+  test('reset: history keeps counters, counts keeps history, all clears both', async () => {
+    const hist = await call(server.baseUrl, 'POST', '/api/v1/stats/reset', { scope: 'history' });
+    assert.equal(hist.status, 200, hist.text);
+    assert.equal(hist.body.scope, 'history');
+    assert.ok(hist.body.events >= 2);
+    assert.equal((await call(server.baseUrl, 'GET', '/api/v1/stats/history')).body.items.length, 0);
+    let m = await call(server.baseUrl, 'POST', '/api/v1/db/metadata', { filepath: 'testlib/Song A.flac' });
+    assert.equal(m.body.metadata['play-count'], 1);
+    const counts = await call(server.baseUrl, 'POST', '/api/v1/stats/reset', { scope: 'counts' });
+    assert.ok(counts.body.tracks >= 1);
+    m = await call(server.baseUrl, 'POST', '/api/v1/db/metadata', { filepath: 'testlib/Song A.flac' });
+    assert.equal(m.body.metadata['play-count'], null);
+    assert.equal((await call(server.baseUrl, 'POST', '/api/v1/stats/reset', { scope: 'everything' })).status, 400);
+    assert.equal((await call(server.baseUrl, 'POST', '/api/v1/stats/reset', {})).status, 400);
+  });
+
+  test('admin rebuild rewrites the rollup; public mode is admin', async () => {
+    await call(server.baseUrl, 'POST', '/api/v1/stats/plays', { plays: [play('r1', 'testlib/Song A.flac', '2026-09-05T10:00:00Z')] });
+    const r = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/rebuild', {});
+    assert.equal(r.status, 200, r.text);
+    assert.deepEqual(r.body, { hours: 1 });
+    const ts = await call(server.baseUrl, 'GET', '/api/v1/stats/timeseries?from=2026-09-05T00:00:00Z&to=2026-09-06T00:00:00Z&bucket=day');
+    assert.deepEqual(ts.body.items.map((i) => [i.bucket, i.plays]), [['2026-09-05', 1]]);
+  });
+
+  test('none of the lifecycle routes is on the federation allowlist', () => {
+    for (const [m, p] of [['DELETE', '/api/v1/stats/plays'], ['DELETE', '/api/v1/stats/plays/x'], ['POST', '/api/v1/stats/reset'],
+      ['GET', '/api/v1/stats/export'], ['POST', '/api/v1/admin/stats/rebuild']]) {
+      assert.equal(isFederationRouteAllowed(m, p), false, `${m} ${p}`);
+    }
+  });
+
+  test('a non-admin user cannot rebuild, and still sees the flag (ends public mode — last)', async () => {
+    const mk = await call(server.baseUrl, 'PUT', '/api/v1/admin/users', { username: 'plain', password: 'plain-pw', vpaths: ['testlib'], admin: false });
+    assert.equal(mk.status, 200, mk.text);
+    const login = await call(server.baseUrl, 'POST', '/api/v1/auth/login', { username: 'plain', password: 'plain-pw' });
+    const token = login.body.token;
+    assert.ok(token);
+    const denied = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/rebuild', {}, { 'x-access-token': token });
+    assert.equal(denied.status, 403);
+    const api = await call(server.baseUrl, 'GET', '/api/', undefined, { 'x-access-token': token });
+    assert.equal(api.body.features.stats, 2);
+    assert.equal((await call(server.baseUrl, 'GET', '/api/v1/stats/export')).status, 401);
+  });
+});


### PR DESCRIPTION
## Summary

The lifecycle half of **Stats API v2** and the switch that turns it on for clients (S3 in the app repo's `PLAY_HISTORY_PLAN.md`). With #968 (ingest) and #969 (reads) merged, this makes the surface complete and advertises it.

## What's in it

**The flag.** `features.stats: 2` in the layered `/api/` — and flattened into ping, which picks its keys by name, so the drift-lock between the two holds. Clients gate on this key, never on the version string, and it lands only now that ingest, reads and management are all in.

**Management routes**, all scoped to the caller like the reads:
- `DELETE /api/v1/stats/plays/:id` and `DELETE /api/v1/stats/plays?from=&to=` — the event goes and exactly what recording it added is subtracted: its hour in the rollup (the row goes at zero) and its track's counters, with the track's first/last played recomputed from what remains.
- `POST /api/v1/stats/reset {scope: counts|history|all}` — `counts` is the legacy reset (counters only; stars and ratings stay), `history` drops the log and its rollup, `all` both.
- `GET /api/v1/stats/export` — the whole log as streamed NDJSON, oldest first, in keyset pages.
- `POST /api/v1/admin/stats/rebuild` — rewrites every rollup hour that still has events; an hour with none keeps its row, because it may be older than retention and the rollup is what outlives pruning. Admin only.

**Retention.** `src/stats/retention.js` prunes raw events older than `stats.retentionMonths` a minute after boot and daily, leaving counters and the rollup alone (totals survive; only per-play detail goes), and runs an incremental vacuum when the database was created in that auto-vacuum mode. Ingest already refuses plays older than the same floor, so the log is bounded at both ends. Stopped and re-armed across the server's reboot path.

**The scrobble shim.** `POST /api/v1/lastfm/scrobble-by-filepath` — the one legacy count path still called (the default web player fires it 30 s into a track) — now records through the shared write as a synthetic counted event (`source` and `client` `legacy`, 30 s listened, outcome `stopped`). `play_count` and `last_played` move exactly as before, the Last.fm forwarding is untouched, and the stats reads finally see those plays too. The old direct UPSERT is gone.

## Verification

- New: `test/db/db-stats-lifecycle.test.mjs` (delete arithmetic incl. the legacy-count edge, reset scopes, rebuild keeping pruned hours, the sweep) and `test/integration/stats-lifecycle.test.mjs` (the flag on `/api/`, the shim counted once and visible in history, delete by id and range with counters following, NDJSON export, reset scopes, admin rebuild, the 403 for a non-admin user, the allowlist). 8/8 integration, 51/51 fast stats tests; the #968/#969 suites still pass; `npm run test:unit` and `test:db` 0 failures; `eslint` clean; the OpenAPI file parses.
- Not runnable here (needs the ffmpeg fixtures): `api-server-info.test.mjs`'s ping/features drift-lock — the ping key is the reason it should pass; CI decides.

## Follow-ups (unchanged from #968)

Last.fm forwarding with the event's own time for offline plays (S5), and the Rust scanner's four-column `migrate_hash_references` mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
