### PR TITLE
tray: a "federation requests waiting" line, icon dot and count while peers wait on the operator

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -141,7 +141,11 @@ server in the background, puts an mStream icon in your tray / menu bar
 (a status line — "Running · up 3h 12m", or Starting… / Stopped — then
 Manage server ▸ (Libraries · Discovery · Federation · Backups · Torrents ·
 Open Admin Panel in browser) · Quick Connect · Start at login · View logs ·
-Restart server · Quit). Boots are quiet once set up — re-click the app icon
+Restart server · Quit). While other mStream servers have federation pairing
+requests waiting on you, an extra line under the update one says so ("2
+federation requests waiting"), the tray icon wears a dot — with the count
+beside it on macOS — and clicking the line opens the Federation room.
+Boots are quiet once set up — re-click the app icon
 (or launch it again) whenever you want the player in your browser. Start-at-login
 is on by default; one click in the tray menu turns it off. On a **first
 install** the tray opens the guided setup wizard by itself (the bundled

--- a/rust-launcher/src/paths.rs
+++ b/rust-launcher/src/paths.rs
@@ -381,6 +381,34 @@ pub fn sanitize_version(s: &str) -> Option<String> {
     (dots == 2 && !s.starts_with('.') && !s.ends_with('.')).then(|| s.to_string())
 }
 
+/// The server's tray-status.json (src/util/tray-status.js): the facts the
+/// tray shows without a session — today the federation requests waiting on
+/// the operator. Same channel and the same tolerance as the update status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrayStatus {
+    pub federation_inbox: u32,
+}
+
+fn tray_status_file() -> PathBuf {
+    data_home().join("tray-status.json")
+}
+
+pub fn read_tray_status() -> Option<TrayStatus> {
+    parse_tray_status(&std::fs::read_to_string(tray_status_file()).ok()?)
+}
+
+/// An absent or non-numeric fact reads as 0 — an older server never writes
+/// the key, and a hand-edited file must not invent a badge. Capped: neither
+/// the menu line nor the badge ever needs more than three digits.
+pub fn parse_tray_status(doc: &str) -> Option<TrayStatus> {
+    let v = serde_json::from_str::<serde_json::Value>(doc).ok()?;
+    if !v.is_object() {
+        return None;
+    }
+    let n = v.get("federationInbox").and_then(|x| x.as_u64()).unwrap_or(0);
+    Some(TrayStatus { federation_inbox: n.min(999) as u32 })
+}
+
 /// Tolerant read of the status file: absent, unreadable, or garbage all come
 /// back as None; unknown fields are ignored (the server may write a newer
 /// schema than this launcher knows).
@@ -542,6 +570,19 @@ mod tests {
         #[cfg(all(unix, not(target_os = "macos")))]
         assert!(key.starts_with("mstream-player-linux-"), "{key}");
         assert!(!key.contains("x86_64") && !key.contains("aarch64"), "node arch names, not Rust's: {key}");
+    }
+
+    #[test]
+    fn tray_status_reads_the_inbox_tolerantly() {
+        let n = |doc: &str| parse_tray_status(doc).map(|s| s.federation_inbox);
+        assert_eq!(n(r#"{"federationInbox": 3, "updatedAt": "2026-09-12T15:00:00.000Z"}"#), Some(3));
+        assert_eq!(n(r#"{"updatedAt": "x"}"#), Some(0), "an older server never writes the key");
+        assert_eq!(n(r#"{"federationInbox": -2}"#), Some(0), "negatives are not counts");
+        assert_eq!(n(r#"{"federationInbox": "7"}"#), Some(0), "strings are not counts");
+        assert_eq!(n(r#"{"federationInbox": 2.5}"#), Some(0), "fractions are not counts");
+        assert_eq!(n(r#"{"federationInbox": 12345}"#), Some(999), "capped at three digits");
+        assert_eq!(n("garbage"), None);
+        assert_eq!(n("[]"), None, "a document that is not an object is no status");
     }
 
     #[test]

--- a/rust-launcher/src/tray_app.rs
+++ b/rust-launcher/src/tray_app.rs
@@ -306,6 +306,14 @@ pub fn run(args: LauncherArgs) -> ! {
     let mut update_item: Option<MenuItem> = None;
     let mut upd: Option<paths::UpdateStatus> = paths::read_update_status();
     let mut upd_text = String::new();
+    // The federation inbox: peers' pairing requests waiting on this
+    // operator, from the server's tray-status.json (util/tray-status.js) —
+    // re-read on the same minute tick as the update file and after each
+    // boot. While non-zero it owns a menu line under the update one, a dot
+    // on the icon, and the count beside the icon where the OS draws one.
+    let mut menu_handle: Option<Menu> = None;
+    let mut inbox_item: Option<MenuItem> = None;
+    let mut inbox: u32 = 0;
     // The apply request we last ACTED on (the file's applyRequestedAt, else
     // the staged version): a failed handoff must not auto-retry itself into
     // a spawn loop, but a NEW request — a later version, or the operator
@@ -343,6 +351,13 @@ pub fn run(args: LauncherArgs) -> ! {
             // it must follow NSApplication activation. Windows tolerates
             // either; one code path keeps all three honest.
             Event::NewEvents(StartCause::Init) => {
+                // What the previous server run left in the facts file: the
+                // icon is built badged from the first frame when peers are
+                // already waiting.
+                inbox = paths::read_tray_status().map(|s| s.federation_inbox).unwrap_or(0);
+                if inbox > 0 {
+                    log.line(&format!("federation inbox: {inbox} waiting (from the last run's file)"));
+                }
                 let menu = Menu::new();
                 // Disabled = the greyed, unclickable status line every tray
                 // app leads with (Docker Desktop, Tailscale). Text tracks
@@ -383,6 +398,10 @@ pub fn run(args: LauncherArgs) -> ! {
                 let _ = menu.append(&logs_item);
                 let _ = menu.append(&restart_item);
                 let _ = menu.append(&quit_item);
+                // A handle for later inserts/removes (the builder takes the
+                // menu itself); the inbox line, if any, goes in now.
+                menu_handle = Some(menu.clone());
+                sync_inbox_item(&menu, &mut inbox_item, inbox);
                 status_item = Some(status);
                 update_item = Some(update);
                 autostart_item = Some(auto_item);
@@ -398,7 +417,7 @@ pub fn run(args: LauncherArgs) -> ! {
                     TrayIconBuilder::new()
                         .with_tooltip("mStream Server")
                         .with_menu(Box::new(menu))
-                        .with_icon(load_icon())
+                        .with_icon(icon_for(inbox))
                         .build()
                 }));
                 match built {
@@ -416,7 +435,10 @@ pub fn run(args: LauncherArgs) -> ! {
                         log.line(&format!("tray unavailable ({msg}) - server continues without it"));
                     }
                 }
-                show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                // The icon was built badged already; this adds the count
+                // beside it where the OS draws one.
+                apply_inbox_tray(tray.as_ref(), inbox, false);
+                show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
             }
             Event::UserEvent(app_event) => match app_event {
                 // The minute tick from the current generation's ticker
@@ -439,6 +461,11 @@ pub fn run(args: LauncherArgs) -> ! {
                         relaunch_target_exists(exe_real.as_deref()),
                         &mut upd_text,
                     );
+                    // The same tick reads the tray facts file (the inbox
+                    // count): one more small file, re-rendered on change.
+                    if sync_inbox(&mut inbox, menu_handle.as_ref(), &mut inbox_item, tray.as_ref(), &log) {
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
+                    }
                     // auto mode / a webapp "restart to update" click: the
                     // server flags applyRequested and this launcher acts on
                     // the next poll. Once PER REQUEST TOKEN — a failed
@@ -492,7 +519,7 @@ pub fn run(args: LauncherArgs) -> ! {
                                 phase = recover_after_failed_apply(
                                     &shared_loop, &bin, &args.server_args, &server_log_loop, ep, &proxy, &log,
                                 );
-                                show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                                show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
                             }
                         }
                     }
@@ -504,7 +531,7 @@ pub fn run(args: LauncherArgs) -> ! {
                         && status_rendered_at.is_none_or(|t| now.duration_since(t) >= Duration::from_secs(1))
                     {
                         status_rendered_at = Some(now);
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
                     }
                 }
                 AppEvent::Menu(id) => match id.as_str() {
@@ -515,33 +542,18 @@ pub fn run(args: LauncherArgs) -> ! {
                         // keeps its own routing: paths::browse_target.)
                         let _ = open::that_detached(format!("{url}/admin"));
                     }
+                    "federation-inbox" => {
+                        // The line under the update item, present only
+                        // while peers wait on this operator: straight into
+                        // the Federation room, whose first section is the
+                        // requests inbox.
+                        log.line("menu: federation inbox");
+                        open_admin_room(platform::AdminRoom::Federation, player_bin.as_deref(), &url, &data_home, console.as_ref(), &log);
+                    }
                     room_id if room_from_menu_id(room_id).is_some() => {
-                        // One of the player's admin rooms in a real terminal
-                        // — the same spawn as the wizard pages, so the same
-                        // per-OS terminal choice and the same log surface.
-                        // The room reuses the admin session the wizard saved
-                        // (or asks once, in-room, and keeps what it gets);
-                        // the browser panel's matching section is the
-                        // fallback when this install has no player binary
-                        // or no terminal opened.
                         let room = room_from_menu_id(room_id).expect("guarded by the match arm");
-                        let name = room.subcommand();
-                        log.line(&format!("menu: manage {name}"));
-                        let mut opened = false;
-                        if let Some(player) = player_bin.as_deref() {
-                            match platform::open_player_terminal(player, &url, &data_home, console.as_ref(), platform::PlayerPage::Admin(room)) {
-                                Ok(via) => {
-                                    log.line(&format!("{name} room opened via {via}"));
-                                    opened = true;
-                                }
-                                Err(e) => log.line(&format!("{name} room terminal failed: {e} - falling back to the admin panel")),
-                            }
-                        } else {
-                            log.line(&format!("{name} room: no player binary in this install - falling back to the admin panel"));
-                        }
-                        if !opened {
-                            let _ = open::that_detached(room_webapp_url(&url, room));
-                        }
+                        log.line(&format!("menu: manage {}", room.subcommand()));
+                        open_admin_room(room, player_bin.as_deref(), &url, &data_home, console.as_ref(), &log);
                     }
                     "quick-connect" => {
                         // The wizard's Quick Connect page (pixel pairing QR)
@@ -609,7 +621,7 @@ pub fn run(args: LauncherArgs) -> ! {
                                 Phase::Stopped
                             }
                         };
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
                     }
                     "update" => {
                         // Recompute from the file at click time — the menu
@@ -650,7 +662,7 @@ pub fn run(args: LauncherArgs) -> ! {
                                         phase = recover_after_failed_apply(
                                             &shared_loop, &bin, &args.server_args, &server_log_loop, ep, &proxy, &log,
                                         );
-                                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
                                     }
                                 }
                             }
@@ -693,12 +705,16 @@ pub fn run(args: LauncherArgs) -> ! {
                             relaunch_target_exists(exe_real.as_deref()),
                             &mut upd_text,
                         );
+                        // The booting server also refreshed tray-status.json
+                        // (its boot write): read it now, not a minute on.
+                        // (The status line below re-renders regardless.)
+                        let _ = sync_inbox(&mut inbox, menu_handle.as_ref(), &mut inbox_item, tray.as_ref(), &log);
                         // Uptime counts from here — "up" means serving, not
                         // spawned. A restart or crash lands back in
                         // Starting/Stopped, so the count resets with it.
                         let since = Instant::now();
                         phase = Phase::Running { since };
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
                         start_ticker(&shared_loop, generation, since, &proxy);
                         // Logged unconditionally (even under --no-open) so
                         // smokes and support can see the routing decision.
@@ -773,7 +789,7 @@ pub fn run(args: LauncherArgs) -> ! {
                         ));
                         let since = spawned_at;
                         phase = Phase::Unverified { since };
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
                         start_ticker(&shared_loop, generation, since, &proxy);
                     }
                 }
@@ -849,7 +865,7 @@ pub fn run(args: LauncherArgs) -> ! {
                                 }
                             }
                         }
-                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()));
+                        show_status(status_item.as_ref(), tray.as_ref(), &phase, &url, &version_label(upd.as_ref()), inbox);
                     }
                 }
             },
@@ -911,6 +927,117 @@ fn room_webapp_url(server_url: &str, room: platform::AdminRoom) -> String {
         Torrents => "torrent-view",
     };
     format!("{server_url}/admin#{view}")
+}
+
+/// One of the player's admin rooms in a real terminal — the same spawn as
+/// the wizard pages, so the same per-OS terminal choice and the same log
+/// surface. The room reuses the admin session the wizard saved (or asks
+/// once, in-room, and keeps what it gets); the browser panel's matching
+/// section is the fallback when this install has no player binary or no
+/// terminal opened.
+fn open_admin_room(
+    room: platform::AdminRoom,
+    player_bin: Option<&Path>,
+    url: &str,
+    data_home: &Path,
+    console: Option<&paths::ConsoleLaunch>,
+    log: &Logger,
+) {
+    let name = room.subcommand();
+    let mut opened = false;
+    if let Some(player) = player_bin {
+        match platform::open_player_terminal(player, url, data_home, console, platform::PlayerPage::Admin(room)) {
+            Ok(via) => {
+                log.line(&format!("{name} room opened via {via}"));
+                opened = true;
+            }
+            Err(e) => log.line(&format!("{name} room terminal failed: {e} - falling back to the admin panel")),
+        }
+    } else {
+        log.line(&format!("{name} room: no player binary in this install - falling back to the admin panel"));
+    }
+    if !opened {
+        let _ = open::that_detached(room_webapp_url(url, room));
+    }
+}
+
+/// Where the inbox line sits: under the status line (0) and the update
+/// line (1), above the first separator.
+const INBOX_POSITION: usize = 2;
+
+/// The inbox menu line's text.
+fn inbox_line(n: u32) -> String {
+    if n == 1 {
+        "1 federation request waiting".into()
+    } else {
+        format!("{n} federation requests waiting")
+    }
+}
+
+/// What the tooltip gains while peers wait — short: Windows keeps 127
+/// characters of a tooltip and the status text already spends most of them.
+fn inbox_suffix(n: u32) -> String {
+    match n {
+        0 => String::new(),
+        1 => " - 1 request waiting".into(),
+        n => format!(" - {n} requests waiting"),
+    }
+}
+
+/// The inbox line is PRESENT only while the count is non-zero — inserted
+/// under the update line, removed at zero, retitled in between. (muda has
+/// no hidden state for an item; insert/remove is the live primitive on all
+/// three backends.)
+fn sync_inbox_item(menu: &Menu, item: &mut Option<MenuItem>, n: u32) {
+    match (n, item.as_ref()) {
+        (0, None) => {}
+        (0, Some(existing)) => {
+            let _ = menu.remove(existing);
+            *item = None;
+        }
+        (_, Some(existing)) => existing.set_text(inbox_line(n)),
+        (_, None) => {
+            let fresh = MenuItem::with_id("federation-inbox", inbox_line(n), true, None);
+            let _ = menu.insert(&fresh, INBOX_POSITION);
+            *item = Some(fresh);
+        }
+    }
+}
+
+/// The icon's badge and the count beside it. `repaint`: false when the
+/// icon was just built for this count (startup) and only the title is due.
+/// set_title is the macOS menu-bar text and the appindicator label; a
+/// no-op on Windows, where the tooltip carries the number instead.
+fn apply_inbox_tray(tray: Option<&TrayIcon>, n: u32, repaint: bool) {
+    if let Some(t) = tray {
+        if repaint {
+            let _ = t.set_icon(Some(icon_for(n)));
+        }
+        t.set_title(if n > 0 { Some(n.to_string()) } else { None });
+    }
+}
+
+/// Re-read the server's facts file and, when the inbox count moved, reflect
+/// it in the menu line, the icon and the title. True when it moved — the
+/// caller re-renders the status line, whose tooltip carries the count too.
+fn sync_inbox(
+    inbox: &mut u32,
+    menu: Option<&Menu>,
+    item: &mut Option<MenuItem>,
+    tray: Option<&TrayIcon>,
+    log: &Logger,
+) -> bool {
+    let n = paths::read_tray_status().map(|s| s.federation_inbox).unwrap_or(0);
+    if n == *inbox {
+        return false;
+    }
+    *inbox = n;
+    log.line(&format!("federation inbox: {n} waiting"));
+    if let Some(m) = menu {
+        sync_inbox_item(m, item, n);
+    }
+    apply_inbox_tray(tray, n, true);
+    true
 }
 
 /// Spawn a server generation plus its two helper threads.
@@ -1357,12 +1484,14 @@ impl Phase {
 /// Push the phase into the status line and tooltip. Both handles are
 /// Options because the tray can be degraded away (no StatusNotifier host)
 /// while the loop, and the server, carry on.
-fn show_status(item: Option<&MenuItem>, tray: Option<&TrayIcon>, phase: &Phase, url: &str, ver: &str) {
+fn show_status(item: Option<&MenuItem>, tray: Option<&TrayIcon>, phase: &Phase, url: &str, ver: &str, inbox: u32) {
     if let Some(i) = item {
         i.set_text(phase.menu_text(ver));
     }
     if let Some(t) = tray {
-        let _ = t.set_tooltip(Some(phase.tooltip(url, ver)));
+        // The count rides on the tooltip too: on Windows the icon's dot is
+        // the only badge and hovering is how one asks what it means.
+        let _ = t.set_tooltip(Some(format!("{}{}", phase.tooltip(url, ver), inbox_suffix(inbox))));
     }
 }
 
@@ -1393,25 +1522,71 @@ fn format_uptime(d: Duration) -> String {
 /// Tray icon: the repo logo (build/icon.png), embedded at compile time; a
 /// plain fallback square if decoding ever fails — an icon must never be the
 /// reason the launcher dies.
-fn load_icon() -> Icon {
-    fn decode() -> Option<(Vec<u8>, u32, u32)> {
-        let bytes: &[u8] = include_bytes!("../../build/icon.png");
-        let decoder = png::Decoder::new(std::io::Cursor::new(bytes));
-        let mut reader = decoder.read_info().ok()?;
-        let mut buf = vec![0u8; reader.output_buffer_size()?];
-        let info = reader.next_frame(&mut buf).ok()?;
-        buf.truncate(info.buffer_size());
-        let rgba = match info.color_type {
-            png::ColorType::Rgba => buf,
-            png::ColorType::Rgb => buf.as_chunks::<3>().0.iter().flat_map(|p| [p[0], p[1], p[2], 255]).collect(),
-            _ => return None,
-        };
-        Some((rgba, info.width, info.height))
+/// The tray mark's pixels, decoded once from the embedded PNG
+/// (build/icon.png): the base every badge variant is painted over.
+fn base_icon() -> &'static (Vec<u8>, u32, u32) {
+    static BASE: std::sync::OnceLock<(Vec<u8>, u32, u32)> = std::sync::OnceLock::new();
+    BASE.get_or_init(|| {
+        fn decode() -> Option<(Vec<u8>, u32, u32)> {
+            let bytes: &[u8] = include_bytes!("../../build/icon.png");
+            let decoder = png::Decoder::new(std::io::Cursor::new(bytes));
+            let mut reader = decoder.read_info().ok()?;
+            let mut buf = vec![0u8; reader.output_buffer_size()?];
+            let info = reader.next_frame(&mut buf).ok()?;
+            buf.truncate(info.buffer_size());
+            let rgba = match info.color_type {
+                png::ColorType::Rgba => buf,
+                png::ColorType::Rgb => buf.as_chunks::<3>().0.iter().flat_map(|p| [p[0], p[1], p[2], 255]).collect(),
+                _ => return None,
+            };
+            Some((rgba, info.width, info.height))
+        }
+        decode().unwrap_or_else(|| ([124, 77, 255, 255].repeat(32 * 32), 32, 32))
+    })
+}
+
+/// The icon for an inbox count: the plain mark at zero, the mark wearing a
+/// red dot in its top-right corner otherwise — the one badge every OS can
+/// show (Windows has no badge API for notification-area icons, and a digit
+/// is illegible at the 16 px the tray draws). The number itself rides in
+/// the menu line, the tooltip, and the macOS / appindicator title.
+fn icon_for(inbox: u32) -> Icon {
+    let (base, w, h) = base_icon();
+    let mut rgba = base.clone();
+    if inbox > 0 {
+        paint_badge(&mut rgba, *w, *h);
     }
-    let (rgba, w, h) = decode().unwrap_or_else(|| ([124, 77, 255, 255].repeat(32 * 32), 32, 32));
-    Icon::from_rgba(rgba, w, h).unwrap_or_else(|_| {
+    Icon::from_rgba(rgba, *w, *h).unwrap_or_else(|_| {
         Icon::from_rgba([124, 77, 255, 255].repeat(32 * 32), 32, 32).expect("solid icon")
     })
+}
+
+/// A filled disc, top-right, a fifth of the icon wide, with a one-pixel soft
+/// edge: big enough to survive the tray's downscale, small enough to leave
+/// the mark recognisable. Straight (non-premultiplied) RGBA, source-over.
+fn paint_badge(rgba: &mut [u8], w: u32, h: u32) {
+    const RED: [f32; 3] = [232.0 / 255.0, 56.0 / 255.0, 48.0 / 255.0];
+    let (wf, hf) = (w as f32, h as f32);
+    let r = wf * 0.21;
+    let (cx, cy) = (wf * 0.76, hf * 0.24);
+    for y in 0..h {
+        for x in 0..w {
+            let d = ((x as f32 + 0.5 - cx).powi(2) + (y as f32 + 0.5 - cy).powi(2)).sqrt();
+            let cover = (r + 0.5 - d).clamp(0.0, 1.0);
+            if cover <= 0.0 {
+                continue;
+            }
+            let i = ((y * w + x) * 4) as usize;
+            let under_a = rgba[i + 3] as f32 / 255.0;
+            let out_a = cover + under_a * (1.0 - cover);
+            for c in 0..3 {
+                let under = rgba[i + c] as f32 / 255.0;
+                let v = (RED[c] * cover + under * under_a * (1.0 - cover)) / out_a.max(1e-6);
+                rgba[i + c] = (v * 255.0).round() as u8;
+            }
+            rgba[i + 3] = (out_a * 255.0).round() as u8;
+        }
+    }
 }
 
 struct Logger(std::path::PathBuf);
@@ -1515,6 +1690,55 @@ mod tests {
         assert_eq!(urls.len(), AdminRoom::ALL.len());
         assert_eq!(room_webapp_url("http://localhost:3000", AdminRoom::Libraries), "http://localhost:3000/admin#folders-view");
         assert_eq!(room_webapp_url("http://[::1]:3000", AdminRoom::Backups), "http://[::1]:3000/admin#backup-view");
+    }
+
+    #[test]
+    fn inbox_texts_count_in_english() {
+        assert_eq!(inbox_line(1), "1 federation request waiting");
+        assert_eq!(inbox_line(2), "2 federation requests waiting");
+        assert_eq!(inbox_line(999), "999 federation requests waiting");
+        assert_eq!(inbox_suffix(0), "", "no count, no suffix: the tooltip stays what it was");
+        assert_eq!(inbox_suffix(1), " - 1 request waiting");
+        assert_eq!(inbox_suffix(12), " - 12 requests waiting");
+        // The whole tooltip stays inside Windows' 127-character szTip even
+        // with a pinned address and the unverified note.
+        let tip = format!(
+            "{}{}",
+            Phase::Unverified { since: Instant::now() }.tooltip("http://192.168.100.200:3000", "6.26.0"),
+            inbox_suffix(999)
+        );
+        assert!(tip.encode_utf16().count() <= 127, "{} chars: {tip}", tip.encode_utf16().count());
+    }
+
+    #[test]
+    fn the_badge_is_a_disc_in_the_top_right_corner_and_nothing_else() {
+        let (w, h) = (64u32, 64u32);
+        let base: Vec<u8> = (0..w * h).flat_map(|_| [10, 20, 30, 255]).collect();
+        let mut painted = base.clone();
+        paint_badge(&mut painted, w, h);
+        let px = |buf: &[u8], x: u32, y: u32| {
+            let i = ((y * w + x) * 4) as usize;
+            [buf[i], buf[i + 1], buf[i + 2], buf[i + 3]]
+        };
+        // Centre (0.76, 0.24) of the icon, radius 0.21 of its width.
+        assert_eq!(px(&painted, 48, 15), [232, 56, 48, 255], "the disc's centre is the badge red");
+        assert_eq!(px(&painted, 48, 25), [232, 56, 48, 255], "inside the radius");
+        assert_eq!(px(&painted, 48, 31), [10, 20, 30, 255], "outside the radius: the mark");
+        assert_eq!(px(&painted, 32, 32), [10, 20, 30, 255], "the mark's centre is untouched");
+        assert_eq!(px(&painted, 8, 56), [10, 20, 30, 255], "the far corner is untouched");
+        let changed = (0..w * h).filter(|&i| painted[(i * 4) as usize..(i * 4 + 4) as usize] != base[(i * 4) as usize..(i * 4 + 4) as usize]).count();
+        let disc = std::f32::consts::PI * (64.0 * 0.21f32).powi(2);
+        assert!((changed as f32) > disc * 0.9 && (changed as f32) < disc * 1.25, "{changed} pixels changed for a disc of ~{disc:.0}");
+        // On transparent ground the disc is fully opaque, the ground stays clear.
+        let mut clear = vec![0u8; (w * h * 4) as usize];
+        paint_badge(&mut clear, w, h);
+        assert_eq!(px(&clear, 48, 15), [232, 56, 48, 255]);
+        assert_eq!(px(&clear, 8, 56), [0, 0, 0, 0]);
+        // The real mark decodes, and both variants build an icon.
+        let (_, bw, bh) = base_icon();
+        assert!(*bw >= 32 && *bh >= 32, "{bw}x{bh}");
+        let _ = icon_for(0);
+        let _ = icon_for(3);
     }
 
     fn status(json: &str) -> Option<crate::paths::UpdateStatus> {

--- a/src/api/admin-federation.js
+++ b/src/api/admin-federation.js
@@ -116,6 +116,8 @@ export function register(mstream) {
     raw.federation.enabled = enabled;
     await admin.saveFile(raw, config.configFile);
     config.program.federation.enabled = enabled;
+    // The tray's inbox count is gated on this flag (util/tray-status.js).
+    (await import('../util/tray-status.js')).kick(`federation ${enabled ? 'enabled' : 'disabled'}`);
 
     try {
       const federation = await import('../state/federation.js');

--- a/src/server.js
+++ b/src/server.js
@@ -61,6 +61,7 @@ import { isAdminAllowed } from './util/admin-network.js';
 import { writeJsonAtomic, completedWrites } from './util/atomic-json.js';
 import * as adminUtil from './util/admin.js';
 import * as updateCheck from './util/update-check.js';
+import * as trayStatus from './util/tray-status.js';
 import * as bootWatchdog from './util/boot-watchdog.js';
 
 
@@ -595,6 +596,10 @@ export async function serveIt(configFile, { relisten = null } = {}) {
     isScanning: () => (taskQueueMod ? taskQueueMod.isScanning() : true),
     msSinceActivity: () => Date.now() - lastUserRequestAt,
   });
+  // The tray's session-less facts file (tray-status.json): written once at
+  // boot so the launcher's post-boot read sees THIS run's truth, then from
+  // the transitions that change it (state/federation-requests.js).
+  trayStatus.refresh('boot').catch(() => {});
   scrobblerApi.setup(mstream);
   remoteApi.setupAfterAuth(mstream, server);
   sharedApi.setupAfterSecurity(mstream);

--- a/src/state/federation-requests.js
+++ b/src/state/federation-requests.js
@@ -37,6 +37,7 @@ import * as reqDb from '../db/federation-requests.js';
 import * as fedDb from '../db/federation.js';
 import * as db from '../db/manager.js';
 import * as p2p from './discovery-p2p.js';
+import * as trayStatus from '../util/tray-status.js';
 
 export const REQUEST_TTL_SECONDS = 14 * 24 * 3600;
 // Retry ladder for owed DMs (seconds): 1m → 5m → 30m → 6h, then 6h forever
@@ -204,6 +205,7 @@ export async function accept(id, { libraryIds, vpathNames, limits, expiresAt = n
     nextAttemptInSeconds: 0,
     failCount: 0,
   });
+  trayStatus.kick('request accepted');
   winston.info(`[federation-requests] ${row.uuid} accepted — minted key '${keyName}' `
     + `for [${vpathNames.join(', ')}]; sending the ticket`);
   attempt(id).catch((err) => winston.warn(`[federation-requests] accept delivery attempt failed: ${err.message}`));
@@ -216,6 +218,7 @@ export function reject(id, reason = null) {
   if (row.state !== 'received') { throw new Error(`cannot reject a request in state '${row.state}'`); }
   const clean = sanitize(reason, CAP.reason);
   reqDb.updateRequest(id, { state: 'rejected', rejectReason: clean, nextAttemptInSeconds: null });
+  trayStatus.kick('request rejected');
   winston.info(`[federation-requests] ${row.uuid} rejected${clean ? ` (${clean})` : ''} — `
     + `peer ${row.peer_endpoint_id.slice(0, 12)}… tombstoned for ${TOMBSTONE_DAYS} days`);
   sendCourtesy(row, { type: 'federation-reject', uuid: row.uuid, ...(clean ? { reason: clean } : {}) });
@@ -410,6 +413,10 @@ export async function runSweep() {
       }
     }
   }
+  // The tray file's catch-all: facts changed outside the transitions that
+  // kick it themselves (an expiry above, a config edit, a row moved by
+  // hand) land within one sweep. A no-op unless something differs.
+  trayStatus.kick('sweep');
   if (config.program.discoveryP2p.enabled !== true || !p2p.isRunning()) { return; }
   const due = reqDb.getDueRetries();
   await Promise.allSettled(due.map((row) => attempt(row.id)));
@@ -480,6 +487,7 @@ function handleRequest(from, payload) {
     state: 'received',
     ttlSeconds: REQUEST_TTL_SECONDS,
   });
+  trayStatus.kick('request received');
   winston.info(`[federation-requests] request ${row.uuid} received from `
     + `'${row.peer_name || 'unnamed'}' (${from.slice(0, 12)}…), offering `
     + `${offer.length ? offer.join(', ') : 'nothing'} — awaiting the operator`);
@@ -611,6 +619,7 @@ function handleWithdraw(from, payload) {
   if (!row) { return; }
   if (row.state === 'received') {
     reqDb.updateRequest(row.id, { state: 'cancelled', nextAttemptInSeconds: null });
+    trayStatus.kick('request withdrawn');
     winston.info(`[federation-requests] ${row.uuid} withdrawn by its sender`);
     return;
   }

--- a/src/util/tray-status.js
+++ b/src/util/tray-status.js
@@ -1,0 +1,90 @@
+// tray-status.json: the facts the desktop launcher shows on its tray icon
+// and menu WITHOUT a session — today one number, the federation requests
+// waiting on the operator. Same channel as update-check.js's
+// update-status.json: a file in the data home the launcher re-reads on its
+// minute tick and right after each boot. Nothing here touches the auth
+// wall — the launcher is by construction the operator's own process on the
+// server's own machine, and the file carries no more than the admin
+// panel's Requests badge does.
+//
+// Written at boot and from every transition that changes a fact (the
+// federation-requests engine kicks it, so does the live federation toggle),
+// and once per requests sweep as the catch-all for everything else (a
+// config edit, a row moved by hand). Only a CHANGE writes, so an idle
+// server never touches the file.
+import fs from 'fs/promises';
+import path from 'path';
+import winston from 'winston';
+import * as config from '../state/config.js';
+import * as reqDb from '../db/federation-requests.js';
+import { userDataHome } from './esm-helpers.js';
+import { writeJsonAtomic } from './atomic-json.js';
+
+export function trayStatusFilePath() {
+  return path.join(userDataHome(), 'tray-status.json');
+}
+
+// Inbound federation requests awaiting the operator: what server-info's
+// `federationInbox` shows an admin (the panel's Requests badge), gated the
+// same way minus the who-is-asking check. 0 when federation is off, or
+// when the admin API is locked — the room the tray line opens would only
+// show its gate, and the tray must not nag about something the operator
+// cannot act on from there.
+export function federationInbox() {
+  const program = config.program;
+  if (!program || program.lockAdmin === true || program.federation?.enabled !== true) { return 0; }
+  return reqDb.countPendingInbound();
+}
+
+// The document, minus the timestamp. One flat object of plain numbers and
+// booleans — the launcher's parser (rust-launcher paths.rs
+// parse_tray_status) tolerates missing keys, never extra ones failing it.
+export function collect() {
+  return { federationInbox: federationInbox() };
+}
+
+let last = null; // the facts as last written by this process
+
+// Recompute the facts and rewrite the file when they changed — always on
+// the first call of a process life, so a stale file from the previous run
+// is refreshed even when nothing differs. Resolves true when a write
+// landed. `file` overrides the destination (tests).
+export async function refresh(reason = '', { file = null } = {}) {
+  let facts;
+  try {
+    facts = collect();
+  } catch (err) {
+    winston.warn(`[tray-status] could not collect (${reason || 'refresh'}): ${err.message}`);
+    return false;
+  }
+  if (last && Object.keys(facts).every((k) => last[k] === facts[k])) { return false; }
+  // Claim the facts before the await: two transitions in the same tick
+  // must not both decide to write. A failed write releases the claim so
+  // the next kick tries again.
+  last = facts;
+  const target = file || trayStatusFilePath();
+  try {
+    // The data home may not exist yet: a server whose storage dirs all
+    // point elsewhere (a scratch config, a first boot before the launcher
+    // ever ran) has nothing else creating it, and the atomic writer
+    // creates no directories.
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await writeJsonAtomic(target, { ...facts, updatedAt: new Date().toISOString() });
+    if (reason) { winston.info(`[tray-status] ${reason}: federationInbox=${facts.federationInbox}`); }
+    return true;
+  } catch (err) {
+    last = null;
+    winston.warn(`[tray-status] could not write ${target}: ${err.message}`);
+    return false;
+  }
+}
+
+// Fire-and-forget for the engine's transitions: the caller's own work
+// never waits on, or fails because of, the tray file.
+export function kick(reason) {
+  refresh(reason).catch((err) => winston.warn(`[tray-status] ${reason}: ${err.message}`));
+}
+
+export function resetForTests() {
+  last = null;
+}

--- a/test/unit/tray-status.test.mjs
+++ b/test/unit/tray-status.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * tray-status.json — the launcher-facing facts file (src/util/tray-status.js):
+ *  - the inbox count is the inbound rows still in `received`, gated on
+ *    federation being on and the admin API unlocked (0 otherwise — the tray
+ *    must not nag about a room that would only show its gate);
+ *  - refresh writes on the first call of a process and on change only; a
+ *    repeat with the same facts leaves the file byte-identical;
+ *  - the document shape the launcher parses (rust-launcher/src/paths.rs
+ *    parse_tray_status): a flat object, `federationInbox` a plain number.
+ *
+ * Against a real manager-backed DB, like the V67 accessor suite.
+ */
+
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let tmpDir, file, config, manager, reqDb, tray;
+
+function request(direction, state) {
+  return reqDb.createRequest({
+    uuid: `uuid-${Math.random().toString(36).slice(2, 10)}`,
+    direction,
+    peerEndpointId: `peer-${Math.random().toString(36).slice(2, 10)}`,
+    state,
+    ttlSeconds: 14 * 24 * 3600,
+  });
+}
+
+const readDoc = () => JSON.parse(fs.readFileSync(file, 'utf8'));
+
+describe('tray-status.json (the launcher facts file)', () => {
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-tray-status-'));
+    fs.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({
+      storage: {
+        dbDirectory: path.join(tmpDir, 'db'),
+        albumArtDirectory: path.join(tmpDir, 'art'),
+        logsDirectory: path.join(tmpDir, 'logs'),
+      },
+      port: 0,
+      federation: { enabled: true },
+    }));
+    config = await import('../../src/state/config.js');
+    await config.setup(path.join(tmpDir, 'config.json'));
+    manager = await import('../../src/db/manager.js');
+    manager.initDB();
+    reqDb = await import('../../src/db/federation-requests.js');
+    tray = await import('../../src/util/tray-status.js');
+    file = path.join(tmpDir, 'tray-status.json');
+  });
+
+  after(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* windows locks */ }
+    setImmediate(() => process.exit(0)); // module-level timers, like the other DB-backed suites
+  });
+
+  test('counts inbound rows in `received` only, gated on federation on and admin unlocked', () => {
+    request('in', 'received');
+    request('in', 'received');
+    request('in', 'accepted');       // already answered: not waiting on anyone here
+    request('out', 'pending-delivery'); // ours: waiting on THEM
+    assert.equal(tray.federationInbox(), 2);
+
+    config.program.lockAdmin = true;
+    assert.equal(tray.federationInbox(), 0, 'a locked admin API has no room to answer from');
+    config.program.lockAdmin = false;
+
+    config.program.federation.enabled = false;
+    assert.equal(tray.federationInbox(), 0, 'federation off: nothing can be pending');
+    config.program.federation.enabled = true;
+    assert.equal(tray.federationInbox(), 2);
+  });
+
+  test('refresh writes on the first call and then only on change', async () => {
+    tray.resetForTests();
+    assert.equal(await tray.refresh('first', { file }), true);
+    const first = readDoc();
+    assert.equal(first.federationInbox, 2);
+    assert.ok(!Number.isNaN(Date.parse(first.updatedAt)), `updatedAt is a date: ${first.updatedAt}`);
+    assert.deepEqual(Object.keys(first).sort(), ['federationInbox', 'updatedAt'], 'flat, no surprises');
+
+    const bytes = fs.readFileSync(file, 'utf8');
+    assert.equal(await tray.refresh('same', { file }), false, 'nothing changed: no write');
+    assert.equal(fs.readFileSync(file, 'utf8'), bytes, 'byte-identical');
+
+    // The operator answers one, the other expires: two writes, then zero.
+    const [a, b] = reqDb.listRequests().filter((r) => r.direction === 'in' && r.state === 'received');
+    reqDb.updateRequest(a.id, { state: 'rejected' });
+    assert.equal(await tray.refresh('rejected', { file }), true);
+    assert.equal(readDoc().federationInbox, 1);
+    reqDb.updateRequest(b.id, { state: 'expired' });
+    assert.equal(await tray.refresh('expired', { file }), true);
+    assert.equal(readDoc().federationInbox, 0);
+    assert.equal(await tray.refresh('idle', { file }), false);
+  });
+
+  test('a fresh process rewrites even unchanged facts (a stale file from the last run)', async () => {
+    fs.writeFileSync(file, JSON.stringify({ federationInbox: 9, updatedAt: '2000-01-01T00:00:00.000Z' }));
+    tray.resetForTests(); // = a new process life
+    assert.equal(await tray.refresh('boot', { file }), true);
+    assert.equal(readDoc().federationInbox, 0);
+  });
+
+  test('writes into a data home that does not exist yet', async () => {
+    // A scratch config keeps every storage dir elsewhere, so nothing else
+    // creates the data home; the first boot must still land the file.
+    const deep = path.join(tmpDir, 'fresh-home', 'mStream', 'tray-status.json');
+    tray.resetForTests();
+    assert.equal(await tray.refresh('boot', { file: deep }), true);
+    assert.equal(JSON.parse(fs.readFileSync(deep, 'utf8')).federationInbox, 0);
+  });
+
+  test('kick never throws and never blocks the caller', () => {
+    tray.resetForTests();
+    assert.doesNotThrow(() => tray.kick('transition'));
+  });
+});


### PR DESCRIPTION
## What

While other mStream servers have federation pairing requests waiting on this operator, the tray says so:

```
mStream 6.26.0 · up 3h 12m          (status)
Up to date (6.26.0)                 (update)
2 federation requests waiting       ← new, only while > 0; click = the Federation room
─────────
Manage server ▸ …
```

plus a red dot on the tray icon on all three platforms, the count beside the icon where the OS draws one (the macOS menu bar; the appindicator label on Linux desktops that show it), and `- 2 requests waiting` on the tooltip (Windows/macOS — on Windows the dot is the only badge, and hovering is how one asks what it means). At zero the line is removed, the dot goes, the title clears.

The count is the inbound requests still in `received` — exactly what the admin panel's Requests badge shows — and 0 when federation is off or the admin API is locked (the room the line opens would only show its gate).

## How

**Server → launcher, no auth involved.** The launcher holds no session and the ping field carrying this number is admin-only, so the server hands it over the way it already hands update state: a file in the data home. `src/util/tray-status.js` writes `tray-status.json` (`{ federationInbox, updatedAt }`, atomic, only on change — an idle server never touches it) at boot and from every transition that moves the count: a request landing, accept, reject, a sender's withdraw, and once per requests sweep as the catch-all (expiry, a config edit, a row moved by hand; the sweep runs every minute). The live federation on/off toggle kicks it too. The writer creates the data home if it does not exist yet — a scratch config with every storage dir elsewhere has nothing else creating it (found by the end-to-end run below).

**Launcher.** `paths::read_tray_status` / `parse_tray_status` (absent or non-numeric → 0, capped at 999; a document that is not an object → None) mirror the update-status reader. The tray re-reads the file on the same minute tick as update-status.json and right after `ServerUp` (the booting server just rewrote it), and at startup from whatever the last run left, so the icon is built badged from the first frame. On change: the menu line is inserted at position 2 / retitled / removed (`Menu::insert`/`remove` — muda's live primitive on all three backends, verified below), the icon is repainted (`icon_for(n)`: the embedded mark, decoded once, with a disc painted over its top-right corner — straight-alpha source-over, one-pixel soft edge, radius a fifth of the width so it survives the 16 px downscale), `set_title` carries the count, and the tooltip gets its suffix. Clicking the line opens the Federation room through #982's `open_admin_room` (factored out of the Manage server arm), browser fallback included. `launcher.log` records each change (`federation inbox: N waiting`).

Docs: `docs/install.md` tray paragraph.

## Tests

- **Server** `test/unit/tray-status.test.mjs` (real manager-backed DB, like the V67 accessor suite): the count is inbound/received only and gated on federation + lockAdmin; refresh writes on the first call and then only on change (byte-identical file otherwise); a fresh process rewrites a stale file; the data home is created when absent; `kick` never throws.
- **Launcher** paths: tolerant parsing matrix (missing key, negative, string, fraction, cap, garbage, non-object). tray_app: the English of the line/suffix and the tooltip staying within Windows' 127-char szTip with a pinned address + the unverified note + 999; the badge paints a disc of the expected area in the top-right corner and nothing else, fully opaque over transparent ground; the real mark decodes and both icon variants build.

## Verified

- **Server end-to-end** (dev server from this branch, scratch config, federation on): boot with an empty inbox → `{"federationInbox": 0}`; one inbound `received` row seeded → next boot writes `1` (`[tray-status] boot: federationInbox=1`); `POST …/requests/2/reject` through the admin API → the file says `0` within the same second (`[tray-status] request rejected: federationInbox=0`).
- **Linux** (Docker rig, Xvfb + session bus, this branch's launcher over the 6.26.0 bundle; the file hand-written since that bundle's server predates the writer): boot with the file at 2 → dbusmenu layout shows `2 federation requests waiting` under the update line, `XAyatanaLabel` = `2`, icon file written; file → 0 → the poll removes the line (52 s), label empty, icon rewritten (`…-1-1.png`); file → 3 → line back at the same position with the new text, label `3`, icon `…-1-2.png` (pulled out of the tray's temp dir and inspected: a red disc over the mark's top-right corner, the mark otherwise untouched); `Event clicked` on the line → `menu: federation inbox` → the Federation room opened in xfce4-terminal.
- **Windows** (this branch's launcher, scratch server on :3999, MSAA readout of the notification area): tooltip `mStream 6.26.0 - http://localhost:3999 (up 2m) - 2 requests waiting` at boot from the file; file → 0 → suffix gone on the next tick; file → 3 → `- 3 requests waiting`. Launcher tests 42 passed, clippy clean; macOS target cross-checked with clippy (tests included).
- **Not driven**: a real Mac (the `set_title` counter beside the menu-bar icon is the crate's documented behaviour; the mac unit tests run in CI), and a request arriving over a live iroh DM (the receive hook sits next to the row insert in `handleRequest`; the integration suite needs the sidecar binary, absent here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
