### PR TITLE
launcher: a Manage server submenu opens the player's admin rooms in a terminal

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -138,8 +138,9 @@ directly, with `manifest.json` holding their sha256s:
 **Just double-click it.** The desktop face of the bundle — `mStream.exe` on
 Windows, `mStream.app` on macOS, `mstream-desktop` on Linux — starts the
 server in the background, puts an mStream icon in your tray / menu bar
-(a status line — "Running · up 3h 12m", or Starting… / Stopped — then Open
-Admin Panel · Quick Connect · Start at login · View logs ·
+(a status line — "Running · up 3h 12m", or Starting… / Stopped — then
+Manage server ▸ (Libraries · Discovery · Federation · Backups · Torrents ·
+Open Admin Panel in browser) · Quick Connect · Start at login · View logs ·
 Restart server · Quit). Boots are quiet once set up — re-click the app icon
 (or launch it again) whenever you want the player in your browser. Start-at-login
 is on by default; one click in the tray menu turns it off. On a **first
@@ -163,6 +164,20 @@ an install has no player binary, or no terminal could be opened, it opens
 the web player's Quick Connect modal instead. Headless installs get the
 setup invitation as a boot log line whenever the server has no folders and
 no accounts yet.
+
+**Manage server** holds the server's management screens as terminal pages
+— the bundled player's admin rooms (`mstream-player admin <room>
+--same-machine`), opened in the same kind of window as the wizard:
+**Libraries** (the music folders; the picker is the OS folder dialog, since
+the terminal runs on the server's own machine), **Discovery** (the P2P
+discovery network), **Federation**, **Backups** and **Torrents**. The rooms
+use the admin session the setup wizard saved when it created your account.
+An install whose admin account was made elsewhere — in the browser, or
+before the wizard existed — gets a one-time sign-in page inside the room
+and keeps that session for next time. When an install has no player
+binary, or no terminal could be opened, a room item opens the matching
+section of the browser admin panel instead; **Open Admin Panel in
+browser**, the submenu's last item, always does exactly that.
 
 **Terminal users lose nothing.** The same desktop binary run from a terminal
 behaves exactly like the server itself (same flags, output, and exit codes) —

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -214,9 +214,9 @@ pub fn setup_complete(config: &Path) -> bool {
 /// has happened, the ADMIN PANEL before it — a fresh install's player is a
 /// dead end. (The post-boot announce goes further and opens the setup
 /// wizard itself on fresh installs; this is its browser fallback and every
-/// other gesture's routing.) The tray's explicit "Open Admin Panel" item
-/// does NOT route through this — it always opens /admin, literally what it
-/// says.
+/// other gesture's routing.) The tray's explicit "Open Admin Panel in
+/// browser" item (under Manage server) does NOT route through this — it
+/// always opens /admin, literally what it says.
 pub fn browse_target(config: &Path, ep: &Endpoint) -> String {
     if setup_complete(config) {
         server_url(ep)
@@ -246,10 +246,11 @@ pub fn player_key() -> String {
     format!("mstream-player-{plat}-{arch}{ext}")
 }
 
-/// The terminal player for the "Set up mStream" item: the copy build-bun
-/// stages next to the server binary in every desktop bundle, else one the
-/// server's runtime fetch installed in the shared data home. None disables
-/// the item — a greyed entry beats a terminal window that dies instantly.
+/// The terminal player behind the wizard, Quick Connect and the Manage
+/// server rooms: the copy build-bun stages next to the server binary in
+/// every desktop bundle, else one the server's runtime fetch installed in
+/// the shared data home. None sends those items to their browser fallbacks
+/// (the webapp's Quick Connect modal, the admin panel's sections).
 pub fn find_player_bin(server_bin: &Path, data_home: &Path) -> Option<PathBuf> {
     let key = player_key();
     let bundled = server_bin.parent()?.join("bin").join("mstream-player").join(&key);

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -479,8 +479,8 @@ fn spawn_ghostty_page(
     player_bin: &std::path::Path,
     server_url: &str,
     scratch_dir: &std::path::Path,
-    page: WizardPage,
-) -> Result<(), String> {
+    page: PlayerPage,
+) ->Result<(), String> {
     let bin = console.ghostty_app.join("Contents").join("MacOS").join("ghostty");
     if !bin.exists() {
         return Err(format!("no ghostty binary at {}", bin.display()));
@@ -510,8 +510,8 @@ fn ghostty_page_config(
     console: &crate::paths::ConsoleLaunch,
     player_bin: &std::path::Path,
     server_url: &str,
-    page: WizardPage,
-) -> String {
+    page: PlayerPage,
+) ->String {
     let mut body = format!(
         "# Written by mStream's tray - safe to delete.\n\
          auto-update = off\n\

--- a/rust-launcher/src/platform.rs
+++ b/rust-launcher/src/platform.rs
@@ -273,61 +273,124 @@ pub fn open_logs_terminal(logs_dir: &std::path::Path) -> Result<(), String> {
     }
 }
 
-/// Which wizard-family page a terminal launch opens. Each carries its own
-/// subcommand, window title, and scratch script name, so the Setup and
-/// Quick Connect tray items never clobber each other's launch files.
-#[derive(Clone, Copy)]
-pub enum WizardPage {
+/// One of the terminal player's admin rooms — `mstream-player admin <room>`,
+/// the server's management screens drawn in a terminal (player PR #21;
+/// pin v0.7.0 is the first with all five plus the in-room sign-in).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdminRoom {
+    /// The server's music folders.
+    Libraries,
+    /// The discovery network (P2P): the mesh, follows, invites, settings.
+    Discovery,
+    /// Federation: requests, minted tickets, readable peers.
+    Federation,
+    /// Backups: each library's copies elsewhere, schedules, runs.
+    Backups,
+    /// Torrents: the client, its list, per-library paths, seeding.
+    Torrents,
+}
+
+impl AdminRoom {
+    /// Menu order — the player's own `admin` help order.
+    pub const ALL: [AdminRoom; 5] = [
+        AdminRoom::Libraries,
+        AdminRoom::Discovery,
+        AdminRoom::Federation,
+        AdminRoom::Backups,
+        AdminRoom::Torrents,
+    ];
+
+    /// The room's name in the player's CLI (`mstream-player admin <this>`).
+    pub fn subcommand(self) -> &'static str {
+        match self {
+            AdminRoom::Libraries => "libraries",
+            AdminRoom::Discovery => "discovery",
+            AdminRoom::Federation => "federation",
+            AdminRoom::Backups => "backups",
+            AdminRoom::Torrents => "torrents",
+        }
+    }
+
+    /// The inverse of [`AdminRoom::subcommand`].
+    pub fn from_subcommand(name: &str) -> Option<AdminRoom> {
+        AdminRoom::ALL.into_iter().find(|r| r.subcommand() == name)
+    }
+}
+
+/// Which player page a terminal launch opens. Each carries its own argv,
+/// window title, and scratch script name, so no two tray items ever clobber
+/// each other's launch files.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlayerPage {
     /// The full first-run wizard (`mstream-player setup`).
     Setup,
     /// The standalone Quick Connect page (`mstream-player qr`) — the
     /// wizard's Done screen: pairing QR plus the app buttons.
     QuickConnect,
+    /// One admin room (`mstream-player admin <room> --same-machine`). The
+    /// launcher only ever runs on the server's own machine, so the rooms'
+    /// folder pickers may open the OS dialog and treat what it picks as the
+    /// server's paths — exactly what `--same-machine` declares.
+    Admin(AdminRoom),
 }
 
-impl WizardPage {
-    fn subcommand(self) -> &'static str {
+impl PlayerPage {
+    /// The player's argv for this page, before the `--server <url>` every
+    /// launch appends. Static words only: nothing here ever needs quoting.
+    fn args(self) -> Vec<&'static str> {
         match self {
-            WizardPage::Setup => "setup",
-            WizardPage::QuickConnect => "qr",
+            PlayerPage::Setup => vec!["setup"],
+            PlayerPage::QuickConnect => vec!["qr"],
+            PlayerPage::Admin(room) => vec!["admin", room.subcommand(), "--same-machine"],
         }
     }
-    // Only the mac ghostty config (and this file's mac-gated tests) call
-    // this; allow, not cfg, keeps the enum's surface uniform across
-    // platforms.
+    // Only the mac ghostty config (and this file's tests) call this; allow,
+    // not cfg, keeps the enum's surface uniform across platforms.
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-    fn title(self) -> &'static str {
+    fn title(self) -> String {
         match self {
-            WizardPage::Setup => "mStream Setup",
-            WizardPage::QuickConnect => "mStream Quick Connect",
+            PlayerPage::Setup => "mStream Setup".into(),
+            PlayerPage::QuickConnect => "mStream Quick Connect".into(),
+            PlayerPage::Admin(room) => format!("mStream {}", capitalized(room.subcommand())),
         }
     }
     #[cfg(target_os = "macos")]
-    fn script_name(self) -> &'static str {
+    fn script_name(self) -> String {
         match self {
-            WizardPage::Setup => "setup-mstream.command",
-            WizardPage::QuickConnect => "quickconnect-mstream.command",
+            PlayerPage::Setup => "setup-mstream.command".into(),
+            PlayerPage::QuickConnect => "quickconnect-mstream.command".into(),
+            PlayerPage::Admin(room) => format!("admin-{}-mstream.command", room.subcommand()),
         }
     }
 }
 
-/// Run one of the terminal player's wizard-family pages in a fresh terminal
-/// window, pointed at this launcher's server. Same per-OS "what is a
-/// terminal" seams as open_logs_terminal; the caller logs a failure — a
-/// missing terminal emulator must never take the tray down. Ok carries
-/// WHICH surface opened (support surface: "it opened in Terminal, not the
-/// mStream console — why?" should be one log line away).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn capitalized(word: &str) -> String {
+    let mut c = word.chars();
+    match c.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + c.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Run one of the terminal player's pages — the setup wizard, Quick
+/// Connect, or an admin room — in a fresh terminal window, pointed at this
+/// launcher's server. Same per-OS "what is a terminal" seams as
+/// open_logs_terminal; the caller logs a failure — a missing terminal
+/// emulator must never take the tray down. Ok carries WHICH surface opened
+/// (support surface: "it opened in Terminal, not the mStream console —
+/// why?" should be one log line away).
 ///
 /// `console`: the bundled Ghostty (macOS bundles only, resolved by
 /// paths::find_console_app) — preferred over Terminal.app because Apple's
 /// terminal has no pixel protocol at all, so the wizard's wordmark and QR
 /// degrade to character art there. Ignored on the other platforms.
-pub fn open_wizard_terminal(
+pub fn open_player_terminal(
     player_bin: &std::path::Path,
     server_url: &str,
     scratch_dir: &std::path::Path,
     console: Option<&crate::paths::ConsoleLaunch>,
-    page: WizardPage,
+    page: PlayerPage,
 ) -> Result<String, String> {
     #[cfg(target_os = "macos")]
     {
@@ -348,10 +411,8 @@ pub fn open_wizard_terminal(
         // doesn't just keeps its size (the wizard reflows).
         let script = scratch_dir.join(page.script_name());
         let body = format!(
-            "#!/bin/sh\n# Written by mStream's tray - safe to delete.\nprintf '\\033[8;42;120t'\nclear\nexec {player} {sub} --server {url}\n",
-            player = sh_quote(player_bin),
-            sub = page.subcommand(),
-            url = sh_quote_str(server_url),
+            "#!/bin/sh\n# Written by mStream's tray - safe to delete.\nprintf '\\033[8;42;120t'\nclear\nexec {}\n",
+            player_shell_words(page, player_bin, server_url),
         );
         std::fs::write(&script, body).map_err(|e| format!("write {}: {e}", script.display()))?;
         let _ = std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755));
@@ -372,7 +433,8 @@ pub fn open_wizard_terminal(
         let _ = console;
         if std::process::Command::new("wt.exe")
             .arg(player_bin)
-            .args([page.subcommand(), "--server", server_url])
+            .args(page.args())
+            .args(["--server", server_url])
             .spawn()
             .is_ok()
         {
@@ -380,7 +442,8 @@ pub fn open_wizard_terminal(
         }
         const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
         std::process::Command::new(player_bin)
-            .args([page.subcommand(), "--server", server_url])
+            .args(page.args())
+            .args(["--server", server_url])
             .creation_flags(CREATE_NEW_CONSOLE)
             .spawn()
             .map(|_| "conhost fallback".into())
@@ -394,10 +457,8 @@ pub fn open_wizard_terminal(
         // on screen behind a "press Enter" instead of a window that flashed
         // and vanished — the support surface for "nothing happened".
         let cmd = format!(
-            "{player} {sub} --server {url}; s=$?; if [ \"$s\" -ne 0 ]; then printf '\\nmstream-player exited with status %s - press Enter to close this window\\n' \"$s\"; read dummy; fi",
-            player = sh_quote(player_bin),
-            sub = page.subcommand(),
-            url = sh_quote_str(server_url),
+            "{}; s=$?; if [ \"$s\" -ne 0 ]; then printf '\\nmstream-player exited with status %s - press Enter to close this window\\n' \"$s\"; read dummy; fi",
+            player_shell_words(page, player_bin, server_url),
         );
         let candidates =
             linux_terminal::candidates(&cmd, Some(linux_terminal::WIZARD_SIZE), linux_terminal::on_wayland());
@@ -465,12 +526,7 @@ fn ghostty_page_config(
         // Config values run to end of line — a spaced path needs no quoting.
         body.push_str(&format!("macos-icon = custom\nmacos-custom-icon = {}\n", icns.display()));
     }
-    body.push_str(&format!(
-        "command = shell:{player} {sub} --server {url}\n",
-        player = sh_quote(player_bin),
-        sub = page.subcommand(),
-        url = sh_quote_str(server_url),
-    ));
+    body.push_str(&format!("command = shell:{}\n", player_shell_words(page, player_bin, server_url)));
     body
 }
 
@@ -899,6 +955,109 @@ fn sh_quote_str(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+/// The one `sh -c` program every unix launch of a player page runs —
+/// `'<player>' <page args…> --server '<url>'` — shared by the macOS
+/// .command script, the bundled-console config and the Linux chain, so all
+/// three agree on the argv and its quoting.
+#[cfg(unix)]
+fn player_shell_words(page: PlayerPage, player_bin: &std::path::Path, server_url: &str) -> String {
+    let mut words = vec![sh_quote(player_bin)];
+    words.extend(page.args().into_iter().map(String::from));
+    words.push("--server".into());
+    words.push(sh_quote_str(server_url));
+    words.join(" ")
+}
+
+#[cfg(test)]
+mod page_tests {
+    use super::{AdminRoom, PlayerPage};
+
+    fn every_page() -> Vec<PlayerPage> {
+        let mut pages = vec![PlayerPage::Setup, PlayerPage::QuickConnect];
+        pages.extend(AdminRoom::ALL.into_iter().map(PlayerPage::Admin));
+        pages
+    }
+
+    #[test]
+    fn each_page_maps_to_its_own_argv_and_title() {
+        assert_eq!(PlayerPage::Setup.args(), ["setup"]);
+        assert_eq!(PlayerPage::QuickConnect.args(), ["qr"]);
+        // A room always declares --same-machine: the launcher IS the
+        // server's machine, so the room's folder picker may use the OS
+        // dialog and hand the server the paths it picks.
+        assert_eq!(
+            PlayerPage::Admin(AdminRoom::Libraries).args(),
+            ["admin", "libraries", "--same-machine"]
+        );
+        assert_eq!(PlayerPage::Admin(AdminRoom::Torrents).args(), ["admin", "torrents", "--same-machine"]);
+        assert_eq!(PlayerPage::Setup.title(), "mStream Setup");
+        assert_eq!(PlayerPage::QuickConnect.title(), "mStream Quick Connect");
+        assert_eq!(PlayerPage::Admin(AdminRoom::Discovery).title(), "mStream Discovery");
+        // Seven pages, seven argvs, seven titles: no two tray items may
+        // open the same thing or the same-named window.
+        let pages = every_page();
+        for (i, a) in pages.iter().enumerate() {
+            for b in &pages[i + 1..] {
+                assert_ne!(a.args(), b.args(), "{a:?} vs {b:?}");
+                assert_ne!(a.title(), b.title(), "{a:?} vs {b:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn rooms_round_trip_through_their_cli_names() {
+        for room in AdminRoom::ALL {
+            assert_eq!(AdminRoom::from_subcommand(room.subcommand()), Some(room));
+        }
+        assert_eq!(AdminRoom::from_subcommand("setup"), None);
+        assert_eq!(AdminRoom::from_subcommand("Libraries"), None, "the CLI names are lowercase");
+        assert_eq!(AdminRoom::from_subcommand(""), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_launches_share_one_quoted_command_line() {
+        let player = std::path::Path::new("/Application Support/bin/mstream-player");
+        assert_eq!(
+            super::player_shell_words(PlayerPage::Setup, player, "http://localhost:3000"),
+            "'/Application Support/bin/mstream-player' setup --server 'http://localhost:3000'"
+        );
+        assert_eq!(
+            super::player_shell_words(PlayerPage::Admin(AdminRoom::Backups), player, "http://x:1"),
+            "'/Application Support/bin/mstream-player' admin backups --same-machine --server 'http://x:1'"
+        );
+        // A quote inside a path survives as the POSIX '\'' dance.
+        let odd = std::path::Path::new("/it's/player");
+        let words = super::player_shell_words(PlayerPage::QuickConnect, odd, "http://x:1");
+        assert!(words.starts_with("'/it'\\''s/player' qr "), "{words}");
+    }
+
+    #[test]
+    #[ignore = "spawns a real terminal window - run manually with --ignored"]
+    fn manual_open_player_terminal() {
+        // MSTREAM_DEMO_PLAYER = a real player binary; MSTREAM_DEMO_SERVER =
+        // the URL to point it at; MSTREAM_DEMO_PAGE = setup (default), qr,
+        // or a room name (libraries, discovery, federation, backups,
+        // torrents); on macOS MSTREAM_DEMO_CONSOLE = optionally a Ghostty.app
+        // to prefer (with MSTREAM_DEMO_ICNS for the Dock icon).
+        let player = std::path::PathBuf::from(std::env::var("MSTREAM_DEMO_PLAYER").expect("set MSTREAM_DEMO_PLAYER"));
+        let url = std::env::var("MSTREAM_DEMO_SERVER").unwrap_or_else(|_| "http://localhost:3000".into());
+        let console = std::env::var("MSTREAM_DEMO_CONSOLE").ok().map(|app| crate::paths::ConsoleLaunch {
+            ghostty_app: std::path::PathBuf::from(app),
+            icon_icns: std::env::var("MSTREAM_DEMO_ICNS").ok().map(std::path::PathBuf::from),
+        });
+        let dir = std::env::temp_dir().join("mstream-page-demo");
+        std::fs::create_dir_all(&dir).unwrap();
+        let page = match std::env::var("MSTREAM_DEMO_PAGE").as_deref() {
+            Ok("qr") => PlayerPage::QuickConnect,
+            Ok(name) => AdminRoom::from_subcommand(name).map(PlayerPage::Admin).unwrap_or(PlayerPage::Setup),
+            Err(_) => PlayerPage::Setup,
+        };
+        let via = super::open_player_terminal(&player, &url, &dir, console.as_ref(), page).unwrap();
+        eprintln!("opened {page:?} via {via}");
+    }
+}
+
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     #[test]
@@ -911,7 +1070,7 @@ mod tests {
             &c,
             std::path::Path::new("/Application Support/bin/mstream-player"),
             "http://localhost:3000",
-            super::WizardPage::Setup,
+            super::PlayerPage::Setup,
         );
         // shell: + sh-quoting is what survives "Application Support" spaces;
         // the command must live in the CONFIG, never a -e argument (consent
@@ -927,25 +1086,36 @@ mod tests {
         assert!(cfg.contains("quit-after-last-window-closed = true\n"), "{cfg}");
 
         let plain = crate::paths::ConsoleLaunch { ghostty_app: "/t/G.app".into(), icon_icns: None };
-        let cfg2 = super::ghostty_page_config(&plain, std::path::Path::new("/p"), "http://x:1", super::WizardPage::Setup);
+        let cfg2 = super::ghostty_page_config(&plain, std::path::Path::new("/p"), "http://x:1", super::PlayerPage::Setup);
         assert!(!cfg2.contains("macos-icon"), "no icns means Ghostty keeps its own icon: {cfg2}");
 
         // The Quick Connect page: same machinery, its own subcommand + title.
-        let qc = super::ghostty_page_config(&plain, std::path::Path::new("/p"), "http://x:1", super::WizardPage::QuickConnect);
+        let qc = super::ghostty_page_config(&plain, std::path::Path::new("/p"), "http://x:1", super::PlayerPage::QuickConnect);
         assert!(qc.contains("command = shell:'/p' qr --server 'http://x:1'"), "{qc}");
         assert!(qc.contains("title = mStream Quick Connect\n"), "{qc}");
+
+        // An admin room: the same window, its own argv (with --same-machine)
+        // and title.
+        let room = super::PlayerPage::Admin(super::AdminRoom::Federation);
+        let fed = super::ghostty_page_config(&plain, std::path::Path::new("/p"), "http://x:1", room);
+        assert!(fed.contains("command = shell:'/p' admin federation --same-machine --server 'http://x:1'"), "{fed}");
+        assert!(fed.contains("title = mStream Federation\n"), "{fed}");
     }
 
     #[test]
-    fn each_page_maps_to_its_own_subcommand_title_and_script() {
-        use super::WizardPage::*;
-        assert_eq!(Setup.subcommand(), "setup");
-        assert_eq!(QuickConnect.subcommand(), "qr");
-        assert_eq!(Setup.title(), "mStream Setup");
-        assert_eq!(QuickConnect.title(), "mStream Quick Connect");
-        // Distinct script files: the two tray items must never clobber
-        // each other's .command.
-        assert_ne!(Setup.script_name(), QuickConnect.script_name());
+    fn each_page_writes_its_own_command_script() {
+        // Distinct script files: no two tray items may clobber each
+        // other's .command while both windows are open.
+        let mut pages = vec![super::PlayerPage::Setup, super::PlayerPage::QuickConnect];
+        pages.extend(super::AdminRoom::ALL.into_iter().map(super::PlayerPage::Admin));
+        let names: Vec<String> = pages.iter().map(|p| p.script_name()).collect();
+        for (i, a) in names.iter().enumerate() {
+            assert!(a.ends_with(".command"), "{a}");
+            for b in &names[i + 1..] {
+                assert_ne!(a, b);
+            }
+        }
+        assert_eq!(super::PlayerPage::Admin(super::AdminRoom::Libraries).script_name(), "admin-libraries-mstream.command");
     }
 
     #[test]
@@ -958,31 +1128,4 @@ mod tests {
         super::open_logs_terminal(&dir).unwrap();
     }
 
-    #[test]
-    #[ignore = "spawns a real Terminal window - run manually with --ignored"]
-    fn manual_open_setup_terminal() {
-        // MSTREAM_DEMO_PLAYER = a real player binary; MSTREAM_DEMO_SERVER =
-        // the URL to point its wizard at; MSTREAM_DEMO_CONSOLE = optionally,
-        // a Ghostty.app to prefer (with MSTREAM_DEMO_ICNS for the Dock icon).
-        let player = std::path::PathBuf::from(
-            std::env::var("MSTREAM_DEMO_PLAYER").expect("set MSTREAM_DEMO_PLAYER"),
-        );
-        let url = std::env::var("MSTREAM_DEMO_SERVER")
-            .unwrap_or_else(|_| "http://localhost:3000".into());
-        let console = std::env::var("MSTREAM_DEMO_CONSOLE").ok().map(|app| {
-            crate::paths::ConsoleLaunch {
-                ghostty_app: std::path::PathBuf::from(app),
-                icon_icns: std::env::var("MSTREAM_DEMO_ICNS").ok().map(std::path::PathBuf::from),
-            }
-        });
-        let dir = std::env::temp_dir().join("mstream-setup-demo");
-        std::fs::create_dir_all(&dir).unwrap();
-        // MSTREAM_DEMO_PAGE=qr opens the Quick Connect page instead.
-        let page = match std::env::var("MSTREAM_DEMO_PAGE").as_deref() {
-            Ok("qr") => super::WizardPage::QuickConnect,
-            _ => super::WizardPage::Setup,
-        };
-        let via = super::open_wizard_terminal(&player, &url, &dir, console.as_ref(), page).unwrap();
-        eprintln!("opened via {via}");
-    }
 }

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tao::event::{Event, StartCause};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
-use tray_icon::menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem};
+use tray_icon::menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
 use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 
 const STOP_GRACE: Duration = Duration::from_secs(8);
@@ -356,7 +356,16 @@ pub fn run(args: LauncherArgs) -> ! {
                     update_item_view(upd.as_ref(), &updates_dir(), relaunch_target_exists(exe_real.as_deref()));
                 let update = MenuItem::with_id("update", utext.clone(), uaction != UpdateAction::None, None);
                 upd_text = utext;
-                let open_item = MenuItem::with_id("open", "Open Admin Panel", true, None);
+                // "Manage server": the terminal player's admin rooms, one
+                // item each, then the browser admin panel as the last
+                // resort that always exists (a room item falls back to
+                // the panel's matching section when no terminal opens).
+                let manage = Submenu::with_id("manage", "Manage server", true);
+                for room in platform::AdminRoom::ALL {
+                    let _ = manage.append(&MenuItem::with_id(room_menu_id(room), room_label(room), true, None));
+                }
+                let _ = manage.append(&PredefinedMenuItem::separator());
+                let _ = manage.append(&MenuItem::with_id("open", "Open Admin Panel in browser", true, None));
                 let qc_item = MenuItem::with_id("quick-connect", "Quick Connect", true, None);
                 let auto_item =
                     CheckMenuItem::with_id("autostart", "Start at login", true, autostart::is_enabled(), None);
@@ -366,7 +375,7 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&status);
                 let _ = menu.append(&update);
                 let _ = menu.append(&PredefinedMenuItem::separator());
-                let _ = menu.append(&open_item);
+                let _ = menu.append(&manage);
                 let _ = menu.append(&qc_item);
                 let _ = menu.append(&PredefinedMenuItem::separator());
                 let _ = menu.append(&auto_item);
@@ -500,11 +509,39 @@ pub fn run(args: LauncherArgs) -> ! {
                 }
                 AppEvent::Menu(id) => match id.as_str() {
                     "open" => {
-                        // The admin panel, explicitly — the tray is the
-                        // operator's surface, and listening happens in the
-                        // apps/players. (The post-boot browser announce keeps
-                        // its own routing: paths::browse_target.)
+                        // The browser admin panel, explicitly — the tray is
+                        // the operator's surface, and listening happens in
+                        // the apps/players. (The post-boot browser announce
+                        // keeps its own routing: paths::browse_target.)
                         let _ = open::that_detached(format!("{url}/admin"));
+                    }
+                    room_id if room_from_menu_id(room_id).is_some() => {
+                        // One of the player's admin rooms in a real terminal
+                        // — the same spawn as the wizard pages, so the same
+                        // per-OS terminal choice and the same log surface.
+                        // The room reuses the admin session the wizard saved
+                        // (or asks once, in-room, and keeps what it gets);
+                        // the browser panel's matching section is the
+                        // fallback when this install has no player binary
+                        // or no terminal opened.
+                        let room = room_from_menu_id(room_id).expect("guarded by the match arm");
+                        let name = room.subcommand();
+                        log.line(&format!("menu: manage {name}"));
+                        let mut opened = false;
+                        if let Some(player) = player_bin.as_deref() {
+                            match platform::open_player_terminal(player, &url, &data_home, console.as_ref(), platform::PlayerPage::Admin(room)) {
+                                Ok(via) => {
+                                    log.line(&format!("{name} room opened via {via}"));
+                                    opened = true;
+                                }
+                                Err(e) => log.line(&format!("{name} room terminal failed: {e} - falling back to the admin panel")),
+                            }
+                        } else {
+                            log.line(&format!("{name} room: no player binary in this install - falling back to the admin panel"));
+                        }
+                        if !opened {
+                            let _ = open::that_detached(room_webapp_url(&url, room));
+                        }
                     }
                     "quick-connect" => {
                         // The wizard's Quick Connect page (pixel pairing QR)
@@ -516,7 +553,7 @@ pub fn run(args: LauncherArgs) -> ! {
                         log.line("menu: quick connect");
                         let mut opened = false;
                         if let Some(player) = player_bin.as_deref() {
-                            match platform::open_wizard_terminal(player, &url, &data_home, console.as_ref(), platform::WizardPage::QuickConnect) {
+                            match platform::open_player_terminal(player, &url, &data_home, console.as_ref(), platform::PlayerPage::QuickConnect) {
                                 Ok(via) => {
                                     log.line(&format!("quick connect opened via {via}"));
                                     opened = true;
@@ -689,7 +726,7 @@ pub fn run(args: LauncherArgs) -> ! {
                             if target.ends_with("/admin") {
                                 let mut wizard_opened = false;
                                 if let Some(player) = player_bin.as_deref() {
-                                    match platform::open_wizard_terminal(player, &url, &data_home, console.as_ref(), platform::WizardPage::Setup) {
+                                    match platform::open_player_terminal(player, &url, &data_home, console.as_ref(), platform::PlayerPage::Setup) {
                                         Ok(via) => {
                                             log.line(&format!("first-run announce: setup wizard opened via {via}"));
                                             wizard_opened = true;
@@ -835,6 +872,45 @@ pub fn run(args: LauncherArgs) -> ! {
             _ => {}
         }
     })
+}
+
+/// The "Manage server" submenu: one menu id per admin room, derived from the
+/// room's CLI name so the id and the argv can never drift apart.
+fn room_menu_id(room: platform::AdminRoom) -> String {
+    format!("admin-{}", room.subcommand())
+}
+
+fn room_from_menu_id(id: &str) -> Option<platform::AdminRoom> {
+    id.strip_prefix("admin-").and_then(platform::AdminRoom::from_subcommand)
+}
+
+/// The menu text — the rooms' own titles, which are also the browser admin
+/// panel's section names (Directories aside: the player and the wizard
+/// call the music folders libraries).
+fn room_label(room: platform::AdminRoom) -> &'static str {
+    use platform::AdminRoom::*;
+    match room {
+        Libraries => "Libraries",
+        Discovery => "Discovery",
+        Federation => "Federation",
+        Backups => "Backups",
+        Torrents => "Torrents",
+    }
+}
+
+/// The browser admin panel opened on the room's section — its URL-hash
+/// deep link (webapp/admin/index.js `_initialViewFromHash`) — the
+/// fallback when the terminal room could not open.
+fn room_webapp_url(server_url: &str, room: platform::AdminRoom) -> String {
+    use platform::AdminRoom::*;
+    let view = match room {
+        Libraries => "folders-view",
+        Discovery => "discovery-view",
+        Federation => "federation-view",
+        Backups => "backup-view",
+        Torrents => "torrent-view",
+    };
+    format!("{server_url}/admin#{view}")
 }
 
 /// Spawn a server generation plus its two helper threads.
@@ -1416,6 +1492,29 @@ mod tests {
         assert!(unverified.ticks());
         assert!(!Phase::Starting.ticks(), "no ticks unless an uptime is showing");
         assert!(!Phase::Stopped.ticks());
+    }
+
+    #[test]
+    fn manage_server_items_round_trip_and_fall_back_to_their_panel_section() {
+        use crate::platform::AdminRoom;
+        for room in AdminRoom::ALL {
+            let id = room_menu_id(room);
+            assert_eq!(room_from_menu_id(&id), Some(room), "{id}");
+            assert!(!room_label(room).is_empty());
+        }
+        // Every other menu id — and a room name without the prefix — is
+        // somebody else's arm, never a room.
+        for other in ["open", "quick-connect", "manage", "libraries", "admin-", "admin-setup", ""] {
+            assert_eq!(room_from_menu_id(other), None, "{other}");
+        }
+        // Five rooms, five labels, five panel sections.
+        let labels: std::collections::BTreeSet<&str> = AdminRoom::ALL.into_iter().map(room_label).collect();
+        assert_eq!(labels.len(), AdminRoom::ALL.len());
+        let urls: std::collections::BTreeSet<String> =
+            AdminRoom::ALL.into_iter().map(|r| room_webapp_url("http://localhost:3000", r)).collect();
+        assert_eq!(urls.len(), AdminRoom::ALL.len());
+        assert_eq!(room_webapp_url("http://localhost:3000", AdminRoom::Libraries), "http://localhost:3000/admin#folders-view");
+        assert_eq!(room_webapp_url("http://[::1]:3000", AdminRoom::Backups), "http://[::1]:3000/admin#backup-view");
     }
 
     fn status(json: &str) -> Option<crate::paths::UpdateStatus> {


### PR DESCRIPTION
## What

The tray's **Open Admin Panel** item becomes a **Manage server** submenu:

```
Manage server ▸   Libraries
                  Discovery
                  Federation
                  Backups
                  Torrents
                  ───────────
                  Open Admin Panel in browser
Quick Connect
```

Each room item runs the bundled player's admin room — `mstream-player admin <room> --same-machine --server <url>` — in a terminal window, exactly the way the setup wizard and Quick Connect already open one (the bundled Ghostty console or Terminal.app on macOS, Windows Terminal or a fresh console window on Windows, the emulator chain on Linux). `--same-machine` is always right here: the launcher is by construction on the server's own machine, so the rooms' folder picker is the OS dialog and the paths it picks are the server's paths. **Open Admin Panel in browser** at the bottom is the old item, kept verbatim in behaviour (`/admin`).

**Auth: nothing new.** The rooms use the admin session the wizard saved in the player's `credentials.toml` when it created the account. An install whose admin was made elsewhere (browser, pre-wizard) gets player v0.7.0's in-room sign-in page once and keeps that session — which is why the pin bump to v0.7.0 (#981) came first.

**Fallback.** No player binary in the install, or no terminal opened (a Linux desktop with none the chain knows) → the browser admin panel opened on the room's own section — the webapp's existing URL-hash deep link (`/admin#folders-view`, `#discovery-view`, `#federation-view`, `#backup-view`, `#torrent-view`) — with the reason one line away in `launcher.log` (`libraries room terminal failed: … - falling back to the admin panel`).

## How

- **platform.rs** — `WizardPage` becomes `PlayerPage { Setup, QuickConnect, Admin(AdminRoom) }`. A page now carries an argv (`args()`: `["setup"]`, `["qr"]`, `["admin", "<room>", "--same-machine"]`), a title (`mStream Libraries`, …) and, on macOS, its own `.command` name. The three unix launch shapes — Terminal.app's `.command`, the bundled-Ghostty config, the Linux chain's `sh -c` program — take one shared, quoted command line (`player_shell_words`), so they can never disagree on argv or quoting; the Windows arms use `.args(page.args())`. `open_wizard_terminal` → `open_player_terminal`. Window size unchanged (120×42; the rooms need 80×24 and fill what they get).
- **tray_app.rs** — `Submenu::with_id("manage", "Manage server")` filled from `AdminRoom::ALL`; menu ids are `admin-<room>`, derived from the CLI names so the id and the argv cannot drift (`room_menu_id` / `room_from_menu_id`); one guarded match arm mirrors the Quick Connect arm (log → `open_player_terminal` → browser fallback). Log lines: `menu: manage <room>`, `<room> room opened via <surface>`.
- **docs/install.md** — the menu list and a *Manage server* paragraph (what opens, the session it reuses, the fallback). `paths.rs` doc comments refreshed.

## Tests

- `platform::page_tests` (all OSes): argv per page including `--same-machine`; seven pages, seven distinct argvs and titles; room-name round-trip. unix: the shared command line, incl. a quote inside the path. macOS: the Ghostty config for a room (`command = shell:'/p' admin federation --same-machine --server 'http://x:1'`, `title = mStream Federation`) and a distinct `.command` per page.
- `tray_app::tests`: id round-trip and rejects (`open`, `manage`, `libraries`, `admin-setup`, …); five distinct labels and fallback URLs (`http://[::1]:3000/admin#backup-view`).
- The ignored `manual_open_player_terminal` demo is cross-platform now; `MSTREAM_DEMO_PAGE` takes `setup`, `qr` or a room name.

## Verified

- **Windows**: `cargo test --release --locked` 39 passed, `clippy -D warnings` clean. The manual demo against a scratch server on :3999 opened a Windows Terminal tab titled *mStream Admin* running the Libraries room (observed command line: `mstream-player-win32-x64.exe admin libraries --same-machine --server http://127.0.0.1:3999`); still alive minutes later.
- **Linux** (Docker bookworm: the v6.26.0 linux-x64 bundle with the v0.7.0 player asset dropped in and this branch's launcher over `mstream-desktop`; Xvfb + a session bus, no window manager): 45 tests + clippy clean. Drove the tray headlessly over dbusmenu — `GetLayout` shows the menu exactly as above (`Manage server` with `children-display: submenu`, ids 6–10 the rooms, 11 a separator, 12 the browser item, 13 Quick Connect); `Event clicked` on Libraries → `xfce4-terminal` via `x-terminal-emulator`, 120×42, showing the sign-in page (an admin account seeded through the public-mode API, no saved session); typed `alice` ⇥ `hunter2` ⏎ → the Libraries room; `credentials.toml` (0600) holds the issued token; Esc closes it; `Event clicked` on Federation → the room straight away, session kept. A run with no terminal emulator on PATH: both clicks log the full chain failure and `falling back to the admin panel`; the tray stays up.
- **Not driven**: macOS (no Mac here — the Ghostty/Terminal.app arms changed only by taking their command line from the shared builder, which the macOS unit tests in `build-rust-launcher` cover), and the Windows tray popup itself (the same muda code builds it; the Linux dbusmenu readout is the structural check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
