### PR TITLE
stats: either-hash counters, peer snapshot enrichment, admin listening-history card, Stats under Navigation

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2681,7 +2681,7 @@ paths:
               description: At least one of the two lists.
               properties:
                 filePaths: { type: array, maxItems: 500, items: { type: string }, description: "Virtual paths (`<vpath>/<rel>`)." }
-                hashes: { type: array, maxItems: 500, items: { type: string }, description: "Canonical track hashes." }
+                hashes: { type: array, maxItems: 500, items: { type: string }, description: "Track hashes — the canonical (audio) hash or the file hash; either resolves to the same counters. A hash this library does not know is looked up as sent (a peer's key)." }
       responses:
         "200":
           description: One item per track that has counters; unknown tracks are omitted.
@@ -2695,7 +2695,8 @@ paths:
                     items:
                       type: object
                       properties:
-                        hash: { type: string }
+                        hash: { type: string, description: "The key as the client sent it." }
+                        canonicalHash: { type: string, description: "Present when the requested hash resolved to a different canonical key (a file hash sent where the counters sit under the audio hash)." }
                         filePath: { type: string, description: "Present for rows requested by path." }
                         plays: { type: integer }
                         skips: { type: integer }
@@ -2790,6 +2791,133 @@ paths:
                 type: string
                 description: "Lines of `{id, startedAt, endedAt, playedMs, durationMs, outcome, counted, source, sessionId, pauseCount, client, filePath, peerId, trackHash, snapshot}`."
         "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/v1/admin/stats:
+    get:
+      tags: [Stats]
+      summary: Listening-history settings and the shape of the log (admin)
+      description: |
+        The live `stats` config block plus whole-log facts: how many plays are on file, from when, for how many
+        accounts, how many federated plays still await their peer's metadata, the retention floor and the last prune,
+        and the enrichment pass's counters. Config values apply without a reboot — the sweep and the ingest read them
+        per run.
+      responses:
+        "200":
+          description: Settings and log facts.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  retentionMonths: { type: integer, description: "0 keeps the per-play log forever." }
+                  playThresholdMs: { type: integer }
+                  playThresholdFraction: { type: number }
+                  log:
+                    type: object
+                    properties:
+                      total: { type: integer }
+                      oldest: { type: string, format: date-time, nullable: true }
+                      newest: { type: string, format: date-time, nullable: true }
+                      users: { type: integer }
+                      peerEvents: { type: integer }
+                      thinPeerEvents: { type: integer, description: "Federated plays not yet completed from the peer." }
+                  retention:
+                    type: object
+                    properties:
+                      floor: { type: string, format: date-time, nullable: true }
+                      lastSweep: { type: object, nullable: true, properties: { at: { type: string, format: date-time }, deleted: { type: integer }, cutoff: { type: string, nullable: true } } }
+                  enrichment:
+                    type: object
+                    properties:
+                      enriched: { type: integer }
+                      rekeyed: { type: integer }
+                      unknown: { type: integer }
+                      failed: { type: integer }
+                      pending: { type: integer }
+                      lastRunAt: { type: string, format: date-time, nullable: true }
+                      lastError: { type: string, nullable: true }
+        "403": { description: "Not an admin." }
+
+  /api/v1/admin/stats/retention:
+    post:
+      tags: [Stats]
+      summary: Set how long the per-play log is kept (admin, live)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [retentionMonths]
+              properties:
+                retentionMonths: { type: integer, minimum: 0, maximum: 1200, description: "0 keeps everything." }
+      responses:
+        "200": { description: "Saved to the config file and applied to the next sweep." }
+        "400": { description: "Validation failed." }
+        "403": { description: "Not an admin." }
+
+  /api/v1/admin/stats/thresholds:
+    post:
+      tags: [Stats]
+      summary: Set when a play counts (admin, live)
+      description: A play counts once it ran for `playThresholdMs`, or for `playThresholdFraction` of the track when the duration is known. Applies to the next batch of plays.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [playThresholdMs, playThresholdFraction]
+              properties:
+                playThresholdMs: { type: integer, minimum: 0, maximum: 3600000 }
+                playThresholdFraction: { type: number, minimum: 0, maximum: 1 }
+      responses:
+        "200": { description: "Saved and applied." }
+        "400": { description: "Validation failed." }
+        "403": { description: "Not an admin." }
+
+  /api/v1/admin/stats/sweep:
+    post:
+      tags: [Stats]
+      summary: Prune the per-play log now (admin)
+      description: Runs the retention sweep immediately with the current `retentionMonths`; the daily pass does the same.
+      responses:
+        "200":
+          description: What the sweep removed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: integer }
+                  cutoff: { type: string, nullable: true }
+        "403": { description: "Not an admin." }
+
+  /api/v1/admin/stats/enrich:
+    post:
+      tags: [Stats]
+      summary: Ask the peers about federated plays still waiting on their metadata (admin)
+      description: |
+        The daily pass does the same. A federated play stores the snapshot the app had at hand; the peer's own
+        metadata completes it (title, artist, album, duration, art, and the canonical audio hash, onto which the play
+        and its counters are re-keyed). Bounded per run; a peer that does not answer leaves its rows for next time.
+      responses:
+        "200":
+          description: This pass's numbers (rows queued, completed, re-keyed, unknown to the peer, unanswered), plus the process-lifetime counters under `totals`.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  queued: { type: integer }
+                  enriched: { type: integer }
+                  rekeyed: { type: integer }
+                  unknown: { type: integer }
+                  failed: { type: integer }
+                  pending: { type: integer }
+                  lastError: { type: string, nullable: true }
+                  totals: { type: object, description: "The same counters since the server started (as GET /api/v1/admin/stats reports)." }
+        "403": { description: "Not an admin." }
 
   /api/v1/admin/stats/rebuild:
     post:

--- a/src/api/stats.js
+++ b/src/api/stats.js
@@ -51,12 +51,15 @@ import { getVPathInfo } from '../util/vpath.js';
 import * as q from '../stats/queries.js';
 import { ingestPlays, resolveLocalTrack, MAX_BATCH } from '../stats/ingest.js';
 import { forwarder, planScrobbles } from '../stats/forward.js';
+import { enricher } from '../stats/enrich.js';
+import { runRetentionSweep, lastSweepInfo } from '../stats/retention.js';
 import { nowPlayingAt } from './scrobbler.js';
+import * as admin from '../util/admin.js';
 import {
-  OUTCOMES, SOURCES, RESET_SCOPES, deletePlayEvents, resetStats, rebuildHourStats,
+  OUTCOMES, SOURCES, RESET_SCOPES, deletePlayEvents, resetStats, rebuildHourStats, logSummary,
 } from '../stats/store.js';
 import {
-  isValidTimeZone, isBucket, periodRange, customRange, toSqlite, fromSqlite, toIso,
+  isValidTimeZone, isBucket, periodRange, customRange, toSqlite, fromSqlite, toIso, retentionFloor,
 } from '../stats/time.js';
 
 const d = () => db.getDB();
@@ -231,6 +234,10 @@ export function setup(mstream) {
       onStored: (stored) => {
         try { forwarder().enqueue(req.user, planScrobbles(stored, now)); }
         catch (err) { winston.warn(`[stats] last.fm forwarding skipped: ${err.message}`); }
+        // Federated plays: complete their snapshots from the peer, off the
+        // request path (stats/enrich.js).
+        try { enricher().enqueue(stored.map(({ event }) => event)); }
+        catch (err) { winston.warn(`[stats] peer enrichment skipped: ${err.message}`); }
       },
     });
     res.json(result);
@@ -358,17 +365,21 @@ export function setup(mstream) {
       filePaths: Joi.array().items(Joi.string().max(2048)).max(500),
       hashes: Joi.array().items(Joi.string().max(128)).max(500),
     }).or('filePaths', 'hashes'), req.body || {});
-    // Resolve every path to its canonical hash first, so one lookup answers
-    // both lists and a path is reported under the key the client sent.
+    // Resolve every path, and every hash, to its canonical key first — a
+    // client may hold the file hash where the counters sit under the audio
+    // hash — so one lookup answers both lists, and each item is reported
+    // under the key the client sent.
     const byPath = new Map();
     for (const p of v.filePaths || []) { byPath.set(p, hashForPath(p, req.user)); }
-    const wanted = [...new Set([...(v.hashes || []), ...[...byPath.values()].filter(Boolean)])];
+    const byHash = q.canonicalHashes(d(), v.hashes || []);
+    const wanted = [...new Set([...byHash.values(), ...[...byPath.values()].filter(Boolean)])];
     const stats = q.trackStats(d(), req.user.id, wanted);
