### PR TITLE
webapp(S6): the player reports complete plays to the Stats API

### DIFF
--- a/src/api/stats.js
+++ b/src/api/stats.js
@@ -103,6 +103,9 @@ const bodySchema = Joi.object({
   }),
   plays: Joi.array().items(playSchema).min(1).max(MAX_BATCH).required(),
 });
+// The wire contract, for the tests of the clients that post here (the
+// webapp's play sessions validate what they build against it).
+export const playsBodySchema = bodySchema;
 
 // `name/version`, the form stored on every row and shown in history.
 export function clientLabel(c) {

--- a/test/unit/webapp-play-session.test.mjs
+++ b/test/unit/webapp-play-session.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * webapp/assets/js/mstream.play-session.js — the web player's play
+ * sessions and outbox, on node. The module is UMD; storage and the request
+ * are injected, so nothing here touches a DOM.
+ *
+ * Also the wire contract: every play the fold produces, and every batch
+ * the outbox sends, validates against the server's own request schema
+ * (src/api/stats.js playsBodySchema) — the webapp and the server cannot
+ * drift apart without this file going red.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { playsBodySchema } from '../../src/api/stats.js';
+
+const require = createRequire(import.meta.url);
+const PS = require('../../webapp/assets/js/mstream.play-session.js');
+
+const T0 = Date.parse('2026-09-10T12:00:00Z');
+const iso = (ms) => new Date(ms).toISOString();
+function memStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => { m.set(k, String(v)); },
+    removeItem: (k) => { m.delete(k); },
+    map: m,
+  };
+}
+const local = { filePath: 'testlib/Let Down.flac', durationMs: 299000, source: 'manual', sessionId: 'tab-1' };
+function schemaError(plays) {
+  const { error } = playsBodySchema.validate({ client: { name: PS.CLIENT_NAME, instanceId: 'inst' }, plays });
+  return error ? error.message : null;
+}
+const play = (id, over = {}) => ({
+  id, filePath: 'testlib/a.flac', startedAt: iso(T0), endedAt: iso(T0 + 60000), playedMs: 60000,
+  outcome: 'completed', source: 'manual', pauseCount: 0, ...over,
+});
+
+describe('the fold', () => {
+  test('forward ticks add listened time; a seek or a backwards jump adds nothing', () => {
+    const s = PS.createSession(local, T0);
+    PS.tick(s, 0); PS.tick(s, 0.25); PS.tick(s, 0.5); PS.tick(s, 1.0);    // +1000
+    PS.tick(s, 60);                                                       // a seek: +0
+    PS.tick(s, 60.5);                                                     // +500
+    PS.tick(s, 10);                                                       // back: +0
+    PS.tick(s, 10.5);                                                     // +500
+    PS.tick(s, NaN); PS.tick(s, -1);                                      // ignored
+    assert.equal(s.playedMs, 2000);
+    assert.equal(s.maxPos, 60.5);
+  });
+
+  test('nothing accrues while paused or not playing; a pause counts once however often it is pressed', () => {
+    const s = PS.createSession(local, T0);
+    PS.tick(s, 0); PS.tick(s, 1);
+    PS.pause(s); PS.pause(s);
+    PS.tick(s, 2); PS.tick(s, 3);
+    PS.resume(s); PS.tick(s, 3.5);
+    PS.tick(s, 4, false);
+    assert.equal(s.pauseCount, 1);
+    assert.equal(s.playedMs, 1500);
+  });
+
+  test('too short is never posted', () => {
+    const s = PS.createSession(local, T0);
+    PS.tick(s, 0); PS.tick(s, 0.9);
+    assert.equal(PS.finish(s, 'completed', T0 + 1000), null);
+    assert.equal(PS.finish(null, 'completed'), null);
+  });
+
+  test('the wire play: ISO instants, the outcome, the source, the pause count, the length', () => {
+    const s = PS.createSession({ ...local, id: 'p-1' }, T0);
+    PS.tick(s, 0); PS.tick(s, 2); PS.tick(s, 4);
+    const p = PS.finish(s, 'skipped', T0 + 4000);
+    assert.deepEqual(p, {
+      id: 'p-1', filePath: 'testlib/Let Down.flac',
+      startedAt: '2026-09-10T12:00:00.000Z', endedAt: '2026-09-10T12:00:04.000Z',
+      playedMs: 4000, outcome: 'skipped', source: 'manual', pauseCount: 0, durationMs: 299000, sessionId: 'tab-1',
+    });
+    assert.equal(schemaError([p]), null);
+    assert.equal(PS.finish(s, 'skipped', T0 - 5000).endedAt, iso(T0), 'an end before the start is clamped');
+  });
+
+  test("reaching the end of a known length is a completion whatever the player says; 'completed' stands; an unknown word is 'stopped'", () => {
+    const s = PS.createSession(local, T0);
+    PS.tick(s, 0); PS.tick(s, 297.5); PS.tick(s, 298.5); PS.tick(s, 299);
+    assert.equal(PS.finish(s, 'skipped', T0 + 5000).outcome, 'completed');
+    const u = PS.createSession({ ...local, durationMs: null }, T0);
+    PS.tick(u, 0); PS.tick(u, 2);
+    assert.equal(PS.finish(u, 'skipped').outcome, 'skipped');
+    assert.equal(PS.finish(u, 'stopped').outcome, 'stopped');
+    assert.equal(PS.finish(u, 'bogus').outcome, 'stopped');
+    assert.equal(PS.finish(u, 'completed').outcome, 'completed');
+  });
+
+  test('a peer play carries its id and a snapshot of the metadata', () => {
+    const snap = PS.snapshotOf({
+      title: ' Remote ', artist: 'Peer', album: '', duration: 200.4, hash: 'fh', 'audio-hash': 'ah', 'album-art': 'x.jpg', bpm: 120,
+    });
+    assert.deepEqual(snap, { title: 'Remote', artist: 'Peer', durationMs: 200400, hash: 'ah', artFile: 'x.jpg' });
+    assert.equal(PS.snapshotOf({ hash: 'fh' }).hash, 'fh', 'the file hash when there is no audio hash');
+    assert.deepEqual(PS.snapshotOf(null), {});
+    const s = PS.createSession({ ...local, filePath: 'remote/x.mp3', peerId: 3, track: snap, durationMs: snap.durationMs }, T0);
+    PS.tick(s, 0); PS.tick(s, 2);
+    const p = PS.finish(s, 'skipped', T0 + 2000);
+    assert.equal(p.peerId, 3);
+    assert.deepEqual(p.track, snap);
+    assert.equal(schemaError([p]), null);
+  });
+
+  test('a late duration is taken once, and only while unknown', () => {
+    const s = PS.createSession({ ...local, durationMs: null }, T0);
+    PS.withDuration(s, 100000);
+    PS.withDuration(s, 5);
+    assert.equal(s.durationMs, 100000);
+    PS.withDuration(PS.createSession(local, T0), 1);
+  });
+
+  test('createSession refuses a missing path and normalises the rest', () => {
+    assert.throws(() => PS.createSession({}), TypeError);
+    const s = PS.createSession({ filePath: 'a', peerId: 0, durationMs: -1, source: '', startedAt: 'x', sessionId: '' }, T0);
+    assert.equal(s.peerId, null);
+    assert.equal(s.durationMs, null);
+    assert.equal(s.source, 'manual');
+    assert.equal(s.sessionId, null);
+    assert.equal(s.startedAt, T0);
+    assert.match(s.id, /^[0-9a-f-]{36}$/);
+  });
+
+  test('uuid: v4 shape, unique', () => {
+    const a = PS.uuid();
+    assert.match(a, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    assert.notEqual(a, PS.uuid());
+  });
+
+  test('one session id per tab, kept in sessionStorage', () => {
+    const st = memStorage();
+    const a = PS.tabSessionId(st);
+    assert.match(a, /^[0-9a-f-]{36}$/);
+    assert.equal(PS.tabSessionId(st), a);
+    assert.equal(st.getItem(PS.KEYS.session), a);
+  });
+});
+
+describe('the outbox', () => {
+  test('posts what is queued with the client block, and settles every id the server names', async () => {
+    const st = memStorage();
+    const sent = [];
+    const post = (body) => { sent.push(body); return Promise.resolve({ accepted: ['a'], duplicates: ['b'], rejected: [{ id: 'c', reason: 'unknown-track' }] }); };
+    const box = PS.createOutbox({ storage: st, post });
+    for (const id of ['a', 'b', 'c', 'd']) { box.enqueue(play(id)); }
+    assert.equal(box.size(), 4);
+    assert.equal(await box.flush(), false, 'd is still waiting');
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].client.name, 'mstream-webapp');
+    assert.match(sent[0].client.instanceId, /^[0-9a-f-]{36}$/);
+    assert.deepEqual(sent[0].plays.map((p) => p.id), ['a', 'b', 'c', 'd']);
+    assert.equal(schemaError(sent[0].plays), null, 'what leaves the outbox passes the server schema');
+    assert.equal(box.size(), 1);
+    assert.equal(st.getItem(PS.KEYS.instance), sent[0].client.instanceId, 'the instance id persists');
+    assert.equal(await box.flush(), false, 'and is retried next time');
+    assert.equal(sent[1].client.instanceId, sent[0].client.instanceId);
+  });
+
+  test('no network keeps everything; a 400 drops the batch; a 401 keeps it', async () => {
+    const st = memStorage();
+    const warns = [];
+    let fail = () => { throw new Error('net'); };
+    const box = PS.createOutbox({ storage: st, post: () => Promise.resolve().then(() => fail()), log: { warn: (m) => warns.push(m) } });
+    box.enqueue(play('a')); box.enqueue(play('b'));
+    assert.equal(await box.flush(), false);
+    assert.equal(box.size(), 2);
+    fail = () => { const e = new Error('unauthorized'); e.status = 401; throw e; };
+    assert.equal(await box.flush(), false);
+    assert.equal(box.size(), 2);
+    fail = () => { const e = new Error('bad'); e.status = 400; throw e; };
+    assert.equal(await box.flush(), true);
+    assert.equal(box.size(), 0);
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /refused a batch of 2/);
+  });
+
+  test('a flush in progress is shared; an empty box is done; a batch is at most BATCH_MAX', async () => {
+    const st = memStorage();
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    const sizes = [];
+    const box = PS.createOutbox({ storage: st, post: async (body) => { sizes.push(body.plays.length); await gate; return { accepted: body.plays.map((p) => p.id) }; } });
+    assert.equal(await box.flush(), true, 'nothing queued → done, no request');
+    assert.equal(sizes.length, 0);
+    for (let i = 0; i < PS.BATCH_MAX + 5; i++) { box.enqueue(play(`p${i}`)); }
+    const p1 = box.flush();
+    const p2 = box.flush();
+    assert.equal(p1, p2);
+    release();
+    assert.equal(await p1, false, 'five left for the next batch');
+    assert.deepEqual(sizes, [PS.BATCH_MAX]);
+    assert.equal(box.size(), 5);
+  });
+
+  test('the cap drops the oldest; enqueue replaces a play with the same id; junk is ignored', () => {
+    const st = memStorage();
+    const box = PS.createOutbox({ storage: st, post: () => Promise.resolve({}) });
+    for (let i = 0; i < PS.OUTBOX_CAP + 2; i++) { box.enqueue(play(`p${i}`)); }
+    assert.equal(box.size(), PS.OUTBOX_CAP);
+    const ids = JSON.parse(st.getItem(PS.KEYS.outbox)).map((p) => p.id);
+    assert.equal(ids[0], 'p2');
+    box.enqueue(play('p2', { playedMs: 1 }));
+    assert.equal(box.size(), PS.OUTBOX_CAP);
+    assert.equal(JSON.parse(st.getItem(PS.KEYS.outbox)).at(-1).playedMs, 1, 'moved to the back, replaced');
+    assert.equal(box.enqueue(null), 0);
+    st.setItem(PS.KEYS.outbox, '{not json');
+    assert.equal(box.size(), 0, 'a corrupt outbox reads as empty');
+  });
+
+  test('checkpoint + recover: the session a closed tab left becomes a stopped play at its checkpoint time', () => {
+    const st = memStorage();
+    let t = T0;
+    const box = PS.createOutbox({ storage: st, post: () => Promise.resolve({}), now: () => t });
+    const s = PS.createSession({ ...local, id: 'left' }, T0);
+    PS.tick(s, 0); PS.tick(s, 1); PS.tick(s, 2); PS.tick(s, 3);
+    t = T0 + 30000;
+    box.checkpoint(s);
+    assert.ok(st.getItem(PS.KEYS.inflight));
+
+    const later = PS.createOutbox({ storage: st, post: () => Promise.resolve({}), now: () => T0 + 999999 });
+    const p = later.recover();
+    assert.equal(p.id, 'left');
+    assert.equal(p.outcome, 'stopped');
+    assert.equal(p.playedMs, 3000);
+    assert.equal(p.endedAt, iso(T0 + 30000), 'ended when it was last seen, not when it was found');
+    assert.equal(schemaError([p]), null);
+    assert.equal(later.size(), 1);
+    assert.equal(later.recover(), null, 'consumed');
+    assert.equal(st.getItem(PS.KEYS.inflight), null);
+  });
+
+  test('recover ignores a too-short or corrupt checkpoint, and clearCheckpoint forgets one', () => {
+    const st = memStorage();
+    const box = PS.createOutbox({ storage: st, post: () => Promise.resolve({}) });
+    const short = PS.createSession(local, T0);
+    PS.tick(short, 0); PS.tick(short, 0.5);
+    box.checkpoint(short);
+    assert.equal(box.recover(), null);
+    assert.equal(box.size(), 0);
+    st.setItem(PS.KEYS.inflight, '{nope');
+    assert.equal(box.recover(), null);
+    box.checkpoint(PS.createSession(local, T0));
+    box.clearCheckpoint();
+    assert.equal(st.getItem(PS.KEYS.inflight), null);
+    assert.equal(box.recover(), null);
+  });
+});

