### PR TITLE
feat(api): POST /api/v1/sync/manifest — library manifest for client-side mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ removed.
 
 ### ✨ New features
 
+- **Library sync manifest.** `POST /api/v1/sync/manifest` (authenticated,
+  every user) lists every track the caller can see — ascending by id,
+  paged by cursor — as the lite metadata row plus the identity a
+  client-side mirror needs (file size, mtime, `hash` / `audio-hash` and
+  the hash scheme generation). A `revision` over the visible set doubles
+  as the `ETag`: send it back as `If-None-Match` on the first page and a
+  periodic sync costs one 304. Advertised by the `sync` flag in
+  `GET /api/` `features` (and flat on `/api/v1/ping`). The server half of
+  the mobile / desktop app's "keep a full copy of this library" and
+  offline browsing. See `docs/openapi.yaml`.
 - **Enrichment scan status API.** `GET /api/v1/scan/status`
   (authenticated, not admin-only) reports every post-scan enrichment
   pass — waveforms, album-art download, lyrics backfill, BPM/key

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -89,6 +89,8 @@ tags:
     description: Directory browsing, upload, M3U parsing.
   - name: Download
     description: Multi-file ZIP downloads.
+  - name: Sync
+    description: Paged library manifest for client-side mirrors and offline indexes.
   - name: Transcode
     description: On-the-fly audio transcoding via ffmpeg.
   - name: Album Art
@@ -441,6 +443,60 @@ components:
           type: boolean
         has-synced-lyrics:
           type: boolean
+
+    SyncManifestEntry:
+      type: object
+      description: |
+        One track in the library manifest: the lite `{filepath, metadata}` row every
+        list endpoint returns, plus the identity fields a mirror needs to keep a
+        byte-identical local copy without touching the file. Multi-word keys are
+        kebab-case, matching `Metadata`.
+      properties:
+        filepath:
+          type: string
+          description: Virtual path (`<vpath>/<rel>`), forward slashes.
+        metadata: { $ref: "#/components/schemas/MetadataLite" }
+        id:
+          type: integer
+          description: Track row id — the paging cursor.
+        file-size: { type: integer, nullable: true, description: "Bytes." }
+        modified: { type: integer, nullable: true, description: "File mtime, epoch milliseconds." }
+        hash:
+          type: string
+          nullable: true
+          description: Whole-file content hash (full MD5 below 25 MB, sampled above — see `hash-v`).
+        audio-hash:
+          type: string
+          nullable: true
+          description: Audio-payload hash, stable across tag edits — the key for rename detection.
+        hash-v:
+          type: integer
+          nullable: true
+          description: Hash scheme generation the row's hashes were computed under (2 = sampled above 25 MB).
+        format: { type: string, nullable: true }
+        album-id: { type: integer, nullable: true }
+        artist-id: { type: integer, nullable: true }
+        created-at: { type: string, nullable: true, description: "When the row was first scanned." }
+
+    SyncManifest:
+      type: object
+      properties:
+        revision:
+          type: string
+          description: |
+            Revision of the caller's visible library set (row count, max id, max mtime,
+            art count, scope). Also sent as the `ETag`. Covers library content only —
+            not per-user ratings or play counts.
+        scanning:
+          type: boolean
+          description: A scan is running; rows can be transiently absent, so a missing path is not a deletion.
+        next:
+          type: integer
+          nullable: true
+          description: Cursor for the next page, or null on the last page.
+        entries:
+          type: array
+          items: { $ref: "#/components/schemas/SyncManifestEntry" }
 
     Album:
       type: object
@@ -1026,6 +1082,13 @@ paths:
                       discoveryP2p:
                         type: boolean
                         description: The discovery network feature is enabled.
+                      sync:
+                        type: boolean
+                        description: >
+                          This server serves `POST /api/v1/sync/manifest` (the
+                          library manifest behind client-side mirrors and
+                          offline indexes). Absent on older servers — gate on
+                          the key, never on a probe.
                       transcode:
                         description: >
                           false when unavailable; otherwise the server's
@@ -1097,6 +1160,7 @@ paths:
                   discoveryReady: true
                   discovery: true
                   discoveryP2p: false