-    const render = (hash, filePath) => {
-      const s = stats.get(hash);
+    const render = (hash, filePath, canonical = hash) => {
+      const s = stats.get(canonical);
       if (!s) { return null; }
       return {
         hash,
+        ...(canonical !== hash ? { canonicalHash: canonical } : {}),
         ...(filePath != null ? { filePath } : {}),
         plays: s.play_count || 0,
         skips: s.skip_count || 0,
@@ -379,7 +390,7 @@ export function setup(mstream) {
     };
     const items = [];
     for (const [p, h] of byPath) { const it = h && render(h, p); if (it) { items.push(it); } }
-    for (const h of v.hashes || []) { const it = render(h); if (it) { items.push(it); } }
+    for (const h of v.hashes || []) { const it = render(h, undefined, byHash.get(h) || h); if (it) { items.push(it); } }
     res.json({ items });
   });
 
@@ -461,6 +472,67 @@ export function setup(mstream) {
     if (!req.user?.admin) { throw new WebError('Forbidden', 403); }
     const { value } = joiValidate(Joi.object({ userId: Joi.number().integer().min(1) }), req.body || {});
     res.json(rebuildHourStats(d(), { userId: value.userId ?? null }));
+  });
+
+  // ── Admin: the listening-history settings and the log's shape ──
+  // config.stats is live: the retention sweep and the ingest's counted rule
+  // read it per run / per batch, so a save applies without a reboot.
+  const requireAdmin = (req) => { if (!req.user?.admin) { throw new WebError('Forbidden', 403); } };
+
+  mstream.get('/api/v1/admin/stats', (req, res) => {
+    requireAdmin(req);
+    const cfg = config.program.stats || {};
+    const retentionMonths = cfg.retentionMonths ?? 24;
+    const floor = retentionMonths > 0 ? retentionFloor(new Date(), retentionMonths) : null;
+    res.json({
+      retentionMonths,
+      playThresholdMs: cfg.playThresholdMs ?? 30000,
+      playThresholdFraction: cfg.playThresholdFraction ?? 0.5,
+      log: logSummary(d()),
+      retention: { floor: floor ? toIso(floor) : null, lastSweep: lastSweepInfo() },
+      enrichment: enricher().stats(),
+    });
+  });
+
+  mstream.post('/api/v1/admin/stats/retention', async (req, res) => {
+    requireAdmin(req);
+    const { value } = joiValidate(Joi.object({
+      retentionMonths: Joi.number().integer().min(0).max(1200).required(),
+    }), req.body || {});
+    await admin.editStatsRetention(value.retentionMonths);
+    res.json({ retentionMonths: value.retentionMonths });
+  });
+
+  mstream.post('/api/v1/admin/stats/thresholds', async (req, res) => {
+    requireAdmin(req);
+    const { value } = joiValidate(Joi.object({
+      playThresholdMs: Joi.number().integer().min(0).max(3_600_000).required(),
+      playThresholdFraction: Joi.number().min(0).max(1).required(),
+    }), req.body || {});
+    await admin.editStatsThresholds(value);
+    res.json(value);
+  });
+
+  // Prune now rather than at the next daily pass; the same sweep, the
+  // current retentionMonths.
+  mstream.post('/api/v1/admin/stats/sweep', (req, res) => {
+    requireAdmin(req);
+    res.json(runRetentionSweep());
+  });
+
+  // Ask the peers about every federated play still waiting on its metadata
+  // (the daily pass does the same, bounded the same way).
+  mstream.post('/api/v1/admin/stats/enrich', async (req, res) => {
+    requireAdmin(req);
+    const before = enricher().stats();
+    const queued = await enricher().backfill();
+    const after = enricher().stats();
+    const delta = (k) => after[k] - before[k];
+    // This pass's own numbers; the process-lifetime counters ride along.
+    res.json({
+      queued, enriched: delta('enriched'), rekeyed: delta('rekeyed'), unknown: delta('unknown'), failed: delta('failed'),
+      pending: after.pending, lastError: after.lastError, totals: after,
+    });
   });
 
   mstream.get('/api/v1/stats/periods', (req, res) => {

--- a/src/stats/enrich.js
+++ b/src/stats/enrich.js
@@ -1,0 +1,218 @@
+// Stats API v2 — completing federated plays from the peer's own metadata.
+//
+// A play of a peer's track counts on THIS server (the peer never sees it),
+// and this library has no row for the track, so the event stores whatever
+// snapshot the app had at hand — often thin: a filename for a title, no
+// album, no duration, and the peer's FILE hash where local counters key on
+// the AUDIO hash. After the ingest commit (and once a day for whatever is
+// still thin), this module asks the peer for the tracks' real metadata,
+// completes the snapshot, and re-keys the play onto the canonical hash so
+// the same file turning up in this library merges the plays.
+//
+// Best-effort, off the request path, never able to fail an ingest: a peer
+// that is offline, slow, or unknown leaves the row as it came, and the
+// backfill asks again next time. A peer that answers — even with "no such
+// track" — settles the row for good (`enrichedAt`), so a row is asked
+// about once.
+
+import winston from 'winston';
+import * as db from '../db/manager.js';
+import * as fedDb from '../db/federation.js';
+import * as fedClient from '../state/federation-client.js';
+import { migrateHashReferences } from '../db/hash-migration.js';
+import { updateEventSnapshot, thinPeerEvents } from './store.js';
+
+export const DEADLINE_MS = 4000;          // dial included — a stopped peer answers nothing
+export const PATHS_PER_CALL = 100;        // one metadata/batch call per chunk
+export const BACKFILL_PER_RUN = 300;      // thin rows per daily pass, newest first
+
+const isStr = (v) => typeof v === 'string' && v.length > 0;
+
+function withDeadline(promise, ms) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_r, reject) => { timer = setTimeout(() => reject(new Error(`no answer within ${ms}ms`)), ms); }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+// The peer call: POST /api/v1/db/metadata/batch (on the federation
+// allowlist) with the peer-side paths; answers { [path]: { filepath,
+// metadata|null } }. A test points it at a local fake over plain HTTP —
+// the same MSTREAM_TEST_* pattern as the Last.fm endpoint.
+export async function fetchPeerMetadata(peer, filepaths, { deadlineMs = DEADLINE_MS } = {}) {
+  const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(filepaths) };
+  const testEndpoint = process.env.MSTREAM_TEST_FED_ENRICH_ENDPOINT;
+  const res = testEndpoint
+    ? await fetch(`http://${testEndpoint}/api/v1/db/metadata/batch`, {
+      ...opts, headers: { ...opts.headers, 'x-federation-key': peer.api_key }, signal: AbortSignal.timeout(deadlineMs),
+    })
+    : await withDeadline(fedClient.fedFetch(peer, '/api/v1/db/metadata/batch', opts), deadlineMs);
+  if (!res.ok) { throw new Error(`http ${res.status}`); }
+  const body = await res.json();
+  return body && typeof body === 'object' ? body : {};
+}
+
+export function parseSnapshot(value) {
+  if (value == null) { return {}; }
+  if (typeof value === 'object') { return { ...value }; }
+  try { const v = JSON.parse(value); return v && typeof v === 'object' ? v : {}; } catch (_) { return {}; }
+}
+
+// The completed snapshot: the peer's library is authoritative for its own
+// track, so its strings win; the app's stay where the peer had none. The
+// hash becomes the canonical key (audio hash, else file hash).
+export function mergeSnapshot(snapshot, metadata, nowMs = Date.now()) {
+  const snap = parseSnapshot(snapshot);
+  const m = metadata && typeof metadata === 'object' ? metadata : null;
+  if (m) {
+    if (isStr(m.title)) { snap.title = m.title; }
+    if (isStr(m.artist)) { snap.artist = m.artist; }
+    if (isStr(m.album)) { snap.album = m.album; }
+    if (Number.isFinite(m.duration) && m.duration > 0) { snap.durationMs = Math.round(m.duration * 1000); }
+    if (isStr(m['album-art'])) { snap.artFile = m['album-art']; }
+    const canonical = isStr(m['audio-hash']) ? m['audio-hash'] : (isStr(m.hash) ? m.hash : null);
+    if (canonical) { snap.hash = canonical; }
+  }
+  snap.enrichedAt = nowMs;
+  return snap;
+}
+
+// One row, one answer (metadata or null): store the completed snapshot
+// and, when the key changed, move the play — and every other row and
+// counter under the old key — onto the canonical one.
+export function applyEnrichment(d, row, metadata, nowMs = Date.now()) {
+  const snap = mergeSnapshot(row.snapshot, metadata, nowMs);
+  updateEventSnapshot(d, row.event_id, snap);
+  const canonical = isStr(snap.hash) ? snap.hash : null;
+  let rekeyed = false;
+  if (canonical && row.track_hash && canonical !== row.track_hash) {
+    migrateHashReferences(d, row.track_hash, canonical);
+    rekeyed = true;
+  } else if (canonical && !row.track_hash) {
+    d.prepare('UPDATE play_events SET track_hash = ? WHERE event_id = ?').run(canonical, row.event_id);
+    rekeyed = true;
+  }
+  return { rekeyed, snapshot: snap };
+}
+
+// Ingest hands over its event objects; the backfill hands over rows. Both
+// become the row shape here.
+export function toRow(e) {
+  return {
+    event_id: e.event_id ?? e.eventId,
+    user_id: e.user_id ?? e.userId ?? null,
+    track_hash: e.track_hash ?? e.trackHash ?? null,
+    filepath: e.filepath,
+    peer_id: e.peer_id ?? e.peerId ?? null,
+    snapshot: e.snapshot ?? null,
+  };
+}
+
+const needsEnrichment = (row) => row.peer_id != null && row.event_id && parseSnapshot(row.snapshot).enrichedAt == null;
+
+// Injectable for tests: the peer call, the peer list, the database, the
+// logger, the clock.
+export function createEnricher({
+  fetchPeer = fetchPeerMetadata,
+  getPeers = () => fedDb.getFederationPeers(),
+  getDb = () => db.getDB(),
+  logger = winston,
+  now = () => Date.now(),
+  deadlineMs = DEADLINE_MS,
+} = {}) {
+  const pending = new Map();   // event_id -> row
+  let draining = null;         // the in-flight drain, for flush()
+  const stats = { enriched: 0, rekeyed: 0, unknown: 0, failed: 0, lastRunAt: null, lastError: null };
+
+  async function drainOnce() {
+    const d = getDb();
+    if (!d || pending.size === 0) { return; }
+    const rows = [...pending.values()];
+    pending.clear();
+    stats.lastRunAt = new Date(now()).toISOString();
+    const peers = new Map((getPeers() || []).map((p) => [p.id, p]));
+    const byPeer = new Map();
+    for (const row of rows) {
+      if (!byPeer.has(row.peer_id)) { byPeer.set(row.peer_id, []); }
+      byPeer.get(row.peer_id).push(row);
+    }
+    for (const [peerId, peerRows] of byPeer) {
+      const peer = peers.get(peerId);
+      if (!peer) { stats.failed += peerRows.length; continue; }   // peer gone since — the row can never be completed
+      const paths = [...new Set(peerRows.map((r) => r.filepath).filter(isStr))];
+      const answers = new Map();
+      try {
+        for (let i = 0; i < paths.length; i += PATHS_PER_CALL) {
+          const chunk = paths.slice(i, i + PATHS_PER_CALL);
+          const body = await fetchPeer(peer, chunk, { deadlineMs });
+          for (const p of chunk) {
+            const entry = body[p];
+            answers.set(p, entry && typeof entry === 'object' ? (entry.metadata ?? null) : null);
+          }
+        }
+      } catch (err) {
+        stats.failed += peerRows.length;
+        stats.lastError = `${peer.name || peerId}: ${err.message}`;
+        logger.debug(`[stats] enrichment: peer ${peerId} ('${peer.name}') not answered — ${err.message}; ${peerRows.length} row(s) left for the backfill`);
+        continue;
+      }
+      d.exec('BEGIN IMMEDIATE');
+      try {
+        for (const row of peerRows) {
+          const metadata = answers.get(row.filepath) ?? null;
+          const r = applyEnrichment(d, row, metadata, now());
+          if (metadata) { stats.enriched++; } else { stats.unknown++; }
+          if (r.rekeyed) { stats.rekeyed++; }
+        }
+        d.exec('COMMIT');
+      } catch (err) {
+        try { d.exec('ROLLBACK'); } catch (_) { /* already out of the transaction */ }
+        stats.failed += peerRows.length;
+        stats.lastError = err.message;
+        logger.warn(`[stats] enrichment: applying peer ${peerId}'s answers failed: ${err.message}`);
+      }
+    }
+  }
+
+  function schedule() {
+    if (draining) { return draining; }
+    draining = new Promise((resolve) => setImmediate(resolve))
+      .then(async () => { while (pending.size > 0) { await drainOnce(); } })
+      .catch((err) => { stats.lastError = err.message; logger.warn(`[stats] enrichment pass failed: ${err.message}`); })
+      .finally(() => { draining = null; });
+    return draining;
+  }
+
+  return {
+    // Rows or ingest events; only federated rows not yet completed are kept.
+    enqueue(items) {
+      let added = 0;
+      for (const item of items || []) {
+        const row = toRow(item);
+        if (!needsEnrichment(row) || pending.has(row.event_id)) { continue; }
+        pending.set(row.event_id, row);
+        added++;
+      }
+      if (added > 0) { schedule(); }
+      return added;
+    },
+    // Whatever is still thin in the log, newest first, bounded per run.
+    backfill({ limit = BACKFILL_PER_RUN } = {}) {
+      const d = getDb();
+      if (!d) { return Promise.resolve(0); }
+      const added = this.enqueue(thinPeerEvents(d, { limit }));
+      return this.flush().then(() => added);
+    },
+    flush() { return draining || Promise.resolve(); },
+    pending() { return pending.size; },
+    stats() { return { ...stats, pending: pending.size }; },
+  };
+}
+
+// The process-wide enricher the routes and the daily sweep use.
+let shared = null;
+export function enricher() {
+  if (!shared) { shared = createEnricher(); }
+  return shared;
+}