--- a/webapp/alpha/api.js
+++ b/webapp/alpha/api.js
@@ -18,7 +18,9 @@ const MSTREAMAPI = (() => {
         // 'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: dataObject ? JSON.stringify(dataObject) : undefined,
-      signal: opts?.signal
+      signal: opts?.signal,
+      // A play posted as the page closes must outlive it.
+      keepalive: opts?.keepalive === true
     });
 
     if (res.ok !== true) {
@@ -451,6 +453,17 @@ const MSTREAMAPI = (() => {
 
   mstreamModule.scrobbleByFilePath =  (filePath) => {
     return req('POST', mstreamModule.currentServer.host +  "api/v1/lastfm/scrobble-by-filepath", { filePath });
+  }
+
+  // Stats API v2 (the ping's `stats` flag, 2 or higher). The player's play
+  // sessions post here once a play is over — assets/js/mstream.player.js
+  // and mstream.play-session.js; `keepalive` carries the last play out of
+  // a closing page.
+  mstreamModule.postPlays = (body, opts) => {
+    return req('POST', mstreamModule.currentServer.host + 'api/v1/stats/plays', body, opts);
+  }
+  mstreamModule.postNowPlaying = (body) => {
+    return req('POST', mstreamModule.currentServer.host + 'api/v1/stats/now-playing', body);
   }
 
   // LOGIN

--- a/webapp/alpha/m.js
+++ b/webapp/alpha/m.js
@@ -710,6 +710,11 @@ async function init() {
     // Discovery capability — consumed by the Discover panel (below) and
     // the Auto-DJ panel's sonic-similarity section.
     MSTREAMAPI.currentServer.discovery = response.discovery === true;
+    // Stats API v2 — with it, the player reports complete plays instead of
+    // the 30-second scrobble (assets/js/mstream.player.js), and posts what
+    // an earlier page left behind.
+    MSTREAMAPI.currentServer.stats = Number(response.stats) || 0;
+    if (typeof MSTREAMPLAYER.statsInit === 'function') { MSTREAMPLAYER.statsInit(); }
     VUEPLAYERCORE.setDiscoveryAvailable(response.discovery === true);
     VUEPLAYERCORE.setDiscoveryP2pAvailable(response.discoveryP2p === true);
     VUEPLAYERCORE.setFederationDiscoveryAvailable(response.federationDiscovery === true);

--- a/webapp/assets/js/mstream.play-session.js
+++ b/webapp/assets/js/mstream.play-session.js
@@ -1,0 +1,305 @@
+// Play sessions for the Stats API v2 — what the web player reports.
+//
+// The player used to fire scrobble-by-filepath 30 seconds into a track, so
+// every web play in the listening log was 30 seconds long and "stopped",
+// and a peer's track never counted at all. This is the replacement: one
+// session per song start, folded from the player's own signals (position
+// ticks, pause and resume, the end of the stream, the user moving on), and
+// posted to POST /api/v1/stats/plays once the play is over — the server
+// decides whether it counts. The 30-second timer stays for a server without
+// the Stats API; the player checks the ping's `stats` flag.
+//
+// Pure: no DOM, no player globals. Storage and the request are injected, so
+// test/unit/webapp-play-session.test.mjs drives it on node — the same UMD
+// shape as alpha/auto-dj.js. The rules mirror the mobile app's fold:
+//   listened time   the sum of forward position deltas while playing; a
+//                   jump of more than SEEK_JUMP_S per tick, or backwards, is
+//                   a seek and adds nothing
+//   pauses          counted on each pause
+//   outcome         `completed` when the stream ended, or when the playhead
+//                   got within END_SLACK_S of a known length before the user
+//                   moved on; otherwise what the player says — `skipped`
+//                   (moved on) or `stopped` (page closed, playback failed)
+//   too short       a session with under MIN_POST_MS listened is dropped —
+//                   a mis-click, a failed load — never posted
+// The outbox keeps unsent plays in localStorage (OUTBOX_CAP, oldest out)
+// and retries; ids are UUIDs, so a retry the server already saw comes back
+// as a duplicate and is dropped. The in-flight session is checkpointed
+// there too, so a crash or a closed tab still yields a `stopped` play on
+// the next load.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) { module.exports = factory(); }
+  else { root.MSTREAMPLAYSESSION = factory(); }
+}(typeof self !== 'undefined' ? self : this, function () {
+  const SEEK_JUMP_S = 3;
+  const END_SLACK_S = 2;
+  const MIN_POST_MS = 1000;
+  const OUTBOX_CAP = 500;
+  const BATCH_MAX = 200;
+  const CLIENT_NAME = 'mstream-webapp';
+  const KEYS = Object.freeze({
+    outbox: 'mstream-stats-outbox',
+    inflight: 'mstream-stats-inflight',
+    instance: 'mstream-stats-instance',
+    session: 'mstream-stats-session',
+  });
+  const OUTCOMES = ['completed', 'skipped', 'stopped'];
+
+  // A v4 UUID. crypto.randomUUID needs a secure context, and mStream on a
+  // LAN is plain http more often than not.
+  function uuid() {
+    const c = (typeof crypto !== 'undefined') ? crypto : null;
+    if (c && typeof c.randomUUID === 'function') {
+      try { return c.randomUUID(); } catch (_) { /* fall through */ }
+    }
+    const b = new Uint8Array(16);
+    if (c && typeof c.getRandomValues === 'function') { c.getRandomValues(b); }
+    else { for (let i = 0; i < 16; i++) { b[i] = Math.floor(Math.random() * 256); } }
+    b[6] = (b[6] & 0x0f) | 0x40;
+    b[8] = (b[8] & 0x3f) | 0x80;
+    const h = Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+    return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+  }
+
+  const str = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+
+  // ── The session ───────────────────────────────────────────────────────
+
+  // One song start. `filePath` is the vpath-prefixed path (a peer's own path
+  // for a peer track); `peerId` + `track` make it a peer play; `durationMs`
+  // may arrive later (withDuration) once the element knows it.
+  function createSession(init, now = Date.now()) {
+    if (!init || !str(init.filePath)) { throw new TypeError('a session needs a filePath'); }
+    return {
+      id: str(init.id) || uuid(),
+      filePath: init.filePath,
+      peerId: Number.isInteger(init.peerId) && init.peerId > 0 ? init.peerId : null,
+      track: init.track || null,
+      durationMs: Number.isInteger(init.durationMs) && init.durationMs > 0 ? init.durationMs : null,
+      source: str(init.source) || 'manual',
+      sessionId: str(init.sessionId) || null,
+      startedAt: Number.isFinite(init.startedAt) ? init.startedAt : now,
+      playedMs: 0,
+      pauseCount: 0,
+      paused: false,
+      lastPos: null,
+      maxPos: 0,
+      checkpointAt: null,
+    };
+  }
+
+  // A position report (seconds). Only a forward step small enough to be
+  // playback — not a seek — adds listened time, and only while playing.
+  function tick(session, positionSec, playing = true) {
+    if (!session || !Number.isFinite(positionSec) || positionSec < 0) { return session; }
+    if (session.lastPos != null && playing && !session.paused) {
+      const delta = positionSec - session.lastPos;
+      if (delta > 0 && delta <= SEEK_JUMP_S) { session.playedMs += Math.round(delta * 1000); }
+    }
+    session.lastPos = positionSec;
+    if (positionSec > session.maxPos) { session.maxPos = positionSec; }
+    return session;
+  }
+
+  function pause(session) {
+    if (session && !session.paused) { session.paused = true; session.pauseCount += 1; }
+    return session;
+  }
+
+  function resume(session) {
+    if (session) { session.paused = false; }
+    return session;
+  }
+
+  function withDuration(session, durationMs) {
+    if (session && session.durationMs == null && Number.isInteger(durationMs) && durationMs > 0) {
+      session.durationMs = durationMs;
+    }
+    return session;
+  }
+
+  // The outcome the play is stored with. The player's word stands, except
+  // that reaching the end of a known length is a completion however the
+  // song was left — a skip during the fade-out is not a skip.
+  function classify(session, requested) {
+    if (requested === 'completed') { return 'completed'; }
+    if (session.durationMs != null && session.maxPos * 1000 >= session.durationMs - END_SLACK_S * 1000) {
+      return 'completed';
+    }
+    return OUTCOMES.includes(requested) ? requested : 'stopped';
+  }
+
+  // The play as the server takes it, or null when too short to post.
+  function finish(session, requested, endedAt = Date.now()) {
+    if (!session || !(session.playedMs >= MIN_POST_MS)) { return null; }
+    const play = {
+      id: session.id,
+      filePath: session.filePath,
+      startedAt: new Date(session.startedAt).toISOString(),
+      endedAt: new Date(Math.max(endedAt, session.startedAt)).toISOString(),
+      playedMs: session.playedMs,
+      outcome: classify(session, requested),
+      source: session.source,
+      pauseCount: session.pauseCount,
+    };
+    if (session.peerId != null) { play.peerId = session.peerId; play.track = session.track || {}; }
+    if (session.durationMs != null) { play.durationMs = session.durationMs; }
+    if (session.sessionId) { play.sessionId = session.sessionId; }
+    return play;
+  }
+
+  // What a peer play carries, from the metadata object the player holds:
+  // the strings, the length, the canonical hash (audio hash, else file
+  // hash), the art file — only what is set.
+  function snapshotOf(meta) {
+    const m = meta || {};
+    const out = {};
+    const title = str(m.title);
+    const artist = str(m.artist);
+    const album = str(m.album);
+    if (title) { out.title = title; }
+    if (artist) { out.artist = artist; }
+    if (album) { out.album = album; }
+    const dur = Number(m.duration);
+    if (Number.isFinite(dur) && dur > 0) { out.durationMs = Math.round(dur * 1000); }
+    const hash = str(m['audio-hash']) || str(m.hash);
+    if (hash) { out.hash = hash; }
+    const art = str(m['album-art']);
+    if (art) { out.artFile = art; }
+    return out;
+  }
+
+  // One id per tab (sessionStorage), so two tabs of one user are two
+  // players to the server's now-playing view.
+  let tabId = null;
+  function tabSessionId(storage) {
+    if (tabId) { return tabId; }
+    const s = storage || (typeof sessionStorage !== 'undefined' ? sessionStorage : null);
+    try {
+      tabId = s && s.getItem(KEYS.session);
+      if (!tabId) { tabId = uuid(); if (s) { s.setItem(KEYS.session, tabId); } }
+    } catch (_) {
+      tabId = uuid();
+    }
+    return tabId;
+  }
+
+  // ── The outbox ────────────────────────────────────────────────────────
+
+  // `post(body, opts)` resolves the server's answer ({ accepted,
+  // duplicates, rejected }) or throws with `status`. `storage` is a
+  // localStorage-shaped object.
+  function createOutbox({ storage, post, log, now } = {}) {
+    const store = storage || (typeof localStorage !== 'undefined' ? localStorage : null);
+    const clock = typeof now === 'function' ? now : () => Date.now();
+    const warn = (log && typeof log.warn === 'function') ? (m) => log.warn(m) : () => {};
+    let inflight = null;
+
+    function readList() {
+      try {
+        const raw = store ? store.getItem(KEYS.outbox) : null;
+        const list = raw ? JSON.parse(raw) : [];
+        return Array.isArray(list) ? list : [];
+      } catch (_) { return []; }
+    }
+    function writeList(list) {
+      try { if (store) { store.setItem(KEYS.outbox, JSON.stringify(list)); } }
+      catch (_) { /* quota — the play is lost, and nothing else can be done */ }
+    }
+    function instanceId() {
+      try {
+        let id = store ? store.getItem(KEYS.instance) : null;
+        if (!id) { id = uuid(); if (store) { store.setItem(KEYS.instance, id); } }
+        return id;
+      } catch (_) { return null; }
+    }
+
+    const box = {
+      // Queue a play (replacing one with the same id); oldest out past the cap.
+      enqueue(play) {
+        if (!play || !play.id) { return 0; }
+        const list = readList().filter((p) => p && p.id !== play.id);
+        list.push(play);
+        while (list.length > OUTBOX_CAP) { list.shift(); }
+        writeList(list);
+        return list.length;
+      },
+      size() { return readList().length; },
+      // Post what is queued, up to BATCH_MAX per call. Every id the server
+      // names is settled — accepted, duplicate, or rejected (a rejection
+      // means "drop it", by contract). A batch the server calls malformed
+      // (400) is dropped too, so a bad play can never wedge the queue;
+      // anything else — no network, 5xx, an expired token — stays for the
+      // next try. Resolves true when nothing is left waiting. A flush in
+      // progress is shared, never doubled.
+      flush(opts = {}) {
+        if (inflight) { return inflight; }
+        const run = async () => {
+          const list = readList();
+          if (list.length === 0) { return true; }
+          const batch = list.slice(0, BATCH_MAX);
+          const client = { name: CLIENT_NAME };
+          const inst = instanceId();
+          if (inst) { client.instanceId = inst; }
+          let r;
+          try {
+            r = await post({ client, plays: batch }, opts);
+          } catch (err) {
+            if (err && err.status === 400) {
+              const ids = new Set(batch.map((p) => p.id));
+              writeList(readList().filter((p) => !ids.has(p.id)));
+              warn(`[stats] the server refused a batch of ${batch.length} play(s) as malformed; dropped`);
+              return readList().length === 0;
+            }
+            return false;
+          }
+          const settled = new Set([
+            ...(Array.isArray(r?.accepted) ? r.accepted : []),
+            ...(Array.isArray(r?.duplicates) ? r.duplicates : []),
+            ...(Array.isArray(r?.rejected) ? r.rejected.map((x) => x && x.id) : []),
+          ]);
+          const rest = readList().filter((p) => !settled.has(p.id));
+          writeList(rest);
+          return rest.length === 0;
+        };
+        // The clearing is a promise reaction, never synchronous — an empty
+        // box resolves without ever yielding, and a `finally` inside `run`
+        // would clear `inflight` BEFORE this assignment, leaving a settled
+        // promise in place that every later flush would return unchanged.
+        inflight = run().finally(() => { inflight = null; });
+        return inflight;
+      },
+      // The in-flight session, so a crash still yields a play.
+      checkpoint(session) {
+        if (!session) { return; }
+        try { if (store) { store.setItem(KEYS.inflight, JSON.stringify({ ...session, checkpointAt: clock() })); } }
+        catch (_) { /* quota */ }
+      },
+      clearCheckpoint() {
+        try { if (store) { store.removeItem(KEYS.inflight); } } catch (_) { /* nothing to clear */ }
+      },
+      // A session left behind by a closed tab or a crash: what had been
+      // listened by the last checkpoint, as a `stopped` play. Queued and
+      // returned, or null when there was none (or it was too short).
+      recover() {
+        let raw = null;
+        try { raw = store ? store.getItem(KEYS.inflight) : null; } catch (_) { raw = null; }
+        if (!raw) { return null; }
+        box.clearCheckpoint();
+        let session = null;
+        try { session = JSON.parse(raw); } catch (_) { return null; }
+        if (!session || !session.id || !session.filePath) { return null; }
+        const play = finish(session, 'stopped', session.checkpointAt || clock());
+        if (play) { box.enqueue(play); }
+        return play;
+      },
+    };
+    return box;
+  }
+
+  return {
+    SEEK_JUMP_S, END_SLACK_S, MIN_POST_MS, OUTBOX_CAP, BATCH_MAX, CLIENT_NAME, KEYS,
+    uuid, createSession, tick, pause, resume, withDuration, classify, finish, snapshotOf, tabSessionId, createOutbox,
+  };
+}));

--- a/webapp/assets/js/mstream.player.js
+++ b/webapp/assets/js/mstream.player.js
@@ -64,6 +64,118 @@ const MSTREAMPLAYER = (() => {
       (response, error) => {});
   }
 
+  // ── Stats API v2: play sessions ──────────────────────────────────────
+  //
+  // On a server with the Stats API (the ping's `stats` flag, read by
+  // alpha/m.js into MSTREAMAPI.currentServer.stats) the 30-second scrobble
+  // above is never armed. Instead every song start opens a session
+  // (assets/js/mstream.play-session.js) fed by the player's own signals —
+  // the timeupdate ticks, pause and resume, the end of the stream, the user
+  // moving on — and the finished play goes to POST /api/v1/stats/plays
+  // through an outbox that retries and survives a closed tab. A peer track
+  // is reported as a peer play (its id + a snapshot of the metadata), which
+  // the legacy path could never count. Server-side playback
+  // (mstream.server-audio.js) keeps the legacy scrobble for now.
+  let playSession = null;
+  let statsOutbox = null;
+  let statsRetryTimer = null;
+  let lastCheckpointAt = 0;
+  const CHECKPOINT_EVERY_MS = 5000;
+
+  function statsEnabled() {
+    return typeof MSTREAMPLAYSESSION !== 'undefined'
+      && typeof MSTREAMAPI !== 'undefined'
+      && Number(MSTREAMAPI.currentServer && MSTREAMAPI.currentServer.stats) >= 2;
+  }
+  function statsOutboxFor() {
+    if (!statsOutbox) {
+      statsOutbox = MSTREAMPLAYSESSION.createOutbox({
+        post: (body, opts) => MSTREAMAPI.postPlays(body, opts),
+        log: console,
+      });
+    }
+    return statsOutbox;
+  }
+  // How the song got here: a DJ pick, the shuffle, or the user.
+  function statsSourceOf(song) {
+    if (mstreamModule.playerStats.autoDJ === true && song.metadata && song.metadata._djPicked === true) { return 'autodj'; }
+    if (mstreamModule.playerStats.shuffle === true) { return 'shuffle'; }
+    return 'manual';
+  }
+  function beginPlaySession(song) {
+    endPlaySession('skipped');
+    if (!statsEnabled() || !song || !song.rawFilePath) { return; }
+    const meta = song.metadata || {};
+    const peerId = song.federation && Number.isFinite(Number(song.federation.peerId))
+      ? Number(song.federation.peerId) : null;
+    const metaDur = Number(meta.duration);
+    try {
+      playSession = MSTREAMPLAYSESSION.createSession({
+        filePath: song.rawFilePath,
+        peerId,
+        track: peerId != null ? MSTREAMPLAYSESSION.snapshotOf(meta) : null,
+        durationMs: Number.isFinite(metaDur) && metaDur > 0 ? Math.round(metaDur * 1000) : null,
+        source: statsSourceOf(song),
+        sessionId: MSTREAMPLAYSESSION.tabSessionId(),
+      });
+    } catch (err) {
+      console.warn('[stats] could not open a play session', err);
+      return;
+    }
+    lastCheckpointAt = Date.now();
+    statsOutboxFor().checkpoint(playSession);
+    const notice = { filePath: playSession.filePath, sessionId: playSession.sessionId };
+    if (peerId != null) { notice.peerId = peerId; notice.track = playSession.track; }
+    try { MSTREAMAPI.postNowPlaying(notice).catch(() => {}); } catch (_) { /* best-effort */ }
+  }
+  // Close the open session with the player's word on how it ended; the
+  // fold may upgrade it to `completed` (the playhead reached the end).
+  function endPlaySession(outcome, flushOpts) {
+    if (!playSession) { return; }
+    const session = playSession;
+    playSession = null;
+    const box = statsOutboxFor();
+    box.clearCheckpoint();
+    const play = MSTREAMPLAYSESSION.finish(session, outcome);
+    if (!play) { return; }
+    box.enqueue(play);
+    box.flush(flushOpts || {}).catch(() => {});
+  }
+  function tickPlaySession() {
+    if (!playSession) { return; }
+    MSTREAMPLAYSESSION.tick(playSession, mstreamModule.playerStats.currentTime, mstreamModule.playerStats.playing === true);
+    const dur = mstreamModule.playerStats.duration;
+    if (Number.isFinite(dur) && dur > 0) { MSTREAMPLAYSESSION.withDuration(playSession, Math.round(dur * 1000)); }
+    const now = Date.now();
+    if (now - lastCheckpointAt >= CHECKPOINT_EVERY_MS) {
+      lastCheckpointAt = now;
+      statsOutboxFor().checkpoint(playSession);
+    }
+  }
+  function pausePlaySession() { if (playSession) { MSTREAMPLAYSESSION.pause(playSession); } }
+  function resumePlaySession() { if (playSession) { MSTREAMPLAYSESSION.resume(playSession); } }
+  // Called by alpha/m.js once the ping has answered: post what an earlier
+  // page left behind, then keep retrying quietly.
+  mstreamModule.statsInit = () => {
+    if (!statsEnabled()) { return false; }
+    const box = statsOutboxFor();
+    box.recover();
+    box.flush().catch(() => {});
+    if (!statsRetryTimer) { statsRetryTimer = setInterval(() => { box.flush().catch(() => {}); }, 60000); }
+    return true;
+  };
+  // A closing page: the play so far leaves as `stopped`, on a request that
+  // outlives the page.
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('pagehide', () => { endPlaySession('stopped', { keepalive: true }); });
+  }
+  // For the console and the smoke tests.
+  mstreamModule.stats = {
+    enabled: statsEnabled,
+    session: () => playSession,
+    outbox: () => statsOutboxFor(),
+  };
+
   // The audioData looks like this
   // var song = {
   //   "url":"vPath/path/to/song.mp3?token=xxx",
@@ -1204,9 +1316,15 @@ const MSTREAMPLAYER = (() => {
 
     }, cacheTimeout);
 
-    // Scrobble song after 30 seconds
+    // Count the play. A server with the Stats API gets the complete play
+    // once this song is over (the session); anything older still gets the
+    // legacy 30-second scrobble.
     clearTimeout(scrobbleTimer);
-    scrobbleTimer = setTimeout(() => { mstreamModule.scrobble() }, 30000);
+    if (statsEnabled()) {
+      beginPlaySession(mstreamModule.playlist[position]);
+    } else {
+      scrobbleTimer = setTimeout(() => { mstreamModule.scrobble() }, 30000);
+    }
   }
 
   // Should be called whenever the "metadata" field of the current song is changed, or