+                  sync: true
                   transcode: false
                   supportedAudioFiles: { mp3: true, flac: true }
         "401":
@@ -3413,6 +3477,56 @@ paths:
           content:
             application/zip:
               schema: { type: string, format: binary }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  # ── Sync ─────────────────────────────────────────────────────────────────
+
+  /api/v1/sync/manifest:
+    post:
+      tags: [Sync]
+      summary: Library manifest (paged)
+      description: |
+        Every track the caller can see, ascending by id, for client-side mirrors and
+        offline indexes: the lite metadata block plus size / mtime / hashes. Page with
+        `cursor` = the previous page's `next`. Send the last `revision` back as
+        `If-None-Match` on the first page (no `cursor`) to get a 304 when nothing
+        changed. Advertised by the `sync` flag in `GET /api/v1/ping`.
+      parameters:
+        - in: header
+          name: If-None-Match
+          required: false
+          schema: { type: string }
+          description: A previously returned `revision`, quoted as the `ETag` header carried it.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              allOf:
+                - type: object
+                  properties:
+                    cursor:
+                      type: integer
+                      minimum: 0
+                      description: Return rows with an id greater than this. Omit for the first page.
+                    limit:
+                      type: integer
+                      minimum: 1
+                      maximum: 5000
+                      default: 2000
+                - { $ref: "#/components/schemas/IgnoreVPaths" }
+      responses:
+        "200":
+          description: One page. The `ETag` header carries the revision.
+          headers:
+            ETag:
+              schema: { type: string }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SyncManifest" }
+        "304":
+          description: Nothing changed since the revision in `If-None-Match` (first page only).
+        "400": { description: "Validation failed." }
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   # ── Transcode ────────────────────────────────────────────────────────────

--- a/src/api/playlist.js
+++ b/src/api/playlist.js
@@ -30,6 +30,8 @@ export function setup(mstream) {
       discoveryP2p: features.discoveryP2p,
       // Stats API v2 version — the same fact /api/ carries under features.
       stats: features.stats,
+      // Library sync manifest route — same fact, same place on /api/.
+      sync: features.sync,
       // A resource (the playlist routes), not a server capability.
       playlists: getPlaylists(req.user.id),
       // Historical version-gate ("this server has the sonic-path route") —

--- a/src/api/server-info.js
+++ b/src/api/server-info.js
@@ -90,6 +90,11 @@ export function buildFeatures() {
     // version string. 2 = ingest, reads and management together; a partial
     // surface was never advertised.
     stats: 2,
+    // Library sync manifest (POST /api/v1/sync/manifest) — the server half
+    // of the mobile / desktop app's local mirror + offline index. Same
+    // contract as the discovery flags: the key's presence says this VERSION
+    // has the route; clients never probe for it.
+    sync: true,
   };
 }
 