--- a/src/stats/queries.js
+++ b/src/stats/queries.js
@@ -561,6 +561,30 @@ export function history(d, { user, origin, ignoreVPaths, from = null, to = null,
 
 // ── Per-track counters ───────────────────────────────────────────────────
 
+// Map every hash a client holds — audio hash or file hash — to the canonical
+// key the counters are stored under (audio hash, else file hash). A hash the
+// library does not know passes through unchanged: a peer's key is stored as
+// it came, and still resolves.
+export function canonicalHashes(d, hashes) {
+  const out = new Map();
+  const uniq = [...new Set((hashes || []).filter((h) => typeof h === 'string' && h.length > 0))];
+  for (const h of uniq) { out.set(h, h); }
+  const CHUNK = 250;
+  for (let i = 0; i < uniq.length; i += CHUNK) {
+    const slice = uniq.slice(i, i + CHUNK);
+    const marks = slice.map(() => '?').join(',');
+    const rows = d.prepare(`SELECT audio_hash, file_hash FROM tracks
+                             WHERE audio_hash IN (${marks}) OR file_hash IN (${marks})`).all(...slice, ...slice);
+    for (const r of rows) {
+      const canonical = r.audio_hash || r.file_hash;
+      if (!canonical) { continue; }
+      if (r.audio_hash && out.has(r.audio_hash)) { out.set(r.audio_hash, canonical); }
+      if (r.file_hash && out.has(r.file_hash)) { out.set(r.file_hash, canonical); }
+    }
+  }
+  return out;
+}
+
 export function trackStats(d, userId, hashes) {
   const out = new Map();
   const uniq = [...new Set(hashes.filter(Boolean))];

--- a/src/stats/retention.js
+++ b/src/stats/retention.js
@@ -13,18 +13,23 @@ import winston from 'winston';
 import * as db from '../db/manager.js';
 import * as config from '../state/config.js';
 import { sweepRetention } from './store.js';
+import { enricher } from './enrich.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const BOOT_DELAY_MS = 60 * 1000;
 
 let bootTimer = null;
 let dailyTimer = null;
+let lastSweep = null;   // { at, deleted, cutoff } of the most recent run
+
+export function lastSweepInfo() { return lastSweep; }
 
 export function runRetentionSweep({ now = new Date() } = {}) {
   const d = db.getDB();
   if (!d) { return { deleted: 0, cutoff: null }; }
   const retentionMonths = config.program.stats?.retentionMonths ?? 24;
   const r = sweepRetention(d, { retentionMonths, now });
+  lastSweep = { at: now.toISOString(), deleted: r.deleted, cutoff: r.cutoff };
   if (r.deleted > 0) {
     winston.info(`[stats] retention: pruned ${r.deleted} play event(s) that started before ${r.cutoff}`);
     try {
@@ -38,6 +43,10 @@ export function runRetentionSweep({ now = new Date() } = {}) {
 
 function safeRun() {
   try { runRetentionSweep(); } catch (err) { winston.warn(`[stats] retention sweep failed: ${err.message}`); }
+  // The same cadence completes federated plays the peers have not answered
+  // for yet (stats/enrich.js) — bounded per pass, failures wait for the next.
+  try { enricher().backfill().catch((err) => winston.warn(`[stats] enrichment backfill failed: ${err.message}`)); }
+  catch (err) { winston.warn(`[stats] enrichment backfill skipped: ${err.message}`); }
 }
 
 export function startRetentionSweep() {

--- a/src/stats/store.js
+++ b/src/stats/store.js
@@ -18,7 +18,21 @@ import { toSqlite, fromSqlite, hourKey, retentionFloor } from './time.js';
 export const OUTCOMES = new Set(['completed', 'skipped', 'stopped']);
 export const SOURCES = new Set(['manual', 'shuffle', 'autodj', 'playlist',
   'smart-playlist', 'auto', 'carplay', 'cast', 'legacy', 'other']);
-const SNAPSHOT_KEYS = new Set(['title', 'artist', 'album', 'durationMs', 'hash', 'artFile']);
+// `enrichedAt` (epoch ms) marks a federated play's snapshot as completed from
+// the peer's own metadata (stats/enrich.js) — set even when the peer had
+// nothing to add, so a row is asked about once.
+const SNAPSHOT_KEYS = new Set(['title', 'artist', 'album', 'durationMs', 'hash', 'artFile', 'enrichedAt']);
+
+// The whitelisted, JSON-ready shape of a snapshot (null when empty).
+export function cleanSnapshot(snapshot) {
+  if (snapshot == null) { return null; }
+  if (typeof snapshot !== 'object') { throw new TypeError('snapshot'); }
+  const clean = {};
+  for (const k of Object.keys(snapshot)) {
+    if (SNAPSHOT_KEYS.has(k) && snapshot[k] != null) { clean[k] = snapshot[k]; }
+  }
+  return clean;
+}
 
 const isInt = (v) => Number.isInteger(v);
 
@@ -294,6 +308,46 @@ export function rebuildHourStats(d, { userId = null } = {}) {
 // Prune raw events that started before the retention floor. Counters and
 // the hourly rollup are deliberately untouched: the totals survive, only
 // the per-play rows go. Returns { deleted, cutoff }.
+// Replace one event's snapshot (a federated play, after enrichment). The
+// counters and the rollup are untouched — only what the row renders as.
+export function updateEventSnapshot(d, eventId, snapshot) {
+  const clean = cleanSnapshot(snapshot);
+  return d.prepare('UPDATE play_events SET snapshot = ? WHERE event_id = ?')
+    .run(clean ? JSON.stringify(clean) : null, eventId).changes;
+}
+
+// Federated plays whose snapshot has not been completed from the peer yet,
+// newest first — the enrichment backfill's worklist.
+export function thinPeerEvents(d, { limit = 500 } = {}) {
+  return d.prepare(`
+    SELECT event_id, user_id, track_hash, filepath, peer_id, snapshot
+      FROM play_events
+     WHERE peer_id IS NOT NULL
+       AND (snapshot IS NULL OR instr(snapshot, '"enrichedAt"') = 0)
+     ORDER BY started_at DESC
+     LIMIT ?`).all(limit);
+}
+
+// Whole-log facts for the admin readout: how many plays are on file, from
+// when, for how many accounts, and how many federated rows still await
+// enrichment.
+export function logSummary(d) {
+  const r = d.prepare(`
+    SELECT COUNT(*) AS total, MIN(started_at) AS oldest, MAX(started_at) AS newest,
+           COUNT(DISTINCT user_id) AS users,
+           SUM(CASE WHEN peer_id IS NOT NULL THEN 1 ELSE 0 END) AS peerEvents,
+           SUM(CASE WHEN peer_id IS NOT NULL AND (snapshot IS NULL OR instr(snapshot, '"enrichedAt"') = 0) THEN 1 ELSE 0 END) AS thinPeerEvents
+      FROM play_events`).get();
+  return {
+    total: r.total || 0,
+    oldest: r.oldest ? fromSqlite(r.oldest).toISOString() : null,
+    newest: r.newest ? fromSqlite(r.newest).toISOString() : null,
+    users: r.users || 0,
+    peerEvents: r.peerEvents || 0,
+    thinPeerEvents: r.thinPeerEvents || 0,
+  };
+}
+
 export function sweepRetention(d, { retentionMonths, now = new Date() } = {}) {
   if (!(retentionMonths > 0)) { return { deleted: 0, cutoff: null }; }
   const cutoff = toSqlite(retentionFloor(now, retentionMonths));

--- a/src/util/admin.js
+++ b/src/util/admin.js
@@ -821,6 +821,30 @@ export async function editAlbumArtServices(val) {
 // Lyrics backfill knobs live under config.lyrics (not scanOptions).
 // Both are LIVE — the backfill worker reads them fresh per pass, so no
 // reboot is needed.
+// ── Listening-history settings (config.stats; live, no reboot) ──
+// The retention sweep and the ingest's counted rule both read
+// config.program.stats at run time, so a saved value applies to the next
+// sweep / the next batch of plays without a restart.
+export async function editStatsRetention(retentionMonths) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.stats) { loadConfig.stats = {}; }
+  loadConfig.stats.retentionMonths = retentionMonths;
+  await saveFile(loadConfig, config.configFile);
+  if (!config.program.stats) { config.program.stats = {}; }
+  config.program.stats.retentionMonths = retentionMonths;
+}
+
+export async function editStatsThresholds({ playThresholdMs, playThresholdFraction }) {
+  const loadConfig = await loadFile(config.configFile);
+  if (!loadConfig.stats) { loadConfig.stats = {}; }
+  loadConfig.stats.playThresholdMs = playThresholdMs;
+  loadConfig.stats.playThresholdFraction = playThresholdFraction;
+  await saveFile(loadConfig, config.configFile);
+  if (!config.program.stats) { config.program.stats = {}; }
+  config.program.stats.playThresholdMs = playThresholdMs;
+  config.program.stats.playThresholdFraction = playThresholdFraction;
+}
+
 export async function editLyricsBackfill(val) {
   const loadConfig = await loadFile(config.configFile);
   if (!loadConfig.lyrics) { loadConfig.lyrics = {}; }

--- a/test/integration/stats-admin.test.mjs
+++ b/test/integration/stats-admin.test.mjs
@@ -1,0 +1,215 @@
+/**
+ * Stats API v2 — the admin's listening-history settings: GET /api/v1/admin/stats
+ * (config + log facts), the live retention and threshold edits (saved to the
+ * config file, applied to the next sweep / the next batch), prune-now, the
+ * enrichment pass with no peers, validation, and the admin gate.
+ *
+ * Same harness as stats-lifecycle.test.mjs: mStream boots in public/no-users
+ * mode (the sentinel user is admin) with an empty library, is stopped, tracks
+ * are seeded straight into the database, and it boots again.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref(); srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => { const { port } = srv.address(); srv.close(() => resolve(port)); });
+  });
+}
+async function waitForReady(baseUrl, timeoutMs = 90_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try { const r = await fetch(`${baseUrl}/api/`); if (r.status < 500) return; } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+async function boot(tmpDir, musicDir) {
+  const port = await findFreePort();
+  const configPath = path.join(tmpDir, 'config.json');
+  let config;
+  try { config = JSON.parse(await fs.readFile(configPath, 'utf8')); } catch { config = null; }
+  if (!config) {
+    config = {
+      port, address: '127.0.0.1',
+      dlna: { mode: 'disabled' },
+      folders: { testlib: { root: musicDir } },
+      storage: { albumArtDirectory: path.join(tmpDir, 'image-cache'), dbDirectory: path.join(tmpDir, 'db'), logsDirectory: path.join(tmpDir, 'logs') },
+      scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+      stats: { playThresholdMs: 30000, playThresholdFraction: 0.5, retentionMonths: 24 },
+    };
+    for (const dir of Object.values(config.storage)) await fs.mkdir(dir, { recursive: true });
+  } else {
+    config.port = port;
+  }
+  await fs.writeFile(configPath, JSON.stringify(config));
+  const proc = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', configPath],
+    { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test' } });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try { await waitForReady(baseUrl); } catch (err) { try { proc.kill('SIGKILL'); } catch { /* gone */ } throw err; }
+  return { proc, baseUrl, configPath };
+}
+async function kill(proc) { if (proc.exitCode == null) { proc.kill('SIGKILL'); await new Promise((r) => proc.once('exit', r)); } }
+
+const H = { 'Content-Type': 'application/json' };
+async function call(baseUrl, method, route, body, headers = {}) {
+  const r = await fetch(`${baseUrl}${route}`, { method, headers: { ...H, ...headers }, body: body === undefined ? undefined : JSON.stringify(body) });
+  const text = await r.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* not json */ }
+  return { status: r.status, body: json ?? text, text };
+}
+function seed(dbPath) {
+  const db = new DatabaseSync(dbPath); db.exec('PRAGMA foreign_keys = ON');
+  const lib = db.prepare("SELECT id FROM libraries WHERE name='testlib'").get().id;
+  const aid = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist')").run().lastInsertRowid);
+  db.prepare(`INSERT INTO tracks (filepath, library_id, title, artist_id, file_hash, audio_hash, duration, modified, scan_id)
+              VALUES ('Song A.flac', ?, 'Song A', ?, 'fhA', 'ahA', 200, 1, 'seed')`).run(lib, aid);
+  db.close();
+}
+const play = (id, startedAt, over = {}) => ({ id, filePath: 'testlib/Song A.flac', startedAt, playedMs: 150000, outcome: 'completed', source: 'manual', ...over });
+const monthsAgo = (n) => { const d = new Date(); d.setUTCMonth(d.getUTCMonth() - n); return d.toISOString(); };
+
+describe('Stats API v2 — admin listening-history settings', () => {
+  let tmpDir, server, dbPath;
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-stats-admin-'));
+    const musicDir = path.join(tmpDir, 'music'); await fs.mkdir(musicDir);
+    server = await boot(tmpDir, musicDir);
+    await kill(server.proc);
+    dbPath = path.join(tmpDir, 'db', 'mstream.db');
+    seed(dbPath);
+    server = await boot(tmpDir, musicDir);
+  });
+  after(async () => {
+    if (server) await kill(server.proc);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('GET: the live config block and the shape of an empty log', async () => {
+    const r = await call(server.baseUrl, 'GET', '/api/v1/admin/stats');
+    assert.equal(r.status, 200, r.text);
+    assert.equal(r.body.retentionMonths, 24);
+    assert.equal(r.body.playThresholdMs, 30000);
+    assert.equal(r.body.playThresholdFraction, 0.5);
+    assert.deepEqual(r.body.log, { total: 0, oldest: null, newest: null, users: 0, peerEvents: 0, thinPeerEvents: 0 });
+    const floor = new Date(r.body.retention.floor);
+    assert.ok(Math.abs(floor.getTime() - new Date(monthsAgo(24)).getTime()) < 36 * 3600_000, 'floor ≈ 24 months back');
+    assert.equal(r.body.retention.lastSweep, null, 'the boot sweep waits a minute');
+    assert.deepEqual(r.body.enrichment, { enriched: 0, rekeyed: 0, unknown: 0, failed: 0, lastRunAt: null, lastError: null, pending: 0 });
+  });
+
+  test('retention: saved to the config file, applied by prune-now, reported by GET', async () => {
+    const posted = await call(server.baseUrl, 'POST', '/api/v1/stats/plays', {
+      client: { name: 'test', version: '1' },
+      plays: [play('old', monthsAgo(3)), play('fresh', new Date(Date.now() - 60_000).toISOString())],
+    });
+    assert.deepEqual(posted.body.accepted, ['old', 'fresh']);
+    let g = await call(server.baseUrl, 'GET', '/api/v1/admin/stats');
+    assert.equal(g.body.log.total, 2);
+    assert.equal(g.body.log.users, 1);
+
+    const set = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/retention', { retentionMonths: 1 });
+    assert.equal(set.status, 200, set.text);
+    assert.deepEqual(set.body, { retentionMonths: 1 });
+    const onDisk = JSON.parse(await fs.readFile(server.configPath, 'utf8'));
+    assert.equal(onDisk.stats.retentionMonths, 1, 'persisted for the next boot');
+    g = await call(server.baseUrl, 'GET', '/api/v1/admin/stats');
+    assert.equal(g.body.retentionMonths, 1);
+    assert.ok(new Date(g.body.retention.floor).getTime() > Date.now() - 45 * 86400_000, 'floor moved to a month back');
+
+    const sweep = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/sweep', {});
+    assert.equal(sweep.status, 200, sweep.text);
+    assert.equal(sweep.body.deleted, 1);
+    assert.ok(sweep.body.cutoff);
+    g = await call(server.baseUrl, 'GET', '/api/v1/admin/stats');
+    assert.equal(g.body.log.total, 1);
+    assert.equal(g.body.retention.lastSweep.deleted, 1);
+    assert.ok(g.body.retention.lastSweep.at);
+    const h = await call(server.baseUrl, 'GET', '/api/v1/stats/history?limit=5');
+    assert.deepEqual(h.body.items.map((i) => i.id), ['fresh']);
+  });
+
+  test('thresholds: saved, and the next batch of plays is judged by them', async () => {
+    const before = await call(server.baseUrl, 'POST', '/api/v1/stats/plays', {
+      client: { name: 'test', version: '1' },
+      plays: [play('short-before', new Date(Date.now() - 50_000).toISOString(), { playedMs: 12000, outcome: 'skipped' })],
+    });
+    assert.deepEqual(before.body.accepted, ['short-before']);
+    let h = await call(server.baseUrl, 'GET', '/api/v1/stats/history?track=ahA&limit=1');
+    assert.equal(h.body.items[0].counted, false, '12 s of a 200 s track: under both defaults');
+
+    const set = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/thresholds', { playThresholdMs: 10000, playThresholdFraction: 0.25 });
+    assert.equal(set.status, 200, set.text);
+    assert.deepEqual(set.body, { playThresholdMs: 10000, playThresholdFraction: 0.25 });
+    const onDisk = JSON.parse(await fs.readFile(server.configPath, 'utf8'));
+    assert.deepEqual([onDisk.stats.playThresholdMs, onDisk.stats.playThresholdFraction], [10000, 0.25]);
+
+    const after = await call(server.baseUrl, 'POST', '/api/v1/stats/plays', {
+      client: { name: 'test', version: '1' },
+      plays: [play('short-after', new Date(Date.now() - 40_000).toISOString(), { playedMs: 12000, outcome: 'skipped' })],
+    });
+    assert.deepEqual(after.body.accepted, ['short-after']);
+    h = await call(server.baseUrl, 'GET', '/api/v1/stats/history?track=ahA&limit=1');
+    assert.equal(h.body.items[0].id, 'short-after');
+    assert.equal(h.body.items[0].counted, true, '12 s clears the new 10 s rule');
+    const g = await call(server.baseUrl, 'GET', '/api/v1/admin/stats');
+    assert.deepEqual([g.body.playThresholdMs, g.body.playThresholdFraction], [10000, 0.25]);
+  });
+
+  test('the enrichment pass with no peers queues nothing', async () => {
+    const r = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/enrich', {});
+    assert.equal(r.status, 200, r.text);
+    assert.equal(r.body.queued, 0);
+    assert.equal(r.body.pending, 0);
+  });
+
+  test('validation: out-of-range or malformed settings are refused', async () => {
+    for (const [route, body] of [
+      ['/api/v1/admin/stats/retention', { retentionMonths: -1 }],
+      ['/api/v1/admin/stats/retention', { retentionMonths: 'x' }],
+      ['/api/v1/admin/stats/retention', {}],
+      ['/api/v1/admin/stats/thresholds', { playThresholdMs: 1000, playThresholdFraction: 1.5 }],
+      ['/api/v1/admin/stats/thresholds', { playThresholdMs: -5, playThresholdFraction: 0.5 }],
+      ['/api/v1/admin/stats/thresholds', { playThresholdMs: 1000 }],
+    ]) {
+      const r = await call(server.baseUrl, 'POST', route, body);
+      assert.equal(r.status, 400, `${route} ${JSON.stringify(body)} → ${r.status}`);
+    }
+    const g = await call(server.baseUrl, 'GET', '/api/v1/admin/stats');
+    assert.deepEqual([g.body.retentionMonths, g.body.playThresholdMs, g.body.playThresholdFraction], [1, 10000, 0.25], 'nothing changed');
+  });
+
+  test('a non-admin user is refused on every admin route (ends public mode — last)', async () => {
+    const mk = await call(server.baseUrl, 'PUT', '/api/v1/admin/users', { username: 'plain', password: 'plain-pw', vpaths: ['testlib'], admin: false });
+    assert.equal(mk.status, 200, mk.text);
+    const login = await call(server.baseUrl, 'POST', '/api/v1/auth/login', { username: 'plain', password: 'plain-pw' });
+    const token = login.body.token;
+    assert.ok(token);
+    for (const [method, route, body] of [
+      ['GET', '/api/v1/admin/stats', undefined],
+      ['POST', '/api/v1/admin/stats/retention', { retentionMonths: 2 }],
+      ['POST', '/api/v1/admin/stats/thresholds', { playThresholdMs: 1, playThresholdFraction: 0 }],
+      ['POST', '/api/v1/admin/stats/sweep', {}],
+      ['POST', '/api/v1/admin/stats/enrich', {}],
+    ]) {
+      const r = await call(server.baseUrl, method, route, body, { 'x-access-token': token });
+      assert.equal(r.status, 403, `${method} ${route} → ${r.status}`);
+    }
+  });
+});

--- a/test/integration/stats-api.test.mjs
+++ b/test/integration/stats-api.test.mjs
@@ -282,6 +282,14 @@ describe('stats API v2 — reads', () => {
     assert.equal(empty.status, 400);
   });
 
+  test('tracks: a file hash finds the counters kept under the audio hash, reported under the key sent', async () => {
+    const r = await post(server.baseUrl, '/api/v1/stats/tracks', { hashes: ['fhA', 'ahA', 'ph1'] });
+    assert.equal(r.status, 200, r.body);
+    assert.deepEqual(r.body.items.map((i) => [i.hash, i.canonicalHash ?? null, i.plays]),
+      [['fhA', 'ahA', 3], ['ahA', null, 3], ['ph1', null, 1]]);   // the peer's key is looked up as sent
+    assert.equal(r.body.items[0].lastPlayed, r.body.items[1].lastPlayed);
+  });
+
   test('periods: bounds and the presets that overlap them', async () => {
     const r = await get(server.baseUrl, '/api/v1/stats/periods?tz=Europe/Berlin');
     assert.equal(r.status, 200, r.body);

--- a/test/integration/stats-enrichment.test.mjs
+++ b/test/integration/stats-enrichment.test.mjs
@@ -1,0 +1,221 @@
+/**
+ * Stats API v2 — federated plays completed from the peer (src/stats/enrich.js),
+ * end to end: a play of a peer's track arrives with a thin snapshot, the
+ * server asks the peer's metadata/batch route after the commit, the row
+ * renders with the peer's strings and is re-keyed onto the audio hash (its
+ * counters move), a track the peer does not know is settled as it came, a
+ * peer that answers 500 leaves its row for the admin/daily pass, and local
+ * plays never trigger a call.
+ *
+ * The peer is a fake HTTP server in this process; MSTREAM_TEST_FED_ENRICH_ENDPOINT
+ * points the server's enrichment call at it — the same pattern as the Last.fm
+ * forwarding test.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref(); srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => { const { port } = srv.address(); srv.close(() => resolve(port)); });
+  });
+}
+async function waitForReady(baseUrl, timeoutMs = 90_000) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try { const r = await fetch(`${baseUrl}/api/`); if (r.status < 500) return; } catch (err) { lastErr = err; }
+    await sleep(150);
+  }
+  throw new Error(`server not ready: ${lastErr?.message || 'unknown'}`, { cause: lastErr });
+}
+async function waitFor(pred, what, timeoutMs = 15_000) {
+  const start = Date.now();
+  let last;
+  while (!(last = await pred())) {
+    if (Date.now() - start > timeoutMs) { throw new Error(`timed out waiting for ${what}`); }
+    await sleep(100);
+  }
+  return last;
+}
+async function boot(tmpDir, musicDir, env = {}) {
+  const port = await findFreePort();
+  const config = {
+    port, address: '127.0.0.1',
+    dlna: { mode: 'disabled' },
+    folders: { testlib: { root: musicDir } },
+    storage: { albumArtDirectory: path.join(tmpDir, 'image-cache'), dbDirectory: path.join(tmpDir, 'db'), logsDirectory: path.join(tmpDir, 'logs') },
+    scanOptions: { bootScanDelay: 9999, scanInterval: 0, autoAlbumArt: false },
+    stats: { playThresholdMs: 30000, playThresholdFraction: 0.5, retentionMonths: 0 },
+  };
+  for (const dir of Object.values(config.storage)) await fs.mkdir(dir, { recursive: true });
+  const configPath = path.join(tmpDir, 'config.json');
+  await fs.writeFile(configPath, JSON.stringify(config));
+  const proc = spawn(process.execPath, ['cli-boot-wrapper.js', '-j', configPath],
+    { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NODE_ENV: 'test', ...env } });
+  proc.stdout.on('data', () => {}); proc.stderr.on('data', () => {});
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try { await waitForReady(baseUrl); } catch (err) { try { proc.kill('SIGKILL'); } catch { /* gone */ } throw err; }
+  return { proc, baseUrl };
+}
+async function kill(proc) { if (proc.exitCode == null) { proc.kill('SIGKILL'); await new Promise((r) => proc.once('exit', r)); } }
+
+const H = { 'Content-Type': 'application/json' };
+async function call(baseUrl, method, route, body, headers = {}) {
+  const r = await fetch(`${baseUrl}${route}`, { method, headers: { ...H, ...headers }, body: body === undefined ? undefined : JSON.stringify(body) });
+  const text = await r.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* not json */ }
+  return { status: r.status, body: json ?? text, text };
+}
+
+// The fake peer: answers POST /api/v1/db/metadata/batch from KNOWN, records
+// every call, and can be taken down (500) for the failure case.
+const KNOWN = {
+  'music/peer.flac': { title: 'Peer Song', artist: 'Peer Artist', album: 'Peer Album', duration: 240.4, hash: 'pfh1', 'audio-hash': 'pah1', 'album-art': 'art.jpg' },
+  'music/fail.flac': { title: 'Fail Song', artist: 'Peer Artist', duration: 100, hash: 'pfh3', 'audio-hash': 'pah3' },
+};
+function startFakePeer() {
+  const calls = [];
+  const state = { down: false };
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      res.setHeader('Content-Type', 'application/json');
+      if (req.method !== 'POST' || req.url !== '/api/v1/db/metadata/batch') { res.statusCode = 404; res.end('{}'); return; }
+      const paths = JSON.parse(body);
+      calls.push({ paths, key: req.headers['x-federation-key'] });
+      if (state.down) { res.statusCode = 500; res.end('{}'); return; }
+      res.end(JSON.stringify(Object.fromEntries(paths.map((p) => [p, { filepath: p, metadata: KNOWN[p] ?? null }]))));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ calls, state, port: server.address().port, close: () => new Promise((r) => server.close(r)) }));
+  });
+}
+
+function seed(dbPath) {
+  const db = new DatabaseSync(dbPath); db.exec('PRAGMA foreign_keys = ON');
+  const lib = db.prepare("SELECT id FROM libraries WHERE name='testlib'").get().id;
+  const aid = Number(db.prepare("INSERT INTO artists (name) VALUES ('Artist')").run().lastInsertRowid);
+  db.prepare(`INSERT INTO tracks (filepath, library_id, title, artist_id, file_hash, audio_hash, duration, modified, scan_id)
+              VALUES ('Song A.flac', ?, 'Song A', ?, 'fhA', 'ahA', 200, 1, 'seed')`).run(lib, aid);
+  const peer = Number(db.prepare("INSERT INTO federation_peers (name, endpoint_ticket, api_key) VALUES ('Bob', 't', 'fedk_bob')").run().lastInsertRowid);
+  db.close();
+  return { peer };
+}
+const snapshotOf = (dbPath, id) => {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try { const r = db.prepare('SELECT snapshot, track_hash FROM play_events WHERE event_id = ?').get(id); return { ...JSON.parse(r.snapshot || '{}'), _hash: r.track_hash }; }
+  finally { db.close(); }
+};
+const ago = (s) => new Date(Date.now() - s * 1000).toISOString();
+
+describe('Stats API v2 — peer snapshot enrichment', () => {
+  let tmpDir, server, peer, fake, dbPath;
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mstream-stats-enrich-'));
+    const musicDir = path.join(tmpDir, 'music'); await fs.mkdir(musicDir);
+    fake = await startFakePeer();
+    server = await boot(tmpDir, musicDir);
+    await kill(server.proc);
+    dbPath = path.join(tmpDir, 'db', 'mstream.db');
+    ({ peer } = seed(dbPath));
+    server = await boot(tmpDir, musicDir, { MSTREAM_TEST_FED_ENRICH_ENDPOINT: `127.0.0.1:${fake.port}` });
+  });
+  after(async () => {
+    if (server) await kill(server.proc);
+    if (fake) await fake.close();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const postPlays = (plays) => call(server.baseUrl, 'POST', '/api/v1/stats/plays', { client: { name: 'test', version: '1' }, plays });
+  const adminStats = async () => (await call(server.baseUrl, 'GET', '/api/v1/admin/stats')).body;
+
+  test('a thin federated play is completed from the peer and re-keyed onto the audio hash', async () => {
+    const r = await postPlays([{ id: 'p1', filePath: 'music/peer.flac', peerId: peer, track: { title: 'peer.flac', hash: 'pfh1' },
+      startedAt: ago(600), playedMs: 200_000, outcome: 'completed', source: 'manual' }]);
+    assert.deepEqual(r.body.accepted, ['p1'], r.text);
+    const h = await waitFor(async () => {
+      const x = await call(server.baseUrl, 'GET', '/api/v1/stats/history?track=pah1');
+      return x.body.items?.[0]?.id === 'p1' ? x.body : null;
+    }, 'the play to turn up under the audio hash');
+    const m = h.items[0].track.metadata;
+    assert.deepEqual([m.title, m.artist, m.album, m.duration, m['album-art'], m.hash], ['Peer Song', 'Peer Artist', 'Peer Album', 240.4, 'art.jpg', 'pah1']);
+    assert.equal(h.items[0].origin, 'peer');
+    assert.equal(h.items[0].peerName, 'Bob');
+    assert.deepEqual(fake.calls, [{ paths: ['music/peer.flac'], key: 'fedk_bob' }]);
+    const snap = snapshotOf(dbPath, 'p1');
+    assert.equal(snap._hash, 'pah1');
+    assert.ok(snap.enrichedAt > 0);
+    assert.equal(snap.durationMs, 240400);
+    // the counters followed the key: nothing left under the file hash
+    const c = await call(server.baseUrl, 'POST', '/api/v1/stats/tracks', { hashes: ['pah1', 'pfh1'] });
+    assert.deepEqual(c.body.items.map((i) => [i.hash, i.plays]), [['pah1', 1]]);
+    const s = await adminStats();
+    assert.deepEqual([s.enrichment.enriched, s.enrichment.rekeyed, s.log.peerEvents, s.log.thinPeerEvents], [1, 1, 1, 0]);
+  });
+
+  test('a track the peer does not know is settled as it came, and not asked about again', async () => {
+    const r = await postPlays([{ id: 'p2', filePath: 'music/gone.flac', peerId: peer, track: { title: 'gone.flac', hash: 'pfh2' },
+      startedAt: ago(500), playedMs: 100_000, outcome: 'completed', source: 'manual' }]);
+    assert.deepEqual(r.body.accepted, ['p2']);
+    const s = await waitFor(async () => { const x = await adminStats(); return x.enrichment.unknown === 1 ? x : null; }, 'the unknown answer');
+    assert.equal(s.log.thinPeerEvents, 0);
+    const snap = snapshotOf(dbPath, 'p2');
+    assert.equal(snap.title, 'gone.flac');
+    assert.equal(snap._hash, 'pfh2');
+    assert.ok(snap.enrichedAt > 0);
+    const before = fake.calls.length;
+    const pass = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/enrich', {});
+    assert.equal(pass.body.queued, 0, 'settled rows are not part of the backfill');
+    assert.equal(fake.calls.length, before);
+  });
+
+  test('a peer that answers 500 leaves its row thin; the admin pass completes it once the peer is back', async () => {
+    fake.state.down = true;
+    const r = await postPlays([{ id: 'p3', filePath: 'music/fail.flac', peerId: peer, track: { title: 'fail.flac', hash: 'pfh3' },
+      startedAt: ago(400), playedMs: 90_000, outcome: 'completed', source: 'manual' }]);
+    assert.deepEqual(r.body.accepted, ['p3']);
+    const s = await waitFor(async () => { const x = await adminStats(); return x.enrichment.failed >= 1 ? x : null; }, 'the failed call');
+    assert.match(s.enrichment.lastError, /Bob: http 500/);
+    assert.equal(s.log.thinPeerEvents, 1);
+    assert.equal(snapshotOf(dbPath, 'p3').enrichedAt, undefined);
+    assert.equal(snapshotOf(dbPath, 'p3')._hash, 'pfh3');
+
+    fake.state.down = false;
+    const pass = await call(server.baseUrl, 'POST', '/api/v1/admin/stats/enrich', {});
+    assert.equal(pass.status, 200, pass.text);
+    assert.equal(pass.body.queued, 1);
+    const done = await waitFor(async () => { const x = await adminStats(); return x.log.thinPeerEvents === 0 ? x : null; }, 'the backfill');
+    assert.equal(done.enrichment.enriched, 2);
+    assert.equal(snapshotOf(dbPath, 'p3').title, 'Fail Song');
+    assert.equal(snapshotOf(dbPath, 'p3')._hash, 'pah3');
+    const h = await call(server.baseUrl, 'GET', '/api/v1/stats/history?track=pah3');
+    assert.deepEqual(h.body.items.map((i) => [i.id, i.track.metadata.title]), [['p3', 'Fail Song']]);
+  });
+
+  test('a local play never asks a peer', async () => {
+    const before = fake.calls.length;
+    const r = await postPlays([{ id: 'l1', filePath: 'testlib/Song A.flac', startedAt: ago(300), playedMs: 150_000, outcome: 'completed', source: 'manual' }]);
+    assert.deepEqual(r.body.accepted, ['l1']);
+    await sleep(500);
+    assert.equal(fake.calls.length, before);
+    const s = await adminStats();
+    assert.deepEqual([s.log.total, s.log.peerEvents, s.log.thinPeerEvents], [4, 3, 0]);
+  });
+});

