### PR TITLE
test(scanner): stale-prebuilt guard rationale + dead import — full-ci carrier

### DIFF
--- a/test/helpers/scanner-runner.mjs
+++ b/test/helpers/scanner-runner.mjs
@@ -26,7 +26,6 @@ import fsp from 'node:fs/promises';
 import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { DatabaseSync } from 'node:sqlite';
-import { MIGRATIONS } from '../../src/db/schema.js';
 import { applyAllMigrations } from './apply-migrations.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -62,11 +61,14 @@ export function findRustParser() {
 // rust-parser/ source. The build workflows stamp each set with the
 // rust-parser/ source TREE it was built from (bin/rust-parser/.source-tree,
 // .source-tree-musl for the musl family); a mismatch with HEAD's tree means
-// an in-flight rust-parser change the binary doesn't carry yet (CI prebuilt
-// until the post-merge rebuild). A dev build under rust-parser/target/ is
-// never stale. For Rust-leg behaviour that has no CLI-visible capability to
-// probe (a scanner-internal SQL change, say) — suites skip that leg on this
-// the way the capability probes above skip on theirs.
+// a rust-parser change the shipped binary doesn't carry yet — a branch that
+// changes the scanner, or the window between a rust-parser merge and the
+// post-merge rebuild. A dev build under rust-parser/target/ is never stale,
+// and test.yml builds one from source before the suite runs, so CI never
+// sees a stale set: this covers a checkout that only has the shipped
+// binaries (no cargo). For Rust-leg behaviour with no CLI-visible capability
+// to probe (a scanner-internal SQL change, say) — suites skip that leg on
+// this the way the capability probes above skip on theirs.
 export function rustParserIsStale(bin) {
   const prebuiltDir = path.join(REPO_ROOT, 'bin', 'rust-parser');
   if (!bin || !bin.startsWith(prebuiltDir + path.sep)) { return false; }

--- a/test/scanner/hash-generation-migration.test.mjs
+++ b/test/scanner/hash-generation-migration.test.mjs
@@ -354,8 +354,8 @@ for (const engine of ['rust', 'js']) {
     test('content replacement onto an identity the user already holds merges the V70 counters', async (t) => {
       if (!available()) { t.skip('ffmpeg/rust binary unavailable or stale'); return; }
       if (engine === 'rust' && rustParserIsStale(rustBin)) {
-        t.skip('rust-parser binary predates the V70 counter merge '
-          + '(CI prebuilt until the post-merge rebuild) — the JS leg still covers the logic');
+        t.skip('shipped rust-parser binary predates the V70 counter merge '
+          + '(build rust-parser from source to run this leg) — the JS leg still covers the logic');
         return;
       }
       const sb = await makeSandbox('collide', engine);


### PR DESCRIPTION
## Summary

Follow-up to #971, and the carrier for the first `full-ci` run since the stats work landed on master.

- **Corrects the stale-prebuilt guard's rationale.** #971 claimed the full-ci matrix scans with the prebuilt binaries. It does not: `test.yml` runs `cargo build --release` in `rust-parser/` before the suite, so `findRustParser` picks the fresh dev build and `rustParserIsStale` never fires in CI. The guard still matters for a checkout that only has the shipped binaries (a contributor without cargo, or the window between a rust-parser merge and the post-merge rebuild), so it stays; its comment and the skip note now say what it is for.
- **Drops the dead `MIGRATIONS` import** in `test/helpers/scanner-runner.mjs` (eslint `no-unused-vars`; `initEmptyDb` delegates to `applyAllMigrations`).

## Why `full-ci`

None of #968, #969, #970 or #971 carried the label, so the CI-only suites they added or touched have never run: the both-engines V70 counter-merge case in `test/scanner/hash-generation-migration.test.mjs`, the stats ingest / api / lifecycle integration suites, and the api-server-info drift-lock test that #970 extended with `features.stats` on ping. This run is the test.

## Local checks

- eslint clean on both files.
- `node --test test/scanner/hash-generation-migration.test.mjs` loads and skips cleanly (14 skipped: no ffmpeg on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