@@ -1303,13 +1421,13 @@ const MSTREAMPLAYER = (() => {
   function howlPlayerPlay() {
     const localPlayer = getCurrentPlayer();
     mstreamModule.playerStats.playing = true;
-
+    resumePlaySession();
     localPlayer.playerObject.play();
   }
   function howlPlayerPause() {
     const localPlayer = getCurrentPlayer();
     mstreamModule.playerStats.playing = false;
-
+    pausePlaySession();
     localPlayer.playerObject.pause();
   }
   function howlPlayerPlayPause() {
@@ -1318,9 +1436,11 @@ const MSTREAMPLAYER = (() => {
     // TODO: Check that media is loaded
     if (localPlayer.playerObject.paused === false) {
       mstreamModule.playerStats.playing = false;
+      pausePlaySession();
       localPlayer.playerObject.pause();
       document.title = "mStream Music"
     } else {
+      resumePlaySession();
       localPlayer.playerObject.play();
       
       let pageTitle = (mstreamModule.playerStats.metadata.title) ? 
@@ -1418,6 +1538,7 @@ const MSTREAMPLAYER = (() => {
       }
 
       if (playerObj === getCurrentPlayer()) {
+        endPlaySession('stopped');
         goToNextSong();
       }else {
         // Invalidate cache
@@ -1433,6 +1554,7 @@ const MSTREAMPLAYER = (() => {
       // offset`, so the element's own currentTime restarts at 0. Add the
       // offset back to report the true position.
       mstreamModule.playerStats.currentTime = (cur.seekOffset || 0) + cur.playerObject.currentTime;
+      tickPlaySession();
 
       // Duration: a chunked transcode stream has no usable audio.duration
       // (Infinity until fully buffered, and a seeked stream only spans the
@@ -1507,6 +1629,7 @@ const MSTREAMPLAYER = (() => {
 
   function callMeOnStreamEnd() {
     mstreamModule.playerStats.playing = false;
+    endPlaySession('completed');
     if (mstreamModule.playerStats.shouldLoopOne === true) {
       return goToSong(mstreamModule.positionCache.val);
     }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -63,6 +63,7 @@
   <script src="assets/js/lib/hyst-modal.js"></script>
   <link rel="stylesheet" href="assets/css/modal.css">
 
+  <script src="assets/js/mstream.play-session.js"></script>
   <script src="assets/js/mstream.player.js"></script>
 
   <!-- Lazy Loading Polyfill-->


### PR DESCRIPTION
## Summary

Lane **S6** of the play-history plan: the default webapp reports complete plays to the Stats API instead of firing the 30-second scrobble.

- **What was wrong.** The player fired `scrobble-by-filepath` 30 seconds into every track, so each web play in the log was 30 seconds long and `stopped`, a skip and a full listen looked the same, and a federated peer's track never counted (its path lives in the peer's namespace).
- **What it does now.** On a server whose ping advertises `stats` ≥ 2, every song start opens a play session and the finished play goes to `POST /api/v1/stats/plays`; the 30-second timer is never armed there, so nothing is counted twice. An older server, or a cached page meeting one, keeps the legacy path untouched.
- **The fold** (`webapp/assets/js/mstream.play-session.js`, new, pure, UMD like `alpha/auto-dj.js`): listened time is the sum of forward position deltas while playing, a jump over 3 s per tick or backwards is a seek and adds nothing; pauses are counted; the outcome is the player's word (`completed` on the stream's end, `skipped` when the user moves on, `stopped` for a closed page or a failed load), upgraded to `completed` when the playhead reached a known length; under 1 s listened is never posted. A peer track becomes a peer play with `peerId` and a metadata snapshot, so it counts for the first time. Source: `autodj` for a DJ pick, `shuffle`, or `manual`.
- **The outbox**: unsent plays in localStorage (cap 500), batches of up to 200, every id the server names settled, a batch the server calls malformed dropped, the rest kept for the next try. The in-flight session is checkpointed every 5 s so a crash yields a `stopped` play at the next load. A closing page posts its session on a keepalive fetch — the plan said `sendBeacon`, but a beacon cannot carry the auth header. One session id per tab for the now-playing view; a per-browser instance id on the client block; UUIDs without `crypto.randomUUID`, which a plain-http page does not get.
- **Hooks**: `goToSong` (open), the `timeupdate` tick, play/pause, the stream's end, a failed load, `pagehide`; the now-playing notice on each start. `alpha/api.js` gains `postPlays` (keepalive-capable) and `postNowPlaying`; `alpha/m.js` reads the ping flag and calls `statsInit` (recover, flush, quiet retry every minute).
- **Left alone on purpose**: server-side playback (`mstream.server-audio.js`) keeps the legacy scrobble; recording it belongs on the server side and is its own lane. The two scrobble routes stay for S7.
- `src/api/stats.js` exports `playsBodySchema` so the unit test holds the webapp to the server's own contract.

## Tests

- **`test/unit/webapp-play-session.test.mjs`** (16): the fold (deltas, seek guard, pauses, outcomes, the end-of-track upgrade, peer snapshots, normalisation) and the outbox (settling, 400/401/network, shared in-flight, cap, checkpoint/recover), with every play and batch validated against `playsBodySchema`. It caught a real bug on the way: an empty flush settled synchronously and left a stale in-flight promise that would have silently stopped all later posting.
- **Browser smoke against a real server** (this branch, demo library, public mode): skip after 8 s with one pause → `skipped`, not counted, pause count 1, client `mstream-webapp`; seek to the tail and let it end → `completed`, counted, 31 s listened with the seek excluded; reload mid-track → the keepalive `stopped` play; a planted checkpoint → recovered on the next load at its checkpoint time; now-playing lists the tab's session and is replaced per song; with the flag forced off, no session opens and the legacy scrobble fires at 30 s; no scrobble request at all in stats mode.
- Existing suites green here: auto-dj-client, webapp-local-search, webapp-waveform-cache, stats-ingest (unit + integration), stats-api, stats-forwarding. eslint clean on the server file and the test; the webapp files are outside eslint's scope and were syntax-checked.

Not covered: a real federated peer play from the webapp (the snapshot path is unit-tested and the server's peer ingest is covered by its own suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