--- a/test/unit/stats-enrich.test.mjs
+++ b/test/unit/stats-enrich.test.mjs
@@ -1,0 +1,166 @@
+/**
+ * src/stats/enrich.js — completing federated plays from the peer's metadata,
+ * on a real-schema database with a fake peer: the completed snapshot, the
+ * re-key onto the audio hash (counters follow), "unknown to the peer"
+ * settling a row, an unanswered peer leaving it for the backfill, and what
+ * enqueue ignores.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { initEmptyDb } from '../helpers/scanner-runner.mjs';
+import { recordPlayEvent, thinPeerEvents, logSummary } from '../../src/stats/store.js';
+import { createEnricher, mergeSnapshot, toRow, PATHS_PER_CALL } from '../../src/stats/enrich.js';
+
+const quiet = { debug() {}, info() {}, warn() {} };
+const T0 = new Date('2026-09-10T10:00:00Z');
+
+let tmp, d, peer;
+function peerEvent(id, filepath, snapshot, over = {}) {
+  return {
+    eventId: id, userId: 1, trackHash: snapshot.hash ?? null, filepath, libraryId: null, peerId: peer.id, snapshot,
+    client: 'test/1', sessionId: null, source: 'manual', outcome: 'completed', counted: true,
+    playedMs: 200_000, durationMs: snapshot.durationMs ?? null, pauseCount: 0,
+    startedAt: new Date(T0.getTime() + Object.keys(over).length), endedAt: new Date(T0.getTime() + 200_000), ...over,
+  };
+}
+const row = (id) => d.prepare('SELECT event_id, user_id, track_hash, filepath, peer_id, snapshot FROM play_events WHERE event_id = ?').get(id);
+const snap = (id) => JSON.parse(row(id).snapshot);
+const counters = (hash) => d.prepare('SELECT play_count FROM user_metadata WHERE user_id = 1 AND track_hash = ?').get(hash)?.play_count ?? null;
+const PEER_META = {
+  title: 'Peer Song', artist: 'Peer Artist', album: 'Peer Album', duration: 240.4, hash: 'pfh1', 'audio-hash': 'pah1', 'album-art': 'art.jpg',
+};
+
+describe('stats enrichment', () => {
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'stats-enrich-'));
+    initEmptyDb(path.join(tmp, 'mstream.db'), tmp);
+    d = new DatabaseSync(path.join(tmp, 'mstream.db'));
+    // node:sqlite enforces foreign keys by default: the plays need their account
+    d.prepare("INSERT INTO users (username, password, salt, is_admin) VALUES ('one', 'pw', 'salt', 1)").run();
+    const id = Number(d.prepare("INSERT INTO federation_peers (name, endpoint_ticket, api_key) VALUES ('Bob', 't', 'fedk_bob')").run().lastInsertRowid);
+    peer = { id, name: 'Bob', endpoint_ticket: 't', api_key: 'fedk_bob' };
+  });
+  after(() => { d.close(); fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  test('mergeSnapshot: the peer wins, the app fills gaps, the key turns canonical', () => {
+    const s = mergeSnapshot({ title: 'peer.flac', album: 'App Album', hash: 'pfh1' }, PEER_META, 1234);
+    assert.deepEqual(s, { title: 'Peer Song', artist: 'Peer Artist', album: 'Peer Album', hash: 'pah1', durationMs: 240400, artFile: 'art.jpg', enrichedAt: 1234 });
+    const kept = mergeSnapshot('{"title":"App Title","hash":"x"}', { title: '', duration: 0 }, 5);
+    assert.deepEqual(kept, { title: 'App Title', hash: 'x', enrichedAt: 5 });
+    assert.deepEqual(mergeSnapshot(null, null, 7), { enrichedAt: 7 });
+    assert.equal(mergeSnapshot({}, { hash: 'onlyfile' }, 1).hash, 'onlyfile');
+  });
+
+  test('toRow: ingest events and log rows both become the row shape', () => {
+    assert.deepEqual(toRow({ eventId: 'e', userId: 2, trackHash: 'h', filepath: 'p', peerId: 3, snapshot: { title: 't' } }),
+      { event_id: 'e', user_id: 2, track_hash: 'h', filepath: 'p', peer_id: 3, snapshot: { title: 't' } });
+    assert.deepEqual(toRow({ event_id: 'e', user_id: 2, track_hash: null, filepath: 'p', peer_id: null, snapshot: '{}' }),
+      { event_id: 'e', user_id: 2, track_hash: null, filepath: 'p', peer_id: null, snapshot: '{}' });
+  });
+
+  test('a thin snapshot is completed and the play re-keyed onto the audio hash, counters following', async () => {
+    const thin = { title: 'peer.flac', hash: 'pfh1' };
+    recordPlayEvent(d, peerEvent('e1', 'music/peer.flac', thin));
+    assert.equal(counters('pfh1'), 1, 'ingest keyed the counters on the file hash');
+    const calls = [];
+    const enricher = createEnricher({
+      fetchPeer: (p, paths) => { calls.push({ peer: p.id, paths }); return Promise.resolve({ 'music/peer.flac': { filepath: 'music/peer.flac', metadata: PEER_META } }); },
+      getPeers: () => [peer], getDb: () => d, logger: quiet, now: () => 4242,
+    });
+    assert.equal(enricher.enqueue([peerEvent('e1', 'music/peer.flac', thin)]), 1);
+    await enricher.flush();
+    assert.deepEqual(calls, [{ peer: peer.id, paths: ['music/peer.flac'] }]);
+    assert.deepEqual(snap('e1'), { title: 'Peer Song', artist: 'Peer Artist', album: 'Peer Album', hash: 'pah1', durationMs: 240400, artFile: 'art.jpg', enrichedAt: 4242 });
+    assert.equal(row('e1').track_hash, 'pah1');
+    assert.equal(counters('pah1'), 1);
+    assert.equal(counters('pfh1'), null, 'the old key is gone');
+    assert.deepEqual(enricher.stats(), { enriched: 1, rekeyed: 1, unknown: 0, failed: 0, lastRunAt: new Date(4242).toISOString(), lastError: null, pending: 0 });
+
+    // A later play of the same track still arrives under the file hash; its
+    // enrichment merges the counters onto the canonical key.
+    recordPlayEvent(d, peerEvent('e2', 'music/peer.flac', thin, { startedAt: new Date(T0.getTime() + 3_600_000) }));
+    assert.equal(counters('pfh1'), 1);
+    enricher.enqueue([peerEvent('e2', 'music/peer.flac', thin)]);
+    await enricher.flush();
+    assert.equal(row('e2').track_hash, 'pah1');
+    assert.equal(counters('pah1'), 2);
+    assert.equal(counters('pfh1'), null);
+    assert.equal(thinPeerEvents(d).length, 0);
+  });
+
+  test('a track the peer does not know settles the row as it came', async () => {
+    recordPlayEvent(d, peerEvent('e3', 'music/gone.flac', { title: 'gone.flac', hash: 'pfh3' }));
+    const enricher = createEnricher({
+      fetchPeer: () => Promise.resolve({ 'music/gone.flac': { filepath: 'music/gone.flac', metadata: null } }),
+      getPeers: () => [peer], getDb: () => d, logger: quiet, now: () => 99,
+    });
+    enricher.enqueue([row('e3')]);
+    await enricher.flush();
+    assert.deepEqual(snap('e3'), { title: 'gone.flac', hash: 'pfh3', enrichedAt: 99 });
+    assert.equal(row('e3').track_hash, 'pfh3');
+    assert.equal(enricher.stats().unknown, 1);
+    assert.equal(thinPeerEvents(d).length, 0, 'settled rows are not asked about again');
+  });
+
+  test('an unanswered peer leaves the row thin; the backfill completes it later', async () => {
+    recordPlayEvent(d, peerEvent('e4', 'music/late.flac', { title: 'late.flac', hash: 'pfh4' }));
+    let up = false;
+    const enricher = createEnricher({
+      fetchPeer: (p, paths) => {
+        if (!up) { return Promise.reject(new Error('no answer within 4000ms')); }
+        return Promise.resolve(Object.fromEntries(paths.map((fp) => [fp, { filepath: fp, metadata: { title: 'Late Song', artist: 'A', duration: 100, hash: 'pfh4', 'audio-hash': 'pah4' } }])));
+      },
+      getPeers: () => [peer], getDb: () => d, logger: quiet,
+    });
+    enricher.enqueue([row('e4')]);
+    await enricher.flush();
+    assert.equal(snap('e4').enrichedAt, undefined);
+    assert.equal(row('e4').track_hash, 'pfh4');
+    assert.equal(enricher.stats().failed, 1);
+    assert.match(enricher.stats().lastError, /Bob: no answer/);
+    assert.deepEqual(thinPeerEvents(d).map((r) => r.event_id), ['e4']);
+    assert.equal(logSummary(d).thinPeerEvents, 1);
+
+    up = true;
+    assert.equal(await enricher.backfill(), 1);
+    assert.equal(snap('e4').title, 'Late Song');
+    assert.equal(row('e4').track_hash, 'pah4');
+    assert.equal(logSummary(d).thinPeerEvents, 0);
+  });
+
+  test('enqueue ignores local plays, settled rows, duplicates, and a peer that is gone', async () => {
+    const calls = [];
+    const enricher = createEnricher({ fetchPeer: (p, paths) => { calls.push(paths); return Promise.resolve({}); }, getPeers: () => [], getDb: () => d, logger: quiet });
+    assert.equal(enricher.enqueue([
+      { eventId: 'local', userId: 1, trackHash: 'ahA', filepath: 'testlib/a.mp3', peerId: null, snapshot: null },
+      row('e1'),                                   // enriched already
+      { eventId: 'e5', userId: 1, trackHash: 'x', filepath: 'music/x.flac', peerId: peer.id, snapshot: { title: 'x' } },
+      { eventId: 'e5', userId: 1, trackHash: 'x', filepath: 'music/x.flac', peerId: peer.id, snapshot: { title: 'x' } },
+    ]), 1);
+    await enricher.flush();
+    assert.deepEqual(calls, [], 'the peer list no longer has the peer: nothing to ask');
+    assert.equal(enricher.stats().failed, 1);
+  });
+
+  test('paths are asked in chunks and deduplicated', async () => {
+    const calls = [];
+    const enricher = createEnricher({
+      fetchPeer: (p, paths) => { calls.push(paths.length); return Promise.resolve(Object.fromEntries(paths.map((fp) => [fp, { filepath: fp, metadata: null }]))); },
+      getPeers: () => [peer], getDb: () => d, logger: quiet,
+    });
+    const items = [];
+    for (let i = 0; i < PATHS_PER_CALL + 5; i++) {
+      recordPlayEvent(d, peerEvent('bulk' + i, 'music/bulk' + (i % (PATHS_PER_CALL + 2)) + '.flac', { title: 'b', hash: 'bh' + i }, { startedAt: new Date(T0.getTime() + 10_000 + i) }));
+      items.push(row('bulk' + i));
+    }
+    enricher.enqueue(items);
+    await enricher.flush();
+    assert.deepEqual(calls, [PATHS_PER_CALL, 2]);
+    assert.equal(enricher.stats().unknown, PATHS_PER_CALL + 5);
+  });
+});

--- a/webapp/admin/index.js
+++ b/webapp/admin/index.js
@@ -36,6 +36,11 @@ const ADMINDATA = (() => {
   // lyrics backfill settings (config.lyrics)
   module.lyricsParams = {};
   module.lyricsParamsUpdated = { ts: 0 };
+  // listening-history settings + log facts (GET /api/v1/admin/stats). Keys
+  // are declared up front so the card's bindings are reactive from the
+  // first render (a key added later would not be).
+  module.statsParams = { retentionMonths: null, playThresholdMs: null, playThresholdFraction: null, log: null, retention: null, enrichment: null };
+  module.statsParamsUpdated = { ts: 0 };
   // server settings
   module.serverParams = {};
   module.serverParamsUpdated = { ts: 0 };
@@ -216,6 +221,17 @@ const ADMINDATA = (() => {
     });
 
     module.lyricsParamsUpdated.ts = Date.now();
+  }
+
+  module.getStatsParams = async () => {
+    const res = await API.axios({
+      method: 'GET',
+      url: `${API.url()}/api/v1/admin/stats`
+    });
+    Object.keys(res.data).forEach(key => {
+      module.statsParams[key] = res.data[key];
+    });
+    module.statsParamsUpdated.ts = Date.now();
   }
 
   module.getServerParams = async () => {
@@ -2008,6 +2024,9 @@ const dbView = Vue.component('db-view', {
   data() {
     return {
       dbParams: ADMINDATA.dbParams,
+      statsParams: ADMINDATA.statsParams,
+      statsParamsTS: ADMINDATA.statsParamsUpdated,
+      statsBusy: '',
       sharedPlaylists: ADMINDATA.sharedPlaylists,
       sharedPlaylistsTS: ADMINDATA.sharedPlaylistUpdated,
       isPullingShared: false,
@@ -2260,6 +2279,55 @@ const dbView = Vue.component('db-view', {
                     </tbody>
                   </table>
                 </template>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col s12">
+            <div class="card">
+              <div class="card-content">
+                <span class="card-title">Listening History</span>
+                <p>Every play the apps report lands in the listening log behind the Stats page. Play counts on tracks are kept for good; the per-play log is pruned once it is older than the retention period. Settings apply live — no restart.</p>
+                <table>
+                  <tbody>
+                    <tr>
+                      <td><b>Plays on file:</b>
+                        <template v-if="statsParams.log">{{ statsParams.log.total.toLocaleString() }}<span v-if="statsParams.log.oldest" class="enrich-muted"> since {{ fmtStatsDate(statsParams.log.oldest) }}, {{ statsParams.log.users }} account{{ statsParams.log.users === 1 ? '' : 's' }}</span></template>
+                        <span v-else class="enrich-muted">loading…</span>
+                      </td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><b>Keep the log for:</b> {{ retentionLabel }}<span v-if="statsParams.retention && statsParams.retention.floor" class="enrich-muted"> — plays before {{ fmtStatsDate(statsParams.retention.floor) }} are pruned</span></td>
+                      <td>[<a v-on:click="openModal('edit-stats-retention-modal')">{{ t('admin.settings.edit') }}</a>]</td>
+                    </tr>
+                    <tr>
+                      <td><b>A play counts after:</b> {{ thresholdLabel }}</td>
+                      <td>[<a v-on:click="openModal('edit-stats-thresholds-modal')">{{ t('admin.settings.edit') }}</a>]</td>
+                    </tr>
+                    <tr>
+                      <td><b>Last prune:</b>
+                        <template v-if="statsParams.retention && statsParams.retention.lastSweep">{{ fmtStatsDate(statsParams.retention.lastSweep.at) }} — {{ statsParams.retention.lastSweep.deleted.toLocaleString() }} play{{ statsParams.retention.lastSweep.deleted === 1 ? '' : 's' }} removed</template>
+                        <span v-else class="enrich-muted">not yet this session (runs a minute after boot, then daily)</span>
+                      </td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><b>Federated plays:</b>
+                        <template v-if="statsParams.log">{{ statsParams.log.peerEvents.toLocaleString() }} on file<span v-if="statsParams.log.thinPeerEvents > 0">, {{ statsParams.log.thinPeerEvents.toLocaleString() }} still waiting on the peer's metadata</span><span v-if="statsParams.enrichment && statsParams.enrichment.lastError" class="enrich-muted"> — last error: {{ statsParams.enrichment.lastError }}</span></template>
+                        <span v-else class="enrich-muted">loading…</span>
+                      </td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <br>
+                <a class="waves-effect waves-light btn" v-bind:class="{ disabled: statsBusy !== '' }" v-on:click="statsAction('sweep')">{{ statsBusy === 'sweep' ? 'Pruning…' : 'Prune now' }}</a>
+                &nbsp;
+                <a class="waves-effect waves-light btn" v-bind:class="{ disabled: statsBusy !== '' }" v-on:click="statsAction('enrich')">{{ statsBusy === 'enrich' ? 'Asking peers…' : 'Ask peers for metadata' }}</a>
+                &nbsp;
+                <a class="waves-effect waves-light btn" v-bind:class="{ disabled: statsBusy !== '' }" v-on:click="statsAction('rebuild')">{{ statsBusy === 'rebuild' ? 'Rebuilding…' : 'Rebuild hourly totals' }}</a>
               </div>
             </div>
           </div>
@@ -2950,6 +3018,28 @@ const dbView = Vue.component('db-view', {
       modVM.currentViewModal = modalView;
       M.Modal.getInstance(document.getElementById('admin-modal')).open();
     },
+    fmtStatsDate: function(iso) {
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) { return '—'; }
+      return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    },
+    statsAction: async function(kind) {
+      if (this.statsBusy) { return; }
+      this.statsBusy = kind;
+      try {
+        const res = await API.axios({ method: 'POST', url: `${API.url()}/api/v1/admin/stats/${kind}`, data: {} });
+        const d = res.data || {};
+        const message = kind === 'sweep' ? `${(d.deleted || 0).toLocaleString()} play${d.deleted === 1 ? '' : 's'} pruned`
+          : kind === 'enrich' ? `${(d.queued || 0).toLocaleString()} queued · ${(d.enriched || 0).toLocaleString()} completed · ${(d.unknown || 0).toLocaleString()} unknown to the peer · ${(d.failed || 0).toLocaleString()} unanswered`
+          : `${(d.hours || 0).toLocaleString()} hour${d.hours === 1 ? '' : 's'} recomputed`;
+        iziToast.success({ title: t('admin.settings.updated'), message: escHtml(message), position: 'topCenter', timeout: 4000 });
+        await ADMINDATA.getStatsParams();
+      } catch (err) {
+        iziToast.error({ title: t('admin.modal.updateFailed'), message: escHtml(err.response?.data?.error || ''), position: 'topCenter', timeout: 3500 });
+      } finally {
+        this.statsBusy = '';
+      }
+    },
     fetchEnrichStatus: async function() {
       // Two GETs per tick: /scan/status (queue + passes + coverage) and
       // /scan/progress (live per-library rows, empty between scans).
@@ -3091,8 +3181,24 @@ const dbView = Vue.component('db-view', {
       return `${Math.round(s / 86400)}d ago`;
     }
   },
+  computed: {
+    retentionLabel: function() {
+      const m = this.statsParams.retentionMonths;
+      if (m === null || m === undefined) { return '…'; }
+      if (m === 0) { return 'forever'; }
+      if (m % 12 === 0) { const y = m / 12; return `${y} year${y === 1 ? '' : 's'}`; }
+      return `${m} month${m === 1 ? '' : 's'}`;
+    },
+    thresholdLabel: function() {
+      const ms = this.statsParams.playThresholdMs; const f = this.statsParams.playThresholdFraction;
+      if (ms === null || ms === undefined) { return '…'; }
+      const secs = Math.round(ms / 1000);
+      return `${secs} second${secs === 1 ? '' : 's'}, or ${Math.round((f || 0) * 100)}% of the track when its length is known`;
+    }
+  },
   created: function() {
     this.fetchEnrichStatus();
+    ADMINDATA.getStatsParams().catch(() => { /* the card keeps showing loading…; the call is admin-only */ });
     // 4s keeps the running pass's progress feeling live without leaning
     // on the server: the endpoint's coverage counts are memoised
     // server-side, so a poll between passes is two cheap map reads.
