### PR TITLE
stats(S5): forward counted plays to Last.fm with the play's own time; now-playing

### DIFF
--- a/docs/json_config.md
+++ b/docs/json_config.md
@@ -284,6 +284,9 @@ How a play is counted, and how far back one may be reported. Clients (the
 mobile app, the web player) send complete plays to `POST /api/v1/stats/plays`
 after they happen; the server judges each one against these settings, stores
 the verdict with the play, and only counted plays move a track's play count.
+For a user who linked a Last.fm account (admin panel → Users → Last.fm), each
+counted play is also scrobbled to Last.fm with the play's own start time —
+Last.fm takes nothing older than 14 days or shorter than 30 seconds.
 
 ```json
   "stats": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2267,6 +2267,13 @@ paths:
         play (`peerId` = the peer's id on this server, `track` = what the peer
         reported), never on the peer. Not reachable with a federation key or a
         guest token.
+
+        For an account linked to Last.fm (admin panel → users → Last.fm), every
+        COUNTED play is also scrobbled with its own start time — after the
+        response, best-effort, queued so a large outbox drains at Last.fm's
+        pace. Nothing Last.fm would ignore is sent: plays older than 14 days,
+        tracks shorter than 30 seconds, plays without an artist and title. A
+        peer play is scrobbled from its `track` snapshot.
       requestBody:
         required: true
         content:
@@ -2346,6 +2353,87 @@ paths:
               schema: { type: object, properties: { deleted: { type: integer } } }
         "400": { description: "Missing or unordered bounds." }
         "401": { $ref: "#/components/responses/Unauthorized" }
+
+
+  /api/v1/stats/now-playing:
+    post:
+      tags: [Stats]
+      summary: Announce what the caller is playing right now
+      description: |
+        Ephemeral and per user: kept in memory for ten minutes (a longer
+        track is re-announced by its player), keyed by the client's
+        `sessionId`, so a re-post replaces the same player's entry and two
+        players show as two entries. Writes no row — the play itself arrives
+        through `/api/v1/stats/plays` once it is over. A linked Last.fm account
+        gets the now-playing notice, best-effort, after the response. A peer's
+        track needs its `track` snapshot, like a peer play. Not reachable with
+        a federation key or a guest token.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [filePath, sessionId]
+              properties:
+                filePath: { type: string, maxLength: 2048, description: "Virtual path (`<vpath>/<rel>`); for a peer's track, the peer's own path." }
+                peerId: { type: integer, description: "Present for a federated peer's track." }
+                sessionId: { type: string, maxLength: 128, description: "The player's session — one entry per player." }
+                track:
+                  type: object
+                  description: Snapshot for a peer's track (ignored for a local one).
+                  properties:
+                    title: { type: string }
+                    artist: { type: string }
+                    album: { type: string }
+                    durationMs: { type: integer }
+                    hash: { type: string }
+                    artFile: { type: string }
+      responses:
+        "200":
+          description: "Stored (`accepted: true`) or answered with why not; never an error for an unknown track."
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted: { type: boolean }
+                  reason: { type: string, enum: [unknown-track, unknown-peer, invalid], description: "Only when `accepted` is false." }
+                  expiresAt: { type: string, format: date-time, description: "Only when accepted." }
+        "400": { description: "Validation failed (a missing path or session id, an unknown key)." }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: "A federation key or guest token." }
+    get:
+      tags: [Stats]
+      summary: The caller's current plays
+      responses:
+        "200":
+          description: Every unexpired entry the caller announced, one per player session.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        sessionId: { type: string }
+                        filePath: { type: string }
+                        peerId: { type: integer, nullable: true }
+                        track:
+                          type: object
+                          properties:
+                            title: { type: string, nullable: true }
+                            artist: { type: string, nullable: true }
+                            album: { type: string, nullable: true }
+                            durationMs: { type: integer, nullable: true }
+                            hash: { type: string, nullable: true }
+                        since: { type: string, format: date-time }
+                        expiresAt: { type: string, format: date-time }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { description: "A federation key or guest token." }
 
 
   # ── Stats API v2 (read side) ─────────────────────────────────────────────

--- a/src/api/scrobbler.js
+++ b/src/api/scrobbler.js
@@ -147,8 +147,61 @@ export function warmScrobbleUser(lastfmUser, lastfmPassword) {
   Scrobbler.addUser(lastfmUser, lastfmPassword);
 }
 
+// Register credentials only when the session map has no entry for them —
+// warmScrobbleUser REPLACES the entry (dropping a warmed session), which is
+// right for newly saved credentials and wrong for every play that follows.
+export function ensureScrobbleUser(lastfmUser, lastfmPassword) {
+  if (!lastfmUser || !lastfmPassword) { return false; }
+  if (!Scrobbler.hasUser(lastfmUser)) { Scrobbler.addUser(lastfmUser, lastfmPassword); }
+  return true;
+}
+
+// The Stats API's forwarders — src/stats/forward.js for scrobbles, the
+// now-playing route for notices — call these with a req.user-shaped account
+// (the lastfm_user / lastfm_password columns). Both resolve { ok, error }
+// and never throw or hang: Last.fm being slow, down, or unhappy with the
+// credentials is a debug line, never a failed request.
+//   not-linked   the account has no Last.fm credentials
+//   no-response  no session could be made, or the request failed
+//   timeout      Last.fm took longer than FORWARD_TIMEOUT_MS
+//   lastfm-N     Last.fm answered error code N (9 = invalid session: the
+//                session is dropped so the next call logs in again)
+const FORWARD_TIMEOUT_MS = 15000;
+function forwardCall(method, user, song) {
+  return new Promise((resolve) => {
+    if (!ensureScrobbleUser(user?.lastfm_user, user?.lastfm_password)) {
+      resolve({ ok: false, error: 'not-linked' });
+      return;
+    }
+    let settled = false;
+    const finish = (r) => { if (!settled) { settled = true; clearTimeout(timer); resolve(r); } };
+    const timer = setTimeout(() => finish({ ok: false, error: 'timeout' }), FORWARD_TIMEOUT_MS);
+    Scrobbler[method](song, user.lastfm_user, (body) => {
+      if (body == null) { finish({ ok: false, error: 'no-response' }); return; }
+      let parsed = null;
+      try { parsed = JSON.parse(body); } catch (_) { /* not JSON: treated as accepted */ }
+      if (parsed && parsed.error != null) {
+        if (parsed.error === 9) { Scrobbler.dropSession(user.lastfm_user); }
+        finish({ ok: false, error: `lastfm-${parsed.error}` });
+        return;
+      }
+      finish({ ok: true });
+    });
+  });
+}
+export const scrobbleAt = (user, song) => forwardCall('Scrobble', user, song);
+export const nowPlayingAt = (user, song) => forwardCall('NowPlaying', user, song);
+
 export function setup(mstream) {
   Scrobbler.setKeys(config.program.lastFM.apiKey, config.program.lastFM.apiSecret);
+
+  // A test points the client at a local fake Last.fm (host:port). Production
+  // never sets this — the same pattern as the other MSTREAM_TEST_* overrides.
+  const testEndpoint = process.env.MSTREAM_TEST_LASTFM_ENDPOINT;
+  if (testEndpoint) {
+    const [host, port] = testEndpoint.split(':');
+    Scrobbler.setEndpoint({ host, port: Number(port) || 80 });
+  }
 
   // Initialize lastfm users from database. getAllUsers() filters out the
   // anonymous sentinel (V25) — pull it in explicitly so a public-mode

--- a/src/api/stats.js
+++ b/src/api/stats.js
@@ -13,6 +13,8 @@
 //   POST /api/v1/stats/reset       zero the counters, drop the log, or both
 //   GET  /api/v1/stats/export      the whole log as NDJSON
 //   POST /api/v1/admin/stats/rebuild  recompute the hourly rollup from the log
+//   POST /api/v1/stats/now-playing what the caller is playing right now (no row)
+//   GET  /api/v1/stats/now-playing the caller's own current plays
 //
 // Write side: clients (the mobile app's outbox, the web player) send plays
 // AFTER they happen, with their own ids and start times. The server resolves
@@ -20,6 +22,9 @@
 // `stats.playThreshold*`), and answers per play — accepted / duplicates /
 // rejected with a reason — so an outbox knows what to drop and what to
 // retry. Rules in src/stats/ingest.js, the write in src/stats/store.js.
+// After the commit, a linked Last.fm account gets each counted play as a
+// scrobble with the play's own start time (src/stats/forward.js) — queued,
+// best-effort, never in the response's path.
 //
 // Read side: every read is scoped to the caller — their events, their
 // visible libraries (`ignoreVPaths` narrows further), and their timezone
@@ -36,6 +41,7 @@
 // on the version string.
 
 import Joi from 'joi';
+import winston from 'winston';
 import * as db from '../db/manager.js';
 import * as fedDb from '../db/federation.js';
 import * as config from '../state/config.js';
@@ -43,7 +49,9 @@ import WebError from '../util/web-error.js';
 import { joiValidate } from '../util/validation.js';
 import { getVPathInfo } from '../util/vpath.js';
 import * as q from '../stats/queries.js';
-import { ingestPlays, MAX_BATCH } from '../stats/ingest.js';
+import { ingestPlays, resolveLocalTrack, MAX_BATCH } from '../stats/ingest.js';
+import { forwarder, planScrobbles } from '../stats/forward.js';
+import { nowPlayingAt } from './scrobbler.js';
 import {
   OUTCOMES, SOURCES, RESET_SCOPES, deletePlayEvents, resetStats, rebuildHourStats,
 } from '../stats/store.js';
@@ -101,6 +109,32 @@ export function clientLabel(c) {
   if (!c) { return null; }
   return `${c.name}${c.version ? `/${c.version}` : ''}`.slice(0, 128);
 }
+
+// ── Now playing ───────────────────────────────────────────────────────────
+//
+// What a client is playing right now: per user, in memory, gone after
+// NOW_PLAYING_TTL_MS unless the client posts again (a track longer than that
+// is re-announced by its player). Writes no row — the play itself arrives
+// through /stats/plays once it is over. A linked Last.fm account gets the
+// now-playing notice. Keyed by the client's sessionId, so two players of the
+// same user show as two entries and a re-post replaces its own.
+export const NOW_PLAYING_TTL_MS = 10 * 60 * 1000;
+const nowPlaying = new Map();   // userId → Map(sessionId → entry)
+
+function liveNowPlaying(userId, nowMs) {
+  const mine = nowPlaying.get(userId);
+  if (!mine) { return null; }
+  for (const [k, e] of mine) { if (e.expiresMs <= nowMs) { mine.delete(k); } }
+  if (mine.size === 0) { nowPlaying.delete(userId); return null; }
+  return mine;
+}
+
+const nowPlayingSchema = Joi.object({
+  filePath: Joi.string().min(1).max(2048).required(),
+  peerId: Joi.number().integer().min(1),
+  sessionId: Joi.string().min(1).max(128).required(),
+  track: trackSnapshot,
+});
 
 // ── Read side ─────────────────────────────────────────────────────────────
 
@@ -181,13 +215,73 @@ export function setup(mstream) {
   mstream.post('/api/v1/stats/plays', (req, res) => {
     requireAccount(req);
     const { value } = joiValidate(bodySchema, req.body || {});
+    const now = new Date();
     const result = ingestPlays(db.getDB(), req.user, value, {
       config: config.program.stats,
-      now: new Date(),
+      now,
       peers: fedDb.getFederationPeers(),
       client: clientLabel(value.client),
+      // After the commit: the counted plays go on to Last.fm for a linked
+      // account, with their own start times. Queued — never in the
+      // response's path, and never able to fail the request.
+      onStored: (stored) => {
+        try { forwarder().enqueue(req.user, planScrobbles(stored, now)); }
+        catch (err) { winston.warn(`[stats] last.fm forwarding skipped: ${err.message}`); }
+      },
     });
     res.json(result);
+  });
+
+  mstream.post('/api/v1/stats/now-playing', (req, res) => {
+    requireAccount(req);
+    const { value } = joiValidate(nowPlayingSchema, req.body || {});
+    const nowMs = Date.now();
+    let track;
+    if (value.peerId != null) {
+      if (!fedDb.getFederationPeers().some((p) => p.id === value.peerId)) {
+        return res.json({ accepted: false, reason: 'unknown-peer' });
+      }
+      if (!value.track) { return res.json({ accepted: false, reason: 'invalid' }); }
+      const snap = value.track;
+      track = {
+        title: snap.title ?? null, artist: snap.artist ?? null, album: snap.album ?? null,
+        durationMs: snap.durationMs ?? null, hash: snap.hash ?? null,
+      };
+    } else {
+      const t = resolveLocalTrack(d(), value.filePath, req.user);
+      if (!t) { return res.json({ accepted: false, reason: 'unknown-track' }); }
+      track = { title: t.title, artist: t.artist, album: t.album, durationMs: t.durationMs, hash: t.trackHash };
+    }
+    const expiresMs = nowMs + NOW_PLAYING_TTL_MS;
+    const entry = {
+      sessionId: value.sessionId,
+      filePath: value.filePath,
+      peerId: value.peerId ?? null,
+      track,
+      since: new Date(nowMs).toISOString(),
+      expiresAt: new Date(expiresMs).toISOString(),
+      expiresMs,
+    };
+    const mine = liveNowPlaying(req.user.id, nowMs) || new Map();
+    mine.set(entry.sessionId, entry);
+    nowPlaying.set(req.user.id, mine);
+    res.json({ accepted: true, expiresAt: entry.expiresAt });
+
+    // The Last.fm notice, after the response and best-effort.
+    if (req.user.lastfm_user && req.user.lastfm_password && track.artist && track.title) {
+      const song = { artist: track.artist, track: track.title, album: track.album || undefined };
+      if (Number.isInteger(track.durationMs) && track.durationMs > 0) { song.duration = Math.round(track.durationMs / 1000); }
+      nowPlayingAt(req.user, song)
+        .then((r) => { if (!r.ok) { winston.debug(`[stats] last.fm: now-playing notice failed: ${r.error}`); } })
+        .catch((err) => winston.debug(`[stats] last.fm: now-playing notice failed: ${err.message}`));
+    }
+  });
+
+  mstream.get('/api/v1/stats/now-playing', (req, res) => {
+    requireAccount(req);
+    const mine = liveNowPlaying(req.user.id, Date.now());
+    const entries = mine ? [...mine.values()].map(({ expiresMs: _e, ...e }) => e) : [];
+    res.json({ entries });
   });
 
   mstream.get('/api/v1/stats/summary', (req, res) => {

--- a/src/state/lastfm.js
+++ b/src/state/lastfm.js
@@ -1,12 +1,33 @@
 // Scrobbler code shamelessly stolen from
 // https://github.com/dittodhole/node-scribble-js
+//
+// Last.fm's signed-call protocol: a write carries api_sig = md5 of its
+// parameters sorted by name, name+value concatenated, the shared secret
+// appended. The three writers (scrobble, now-playing, love) build a
+// parameter set and hand it to signedForm(); the hand-built per-method
+// signature strings this file used to carry went when scrobble gained
+// `timestamp` and `duration` for the Stats API (the sort order has to be
+// right for any parameter set, so it is computed, not typed).
+//
+// Nothing here throws inside an HTTP callback — an unknown user, a failed
+// login, a network error or a timeout answer the caller's callback with
+// null. (A thrown TypeError in a response handler takes the process down;
+// `ret.session.key` on an "Authentication Failed" answer used to do that.)
+//
+// Endpoint: ws.audioscrobbler.com over plain HTTP, as it always was. A test
+// points an instance at a local fake with setEndpoint(); scrobbler.js reads
+// MSTREAM_TEST_LASTFM_ENDPOINT for that.
 
 import http from 'http';
 import crypto from 'crypto';
 import querystring from 'querystring';
 
+const DEFAULT_ENDPOINT = Object.freeze({ host: 'ws.audioscrobbler.com', port: 80 });
+const REQUEST_TIMEOUT_MS = 10000;
+
 const Scribble = function () {
   this.users = {}
+  this.endpoint = { ...DEFAULT_ENDPOINT }
 }
 
 Scribble.prototype.addUser = function (username, password) {
@@ -14,6 +35,16 @@ Scribble.prototype.addUser = function (username, password) {
     password: password,
     sessionKey: null
   }
+}
+
+Scribble.prototype.hasUser = function (username) {
+  return Object.prototype.hasOwnProperty.call(this.users, username)
+}
+
+// Forget a user's session so the next call logs in again — the answer to
+// Last.fm's error 9 (invalid session key).
+Scribble.prototype.dropSession = function (username) {
+  if (this.users[username]) { this.users[username].sessionKey = null }
 }
 
 Scribble.prototype.reset = function () {
@@ -25,242 +56,222 @@ Scribble.prototype.setKeys = function (api_key, api_secret) {
   this.apiSecret = api_secret
 }
 
+Scribble.prototype.setEndpoint = function (endpoint) {
+  this.endpoint = { ...DEFAULT_ENDPOINT, ...(endpoint || {}) }
+}
+
 Scribble.prototype.Love = function (song, username, callback) {
   const self = this
-  if (self.users[username].sessionKey == null) {
-    self.MakeSession(username, function (sk) {
-      postLove(self, song, sk, username, callback)
-    })
-  } else {
-    postLove(self, song, self.users[username].sessionKey, username, callback)
-  }
+  withSession(self, username, callback, (sk) => postLove(self, song, sk, callback))
 }
 
 Scribble.prototype.Scrobble = function (song, username, callback) {
   const self = this
-
-  if (self.users[username].sessionKey == null) {
-    self.MakeSession(username, function (sk) {
-      postScrobble(self, song, sk, username, callback)
-    })
-  } else {
-    postScrobble(self, song, self.users[username].sessionKey, username, callback)
-  }
+  withSession(self, username, callback, (sk) => postScrobble(self, song, sk, callback))
 }
 
 Scribble.prototype.NowPlaying = function (song, username, callback) {
   const self = this
-  if (self.users[username].sessionKey == null) {
-    self.MakeSession(username, function (sk) {
-      postNowPlaying(self, song, sk, username, callback)
-    })
-  } else {
-    postNowPlaying(self, song, self.users[username].sessionKey, username, callback)
-  }
+  withSession(self, username, callback, (sk) => postNowPlaying(self, song, sk, callback))
 }
 
 Scribble.prototype.MakeSession = function (username, callback) {
   const self = this
-  const password = this.users[username].password;
+  const user = this.users[username]
+  if (!user) { done(callback, null); return }
 
-  const token = makeHash(username + makeHash(password))
+  const token = makeHash(username + makeHash(user.password))
     , apiSig = makeHash('api_key' + this.apiKey + 'authToken' + token + 'methodauth.getMobileSessionusername' + username + this.apiSecret)
     , path = '/2.0/?method=auth.getMobileSession&' +
-      'username=' + username +
+      'username=' + encodeURIComponent(username) +
       '&authToken=' + token +
       '&api_key=' + this.apiKey +
       '&api_sig=' + apiSig + '&format=json'
-  sendGet(path, function (ret) {
-    self.users[username].sessionKey = ret.session.key
-    if (typeof (callback) === 'function') {
-      callback(ret.session.key)
-    }
+  sendGet(self, path, function (ret) {
+    const key = ret && ret.session && ret.session.key
+    if (!key) { done(callback, null); return }
+    user.sessionKey = key
+    done(callback, key)
   })
 }
 
 Scribble.prototype.GetArtistInfo = function (artist, callback) {
   const path = '/2.0/?method=artist.getInfo&artist=' + artist + '&api_key=' + this.apiKey + '&format=json'
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
-  })
+  sendGet(this, path, callback)
 }
 
 Scribble.prototype.GetSimilarArtists = function (artist, callback, limit) {
   const amt = limit || 50;
   const path = '/2.0/?method=artist.getSimilar&artist=' + artist + '&api_key=' + this.apiKey + '&format=json&limit=' + amt
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
-  })
+  sendGet(this, path, callback)
 }
 
 Scribble.prototype.GetArtistEvents = function (artist, callback, limit) {
   const amt = limit || 50;
   const path = '/2.0/?method=artist.getevents&artist=' + artist + '&api_key=' + this.apiKey + '&format=json&limit=' + amt
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
-  })
+  sendGet(this, path, callback)
 }
 
 Scribble.prototype.GetArtistTopAlbums = function (artist, callback, limit) {
   const amt = limit || 50;
   const path = '/2.0/?method=artist.gettopalbums&artist=' + artist + '&api_key=' + this.apiKey + '&format=json&limit=' + amt
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
-  })
+  sendGet(this, path, callback)
 }
 
 Scribble.prototype.GetArtistTopTracks = function (artist, callback, limit) {
   const amt = limit || 50;
   const path = '/2.0/?method=artist.gettoptracks&artist=' + artist + '&api_key=' + this.apiKey + '&format=json&limit=' + amt
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
-  })
+  sendGet(this, path, callback)
 }
 
 Scribble.prototype.GetSimilarSongs = function (song, callback, limit) {
   const amt = limit || 50;
   const path = '/2.0/?method=track.getSimilar&artist=' + song.artist + '&track=' + song.track + '&api_key=' + this.apiKey + '&format=json&limit=' + amt
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
-  })
+  sendGet(this, path, callback)
 }
 
 Scribble.prototype.GetTrackInfo = function (song, callback) {
   const path = '/2.0/?method=track.getInfo&api_key=' + this.apiKey + '&artist=' + encodeURIComponent(song.artist) + '&track=' + encodeURIComponent(song.track) + '&format=json'
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
-  })
+  sendGet(this, path, callback)
 }
 
 Scribble.prototype.GetAlbumInfo = function (song, callback) {
   song.album = song.album.replace(/\s/g, '%20')
   const path = '2.0/?method=album.getinfo&api_key=' + this.apiKey + '&artist=' + song.artist + '&album=' + song.album + '&format=json'
-  sendGet(path, function (ret) {
-    if (typeof (callback) === 'function')
-      {callback(ret)}
+  sendGet(this, path, callback)
+}
+
+// ── Signing ─────────────────────────────────────────────────────────────────
+
+// The request signature: parameters sorted by name, name+value concatenated,
+// the shared secret appended, md5'd. `format` never takes part; absent
+// values are not sent and so not signed.
+export function signParams(params, secret) {
+  const keys = Object.keys(params)
+    .filter((k) => k !== 'format' && params[k] !== undefined && params[k] !== null)
+    .sort()
+  return makeHash(keys.map((k) => k + String(params[k])).join('') + secret)
+}
+
+// The signed form body for a write: api_key added, api_sig computed over
+// what is actually sent, `format=json` so the answer can be read for errors.
+function signedForm(self, params) {
+  const clean = {}
+  for (const k of Object.keys(params)) {
+    if (params[k] !== undefined && params[k] !== null) { clean[k] = params[k] }
+  }
+  clean.api_key = self.apiKey
+  clean.api_sig = signParams(clean, self.apiSecret)
+  clean.format = 'json'
+  return querystring.stringify(clean)
+}
+
+// ── Writers ─────────────────────────────────────────────────────────────────
+
+function postLove(self, song, sk, callback) {
+  sendPost(self, signedForm(self, {
+    method: 'track.love',
+    sk,
+    artist: song.artist,
+    track: song.track,
+    album: song.album || '_',
+  }), callback)
+}
+
+function postNowPlaying(self, song, sk, callback) {
+  sendPost(self, signedForm(self, {
+    method: 'track.updateNowPlaying',
+    sk,
+    artist: song.artist,
+    track: song.track,
+    album: song.album || '_',
+    duration: song.duration || undefined,
+  }), callback)
+}
+
+// `song.timestamp` is the play's own start in epoch seconds — the Stats API
+// forwards plays after the fact, so an offline afternoon lands on the right
+// day. A caller without one gets "now", as before. `song.duration` (seconds)
+// rides along when known.
+function postScrobble(self, song, sk, callback) {
+  const timestamp = Number.isInteger(song.timestamp) ? song.timestamp : Math.floor(Date.now() / 1000)
+  sendPost(self, signedForm(self, {
+    method: 'track.scrobble',
+    sk,
+    timestamp,
+    artist: song.artist,
+    track: song.track,
+    album: song.album || '_',
+    duration: song.duration || undefined,
+  }), callback)
+}
+
+// ── Transport ───────────────────────────────────────────────────────────────
+
+// Log in when there is no session yet, then post. An unknown user or a
+// failed login answers the callback with null.
+function withSession(self, username, callback, post) {
+  const user = self.users[username]
+  if (!user) { done(callback, null); return }
+  if (user.sessionKey != null) { post(user.sessionKey); return }
+  self.MakeSession(username, function (sk) {
+    if (!sk) { done(callback, null); return }
+    post(sk)
   })
 }
 
-function postLove(self, song, sk, username, callback) {
-  if (sk && self.users[username].sessionKey == null) {
-    self.users[username].sessionKey = sk
-  }
-  const apiSig = makeHash('album' + (song.album || '_') + 'api_key' + self.apiKey + 'artist' + song.artist + 'methodtrack.lovesk' + self.users[username].sessionKey + 'track' + song.track + self.apiSecret)
-    , post_data = querystring.stringify({
-      method: 'track.love',
-      api_key: self.apiKey,
-      sk: self.users[username].sessionKey,
-      api_sig: apiSig,
-      artist: song.artist,
-      track: song.track,
-      album: song.album || '_'
-    })
-  sendPost(post_data, callback)
+function done(callback, value) {
+  if (typeof callback === 'function') { callback(value) }
 }
 
-function postNowPlaying(self, song, sk, username, callback) {
-  if (sk && self.users[username].sessionKey == null) {
-    self.users[username].sessionKey = sk
-  }
-  const dur = (song.duration) ? 'duration' + song.duration : ''
-    , apiSig = makeHash('album' + (song.album || '_') + 'api_key' + self.apiKey + 'artist' + song.artist + dur + 'methodtrack.updateNowPlayingsk' + self.users[username].sessionKey + 'track' + song.track + self.apiSecret)
-    , post_data = querystring.stringify({
-      method: 'track.updateNowPlaying',
-      artist: song.artist,
-      track: song.track,
-      album: song.album || '_',
-      duration: song.duration,
-      api_key: self.apiKey,
-      api_sig: apiSig,
-      sk: self.users[username].sessionKey
-    })
-  sendPost(post_data, callback)
-}
-
-function postScrobble(self, song, sk, username, callback) {
-  if (sk && self.users[username].sessionKey == null) {
-    self.users[username].sessionKey = sk
-  }
-  const now = new Date().getTime()
-    , timestamp = Math.floor(now / 1000)
-    , apiSig = makeHash('album' + (song.album || '_') + 'api_key' + self.apiKey + 'artist' + song.artist + 'methodtrack.scrobblesk' + self.users[username].sessionKey + 'timestamp' + timestamp + 'track' + song.track + self.apiSecret)
-    , post_data = querystring.stringify({
-      method: 'track.scrobble',
-      api_key: self.apiKey,
-      sk: self.users[username].sessionKey,
-      api_sig: apiSig,
-      timestamp: timestamp,
-      artist: song.artist,
-      track: song.track,
-      album: song.album || '_'
-    })
-  sendPost(post_data, callback)
-}
-
-function sendPost(data, callback) {
+// POST a form body; the callback gets the response text, or null on a
+// network error or timeout.
+function sendPost(self, data, callback) {
+  let settled = false
+  const finish = (v) => { if (!settled) { settled = true; done(callback, v) } }
   const options = {
-    host: 'ws.audioscrobbler.com',
+    host: self.endpoint.host,
+    port: self.endpoint.port,
     path: '/2.0/',
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'Content-Length': data.length
+      'Content-Length': Buffer.byteLength(data)
     }
   }
-    , doPOST = http.request(options, function (request) {
-      let reqReturn = ''
-      request.setEncoding('utf8')
-      request.on('data', function (chunk) {
-        reqReturn += chunk
-      })
-      request.on('end', function () {
-        if (typeof (callback) === 'function')
-          {callback(reqReturn)}
-      })
-    }).on('error', function (_err) {
-      // TODO
-    })
-  doPOST.write(data)
-  doPOST.end()
+  const req = http.request(options, function (res) {
+    let body = ''
+    res.setEncoding('utf8')
+    res.on('data', (chunk) => { body += chunk })
+    res.on('end', () => finish(body))
+  })
+  req.on('error', () => finish(null))
+  req.setTimeout(REQUEST_TIMEOUT_MS, () => req.destroy(new Error('timeout')))
+  req.write(data)
+  req.end()
 }
 
-function sendGet(path, callback) {
-  let response = '';
-  const apiCall = {
-      host: 'ws.audioscrobbler.com',
-      port: 80,
-      path: path
-    }
-  http.get(apiCall, function (res) {
-    res.on('data', function (chunk) {
+// GET a JSON answer; the callback gets the parsed object, or null on a
+// network error, timeout, or a body that is not JSON.
+function sendGet(self, path, callback) {
+  let settled = false
+  const finish = (v) => { if (!settled) { settled = true; done(callback, v) } }
+  const req = http.get({ host: self.endpoint.host, port: self.endpoint.port, path }, function (res) {
+    let body = ''
+    res.setEncoding('utf8')
+    res.on('data', (chunk) => { body += chunk })
+    res.on('end', () => {
+      let ret = null
       try {
-        response += chunk
+        ret = JSON.parse(body)
       } catch (_err) {
-        // TODO
+        console.log('[INVALID RETURN] the return was invalid JSON: ' + body.slice(0, 200))
       }
+      finish(ret)
     })
-    res.on('end', function () {
-      try {
-        const ret = JSON.parse(response)
-        //var ret = response
-        if (typeof (callback) === 'function')
-          {callback(ret)}
-      } catch (err) {
-        // TODO
-        console.log(err)
-        console.log('[INVALID RETURN] the return was invalid JSON: ' + err)
-      }
-    })
-  }).on('error', function (err) {
-    console.log(err.message)
   })
+  req.on('error', (err) => { console.log(err.message); finish(null) })
+  req.setTimeout(REQUEST_TIMEOUT_MS, () => req.destroy(new Error('timeout')))
 }
 
 function makeHash(input) {

--- a/src/stats/forward.js
+++ b/src/stats/forward.js
@@ -1,0 +1,129 @@
+// Stats API v2 — forwarding counted plays to Last.fm.
+//
+// Ingest stores a play first (src/stats/ingest.js); after the commit the
+// route hands the stored plays here, and for a user who linked a Last.fm
+// account (admin panel → users → Last.fm) each COUNTED play becomes a
+// scrobble carrying the play's own start time — the point of reporting
+// plays after the fact is that an offline afternoon lands on the right day.
+// Last.fm's own rules are applied here so nothing it would ignore is sent:
+//   - the timestamp must fall within the last 14 days, and never ahead of now
+//   - artist and track are required: a local play's strings come from the
+//     library (ingest's resolved track), a peer play's from its snapshot
+//   - a track shorter than 30 seconds is never scrobbled
+// Best-effort by construction: one queue drained a request at a time with a
+// gap between sends (Last.fm allows about five requests per second per IP,
+// and an outbox may hand over two hundred plays at once), failures logged
+// and dropped, and no HTTP request ever in the ingest response's path.
+// The legacy scrobble shim (src/api/scrobbler.js) keeps its own direct call
+// — it never goes through ingest, so nothing is forwarded twice.
+
+import winston from 'winston';
+import { scrobbleAt } from '../api/scrobbler.js';
+
+export const LASTFM_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+export const LASTFM_MIN_TRACK_MS = 30000;
+export const DEFAULT_SPACING_MS = 250;
+export const DEFAULT_MAX_QUEUE = 1000;
+
+const str = (v) => (typeof v === 'string' && v.trim().length > 0 ? v.trim() : null);
+
+// The Last.fm scrobble for one stored play, or null when Last.fm would not
+// take it. `event` is the stored event (counted, startedAt, durationMs,
+// peerId, snapshot); `track` is ingest's resolved track, which carries
+// title / artist / album for a local play.
+export function scrobbleFor(event, track, now = new Date()) {
+  if (!event?.counted) { return null; }
+  const started = event.startedAt instanceof Date ? event.startedAt : new Date(event.startedAt);
+  if (Number.isNaN(started.getTime())) { return null; }
+  const age = now.getTime() - started.getTime();
+  if (age < 0 || age > LASTFM_WINDOW_MS) { return null; }
+  const src = event.peerId != null ? (event.snapshot || {}) : (track || {});
+  const artist = str(src.artist);
+  const title = str(src.title);
+  if (!artist || !title) { return null; }
+  const durationMs = Number.isInteger(event.durationMs) && event.durationMs > 0 ? event.durationMs : null;
+  if (durationMs != null && durationMs < LASTFM_MIN_TRACK_MS) { return null; }
+  const song = {
+    artist,
+    track: title,
+    album: str(src.album) || undefined,
+    timestamp: Math.floor(started.getTime() / 1000),
+  };
+  if (durationMs != null) { song.duration = Math.round(durationMs / 1000); }
+  return song;
+}
+
+// The scrobbles for a batch of stored plays ({ event, track } each).
+export function planScrobbles(stored, now = new Date()) {
+  const out = [];
+  for (const s of stored || []) {
+    const song = scrobbleFor(s.event, s.track, now);
+    if (song) { out.push(song); }
+  }
+  return out;
+}
+
+// A forwarding queue. `send(user, song)` resolves { ok, error } and never
+// throws in production (scrobbleAt); the queue guards against it anyway.
+// Injectable for tests: send, the gap, the cap, the logger, the sleeper.
+export function createForwarder({
+  send = scrobbleAt,
+  spacingMs = DEFAULT_SPACING_MS,
+  maxQueue = DEFAULT_MAX_QUEUE,
+  log = winston,
+  sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+} = {}) {
+  const queue = [];
+  const stats = { sent: 0, failed: 0, dropped: 0 };
+  let draining = null;
+
+  async function drain() {
+    while (queue.length > 0) {
+      const { user, song } = queue.shift();
+      let r;
+      try { r = await send(user, song); } catch (err) { r = { ok: false, error: err?.message || String(err) }; }
+      const what = `${song.artist} — ${song.track} @${song.timestamp} for ${user.lastfm_user}`;
+      if (r?.ok) {
+        stats.sent++;
+        log.debug(`[stats] last.fm: scrobbled ${what}`);
+      } else {
+        stats.failed++;
+        log.debug(`[stats] last.fm: scrobble of ${what} failed: ${r?.error || 'unknown'}`);
+      }
+      if (queue.length > 0 && spacingMs > 0) { await sleep(spacingMs); }
+    }
+    draining = null;
+  }
+
+  return {
+    // Queue every song for [user]. Returns how many were queued — 0 when
+    // the account has no Last.fm credentials. Only what a send needs is
+    // kept: the account's id and its Last.fm credentials.
+    enqueue(user, songs) {
+      if (!user?.lastfm_user || !user?.lastfm_password || !songs?.length) { return 0; }
+      const account = { id: user.id, lastfm_user: user.lastfm_user, lastfm_password: user.lastfm_password };
+      let dropped = 0;
+      for (const song of songs) {
+        if (queue.length >= maxQueue) { queue.shift(); dropped++; }
+        queue.push({ user: account, song });
+      }
+      if (dropped > 0) {
+        stats.dropped += dropped;
+        log.warn(`[stats] last.fm: forwarding queue full, dropped the ${dropped} oldest scrobble(s)`);
+      }
+      if (!draining) { draining = drain(); }
+      return songs.length;
+    },
+    // Resolves once the queue has drained — for tests and shutdown.
+    idle() { return draining || Promise.resolve(); },
+    get pending() { return queue.length; },
+    stats,
+  };
+}
+
+// The process-wide queue the routes use.
+let shared = null;
+export function forwarder() {
+  if (!shared) { shared = createForwarder(); }
+  return shared;
+}

--- a/src/stats/ingest.js
+++ b/src/stats/ingest.js
@@ -83,12 +83,18 @@ export function checkStartedAt(value, {
 const stripSlash = (p) => (typeof p === 'string' && p.startsWith('/') ? p.slice(1) : p);
 
 // A scanned track by (library, relative path): the canonical key (audio
-// hash, else file hash), the library id, the path, and the library's own
-// duration for when the client sent none. A row with no hash at all (a
-// failed parse) resolves with trackHash null — the event is kept for
-// history, but there is no counter row to bump.
+// hash, else file hash), the library id, the path, the library's own
+// duration for when the client sent none, and the title / artist / album
+// strings the Last.fm forwarder needs. A row with no hash at all (a failed
+// parse) resolves with trackHash null — the event is kept for history, but
+// there is no counter row to bump.
 export function lookupTrack(d, libraryId, relativePath) {
-  const row = d.prepare('SELECT audio_hash, file_hash, duration FROM tracks WHERE filepath = ? AND library_id = ?')
+  const row = d.prepare(`SELECT t.audio_hash, t.file_hash, t.duration, t.title,
+                                a.name AS artist, al.name AS album
+                           FROM tracks t
+                           LEFT JOIN artists a ON a.id = t.artist_id
+                           LEFT JOIN albums al ON al.id = t.album_id
+                          WHERE t.filepath = ? AND t.library_id = ?`)
     .get(relativePath, libraryId);
   if (!row) { return null; }
   return {
@@ -96,6 +102,9 @@ export function lookupTrack(d, libraryId, relativePath) {
     libraryId,
     filepath: relativePath,
     durationMs: typeof row.duration === 'number' && row.duration > 0 ? Math.round(row.duration * 1000) : null,
+    title: row.title ?? null,
+    artist: row.artist ?? null,
+    album: row.album ?? null,
   };
 }
 
@@ -113,15 +122,21 @@ export function resolveLocalTrack(d, filePath, user) {
 // accepted plays commit together, so a database failure rolls the whole
 // batch back and throws. Options: config (the `stats` block), now, peers
 // (this server's federation_peers rows), client (stored on every row),
-// resolveLocal (injectable for tests).
+// resolveLocal (injectable for tests), onStored — called once AFTER the
+// commit with the plays that were actually inserted, as [{ event, track }]
+// (the stored event and the resolved track it was matched to), never for a
+// duplicate or a rejection; the Last.fm forwarder hangs off it. It is not
+// called when nothing was inserted.
 export function ingestPlays(d, user, body, {
   config = DEFAULTS, now = new Date(), peers = [], client = null, resolveLocal = resolveLocalTrack,
+  onStored = null,
 } = {}) {
   const accepted = [];
   const duplicates = [];
   const rejected = [];
   const seen = new Set();
   const prepared = [];
+  const stored = [];
   const retentionMonths = config?.retentionMonths ?? DEFAULTS.retentionMonths;
 
   for (const play of body?.plays || []) {
@@ -161,6 +176,7 @@ export function ingestPlays(d, user, body, {
 
     prepared.push({
       id,
+      track,
       event: {
         eventId: id,
         userId: user.id,
@@ -187,7 +203,7 @@ export function ingestPlays(d, user, body, {
     d.exec('BEGIN IMMEDIATE');
     try {
       const owner = d.prepare('SELECT user_id FROM play_events WHERE event_id = ?');
-      for (const { id, event } of prepared) {
+      for (const { id, event, track } of prepared) {
         const existing = owner.get(id);
         if (existing) {
           if (existing.user_id === user.id) { duplicates.push(id); } else { rejected.push({ id, reason: REASONS.invalid }); }
@@ -195,6 +211,7 @@ export function ingestPlays(d, user, body, {
         }
         recordPlayEvent(d, event);
         accepted.push(id);
+        stored.push({ event, track });
       }
       d.exec('COMMIT');
     } catch (err) {
@@ -202,5 +219,6 @@ export function ingestPlays(d, user, body, {
       throw err;
     }
   }
+  if (onStored && stored.length > 0) { onStored(stored); }
   return { accepted, duplicates, rejected };
 }

--- a/test/db/db-stats-ingest.test.mjs
+++ b/test/db/db-stats-ingest.test.mjs
@@ -171,3 +171,51 @@ describe('ingestPlays', () => {
     assert.deepEqual(ingestPlays(c.db, c.alice, {}, { now: NOW }), { accepted: [], duplicates: [], rejected: [] });
   });
 });
+
+// What the Last.fm forwarder (src/stats/forward.js) is handed: the resolved
+// track's strings, and the post-commit hook with the inserted plays only.
+describe('ingestPlays → the forwarder hook', () => {
+  test('lookupTrack carries the title / artist / album strings', () => {
+    const c = seed();
+    const aid = Number(c.db.prepare("INSERT INTO artists (name) VALUES ('Radiohead')").run().lastInsertRowid);
+    const alid = Number(c.db.prepare("INSERT INTO albums (name, artist_id) VALUES ('OK Computer', ?)").run(aid).lastInsertRowid);
+    c.db.prepare("UPDATE tracks SET artist_id = ?, album_id = ? WHERE filepath = 'Radiohead/Let Down.flac'").run(aid, alid);
+    const t = lookupTrack(c.db, c.lib, 'Radiohead/Let Down.flac');
+    assert.deepEqual([t.title, t.artist, t.album], ['Let Down', 'Radiohead', 'OK Computer']);
+    assert.equal(t.trackHash, 'ahA');
+    const bare = lookupTrack(c.db, c.lib, 'Portishead/Glory Box.mp3');
+    assert.deepEqual([bare.title, bare.artist, bare.album], ['Glory Box', null, null], 'no artist or album row → nulls, not a miss');
+  });
+
+  test('onStored fires once, after the commit, with the inserted plays only', () => {
+    const c = seed();
+    const calls = [];
+    const hook = (stored) => calls.push(stored.map((s) => ({
+      id: s.event.eventId,
+      counted: s.event.counted,
+      // the same source rule the forwarder applies: snapshot for a peer play, library row otherwise
+      title: s.event.peerId != null ? s.event.snapshot?.title : s.track?.title,
+      artist: s.event.peerId != null ? s.event.snapshot?.artist : s.track?.artist,
+      peer: s.event.peerId,
+      committed: c.db.isTransaction === false,
+      rows: c.db.prepare('SELECT COUNT(*) AS n FROM play_events').get().n,
+    })));
+    const remote = play({
+      id: 'pp', peerId: c.peer, filePath: 'remote/x.mp3', playedMs: 120000,
+      track: { title: 'Remote', artist: 'Peer', album: 'Far', hash: 'ph', durationMs: 200000 },
+    });
+    const r = ingest(c, c.alice, [play(), remote, play({ id: 'p3', filePath: 'music/Nope.flac' })], { onStored: hook });
+    assert.deepEqual(r.accepted, ['p1', 'pp']);
+    assert.deepEqual(r.rejected, [{ id: 'p3', reason: REASONS.unknownTrack }]);
+    assert.deepEqual(calls, [[
+      { id: 'p1', counted: true, title: 'Let Down', artist: null, peer: null, committed: true, rows: 2 },
+      { id: 'pp', counted: true, title: 'Remote', artist: 'Peer', peer: c.peer, committed: true, rows: 2 },
+    ]]);
+
+    // The replay is duplicates only — the hook stays quiet; so does a batch
+    // of nothing but rejections.
+    ingest(c, c.alice, [play(), remote], { onStored: hook });
+    ingest(c, c.alice, [play({ id: 'p9', filePath: 'music/Nope.flac' })], { onStored: hook });
+    assert.equal(calls.length, 1);
+  });
+});

--- a/test/integration/stats-forwarding.test.mjs
+++ b/test/integration/stats-forwarding.test.mjs
@@ -1,0 +1,263 @@
+/**
+ * Stats API v2 — Last.fm forwarding and the now-playing routes, end to end.
+ *
+ * A fake Last.fm runs in this process (it answers the mobile-session login
+ * and records every write); the server is pointed at it through
+ * MSTREAM_TEST_LASTFM_ENDPOINT. The operator's account is the public-mode
+ * sentinel, given Last.fm credentials straight in the users row between two
+ * boots (scrobbler.js pre-loads them at boot). Pins:
+ *   - a counted play is scrobbled with ITS OWN start time (epoch seconds),
+ *     the library's artist / title / album and length, on one session;
+ *   - an uncounted skip, a play older than Last.fm's 14-day window (accepted
+ *     by ingest — retentionMonths is 0 here) and a track shorter than 30 s
+ *     are stored but never sent; a peer play is sent with its snapshot;
+ *   - a replay (all duplicates) sends nothing again;
+ *   - now-playing: per-session entries with a TTL, listed back, forwarded as
+ *     a Last.fm notice; unknown track / peer answered, not stored; the
+ *     route is off the federation allowlist.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { isFederationRouteAllowed } from '../../src/api/federation-auth.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const iso = (ms) => new Date(ms).toISOString();
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref(); srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => { const { port } = srv.address(); srv.close(() => resolve(port)); });
+  });
+}
+
+async function waitForReady(baseUrl, timeoutMs = 90_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try { const r = await fetch(`${baseUrl}/api/`); if (r.status < 500) return; } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+
+async function waitFor(pred, what, timeoutMs = 15_000) {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) { throw new Error(`timed out waiting for ${what}`); }
+    await sleep(50);
+  }
+}
+
+// The fake Last.fm: every request is recorded as { method, params }.
+function startFakeLastfm() {
+  const calls = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      res.setHeader('Content-Type', 'application/json');
+      if (req.method === 'GET') {
+        calls.push({ method: 'GET', params: Object.fromEntries(new URL(req.url, 'http://fake').searchParams) });
+        res.end(JSON.stringify({ session: { name: 'lfm-user', key: 'sk-test', subscriber: 0 } }));
+        return;
+      }
+      const params = Object.fromEntries(new URLSearchParams(body));
+      calls.push({ method: 'POST', params });
+      res.end(JSON.stringify(params.method === 'track.scrobble'
+        ? { scrobbles: { '@attr': { accepted: 1, ignored: 0 } } }
+        : { nowplaying: {} }));
+    });
+  });
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve({
+    port: server.address().port,
+    calls,
+    scrobbles: () => calls.filter((c) => c.params.method === 'track.scrobble'),
+    close: () => { server.closeAllConnections(); return new Promise((r) => server.close(r)); },
+  })));
+}
+
+async function boot(tmpDir, musicDir, lastfmPort) {
+  const port = await findFreePort();
+  const config = {
+    port, address: '127.0.0.1',
+    dlna: { mode: 'disabled' },
+    folders: { testlib: { root: musicDir } },
+    storage: {
+      albumArtDirectory: path.join(tmpDir, 'image-cache'),
+      dbDirectory: path.join(tmpDir, 'db'),
+      logsDirectory: path.join(tmpDir, 'logs'),
+    },
+    scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+    stats: { playThresholdMs: 30000, playThresholdFraction: 0.5, retentionMonths: 0 },
+  };
+  for (const dir of Object.values(config.storage)) await fs.mkdir(dir, { recursive: true });
+  const configPath = path.join(tmpDir, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify(config));
+  const proc = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', configPath], {
+    cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, NODE_ENV: 'test', MSTREAM_TEST_LASTFM_ENDPOINT: `127.0.0.1:${lastfmPort}` },
+  });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try { await waitForReady(baseUrl); } catch (err) { try { proc.kill('SIGKILL'); } catch { /* gone */ } throw err; }
+  return { proc, baseUrl };
+}
+async function kill(proc) { if (proc.exitCode == null) { proc.kill('SIGKILL'); await new Promise((r) => proc.once('exit', r)); } }
+
+async function call(baseUrl, method, route, body) {
+  const r = await fetch(`${baseUrl}${route}`, {
+    method, headers: body ? { 'Content-Type': 'application/json' } : {}, body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: r.status, body: r.status === 200 ? await r.json() : await r.text() };
+}
+
+// Two real tracks, one 20-second ident, a federation peer, and the sentinel's
+// Last.fm link.
+function seed(dbPath) {
+  const db = new DatabaseSync(dbPath); db.exec('PRAGMA foreign_keys = ON');
+  const lib = db.prepare("SELECT id FROM libraries WHERE name='testlib'").get().id;
+  const aid = Number(db.prepare("INSERT INTO artists (name) VALUES ('Radiohead')").run().lastInsertRowid);
+  const alid = Number(db.prepare("INSERT INTO albums (name, artist_id, year) VALUES ('OK Computer', ?, 1997)").run(aid).lastInsertRowid);
+  const ins = db.prepare(`INSERT INTO tracks (filepath, library_id, title, artist_id, album_id, file_hash, audio_hash, duration, modified, scan_id)
+                          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 'seed')`);
+  ins.run('Let Down.flac', lib, 'Let Down', aid, alid, 'fhA', 'ahA', 299);
+  ins.run('Karma Police.flac', lib, 'Karma Police', aid, alid, 'fhB', 'ahB', 264);
+  ins.run('Ident.mp3', lib, 'Ident', aid, null, 'fhI', 'ahI', 20);
+  const peerId = Number(db.prepare("INSERT INTO federation_peers (name, endpoint_ticket, api_key) VALUES ('Bob', 't', 'fedk_bob')").run().lastInsertRowid);
+  const linked = db.prepare("UPDATE users SET lastfm_user = 'lfm-user', lastfm_password = 'lfm-pass' WHERE is_anonymous_sentinel = 1").run().changes;
+  assert.equal(linked, 1, 'the public-mode sentinel exists and now has a Last.fm link');
+  db.close();
+  return { peerId };
+}
+
+const play = (over = {}) => ({
+  id: 'p1', filePath: 'testlib/Let Down.flac', playedMs: 240000, outcome: 'completed', source: 'manual', ...over,
+});
+
+describe('Last.fm forwarding + now-playing', () => {
+  let tmpDir, server, fake, peerId;
+  before(async () => {
+    fake = await startFakeLastfm();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-fwd-'));
+    const musicDir = path.join(tmpDir, 'music'); await fs.mkdir(musicDir, { recursive: true });
+    server = await boot(tmpDir, musicDir, fake.port);
+    await kill(server.proc); await sleep(200);
+    ({ peerId } = seed(path.join(tmpDir, 'db', 'mstream.db')));
+    server = await boot(tmpDir, musicDir, fake.port);
+  });
+  after(async () => {
+    if (server?.proc) await kill(server.proc);
+    if (fake) await fake.close();
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('counted plays are scrobbled with their own start time; skips, old plays and short tracks are not; a replay sends nothing', async () => {
+    const now = Date.now();
+    const t1 = now - 3_600_000;
+    const t4 = now - 7_200_000;
+    const plays = [
+      play({ id: 'p1', startedAt: iso(t1) }),
+      play({ id: 'p2', filePath: 'testlib/Karma Police.flac', playedMs: 8000, outcome: 'skipped', startedAt: iso(now - 3_000_000) }),
+      play({ id: 'p3', startedAt: iso(now - 20 * 86_400_000) }),
+      play({ id: 'p4', peerId, filePath: 'remote/song.mp3', playedMs: 150000, startedAt: iso(t4),
+        track: { title: 'Remote Song', artist: 'Peer Artist', album: 'Peer Album', hash: 'ph1', durationMs: 200000 } }),
+      play({ id: 'p5', filePath: 'testlib/Ident.mp3', playedMs: 20000, startedAt: iso(now - 600_000) }),
+    ];
+    const r = await call(server.baseUrl, 'POST', '/api/v1/stats/plays', { client: { name: 'test', version: '1' }, plays });
+    assert.equal(r.status, 200, r.body);
+    assert.deepEqual(r.body.accepted, ['p1', 'p2', 'p3', 'p4', 'p5'], 'ingest keeps all five — forwarding is a separate judgement');
+
+    await waitFor(() => fake.scrobbles().length >= 2, 'two scrobbles');
+    await sleep(800);   // room for anything extra to arrive
+    const byTrack = Object.fromEntries(fake.scrobbles().map((c) => [c.params.track, c.params]));
+    assert.deepEqual(Object.keys(byTrack).sort(), ['Let Down', 'Remote Song'],
+      'the skip, the 20-day-old play and the 20-second ident never reach Last.fm');
+
+    assert.equal(byTrack['Let Down'].timestamp, String(Math.floor(t1 / 1000)), "the play's own start, not the request time");
+    assert.equal(byTrack['Let Down'].artist, 'Radiohead');
+    assert.equal(byTrack['Let Down'].album, 'OK Computer');
+    assert.equal(byTrack['Let Down'].duration, '299');
+    assert.equal(byTrack['Let Down'].sk, 'sk-test');
+    assert.equal(byTrack['Let Down'].format, 'json');
+    assert.equal(byTrack['Remote Song'].timestamp, String(Math.floor(t4 / 1000)));
+    assert.equal(byTrack['Remote Song'].artist, 'Peer Artist', 'a peer play carries its snapshot');
+    assert.equal(byTrack['Remote Song'].album, 'Peer Album');
+    assert.equal(byTrack['Remote Song'].duration, '200');
+    assert.equal(fake.calls.filter((c) => c.method === 'GET').length, 1, 'one login, one session');
+    assert.equal(fake.calls[0].params.username, 'lfm-user', "the sentinel's linked account");
+
+    const again = await call(server.baseUrl, 'POST', '/api/v1/stats/plays', { client: { name: 'test', version: '1' }, plays });
+    assert.equal(again.body.accepted.length, 0);
+    assert.equal(again.body.duplicates.length, 5);
+    await sleep(800);
+    assert.equal(fake.scrobbles().length, 2, 'a replay is never scrobbled twice');
+  });
+
+  test('now-playing: per-session entries with a TTL, listed back, forwarded as a notice; unknowns answered, not stored', async () => {
+    const NP = '/api/v1/stats/now-playing';
+    const mark = fake.calls.length;
+    const r = await call(server.baseUrl, 'POST', NP, { filePath: 'testlib/Let Down.flac', sessionId: 's1' });
+    assert.equal(r.status, 200, r.body);
+    assert.equal(r.body.accepted, true);
+    assert.ok(Date.parse(r.body.expiresAt) > Date.now() + 9 * 60_000, 'ten-minute TTL');
+
+    const g = await call(server.baseUrl, 'GET', NP);
+    assert.equal(g.body.entries.length, 1);
+    const e = g.body.entries[0];
+    assert.equal(e.sessionId, 's1');
+    assert.equal(e.filePath, 'testlib/Let Down.flac');
+    assert.equal(e.peerId, null);
+    assert.deepEqual(e.track, { title: 'Let Down', artist: 'Radiohead', album: 'OK Computer', durationMs: 299000, hash: 'ahA' });
+    assert.ok(e.since && e.expiresAt);
+    assert.equal(e.expiresMs, undefined, 'the internal deadline stays internal');
+
+    await waitFor(() => fake.calls.slice(mark).some((c) => c.params.method === 'track.updateNowPlaying'), 'the now-playing notice');
+    const np = fake.calls.slice(mark).find((c) => c.params.method === 'track.updateNowPlaying').params;
+    assert.equal(np.artist, 'Radiohead');
+    assert.equal(np.track, 'Let Down');
+    assert.equal(np.album, 'OK Computer');
+    assert.equal(np.duration, '299');
+
+    // A second player is a second entry; the first player re-posting replaces its own.
+    await call(server.baseUrl, 'POST', NP, { filePath: 'testlib/Karma Police.flac', sessionId: 's2' });
+    await call(server.baseUrl, 'POST', NP, { filePath: 'testlib/Karma Police.flac', sessionId: 's1' });
+    const g2 = await call(server.baseUrl, 'GET', NP);
+    assert.deepEqual(g2.body.entries.map((x) => [x.sessionId, x.track.title]).sort(), [['s1', 'Karma Police'], ['s2', 'Karma Police']]);
+
+    // Unknowns are answered, never stored; a peer needs its snapshot.
+    assert.deepEqual((await call(server.baseUrl, 'POST', NP, { filePath: 'testlib/Nope.flac', sessionId: 's9' })).body,
+      { accepted: false, reason: 'unknown-track' });
+    assert.deepEqual((await call(server.baseUrl, 'POST', NP, { filePath: 'remote/x.mp3', peerId: 999, sessionId: 's9', track: { title: 'x' } })).body,
+      { accepted: false, reason: 'unknown-peer' });
+    assert.deepEqual((await call(server.baseUrl, 'POST', NP, { filePath: 'remote/x.mp3', peerId, sessionId: 's9' })).body,
+      { accepted: false, reason: 'invalid' });
+    const remote = await call(server.baseUrl, 'POST', NP, { filePath: 'remote/x.mp3', peerId, sessionId: 's3', track: { title: 'Remote', artist: 'Peer' } });
+    assert.equal(remote.body.accepted, true);
+    const g3 = await call(server.baseUrl, 'GET', NP);
+    assert.equal(g3.body.entries.length, 3, 's9 was never stored; s3 was');
+    assert.deepEqual(g3.body.entries.find((x) => x.sessionId === 's3').track,
+      { title: 'Remote', artist: 'Peer', album: null, durationMs: null, hash: null });
+
+    // Validation: the path and the session id are required, unknown keys refused.
+    assert.equal((await call(server.baseUrl, 'POST', NP, { sessionId: 's1' })).status, 400);
+    assert.equal((await call(server.baseUrl, 'POST', NP, { filePath: 'testlib/Let Down.flac' })).status, 400);
+    assert.equal((await call(server.baseUrl, 'POST', NP, { filePath: 'testlib/Let Down.flac', sessionId: 's1', bogus: 1 })).status, 400);
+  });
+
+  test('never reachable through federation', () => {
+    assert.equal(isFederationRouteAllowed('POST', '/api/v1/stats/now-playing'), false);
+    assert.equal(isFederationRouteAllowed('GET', '/api/v1/stats/now-playing'), false);
+  });
+});

--- a/test/unit/lastfm-client.test.mjs
+++ b/test/unit/lastfm-client.test.mjs
@@ -1,0 +1,148 @@
+/**
+ * The Last.fm client (src/state/lastfm.js) against a local fake Last.fm.
+ *
+ * Pins what the Stats API's forwarding relies on: a scrobble carries the
+ * caller's `timestamp` (the play's own start) and `duration`, the signature
+ * is computed over the parameters actually sent (sorted by name, secret
+ * appended — the Last.fm rule), the session is fetched once and reused, and
+ * every failure path — unknown user, refused login, unreachable host —
+ * answers the callback with null instead of throwing inside an HTTP callback
+ * (which would take the server down).
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import crypto from 'node:crypto';
+import Scribble, { signParams } from '../../src/state/lastfm.js';
+
+const md5 = (s) => crypto.createHash('md5').update(s, 'utf8').digest('hex');
+
+let server;
+let port;
+let calls = [];
+let sessionResponse = { session: { name: 'u', key: 'sk1' } };
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      res.setHeader('Content-Type', 'application/json');
+      if (req.method === 'GET') {
+        calls.push({ method: 'GET', params: Object.fromEntries(new URL(req.url, 'http://fake').searchParams) });
+        res.end(JSON.stringify(sessionResponse));
+        return;
+      }
+      const params = Object.fromEntries(new URLSearchParams(body));
+      calls.push({ method: 'POST', params });
+      res.end(JSON.stringify(params.method === 'track.scrobble'
+        ? { scrobbles: { '@attr': { accepted: 1, ignored: 0 } } }
+        : { nowplaying: {} }));
+    });
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  port = server.address().port;
+});
+after(async () => { server.closeAllConnections(); await new Promise((r) => server.close(r)); });
+
+function client() {
+  const s = new Scribble();
+  s.setKeys('key', 'secret');
+  s.setEndpoint({ host: '127.0.0.1', port });
+  return s;
+}
+const call = (s, method, song, user) => new Promise((resolve) => s[method](song, user, resolve));
+
+describe('Scribble — the Last.fm client', () => {
+  test('signParams: sorted by name, format and absent values left out, secret appended', () => {
+    const sig = signParams({
+      track: 'T', method: 'track.love', artist: 'A', album: '_', api_key: 'key', sk: 'S',
+      format: 'json', duration: undefined, timestamp: null,
+    }, 'secret');
+    assert.equal(sig, md5('album_api_keykeyartistAmethodtrack.loveskStrackTsecret'));
+  });
+
+  test('a scrobble logs in once, then posts the given timestamp and duration, correctly signed', async () => {
+    calls = []; sessionResponse = { session: { name: 'u', key: 'sk1' } };
+    const s = client();
+    s.addUser('u', 'pw');
+    const body = await call(s, 'Scrobble',
+      { artist: 'Radiohead', track: 'Let Down', album: 'OK Computer', timestamp: 1757415600, duration: 299 }, 'u');
+    assert.ok(JSON.parse(body).scrobbles, 'the response text comes back to the caller');
+
+    assert.equal(calls[0].method, 'GET');
+    assert.equal(calls[0].params.method, 'auth.getMobileSession');
+    assert.equal(calls[0].params.authToken, md5('u' + md5('pw')));
+    assert.equal(calls[0].params.format, 'json');
+
+    const p = calls[1].params;
+    assert.equal(calls[1].method, 'POST');
+    assert.equal(p.method, 'track.scrobble');
+    assert.equal(p.timestamp, '1757415600');
+    assert.equal(p.duration, '299');
+    assert.equal(p.sk, 'sk1');
+    assert.equal(p.api_key, 'key');
+    assert.equal(p.format, 'json', 'answers come back as JSON so errors can be read');
+    assert.equal(p.api_sig,
+      md5('albumOK Computerapi_keykeyartistRadioheadduration299methodtrack.scrobblesksk1timestamp1757415600trackLet Downsecret'));
+
+    // The second call reuses the session; no timestamp means "now", and
+    // the album still defaults to "_" the way it always did.
+    const before = Math.floor(Date.now() / 1000);
+    await call(s, 'Scrobble', { artist: 'A', track: 'B' }, 'u');
+    assert.equal(calls.filter((c) => c.method === 'GET').length, 1);
+    assert.equal(calls[2].params.album, '_');
+    assert.equal(calls[2].params.duration, undefined, 'no duration → not sent, not signed');
+    const ts = Number(calls[2].params.timestamp);
+    assert.ok(ts >= before && ts <= before + 5, `timestamp ${ts} is now`);
+  });
+
+  test('now-playing keeps the pre-existing signature (regression against the hand-built string)', async () => {
+    calls = []; sessionResponse = { session: { key: 'sk2' } };
+    const s = client();
+    s.addUser('u', 'pw');
+    await call(s, 'NowPlaying', { artist: 'A', track: 'T', album: 'L', duration: 180 }, 'u');
+    const p = calls[1].params;
+    assert.equal(p.method, 'track.updateNowPlaying');
+    // What src/state/lastfm.js used to concatenate by hand for this call.
+    const legacy = md5('album' + 'L' + 'api_key' + 'key' + 'artist' + 'A' + 'duration' + 180
+      + 'methodtrack.updateNowPlayingsk' + 'sk2' + 'track' + 'T' + 'secret');
+    assert.equal(p.api_sig, legacy);
+  });
+
+  test('a refused login answers null and posts nothing — no throw inside the HTTP callback', async () => {
+    calls = []; sessionResponse = { error: 4, message: 'Authentication Failed' };
+    const s = client();
+    s.addUser('bad', 'pw');
+    assert.equal(await call(s, 'Scrobble', { artist: 'A', track: 'T' }, 'bad'), null);
+    assert.equal(calls.filter((c) => c.method === 'POST').length, 0);
+    assert.equal(s.users.bad.sessionKey, null, 'nothing cached from a refusal');
+  });
+
+  test('an unknown user answers null', async () => {
+    const s = client();
+    assert.equal(await call(s, 'Scrobble', { artist: 'A', track: 'T' }, 'nobody'), null);
+    assert.equal(await call(s, 'NowPlaying', { artist: 'A', track: 'T' }, 'nobody'), null);
+  });
+
+  test('an unreachable endpoint answers null instead of hanging', async () => {
+    const s = new Scribble();
+    s.setKeys('k', 's');
+    s.setEndpoint({ host: '127.0.0.1', port: 1 });
+    s.addUser('u', 'pw');
+    assert.equal(await call(s, 'Scrobble', { artist: 'A', track: 'T' }, 'u'), null);
+  });
+
+  test('dropSession forgets the key so the next call logs in again', async () => {
+    calls = []; sessionResponse = { session: { key: 'sk3' } };
+    const s = client();
+    s.addUser('u', 'pw');
+    await call(s, 'Scrobble', { artist: 'A', track: 'T' }, 'u');
+    s.dropSession('u');
+    await call(s, 'Scrobble', { artist: 'A', track: 'T' }, 'u');
+    assert.equal(calls.filter((c) => c.method === 'GET').length, 2);
+    assert.equal(s.hasUser('u'), true);
+    assert.equal(s.hasUser('x'), false);
+  });
+});

--- a/test/unit/stats-forward.test.mjs
+++ b/test/unit/stats-forward.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * src/stats/forward.js — which stored plays become Last.fm scrobbles, and
+ * the queue that sends them.
+ *
+ * Pure: `send` is injected, so no Last.fm client is involved; the client
+ * itself is pinned by lastfm-client.test.mjs and the whole path by
+ * test/integration/stats-forwarding.test.mjs.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  scrobbleFor, planScrobbles, createForwarder, LASTFM_WINDOW_MS, LASTFM_MIN_TRACK_MS,
+} from '../../src/stats/forward.js';
+
+const NOW = new Date('2026-09-10T12:00:00Z');
+const STARTED = new Date('2026-09-10T11:00:00Z');
+const STARTED_S = Math.floor(STARTED.getTime() / 1000);
+const ev = (over = {}) => ({
+  eventId: 'e', counted: true, startedAt: STARTED, durationMs: 299400, peerId: null, snapshot: null, ...over,
+});
+const local = { title: 'Let Down', artist: 'Radiohead', album: 'OK Computer' };
+const quiet = { debug() {}, warn() {} };
+const account = { id: 1, lastfm_user: 'u', lastfm_password: 'p' };
+
+describe('scrobbleFor', () => {
+  test('a counted local play: the library strings, the start in epoch seconds, the length in seconds', () => {
+    assert.deepEqual(scrobbleFor(ev(), local, NOW),
+      { artist: 'Radiohead', track: 'Let Down', album: 'OK Computer', timestamp: STARTED_S, duration: 299 });
+  });
+
+  test('an uncounted play is never scrobbled', () => {
+    assert.equal(scrobbleFor(ev({ counted: false }), local, NOW), null);
+  });
+
+  test("Last.fm's window: older than 14 days or ahead of now → nothing", () => {
+    assert.equal(scrobbleFor(ev({ startedAt: new Date(NOW.getTime() - LASTFM_WINDOW_MS - 1000) }), local, NOW), null);
+    assert.equal(scrobbleFor(ev({ startedAt: new Date(NOW.getTime() + 60_000) }), local, NOW), null);
+    assert.ok(scrobbleFor(ev({ startedAt: new Date(NOW.getTime() - LASTFM_WINDOW_MS + 60_000) }), local, NOW), 'just inside');
+    assert.ok(scrobbleFor(ev({ startedAt: NOW }), local, NOW), 'starting right now is fine');
+  });
+
+  test('artist and title are required; blanks count as missing; album is optional', () => {
+    assert.equal(scrobbleFor(ev(), { ...local, artist: null }, NOW), null);
+    assert.equal(scrobbleFor(ev(), { ...local, title: '   ' }, NOW), null);
+    assert.equal(scrobbleFor(ev(), null, NOW), null);
+    assert.equal(scrobbleFor(ev(), { title: 'T', artist: ' A ' }, NOW).album, undefined);
+    assert.equal(scrobbleFor(ev(), { title: 'T', artist: ' A ' }, NOW).artist, 'A', 'trimmed');
+  });
+
+  test('a track shorter than 30 s is never scrobbled; an unknown length is sent without one', () => {
+    assert.equal(scrobbleFor(ev({ durationMs: LASTFM_MIN_TRACK_MS - 1 }), local, NOW), null);
+    assert.equal(scrobbleFor(ev({ durationMs: LASTFM_MIN_TRACK_MS }), local, NOW).duration, 30);
+    assert.equal(scrobbleFor(ev({ durationMs: null }), local, NOW).duration, undefined);
+    assert.equal(scrobbleFor(ev({ durationMs: 0 }), local, NOW).duration, undefined);
+  });
+
+  test("a peer play takes its strings from the snapshot — there is no library row to read", () => {
+    const e = ev({ peerId: 3, snapshot: { title: 'Remote', artist: 'Peer', album: 'Far', hash: 'h' }, durationMs: 200000 });
+    assert.deepEqual(scrobbleFor(e, null, NOW),
+      { artist: 'Peer', track: 'Remote', album: 'Far', timestamp: STARTED_S, duration: 200 });
+    assert.equal(scrobbleFor(ev({ peerId: 3, snapshot: { title: 'Remote' } }), local, NOW), null,
+      'a snapshot without an artist is not filled in from anywhere else');
+  });
+
+  test('a stored-text start time is read too', () => {
+    assert.equal(scrobbleFor(ev({ startedAt: '2026-09-10T11:00:00.000Z' }), local, NOW).timestamp, STARTED_S);
+    assert.equal(scrobbleFor(ev({ startedAt: 'garbage' }), local, NOW), null);
+  });
+});
+
+describe('planScrobbles', () => {
+  test('keeps the batch order and drops what Last.fm would not take', () => {
+    const stored = [
+      { event: ev({ eventId: 'a' }), track: local },
+      { event: ev({ eventId: 'b', counted: false }), track: local },
+      { event: ev({ eventId: 'c', peerId: 2, snapshot: { title: 'R', artist: 'P' } }), track: null },
+    ];
+    assert.deepEqual(planScrobbles(stored, NOW).map((s) => s.track), ['Let Down', 'R']);
+    assert.deepEqual(planScrobbles([], NOW), []);
+    assert.deepEqual(planScrobbles(undefined, NOW), []);
+  });
+});
+
+describe('createForwarder', () => {
+  test('drains one at a time with a gap between sends; a failure or a throw costs only its own scrobble', async () => {
+    const sent = [];
+    const gaps = [];
+    const send = (user, song) => {
+      sent.push(`${user.lastfm_user}:${song.track}`);
+      if (song.track === 'boom') { return Promise.reject(new Error('boom')); }
+      return Promise.resolve(song.track === 'nope' ? { ok: false, error: 'lastfm-9' } : { ok: true });
+    };
+    const f = createForwarder({ send, spacingMs: 7, sleep: (ms) => { gaps.push(ms); return Promise.resolve(); }, log: quiet });
+    const songs = ['a', 'boom', 'nope', 'd'].map((t, i) => ({ artist: 'x', track: t, timestamp: i }));
+    assert.equal(f.enqueue(account, songs), 4);
+    await f.idle();
+    assert.deepEqual(sent, ['u:a', 'u:boom', 'u:nope', 'u:d']);
+    assert.deepEqual(gaps, [7, 7, 7], 'a gap between sends, none after the last');
+    assert.deepEqual(f.stats, { sent: 2, failed: 2, dropped: 0 });
+    assert.equal(f.pending, 0);
+  });
+
+  test('only the account is kept on the queue, never the whole request user', async () => {
+    const seen = [];
+    const f = createForwarder({ send: (user) => { seen.push(user); return Promise.resolve({ ok: true }); }, spacingMs: 0, log: quiet });
+    f.enqueue({ ...account, username: 'alice', password: 'hash', vpaths: ['music'] }, [{ artist: 'x', track: 't', timestamp: 1 }]);
+    await f.idle();
+    assert.deepEqual(seen, [account]);
+  });
+
+  test('no linked account, or nothing to send → nothing queued', async () => {
+    let sends = 0;
+    const f = createForwarder({ send: () => { sends++; return Promise.resolve({ ok: true }); }, spacingMs: 0, log: quiet });
+    assert.equal(f.enqueue({ id: 1 }, [{ artist: 'x', track: 't', timestamp: 1 }]), 0);
+    assert.equal(f.enqueue({ id: 1, lastfm_user: 'u' }, [{ artist: 'x', track: 't', timestamp: 1 }]), 0, 'a user without a password');
+    assert.equal(f.enqueue(account, []), 0);
+    await f.idle();
+    assert.equal(sends, 0);
+  });
+
+  test('the queue is capped: the oldest waiting scrobbles go, with one warning', async () => {
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    const sent = [];
+    const warns = [];
+    const send = async (_u, song) => { sent.push(song.track); await gate; return { ok: true }; };
+    const f = createForwarder({ send, spacingMs: 0, maxQueue: 2, log: { debug() {}, warn: (m) => warns.push(m) } });
+    const song = (t) => ({ artist: 'x', track: t, timestamp: 1 });
+    f.enqueue(account, [song('first')]);                       // taken by the drain at once, parked on the gate
+    f.enqueue(account, [song('a'), song('b'), song('c')]);      // cap 2 → 'a' is dropped
+    assert.equal(f.pending, 2);
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /dropped the 1 oldest/);
+    assert.equal(f.stats.dropped, 1);
+    release();
+    await f.idle();
+    assert.deepEqual(sent, ['first', 'b', 'c']);
+  });
+
+  test('a second batch during a drain joins the same drain', async () => {
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    const sent = [];
+    const send = async (_u, song) => { sent.push(song.track); if (song.track === 'first') { await gate; } return { ok: true }; };
+    const f = createForwarder({ send, spacingMs: 0, log: quiet });
+    const song = (t) => ({ artist: 'x', track: t, timestamp: 1 });
+    f.enqueue(account, [song('first')]);
+    f.enqueue(account, [song('second')]);
+    release();
+    await f.idle();
+    assert.deepEqual(sent, ['first', 'second']);
+    assert.equal(f.stats.sent, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Lane **S5** of the play-history plan: plays posted to `POST /api/v1/stats/plays` now reach Last.fm, and a client can announce what it is playing.

- **Forwarding with the play's own time.** After ingest commits, each *counted* play of a user who linked a Last.fm account (admin panel → users → Last.fm) is scrobbled with its own start time, so an offline afternoon's outbox lands on the right day. A peer play is scrobbled from its `track` snapshot. Last.fm's rules are applied before sending: nothing older than 14 days or ahead of now, nothing without an artist and title, no track under 30 seconds. A queue drains one request at a time with a 250 ms gap (Last.fm allows about five requests a second per IP; an outbox may hand over 200 plays). Failures are logged and dropped. No Last.fm request is ever in the response's path. The legacy scrobble shim keeps its own direct call and never goes through ingest, so nothing is forwarded twice.
- **The existing client is reused, not replaced.** `src/state/lastfm.js` (Scribble): `Scrobble` gains `song.timestamp` and `song.duration`; the three writers sign through one sorted-key signer (Last.fm's rule; the hand-built strings could not grow a parameter); writes ask for `format=json` so errors are readable; and the failure paths (unknown user, refused login, network error, timeout) answer the callback with `null` instead of throwing inside an HTTP callback. That last one is a latent crash on master: `ret.session.key` on an "Authentication Failed" answer throws in a response handler and takes the process down. `scrobbler.js` exposes `scrobbleAt` / `nowPlayingAt` on the shared, warmed instance (promise of `{ ok, error }`, 15 s cap, error 9 drops the session) and honours `MSTREAM_TEST_LASTFM_ENDPOINT` so a test can stand in for Last.fm.
- **`POST /api/v1/stats/now-playing`** `{filePath, peerId?, sessionId, track?}`: per user and player session, in memory for ten minutes, no row; forwards the Last.fm now-playing notice; answers `unknown-track` / `unknown-peer` / `invalid` without an error. **`GET`** returns the caller's own entries. Off the federation allowlist like the rest of the surface.
- **Ingest:** `lookupTrack` carries title / artist / album; `ingestPlays` takes `onStored`, called once after the commit with the inserted plays (never duplicates or rejections). Return shape unchanged.
- **Docs:** the plays entry describes forwarding; now-playing entries added to `docs/openapi.yaml` (redocly-valid; the two new warnings are the repo-wide missing-operationId class); one sentence in `docs/json_config.md`.

ListenBrainz went with the velvet UI, so the lane is Last.fm only. `features.stats` stays at 2 — nothing has shipped yet.

## Tests

- `test/unit/lastfm-client.test.mjs` (7): the client against a fake Last.fm — one login per session, timestamp and duration sent and signed correctly, the pre-existing now-playing signature unchanged (regression against the old hand-built string), refused login / unknown user / unreachable host answer null.
- `test/unit/stats-forward.test.mjs` (13): which stored plays become scrobbles (counted only, the 14-day window, strings, the 30 s floor, peer snapshots) and the queue (one at a time with the gap, failure and throw isolation, cap with one warning, only the account kept).
- `test/db/db-stats-ingest.test.mjs` (+2): the strings, and `onStored` after the commit with the inserted plays only.
- `test/integration/stats-forwarding.test.mjs` (3): a real server against a fake Last.fm — a batch of five plays yields exactly two scrobbles (the counted local play and the peer play) with their own start times, strings and lengths on one session; the skip, the 20-day-old play and the 20-second ident are stored but never sent; a replay sends nothing; now-playing stores, lists, forwards, answers unknowns, validates; the route is off the federation allowlist.
- Existing suites green here: stats ingest / api / lifecycle, stats-time, lastfm-cache, lastfm-status, admin-users-lastfm, canonical-hash-endpoints, api-server-info. eslint clean with zero warnings on every touched file.

Not verified against the real Last.fm service (that needs a linked account); the wire format is pinned by signature checks in the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