--- a/src/api/sync.js
+++ b/src/api/sync.js
@@ -1,0 +1,133 @@
+// Library sync manifest — the server half of the app's local mirror and
+// offline index (mstream_music: BACKUP_SYNC_PLAN.md / BACKUP_SYNC_IMPLEMENTATION.md §1).
+//
+// One paged, id-ordered listing of every track the caller can see, carrying
+// both halves of what a mirror needs:
+//   - identity for byte-exact sync: file size, mtime, file_hash / audio_hash
+//     (+ the hash scheme generation), so a client can decide unchanged /
+//     changed / renamed without touching the file;
+//   - the lite metadata block + genres (the same `metadata` object every
+//     list endpoint returns), so an offline library index never needs a
+//     per-track /db/metadata round-trip.
+//
+// Change detection is a revision string over the caller's visible set,
+// returned as `revision` and as the ETag. A client that sends it back as
+// If-None-Match on its first page gets a 304 and does nothing — the common
+// case for a periodic sync.
+//
+// Flag, never a probe: /api/v1/ping advertises `sync: true` on servers that
+// have this route; older builds omit the key.
+
+import Joi from 'joi';
+import * as db from '../db/manager.js';
+import * as dbQueue from '../db/task-queue.js';
+import { joiValidate } from '../util/validation.js';
+import {
+  libraryFilter, trackQuery, enrichRowsWithGenres, renderMetadataObj, toLiteMetadata,
+} from './db.js';
+
+export const MANIFEST_DEFAULT_LIMIT = 2000;
+export const MANIFEST_MAX_LIMIT = 5000;
+
+// Revision of the caller's visible library set: four cheap aggregates in one
+// indexed pass. Row count (adds / deletes), max id (a delete + add that keeps
+// the count — ids are AUTOINCREMENT, so a new row always raises it), max
+// mtime (any file change), and the number of rows carrying album art (the
+// art backfill sets album_art_file without touching mtime). Prefixed with the
+// library ids so a scope change is its own revision. Deliberately NOT
+// covering per-user state (ratings, play counts): that changes on every
+// play and would make the 304 fast path nearly useless.
+export function manifestRevision(d, filter) {
+  const row = d.prepare(`
+    SELECT COUNT(*) AS n, MAX(t.id) AS max_id, MAX(t.modified) AS max_modified,
+           COUNT(t.album_art_file) AS with_art
+      FROM tracks t
+     WHERE ${filter.clause}
+  `).get(...filter.params);
+  return `${filter.params.join('.')}:${row.n}:${row.max_id ?? 0}:${row.max_modified ?? 0}:${row.with_art}`;
+}
+
+// One page: up to `limit` rows with id > cursor, ascending id. `next` is the
+// last id on the page when more rows exist, else null — learned by fetching
+// limit + 1 rows rather than paying a COUNT per page.
+export function manifestPage(d, filter, userId,
+  { cursor = 0, limit = MANIFEST_DEFAULT_LIMIT } = {}) {
+  // trackQuery's user_metadata join binds the user id BEFORE the WHERE
+  // params (same order recent/added uses).
+  const userParams = userId ? [userId] : [];
+  const rows = d.prepare(`
+    ${trackQuery(userId, { includeGenres: false })}
+    WHERE ${filter.clause} AND t.id > ?
+    ORDER BY t.id
+    LIMIT ?
+  `).all(...userParams, ...filter.params, cursor, limit + 1);
+  const more = rows.length > limit;
+  if (more) { rows.length = limit; }
+  enrichRowsWithGenres(d, rows);
+  return {
+    entries: rows.map(toManifestEntry),
+    next: more ? rows[rows.length - 1].id : null,
+  };
+}
+
+// The lite `{filepath, metadata}` row every list endpoint returns, plus the
+// sync-only identity fields at the top level. Multi-word keys are kebab-case
+// on the wire, matching renderMetadataObj.
+function toManifestEntry(row) {
+  const full = renderMetadataObj(row);
+  return {
+    filepath: full.filepath,
+    metadata: toLiteMetadata(full.metadata),
+    id: row.id,
+    'file-size': row.file_size ?? null,
+    modified: row.modified ?? null,
+    hash: row.file_hash || null,
+    'audio-hash': row.audio_hash || null,
+    'hash-v': row.hash_v ?? null,
+    format: row.format || null,
+    'album-id': row.album_id ?? null,
+    'artist-id': row.artist_id ?? null,
+    'created-at': row.created_at || null,
+  };
+}
+
+// If-None-Match may carry several entity tags, each optionally weak
+// (`W/"…"`). Ours is strong; match on the tag value alone.
+function matchesEtag(header, revision) {
+  if (!header) { return false; }
+  return header.split(',').some((tag) =>
+    tag.trim().replace(/^W\//, '').replace(/^"|"$/g, '') === revision);
+}
+
+export function setup(mstream) {
+  const d = () => db.getDB();
+
+  mstream.post('/api/v1/sync/manifest', (req, res) => {
+    const schema = Joi.object({
+      cursor: Joi.number().integer().min(0).optional(),
+      limit: Joi.number().integer().min(1).max(MANIFEST_MAX_LIMIT).optional(),
+      ignoreVPaths: Joi.array().items(Joi.string()).optional(),
+    });
+    const { value } = joiValidate(schema, req.body ?? {});
+
+    const filter = libraryFilter(req.user, value.ignoreVPaths);
+    const revision = manifestRevision(d(), filter);
+    res.set('ETag', `"${revision}"`);
+    // Only the first page asks "has anything changed?" — a cursor means the
+    // client is mid-walk and must get its rows whatever the tag says.
+    if (value.cursor === undefined && matchesEtag(req.get('If-None-Match'), revision)) {
+      return res.status(304).end();
+    }
+
+    const page = manifestPage(d(), filter, req.user?.id,
+      { cursor: value.cursor, limit: value.limit });
+    res.json({
+      revision,
+      // Rows can be transiently absent mid-scan: a client must not read a
+      // missing path as a deletion while this is true.
+      scanning: dbQueue.isScanning(),
+      next: page.next,
+      entries: page.entries,
+    });
+  });
+}

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ import { dataRoot, usingFallbackDataRoot } from './util/esm-helpers.js';
 import { installedPlayerPath, playerLoadableHere } from './util/mstream-player-bootstrap.js';
 
 import * as dbApi from './api/db.js';
+import * as syncApi from './api/sync.js';
 import * as statsApi from './api/stats.js';
 import { startRetentionSweep, stopRetentionSweep } from './stats/retention.js';
 import * as discoveryApi from './api/discovery.js';
@@ -573,6 +574,7 @@ export async function serveIt(configFile, { relisten = null } = {}) {
   discoveryP2pApi.setup(mstream);
   discoveryFederationApi.setup(mstream);
   dbApi.setup(mstream);
+  syncApi.setup(mstream);
   statsApi.setup(mstream);
   startRetentionSweep();
   searchApi.setup(mstream);

--- a/test/db/sync-manifest.test.mjs
+++ b/test/db/sync-manifest.test.mjs
@@ -1,0 +1,307 @@
+/**
+ * POST /api/v1/sync/manifest — the paged library manifest behind the app's
+ * local mirror / offline index (mstream_music BACKUP_SYNC_PLAN.md):
+ *
+ *   - every visible track, ascending id, as the lite `{filepath, metadata}`
+ *     row plus the sync identity fields (size / mtime / hashes / scheme);
+ *   - id-cursor paging with no gaps or overlap, even when a row lands
+ *     mid-walk, and a full last page still ends with `next: null`;
+ *   - the same library scoping as every db/* route (grant + ignoreVPaths);
+ *   - a revision that moves on add / delete / mtime bump / art backfill /
+ *     scope change and returns to its old value when the set is restored,
+ *     doubling as a strong ETag: If-None-Match on the first page → 304, a
+ *     cursor never short-circuits;
+ *   - the per-user rating rides in the lite block (pins trackQuery's
+ *     user-id-first parameter order);
+ *   - Joi validation → 400 through the same handler shape server.js mounts.
+ *
+ * Mounted on a bare express app so req.user can be driven directly, like
+ * db-read-paths.test.mjs.
+ */
+
+import { describe, before, after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import express from 'express';
+import Joi from 'joi';
+
+let testRoot, server, base;
+let manager, dbApi, syncApi;
+let LIB_A, LIB_B, ALICE, BOB, FIRST, USER_ID;
+let asUser = null;      // null => public mode (every library visible)
+const ids = {};         // fixture track ids by label, in insertion order
+
+// One track row with every column the manifest surfaces. Deterministic
+// per-row values (hashes f<n>/a<n>, mtime 1.7e12 + n s, created 2024-01-0n)
+// so assertions can name them.
+function addTrack(label, lib, filepath, artist, album, track, size, art) {
+  const n = Object.keys(ids).length + 1;
+  const r = manager.getDB().prepare(`INSERT INTO tracks
+    (filepath, library_id, title, artist_id, album_id, track_number, disc_number, year,
+     duration, format, file_size, file_hash, audio_hash, hash_v, modified, created_at,
+     album_art_file)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+    .run(filepath, lib, `Track ${n}`, artist, album, track, 1, 2001, 200 + n,
+      path.extname(filepath).slice(1), size, `f${n}`, `a${n}`, 2,
+      1_700_000_000_000 + n * 1000, `2024-01-0${n} 00:00:00`, art);
+  ids[label] = Number(r.lastInsertRowid);
+  return ids[label];
+}
+
+before(async () => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mstream-sync-'));
+  fs.mkdirSync(path.join(testRoot, 'db'), { recursive: true });
+  fs.writeFileSync(path.join(testRoot, 'config.json'), JSON.stringify({
+    storage: {
+      dbDirectory: path.join(testRoot, 'db'),
+      albumArtDirectory: path.join(testRoot, 'art'),
+      logsDirectory: path.join(testRoot, 'logs'),
+      waveformCacheDirectory: path.join(testRoot, 'waveforms'),
+    },
+    port: 0,
+  }, null, 2));
+
+  const config = await import('../../src/state/config.js');
+  await config.setup(path.join(testRoot, 'config.json'));
+  manager = await import('../../src/db/manager.js');
+  manager.initDB();
+  dbApi = await import('../../src/api/db.js');
+  syncApi = await import('../../src/api/sync.js');
+
+  const d = manager.getDB();
+  d.exec('BEGIN');
+  for (const name of ['libA', 'libB']) {
+    d.prepare(`INSERT INTO libraries (name, root_path, type, follow_symlinks)
+               VALUES (?, ?, 'music', 0)`).run(name, path.join(testRoot, name));
+  }
+  manager.invalidateCache();
+  LIB_A = d.prepare("SELECT id FROM libraries WHERE name='libA'").get().id;
+  LIB_B = d.prepare("SELECT id FROM libraries WHERE name='libB'").get().id;
+
+  const insArtist = d.prepare('INSERT INTO artists (name) VALUES (?)');
+  ALICE = Number(insArtist.run('Alice').lastInsertRowid);
+  BOB = Number(insArtist.run('Bob').lastInsertRowid);
+  const insAlbum = d.prepare(
+    'INSERT INTO albums (name, artist_id, year, album_art_file) VALUES (?, ?, ?, ?)');
+  FIRST = Number(insAlbum.run('First', ALICE, 2001, 'aa.jpg').lastInsertRowid);
+  const second = Number(insAlbum.run('Second', BOB, 2002, null).lastInsertRowid);
+  const hidden = Number(insAlbum.run('Hidden', BOB, 2003, null).lastInsertRowid);
+
+  addTrack('a1', LIB_A, 'Alice/First/01.flac', ALICE, FIRST, 1, 1000, 'aa.jpg');
+  addTrack('a2', LIB_A, 'Alice/First/02.flac', ALICE, FIRST, 2, 2000, 'aa.jpg');
+  addTrack('b1', LIB_A, 'Bob/Second/01.mp3', BOB, second, 1, 3000, null);
+  // The shape a Windows-hosted scan stores; the wire form is forward-slash.
+  addTrack('b2', LIB_A, 'Bob\\Second\\02.mp3', BOB, second, 2, 4000, null);
+  addTrack('h1', LIB_B, 'Hidden/01.ogg', BOB, hidden, 1, 5000, null);
+
+  for (const g of ['Rock', 'Jazz']) { d.prepare('INSERT INTO genres (name) VALUES (?)').run(g); }
+  const genreId = (g) => d.prepare('SELECT id FROM genres WHERE name = ?').get(g).id;
+  const insTg = d.prepare('INSERT INTO track_genres (track_id, genre_id) VALUES (?, ?)');
+  insTg.run(ids.a1, genreId('Rock'));
+  insTg.run(ids.a2, genreId('Rock'));
+  insTg.run(ids.h1, genreId('Jazz'));
+
+  // A real user with one rating: user_metadata keys on COALESCE(audio_hash,
+  // file_hash), i.e. 'a1' for track a1.
+  USER_ID = Number(d.prepare(
+    "INSERT INTO users (username, password, salt, is_admin) VALUES ('rater', '!', '!', 0)")
+    .run().lastInsertRowid);
+  d.prepare('INSERT INTO user_metadata (user_id, track_hash, rating) VALUES (?, ?, ?)')
+    .run(USER_ID, 'a1', 8);
+  d.exec('COMMIT');
+
+  const app = express();
+  app.use(express.json({ limit: '10mb' }));
+  app.use((req, _res, next) => { req.user = asUser ?? undefined; next(); });
+  syncApi.setup(app);
+  // The shape server.js mounts: Joi validation → 400, anything else → 500.
+  app.use((error, _req, res, _next) => {
+    res.status(error instanceof Joi.ValidationError ? 400 : 500).json({ error: error.message });
+  });
+  server = http.createServer(app);
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  try { if (server) { server.close(); } } catch (_e) { /* closed */ }
+  try { manager.close(); } catch (_e) { /* closed */ }
+  try { fs.rmSync(testRoot, { recursive: true, force: true }); } catch (_e) { /* win locks */ }
+  setImmediate(() => process.exit(0));
+});
+
+async function manifest(body = {}, headers = {}) {
+  const r = await fetch(`${base}/api/v1/sync/manifest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+  const text = await r.text();
+  return { status: r.status, etag: r.headers.get('etag'), text, body: text ? JSON.parse(text) : null };
+}
+// Scope the next calls to a library set (the federation-grant shape, which is
+// the same input libraryFilter sees for a vpath-restricted user); `id` drives
+// the per-user joins.
+const scopeTo = (libIds, id = null) => { asUser = libIds ? { id, libraryIds: libIds } : null; };
+const entryIds = (r) => r.body.entries.map((e) => e.id);
+
+describe('sync/manifest', () => {
+  test('lists every visible track ascending by id with lite metadata + sync identity', async () => {
+    scopeTo(null);
+    const r = await manifest();
+    assert.equal(r.status, 200);
+    const { revision, scanning, next, entries } = r.body;
+    assert.equal(typeof revision, 'string');
+    assert.equal(scanning, false);
+    assert.equal(next, null, 'one page holds the whole fixture');
+    assert.deepEqual(entryIds(r), [ids.a1, ids.a2, ids.b1, ids.b2, ids.h1]);
+
+    const e = entries[0];
+    assert.equal(e.filepath, 'libA/Alice/First/01.flac');
+    assert.deepEqual(Object.keys(e.metadata).sort(), [...dbApi.LITE_METADATA_FIELDS].sort(),
+      'metadata is exactly the lite block');
+    assert.equal(e.metadata.title, 'Track 1');
+    assert.equal(e.metadata.artist, 'Alice');
+    assert.equal(e.metadata.album, 'First');
+    assert.equal(e.metadata.track, 1);
+    assert.equal(e.metadata.duration, 201);
+    assert.equal(e.metadata['album-art'], 'aa.jpg');
+    assert.deepEqual(e.metadata.genres, ['Rock']);
+    assert.equal(e.metadata.rating, null, 'public mode has no user to rate as');
+
+    assert.equal(e.id, ids.a1);
+    assert.equal(e['file-size'], 1000);
+    assert.equal(e.modified, 1_700_000_001_000);
+    assert.equal(e.hash, 'f1');
+    assert.equal(e['audio-hash'], 'a1');
+    assert.equal(e['hash-v'], 2);
+    assert.equal(e.format, 'flac');
+    assert.equal(e['album-id'], FIRST);
+    assert.equal(e['artist-id'], ALICE);
+    assert.equal(e['created-at'], '2024-01-01 00:00:00');
+    // The sync fields are an explicit allowlist — nothing else from the full
+    // block leaks to the top level.
+    assert.equal('bitrate' in e, false);
+    assert.equal('play-count' in e.metadata, false);
+    assert.deepEqual(entries.find((x) => x.id === ids.h1).metadata.genres, ['Jazz']);
+  });
+
+  test('renders backslash filepaths with forward slashes', async () => {
+    scopeTo(null);
+    const r = await manifest();
+    assert.equal(r.body.entries.find((e) => e.id === ids.b2).filepath, 'libA/Bob/Second/02.mp3');
+  });
+
+  test('scopes to the caller\'s libraries and honours ignoreVPaths', async () => {
+    scopeTo([LIB_B]);
+    assert.deepEqual(entryIds(await manifest()), [ids.h1]);
+
+    scopeTo(null);
+    const trimmed = await manifest({ ignoreVPaths: ['libB'] });
+    assert.deepEqual(entryIds(trimmed), [ids.a1, ids.a2, ids.b1, ids.b2]);
+
+    scopeTo([]);
+    const nothing = await manifest();
+    assert.equal(nothing.status, 200);
+    assert.deepEqual(nothing.body.entries, []);
+    assert.equal(nothing.body.next, null);
+    assert.equal(typeof nothing.body.revision, 'string');
+  });
+
+  test('the per-user rating rides in the lite block', async () => {
+    scopeTo([LIB_A, LIB_B], USER_ID);
+    const r = await manifest();
+    assert.equal(r.status, 200);
+    assert.equal(r.body.entries.find((e) => e.id === ids.a1).metadata.rating, 8);
+    assert.equal(r.body.entries.find((e) => e.id === ids.a2).metadata.rating, null);
+  });
+
+  test('ETag / If-None-Match: 304 on a matching tag, first page only', async () => {
+    scopeTo(null);
+    const first = await manifest();
+    assert.equal(first.status, 200);
+    assert.equal(first.etag, `"${first.body.revision}"`, 'the ETag is the quoted revision');
+
+    const again = await manifest({}, { 'If-None-Match': first.etag });
+    assert.equal(again.status, 304);
+    assert.equal(again.text, '');
+    assert.equal(again.etag, first.etag, 'a 304 still carries the ETag');
+
+    assert.equal((await manifest({}, { 'If-None-Match': `W/${first.etag}` })).status, 304,
+      'a weak tag with the same value matches');
+    assert.equal((await manifest({}, { 'If-None-Match': `"stale", ${first.etag}` })).status, 304,
+      'any tag in a list matches');
+
+    const stale = await manifest({}, { 'If-None-Match': '"nope"' });
+    assert.equal(stale.status, 200);
+    assert.equal(stale.body.entries.length, 5);
+
+    const paged = await manifest({ cursor: 0 }, { 'If-None-Match': first.etag });
+    assert.equal(paged.status, 200, 'a cursor is a walk in progress — never a 304');
+    assert.equal(paged.body.entries.length, 5);
+  });
+
+  test('pages by id with no gaps or overlap, even when a row lands mid-walk', async () => {
+    scopeTo(null);
+    const p1 = await manifest({ limit: 2 });
+    assert.deepEqual(entryIds(p1), [ids.a1, ids.a2]);
+    assert.equal(p1.body.next, ids.a2);
+
+    // A scan adds a track while the client is between pages.
+    addTrack('late', LIB_A, 'Late/01.mp3', BOB, null, 1, 6000, null);
+
+    const p2 = await manifest({ limit: 2, cursor: p1.body.next });
+    assert.deepEqual(entryIds(p2), [ids.b1, ids.b2]);
+    assert.equal(p2.body.next, ids.b2);
+
+    const p3 = await manifest({ limit: 2, cursor: p2.body.next });
+    assert.deepEqual(entryIds(p3), [ids.h1, ids.late], 'the new row appears at the end');
+    assert.equal(p3.body.next, null, 'a full last page still ends the walk');
+
+    const walked = [...entryIds(p1), ...entryIds(p2), ...entryIds(p3)];
+    assert.deepEqual(walked, [...new Set(walked)], 'no duplicates');
+    assert.deepEqual(walked, entryIds(await manifest()), 'the pages are the whole listing');
+  });
+
+  test('revision: stable when nothing changed, moves on add / mtime / art / delete / scope', async () => {
+    scopeTo(null);
+    const r0 = (await manifest()).body.revision;
+    assert.equal((await manifest()).body.revision, r0, 'a no-op call is a no-op');
+
+    const d = manager.getDB();
+    const extra = addTrack('extra', LIB_A, 'Extra/01.mp3', BOB, null, 1, 7000, null);
+    const r1 = (await manifest()).body.revision;
+    assert.notEqual(r1, r0, 'an added row');
+
+    d.prepare('UPDATE tracks SET modified = modified + 5000 WHERE id = ?').run(extra);
+    const r2 = (await manifest()).body.revision;
+    assert.notEqual(r2, r1, 'a changed file (mtime)');
+
+    d.prepare("UPDATE tracks SET album_art_file = 'zz.jpg' WHERE id = ?").run(extra);
+    const r3 = (await manifest()).body.revision;
+    assert.notEqual(r3, r2, 'the art backfill, which leaves mtime alone');
+
+    d.prepare('DELETE FROM tracks WHERE id = ?').run(extra);
+    const r4 = (await manifest()).body.revision;
+    assert.notEqual(r4, r3, 'a deleted row');
+    assert.equal(r4, r0, 'the original set is the original revision — the string is a pure function of it');
+
+    scopeTo([LIB_A]);
+    assert.notEqual((await manifest()).body.revision, r0, 'a different scope is a different revision');
+  });
+
+  test('validation failures are 400s', async () => {
+    scopeTo(null);
+    for (const body of [
+      { limit: 0 }, { limit: 5001 }, { limit: 1.5 }, { cursor: -1 }, { cursor: 'x' },
+      { ignoreVPaths: 'libB' }, { bogus: true },
+    ]) {
+      const r = await manifest(body);
+      assert.equal(r.status, 400, `${JSON.stringify(body)} must be rejected`);
+      assert.equal(typeof r.body.error, 'string');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The server half of the mobile / desktop app's upcoming **library mirror + offline index** (mstream_music `BACKUP_SYNC_PLAN.md` / `BACKUP_SYNC_IMPLEMENTATION.md` §1). One new route, one new capability flag, no schema change.

**`POST /api/v1/sync/manifest`** — every track the caller can see, ascending by id, paged by cursor. Each entry is the lite `{filepath, metadata}` row every list endpoint already returns (title / artist / album / art / genres / rating …) plus the identity a mirror needs to keep a byte-identical copy without touching the file: `file-size`, `modified`, `hash`, `audio-hash`, `hash-v`, `format`, `album-id`, `artist-id`, `created-at`.

- Scope is `libraryFilter` (grant + `ignoreVPaths`), exactly like `db/*`.
- `revision` = row count + max id + max mtime + art count over the visible set, prefixed by the library ids. Sent as the `ETag`; `If-None-Match` on the first page (no `cursor`) → **304**, so a periodic sync that finds nothing new costs one round-trip. A cursor never short-circuits. Per-user state (ratings, play counts) is deliberately outside the revision.
- `scanning` mirrors `dbQueue.isScanning()` so a client never reads a transiently-missing row as a deletion mid-scan.
- Pages fetch `limit + 1` rows to learn whether a next page exists — no COUNT per page. `limit` 1–5000, default 2000; genres attached with the batched `enrichRowsWithGenres`, never the whole-table join.
- **Not** on the federation allowlist.

**`sync: true`** in `buildFeatures()` — under `features` on `GET /api/`, flat on `/api/v1/ping` — following the house rule (flags, never probes). Older servers omit the key.

Also: `docs/openapi.yaml` (new `Sync` tag, path, `SyncManifest` / `SyncManifestEntry` schemas, `features.sync`), CHANGELOG entry.

## Test plan

- [x] `test/db/sync-manifest.test.mjs` (new, 8 tests on a bare express mount like `db-read-paths`): listing shape + lite key set, backslash path rendering, library scoping + `ignoreVPaths` + empty grant, per-user rating (pins the user-id-first param order), ETag / weak tag / tag list / stale tag / cursor-never-304, id paging with a row landing mid-walk and a full last page, revision stability + movement on add / mtime / art backfill / delete / scope, Joi → 400.
- [x] `npm run test:db` — 336 tests, all pass with the bundled ffmpeg linked into the worktree (the only failures without it are the ffmpeg-fixture suites, unrelated).
- [x] `test/integration/api-server-info.test.mjs` — 13/13, including the ping ↔ `/api/` drift-lock with the new flag.
- [x] `eslint` clean on the touched files; `redocly lint docs/openapi.yaml` — 0 errors (the 271 warnings are the pre-existing operationId-style ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