@@ -9547,6 +9653,114 @@ const editDiscoveryPerRunView = Vue.component('edit-discovery-per-run-modal', {
   }
 });
 
+// Listening history: how long the per-play log is kept. Live — the next
+// sweep reads it (config.stats.retentionMonths).
+const editStatsRetentionView = Vue.component('edit-stats-retention-modal', {
+  data() {
+    return {
+      submitPending: false,
+      editValue: ADMINDATA.statsParams.retentionMonths ?? 24
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>Keep the listening log for</h4>
+        <div class="input-field">
+          <input v-model="editValue" id="edit-stats-retention" required type="number" min="0" max="1200">
+          <label for="edit-stats-retention">Months</label>
+          <span class="helper-text">Plays older than this are pruned from the per-play log once a day; play counts, hourly totals and the Stats page's long-range charts keep their numbers. 0 keeps every play forever.</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/stats/retention`,
+          data: { retentionMonths: Number(this.editValue) }
+        });
+        ADMINDATA.statsParams.retentionMonths = Number(this.editValue);
+        ADMINDATA.getStatsParams().catch(() => {});
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+        iziToast.success({ title: t('admin.settings.updated'), position: 'topCenter', timeout: 3500 });
+      } catch(err) {
+        iziToast.error({ title: t('admin.modal.updateFailed'), message: escHtml(err.response?.data?.error || ''), position: 'topCenter', timeout: 3500 });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
+// Listening history: when a play counts. Live — the next batch of plays
+// is judged by it (config.stats.playThresholdMs / playThresholdFraction).
+const editStatsThresholdsView = Vue.component('edit-stats-thresholds-modal', {
+  data() {
+    return {
+      submitPending: false,
+      seconds: Math.round((ADMINDATA.statsParams.playThresholdMs ?? 30000) / 1000),
+      percent: Math.round((ADMINDATA.statsParams.playThresholdFraction ?? 0.5) * 100)
+    };
+  },
+  template: `
+    <form @submit.prevent="updateParam">
+      <div class="modal-content">
+        <h4>When a play counts</h4>
+        <p>A play is counted once it has run for this many seconds, <i>or</i> for this share of the track when its length is known — whichever comes first. Shorter plays are still logged, as skips.</p>
+        <div class="input-field">
+          <input v-model="seconds" id="edit-stats-threshold-seconds" required type="number" min="0" max="3600">
+          <label for="edit-stats-threshold-seconds">Seconds played</label>
+        </div>
+        <div class="input-field">
+          <input v-model="percent" id="edit-stats-threshold-percent" required type="number" min="0" max="100">
+          <label for="edit-stats-threshold-percent">Percent of the track</label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">{{ t('admin.modal.goBack') }}</a>
+        <button class="btn green waves-effect waves-light" type="submit" :disabled="submitPending === true">
+          {{ submitPending === false ? t('admin.modal.update') : t('admin.modal.updating') }}
+        </button>
+      </div>
+    </form>`,
+  mounted: function () {
+    M.updateTextFields();
+  },
+  methods: {
+    updateParam: async function() {
+      try {
+        this.submitPending = true;
+        const data = { playThresholdMs: Math.round(Number(this.seconds) * 1000), playThresholdFraction: Number(this.percent) / 100 };
+        await API.axios({
+          method: 'POST',
+          url: `${API.url()}/api/v1/admin/stats/thresholds`,
+          data
+        });
+        ADMINDATA.statsParams.playThresholdMs = data.playThresholdMs;
+        ADMINDATA.statsParams.playThresholdFraction = data.playThresholdFraction;
+        M.Modal.getInstance(document.getElementById('admin-modal')).close();
+        iziToast.success({ title: t('admin.settings.updated'), position: 'topCenter', timeout: 3500 });
+      } catch(err) {
+        iziToast.error({ title: t('admin.modal.updateFailed'), message: escHtml(err.response?.data?.error || ''), position: 'topCenter', timeout: 3500 });
+      } finally {
+        this.submitPending = false;
+      }
+    }
+  }
+});
+
 const editScanIntervalView = Vue.component('edit-scan-interval-modal', {
   data() {
     return {
@@ -10762,6 +10976,8 @@ const modVM = new Vue({
     'edit-request-size-modal': editRequestSizeModal,
     'edit-address-modal': editAddressModal,
     'edit-scan-interval-modal': editScanIntervalView,
+    'edit-stats-retention-modal': editStatsRetentionView,
+    'edit-stats-thresholds-modal': editStatsThresholdsView,
     'edit-boot-scan-delay-modal': editBootScanView,
     'edit-select-codec-modal': editTranscodeCodecModal,
     'edit-transcode-bitrate-modal': editTranscodeDefaultBitrate,

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -606,10 +606,6 @@
       <svg xmlns="http://www.w3.org/2000/svg" height="22px" viewBox="0 0 24 24" width="22px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"/></svg>
       <span data-i18n="nav.mostPlayed">Most Played</span>
     </div>
-    <div id="nav-stats" class="local-only side-nav-item my-waves super-hide" onclick="window.location.href = './stats';">
-      <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" fill="none" stroke="#FFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20V10"></path><path d="M10 20V4"></path><path d="M16 20v-7"></path><path d="M22 20H2"></path></svg>
-      <span data-i18n="nav.stats">Stats</span>
-    </div>
     <div class="local-only side-nav-item my-waves" onclick="changeView(getRatedSongs, this)" data-panel="allRated">
       <?xml version="1.0" encoding="iso-8859-1"?><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="-3 0 62 62" style="enable-background:new 0 0 53.867 53.867"><path style="fill:#efce4a" d="M26.934 1.318l8.322 16.864 18.611 2.705L40.4 34.013l3.179 18.536-16.645-8.751-16.646 8.751 3.179-18.536L0 20.887l18.611-2.705z"/></svg>
       <span data-i18n="nav.rated">Rated</span>
@@ -657,6 +653,10 @@
     </div> -->
     <div class="side-nav-header">
       <span data-i18n="nav.navigation">Navigation</span>
+    </div>
+    <div id="nav-stats" class="local-only side-nav-item my-waves super-hide" onclick="window.location.href = './stats';">
+      <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" fill="none" stroke="#FFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20V10"></path><path d="M10 20V4"></path><path d="M16 20v-7"></path><path d="M22 20H2"></path></svg>
+      <span data-i18n="nav.stats">Stats</span>
     </div>
     <div id="admin-side-link" class="side-nav-item my-waves" onclick="window.open('./admin', '_blank');">
       <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24"><g><rect fill="none" height="24" width="24"/></g><g><g><path d="M17,11c0.34,0,0.67,0.04,1,0.09V6.27L10.5,3L3,6.27v4.91c0,4.54,3.2,8.79,7.5,9.82c0.55-0.13,1.08-0.32,1.6-0.55 C11.41,19.47,11,18.28,11,17C11,13.69,13.69,11,17,11z"/><path d="M17,13c-2.21,0-4,1.79-4,4c0,2.21,1.79,4,4,4s4-1.79,4-4C21,14.79,19.21,13,17,13z M17,14.38c0.62,0,1.12,0.51,1.12,1.12 s-0.51,1.12-1.12,1.12s-1.12-0.51-1.12-1.12S16.38,14.38,17,14.38z M17,19.75c-0.93,0-1.74-0.46-2.24-1.17 c0.05-0.72,1.51-1.08,2.24-1.08s2.19,0.36,2.24,1.08C18.74,19.29,17.93,19.75,17,19.75z"/></g></g></svg>


### PR DESCRIPTION
The optional items left after #977, plus one webapp change.

## Either-hash lookups on the per-track counters (`POST /api/v1/stats/tracks`)
A client holding the **file** hash of a track whose counters sit under the **audio** hash got nothing back. Every requested hash is now resolved through the tracks table in one batched query and looked up by its canonical key; each item is reported under the hash the client sent, with `canonicalHash` alongside when they differ. A hash the library does not know (a peer's key) is looked up as sent, so peer-keyed counters still resolve.

## Peer snapshot enrichment (`src/stats/enrich.js`)
A play of a peer's track stores whatever snapshot the app had at hand, often thin. After the ingest commit the server now asks the peer for the tracks' real metadata (`POST /api/v1/db/metadata/batch` on the peer, already on the federation allowlist, 4 s deadline, one call per peer per batch), completes the snapshot (the peer's strings win; duration and art fill in), and re-keys the play and its counters onto the audio hash through the shared hash migration, so the identical file turning up in this library merges the plays. A row is settled once (`enrichedAt`), even when the peer does not know the track; an unanswered peer leaves its rows for the daily pass, which runs on the retention sweep's cadence, bounded per run. It never fails an ingest. Tests reach it through `MSTREAM_TEST_FED_ENRICH_ENDPOINT`, the same pattern as the Last.fm fake.

## Admin retention UI
- New admin routes: `GET /api/v1/admin/stats` (the live `stats` config block, plays on file / oldest / accounts / federated rows still thin, the retention floor and last sweep, the enrichment counters), `POST …/retention`, `POST …/thresholds` (saved to the config file and applied live: the sweep and the counted rule read config per run), `POST …/sweep` (prune now), `POST …/enrich` (ask the peers now; per-pass numbers plus lifetime totals).
- Admin › Database gains a **Listening History** card with those facts, two edit modals (retention months; seconds / percent for when a play counts), and Prune now / Ask peers for metadata / Rebuild hourly totals buttons.

## Webapp
- The **Stats** sidenav entry moves from the Music section to the Navigation section, above Admin Panel.

## Verification
- New tests: `test/unit/stats-enrich.test.mjs` (real schema, fake peer: completion, re-key with counters following, unknown-to-peer settling, unanswered → backfill, enqueue filters, chunking), `test/integration/stats-enrichment.test.mjs` (fake peer over HTTP end to end incl. the 500 → admin pass recovery), `test/integration/stats-admin.test.mjs` (config file round-trips, live sweep and thresholds, validation, the admin gate), plus the either-hash case in `stats-api`.
- Full `npm test` run on the branch (result in the comments below), eslint and redocly clean.
- Browser smoke on a server booted from this branch with the seeded 120-day log (port 3161): the sidenav reads Navigation → Stats → Admin Panel → Log Out; the admin card shows 1,127 plays since May 13, the retention modal saved 12 months to disk and re-rendered the floor, Prune now and Ask peers both toasted their results, and the card surfaces the enrichment error honestly when federation is off ("federation endpoint is not running").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
